### PR TITLE
[bitnami/grafana-tempo] Remove extraDeploy from runtime-parameters (Revert #17019)

### DIFF
--- a/.vib/grafana-tempo/goss/goss.yaml
+++ b/.vib/grafana-tempo/goss/goss.yaml
@@ -36,13 +36,6 @@ command:
     exit-status: 0
     stdout:
       - "vulture"
-  # Due to an upstream issue, 'tempo-cli query api search' test has been temporarily disabled
-  # Ref: https://github.com/grafana/tempo/issues/2913
-  # xk6-client-registered-traces:
-  #   exec: tempo-cli query api search http://grafana-tempo-query-frontend:{{ .Vars.queryFrontend.service.ports.http }}
-  #   exit-status: 0
-  #   stdout:
-  #     - "article-to-cart"
   {{- $uid := .Vars.compactor.containerSecurityContext.runAsUser }}
   {{- $gid := .Vars.compactor.podSecurityContext.fsGroup }}
   check-user-info:

--- a/.vib/grafana-tempo/runtime-parameters.yaml
+++ b/.vib/grafana-tempo/runtime-parameters.yaml
@@ -43,26 +43,3 @@ queryFrontend:
       http: 80
 vulture:
   enabled: true
-extraDeploy:
-- apiVersion: apps/v1
-  kind: Deployment
-  metadata:
-    labels:
-      app: vib-xk6-client-tracing
-    name: vib-xk6-client-tracing
-  spec:
-    replicas: 1
-    selector:
-      matchLabels:
-        app: vib-xk6-client-tracing
-    template:
-      metadata:
-        labels:
-          app: vib-xk6-client-tracing
-      spec:
-        containers:
-        - image: ghcr.io/grafana/xk6-client-tracing:v0.0.2
-          name: xk6-client-tracing
-          env:
-          - name: ENDPOINT
-            value: grafana-tempo-distributor:4317


### PR DESCRIPTION
### Description of the change

Removes the section of the runtime-parameters and tests that depend on third-party image.

### Applicable issues

- reverts #17019

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
