### PR TITLE
[bitnami/apisix] Use different app.kubernetes.io/version label on subcomponents

### DIFF
--- a/bitnami/apisix/Chart.lock
+++ b/bitnami/apisix/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: etcd
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 9.4.1
+  version: 9.5.0
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.10.0
-digest: sha256:c100ca0d7b1dc2763ae55f09ec1d4d708a5cccde81bb9989691811687df80308
-generated: "2023-09-05T11:31:18.260047+02:00"
+  version: 2.11.1
+digest: sha256:5b88c568343a6ccf9d6e34838d2376d8447691716b828e5205232fc83cd6fb6a
+generated: "2023-09-18T11:06:02.468347+02:00"

--- a/bitnami/apisix/Chart.yaml
+++ b/bitnami/apisix/Chart.yaml
@@ -45,4 +45,4 @@ sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/apisix
   - https://github.com/bitnami/charts/tree/main/bitnami/apisix-dashboard
   - https://github.com/bitnami/charts/tree/main/bitnami/apisix-ingress-controller
-version: 2.1.2
+version: 2.1.3

--- a/bitnami/apisix/templates/dashboard/configmap.yaml
+++ b/bitnami/apisix/templates/dashboard/configmap.yaml
@@ -9,7 +9,9 @@ kind: ConfigMap
 metadata:
   name: {{ printf "%s-default" (include "apisix.dashboard.fullname" .) | trunc 63 | trimSuffix "-" }}
   namespace: {{ include "common.names.namespace" . | quote }}
-  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- $versionLabel := dict "app.kubernetes.io/version" ( include "common.images.version" ( dict "imageRoot" .Values.dashboard.image "chart" .Chart ) ) }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.commonLabels $versionLabel ) "context" . ) }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: apisix
     app.kubernetes.io/component: dashboard
   {{- if .Values.commonAnnotations }}

--- a/bitnami/apisix/templates/dashboard/deployment.yaml
+++ b/bitnami/apisix/templates/dashboard/deployment.yaml
@@ -9,7 +9,9 @@ kind: Deployment
 metadata:
   name: {{ template "apisix.dashboard.fullname" . }}
   namespace: {{ include "common.names.namespace" . | quote }}
-  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- $versionLabel := dict "app.kubernetes.io/version" ( include "common.images.version" ( dict "imageRoot" .Values.dashboard.image "chart" .Chart ) ) }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.commonLabels $versionLabel ) "context" . ) }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: apisix
     app.kubernetes.io/component: dashboard
   {{- if .Values.commonAnnotations }}
@@ -22,7 +24,7 @@ spec:
   {{- if not .Values.dashboard.autoscaling.hpa.enabled }}
   replicas: {{ .Values.dashboard.replicaCount }}
   {{- end }}
-  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.dashboard.podLabels .Values.commonLabels ) "context" . ) }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.dashboard.podLabels .Values.commonLabels $versionLabel ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/part-of: apisix

--- a/bitnami/apisix/templates/dashboard/extra-configmap.yaml
+++ b/bitnami/apisix/templates/dashboard/extra-configmap.yaml
@@ -9,7 +9,9 @@ kind: ConfigMap
 metadata:
   name: {{ printf "%s-extra" (include "apisix.dashboard.fullname" .) | trunc 63 | trimSuffix "-" }}
   namespace: {{ include "common.names.namespace" . | quote }}
-  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- $versionLabel := dict "app.kubernetes.io/version" ( include "common.images.version" ( dict "imageRoot" .Values.dashboard.image "chart" .Chart ) ) }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.commonLabels $versionLabel ) "context" . ) }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: apisix
     app.kubernetes.io/component: dashboard
   {{- if .Values.commonAnnotations }}

--- a/bitnami/apisix/templates/dashboard/hpa.yaml
+++ b/bitnami/apisix/templates/dashboard/hpa.yaml
@@ -9,7 +9,9 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "apisix.dashboard.fullname" . }}
   namespace: {{ .Release.Namespace | quote }}
-  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- $versionLabel := dict "app.kubernetes.io/version" ( include "common.images.version" ( dict "imageRoot" .Values.dashboard.image "chart" .Chart ) ) }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.commonLabels $versionLabel ) "context" . ) }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}

