### PR TITLE
[bitnami/appsmith] Create options for local git repo data on persistent storage

### DIFF
--- a/bitnami/appsmith/Chart.yaml
+++ b/bitnami/appsmith/Chart.yaml
@@ -37,4 +37,4 @@ maintainers:
 name: appsmith
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/appsmith
-version: 2.0.2
+version: 2.0.3

--- a/bitnami/appsmith/README.md
+++ b/bitnami/appsmith/README.md
@@ -269,18 +269,19 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Backend Persistence Parameters
 
-| Name                                | Description                                                                                             | Value               |
-| ----------------------------------- | ------------------------------------------------------------------------------------------------------- | ------------------- |
-| `backend.persistence.enabled`       | Enable persistence using Persistent Volume Claims                                                       | `true`              |
-| `backend.persistence.mountPath`     | Path to mount the volume at.                                                                            | `/bitnami/appsmith` |
-| `backend.persistence.subPath`       | The subdirectory of the volume to mount to, useful in dev environments and one PV for multiple services | `""`                |
-| `backend.persistence.storageClass`  | Storage class of backing PVC                                                                            | `""`                |
-| `backend.persistence.annotations`   | Persistent Volume Claim annotations                                                                     | `{}`                |
-| `backend.persistence.accessModes`   | Persistent Volume Access Modes                                                                          | `["ReadWriteOnce"]` |
-| `backend.persistence.size`          | Size of data volume                                                                                     | `8Gi`               |
-| `backend.persistence.existingClaim` | The name of an existing PVC to use for persistence                                                      | `""`                |
-| `backend.persistence.selector`      | Selector to match an existing Persistent Volume for WordPress data PVC                                  | `{}`                |
-| `backend.persistence.dataSource`    | Custom PVC data source                                                                                  | `{}`                |
+| Name                                | Description                                                                                                        | Value               |
+| ----------------------------------- | ------------------------------------------------------------------------------------------------------------------ | ------------------- |
+| `backend.persistence.enabled`       | Enable persistence using Persistent Volume Claims                                                                  | `true`              |
+| `backend.persistence.mountPath`     | Path to mount the volume at.                                                                                       | `/bitnami/appsmith` |
+| `backend.persistence.subPath`       | The subdirectory of the volume to mount to, useful in dev environments and one PV for multiple services            | `""`                |
+| `backend.persistence.gitDataPath`   | The subdirectory in `/mountPath` or `/mountPath/subPath` where git connected apps will store their local git data. | `""`                |
+| `backend.persistence.storageClass`  | Storage class of backing PVC                                                                                       | `""`                |
+| `backend.persistence.annotations`   | Persistent Volume Claim annotations                                                                                | `{}`                |
+| `backend.persistence.accessModes`   | Persistent Volume Access Modes                                                                                     | `["ReadWriteOnce"]` |
+| `backend.persistence.size`          | Size of data volume                                                                                                | `8Gi`               |
+| `backend.persistence.existingClaim` | The name of an existing PVC to use for persistence                                                                 | `""`                |
+| `backend.persistence.selector`      | Selector to match an existing Persistent Volume for WordPress data PVC                                             | `{}`                |
+| `backend.persistence.dataSource`    | Custom PVC data source                                                                                             | `{}`                |
 
 ### Appsmith RTS Parameters
 

--- a/bitnami/appsmith/templates/_helpers.tpl
+++ b/bitnami/appsmith/templates/_helpers.tpl
@@ -95,6 +95,19 @@ Create the name of the service account to use
 {{- end -}}
 
 {{/*
+Set the subdirectory for git connected apps to store their local repo
+*/}}
+{{- define "appsmith.gitDataPath" -}}
+{{- if and .Values.backend.persistence.enabled .Values.backend.persistence.gitDataPath -}}
+    {{- if .Values.backend.persistence.subPath -}}
+        {{- printf "%s/%s/%s" .Values.backend.persistence.mountPath .Values.backend.persistence.subPath .Values.backend.persistence.gitDataPath }}
+    {{- else -}}
+        {{- printf "%s/%s" .Values.backend.persistence.mountPath .Values.backend.persistence.gitDataPath }}
+    {{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Return Redis(TM) fullname
 */}}
 {{- define "appsmith.redis.fullname" -}}

--- a/bitnami/appsmith/templates/backend/deployment.yaml
+++ b/bitnami/appsmith/templates/backend/deployment.yaml
@@ -156,6 +156,10 @@ spec:
                   key: {{ include "appsmith.redis.secretKey" . }}
             - name: APPSMITH_RTS_PORT
               value: {{ .Values.rts.containerPorts.http | quote }}
+            {{- if .Values.backend.persistence.gitDataPath }}
+            - name: APPSMITH_GIT_ROOT
+              value: {{ include "appsmith.gitDataPath" . }}
+            {{- end }}
             {{- if .Values.backend.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.backend.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}

--- a/bitnami/appsmith/values.yaml
+++ b/bitnami/appsmith/values.yaml
@@ -787,6 +787,9 @@ backend:
     ## @param backend.persistence.subPath The subdirectory of the volume to mount to, useful in dev environments and one PV for multiple services
     ##
     subPath: ""
+    ## @param backend.persistence.gitDataPath The subdirectory in `/mountPath` or `/mountPath/subPath` where git connected apps will store their local git data.
+    ##
+    gitDataPath: ""
     ## @param backend.persistence.storageClass Storage class of backing PVC
     ## If defined, storageClassName: <storageClass>
     ## If set to "-", storageClassName: "", which disables dynamic provisioning


### PR DESCRIPTION
### Description of the change

Currently on an install with default values, when storage persistence is set for the backend deployment apps try to save the local git repo under /data which does not exist.  This change will add functionality to set the APPSMITH_GIT_ROOT environment variable for the backend deployment in a way that does not disrupt current deployments.  This environment variable sets the destination of the local git repository data when the app is connected to a git repository.

### Benefits

This makes it a bit more obvious that this "gotcha" exists and offers a way to get this set "automagically" without disrupting current installs.

### Possible drawbacks

Since the default value for this is empty, folks will probably not set this until they run into the snag in their current deployment.  I just can't think of a good way to easily do this that doesn't muck up current installs.

### Applicable issues

- fixes #19258 

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
