### PR TITLE
[bitnami/kiam] Use common capabilities for PSP

### DIFF
--- a/bitnami/kiam/Chart.lock
+++ b/bitnami/kiam/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.11.1
-digest: sha256:ead8f26c76a9ec082f23629a358e8efd8f88d87aaed734bf41febcb8a7bc5d4c
-generated: "2023-09-20T18:45:04.851916321Z"
+  version: 2.13.0
+digest: sha256:6b6084c51b6a028a651f6e8539d0197487ee807c5bae44867d4ea6ccd1f9ae93
+generated: "2023-09-29T11:00:37.932969+02:00"

--- a/bitnami/kiam/Chart.yaml
+++ b/bitnami/kiam/Chart.yaml
@@ -28,4 +28,4 @@ maintainers:
 name: kiam
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/kiam
-version: 1.4.2
+version: 1.4.3

--- a/bitnami/kiam/templates/agent/agent-psp-clusterrole.yaml
+++ b/bitnami/kiam/templates/agent/agent-psp-clusterrole.yaml
@@ -3,8 +3,7 @@ Copyright VMware, Inc.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- $pspAvailable := (semverCompare "<1.25-0" (include "common.capabilities.kubeVersion" .)) -}}
-{{- if and $pspAvailable .Values.agent.enabled .Values.agent.podSecurityPolicy.create .Values.rbac.create }}
+{{- if and (include "common.capabilities.psp.supported" .) .Values.agent.enabled .Values.agent.podSecurityPolicy.create .Values.rbac.create }}
 kind: ClusterRole
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 metadata:

--- a/bitnami/kiam/templates/agent/agent-psp-clusterrolebinding.yaml
+++ b/bitnami/kiam/templates/agent/agent-psp-clusterrolebinding.yaml
@@ -3,8 +3,7 @@ Copyright VMware, Inc.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- $pspAvailable := (semverCompare "<1.25-0" (include "common.capabilities.kubeVersion" .)) -}}
-{{- if and $pspAvailable .Values.agent.enabled .Values.agent.podSecurityPolicy.create .Values.rbac.create }}
+{{- if and (include "common.capabilities.psp.supported" .) .Values.agent.enabled .Values.agent.podSecurityPolicy.create .Values.rbac.create }}
 kind: ClusterRoleBinding
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 metadata:

--- a/bitnami/kiam/templates/agent/agent-psp.yaml
+++ b/bitnami/kiam/templates/agent/agent-psp.yaml
@@ -3,8 +3,7 @@ Copyright VMware, Inc.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- $pspAvailable := (semverCompare "<1.25-0" (include "common.capabilities.kubeVersion" .)) -}}
-{{- if and $pspAvailable .Values.agent.enabled .Values.agent.podSecurityPolicy.create }}
+{{- if and (include "common.capabilities.psp.supported" .) .Values.agent.enabled .Values.agent.podSecurityPolicy.create }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:

--- a/bitnami/kiam/templates/server/server-psp-clusterrole.yaml
+++ b/bitnami/kiam/templates/server/server-psp-clusterrole.yaml
@@ -3,8 +3,7 @@ Copyright VMware, Inc.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- $pspAvailable := (semverCompare "<1.25-0" (include "common.capabilities.kubeVersion" .)) -}}
-{{- if and $pspAvailable .Values.server.enabled .Values.server.podSecurityPolicy.create .Values.rbac.create }}
+{{- if and (include "common.capabilities.psp.supported" .) .Values.server.enabled .Values.server.podSecurityPolicy.create .Values.rbac.create }}
 kind: ClusterRole
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 metadata:

--- a/bitnami/kiam/templates/server/server-psp-clusterrolebinding.yaml
+++ b/bitnami/kiam/templates/server/server-psp-clusterrolebinding.yaml
@@ -3,8 +3,7 @@ Copyright VMware, Inc.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- $pspAvailable := (semverCompare "<1.25-0" (include "common.capabilities.kubeVersion" .)) -}}
-{{- if and $pspAvailable .Values.server.enabled .Values.server.podSecurityPolicy.create .Values.rbac.create }}
+{{- if and (include "common.capabilities.psp.supported" .) .Values.server.enabled .Values.server.podSecurityPolicy.create .Values.rbac.create }}
 kind: ClusterRoleBinding
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 metadata:

--- a/bitnami/kiam/templates/server/server-psp.yaml
+++ b/bitnami/kiam/templates/server/server-psp.yaml
@@ -3,8 +3,7 @@ Copyright VMware, Inc.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- $pspAvailable := (semverCompare "<1.25-0" (include "common.capabilities.kubeVersion" .)) -}}
-{{- if and $pspAvailable .Values.server.enabled .Values.server.podSecurityPolicy.create }}
+{{- if and (include "common.capabilities.psp.supported" .) .Values.server.enabled .Values.server.podSecurityPolicy.create }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:


### PR DESCRIPTION
### Description of the change

This PR follows up https://github.com/bitnami/charts/pull/19428 adopting the new "common.capabilities.psp.supported" helper to decided whether PodSecurityPolicy is supported or not.

### Benefits

Standardization

### Possible drawbacks

None

### Applicable issues

N/A

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