--- a/bitnami/apisix/templates/dashboard/ingress-tls-secret.yaml
+++ b/bitnami/apisix/templates/dashboard/ingress-tls-secret.yaml
@@ -4,6 +4,8 @@ SPDX-License-Identifier: APACHE-2.0
 */}}
 
 {{- if .Values.dashboard.ingress.enabled }}
+{{- $versionLabel := dict "app.kubernetes.io/version" ( include "common.images.version" ( dict "imageRoot" .Values.dashboard.image "chart" .Chart ) ) }}
+{{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.commonLabels $versionLabel ) "context" . ) }}
 {{- if .Values.dashboard.ingress.secrets }}
 {{- range .Values.dashboard.ingress.secrets }}
 apiVersion: v1
@@ -11,7 +13,7 @@ kind: Secret
 metadata:
   name: {{ .name }}
   namespace: {{ include "common.names.namespace" $ | quote }}
-  labels: {{- include "common.labels.standard" ( dict "customLabels" $.Values.commonLabels "context" $ ) | nindent 4 }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: apisix
     app.kubernetes.io/component: dashboard
   {{- if $.Values.commonAnnotations }}
@@ -33,7 +35,7 @@ kind: Secret
 metadata:
   name: {{ $secretName }}
   namespace: {{ include "common.names.namespace" . | quote }}
-  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: apisix
     app.kubernetes.io/component: dashboard
   {{- if .Values.commonAnnotations }}

--- a/bitnami/apisix/templates/dashboard/ingress.yaml
+++ b/bitnami/apisix/templates/dashboard/ingress.yaml
@@ -9,7 +9,9 @@ kind: Ingress
 metadata:
   name: {{ template "apisix.dashboard.fullname" . }}
   namespace: {{ include "common.names.namespace" . | quote }}
-  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- $versionLabel := dict "app.kubernetes.io/version" ( include "common.images.version" ( dict "imageRoot" .Values.dashboard.image "chart" .Chart ) ) }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.commonLabels $versionLabel ) "context" . ) }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: apisix
     app.kubernetes.io/component: dashboard
   {{- if or .Values.dashboard.ingress.annotations .Values.commonAnnotations }}

--- a/bitnami/apisix/templates/dashboard/pdb.yaml
+++ b/bitnami/apisix/templates/dashboard/pdb.yaml
@@ -9,7 +9,9 @@ kind: PodDisruptionBudget
 metadata:
   name: {{ template "apisix.dashboard.fullname" . }}
   namespace: {{ include "common.names.namespace" . | quote }}
-  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- $versionLabel := dict "app.kubernetes.io/version" ( include "common.images.version" ( dict "imageRoot" .Values.dashboard.image "chart" .Chart ) ) }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.commonLabels $versionLabel ) "context" . ) }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: apisix
     app.kubernetes.io/component: dashboard
   {{- if .Values.commonAnnotations }}

--- a/bitnami/apisix/templates/dashboard/secret.yaml
+++ b/bitnami/apisix/templates/dashboard/secret.yaml
@@ -9,7 +9,9 @@ kind: Secret
 metadata:
   name: {{ include "apisix.dashboard.fullname" . }}
   namespace: {{ include "common.names.namespace" . | quote }}
-  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- $versionLabel := dict "app.kubernetes.io/version" ( include "common.images.version" ( dict "imageRoot" .Values.dashboard.image "chart" .Chart ) ) }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.commonLabels $versionLabel ) "context" . ) }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: apisix
     app.kubernetes.io/component: dashboard
   {{- if .Values.commonAnnotations }}

--- a/bitnami/apisix/templates/dashboard/service-account.yaml
+++ b/bitnami/apisix/templates/dashboard/service-account.yaml
@@ -9,7 +9,9 @@ kind: ServiceAccount
 metadata:
   name: {{ include "apisix.dashboard.serviceAccountName" . }}
   namespace: {{ include "common.names.namespace" . | quote }}
-  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- $versionLabel := dict "app.kubernetes.io/version" ( include "common.images.version" ( dict "imageRoot" .Values.dashboard.image "chart" .Chart ) ) }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.commonLabels $versionLabel ) "context" . ) }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
   {{- if or .Values.dashboard.serviceAccount.annotations .Values.commonAnnotations }}
   {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.dashboard.serviceAccount.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}

