### PR TITLE
[grafana-mimir] Increment cluster size for testing Grafana Mimir in VIB

### DIFF
--- a/.vib/grafana-mimir/vib-publish.json
+++ b/.vib/grafana-mimir/vib-publish.json
@@ -25,7 +25,7 @@
         "target_platform": {
           "target_platform_id": "{VIB_ENV_TARGET_PLATFORM}",
           "size": {
-            "name": "S4"
+            "name": "M4"
           }
         }
       },

--- a/.vib/grafana-mimir/vib-verify.json
+++ b/.vib/grafana-mimir/vib-verify.json
@@ -25,7 +25,7 @@
         "target_platform": {
           "target_platform_id": "{VIB_ENV_TARGET_PLATFORM}",
           "size": {
-            "name": "S4"
+            "name": "M4"
           }
         }
       },


### PR DESCRIPTION
### Description of the change

This PR increments the cluster size to use for testing Grafana Mimir to M4 (same used for Grafana Tempo) given the big amount of pods this chart deploys by default.

### Benefits

Improve tests reliability

### Possible drawbacks

None

### Applicable issues

N/A

### Additional information

N/A

### Checklist

- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
