### PR TITLE
[bitnami/fluentd] Use common capabilities for PSP

### DIFF
--- a/bitnami/fluentd/Chart.lock
+++ b/bitnami/fluentd/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.10.0
-digest: sha256:023ded170632d04528f30332370f34fc8fb96efb2886a01d934cb3bd6e6d2e09
-generated: "2023-09-05T11:32:25.367564+02:00"
+  version: 2.13.0
+digest: sha256:6b6084c51b6a028a651f6e8539d0197487ee807c5bae44867d4ea6ccd1f9ae93
+generated: "2023-09-29T11:00:01.045916+02:00"

--- a/bitnami/fluentd/Chart.yaml
+++ b/bitnami/fluentd/Chart.yaml
@@ -30,4 +30,4 @@ maintainers:
 name: fluentd
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/fluentd
-version: 5.9.3
+version: 5.9.4

--- a/bitnami/fluentd/templates/forwarder-clusterrole.yaml
+++ b/bitnami/fluentd/templates/forwarder-clusterrole.yaml
@@ -22,8 +22,7 @@ rules:
       - "get"
       - "watch"
       - "list"
-  {{- $pspAvailable := (semverCompare "<1.25-0" (include "common.capabilities.kubeVersion" .)) -}}
-  {{- if and $pspAvailable .Values.forwarder.rbac.pspEnabled }}
+  {{- if and (include "common.capabilities.psp.supported" .) .Values.forwarder.rbac.pspEnabled }}
   - apiGroups:
       - "policy"
     resources:

--- a/bitnami/fluentd/templates/forwarder-psp.yaml
+++ b/bitnami/fluentd/templates/forwarder-psp.yaml
@@ -3,8 +3,7 @@ Copyright VMware, Inc.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- $pspAvailable := (semverCompare "<1.25-0" (include "common.capabilities.kubeVersion" .)) -}}
-{{- if and $pspAvailable .Values.forwarder.enabled .Values.forwarder.rbac.create .Values.forwarder.rbac.pspEnabled }}
+{{- if and (include "common.capabilities.psp.supported" .) .Values.forwarder.enabled .Values.forwarder.rbac.create .Values.forwarder.rbac.pspEnabled }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:


### PR DESCRIPTION
### Description of the change

This PR follows up https://github.com/bitnami/charts/pull/19428 adopting the new "common.capabilities.psp.supported" helper to decided whether PodSecurityPolicy is supported or not.

### Benefits

Standardization

### Possible drawbacks

None

### Applicable issues

N/A

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