--- a/bitnami/apisix/templates/dashboard/service.yaml
+++ b/bitnami/apisix/templates/dashboard/service.yaml
@@ -9,7 +9,9 @@ kind: Service
 metadata:
   name: {{ include "apisix.dashboard.fullname" . }}
   namespace: {{ include "common.names.namespace" . | quote }}
-  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- $versionLabel := dict "app.kubernetes.io/version" ( include "common.images.version" ( dict "imageRoot" .Values.dashboard.image "chart" .Chart ) ) }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.commonLabels $versionLabel ) "context" . ) }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: apisix
     app.kubernetes.io/component: dashboard
   {{- if or .Values.dashboard.service.annotations .Values.commonAnnotations }}

--- a/bitnami/apisix/templates/dashboard/vpa.yaml
+++ b/bitnami/apisix/templates/dashboard/vpa.yaml
@@ -9,7 +9,9 @@ kind: VerticalPodAutoscaler
 metadata:
   name: {{ include "apisix.dashboard.fullname" . }}
   namespace: {{ include "common.names.namespace" . | quote }}
-  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- $versionLabel := dict "app.kubernetes.io/version" ( include "common.images.version" ( dict "imageRoot" .Values.dashboard.image "chart" .Chart ) ) }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.commonLabels $versionLabel ) "context" . ) }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: apisix
     app.kubernetes.io/component: dashboard
   {{- if or .Values.dashboard.autoscaling.vpa.annotations .Values.commonAnnotations }}

--- a/bitnami/apisix/templates/ingress-controller/clusterrolebinding.yaml
+++ b/bitnami/apisix/templates/ingress-controller/clusterrolebinding.yaml
@@ -8,7 +8,9 @@ kind: ClusterRoleBinding
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 metadata:
   name: {{ include "apisix.ingress-controller.fullname.namespace" . }}
-  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- $versionLabel := dict "app.kubernetes.io/version" ( include "common.images.version" ( dict "imageRoot" .Values.ingressController.image "chart" .Chart ) ) }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.commonLabels $versionLabel ) "context" . ) }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: apisix
     app.kubernetes.io/component: ingress-controller
   {{- if .Values.commonAnnotations }}

--- a/bitnami/apisix/templates/ingress-controller/clusterroles.yaml
+++ b/bitnami/apisix/templates/ingress-controller/clusterroles.yaml
@@ -8,7 +8,9 @@ kind: ClusterRole
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 metadata:
   name: {{ include "apisix.ingress-controller.fullname.namespace" . }}
-  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- $versionLabel := dict "app.kubernetes.io/version" ( include "common.images.version" ( dict "imageRoot" .Values.ingressController.image "chart" .Chart ) ) }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.commonLabels $versionLabel ) "context" . ) }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: apisix
     app.kubernetes.io/component: ingress-controller
   {{- if .Values.commonAnnotations }}

--- a/bitnami/apisix/templates/ingress-controller/configmap.yaml
+++ b/bitnami/apisix/templates/ingress-controller/configmap.yaml
@@ -9,7 +9,9 @@ kind: ConfigMap
 metadata:
   name: {{ printf "%s-default" (include "apisix.ingress-controller.fullname" .) | trunc 63 | trimSuffix "-" }}
   namespace: {{ include "common.names.namespace" . | quote }}
-  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- $versionLabel := dict "app.kubernetes.io/version" ( include "common.images.version" ( dict "imageRoot" .Values.ingressController.image "chart" .Chart ) ) }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.commonLabels $versionLabel ) "context" . ) }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: apisix
     app.kubernetes.io/component: ingress-controller
   {{- if .Values.commonAnnotations }}

--- a/bitnami/apisix/templates/ingress-controller/deployment.yaml
+++ b/bitnami/apisix/templates/ingress-controller/deployment.yaml
@@ -9,7 +9,9 @@ kind: Deployment
 metadata:
   name: {{ template "apisix.ingress-controller.fullname" . }}
   namespace: {{ include "common.names.namespace" . | quote }}
