### PR TITLE
[bitnami/appsmith] - Bug 19474 - Updated reference to external redis secret

### DIFF
--- a/bitnami/appsmith/Chart.yaml
+++ b/bitnami/appsmith/Chart.yaml
@@ -37,4 +37,4 @@ maintainers:
 name: appsmith
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/appsmith
-version: 1.0.5
+version: 1.0.6

--- a/bitnami/appsmith/templates/_helpers.tpl
+++ b/bitnami/appsmith/templates/_helpers.tpl
@@ -329,8 +329,8 @@ Return the Redis Secret Name
 {{- define "appsmith.redis.secretName" -}}
 {{- if .Values.redis.enabled }}
     {{- printf "%s" (include "appsmith.redis.fullname" .) -}}
-{{- else if .Values.externalDatabase.existingSecret -}}
-    {{- printf "%s" .Values.externalDatabase.existingSecret -}}
+{{- else if .Values.externalRedis.existingSecret -}}
+    {{- printf "%s" .Values.externalRedis.existingSecret -}}
 {{- else -}}
     {{- printf "%s-externalredis" (include "common.names.fullname" .) | trunc 63 | trimSuffix "-" -}}
 {{- end -}}


### PR DESCRIPTION
### Description of the change

Currently, the Appsmith helper template references the MongoDB secret.  This updates the helper template to reference the external Redis secret in the deployment yaml.

### Applicable issues

- fixes 19474

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)