### PR TITLE
[bitnami/nginx] add `cloneStaticSiteFromGit.extraEnvVarsSecret`

### DIFF
--- a/bitnami/nginx/Chart.lock
+++ b/bitnami/nginx/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.10.0
-digest: sha256:023ded170632d04528f30332370f34fc8fb96efb2886a01d934cb3bd6e6d2e09
-generated: "2023-09-05T11:35:00.085917+02:00"
+  version: 2.11.1
+digest: sha256:ead8f26c76a9ec082f23629a358e8efd8f88d87aaed734bf41febcb8a7bc5d4c
+generated: "2023-09-17T03:13:06.703689648+02:00"

--- a/bitnami/nginx/Chart.yaml
+++ b/bitnami/nginx/Chart.yaml
@@ -34,4 +34,4 @@ maintainers:
 name: nginx
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/nginx
-version: 15.2.1
+version: 15.3.0

--- a/bitnami/nginx/README.md
+++ b/bitnami/nginx/README.md
@@ -183,7 +183,6 @@ The command removes all the Kubernetes components associated with the chart and 
 | `cloneStaticSiteFromGit.repository`                 | Git Repository to clone static content from                                                         | `""`                   |
 | `cloneStaticSiteFromGit.branch`                     | Git branch to checkout                                                                              | `""`                   |
 | `cloneStaticSiteFromGit.interval`                   | Interval for sidecar container pull from the Git repository                                         | `60`                   |
-| `cloneStaticSiteFromGit.extraEnvVarsSecret`         | Secret with extra environment variables                                                             | `""`                   |
 | `cloneStaticSiteFromGit.gitClone.command`           | Override default container command for git-clone-repository                                         | `[]`                   |
 | `cloneStaticSiteFromGit.gitClone.args`              | Override default container args for git-clone-repository                                            | `[]`                   |
 | `cloneStaticSiteFromGit.gitSync.command`            | Override default container command for git-repo-syncer                                              | `[]`                   |
@@ -191,6 +190,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `cloneStaticSiteFromGit.gitSync.resources.limits`   | The resources limits for the git-repo-syncer container                                              | `{}`                   |
 | `cloneStaticSiteFromGit.gitSync.resources.requests` | The requested resources for the git-repo-syncer container                                           | `{}`                   |
 | `cloneStaticSiteFromGit.extraEnvVars`               | Additional environment variables to set for the in the containers that clone static site from git   | `[]`                   |
+| `cloneStaticSiteFromGit.extraEnvVarsSecret`         | Secret with extra environment variables                                                             | `""`                   |
 | `cloneStaticSiteFromGit.extraVolumeMounts`          | Add extra volume mounts for the Git containers                                                      | `[]`                   |
 | `serverBlock`                                       | Custom server block to be added to NGINX configuration                                              | `""`                   |
 | `existingServerBlockConfigmap`                      | ConfigMap with custom server block to be added to NGINX configuration                               | `""`                   |

--- a/bitnami/nginx/README.md
+++ b/bitnami/nginx/README.md
@@ -171,30 +171,31 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Custom NGINX application parameters
 
