### PR TITLE
[bitnami/argo-workflows] Use different app.kubernetes.io/version label on subcomponents

### DIFF
--- a/bitnami/argo-workflows/Chart.lock
+++ b/bitnami/argo-workflows/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: postgresql
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 12.11.1
+  version: 12.11.2
 - name: mysql
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 9.12.1
+  version: 9.12.2
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.10.0
-digest: sha256:692e5983e9d0b56dd3d705127ab07b607e00fd1172ddbe366f04389405e519d7
-generated: "2023-09-08T11:25:45.021508217Z"
+  version: 2.11.1
+digest: sha256:237b4b88d85d5e56f328b72ff9429a70cf0896c1e7162bf6a38f9757a90345a1
+generated: "2023-09-18T11:06:59.691744+02:00"

--- a/bitnami/argo-workflows/Chart.yaml
+++ b/bitnami/argo-workflows/Chart.yaml
@@ -42,4 +42,4 @@ maintainers:
 name: argo-workflows
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/argo-workflows
-version: 5.4.3
+version: 5.4.4

--- a/bitnami/argo-workflows/templates/controller/aggregate-cluster-roles.yaml
+++ b/bitnami/argo-workflows/templates/controller/aggregate-cluster-roles.yaml
@@ -4,11 +4,13 @@ SPDX-License-Identifier: APACHE-2.0
 */}}
 
 {{- if and .Values.createAggregateRoles .Values.controller.rbac.create }}
+{{- $versionLabel := dict "app.kubernetes.io/version" ( include "common.images.version" ( dict "imageRoot" .Values.controller.image "chart" .Chart ) ) }}
+{{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.commonLabels $versionLabel ) "context" . ) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ include "common.names.fullname.namespace" . }}-view
-  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     rbac.authorization.k8s.io/aggregate-to-view: "true"
     app.kubernetes.io/part-of: argo-workflows
     app.kubernetes.io/component: controller
@@ -38,7 +40,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ include "common.names.fullname.namespace" . }}-edit
-  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     app.kubernetes.io/part-of: argo-workflows
     app.kubernetes.io/component: controller
@@ -73,7 +75,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ include "common.names.fullname.namespace" . }}-admin
-  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     app.kubernetes.io/part-of: argo-workflows
     app.kubernetes.io/component: controller

--- a/bitnami/argo-workflows/templates/controller/clusterrolebinding.yaml
+++ b/bitnami/argo-workflows/templates/controller/clusterrolebinding.yaml
@@ -4,6 +4,8 @@ SPDX-License-Identifier: APACHE-2.0
 */}}
 
 {{- if .Values.controller.rbac.create }}
+{{- $versionLabel := dict "app.kubernetes.io/version" ( include "common.images.version" ( dict "imageRoot" .Values.controller.image "chart" .Chart ) ) }}
+{{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.commonLabels $versionLabel ) "context" . ) }}
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 {{- if .Values.rbac.singleNamespace }}
 kind: RoleBinding
@@ -15,7 +17,7 @@ metadata:
   {{- if .Values.rbac.singleNamespace }}
   namespace: {{ .Release.Namespace | quote }}
   {{- end }}
-  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: argo-workflows
     app.kubernetes.io/component: controller
   {{- if .Values.commonAnnotations }}
@@ -51,7 +53,7 @@ apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRoleBinding
 metadata:
   name: {{ include "argo-workflows.controller.fullname.namespace" . }}-cluster-template
-  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: controller
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}

--- a/bitnami/argo-workflows/templates/controller/controller-cluster-roles.yaml
+++ b/bitnami/argo-workflows/templates/controller/controller-cluster-roles.yaml
@@ -4,6 +4,8 @@ SPDX-License-Identifier: APACHE-2.0
 */}}
 
 {{- if .Values.controller.rbac.create }}
+{{- $versionLabel := dict "app.kubernetes.io/version" ( include "common.images.version" ( dict "imageRoot" .Values.controller.image "chart" .Chart ) ) }}
+{{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.commonLabels $versionLabel ) "context" . ) }}
 apiVersion: rbac.authorization.k8s.io/v1
 {{- if .Values.rbac.singleNamespace }}
 kind: Role
