### PR TITLE
[bitnami/grafana-tempo] Use different app.kubernetes.io/version label on subcomponents

### DIFF
--- a/bitnami/grafana-tempo/Chart.lock
+++ b/bitnami/grafana-tempo/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: memcached
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 6.6.0
+  version: 6.6.2
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.10.0
-digest: sha256:317713af7e60054c878e86b0ee4e964d9ded4bbc62055a5500cd36565518300f
-generated: "2023-09-05T11:32:55.595219+02:00"
+  version: 2.11.1
+digest: sha256:a1299991ca3a56ba86ec9cb036063ba79e729542824c1189cb5e88755173fb38
+generated: "2023-09-18T13:38:55.781753+02:00"

--- a/bitnami/grafana-tempo/Chart.yaml
+++ b/bitnami/grafana-tempo/Chart.yaml
@@ -39,4 +39,4 @@ maintainers:
 name: grafana-tempo
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/grafana-tempo
-version: 2.4.3
+version: 2.4.4

--- a/bitnami/grafana-tempo/templates/query-frontend/deployment.yaml
+++ b/bitnami/grafana-tempo/templates/query-frontend/deployment.yaml
@@ -8,7 +8,9 @@ kind: Deployment
 metadata:
   name: {{ template "grafana-tempo.query-frontend.fullname" . }}
   namespace: {{ .Release.Namespace | quote }}
-  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- $versionLabel := dict "app.kubernetes.io/version" ( include "common.images.version" ( dict "imageRoot" .Values.queryFrontend.query.image "chart" .Chart ) ) }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.commonLabels $versionLabel ) "context" . ) }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: query-frontend
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
@@ -18,7 +20,7 @@ spec:
   {{- if .Values.queryFrontend.updateStrategy }}
   strategy: {{- toYaml .Values.queryFrontend.updateStrategy | nindent 4 }}
   {{- end }}
-  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.queryFrontend.podLabels .Values.commonLabels ) "context" . ) }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.queryFrontend.podLabels .Values.commonLabels $versionLabel ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: query-frontend

--- a/bitnami/grafana-tempo/templates/query-frontend/headless-service.yaml
+++ b/bitnami/grafana-tempo/templates/query-frontend/headless-service.yaml
@@ -8,7 +8,9 @@ kind: Service
 metadata:
   name: {{ template "grafana-tempo.query-frontend.fullname" . }}-headless
   namespace: {{ .Release.Namespace | quote }}
-  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- $versionLabel := dict "app.kubernetes.io/version" ( include "common.images.version" ( dict "imageRoot" .Values.queryFrontend.query.image "chart" .Chart ) ) }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.commonLabels $versionLabel ) "context" . ) }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: query-frontend
   {{- if or .Values.commonAnnotations .Values.queryFrontend.service.headless.annotations }}
   {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.queryFrontend.service.headless.annotations .Values.commonAnnotations ) "context" . ) }}

--- a/bitnami/grafana-tempo/templates/query-frontend/query-configmap.yaml
+++ b/bitnami/grafana-tempo/templates/query-frontend/query-configmap.yaml
@@ -8,7 +8,9 @@ kind: ConfigMap
 metadata:
   name: {{ template "grafana-tempo.query-frontend.fullname" . }}
   namespace: {{ .Release.Namespace | quote }}
-  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- $versionLabel := dict "app.kubernetes.io/version" ( include "common.images.version" ( dict "imageRoot" .Values.queryFrontend.query.image "chart" .Chart ) ) }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.commonLabels $versionLabel ) "context" . ) }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: query
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}

--- a/bitnami/grafana-tempo/templates/query-frontend/service.yaml
+++ b/bitnami/grafana-tempo/templates/query-frontend/service.yaml
@@ -8,7 +8,9 @@ kind: Service
 metadata:
   name: {{ template "grafana-tempo.query-frontend.fullname" . }}
   namespace: {{ .Release.Namespace | quote }}
