### PR TITLE
[bitnami/mongodb] Use common capabilities for PSP

### DIFF
--- a/bitnami/mongodb/Chart.lock
+++ b/bitnami/mongodb/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.12.0
-digest: sha256:bee62139700f032539621dd38fa1d7285f277b91577c55ea26045254d33825ed
-generated: "2023-09-22T13:42:21.235465219Z"
+  version: 2.13.0
+digest: sha256:6b6084c51b6a028a651f6e8539d0197487ee807c5bae44867d4ea6ccd1f9ae93
+generated: "2023-09-29T11:02:58.010461+02:00"

--- a/bitnami/mongodb/Chart.yaml
+++ b/bitnami/mongodb/Chart.yaml
@@ -39,4 +39,4 @@ maintainers:
 name: mongodb
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/mongodb
-version: 14.0.2
+version: 14.0.3

--- a/bitnami/mongodb/templates/psp.yaml
+++ b/bitnami/mongodb/templates/psp.yaml
@@ -3,8 +3,7 @@ Copyright VMware, Inc.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- $pspAvailable := (semverCompare "<1.25-0" (include "common.capabilities.kubeVersion" .)) -}}
-{{- if and $pspAvailable .Values.podSecurityPolicy.create }}
+{{- if and (include "common.capabilities.psp.supported" .) .Values.podSecurityPolicy.create }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:

--- a/bitnami/mongodb/templates/role.yaml
+++ b/bitnami/mongodb/templates/role.yaml
@@ -22,8 +22,7 @@ rules:
 {{- if .Values.rbac.rules }}
 {{- include "common.tplvalues.render" ( dict "value" .Values.rbac.rules "context" $ ) | nindent 2 }}
 {{- end -}}
-{{- $pspAvailable := (semverCompare "<1.25-0" (include "common.capabilities.kubeVersion" .)) -}}
-{{- if and $pspAvailable .Values.podSecurityPolicy.create }}
+{{- if and (include "common.capabilities.psp.supported" .) .Values.podSecurityPolicy.create }}
   - apiGroups: ['{{ template "podSecurityPolicy.apiGroup" . }}']
     resources: ['podsecuritypolicies']
     verbs: ['use']


### PR DESCRIPTION
### Description of the change

This PR follows up https://github.com/bitnami/charts/pull/19428 adopting the new "common.capabilities.psp.supported" helper to decided whether PodSecurityPolicy is supported or not.

### Benefits

Standardization

### Possible drawbacks

None

### Applicable issues

N/A

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