@@ -15,7 +17,7 @@ metadata:
   {{- if .Values.rbac.singleNamespace }}
   namespace: {{ .Release.Namespace | quote }}
   {{- end }}
-  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: argo-workflows
     app.kubernetes.io/component: controller
   {{- if .Values.commonAnnotations }}
@@ -169,7 +171,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ include "argo-workflows.controller.fullname.namespace" . }}-cluster-template
-  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: argo-workflows
     app.kubernetes.io/component: controller
   {{- if .Values.commonAnnotations }}

--- a/bitnami/argo-workflows/templates/controller/database-secret.yaml
+++ b/bitnami/argo-workflows/templates/controller/database-secret.yaml
@@ -9,7 +9,9 @@ kind: Secret
 metadata:
   name: {{ include "argo-workflows.controller.database.username.secret" . }}
   namespace: {{ .Release.Namespace | quote }}
-  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- $versionLabel := dict "app.kubernetes.io/version" ( include "common.images.version" ( dict "imageRoot" .Values.controller.image "chart" .Chart ) ) }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.commonLabels $versionLabel ) "context" . ) }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: controller
     app.kubernetes.io/part-of: argo-workflows
   {{- if .Values.commonAnnotations }}

--- a/bitnami/argo-workflows/templates/controller/deployment.yaml
+++ b/bitnami/argo-workflows/templates/controller/deployment.yaml
@@ -8,7 +8,9 @@ kind: Deployment
 metadata:
   name: {{ include "argo-workflows.controller.fullname" . }}
   namespace: {{ .Release.Namespace | quote }}
-  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- $versionLabel := dict "app.kubernetes.io/version" ( include "common.images.version" ( dict "imageRoot" .Values.controller.image "chart" .Chart ) ) }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.commonLabels $versionLabel ) "context" . ) }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: controller
     app.kubernetes.io/part-of: argo-workflows
   {{- if .Values.commonAnnotations }}
@@ -19,7 +21,7 @@ spec:
   {{- if .Values.controller.updateStrategy }}
   strategy: {{- toYaml .Values.controller.updateStrategy | nindent 4 }}
   {{- end }}
-  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.controller.podLabels .Values.commonLabels ) "context" . ) }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.controller.podLabels .Values.commonLabels $versionLabel ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: controller

--- a/bitnami/argo-workflows/templates/controller/pdb.yaml
+++ b/bitnami/argo-workflows/templates/controller/pdb.yaml
@@ -9,7 +9,9 @@ kind: PodDisruptionBudget
 metadata:
   name: {{ include "argo-workflows.controller.fullname" . }}
   namespace: {{ .Release.Namespace | quote }}
-  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- $versionLabel := dict "app.kubernetes.io/version" ( include "common.images.version" ( dict "imageRoot" .Values.controller.image "chart" .Chart ) ) }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.commonLabels $versionLabel ) "context" . ) }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: argo-workflows
     app.kubernetes.io/component: controller
   {{- if .Values.commonAnnotations }}

--- a/bitnami/argo-workflows/templates/controller/service-account.yaml
+++ b/bitnami/argo-workflows/templates/controller/service-account.yaml
@@ -9,7 +9,9 @@ kind: ServiceAccount
 metadata:
   name: {{ include "argo-workflows.controller.serviceAccountName" . }}
   namespace: {{ .Release.Namespace | quote }}
-  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- $versionLabel := dict "app.kubernetes.io/version" ( include "common.images.version" ( dict "imageRoot" .Values.controller.image "chart" .Chart ) ) }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.commonLabels $versionLabel ) "context" . ) }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: controller
     app.kubernetes.io/part-of: argo-workflows
   {{- if or .Values.controller.serviceAccount.annotations .Values.commonAnnotations }}

--- a/bitnami/argo-workflows/templates/controller/service.yaml
+++ b/bitnami/argo-workflows/templates/controller/service.yaml
@@ -9,7 +9,9 @@ kind: Service
 metadata:
   name: {{ include "argo-workflows.controller.fullname" . }}
   namespace: {{ .Release.Namespace | quote }}
