### PR TITLE
[bitnami/influxdb] Use common capabilities for PSP

### DIFF
--- a/bitnami/influxdb/Chart.lock
+++ b/bitnami/influxdb/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.10.0
-digest: sha256:023ded170632d04528f30332370f34fc8fb96efb2886a01d934cb3bd6e6d2e09
-generated: "2023-09-06T21:50:29.857137178Z"
+  version: 2.13.0
+digest: sha256:6b6084c51b6a028a651f6e8539d0197487ee807c5bae44867d4ea6ccd1f9ae93
+generated: "2023-09-29T10:57:21.706211+02:00"

--- a/bitnami/influxdb/Chart.yaml
+++ b/bitnami/influxdb/Chart.yaml
@@ -37,4 +37,4 @@ maintainers:
 name: influxdb
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/influxdb
-version: 5.9.3
+version: 5.9.4

--- a/bitnami/influxdb/templates/psp-role.yaml
+++ b/bitnami/influxdb/templates/psp-role.yaml
@@ -3,7 +3,7 @@ Copyright VMware, Inc.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- if .Values.rbac.create }}
+{{- if and (include "common.capabilities.psp.supported" .) .Values.rbac.create .Values.psp.create }}
 kind: Role
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 metadata:
@@ -14,12 +14,9 @@ metadata:
   {{- end }}
   namespace: {{ .Release.Namespace | quote }}
 rules:
-  {{- $pspAvailable := (semverCompare "<1.25-0" (include "common.capabilities.kubeVersion" .)) -}}
-  {{- if and $pspAvailable .Values.psp.create }}
   - apiGroups: ["extensions"]
     resources: ["podsecuritypolicies"]
     verbs: ["use"]
     resourceNames:
       - {{ template "common.names.fullname" . }}
-  {{- end }}
 {{- end }}

--- a/bitnami/influxdb/templates/psp-rolebinding.yaml
+++ b/bitnami/influxdb/templates/psp-rolebinding.yaml
@@ -3,7 +3,7 @@ Copyright VMware, Inc.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- if .Values.rbac.create }}
+{{- if and (include "common.capabilities.psp.supported" .) .Values.rbac.create .Values.psp.create }}
 kind: RoleBinding
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 metadata:

--- a/bitnami/influxdb/templates/psp.yaml
+++ b/bitnami/influxdb/templates/psp.yaml
@@ -3,8 +3,7 @@ Copyright VMware, Inc.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- $pspAvailable := (semverCompare "<1.25-0" (include "common.capabilities.kubeVersion" .)) -}}
-{{- if and $pspAvailable .Values.psp.create }}
+{{- if and (include "common.capabilities.psp.supported" .) .Values.psp.create }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:


### PR DESCRIPTION
### Description of the change

This PR follows up https://github.com/bitnami/charts/pull/19428 adopting the new "common.capabilities.psp.supported" helper to decided whether PodSecurityPolicy is supported or not.

### Benefits

Standardization

### Possible drawbacks

None

### Applicable issues

N/A

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
