### PR TITLE
[bitnami/elasticsearch] Add support for single-node

### DIFF
--- a/.vib/elasticsearch/ginkgo/elasticsearch_suite_test.go
+++ b/.vib/elasticsearch/ginkgo/elasticsearch_suite_test.go
@@ -27,7 +27,7 @@ func init() {
 	flag.StringVar(&kubeconfig, "kubeconfig", "", "absolute path to the kubeconfig file")
 	flag.StringVar(&releaseName, "name", "", "name of the primary statefulset")
 	flag.StringVar(&namespace, "namespace", "", "namespace where the application is running")
-	flag.IntVar(&timeoutSeconds, "timeout", 480, "timeout in seconds")
+	flag.IntVar(&timeoutSeconds, "timeout", 600, "timeout in seconds")
 	timeout = time.Duration(timeoutSeconds) * time.Second
 }
 

--- a/bitnami/elasticsearch/Chart.yaml
+++ b/bitnami/elasticsearch/Chart.yaml
@@ -34,4 +34,4 @@ maintainers:
 name: elasticsearch
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/elasticsearch
-version: 19.11.4
+version: 19.12.0

--- a/bitnami/elasticsearch/README.md
+++ b/bitnami/elasticsearch/README.md
@@ -737,6 +737,33 @@ kibana:
         enabled: true
 ```
 
+### How to deploy a single node
+
+This chart allows you to deploy Elasticsearch as a "single-node" cluster (one master node replica) that assumes all the roles. The following inputs should be provided:
+
+```yaml
+master:
+  masterOnly: false
+  replicaCount: 1
+data:
+  replicaCount: 0
+coordinating:
+  replicaCount: 0
+ingest:
+  replicaCount: 0
+```
+
+The "single-node" cluster will be configured with [single-node discovery](https://www.elastic.co/guide/en/elasticsearch/reference/current/bootstrap-checks.html#single-node-discovery).
+
+If you want to scale up to more replicas, make sure you refresh the configuration of the existing StatefulSet. For example, scale down to 0 replicas first to avoid inconsistencies in the configuration:
+
+```console
+kubectl scale statefulset <DEPLOYMENT_NAME>-master --replicas=0
+helm upgrade <DEPLOYMENT_NAME> oci://registry-1.docker.io/bitnamicharts/elasticsearch --reset-values --set master.masterOnly=false
+```
+
+Please note that the master nodes should continue assuming all the roles (`master.masterOnly: false`) since there is shard data on the first replica.
+
 ### Adding extra environment variables
 
 In case you want to add extra environment variables (useful for advanced operations like custom init scripts), you can use the `extraEnvVars` property.

--- a/bitnami/elasticsearch/templates/NOTES.txt
+++ b/bitnami/elasticsearch/templates/NOTES.txt
@@ -2,6 +2,24 @@ CHART NAME: {{ .Chart.Name }}
 CHART VERSION: {{ .Chart.Version }}
 APP VERSION: {{ .Chart.AppVersion }}
 
+{{- if (include "elasticsearch.singleNode.enabled" .) }}
+
+-------------------------------------------------------------------------------
+ WARNING
+
+    Elasticsearch is only running one master node replica, assuming all the
+    roles and with "single-node" discovery configured. If you want to scale up
+    to more replicas, make sure you refresh the configuration of the existing
+    statefulset. For example, scale down to 0 replicas first to avoid
+    inconsistencies in the configuration:
+
+      kubectl scale --namespace {{ include "common.names.namespace" . }} statefulset {{ .Release.Name }}-master --replicas=0
+      helm upgrade --namespace {{ include "common.names.namespace" . }} {{ .Release.Name }} oci://registry-1.docker.io/bitnamicharts/elasticsearch --reset-values --set master.masterOnly=false
+
+    Please note that the master nodes should continue assuming all the roles
+    (master.masterOnly: false) since there is shard data on the first replica.
+-------------------------------------------------------------------------------
+{{- end }}
 {{- if contains .Values.service.type "LoadBalancer" }}
 
 -------------------------------------------------------------------------------

--- a/bitnami/elasticsearch/templates/_helpers.tpl
+++ b/bitnami/elasticsearch/templates/_helpers.tpl
@@ -221,6 +221,15 @@ Returns true if at least one ingest-only node replica has been configured.
 {{- end -}}
 
 {{/*
+Returns true if only one master node replica has been configured to assume all the roles
+*/}}
+{{- define "elasticsearch.singleNode.enabled" -}}
+{{- if and (eq (int .Values.master.replicaCount) 1) (not (or .Values.master.masterOnly .Values.master.autoscaling.enabled (include "elasticsearch.data.enabled" .) (include "elasticsearch.coordinating.enabled" .) (include "elasticsearch.ingest.enabled" .))) -}}
+    {{- true -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Return the hostname of every ElasticSearch seed node
 */}}
 {{- define "elasticsearch.hosts" -}}

--- a/bitnami/elasticsearch/templates/master/statefulset.yaml
+++ b/bitnami/elasticsearch/templates/master/statefulset.yaml
@@ -167,6 +167,7 @@ spec:
               value: {{ .Values.containerPorts.restAPI | quote }}
             - name: ELASTICSEARCH_CLUSTER_NAME
               value: {{ .Values.clusterName | quote }}
+            {{ if not (include "elasticsearch.singleNode.enabled" .) }}
             - name: ELASTICSEARCH_CLUSTER_HOSTS
               value: {{ include "elasticsearch.hosts" . | quote }}
             - name: ELASTICSEARCH_TOTAL_NODES
@@ -179,6 +180,7 @@ spec:
               value: {{ add (div (ternary .Values.master.autoscaling.minReplicas .Values.master.replicaCount .Values.master.autoscaling.enabled) 2) 1 | quote }}
             - name: ELASTICSEARCH_ADVERTISED_HOSTNAME
               value: "$(MY_POD_NAME).{{ (include "elasticsearch.master.servicename" .) | trunc 63 | trimSuffix "-" }}.{{ include "common.names.namespace" . }}.svc.{{ .Values.clusterDomain }}"
+            {{- end }}
             {{- if .Values.plugins }}
             - name: ELASTICSEARCH_PLUGINS
               value: {{ .Values.plugins | quote }}


### PR DESCRIPTION
### Description of the change

This PR adds the option to deploy a single-node cluster that assumes all the roles. The following inputs should be provided:

```yaml
master:
  masterOnly: false
  replicaCount: 1
data:
  replicaCount: 0
coordinating:
  replicaCount: 0
ingest:
  replicaCount: 0
```

The single-node cluster will be configured with [single-node discovery](https://www.elastic.co/guide/en/elasticsearch/reference/current/bootstrap-checks.html#single-node-discovery) in that case.


### Benefits

- Cover more use cases.

### Possible drawbacks

- Scaling the replicas up requires reloading the configuration in the existing node. A warning was added in the `NOTES.txt`.

### Applicable issues

- Originated in #18996, thank you @fabiocastagnino!

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] (n/a) ~Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)~
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