-  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- $versionLabel := dict "app.kubernetes.io/version" ( include "common.images.version" ( dict "imageRoot" .Values.ingressController.image "chart" .Chart ) ) }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.commonLabels $versionLabel ) "context" . ) }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: apisix
     app.kubernetes.io/component: ingress-controller
   {{- if .Values.commonAnnotations }}
@@ -22,7 +24,7 @@ spec:
   {{- if .Values.ingressController.updateStrategy }}
   strategy: {{- toYaml .Values.ingressController.updateStrategy | nindent 4 }}
   {{- end }}
-  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.ingressController.podLabels .Values.commonLabels ) "context" . ) }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.ingressController.podLabels .Values.commonLabels $versionLabel ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/part-of: apisix

--- a/bitnami/apisix/templates/ingress-controller/extra-configmap.yaml
+++ b/bitnami/apisix/templates/ingress-controller/extra-configmap.yaml
@@ -9,7 +9,9 @@ kind: ConfigMap
 metadata:
   name: {{ printf "%s-extra" (include "apisix.ingress-controller.fullname" .) | trunc 63 | trimSuffix "-" }}
   namespace: {{ include "common.names.namespace" . | quote }}
-  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- $versionLabel := dict "app.kubernetes.io/version" ( include "common.images.version" ( dict "imageRoot" .Values.ingressController.image "chart" .Chart ) ) }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.commonLabels $versionLabel ) "context" . ) }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: apisix
     app.kubernetes.io/component: ingress-controller
   {{- if .Values.commonAnnotations }}

--- a/bitnami/apisix/templates/ingress-controller/hpa.yaml
+++ b/bitnami/apisix/templates/ingress-controller/hpa.yaml
@@ -9,7 +9,9 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "apisix.ingress-controller.fullname" . }}
   namespace: {{ .Release.Namespace | quote }}
-  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- $versionLabel := dict "app.kubernetes.io/version" ( include "common.images.version" ( dict "imageRoot" .Values.ingressController.image "chart" .Chart ) ) }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.commonLabels $versionLabel ) "context" . ) }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}

--- a/bitnami/apisix/templates/ingress-controller/ingress-tls-secret.yaml
+++ b/bitnami/apisix/templates/ingress-controller/ingress-tls-secret.yaml
@@ -4,6 +4,8 @@ SPDX-License-Identifier: APACHE-2.0
 */}}
 
 {{- if .Values.ingressController.ingress.enabled }}
+{{- $versionLabel := dict "app.kubernetes.io/version" ( include "common.images.version" ( dict "imageRoot" .Values.ingressController.image "chart" .Chart ) ) }}
+{{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.commonLabels $versionLabel ) "context" . ) }}
 {{- if .Values.ingressController.ingress.secrets }}
 {{- range .Values.ingressController.ingress.secrets }}
 apiVersion: v1
@@ -11,7 +13,7 @@ kind: Secret
 metadata:
   name: {{ .name }}
   namespace: {{ include "common.names.namespace" $ | quote }}
-  labels: {{- include "common.labels.standard" ( dict "customLabels" $.Values.commonLabels "context" $ ) | nindent 4 }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: apisix
     app.kubernetes.io/component: ingress-controller
   {{- if $.Values.commonAnnotations }}
@@ -33,7 +35,7 @@ kind: Secret
 metadata:
   name: {{ $secretName }}
   namespace: {{ include "common.names.namespace" . | quote }}
-  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: apisix
     app.kubernetes.io/component: ingress-controller
   {{- if .Values.commonAnnotations }}

--- a/bitnami/apisix/templates/ingress-controller/ingress.yaml
+++ b/bitnami/apisix/templates/ingress-controller/ingress.yaml
@@ -9,7 +9,9 @@ kind: Ingress
 metadata:
   name: {{ template "apisix.ingress-controller.fullname" . }}
   namespace: {{ include "common.names.namespace" . | quote }}
-  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- $versionLabel := dict "app.kubernetes.io/version" ( include "common.images.version" ( dict "imageRoot" .Values.ingressController.image "chart" .Chart ) ) }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.commonLabels $versionLabel ) "context" . ) }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: apisix
     app.kubernetes.io/component: ingress-controller
   {{- if or .Values.ingressController.ingress.annotations .Values.commonAnnotations }}

