### PR TITLE
[bitnami/thanos] Fix line break issue with serviceMonitor selector labels

### DIFF
--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: thanos
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/thanos
-version: 12.13.3
+version: 12.13.4

--- a/bitnami/thanos/templates/_helpers.tpl
+++ b/bitnami/thanos/templates/_helpers.tpl
@@ -469,7 +469,7 @@ Labels to use on serviceMonitor.spec.selector
 */}}
 {{- define "thanos.servicemonitor.selector" -}}
 {{- include "thanos.servicemonitor.matchLabels" $ }}
-{{- if .Values.metrics.serviceMonitor.selector -}}
+{{ if .Values.metrics.serviceMonitor.selector -}}
 {{- include "common.tplvalues.render" (dict "value" .Values.metrics.serviceMonitor.selector "context" $)}}
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
### Description of the change

Fixes #19285

Adds back in a missing newline which causes invalid YAML when serviceMonitor selector labels are specified.

### Benefits

Valid YAML when the setting is used.

### Possible drawbacks

I have tested with an without the `selector` configured and the output looks good.

### Applicable issues

#19285

### Additional information

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
