### PR TITLE
Fixing HPA resource.target format to be compatible with Api autoscaling/v2

### DIFF
--- a/bitnami/schema-registry/Chart.yaml
+++ b/bitnami/schema-registry/Chart.yaml
@@ -34,4 +34,4 @@ maintainers:
 name: schema-registry
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/schema-registry
-version: 14.0.1
+version: 14.1.1

--- a/bitnami/schema-registry/templates/hpa.yaml
+++ b/bitnami/schema-registry/templates/hpa.yaml
@@ -25,12 +25,16 @@ spec:
     - type: Resource
       resource:
         name: cpu
-        targetAverageUtilization: {{ .Values.autoscaling.targetCPU }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPU }}
     {{- end }}
     {{- if .Values.autoscaling.targetMemory }}
     - type: Resource
       resource:
         name: memory
-        targetAverageUtilization: {{ .Values.autoscaling.targetMemory  }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemory  }}
     {{- end }}
 {{- end }}


### PR DESCRIPTION
The change is very simple and straightforward, I updated the hpa resource.target format to be compatible with the autoscaling/v2 API.

When I tried to launch the schema registry enabling autoscaling, I got this error message:
```
failed to create resource: HorizontalPodAutoscaler.autoscaling "schema-registry" is invalid: [spec.metrics[0].resource.target.type: Required value: must specify a metric target type, spec.metrics[0].resource.target.type: Invalid value: "": must be either Utilization, Value, or AverageValue, spec.metrics[0].resource.target.averageUtilization: Required value: must set either a target raw value or a target utilization, spec.metrics[1].resource.target.type: Required value: must specify a metric target type, spec.metrics[1].resource.target.type: Invalid value: "": must be either Utilization, Value, or AverageValue, spec.metrics[1].resource.target.averageUtilization: Required value: must set either a target raw value or a target utilization]
the current format of the autoscaling target is not correct for this API version
```

I tested the code, and in a GKE cluster with Kubernetes version 1.27.3-gke.100 it now works as expected.