-  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- $versionLabel := dict "app.kubernetes.io/version" ( include "common.images.version" ( dict "imageRoot" .Values.controller.image "chart" .Chart ) ) }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.commonLabels $versionLabel ) "context" . ) }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: argo-workflows
     app.kubernetes.io/component: controller
   {{- if or .Values.controller.service.annotations .Values.commonAnnotations }}

--- a/bitnami/argo-workflows/templates/controller/servicemonitor.yaml
+++ b/bitnami/argo-workflows/templates/controller/servicemonitor.yaml
@@ -9,7 +9,9 @@ kind: ServiceMonitor
 metadata:
   name: {{ include "argo-workflows.controller.fullname" . }}
   namespace: {{ .Release.Namespace | quote }}
-  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- $versionLabel := dict "app.kubernetes.io/version" ( include "common.images.version" ( dict "imageRoot" .Values.controller.image "chart" .Chart ) ) }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.commonLabels $versionLabel ) "context" . ) }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: argo-workflows
     app.kubernetes.io/component: controller
   {{- if .Values.commonAnnotations }}

--- a/bitnami/argo-workflows/templates/controller/workflow-role.yaml
+++ b/bitnami/argo-workflows/templates/controller/workflow-role.yaml
@@ -8,6 +8,8 @@ SPDX-License-Identifier: APACHE-2.0
 {{- if and (not .Values.rbac.singleNamespace) .Values.controller.workflowNamespaces }}
 {{- $namespaces := .Values.controller.workflowNamespaces }}
 {{- end }}
+{{- $versionLabel := dict "app.kubernetes.io/version" ( include "common.images.version" ( dict "imageRoot" .Values.controller.image "chart" .Chart ) ) }}
+{{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.commonLabels $versionLabel ) "context" . ) }}
 {{- range $namespaces }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -15,7 +17,7 @@ kind: Role
 metadata:
   name: {{ include "common.names.fullname" $ }}-workflow
   namespace: {{ . | quote }}
-  labels: {{- include "common.labels.standard" ( dict "customLabels" $.Values.commonLabels "context" $ ) | nindent 4 }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: controller
     app.kubernetes.io/part-of: argo-workflows
   {{- if $.Values.commonAnnotations }}

--- a/bitnami/argo-workflows/templates/controller/workflow-rolebinding.yaml
+++ b/bitnami/argo-workflows/templates/controller/workflow-rolebinding.yaml
@@ -8,13 +8,15 @@ SPDX-License-Identifier: APACHE-2.0
 {{- if and (not .Values.rbac.singleNamespace) .Values.controller.workflowNamespaces }}
 {{- $namespaces := .Values.controller.workflowNamespaces }}
 {{- end }}
+{{- $versionLabel := dict "app.kubernetes.io/version" ( include "common.images.version" ( dict "imageRoot" .Values.controller.image "chart" .Chart ) ) }}
+{{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.commonLabels $versionLabel ) "context" . ) }}
 {{- range $namespaces }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ include "common.names.fullname" $ }}-workflow
   namespace: {{ . | quote }}
-  labels: {{- include "common.labels.standard" ( dict "customLabels" $.Values.commonLabels "context" $ ) | nindent 4 }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: controller
     app.kubernetes.io/part-of: argo-workflows
   {{- if $.Values.commonAnnotations }}

--- a/bitnami/argo-workflows/templates/controller/workflow-serviceaccount.yaml
+++ b/bitnami/argo-workflows/templates/controller/workflow-serviceaccount.yaml
@@ -8,13 +8,15 @@ SPDX-License-Identifier: APACHE-2.0
 {{- if and (not .Values.rbac.singleNamespace) .Values.controller.workflowNamespaces }}
 {{- $namespaces = .Values.controller.workflowNamespaces }}
 {{- end }}
+{{- $versionLabel := dict "app.kubernetes.io/version" ( include "common.images.version" ( dict "imageRoot" .Values.controller.image "chart" .Chart ) ) }}
+{{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.commonLabels $versionLabel ) "context" . ) }}
 {{- range $namespaces }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "argo-workflows.workflows.serviceAccountName" $ }}
   namespace: {{ . | quote }}