-  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- $versionLabel := dict "app.kubernetes.io/version" ( include "common.images.version" ( dict "imageRoot" .Values.queryFrontend.query.image "chart" .Chart ) ) }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.commonLabels $versionLabel ) "context" . ) }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: query-frontend
   {{- if or .Values.commonAnnotations .Values.queryFrontend.service.annotations }}
   {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.queryFrontend.service.annotations .Values.commonAnnotations ) "context" . ) }}

--- a/bitnami/grafana-tempo/templates/query-frontend/servicemonitor.yaml
+++ b/bitnami/grafana-tempo/templates/query-frontend/servicemonitor.yaml
@@ -9,7 +9,8 @@ kind: ServiceMonitor
 metadata:
   name: {{ template "grafana-tempo.query-frontend.fullname" . }}
   namespace: {{ default .Release.Namespace .Values.metrics.serviceMonitor.namespace | quote }}
-  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.metrics.serviceMonitor.labels .Values.commonLabels ) "context" . ) }}
+  {{- $versionLabel := dict "app.kubernetes.io/version" ( include "common.images.version" ( dict "imageRoot" .Values.queryFrontend.query.image "chart" .Chart ) ) }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.metrics.serviceMonitor.labels .Values.commonLabels $versionLabel ) "context" . ) }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: query-frontend
   {{- if .Values.commonAnnotations }}

--- a/bitnami/grafana-tempo/templates/vulture/deployment.yaml
+++ b/bitnami/grafana-tempo/templates/vulture/deployment.yaml
@@ -9,7 +9,9 @@ kind: Deployment
 metadata:
   name: {{ template "grafana-tempo.vulture.fullname" . }}
   namespace: {{ .Release.Namespace | quote }}
-  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- $versionLabel := dict "app.kubernetes.io/version" ( include "common.images.version" ( dict "imageRoot" .Values.vulture.image "chart" .Chart ) ) }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.commonLabels $versionLabel ) "context" . ) }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: vulture
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
@@ -19,7 +21,7 @@ spec:
   {{- if .Values.vulture.updateStrategy }}
   strategy: {{- toYaml .Values.vulture.updateStrategy | nindent 4 }}
   {{- end }}
-  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.vulture.podLabels .Values.commonLabels ) "context" . ) }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.vulture.podLabels .Values.commonLabels $versionLabel ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: vulture

--- a/bitnami/grafana-tempo/templates/vulture/service.yaml
+++ b/bitnami/grafana-tempo/templates/vulture/service.yaml
@@ -9,7 +9,9 @@ kind: Service
 metadata:
   name: {{ template "grafana-tempo.vulture.fullname" . }}
   namespace: {{ .Release.Namespace | quote }}
-  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- $versionLabel := dict "app.kubernetes.io/version" ( include "common.images.version" ( dict "imageRoot" .Values.vulture.image "chart" .Chart ) ) }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.commonLabels $versionLabel ) "context" . ) }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: vulture
   {{- if or .Values.commonAnnotations .Values.vulture.service.annotations }}
   {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.vulture.service.annotations .Values.commonAnnotations ) "context" . ) }}

--- a/bitnami/grafana-tempo/templates/vulture/servicemonitor.yaml
+++ b/bitnami/grafana-tempo/templates/vulture/servicemonitor.yaml
@@ -9,7 +9,8 @@ kind: ServiceMonitor
 metadata:
   name: {{ template "grafana-tempo.vulture.fullname" . }}
   namespace: {{ default .Release.Namespace .Values.metrics.serviceMonitor.namespace | quote }}
-  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.metrics.serviceMonitor.labels .Values.commonLabels ) "context" . ) }}
+  {{- $versionLabel := dict "app.kubernetes.io/version" ( include "common.images.version" ( dict "imageRoot" .Values.vulture.image "chart" .Chart ) ) }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.metrics.serviceMonitor.labels .Values.commonLabels $versionLabel ) "context" . ) }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: vulture
   {{- if .Values.commonAnnotations }}


### PR DESCRIPTION
### Description of the change

This PR follows up #17201 ensuring we use a different `app.kubernetes.io/version` label on subcomponents.

### Benefits

Improve manifests labelling.

### Possible drawbacks

None

### Applicable issues

N/A

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
