### PR TITLE
[bitnami/metallb] Use common capabilities for PSP

### DIFF
--- a/bitnami/metallb/Chart.lock
+++ b/bitnami/metallb/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.11.1
-digest: sha256:ead8f26c76a9ec082f23629a358e8efd8f88d87aaed734bf41febcb8a7bc5d4c
-generated: "2023-09-18T14:42:34.646382+02:00"
+  version: 2.13.0
+digest: sha256:6b6084c51b6a028a651f6e8539d0197487ee807c5bae44867d4ea6ccd1f9ae93
+generated: "2023-09-29T11:02:24.606057+02:00"

--- a/bitnami/metallb/Chart.yaml
+++ b/bitnami/metallb/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: metallb
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/metallb
-version: 4.7.3
+version: 4.7.4

--- a/bitnami/metallb/templates/controller/psp.yaml
+++ b/bitnami/metallb/templates/controller/psp.yaml
@@ -3,8 +3,7 @@ Copyright VMware, Inc.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- $pspAvailable := (semverCompare "<1.25-0" (include "common.capabilities.kubeVersion" .)) -}}
-{{- if and $pspAvailable .Values.psp.create .Values.controller.psp.create -}}
+{{- if and (include "common.capabilities.psp.supported" .) .Values.psp.create .Values.controller.psp.create -}}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:

--- a/bitnami/metallb/templates/controller/rbac.yaml
+++ b/bitnami/metallb/templates/controller/rbac.yaml
@@ -51,6 +51,7 @@ rules:
       - list
       - watch
       - get
+  {{- if and (include "common.capabilities.psp.supported" .) .Values.psp.create .Values.controller.psp.create -}}
   - apiGroups:
       - policy
     resourceNames:
@@ -59,6 +60,7 @@ rules:
       - podsecuritypolicies
     verbs:
       - use
+  {{- end }}
   - apiGroups:
       - admissionregistration.k8s.io
     resources:

--- a/bitnami/metallb/templates/speaker/psp.yaml
+++ b/bitnami/metallb/templates/speaker/psp.yaml
@@ -4,8 +4,7 @@ SPDX-License-Identifier: APACHE-2.0
 */}}
 
 {{- if .Values.speaker.enabled }}
-{{- $pspAvailable := (semverCompare "<1.25-0" (include "common.capabilities.kubeVersion" .)) -}}
-{{- if and $pspAvailable .Values.psp.create .Values.speaker.psp.create -}}
+{{- if and (include "common.capabilities.psp.supported" .) .Values.psp.create .Values.speaker.psp.create -}}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:

--- a/bitnami/metallb/templates/speaker/rbac.yaml
+++ b/bitnami/metallb/templates/speaker/rbac.yaml
@@ -34,6 +34,7 @@ rules:
     verbs:
       - create
       - patch
+  {{- if and (include "common.capabilities.psp.supported" .) .Values.psp.create .Values.speaker.psp.create -}}
   - apiGroups:
       - policy
     resourceNames:
@@ -42,6 +43,7 @@ rules:
       - podsecuritypolicies
     verbs:
       - use
+  {{- end }}
   - apiGroups:
       - discovery.k8s.io
     resources:


### PR DESCRIPTION
### Description of the change

This PR follows up https://github.com/bitnami/charts/pull/19428 adopting the new "common.capabilities.psp.supported" helper to decided whether PodSecurityPolicy is supported or not.

### Benefits

Standardization

### Possible drawbacks

None

### Applicable issues

N/A

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
