### PR TITLE
[bitnami/mongodb] enable backup with auth: {enabled: false}

### DIFF
--- a/bitnami/mongodb/Chart.yaml
+++ b/bitnami/mongodb/Chart.yaml
@@ -39,4 +39,4 @@ maintainers:
 name: mongodb
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/mongodb
-version: 13.18.3
+version: 13.18.4

--- a/bitnami/mongodb/templates/backup/cronjob.yaml
+++ b/bitnami/mongodb/templates/backup/cronjob.yaml
@@ -88,11 +88,7 @@ spec:
             command:
               - /bin/sh
               - -c
-            {{- if .Values.auth.enabled }}
-              - "mongodump --username=${MONGODB_ROOT_USER} --password=${MONGODB_ROOT_PASSWORD} --host=${MONGODB_SERVICE_NAME} --port=${MONGODB_PORT_NUMBER} ${MONGODB_CLIENT_EXTRA_FLAGS} --oplog --gzip --archive=${MONGODUMP_DIR}/mongodump-$(date '+%Y-%m-%d-%H-%M').gz"
-            {{- else }}
-              - "mongodump --host=${MONGODB_SERVICE_NAME} --port=${MONGODB_PORT_NUMBER} ${MONGODB_CLIENT_EXTRA_FLAGS} --oplog --gzip --archive=${MONGODUMP_DIR}/mongodump-$(date '+%Y-%m-%d-%H-%M').gz"
-            {{- end }}
+              - "mongodump {{- if .Values.auth.enabled }} --username=${MONGODB_ROOT_USER} --password=${MONGODB_ROOT_PASSWORD} {{- end }} --host=${MONGODB_SERVICE_NAME} --port=${MONGODB_PORT_NUMBER} ${MONGODB_CLIENT_EXTRA_FLAGS} --oplog --gzip --archive=${MONGODUMP_DIR}/mongodump-$(date '+%Y-%m-%d-%H-%M').gz"
             {{- end }}
             volumeMounts:
               {{- if .Values.tls.enabled }}

--- a/bitnami/mongodb/templates/backup/cronjob.yaml
+++ b/bitnami/mongodb/templates/backup/cronjob.yaml
@@ -63,6 +63,7 @@ spec:
           - name: {{ include "mongodb.fullname" . }}-mongodump
             image: {{ include "mongodb.image" . }}
             env:
+            {{- if .Values.auth.enabled }}
               - name: MONGODB_ROOT_USER
                 value: {{ .Values.auth.rootUser | quote }}
               - name: MONGODB_ROOT_PASSWORD
@@ -70,6 +71,7 @@ spec:
                   secretKeyRef:
                     name: {{ include "mongodb.secretName" . }}
                     key: mongodb-root-password
+            {{- end }}
               - name: MONGODB_SERVICE_NAME
                 value: {{ include "mongodb.service.nameOverride" . }}
               - name: MONGODB_PORT_NUMBER
@@ -83,10 +85,14 @@ spec:
             {{- if .Values.backup.cronjob.command }}
             command: {{- include "common.tplvalues.render" (dict "value" .Values.backup.cronjob.command "context" $) | nindent 14 }}
             {{- else }}
-            command: 
+            command:
               - /bin/sh
               - -c
+            {{- if .Values.auth.enabled }}
               - "mongodump --username=${MONGODB_ROOT_USER} --password=${MONGODB_ROOT_PASSWORD} --host=${MONGODB_SERVICE_NAME} --port=${MONGODB_PORT_NUMBER} ${MONGODB_CLIENT_EXTRA_FLAGS} --oplog --gzip --archive=${MONGODUMP_DIR}/mongodump-$(date '+%Y-%m-%d-%H-%M').gz"
+            {{- else }}
+              - "mongodump --host=${MONGODB_SERVICE_NAME} --port=${MONGODB_PORT_NUMBER} ${MONGODB_CLIENT_EXTRA_FLAGS} --oplog --gzip --archive=${MONGODUMP_DIR}/mongodump-$(date '+%Y-%m-%d-%H-%M').gz"
+            {{- end }}
             {{- end }}
             volumeMounts:
               {{- if .Values.tls.enabled }}


### PR DESCRIPTION
### Description of the change

This will enable backups with `auth: {enabled: false}`

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)