--- a/bitnami/apisix/templates/ingress-controller/pdb.yaml
+++ b/bitnami/apisix/templates/ingress-controller/pdb.yaml
@@ -9,7 +9,9 @@ kind: PodDisruptionBudget
 metadata:
   name: {{ template "apisix.ingress-controller.fullname" . }}
   namespace: {{ include "common.names.namespace" . | quote }}
-  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- $versionLabel := dict "app.kubernetes.io/version" ( include "common.images.version" ( dict "imageRoot" .Values.ingressController.image "chart" .Chart ) ) }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.commonLabels $versionLabel ) "context" . ) }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: apisix
     app.kubernetes.io/component: ingress-controller
   {{- if .Values.commonAnnotations }}

--- a/bitnami/apisix/templates/ingress-controller/service-account.yaml
+++ b/bitnami/apisix/templates/ingress-controller/service-account.yaml
@@ -9,7 +9,9 @@ kind: ServiceAccount
 metadata:
   name: {{ include "apisix.ingress-controller.serviceAccountName" . }}
   namespace: {{ include "common.names.namespace" . | quote }}
-  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- $versionLabel := dict "app.kubernetes.io/version" ( include "common.images.version" ( dict "imageRoot" .Values.ingressController.image "chart" .Chart ) ) }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.commonLabels $versionLabel ) "context" . ) }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
   {{- if or .Values.ingressController.serviceAccount.annotations .Values.commonAnnotations }}
   {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.ingressController.serviceAccount.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}

--- a/bitnami/apisix/templates/ingress-controller/service.yaml
+++ b/bitnami/apisix/templates/ingress-controller/service.yaml
@@ -9,7 +9,9 @@ kind: Service
 metadata:
   name: {{ include "apisix.ingress-controller.fullname" . }}
   namespace: {{ include "common.names.namespace" . | quote }}
-  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- $versionLabel := dict "app.kubernetes.io/version" ( include "common.images.version" ( dict "imageRoot" .Values.ingressController.image "chart" .Chart ) ) }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.commonLabels $versionLabel ) "context" . ) }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: apisix
     app.kubernetes.io/component: ingress-controller
   {{- if or .Values.ingressController.service.annotations .Values.commonAnnotations (and .Values.ingressController.metrics.enabled .Values.ingressController.metrics.annotations) }}

--- a/bitnami/apisix/templates/ingress-controller/servicemonitor.yaml
+++ b/bitnami/apisix/templates/ingress-controller/servicemonitor.yaml
@@ -9,7 +9,8 @@ kind: ServiceMonitor
 metadata:
   name: {{ template "apisix.ingress-controller.fullname" . }}
   namespace: {{ default (include "common.names.namespace" .) .Values.ingressController.metrics.serviceMonitor.namespace | quote }}
-  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.ingressController.metrics.serviceMonitor.labels .Values.commonLabels ) "context" . ) }}
+  {{- $versionLabel := dict "app.kubernetes.io/version" ( include "common.images.version" ( dict "imageRoot" .Values.ingressController.image "chart" .Chart ) ) }}  
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.ingressController.metrics.serviceMonitor.labels .Values.commonLabels $versionLabel ) "context" . ) }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: apisix
     app.kubernetes.io/component: ingress-controller

--- a/bitnami/apisix/templates/ingress-controller/vpa.yaml
+++ b/bitnami/apisix/templates/ingress-controller/vpa.yaml
@@ -9,7 +9,9 @@ kind: VerticalPodAutoscaler
 metadata:
   name: {{ include "apisix.ingress-controller.fullname" . }}
   namespace: {{ include "common.names.namespace" . | quote }}
-  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- $versionLabel := dict "app.kubernetes.io/version" ( include "common.images.version" ( dict "imageRoot" .Values.ingressController.image "chart" .Chart ) ) }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.commonLabels $versionLabel ) "context" . ) }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: apisix
     app.kubernetes.io/component: ingress-controller
   {{- if or .Values.ingressController.autoscaling.vpa.annotations .Values.commonAnnotations }}


### PR DESCRIPTION
### Description of the change

This PR follows up #17201 ensuring we use a different `app.kubernetes.io/version` label on subcomponents.

### Benefits

Improve manifests labelling.

### Possible drawbacks

None

### Applicable issues

N/A

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