-| Name                                                | Description                                                                                         | Value                  |
-| --------------------------------------------------- | --------------------------------------------------------------------------------------------------- | ---------------------- |
-| `cloneStaticSiteFromGit.enabled`                    | Get the server static content from a Git repository                                                 | `false`                |
-| `cloneStaticSiteFromGit.image.registry`             | Git image registry                                                                                  | `docker.io`            |
-| `cloneStaticSiteFromGit.image.repository`           | Git image repository                                                                                | `bitnami/git`          |
-| `cloneStaticSiteFromGit.image.tag`                  | Git image tag (immutable tags are recommended)                                                      | `2.41.0-debian-11-r76` |
-| `cloneStaticSiteFromGit.image.digest`               | Git image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                   |
-| `cloneStaticSiteFromGit.image.pullPolicy`           | Git image pull policy                                                                               | `IfNotPresent`         |
-| `cloneStaticSiteFromGit.image.pullSecrets`          | Specify docker-registry secret names as an array                                                    | `[]`                   |
-| `cloneStaticSiteFromGit.repository`                 | Git Repository to clone static content from                                                         | `""`                   |
-| `cloneStaticSiteFromGit.branch`                     | Git branch to checkout                                                                              | `""`                   |
-| `cloneStaticSiteFromGit.interval`                   | Interval for sidecar container pull from the Git repository                                         | `60`                   |
-| `cloneStaticSiteFromGit.gitClone.command`           | Override default container command for git-clone-repository                                         | `[]`                   |
-| `cloneStaticSiteFromGit.gitClone.args`              | Override default container args for git-clone-repository                                            | `[]`                   |
-| `cloneStaticSiteFromGit.gitSync.command`            | Override default container command for git-repo-syncer                                              | `[]`                   |
-| `cloneStaticSiteFromGit.gitSync.args`               | Override default container args for git-repo-syncer                                                 | `[]`                   |
-| `cloneStaticSiteFromGit.gitSync.resources.limits`   | The resources limits for the git-repo-syncer container                                              | `{}`                   |
-| `cloneStaticSiteFromGit.gitSync.resources.requests` | The requested resources for the git-repo-syncer container                                           | `{}`                   |
-| `cloneStaticSiteFromGit.extraEnvVars`               | Additional environment variables to set for the in the containers that clone static site from git   | `[]`                   |
-| `cloneStaticSiteFromGit.extraVolumeMounts`          | Add extra volume mounts for the Git containers                                                      | `[]`                   |
-| `serverBlock`                                       | Custom server block to be added to NGINX configuration                                              | `""`                   |
-| `existingServerBlockConfigmap`                      | ConfigMap with custom server block to be added to NGINX configuration                               | `""`                   |
-| `staticSiteConfigmap`                               | Name of existing ConfigMap with the server static site content                                      | `""`                   |
-| `staticSitePVC`                                     | Name of existing PVC with the server static site content                                            | `""`                   |
+| Name                                                 | Description                                                                                         | Value                  |
+| ---------------------------------------------------- | --------------------------------------------------------------------------------------------------- | ---------------------- |
+| `cloneStaticSiteFromGit.enabled`                     | Get the server static content from a Git repository                                                 | `false`                |
+| `cloneStaticSiteFromGit.image.registry`              | Git image registry                                                                                  | `docker.io`            |
+| `cloneStaticSiteFromGit.image.repository`            | Git image repository                                                                                | `bitnami/git`          |
+| `cloneStaticSiteFromGit.image.tag`                   | Git image tag (immutable tags are recommended)                                                      | `2.41.0-debian-11-r76` |
+| `cloneStaticSiteFromGit.image.digest`                | Git image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                   |
+| `cloneStaticSiteFromGit.image.pullPolicy`            | Git image pull policy                                                                               | `IfNotPresent`         |
+| `cloneStaticSiteFromGit.image.pullSecrets`           | Specify docker-registry secret names as an array                                                    | `[]`                   |
+| `cloneStaticSiteFromGit.repository`                  | Git Repository to clone static content from                                                         | `""`                   |
+| `cloneStaticSiteFromGit.branch`                      | Git branch to checkout                                                                              | `""`                   |
+| `cloneStaticSiteFromGit.interval`                    | Interval for sidecar container pull from the Git repository                                         | `60`                   |
+| `cloneStaticSiteFromGit.gitClone.command`            | Override default container command for git-clone-repository                                         | `[]`                   |
+| `cloneStaticSiteFromGit.gitClone.args`               | Override default container args for git-clone-repository                                            | `[]`                   |
+| `cloneStaticSiteFromGit.gitClone.extraEnvVarsSecret` | Secret with extra environment variables                                                             | `""`                   |
+| `cloneStaticSiteFromGit.gitSync.command`             | Override default container command for git-repo-syncer                                              | `[]`                   |
+| `cloneStaticSiteFromGit.gitSync.args`                | Override default container args for git-repo-syncer                                                 | `[]`                   |
+| `cloneStaticSiteFromGit.gitSync.resources.limits`    | The resources limits for the git-repo-syncer container                                              | `{}`                   |
+| `cloneStaticSiteFromGit.gitSync.resources.requests`  | The requested resources for the git-repo-syncer container                                           | `{}`                   |
+| `cloneStaticSiteFromGit.extraEnvVars`                | Additional environment variables to set for the in the containers that clone static site from git   | `[]`                   |
+| `cloneStaticSiteFromGit.extraVolumeMounts`           | Add extra volume mounts for the Git containers                                                      | `[]`                   |
+| `serverBlock`                                        | Custom server block to be added to NGINX configuration                                              | `""`                   |
+| `existingServerBlockConfigmap`                       | ConfigMap with custom server block to be added to NGINX configuration                               | `""`                   |
+| `staticSiteConfigmap`                                | Name of existing ConfigMap with the server static site content                                      | `""`                   |
+| `staticSitePVC`                                      | Name of existing PVC with the server static site content                                            | `""`                   |
 
 ### Traffic Exposure parameters
 

