### PR TITLE
[bitnami/prometheus] Adapt runtime-params for non-GKE testing

### DIFF
--- a/.vib/prometheus/runtime-parameters.yaml
+++ b/.vib/prometheus/runtime-parameters.yaml
@@ -1,5 +1,3 @@
-volumePermissions:
-  enabled: true
 server:
   replicaCount: 1
   serviceAccount:
@@ -26,6 +24,7 @@ server:
     type: LoadBalancer
     ports:
       http: 80
+    sessionAffinity: None
   enableFeatures: [ "memory-snapshot-on-shutdown" ]
   containerPorts:
     http: 8080


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

- Removes `volumePermissions.enabled=true` from the testing params as it isn't checked by any test and generated incompatibilities with OpenShift
- Uses `server.service.sessionAffinity=None` as `ClientIP` is not compatible con AWS clusters. Moreover, this config is not relevant in the current testing env.

### Benefits

Testing params support AWS clusters

### Possible drawbacks

None

### Applicable issues

N/A

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
