### PR TITLE
[bitnami/mongodb-sharded] Bump major version not bumped at #19575

### DIFF
--- a/bitnami/mongodb-sharded/Chart.yaml
+++ b/bitnami/mongodb-sharded/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: mongodb-sharded
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/mongodb-sharded
-version: 6.6.8
+version: 7.0.0

--- a/bitnami/mongodb-sharded/README.md
+++ b/bitnami/mongodb-sharded/README.md
@@ -638,7 +638,7 @@ helm upgrade my-release oci://registry-1.docker.io/bitnamicharts/mongodb-sharded
 
 ### To 7.0.0
 
-This major version updates the MongoDB container image version used from 6.0 to 7.0, the new stable version. There are no major changes in the chart, but we recommend checking the [MongoDB 7.0 release notes](https://www.mongodb.com/docs/manual/release-notes/7.0/) before upgrading.
+This major version updates the MongoDB&reg; container image version used from 6.0 to 7.0, the new stable version. There are no major changes in the chart, but we recommend checking the [MongoDB&reg; 7.0 release notes](https://www.mongodb.com/docs/manual/release-notes/7.0/) before upgrading.
 
 > Note: Due to an error in our release process, the latest version in the previous major branch (6.6.8) already uses 7.0 by default, see [PR#19575](https://github.com/bitnami/charts/pull/19575)
 

--- a/bitnami/mongodb-sharded/README.md
+++ b/bitnami/mongodb-sharded/README.md
@@ -636,6 +636,12 @@ helm upgrade my-release oci://registry-1.docker.io/bitnamicharts/mongodb-sharded
 
 > Note: you need to substitute the placeholders [PASSWORD] and [auth.replicaSetKey] with the values obtained in the installation notes.
 
+### To 7.0.0
+
+This major version updates the MongoDB container image version used from 6.0 to 7.0, the new stable version. There are no major changes in the chart, but we recommend checking the [MongoDB 7.0 release notes](https://www.mongodb.com/docs/manual/release-notes/7.0/) before upgrading.
+
+> Note: Due to an error in our release process, the latest version in the previous major branch (6.6.8) already uses 7.0 by default, see [PR#19575](https://github.com/bitnami/charts/pull/19575)
+
 ### To 5.0.0
 
 This major release renames several values in this chart and adds missing features, in order to be inline with the rest of assets in the Bitnami charts repository.


### PR DESCRIPTION
This PR bumps the chart version in a major since the application has a new major version (6.x.x -> 7.x.x). The major version bump should have been done at https://github.com/bitnami/charts/pull/19575 but it was released as a patch version by mistake