### PR TITLE
bitnami/postgresql  Added ImagePullSecrets and ImagePullPolicy to be passed through to backup-cronjob

### DIFF
--- a/bitnami/postgresql/Chart.yaml
+++ b/bitnami/postgresql/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: postgresql
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/postgresql
-version: 12.12.7
+version: 12.12.8

--- a/bitnami/postgresql/templates/backup/cronjob.yaml
+++ b/bitnami/postgresql/templates/backup/cronjob.yaml
@@ -38,12 +38,14 @@ spec:
           annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 12 }}
           {{- end }}
         spec:
+          {{- include "postgresql.v1.imagePullSecrets" . | nindent 10 }}
           {{- if .Values.backup.cronjob.nodeSelector }}
           nodeSelector: {{- include "common.tplvalues.render" (dict "value" .Values.backup.cronjob.nodeSelector "context" $) | nindent 12 }}
           {{- end }}
           containers:
           - name: {{ include "postgresql.v1.primary.fullname" . }}-pgdumpall
             image: {{ include "postgresql.v1.image" . }}
+            imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
             env:
               - name: PGUSER
               {{- if .Values.auth.enablePostgresUser }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->
The changes will consider the values passed of ImagePullSecrets and ImagePullPolicy to be passed to backup-cronjob. 

### Benefits

You can pull images from private Repositories and adjust the pull-Strategy.

### Possible drawbacks

Users who do not want the values to be passed to the cronjob might have issues. To solve this you might want to make these values configurable for each type of deployment.
However I don't think that there are users who do not want this to happen.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #19488

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
