### PR TITLE
[bitnami/external-dns] Fix schema and default value of zonesCacheDuration

### DIFF
--- a/bitnami/external-dns/Chart.yaml
+++ b/bitnami/external-dns/Chart.yaml
@@ -28,4 +28,4 @@ maintainers:
 name: external-dns
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/external-dns
-version: 6.26.0
+version: 6.26.1

--- a/bitnami/external-dns/values.schema.json
+++ b/bitnami/external-dns/values.schema.json
@@ -352,9 +352,9 @@
                     "default": 1000
                 },
                 "zonesCacheDuration": {
-                    "type": "number",
+                    "type": "string",
                     "description": "If the list of Route53 zones managed by ExternalDNS doesn't change frequently, cache it by setting a TTL",
-                    "default": 0
+                    "default": "0"
                 },
                 "zoneTags": {
                     "type": "array",

--- a/bitnami/external-dns/values.yaml
+++ b/bitnami/external-dns/values.yaml
@@ -241,7 +241,7 @@ aws:
   ## @param aws.zonesCacheDuration If the list of Route53 zones managed by ExternalDNS doesn't change frequently, cache it by setting a TTL
   ## (default 0 - disabled, can be set to time interval like 1m or 1h)
   ##
-  zonesCacheDuration: 0
+  zonesCacheDuration: "0"
   ## @param aws.zoneTags When using the AWS provider, filter for zones with these tags
   ##
   zoneTags: []


### PR DESCRIPTION
### Description of the change

Fixes a bug in the schemas for external dns. The bug prevented correct values ( i.e. "5d") from being used with this chart. 

### Benefits

Allows for configuration of zonesCacheDuration

### Possible drawbacks

None

### Applicable issues

- fixes #19284

### Additional information


### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