--- a/bitnami/nginx/README.md
+++ b/bitnami/nginx/README.md
@@ -171,31 +171,31 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Custom NGINX application parameters
 
-| Name                                                 | Description                                                                                         | Value                  |
-| ---------------------------------------------------- | --------------------------------------------------------------------------------------------------- | ---------------------- |
-| `cloneStaticSiteFromGit.enabled`                     | Get the server static content from a Git repository                                                 | `false`                |
-| `cloneStaticSiteFromGit.extraEnvVarsSecret`          | Secret with extra environment variables                                                             | `""`                   |
-| `cloneStaticSiteFromGit.image.registry`              | Git image registry                                                                                  | `docker.io`            |
-| `cloneStaticSiteFromGit.image.repository`            | Git image repository                                                                                | `bitnami/git`          |
-| `cloneStaticSiteFromGit.image.tag`                   | Git image tag (immutable tags are recommended)                                                      | `2.41.0-debian-11-r76` |
-| `cloneStaticSiteFromGit.image.digest`                | Git image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                   |
-| `cloneStaticSiteFromGit.image.pullPolicy`            | Git image pull policy                                                                               | `IfNotPresent`         |
-| `cloneStaticSiteFromGit.image.pullSecrets`           | Specify docker-registry secret names as an array                                                    | `[]`                   |
-| `cloneStaticSiteFromGit.repository`                  | Git Repository to clone static content from                                                         | `""`                   |
-| `cloneStaticSiteFromGit.branch`                      | Git branch to checkout                                                                              | `""`                   |
-| `cloneStaticSiteFromGit.interval`                    | Interval for sidecar container pull from the Git repository                                         | `60`                   |
-| `cloneStaticSiteFromGit.gitClone.command`            | Override default container command for git-clone-repository                                         | `[]`                   |
-| `cloneStaticSiteFromGit.gitClone.args`               | Override default container args for git-clone-repository                                            | `[]`                   |
-| `cloneStaticSiteFromGit.gitSync.command`             | Override default container command for git-repo-syncer                                              | `[]`                   |
-| `cloneStaticSiteFromGit.gitSync.args`                | Override default container args for git-repo-syncer                                                 | `[]`                   |
-| `cloneStaticSiteFromGit.gitSync.resources.limits`    | The resources limits for the git-repo-syncer container                                              | `{}`                   |
-| `cloneStaticSiteFromGit.gitSync.resources.requests`  | The requested resources for the git-repo-syncer container                                           | `{}`                   |
-| `cloneStaticSiteFromGit.extraEnvVars`                | Additional environment variables to set for the in the containers that clone static site from git   | `[]`                   |
-| `cloneStaticSiteFromGit.extraVolumeMounts`           | Add extra volume mounts for the Git containers                                                      | `[]`                   |
-| `serverBlock`                                        | Custom server block to be added to NGINX configuration                                              | `""`                   |
-| `existingServerBlockConfigmap`                       | ConfigMap with custom server block to be added to NGINX configuration                               | `""`                   |
-| `staticSiteConfigmap`                                | Name of existing ConfigMap with the server static site content                                      | `""`                   |
-| `staticSitePVC`                                      | Name of existing PVC with the server static site content                                            | `""`                   |
+| Name                                                | Description                                                                                         | Value                  |
+| --------------------------------------------------- | --------------------------------------------------------------------------------------------------- | ---------------------- |
+| `cloneStaticSiteFromGit.enabled`                    | Get the server static content from a Git repository                                                 | `false`                |
+| `cloneStaticSiteFromGit.image.registry`             | Git image registry                                                                                  | `docker.io`            |
+| `cloneStaticSiteFromGit.image.repository`           | Git image repository                                                                                | `bitnami/git`          |
+| `cloneStaticSiteFromGit.image.tag`                  | Git image tag (immutable tags are recommended)                                                      | `2.41.0-debian-11-r76` |
+| `cloneStaticSiteFromGit.image.digest`               | Git image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                   |
+| `cloneStaticSiteFromGit.image.pullPolicy`           | Git image pull policy                                                                               | `IfNotPresent`         |
+| `cloneStaticSiteFromGit.image.pullSecrets`          | Specify docker-registry secret names as an array                                                    | `[]`                   |
+| `cloneStaticSiteFromGit.repository`                 | Git Repository to clone static content from                                                         | `""`                   |
+| `cloneStaticSiteFromGit.branch`                     | Git branch to checkout                                                                              | `""`                   |
+| `cloneStaticSiteFromGit.interval`                   | Interval for sidecar container pull from the Git repository                                         | `60`                   |
+| `cloneStaticSiteFromGit.extraEnvVarsSecret`         | Secret with extra environment variables                                                             | `""`                   |
+| `cloneStaticSiteFromGit.gitClone.command`           | Override default container command for git-clone-repository                                         | `[]`                   |
+| `cloneStaticSiteFromGit.gitClone.args`              | Override default container args for git-clone-repository                                            | `[]`                   |
+| `cloneStaticSiteFromGit.gitSync.command`            | Override default container command for git-repo-syncer                                              | `[]`                   |
+| `cloneStaticSiteFromGit.gitSync.args`               | Override default container args for git-repo-syncer                                                 | `[]`                   |
+| `cloneStaticSiteFromGit.gitSync.resources.limits`   | The resources limits for the git-repo-syncer container                                              | `{}`                   |
+| `cloneStaticSiteFromGit.gitSync.resources.requests` | The requested resources for the git-repo-syncer container                                           | `{}`                   |
+| `cloneStaticSiteFromGit.extraEnvVars`               | Additional environment variables to set for the in the containers that clone static site from git   | `[]`                   |
+| `cloneStaticSiteFromGit.extraVolumeMounts`          | Add extra volume mounts for the Git containers                                                      | `[]`                   |
+| `serverBlock`                                       | Custom server block to be added to NGINX configuration                                              | `""`                   |
+| `existingServerBlockConfigmap`                      | ConfigMap with custom server block to be added to NGINX configuration                               | `""`                   |
+| `staticSiteConfigmap`                               | Name of existing ConfigMap with the server static site content                                      | `""`                   |
+| `staticSitePVC`                                     | Name of existing PVC with the server static site content                                            | `""`                   |
 
 ### Traffic Exposure parameters
 

