### PR TITLE
[bitnami/kube-prometheus] Allow setting ServiceMonitors' sampleLimit for Prometheus and other components

### DIFF
--- a/bitnami/kube-prometheus/Chart.yaml
+++ b/bitnami/kube-prometheus/Chart.yaml
@@ -21,11 +21,11 @@ dependencies:
 - condition: exporters.enabled,exporters.node-exporter.enabled
   name: node-exporter
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 3.8.x
+  version: 3.x.x
 - condition: exporters.enabled,exporters.kube-state-metrics.enabled
   name: kube-state-metrics
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 3.7.x
+  version: 3.x.x
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
   tags:

--- a/bitnami/kube-prometheus/Chart.yaml
+++ b/bitnami/kube-prometheus/Chart.yaml
@@ -21,11 +21,11 @@ dependencies:
 - condition: exporters.enabled,exporters.node-exporter.enabled
   name: node-exporter
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 3.x.x
+  version: 3.8.x
 - condition: exporters.enabled,exporters.kube-state-metrics.enabled
   name: kube-state-metrics
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 3.x.x
+  version: 3.7.x
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
   tags:
@@ -46,4 +46,4 @@ maintainers:
 name: kube-prometheus
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/kube-prometheus
-version: 8.18.3
+version: 8.19.0

--- a/bitnami/kube-prometheus/README.md
+++ b/bitnami/kube-prometheus/README.md
@@ -142,6 +142,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `operator.serviceMonitor.labels`                                                      | Extra labels for the ServiceMonitor                                                                                    | `{}`                          |
 | `operator.serviceMonitor.annotations`                                                 | Extra annotations for the ServiceMonitor                                                                               | `{}`                          |
 | `operator.serviceMonitor.extraParameters`                                             | Any extra parameter to be added to the endpoint configured in the ServiceMonitor                                       | `{}`                          |
