### PR TITLE
[bitnami/prometheus] Use different app.kubernetes.io/version label on subcomponents

### DIFF
--- a/bitnami/prometheus/Chart.lock
+++ b/bitnami/prometheus/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.10.0
-digest: sha256:023ded170632d04528f30332370f34fc8fb96efb2886a01d934cb3bd6e6d2e09
-generated: "2023-09-06T15:15:43.364626511Z"
+  version: 2.11.1
+digest: sha256:ead8f26c76a9ec082f23629a358e8efd8f88d87aaed734bf41febcb8a7bc5d4c
+generated: "2023-09-18T16:12:04.075557+02:00"

--- a/bitnami/prometheus/Chart.yaml
+++ b/bitnami/prometheus/Chart.yaml
@@ -35,4 +35,4 @@ sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/prometheus
   - https://github.com/prometheus/prometheus
   - https://github.com/prometheus-community/helm-charts
-version: 0.2.2
+version: 0.2.3

--- a/bitnami/prometheus/templates/alertmanager/configmap.yaml
+++ b/bitnami/prometheus/templates/alertmanager/configmap.yaml
@@ -9,7 +9,9 @@ kind: ConfigMap
 metadata:
   name: {{ include "prometheus.alertmanager.fullname" . | quote }}
   namespace: {{ include "common.names.namespace" . | quote }}
-  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- $versionLabel := dict "app.kubernetes.io/version" ( include "common.images.version" ( dict "imageRoot" .Values.alertmanager.image "chart" .Chart ) ) }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.commonLabels $versionLabel ) "context" . ) }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: prometheus
     app.kubernetes.io/component: alertmanager
   {{- if .Values.commonAnnotations }}

--- a/bitnami/prometheus/templates/alertmanager/ingress.yaml
+++ b/bitnami/prometheus/templates/alertmanager/ingress.yaml
@@ -9,7 +9,9 @@ kind: Ingress
 metadata:
   name: {{ include "prometheus.alertmanager.fullname" . | quote }}
   namespace: {{ include "common.names.namespace" . | quote }}
-  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- $versionLabel := dict "app.kubernetes.io/version" ( include "common.images.version" ( dict "imageRoot" .Values.alertmanager.image "chart" .Chart ) ) }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.commonLabels $versionLabel ) "context" . ) }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: prometheus
     app.kubernetes.io/component: alertmanager
   {{- if or .Values.alertmanager.ingress.annotations .Values.commonAnnotations }}

--- a/bitnami/prometheus/templates/alertmanager/pdb.yaml
+++ b/bitnami/prometheus/templates/alertmanager/pdb.yaml
@@ -10,7 +10,9 @@ kind: PodDisruptionBudget
 metadata:
   name: {{ include "prometheus.alertmanager.fullname" . | quote }}
   namespace: {{ include "common.names.namespace" . | quote }}
-  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- $versionLabel := dict "app.kubernetes.io/version" ( include "common.images.version" ( dict "imageRoot" .Values.alertmanager.image "chart" .Chart ) ) }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.commonLabels $versionLabel ) "context" . ) }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: prometheus
     app.kubernetes.io/component: alertmanager
   {{- if .Values.commonAnnotations }}

--- a/bitnami/prometheus/templates/alertmanager/service-account.yaml
+++ b/bitnami/prometheus/templates/alertmanager/service-account.yaml
@@ -9,7 +9,9 @@ kind: ServiceAccount
 metadata:
   name: {{ include "prometheus.alertmanager.serviceAccountName" . | quote }}
   namespace: {{ include "common.names.namespace" . | quote }}
-  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- $versionLabel := dict "app.kubernetes.io/version" ( include "common.images.version" ( dict "imageRoot" .Values.alertmanager.image "chart" .Chart ) ) }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.commonLabels $versionLabel ) "context" . ) }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: prometheus
     app.kubernetes.io/component: alertmanager
   {{- if or .Values.alertmanager.serviceAccount.annotations .Values.commonAnnotations }}

--- a/bitnami/prometheus/templates/alertmanager/service-headless.yaml
+++ b/bitnami/prometheus/templates/alertmanager/service-headless.yaml
@@ -9,7 +9,9 @@ kind: Service
 metadata:
   name: {{ printf "%s-headless" (include "prometheus.alertmanager.fullname" .) }}
   namespace: {{ include "common.names.namespace" . | quote }}
-  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- $versionLabel := dict "app.kubernetes.io/version" ( include "common.images.version" ( dict "imageRoot" .Values.alertmanager.image "chart" .Chart ) ) }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.commonLabels $versionLabel ) "context" . ) }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: prometheus
     app.kubernetes.io/component: alertmanager
   {{- if or .Values.alertmanager.service.annotations .Values.commonAnnotations }}

--- a/bitnami/prometheus/templates/alertmanager/service.yaml
+++ b/bitnami/prometheus/templates/alertmanager/service.yaml
@@ -9,7 +9,9 @@ kind: Service
 metadata:
   name: {{ include "prometheus.alertmanager.fullname" . | quote }}
   namespace: {{ include "common.names.namespace" . | quote }}
-  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- $versionLabel := dict "app.kubernetes.io/version" ( include "common.images.version" ( dict "imageRoot" .Values.alertmanager.image "chart" .Chart ) ) }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.commonLabels $versionLabel ) "context" . ) }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: prometheus
     app.kubernetes.io/component: alertmanager
   {{- if or .Values.alertmanager.service.annotations .Values.commonAnnotations }}

--- a/bitnami/prometheus/templates/alertmanager/statefulset.yaml
+++ b/bitnami/prometheus/templates/alertmanager/statefulset.yaml
@@ -10,7 +10,9 @@ kind: StatefulSet
 metadata:
   name: {{ include "prometheus.alertmanager.fullname" . | quote }}
   namespace: {{ include "common.names.namespace" . | quote }}
-  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- $versionLabel := dict "app.kubernetes.io/version" ( include "common.images.version" ( dict "imageRoot" .Values.alertmanager.image "chart" .Chart ) ) }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.commonLabels $versionLabel ) "context" . ) }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: prometheus
     app.kubernetes.io/component: alertmanager
   {{- if .Values.commonAnnotations }}
@@ -19,7 +21,7 @@ metadata:
 spec:
   replicas: {{ .Values.alertmanager.replicaCount }}
   podManagementPolicy: {{ .Values.alertmanager.podManagementPolicy | quote }}
-  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.alertmanager.podLabels .Values.commonLabels ) "context" . ) }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.alertmanager.podLabels .Values.commonLabels $versionLabel ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/part-of: prometheus


### PR DESCRIPTION
### Description of the change

This PR follows up #17201 ensuring we use a different `app.kubernetes.io/version` label on subcomponents.

### Benefits

Improve manifests labelling.

### Possible drawbacks

None

### Applicable issues

N/A

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