--- a/bitnami/nginx/README.md
+++ b/bitnami/nginx/README.md
@@ -174,6 +174,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | Name                                                 | Description                                                                                         | Value                  |
 | ---------------------------------------------------- | --------------------------------------------------------------------------------------------------- | ---------------------- |
 | `cloneStaticSiteFromGit.enabled`                     | Get the server static content from a Git repository                                                 | `false`                |
+| `cloneStaticSiteFromGit.extraEnvVarsSecret`          | Secret with extra environment variables                                                             | `""`                   |
 | `cloneStaticSiteFromGit.image.registry`              | Git image registry                                                                                  | `docker.io`            |
 | `cloneStaticSiteFromGit.image.repository`            | Git image repository                                                                                | `bitnami/git`          |
 | `cloneStaticSiteFromGit.image.tag`                   | Git image tag (immutable tags are recommended)                                                      | `2.41.0-debian-11-r76` |
@@ -185,7 +186,6 @@ The command removes all the Kubernetes components associated with the chart and 
 | `cloneStaticSiteFromGit.interval`                    | Interval for sidecar container pull from the Git repository                                         | `60`                   |
 | `cloneStaticSiteFromGit.gitClone.command`            | Override default container command for git-clone-repository                                         | `[]`                   |
 | `cloneStaticSiteFromGit.gitClone.args`               | Override default container args for git-clone-repository                                            | `[]`                   |