-  labels: {{- include "common.labels.standard" ( dict "customLabels" $.Values.commonLabels "context" $ ) | nindent 4 }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: controller
     app.kubernetes.io/part-of: argo-workflows
   {{- if or $.Values.workflows.serviceAccount.annotations $.Values.commonAnnotations }}

--- a/bitnami/argo-workflows/templates/server/cluster-role.yaml
+++ b/bitnami/argo-workflows/templates/server/cluster-role.yaml
@@ -4,6 +4,8 @@ SPDX-License-Identifier: APACHE-2.0
 */}}
 
 {{- if and .Values.server.enabled .Values.server.rbac.create }}
+{{- $versionLabel := dict "app.kubernetes.io/version" ( include "common.images.version" ( dict "imageRoot" .Values.server.image "chart" .Chart ) ) }}
+{{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.commonLabels $versionLabel ) "context" . ) }}
 apiVersion: rbac.authorization.k8s.io/v1
 {{- if .Values.rbac.singleNamespace }}
 kind: Role
@@ -15,7 +17,7 @@ metadata:
   {{- if .Values.rbac.singleNamespace }}
   namespace: {{ .Release.Namespace | quote }}
   {{- end }}
-  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: argo-workflows
     app.kubernetes.io/component: server
   {{- if .Values.commonAnnotations }}
@@ -139,7 +141,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ include "argo-workflows.server.fullname.namespace" . }}-cluster-template
-  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: argo-workflows
     app.kubernetes.io/component: server
   {{- if .Values.commonAnnotations }}

--- a/bitnami/argo-workflows/templates/server/clusterrolebinding.yaml
+++ b/bitnami/argo-workflows/templates/server/clusterrolebinding.yaml
@@ -4,6 +4,8 @@ SPDX-License-Identifier: APACHE-2.0
 */}}
 
 {{- if and .Values.server.rbac.create .Values.server.enabled -}}
+{{- $versionLabel := dict "app.kubernetes.io/version" ( include "common.images.version" ( dict "imageRoot" .Values.server.image "chart" .Chart ) ) }}
+{{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.commonLabels $versionLabel ) "context" . ) }}
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 {{- if .Values.rbac.singleNamespace }}
 kind: RoleBinding
@@ -15,7 +17,7 @@ metadata:
   {{- if .Values.rbac.singleNamespace }}
   namespace: {{ .Release.Namespace | quote }}
   {{- end }}
-  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: argo-workflows
     app.kubernetes.io/component: server
   {{- if .Values.commonAnnotations }}
@@ -40,7 +42,7 @@ apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRoleBinding
 metadata:
   name: {{ include "argo-workflows.server.fullname.namespace" . }}-cluster-template
-  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: argo-workflows
     app.kubernetes.io/component: server
   {{- if .Values.commonAnnotations }}

--- a/bitnami/argo-workflows/templates/server/deployment.yaml
+++ b/bitnami/argo-workflows/templates/server/deployment.yaml
@@ -9,7 +9,9 @@ kind: Deployment
 metadata:
   name: {{ include "argo-workflows.server.fullname" . }}
   namespace: {{ .Release.Namespace | quote }}
-  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- $versionLabel := dict "app.kubernetes.io/version" ( include "common.images.version" ( dict "imageRoot" .Values.server.image "chart" .Chart ) ) }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.commonLabels $versionLabel ) "context" . ) }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: argo-workflows
     app.kubernetes.io/component: server
   {{- if .Values.commonAnnotations }}
@@ -20,7 +22,7 @@ spec:
   {{- if .Values.server.updateStrategy }}
   strategy: {{- toYaml .Values.server.updateStrategy | nindent 4 }}
   {{- end }}
-  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.server.podLabels .Values.commonLabels ) "context" . ) }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.server.podLabels .Values.commonLabels $versionLabel ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: server

--- a/bitnami/argo-workflows/templates/server/ingress.yaml
+++ b/bitnami/argo-workflows/templates/server/ingress.yaml
@@ -9,7 +9,9 @@ kind: Ingress
 metadata:
   name: {{ include "argo-workflows.server.fullname" . }}
   namespace: {{ .Release.Namespace | quote }}
