### PR TITLE
[bitnami/magento] Fix magentoHost when using Ingress #19262

### DIFF
--- a/bitnami/magento/Chart.yaml
+++ b/bitnami/magento/Chart.yaml
@@ -48,4 +48,4 @@ maintainers:
 name: magento
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/magento
-version: 23.1.1
+version: 23.1.2

--- a/bitnami/magento/README.md
+++ b/bitnami/magento/README.md
@@ -261,8 +261,8 @@ The command removes all the Kubernetes components associated with the chart and 
 | Name                               | Description                                                                                                                      | Value                    |
 | ---------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- | ------------------------ |
 | `service.type`                     | Kubernetes Service type                                                                                                          | `LoadBalancer`           |
-| `service.ports.http`               | Service HTTP port                                                                                                                | `8080`                   |
-| `service.ports.https`              | Service HTTPS port                                                                                                               | `8443`                   |
+| `service.ports.http`               | Service HTTP port                                                                                                                | `80`                     |
+| `service.ports.https`              | Service HTTPS port                                                                                                               | `443`                    |
 | `service.nodePorts.http`           | Kubernetes http node port                                                                                                        | `""`                     |
 | `service.nodePorts.https`          | Kubernetes https node port                                                                                                       | `""`                     |
 | `service.clusterIP`                | Static clusterIP or None for headless services                                                                                   | `""`                     |

--- a/bitnami/magento/templates/_helpers.tpl
+++ b/bitnami/magento/templates/_helpers.tpl
@@ -57,11 +57,12 @@ When using Ingress, it will be set to the Ingress hostname.
 {{- define "magento.host" -}}
 {{- if .Values.ingress.enabled }}
 {{- $host := .Values.ingress.hostname | default "" -}}
-{{- default (include "magento.serviceIP" .) $host -}}
+{{- else if .Values.magentoHost -}}
+{{- $host := .Values.magentoHost | default "" -}}
 {{- else -}}
 {{- $host := index .Values (printf "%sHost" .Chart.Name) | default "" -}}
-{{- default (include "magento.serviceIP" .) $host -}}
 {{- end -}}
+{{- default (include "magento.serviceIP" .) $host -}}
 {{- end -}}
 
 {{/*

--- a/bitnami/magento/templates/_helpers.tpl
+++ b/bitnami/magento/templates/_helpers.tpl
@@ -57,12 +57,14 @@ When using Ingress, it will be set to the Ingress hostname.
 {{- define "magento.host" -}}
 {{- if .Values.ingress.enabled }}
 {{- $host := .Values.ingress.hostname | default "" -}}
+{{- default (include "magento.serviceIP" .) $host -}}
 {{- else if .Values.magentoHost -}}
 {{- $host := .Values.magentoHost | default "" -}}
+{{- default (include "magento.serviceIP" .) $host -}}
 {{- else -}}
 {{- $host := index .Values (printf "%sHost" .Chart.Name) | default "" -}}
-{{- end -}}
 {{- default (include "magento.serviceIP" .) $host -}}
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/bitnami/magento/values.yaml
+++ b/bitnami/magento/values.yaml
@@ -742,8 +742,8 @@ service:
   ## @param service.ports.https Service HTTPS port
   ##
   ports:
-    http: 8080
-    https: 8443
+    http: 80
+    https: 443
   ## @param service.nodePorts.http Kubernetes http node port
   ## @param service.nodePorts.https Kubernetes https node port
   ## e.g:


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

It uses ports 80 and 443 as default ports for the service. It also adds the use of `magentoHost`.

### Benefits

Fix usage with ingress.

### Possible drawbacks

N/A

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #19231

### Additional information

N/A

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