-| `cloneStaticSiteFromGit.gitClone.extraEnvVarsSecret` | Secret with extra environment variables                                                             | `""`                   |
 | `cloneStaticSiteFromGit.gitSync.command`             | Override default container command for git-repo-syncer                                              | `[]`                   |
 | `cloneStaticSiteFromGit.gitSync.args`                | Override default container args for git-repo-syncer                                                 | `[]`                   |
 | `cloneStaticSiteFromGit.gitSync.resources.limits`    | The resources limits for the git-repo-syncer container                                              | `{}`                   |

--- a/bitnami/nginx/templates/deployment.yaml
+++ b/bitnami/nginx/templates/deployment.yaml
@@ -106,10 +106,10 @@ spec:
           {{- if .Values.cloneStaticSiteFromGit.extraEnvVars }}
           env: {{- include "common.tplvalues.render" (dict "value" .Values.cloneStaticSiteFromGit.extraEnvVars "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.cloneStaticSiteFromGit.gitClone.extraEnvVarsSecret }}
+          {{- if .Values.cloneStaticSiteFromGit.extraEnvVarsSecret }}
           envFrom:
             - secretRef:
-                name: {{ include "common.tplvalues.render" (dict "value" .Values.cloneStaticSiteFromGit.gitClone.extraEnvVarsSecret "context" $) }}
+                name: {{ include "common.tplvalues.render" (dict "value" .Values.cloneStaticSiteFromGit.extraEnvVarsSecret "context" $) }}
           {{- end }}
         {{- end }}
         {{- if .Values.initContainers }}
@@ -150,6 +150,11 @@ spec:
             {{- end }}
           {{- if .Values.cloneStaticSiteFromGit.extraEnvVars }}
           env: {{- include "common.tplvalues.render" (dict "value" .Values.cloneStaticSiteFromGit.extraEnvVars "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if .Values.cloneStaticSiteFromGit.extraEnvVarsSecret }}
+          envFrom:
+            - secretRef:
+                name: {{ include "common.tplvalues.render" (dict "value" .Values.cloneStaticSiteFromGit.extraEnvVarsSecret "context" $) }}
           {{- end }}
         {{- end }}
         - name: nginx

--- a/bitnami/nginx/templates/deployment.yaml
+++ b/bitnami/nginx/templates/deployment.yaml
@@ -106,6 +106,11 @@ spec:
           {{- if .Values.cloneStaticSiteFromGit.extraEnvVars }}
           env: {{- include "common.tplvalues.render" (dict "value" .Values.cloneStaticSiteFromGit.extraEnvVars "context" $) | nindent 12 }}
           {{- end }}
+          envFrom:
+            {{- if .Values.cloneStaticSiteFromGit.gitClone.extraEnvVarsSecret }}
+            - secretRef:
+                name: {{ include "common.tplvalues.render" (dict "value" .Values.cloneStaticSiteFromGit.gitClone.extraEnvVarsSecret "context" $) }}
+            {{- end }}
         {{- end }}
         {{- if .Values.initContainers }}
         {{- include "common.tplvalues.render" (dict "value" .Values.initContainers "context" $) | nindent 8 }}

--- a/bitnami/nginx/templates/deployment.yaml
+++ b/bitnami/nginx/templates/deployment.yaml
@@ -106,11 +106,11 @@ spec:
           {{- if .Values.cloneStaticSiteFromGit.extraEnvVars }}
           env: {{- include "common.tplvalues.render" (dict "value" .Values.cloneStaticSiteFromGit.extraEnvVars "context" $) | nindent 12 }}
           {{- end }}
+          {{- if .Values.cloneStaticSiteFromGit.gitClone.extraEnvVarsSecret }}
           envFrom:
-            {{- if .Values.cloneStaticSiteFromGit.gitClone.extraEnvVarsSecret }}
             - secretRef:
                 name: {{ include "common.tplvalues.render" (dict "value" .Values.cloneStaticSiteFromGit.gitClone.extraEnvVarsSecret "context" $) }}
-            {{- end }}
+          {{- end }}
         {{- end }}
         {{- if .Values.initContainers }}
         {{- include "common.tplvalues.render" (dict "value" .Values.initContainers "context" $) | nindent 8 }}

--- a/bitnami/nginx/values.yaml
+++ b/bitnami/nginx/values.yaml
@@ -452,6 +452,9 @@ cloneStaticSiteFromGit:
   ## @param cloneStaticSiteFromGit.interval Interval for sidecar container pull from the Git repository
   ##
   interval: 60
+  ## @param cloneStaticSiteFromGit.extraEnvVarsSecret Secret with extra environment variables
+  ##
+  extraEnvVarsSecret: ""
   ## Additional configuration for git-clone-repository initContainer
   ##
   gitClone:
@@ -461,9 +464,6 @@ cloneStaticSiteFromGit:
     ## @param cloneStaticSiteFromGit.gitClone.args Override default container args for git-clone-repository
     ##
     args: []
-    ## @param cloneStaticSiteFromGit.gitClone.extraEnvVarsSecret Secret with extra environment variables
-    ##
-    extraEnvVarsSecret: ""
   ## Additional configuration for the git-repo-syncer container
   ##
   gitSync:

--- a/bitnami/nginx/values.yaml
+++ b/bitnami/nginx/values.yaml
@@ -461,6 +461,9 @@ cloneStaticSiteFromGit:
     ## @param cloneStaticSiteFromGit.gitClone.args Override default container args for git-clone-repository
     ##
     args: []
+    ## @param cloneStaticSiteFromGit.gitClone.extraEnvVarsSecret Secret with extra environment variables
+    ##
+    extraEnvVarsSecret: ""
   ## Additional configuration for the git-repo-syncer container
   ##
   gitSync:

--- a/bitnami/nginx/values.yaml
+++ b/bitnami/nginx/values.yaml
@@ -452,9 +452,6 @@ cloneStaticSiteFromGit:
   ## @param cloneStaticSiteFromGit.interval Interval for sidecar container pull from the Git repository
   ##
   interval: 60
-  ## @param cloneStaticSiteFromGit.extraEnvVarsSecret Secret with extra environment variables
-  ##
-  extraEnvVarsSecret: ""
   ## Additional configuration for git-clone-repository initContainer
   ##
   gitClone:
@@ -488,6 +485,9 @@ cloneStaticSiteFromGit:
   ##     value: BAR
   ##
   extraEnvVars: []
+  ## @param cloneStaticSiteFromGit.extraEnvVarsSecret Secret with extra environment variables
+  ##
+  extraEnvVarsSecret: ""
   ## @param cloneStaticSiteFromGit.extraVolumeMounts Add extra volume mounts for the Git containers
   ## Useful to mount keys to connect through ssh. (normally used with extraVolumes)
   ## E.g:


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->
 Add `cloneStaticSiteFromGit.extraEnvVarsSecret` value

### Benefits

<!-- What benefits will be realized by the code change? -->
Allow to use credentials as secret mounted as variables to clone the content of a private repository by using a token instead of a ssh key.
With this, we can use cloneStaticSiteFromGit.repository: "https://oauth2:${token}@github.com/example/test.git" by pickup the token from a secret.

### Possible drawbacks

<!-- Describe any known limitations with your change -->
None

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