+| `operator.serviceMonitor.sampleLimit`                                                 | Per-scrape limit on number of scraped samples that will be accepted.                                                   | `""`                          |
 | `operator.resources`                                                                  | Configure resource requests and limits                                                                                 | `{}`                          |
 | `operator.podAffinityPreset`                                                          | Pod affinity preset                                                                                                    | `""`                          |
 | `operator.podAntiAffinityPreset`                                                      | Prometheus Operator Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`           | `soft`                        |
@@ -199,7 +200,6 @@ The command removes all the Kubernetes components associated with the chart and 
 | `operator.prometheusConfigReloader.readinessProbe.failureThreshold`                   | Minimum consecutive failures for the probe                                                                             | `6`                           |
 | `operator.prometheusConfigReloader.readinessProbe.successThreshold`                   | Minimum consecutive successes for the probe                                                                            | `1`                           |
 | `operator.namespaces`                                                                 | Optional comma-separated list of namespaces to watch (default=all).                                                    | `""`                          |
-| `operator.serviceMonitor.sampleLimit`                                                 | Per-scrape limit on number of scraped samples that will be accepted                                                    | `""`                          |
 
 ### Prometheus Parameters
 
@@ -243,7 +243,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `prometheus.serviceMonitor.interval`                                  | Scrape interval (use by default, falling back to Prometheus' default)                                                            | `""`                      |
 | `prometheus.serviceMonitor.metricRelabelings`                         | Metric relabeling                                                                                                                | `[]`                      |
 | `prometheus.serviceMonitor.relabelings`                               | Relabel configs                                                                                                                  | `[]`                      |
-| `prometheus.serviceMonitor.sampleLimit`                               | Per-scrape limit on number of scraped samples that will be accepted                                                              | `""`                      |
+| `prometheus.serviceMonitor.sampleLimit`                               | Per-scrape limit on number of scraped samples that will be accepted.                                                             | `""`                      |
 | `prometheus.ingress.enabled`                                          | Enable ingress controller resource                                                                                               | `false`                   |
 | `prometheus.ingress.pathType`                                         | Ingress Path type                                                                                                                | `ImplementationSpecific`  |
 | `prometheus.ingress.apiVersion`                                       | Override API Version (automatically detected if not set)                                                                         | `""`                      |
@@ -436,7 +436,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `prometheus.configReloader.serviceMonitor.jobLabel`                   | The name of the label on the target service to use as the job name in prometheus.                                                | `""`                      |
 | `prometheus.configReloader.serviceMonitor.metricRelabelings`          | Metric relabeling                                                                                                                | `[]`                      |
 | `prometheus.configReloader.serviceMonitor.relabelings`                | Relabel configs                                                                                                                  | `[]`                      |
-| `prometheus.configReloader.serviceMonitor.sampleLimit`                | Per-scrape limit on number of scraped samples that will be accepted                                                              | `""`                      |
+| `prometheus.configReloader.serviceMonitor.sampleLimit`                | Per-scrape limit on number of scraped samples that will be accepted.                                                             | `""`                      |
 | `prometheus.portName`                                                 | Port name used for the pods and governing service. This defaults to web                                                          | `web`                     |
 
 ### Alertmanager Parameters
@@ -487,7 +487,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `alertmanager.serviceMonitor.annotations`                        | Extra annotations for the ServiceMonitor                                                                                                                                                                                                                                                                   | `{}`                     |
 | `alertmanager.serviceMonitor.honorLabels`                        | honorLabels chooses the metric's labels on collisions with target labels                                                                                                                                                                                                                                   | `false`                  |
 | `alertmanager.serviceMonitor.extraParameters`                    | Any extra parameter to be added to the endpoint configured in the ServiceMonitor                                                                                                                                                                                                                           | `{}`                     |
-| `alertmanager.serviceMonitor.sampleLimit`                        | Per-scrape limit on number of scraped samples that will be accepted                                                                                                                                                                                                                                        | `""`                     |
+| `alertmanager.serviceMonitor.sampleLimit`                        | Per-scrape limit on number of scraped samples that will be accepted.                                                                                                                                                                                                                                       | `""`                     |
 | `alertmanager.ingress.enabled`                                   | Enable ingress controller resource                                                                                                                                                                                                                                                                         | `false`                  |
 | `alertmanager.ingress.pathType`                                  | Ingress Path type                                                                                                                                                                                                                                                                                          | `ImplementationSpecific` |
 | `alertmanager.ingress.apiVersion`                                | Override API Version (automatically detected if not set)                                                                                                                                                                                                                                                   | `""`                     |
@@ -579,7 +579,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `kubelet.serviceMonitor.cAdvisorRelabelings`       | Relabel configs for scraping cAdvisor                                                                  | `[]`                         |
 | `kubelet.serviceMonitor.labels`                    | Extra labels for the ServiceMonitor                                                                    | `{}`                         |
 | `kubelet.serviceMonitor.annotations`               | Extra annotations for the ServiceMonitor                                                               | `{}`                         |
-| `kubelet.serviceMonitor.sampleLimit`                | Per-scrape limit on number of scraped samples that will be accepted                                   | `""`                         |
+| `kubelet.serviceMonitor.sampleLimit`               | Per-scrape limit on number of scraped samples that will be accepted.                                   | `""`                         |
 
 ### Blackbox Exporter Deployment Parameters
 
@@ -677,7 +677,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `kubeApiServer.serviceMonitor.relabelings`                | Relabel configs                                                                                                                 | `[]`          |
 | `kubeApiServer.serviceMonitor.labels`                     | Extra labels for the ServiceMonitor                                                                                             | `{}`          |
 | `kubeApiServer.serviceMonitor.annotations`                | Extra annotations for the ServiceMonitor                                                                                        | `{}`          |
-| `kubeApiServer.serviceMonitor.sampleLimit`                | Per-scrape limit on number of scraped samples that will be accepted                                                             | `""`          |
+| `kubeApiServer.serviceMonitor.sampleLimit`                | Per-scrape limit on number of scraped samples that will be accepted.                                                            | `""`          |
 | `kubeControllerManager.enabled`                           | Create a ServiceMonitor to scrape kube-controller-manager service                                                               | `true`        |
 | `kubeControllerManager.endpoints`                         | If your kube controller manager is not deployed as a pod, specify IPs it can be found on                                        | `[]`          |
 | `kubeControllerManager.namespace`                         | Namespace where kube-controller-manager service is deployed.                                                                    | `kube-system` |
@@ -695,7 +695,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `kubeControllerManager.serviceMonitor.relabelings`        | Relabel configs                                                                                                                 | `[]`          |
 | `kubeControllerManager.serviceMonitor.labels`             | Extra labels for the ServiceMonitor                                                                                             | `{}`          |
 | `kubeControllerManager.serviceMonitor.annotations`        | Extra annotations for the ServiceMonitor                                                                                        | `{}`          |
-| `kubeControllerManager.serviceMonitor.sampleLimit`        | Per-scrape limit on number of scraped samples that will be accepted                                                             | `""`          |
+| `kubeControllerManager.serviceMonitor.sampleLimit`        | Per-scrape limit on number of scraped samples that will be accepted.                                                            | `""`          |
 | `kubeScheduler.enabled`                                   | Create a ServiceMonitor to scrape kube-scheduler service                                                                        | `true`        |
 | `kubeScheduler.endpoints`                                 | If your kube scheduler is not deployed as a pod, specify IPs it can be found on                                                 | `[]`          |
 | `kubeScheduler.namespace`                                 | Namespace where kube-scheduler service is deployed.                                                                             | `kube-system` |
@@ -713,7 +713,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `kubeScheduler.serviceMonitor.relabelings`                | Relabel configs                                                                                                                 | `[]`          |
 | `kubeScheduler.serviceMonitor.labels`                     | Extra labels for the ServiceMonitor                                                                                             | `{}`          |
 | `kubeScheduler.serviceMonitor.annotations`                | Extra annotations for the ServiceMonitor                                                                                        | `{}`          |
-| `kubeScheduler.serviceMonitor.sampleLimit`                | Per-scrape limit on number of scraped samples that will be accepted                                                             | `""`          |
+| `kubeScheduler.serviceMonitor.sampleLimit`                | Per-scrape limit on number of scraped samples that will be accepted.                                                            | `""`          |
 | `coreDns.enabled`                                         | Create a ServiceMonitor to scrape coredns service                                                                               | `true`        |
 | `coreDns.namespace`                                       | Namespace where core dns service is deployed.                                                                                   | `kube-system` |
 | `coreDns.service.enabled`                                 | Whether or not to create a Service object for coredns                                                                           | `true`        |
@@ -727,7 +727,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `coreDns.serviceMonitor.relabelings`                      | Relabel configs to apply to samples before ingestion.                                                                           | `[]`          |
 | `coreDns.serviceMonitor.labels`                           | Extra labels for the ServiceMonitor                                                                                             | `{}`          |
 | `coreDns.serviceMonitor.annotations`                      | Extra annotations for the ServiceMonitor                                                                                        | `{}`          |
-| `coreDns.serviceMonitor.sampleLimit`                      | Per-scrape limit on number of scraped samples that will be accepted                                                             | `""`          |
+| `coreDns.serviceMonitor.sampleLimit`                      | Per-scrape limit on number of scraped samples that will be accepted.                                                            | `""`          |
 | `kubeProxy.enabled`                                       | Create a ServiceMonitor to scrape the kube-proxy Service                                                                        | `true`        |
 | `kubeProxy.endpoints`                                     | If your kube-proxy is not deployed as a pod, specify IPs it can be found on                                                     | `[]`          |
 | `kubeProxy.namespace`                                     | Namespace where kube-proxy service is deployed.                                                                                 | `kube-system` |
@@ -743,7 +743,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `kubeProxy.serviceMonitor.relabelings`                    | Relabel configs                                                                                                                 | `[]`          |
 | `kubeProxy.serviceMonitor.labels`                         | Extra labels for the ServiceMonitor                                                                                             | `{}`          |
 | `kubeProxy.serviceMonitor.annotations`                    | Extra annotations for the ServiceMonitor                                                                                        | `{}`          |
-| `kubeProxy.serviceMonitor.sampleLimit`                    | Per-scrape limit on number of scraped samples that will be accepted                                                             | `""`          |
+| `kubeProxy.serviceMonitor.sampleLimit`                    | Per-scrape limit on number of scraped samples that will be accepted.                                                            | `""`          |
 
 ### RBAC parameters
 

--- a/bitnami/kube-prometheus/README.md
+++ b/bitnami/kube-prometheus/README.md
@@ -581,7 +581,6 @@ The command removes all the Kubernetes components associated with the chart and 
 | `kubelet.serviceMonitor.annotations`               | Extra annotations for the ServiceMonitor                                                               | `{}`                         |
 | `kubelet.serviceMonitor.sampleLimit`                | Per-scrape limit on number of scraped samples that will be accepted                                   | `""`                         |
 
-
 ### Blackbox Exporter Deployment Parameters
 
 | Name                                                           | Description                                                                                                       | Value                       |
@@ -745,7 +744,6 @@ The command removes all the Kubernetes components associated with the chart and 
 | `kubeProxy.serviceMonitor.labels`                         | Extra labels for the ServiceMonitor                                                                                             | `{}`          |
 | `kubeProxy.serviceMonitor.annotations`                    | Extra annotations for the ServiceMonitor                                                                                        | `{}`          |
 | `kubeProxy.serviceMonitor.sampleLimit`                    | Per-scrape limit on number of scraped samples that will be accepted                                                             | `""`          |
-
 
 ### RBAC parameters
 

--- a/bitnami/kube-prometheus/README.md
+++ b/bitnami/kube-prometheus/README.md
@@ -199,6 +199,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `operator.prometheusConfigReloader.readinessProbe.failureThreshold`                   | Minimum consecutive failures for the probe                                                                             | `6`                           |
 | `operator.prometheusConfigReloader.readinessProbe.successThreshold`                   | Minimum consecutive successes for the probe                                                                            | `1`                           |
 | `operator.namespaces`                                                                 | Optional comma-separated list of namespaces to watch (default=all).                                                    | `""`                          |
+| `operator.serviceMonitor.sampleLimit`                                                 | Per-scrape limit on number of scraped samples that will be accepted                                                    | `""`                          |
 
 ### Prometheus Parameters
 
@@ -242,6 +243,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `prometheus.serviceMonitor.interval`                                  | Scrape interval (use by default, falling back to Prometheus' default)                                                            | `""`                      |
 | `prometheus.serviceMonitor.metricRelabelings`                         | Metric relabeling                                                                                                                | `[]`                      |
 | `prometheus.serviceMonitor.relabelings`                               | Relabel configs                                                                                                                  | `[]`                      |
+| `prometheus.serviceMonitor.sampleLimit`                               | Per-scrape limit on number of scraped samples that will be accepted                                                              | `""`                      |
 | `prometheus.ingress.enabled`                                          | Enable ingress controller resource                                                                                               | `false`                   |
 | `prometheus.ingress.pathType`                                         | Ingress Path type                                                                                                                | `ImplementationSpecific`  |
 | `prometheus.ingress.apiVersion`                                       | Override API Version (automatically detected if not set)                                                                         | `""`                      |
@@ -434,6 +436,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `prometheus.configReloader.serviceMonitor.jobLabel`                   | The name of the label on the target service to use as the job name in prometheus.                                                | `""`                      |
 | `prometheus.configReloader.serviceMonitor.metricRelabelings`          | Metric relabeling                                                                                                                | `[]`                      |
 | `prometheus.configReloader.serviceMonitor.relabelings`                | Relabel configs                                                                                                                  | `[]`                      |
+| `prometheus.configReloader.serviceMonitor.sampleLimit`                | Per-scrape limit on number of scraped samples that will be accepted                                                              | `""`                      |
 | `prometheus.portName`                                                 | Port name used for the pods and governing service. This defaults to web                                                          | `web`                     |
 
 ### Alertmanager Parameters
@@ -484,6 +487,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `alertmanager.serviceMonitor.annotations`                        | Extra annotations for the ServiceMonitor                                                                                                                                                                                                                                                                   | `{}`                     |
 | `alertmanager.serviceMonitor.honorLabels`                        | honorLabels chooses the metric's labels on collisions with target labels                                                                                                                                                                                                                                   | `false`                  |
 | `alertmanager.serviceMonitor.extraParameters`                    | Any extra parameter to be added to the endpoint configured in the ServiceMonitor                                                                                                                                                                                                                           | `{}`                     |
+| `alertmanager.serviceMonitor.sampleLimit`                        | Per-scrape limit on number of scraped samples that will be accepted                                                                                                                                                                                                                                        | `""`                     |
 | `alertmanager.ingress.enabled`                                   | Enable ingress controller resource                                                                                                                                                                                                                                                                         | `false`                  |
 | `alertmanager.ingress.pathType`                                  | Ingress Path type                                                                                                                                                                                                                                                                                          | `ImplementationSpecific` |
 | `alertmanager.ingress.apiVersion`                                | Override API Version (automatically detected if not set)                                                                                                                                                                                                                                                   | `""`                     |
@@ -575,6 +579,8 @@ The command removes all the Kubernetes components associated with the chart and 
 | `kubelet.serviceMonitor.cAdvisorRelabelings`       | Relabel configs for scraping cAdvisor                                                                  | `[]`                         |
 | `kubelet.serviceMonitor.labels`                    | Extra labels for the ServiceMonitor                                                                    | `{}`                         |
 | `kubelet.serviceMonitor.annotations`               | Extra annotations for the ServiceMonitor                                                               | `{}`                         |
+| `kubelet.serviceMonitor.sampleLimit`                | Per-scrape limit on number of scraped samples that will be accepted                                   | `""`                         |
+
 
 ### Blackbox Exporter Deployment Parameters
 
@@ -672,6 +678,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `kubeApiServer.serviceMonitor.relabelings`                | Relabel configs                                                                                                                 | `[]`          |
 | `kubeApiServer.serviceMonitor.labels`                     | Extra labels for the ServiceMonitor                                                                                             | `{}`          |
 | `kubeApiServer.serviceMonitor.annotations`                | Extra annotations for the ServiceMonitor                                                                                        | `{}`          |
+| `kubeApiServer.serviceMonitor.sampleLimit`                | Per-scrape limit on number of scraped samples that will be accepted                                                             | `""`          |
 | `kubeControllerManager.enabled`                           | Create a ServiceMonitor to scrape kube-controller-manager service                                                               | `true`        |
 | `kubeControllerManager.endpoints`                         | If your kube controller manager is not deployed as a pod, specify IPs it can be found on                                        | `[]`          |
 | `kubeControllerManager.namespace`                         | Namespace where kube-controller-manager service is deployed.                                                                    | `kube-system` |
@@ -689,6 +696,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `kubeControllerManager.serviceMonitor.relabelings`        | Relabel configs                                                                                                                 | `[]`          |
 | `kubeControllerManager.serviceMonitor.labels`             | Extra labels for the ServiceMonitor                                                                                             | `{}`          |
 | `kubeControllerManager.serviceMonitor.annotations`        | Extra annotations for the ServiceMonitor                                                                                        | `{}`          |
+| `kubeControllerManager.serviceMonitor.sampleLimit`        | Per-scrape limit on number of scraped samples that will be accepted                                                             | `""`          |
 | `kubeScheduler.enabled`                                   | Create a ServiceMonitor to scrape kube-scheduler service                                                                        | `true`        |
 | `kubeScheduler.endpoints`                                 | If your kube scheduler is not deployed as a pod, specify IPs it can be found on                                                 | `[]`          |
 | `kubeScheduler.namespace`                                 | Namespace where kube-scheduler service is deployed.                                                                             | `kube-system` |
@@ -706,6 +714,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `kubeScheduler.serviceMonitor.relabelings`                | Relabel configs                                                                                                                 | `[]`          |
 | `kubeScheduler.serviceMonitor.labels`                     | Extra labels for the ServiceMonitor                                                                                             | `{}`          |
 | `kubeScheduler.serviceMonitor.annotations`                | Extra annotations for the ServiceMonitor                                                                                        | `{}`          |
+| `kubeScheduler.serviceMonitor.sampleLimit`                | Per-scrape limit on number of scraped samples that will be accepted                                                             | `""`          |
 | `coreDns.enabled`                                         | Create a ServiceMonitor to scrape coredns service                                                                               | `true`        |
 | `coreDns.namespace`                                       | Namespace where core dns service is deployed.                                                                                   | `kube-system` |
 | `coreDns.service.enabled`                                 | Whether or not to create a Service object for coredns                                                                           | `true`        |
@@ -719,6 +728,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `coreDns.serviceMonitor.relabelings`                      | Relabel configs to apply to samples before ingestion.                                                                           | `[]`          |
 | `coreDns.serviceMonitor.labels`                           | Extra labels for the ServiceMonitor                                                                                             | `{}`          |
 | `coreDns.serviceMonitor.annotations`                      | Extra annotations for the ServiceMonitor                                                                                        | `{}`          |
+| `coreDns.serviceMonitor.sampleLimit`                      | Per-scrape limit on number of scraped samples that will be accepted                                                             | `""`          |
 | `kubeProxy.enabled`                                       | Create a ServiceMonitor to scrape the kube-proxy Service                                                                        | `true`        |
 | `kubeProxy.endpoints`                                     | If your kube-proxy is not deployed as a pod, specify IPs it can be found on                                                     | `[]`          |
 | `kubeProxy.namespace`                                     | Namespace where kube-proxy service is deployed.                                                                                 | `kube-system` |
@@ -734,6 +744,8 @@ The command removes all the Kubernetes components associated with the chart and 
 | `kubeProxy.serviceMonitor.relabelings`                    | Relabel configs                                                                                                                 | `[]`          |
 | `kubeProxy.serviceMonitor.labels`                         | Extra labels for the ServiceMonitor                                                                                             | `{}`          |
 | `kubeProxy.serviceMonitor.annotations`                    | Extra annotations for the ServiceMonitor                                                                                        | `{}`          |
+| `kubeProxy.serviceMonitor.sampleLimit`                    | Per-scrape limit on number of scraped samples that will be accepted                                                             | `""`          |
+
 
 ### RBAC parameters
 

--- a/bitnami/kube-prometheus/templates/exporters/core-dns/servicemonitor.yaml
+++ b/bitnami/kube-prometheus/templates/exporters/core-dns/servicemonitor.yaml
@@ -24,6 +24,9 @@ spec:
   namespaceSelector:
     matchNames:
       - {{ .Values.coreDns.namespace }}
+  {{- with .Values.coreDns.serviceMonitor.sampleLimit }}
+  sampleLimit: {{ . }}
+  {{- end }}
   endpoints:
     - port: http-metrics
       {{- if .Values.coreDns.serviceMonitor.interval }}

--- a/bitnami/kube-prometheus/templates/exporters/kube-apiserver/servicemonitor.yaml
+++ b/bitnami/kube-prometheus/templates/exporters/kube-apiserver/servicemonitor.yaml
@@ -25,6 +25,9 @@ spec:
   namespaceSelector:
     matchNames:
       - default
+  {{- with .Values.kubeApiServer.serviceMonitor.sampleLimit }}
+  sampleLimit: {{ . }}
+  {{- end }}
   endpoints:
     - port: https
       scheme: https

--- a/bitnami/kube-prometheus/templates/exporters/kube-controller-manager/servicemonitor.yaml
+++ b/bitnami/kube-prometheus/templates/exporters/kube-controller-manager/servicemonitor.yaml
@@ -24,6 +24,9 @@ spec:
   namespaceSelector:
     matchNames:
       - {{ .Values.kubeControllerManager.namespace }}
+  {{- with .Values.kubeControllerManager.serviceMonitor.sampleLimit }}
+  sampleLimit: {{ . }}
+  {{- end }}
   endpoints:
     - port: http-metrics
       bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token

--- a/bitnami/kube-prometheus/templates/exporters/kube-proxy/servicemonitor.yaml
+++ b/bitnami/kube-prometheus/templates/exporters/kube-proxy/servicemonitor.yaml
@@ -24,6 +24,9 @@ spec:
   namespaceSelector:
     matchNames:
       - {{ .Values.kubeProxy.namespace }}
+  {{- with .Values.kubeProxy.serviceMonitor.sampleLimit }}
+  sampleLimit: {{ . }}
+  {{- end }}
   endpoints:
     - port: http-metrics
       bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token

--- a/bitnami/kube-prometheus/templates/exporters/kube-scheduler/servicemonitor.yaml
+++ b/bitnami/kube-prometheus/templates/exporters/kube-scheduler/servicemonitor.yaml
@@ -24,6 +24,9 @@ spec:
   namespaceSelector:
     matchNames:
       - {{ .Values.kubeScheduler.namespace }}
+  {{- with .Values.kubeScheduler.serviceMonitor.sampleLimit }}
+  sampleLimit: {{ . }}
+  {{- end }}
   endpoints:
     - port: http-metrics
       bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token

--- a/bitnami/kube-prometheus/templates/exporters/kubelet/servicemonitor.yaml
+++ b/bitnami/kube-prometheus/templates/exporters/kubelet/servicemonitor.yaml
@@ -24,6 +24,9 @@ spec:
   namespaceSelector:
     matchNames:
       - {{ .Values.kubelet.namespace }}
+  {{- with .Values.kubelet.serviceMonitor.sampleLimit }}
+  sampleLimit: {{ . }}
+  {{- end }}
   endpoints:
       {{- $scheme := ternary "https" "http" .Values.kubelet.serviceMonitor.https }}
     - port: {{ printf "%s-metrics" $scheme }}

--- a/bitnami/kube-prometheus/templates/prometheus/servicemonitor.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus/servicemonitor.yaml
@@ -21,6 +21,9 @@ spec:
   namespaceSelector:
     matchNames:
       - {{ include "common.names.namespace" . | quote }}
+  {{- with .Values.prometheus.serviceMonitor.sampleLimit }}
+  sampleLimit: {{ . }}
+  {{- end }}
   endpoints:
     - port: http
       {{- if .Values.prometheus.serviceMonitor.interval }}

--- a/bitnami/kube-prometheus/values.yaml
+++ b/bitnami/kube-prometheus/values.yaml
@@ -2618,7 +2618,7 @@ kubeControllerManager:
     ## @param kubeControllerManager.serviceMonitor.annotations Extra annotations for the ServiceMonitor
     ##
     annotations: { }
-    ## @param operator.serviceMonitor.sampleLimit Per-scrape limit on number of scraped samples that will be accepted.
+    ## @param kubeControllerManager.serviceMonitor.sampleLimit Per-scrape limit on number of scraped samples that will be accepted.
     ##
     sampleLimit: ""
 ## Component scraping kube scheduler
@@ -2696,7 +2696,7 @@ kubeScheduler:
     ## @param kubeScheduler.serviceMonitor.annotations Extra annotations for the ServiceMonitor
     ##
     annotations: {}
-    ## @param operator.serviceMonitor.sampleLimit Per-scrape limit on number of scraped samples that will be accepted.
+    ## @param kubeScheduler.serviceMonitor.sampleLimit Per-scrape limit on number of scraped samples that will be accepted.
     ##
     sampleLimit: ""
 ## Component scraping coreDns
@@ -2757,7 +2757,7 @@ coreDns:
     ## @param coreDns.serviceMonitor.annotations Extra annotations for the ServiceMonitor
     ##
     annotations: {}
-    ## @param operator.serviceMonitor.sampleLimit Per-scrape limit on number of scraped samples that will be accepted.
+    ## @param coreDns.serviceMonitor.sampleLimit Per-scrape limit on number of scraped samples that will be accepted.
     ##
     sampleLimit: ""
 ## Component scraping the kube-proxy
@@ -2820,7 +2820,7 @@ kubeProxy:
     ## @param kubeProxy.serviceMonitor.annotations Extra annotations for the ServiceMonitor
     ##
     annotations: {}
-    ## @param operator.serviceMonitor.sampleLimit Per-scrape limit on number of scraped samples that will be accepted.
+    ## @param kubeProxy.serviceMonitor.sampleLimit Per-scrape limit on number of scraped samples that will be accepted.
     ##
     sampleLimit: ""
 

--- a/bitnami/kube-prometheus/values.yaml
+++ b/bitnami/kube-prometheus/values.yaml
@@ -298,6 +298,9 @@ operator:
     ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#monitoring.coreos.com/v1.Endpoint
     ##
     extraParameters: {}
+    ## @param operator.serviceMonitor.sampleLimit Per-scrape limit on number of scraped samples that will be accepted.
+    ##
+    sampleLimit: ""
   ## @param operator.resources Configure resource requests and limits
   ## ref: https://kubernetes.io/docs/user-guide/compute-resources/
   ##
@@ -663,6 +666,9 @@ prometheus:
     ## ref: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
     ##
     relabelings: []
+    ## @param prometheus.serviceMonitor.sampleLimit Per-scrape limit on number of scraped samples that will be accepted.
+    ##
+    sampleLimit: ""
 
   ## Configure the ingress resource that allows you to access the
   ## Prometheus installation. Set up the URL
@@ -1555,6 +1561,9 @@ prometheus:
       ## ref: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
       ##
       relabelings: []
+      ## @param prometheus.configReloader.serviceMonitor.sampleLimit Per-scrape limit on number of scraped samples that will be accepted.
+      ##
+      sampleLimit: ""
   ## @param prometheus.portName Port name used for the pods and governing service. This defaults to web
   ##
   portName: web
@@ -1749,6 +1758,9 @@ alertmanager:
     ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#monitoring.coreos.com/v1.Endpoint
     ##
     extraParameters: {}
+    ## @param alertmanager.serviceMonitor.sampleLimit Per-scrape limit on number of scraped samples that will be accepted.
+    ##
+    sampleLimit: ""
   ## Configure the ingress resource that allows you to access the
   ## Alertmanager installation. Set up the URL
   ## ref: https://kubernetes.io/docs/user-guide/ingress/
@@ -2148,6 +2160,9 @@ kubelet:
     ## @param kubelet.serviceMonitor.annotations Extra annotations for the ServiceMonitor
     ##
     annotations: {}
+    ## @param kubelet.serviceMonitor.sampleLimit Per-scrape limit on number of scraped samples that will be accepted.
+    ##
+    sampleLimit: ""
 
 ## @section Blackbox Exporter Deployment Parameters
 ##
@@ -2533,6 +2548,9 @@ kubeApiServer:
     ## @param kubeApiServer.serviceMonitor.annotations Extra annotations for the ServiceMonitor
     ##
     annotations: { }
+    ## @param kubeApiServer.serviceMonitor.sampleLimit Per-scrape limit on number of scraped samples that will be accepted.
+    ##
+    sampleLimit: ""
 ## Component scraping the kube-controller-manager
 ##
 kubeControllerManager:
@@ -2600,6 +2618,9 @@ kubeControllerManager:
     ## @param kubeControllerManager.serviceMonitor.annotations Extra annotations for the ServiceMonitor
     ##
     annotations: { }
+    ## @param operator.serviceMonitor.sampleLimit Per-scrape limit on number of scraped samples that will be accepted.
+    ##
+    sampleLimit: ""
 ## Component scraping kube scheduler
 ##
 kubeScheduler:
@@ -2675,6 +2696,9 @@ kubeScheduler:
     ## @param kubeScheduler.serviceMonitor.annotations Extra annotations for the ServiceMonitor
     ##
     annotations: {}
+    ## @param operator.serviceMonitor.sampleLimit Per-scrape limit on number of scraped samples that will be accepted.
+    ##
+    sampleLimit: ""
 ## Component scraping coreDns
 ##
 coreDns:
@@ -2733,6 +2757,9 @@ coreDns:
     ## @param coreDns.serviceMonitor.annotations Extra annotations for the ServiceMonitor
     ##
     annotations: {}
+    ## @param operator.serviceMonitor.sampleLimit Per-scrape limit on number of scraped samples that will be accepted.
+    ##
+    sampleLimit: ""
 ## Component scraping the kube-proxy
 ##
 kubeProxy:
@@ -2793,6 +2820,9 @@ kubeProxy:
     ## @param kubeProxy.serviceMonitor.annotations Extra annotations for the ServiceMonitor
     ##
     annotations: {}
+    ## @param operator.serviceMonitor.sampleLimit Per-scrape limit on number of scraped samples that will be accepted.
+    ##
+    sampleLimit: ""
 
 ## @section RBAC parameters
 ##


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

This is a follow-up of sorts to #18413: when setting the *global* sample limit, one might also need to set higher sample limits for some service monitors.

### Benefits

More control over the amount of data collected.

### Possible drawbacks

None.

### Applicable issues

None.

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

Related PRs: #19299, #19323, #19322

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
