### PR TITLE
[bitnami/charts] Increase initialDelaySeconds for testing environments

### DIFF
--- a/.vib/matomo/runtime-parameters.yaml
+++ b/.vib/matomo/runtime-parameters.yaml
@@ -6,3 +6,5 @@ service:
   type: LoadBalancer
   ports:
     http: 80
+readinessProbe:
+  initialDelaySeconds: 90


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Increase `initialDelaySeconds` for testing.

### Benefits

In my local environment, first Matomo intialization takes around 20 seconds after waiting for the database, taking in total around 50 seconds. During the initialization process (20 seconds), the path `/matomo.php` is ready and returning 200 codes, so the container is exposed in the service but it's not fully operative and current cypress tests can fail sporadically. This problem is even worse if the tests are preformed in small platforms.

### Possible drawbacks

N/A

### Additional information

At the moment Matomo doesn't provide a better way to check if the [service is ready](https://matomo.org/faq/how-to/faq_20278/) or not. Even if we try to reach `/index.php` and the application is not fully initialized, the application will return a 200 status code.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
