### PR TITLE
[bitnami/mysql] Remove the specified charset config to keep it as default

### DIFF
--- a/bitnami/mysql/Chart.yaml
+++ b/bitnami/mysql/Chart.yaml
@@ -34,4 +34,4 @@ maintainers:
 name: mysql
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/mysql
-version: 9.12.2
+version: 9.12.3

--- a/bitnami/mysql/values.yaml
+++ b/bitnami/mysql/values.yaml
@@ -213,15 +213,12 @@ primary:
     bind-address=*
     pid-file=/opt/bitnami/mysql/tmp/mysqld.pid
     log-error=/opt/bitnami/mysql/logs/mysqld.log
-    character-set-server=UTF8
-    collation-server=utf8_general_ci
     slow_query_log=0
     long_query_time=10.0
 
     [client]
     port=3306
     socket=/opt/bitnami/mysql/tmp/mysql.sock
-    default-character-set=UTF8
     plugin_dir=/opt/bitnami/mysql/lib/plugin
 
     [manager]
@@ -591,15 +588,12 @@ secondary:
     bind-address=*
     pid-file=/opt/bitnami/mysql/tmp/mysqld.pid
     log-error=/opt/bitnami/mysql/logs/mysqld.log
-    character-set-server=UTF8
-    collation-server=utf8_general_ci
     slow_query_log=0
     long_query_time=10.0
 
     [client]
     port=3306
     socket=/opt/bitnami/mysql/tmp/mysql.sock
-    default-character-set=UTF8
     plugin_dir=/opt/bitnami/mysql/lib/plugin
 
     [manager]


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Removed three specified charset configs in `primary.configuration` and `secondary.configuration`:

1. `character-set-server=UTF8`
2. `collation-server=utf8_general_ci`
3. `default-character-set=UTF8`

### Benefits

This chart has specified `character-set-server=utf8` and `collation-server=utf8_general_ci`, which might be useful for mysql-5.7.

But `utf8mb3` has a lot of problems，so we prefer to use `utf8mb4` now.

Since mysql-8.0, default collation has changed from `utf8mb4_general_ci` to `utf8mb4_0900_ai_ci`.

After this commit, we can just specify `--character-set-server=utf8mb4` in `extraFlags` and no need to override the entire `configuration`.

### Possible drawbacks

There are some defaults:

1. mysql-5.7:

   ```sql
   mysql> show global variables like '%character_set_server%';
   +----------------------+--------+
   | Variable_name        | Value  |
   +----------------------+--------+
   | character_set_server | latin1 |
   +----------------------+--------+
   1 row in set (0.00 sec)

   mysql> show global variables like '%collation_server%';
   +------------------+-------------------+
   | Variable_name    | Value             |
   +------------------+-------------------+
   | collation_server | latin1_swedish_ci |
   +------------------+-------------------+
   1 row in set (0.00 sec)

   mysql> set character_set_server=utf8mb4;
   Query OK, 0 rows affected (0.00 sec)

   mysql> show variables like '%character_set_server%';
   +----------------------+---------+
   | Variable_name        | Value   |
   +----------------------+---------+
   | character_set_server | utf8mb4 |
   +----------------------+---------+
   1 row in set (0.00 sec)

   mysql> show variables like '%collation_server%';
   +------------------+--------------------+
   | Variable_name    | Value              |
   +------------------+--------------------+
   | collation_server | utf8mb4_general_ci |
   +------------------+--------------------+
   1 row in set (0.01 sec)
   ```

2. mysql-8.0:

   ```sql
   mysql> show global variables like '%character_set_server%';
   +----------------------+---------+
   | Variable_name        | Value   |
   +----------------------+---------+
   | character_set_server | utf8mb4 |
   +----------------------+---------+
   1 row in set (0.00 sec)

   mysql> show global variables like '%collation_server%';
   +------------------+--------------------+
   | Variable_name    | Value              |
   +------------------+--------------------+
   | collation_server | utf8mb4_0900_ai_ci |
   +------------------+--------------------+
   1 row in set (0.01 sec)
   ```

### Applicable issues

### Additional information

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