-  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- $versionLabel := dict "app.kubernetes.io/version" ( include "common.images.version" ( dict "imageRoot" .Values.server.image "chart" .Chart ) ) }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.commonLabels $versionLabel ) "context" . ) }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: server
     app.kubernetes.io/part-of: argo-workflows
   annotations:

--- a/bitnami/argo-workflows/templates/server/pdb.yaml
+++ b/bitnami/argo-workflows/templates/server/pdb.yaml
@@ -10,7 +10,9 @@ kind: PodDisruptionBudget
 metadata:
   name: {{ include "argo-workflows.server.fullname" . }}
   namespace: {{ .Release.Namespace | quote }}
-  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- $versionLabel := dict "app.kubernetes.io/version" ( include "common.images.version" ( dict "imageRoot" .Values.server.image "chart" .Chart ) ) }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.commonLabels $versionLabel ) "context" . ) }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: argo-workflows
     app.kubernetes.io/component: server
   {{- if .Values.commonAnnotations }}

--- a/bitnami/argo-workflows/templates/server/service-account.yaml
+++ b/bitnami/argo-workflows/templates/server/service-account.yaml
@@ -9,7 +9,9 @@ kind: ServiceAccount
 metadata:
   name: {{ include "argo-workflows.server.serviceAccountName" . }}
   namespace: {{ .Release.Namespace | quote }}
-  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- $versionLabel := dict "app.kubernetes.io/version" ( include "common.images.version" ( dict "imageRoot" .Values.server.image "chart" .Chart ) ) }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.commonLabels $versionLabel ) "context" . ) }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: server
     app.kubernetes.io/part-of: argo-workflows
   {{- if or .Values.server.serviceAccount.annotations .Values.commonAnnotations }}

--- a/bitnami/argo-workflows/templates/server/service.yaml
+++ b/bitnami/argo-workflows/templates/server/service.yaml
@@ -8,7 +8,9 @@ kind: Service
 metadata:
   name: {{ include "argo-workflows.server.fullname" . }}
   namespace: {{ .Release.Namespace | quote }}
-  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- $versionLabel := dict "app.kubernetes.io/version" ( include "common.images.version" ( dict "imageRoot" .Values.server.image "chart" .Chart ) ) }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.commonLabels $versionLabel ) "context" . ) }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: argo-workflows
     app.kubernetes.io/component: server
   {{- if or .Values.server.service.annotations .Values.commonAnnotations }}

--- a/bitnami/argo-workflows/templates/server/tls-secrets.yaml
+++ b/bitnami/argo-workflows/templates/server/tls-secrets.yaml
@@ -4,6 +4,8 @@ SPDX-License-Identifier: APACHE-2.0
 */}}
 
 {{- if .Values.ingress.enabled }}
+{{- $versionLabel := dict "app.kubernetes.io/version" ( include "common.images.version" ( dict "imageRoot" .Values.server.image "chart" .Chart ) ) }}
+{{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.commonLabels $versionLabel ) "context" . ) }}
 {{- if .Values.ingress.secrets }}
 {{- range .Values.ingress.secrets }}
 apiVersion: v1
@@ -11,7 +13,7 @@ kind: Secret
 metadata:
   name: {{ .name }}
   namespace: {{ $.Release.Namespace | quote }}
-  labels: {{- include "common.labels.standard" ( dict "customLabels" $.Values.commonLabels "context" $ ) | nindent 4 }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: server
     app.kubernetes.io/part-of: argo-workflows
   {{- if $.Values.commonAnnotations }}
@@ -33,7 +35,7 @@ kind: Secret
 metadata:
   name: {{ $secretName }}
   namespace: {{ .Release.Namespace | quote }}
-  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: server
     app.kubernetes.io/part-of: argo-workflows
   {{- if .Values.commonAnnotations }}


### PR DESCRIPTION
### Description of the change

This PR follows up #17201 ensuring we use a different `app.kubernetes.io/version` label on subcomponents.

### Benefits

Improve manifests labelling.

### Possible drawbacks

None

### Applicable issues

N/A

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
