### PR TITLE
[bitnami/redis-cluster] feat: optionally disable Service.spec.loadBalancerIP for external access

### DIFF
--- a/bitnami/redis-cluster/Chart.yaml
+++ b/bitnami/redis-cluster/Chart.yaml
@@ -32,4 +32,4 @@ maintainers:
 name: redis-cluster
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/redis-cluster
-version: 9.0.7
+version: 9.0.8

--- a/bitnami/redis-cluster/README.md
+++ b/bitnami/redis-cluster/README.md
@@ -267,22 +267,24 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Cluster management parameters
 
-| Name                                                      | Description                                                                                   | Value          |
-| --------------------------------------------------------- | --------------------------------------------------------------------------------------------- | -------------- |
-| `cluster.init`                                            | Enable the initialization of the Redis&reg; Cluster                                           | `true`         |
-| `cluster.nodes`                                           | The number of master nodes should always be >= 3, otherwise cluster creation will fail        | `6`            |
-| `cluster.replicas`                                        | Number of replicas for every master in the cluster                                            | `1`            |
-| `cluster.externalAccess.enabled`                          | Enable access to the Redis                                                                    | `false`        |
-| `cluster.externalAccess.hostMode`                         | Set cluster preferred endpoint type as hostname                                               | `false`        |
-| `cluster.externalAccess.service.type`                     | Type for the services used to expose every Pod                                                | `LoadBalancer` |
-| `cluster.externalAccess.service.port`                     | Port for the services used to expose every Pod                                                | `6379`         |
-| `cluster.externalAccess.service.loadBalancerIP`           | Array of load balancer IPs for each Redis&reg; node. Length must be the same as cluster.nodes | `[]`           |
-| `cluster.externalAccess.service.loadBalancerSourceRanges` | Service Load Balancer sources                                                                 | `[]`           |
-| `cluster.externalAccess.service.annotations`              | Annotations to add to the services used to expose every Pod of the Redis&reg; Cluster         | `{}`           |
-| `cluster.update.addNodes`                                 | Boolean to specify if you want to add nodes after the upgrade                                 | `false`        |
-| `cluster.update.currentNumberOfNodes`                     | Number of currently deployed Redis&reg; nodes                                                 | `6`            |
-| `cluster.update.currentNumberOfReplicas`                  | Number of currently deployed Redis&reg; replicas                                              | `1`            |
-| `cluster.update.newExternalIPs`                           | External IPs obtained from the services for the new nodes to add to the cluster               | `[]`           |
+| Name                                                      | Description                                                                                                | Value          |
+| --------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- | -------------- |
+| `cluster.init`                                            | Enable the initialization of the Redis&reg; Cluster                                                        | `true`         |
+| `cluster.nodes`                                           | The number of master nodes should always be >= 3, otherwise cluster creation will fail                     | `6`            |
+| `cluster.replicas`                                        | Number of replicas for every master in the cluster                                                         | `1`            |
+| `cluster.externalAccess.enabled`                          | Enable access to the Redis                                                                                 | `false`        |
+| `cluster.externalAccess.hostMode`                         | Set cluster preferred endpoint type as hostname                                                            | `false`        |
+| `cluster.externalAccess.service.type`                     | Type for the services used to expose every Pod                                                             | `LoadBalancer` |
+| `cluster.externalAccess.service.port`                     | Port for the services used to expose every Pod                                                             | `6379`         |
+| `cluster.externalAccess.service.loadBalancerIP`           | Array of load balancer IPs for each Redis&reg; node. Length must be the same as cluster.nodes              | `[]`           |
+| `cluster.externalAccess.service.loadBalancerSourceRanges` | Service Load Balancer sources                                                                              | `[]`           |
+| `cluster.externalAccess.service.annotations`              | Annotations to add to the services used to expose every Pod of the Redis&reg; Cluster                      | `{}`           |
+| `cluster.externalAccess.service.loadBalancerIPAnnotaion`  | Name of annotation to specify fixed IP for service in. Disables `Service.spec.loadBalancerIP` if not empty | `""`           |
+| `cluster.externalAccess.service.disableLoadBalancerIP`    | Disable use of `Service.spec.loadBalancerIP`                                                               | `false`        |
+| `cluster.update.addNodes`                                 | Boolean to specify if you want to add nodes after the upgrade                                              | `false`        |
+| `cluster.update.currentNumberOfNodes`                     | Number of currently deployed Redis&reg; nodes                                                              | `6`            |
+| `cluster.update.currentNumberOfReplicas`                  | Number of currently deployed Redis&reg; replicas                                                           | `1`            |
+| `cluster.update.newExternalIPs`                           | External IPs obtained from the services for the new nodes to add to the cluster                            | `[]`           |
 
 ### Metrics sidecar parameters
 

--- a/bitnami/redis-cluster/README.md
+++ b/bitnami/redis-cluster/README.md
@@ -274,13 +274,13 @@ The command removes all the Kubernetes components associated with the chart and 
 | `cluster.replicas`                                        | Number of replicas for every master in the cluster                                                         | `1`            |
 | `cluster.externalAccess.enabled`                          | Enable access to the Redis                                                                                 | `false`        |
 | `cluster.externalAccess.hostMode`                         | Set cluster preferred endpoint type as hostname                                                            | `false`        |
