### PR TITLE
[bitnami/nginx-ingress-controller] Add Service spec: ipFamilyPolicy and ipFamilies

### DIFF
--- a/bitnami/nginx-ingress-controller/Chart.yaml
+++ b/bitnami/nginx-ingress-controller/Chart.yaml
@@ -34,4 +34,4 @@ maintainers:
 name: nginx-ingress-controller
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/nginx-ingress-controller
-version: 9.8.6
+version: 9.9.0

--- a/bitnami/nginx-ingress-controller/README.md
+++ b/bitnami/nginx-ingress-controller/README.md
@@ -270,6 +270,8 @@ The command removes all the Kubernetes components associated with the chart and 
 | `service.labels`                   | Labels for controller service                                                                                                          | `{}`           |
 | `service.clusterIP`                | Controller Internal Cluster Service IP (optional)                                                                                      | `""`           |
 | `service.externalIPs`              | Controller Service external IP addresses                                                                                               | `[]`           |
+| `service.ipFamilyPolicy`           | Controller Service ipFamilyPolicy (optional, cloud specific)                                                                           | `""`           |
+| `service.ipFamilies`               | Controller Service ipFamilies (optional, cloud specific)                                                                               | `[]`           |
 | `service.loadBalancerIP`           | Kubernetes LoadBalancerIP to request for Controller (optional, cloud specific)                                                         | `""`           |
 | `service.loadBalancerSourceRanges` | List of IP CIDRs allowed access to load balancer (if supported)                                                                        | `[]`           |
 | `service.extraPorts`               | Extra ports to expose (normally used with the `sidecar` value)                                                                         | `[]`           |

--- a/bitnami/nginx-ingress-controller/templates/controller-service.yaml
+++ b/bitnami/nginx-ingress-controller/templates/controller-service.yaml
@@ -29,6 +29,12 @@ spec:
   {{- if .Values.service.externalIPs }}
   externalIPs: {{- toYaml .Values.service.externalIPs | nindent 4 }}
   {{- end }}
+  {{- if .Values.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ .Values.service.ipFamilyPolicy }}
+  {{- end }}
+  {{- if not (empty .Values.service.ipFamilies)}}
+  ipFamilies: {{- toYaml .Values.service.ipFamilies | nindent 4 }}
+  {{- end }}
   {{- if and (eq .Values.service.type "LoadBalancer") (not (empty .Values.service.loadBalancerIP)) }}
   loadBalancerIP: {{ .Values.service.loadBalancerIP | quote }}
   {{- end }}

--- a/bitnami/nginx-ingress-controller/values.yaml
+++ b/bitnami/nginx-ingress-controller/values.yaml
@@ -801,6 +801,16 @@ service:
   ## Ref: https://kubernetes.io/docs/user-guide/services/#external-ips
   ##
   externalIPs: []
+  ## @param service.ipFamilyPolicy Controller Service ipFamilyPolicy (optional, cloud specific)
+  ## This can be either SingleStack, PreferDualStack or RequireDualStack
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/dual-stack/#services
+  ##
+  ipFamilyPolicy: ""
+  ## @param service.ipFamilies Controller Service ipFamilies (optional, cloud specific)
+  ## This can be either ["IPv4"], ["IPv6"], ["IPv4", "IPv6"] or ["IPv6", "IPv4"]
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/dual-stack/#services
+  ##
+  ipFamilies: []
   ## @param service.loadBalancerIP Kubernetes LoadBalancerIP to request for Controller (optional, cloud specific)
   ## ref: https://kubernetes.io/docs/user-guide/services/#type-loadbalancer
   ##


### PR DESCRIPTION
### Description of the change

This pull request adds support for setting ipFamilyPolicy and ipFamilies in nginx-ingress-controller's service spec

### Benefits

Allows users of this chart to enable dual stack or use IPv6 for the Kubernetes Service.

### Possible drawbacks

None

### Additional information

I'm not sure about my documentation, please help me out here since it's the first time contributing to this project

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