+| `cluster.externalAccess.service.disableLoadBalancerIP`    | Disable use of `Service.spec.loadBalancerIP`                                                               | `false`        |
+| `cluster.externalAccess.service.loadBalancerIPAnnotaion`  | Name of annotation to specify fixed IP for service in. Disables `Service.spec.loadBalancerIP` if not empty | `""`           |
 | `cluster.externalAccess.service.type`                     | Type for the services used to expose every Pod                                                             | `LoadBalancer` |
 | `cluster.externalAccess.service.port`                     | Port for the services used to expose every Pod                                                             | `6379`         |
 | `cluster.externalAccess.service.loadBalancerIP`           | Array of load balancer IPs for each Redis&reg; node. Length must be the same as cluster.nodes              | `[]`           |
 | `cluster.externalAccess.service.loadBalancerSourceRanges` | Service Load Balancer sources                                                                              | `[]`           |
 | `cluster.externalAccess.service.annotations`              | Annotations to add to the services used to expose every Pod of the Redis&reg; Cluster                      | `{}`           |
-| `cluster.externalAccess.service.loadBalancerIPAnnotaion`  | Name of annotation to specify fixed IP for service in. Disables `Service.spec.loadBalancerIP` if not empty | `""`           |
-| `cluster.externalAccess.service.disableLoadBalancerIP`    | Disable use of `Service.spec.loadBalancerIP`                                                               | `false`        |
 | `cluster.update.addNodes`                                 | Boolean to specify if you want to add nodes after the upgrade                                              | `false`        |
 | `cluster.update.currentNumberOfNodes`                     | Number of currently deployed Redis&reg; nodes                                                              | `6`            |
 | `cluster.update.currentNumberOfReplicas`                  | Number of currently deployed Redis&reg; replicas                                                           | `1`            |

--- a/bitnami/redis-cluster/templates/svc-cluster-external-access.yaml
+++ b/bitnami/redis-cluster/templates/svc-cluster-external-access.yaml
@@ -18,13 +18,32 @@ metadata:
   namespace: {{ $.Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" $root.Values.commonLabels "context" $ ) | nindent 4 }}
     pod: {{ $targetPod }}
-  {{- if or $root.Values.cluster.externalAccess.service.annotations $root.Values.commonAnnotations }}
-  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list $root.Values.cluster.externalAccess.service.annotations $root.Values.commonAnnotations ) "context" $ ) }}
+  {{- if or
+    ($root.Values.cluster.externalAccess.service.annotations)
+    ($root.Values.commonAnnotations)
+    (ne $root.Values.cluster.externalAccess.service.loadBalancerIPAnnotaion "") }}
+  {{- $loadBalancerIPAnnotaion := "" }}
+  {{- if ne $root.Values.cluster.externalAccess.service.loadBalancerIPAnnotaion ""}}
+    {{- $loadBalancerIPAnnotaion = printf
+      "%s: %s"
+      $root.Values.cluster.externalAccess.service.loadBalancerIPAnnotaion
+      (index $root.Values.cluster.externalAccess.service.loadBalancerIP $i) }}
+  {{- end }}
+  {{- $annotations := include "common.tplvalues.merge"
+    ( dict "values"
+      ( list
+        $root.Values.cluster.externalAccess.service.annotations
+        $root.Values.commonAnnotations
+        $loadBalancerIPAnnotaion
+      ) "context" $ ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
   type: {{ $root.Values.cluster.externalAccess.service.type }}
-  {{- if $root.Values.cluster.externalAccess.service.loadBalancerIP }}
+  {{- if and
+    ($root.Values.cluster.externalAccess.service.loadBalancerIP)
+    (eq $root.Values.cluster.externalAccess.service.loadBalancerIPAnnotaion "")
+    (not $root.Values.cluster.externalAccess.service.disableLoadBalancerIP) }}
   loadBalancerIP: {{ index $root.Values.cluster.externalAccess.service.loadBalancerIP $i }}
   {{- end }}
   {{- if and (eq $root.Values.cluster.externalAccess.service.type "LoadBalancer") $root.Values.cluster.externalAccess.service.loadBalancerSourceRanges }}

--- a/bitnami/redis-cluster/values.yaml
+++ b/bitnami/redis-cluster/values.yaml
@@ -787,6 +787,12 @@ cluster:
     ##
     hostMode: false
     service:
+      ## @param cluster.externalAccess.service.disableLoadBalancerIP Disable use of `Service.spec.loadBalancerIP`
+      ##
+      disableLoadBalancerIP: false
+      ## @param cluster.externalAccess.service.loadBalancerIPAnnotaion Name of annotation to specify fixed IP for service in. Disables `Service.spec.loadBalancerIP` if not empty
+      ##
+      loadBalancerIPAnnotaion: ""
       ## @param cluster.externalAccess.service.type Type for the services used to expose every Pod
       ## At this moment only LoadBalancer is supported
       ##


### PR DESCRIPTION
### Description of the change

With theses changes, the user can optionally disable the Service.spec.loadBalancerIP for external access. Alternatively, the user can specify an annotation name with `cluster.externalAccess.service.loadBalancerIPAnnotation` to use service annotations for fixed IPs.
This MR only ist for external access service. The same should be done for metrics-svc and redis-svc. I will file separate issues for that

### Benefits

Provide migration path for the deprecation of `Service.spec.loadBalancerIP`

### Applicable issues

- fixes #19535

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
