### PR TITLE
[bitnami/postgresql] Use common capabilities for PSP

### DIFF
--- a/bitnami/postgresql/Chart.lock
+++ b/bitnami/postgresql/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.12.0
-digest: sha256:bee62139700f032539621dd38fa1d7285f277b91577c55ea26045254d33825ed
-generated: "2023-09-22T17:01:50.438576915Z"
+  version: 2.13.0
+digest: sha256:6b6084c51b6a028a651f6e8539d0197487ee807c5bae44867d4ea6ccd1f9ae93
+generated: "2023-09-29T11:05:05.28309+02:00"

--- a/bitnami/postgresql/Chart.yaml
+++ b/bitnami/postgresql/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: postgresql
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/postgresql
-version: 13.0.0
+version: 13.0.1

--- a/bitnami/postgresql/templates/psp.yaml
+++ b/bitnami/postgresql/templates/psp.yaml
@@ -3,8 +3,7 @@ Copyright VMware, Inc.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- $pspAvailable := (semverCompare "<1.25-0" (include "common.capabilities.kubeVersion" .)) -}}
-{{- if and $pspAvailable .Values.psp.create }}
+{{- if and (include "common.capabilities.psp.supported" .) .Values.psp.create }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:

--- a/bitnami/postgresql/templates/role.yaml
+++ b/bitnami/postgresql/templates/role.yaml
@@ -15,8 +15,7 @@ metadata:
   {{- end }}
 # yamllint disable rule:indentation
 rules:
-  {{- $pspAvailable := (semverCompare "<1.25-0" (include "common.capabilities.kubeVersion" .)) -}}
-  {{- if and $pspAvailable .Values.psp.create }}
+  {{- if and (include "common.capabilities.psp.supported" .) .Values.psp.create }}
   - apiGroups:
       - 'policy'
     resources:


### PR DESCRIPTION
### Description of the change

This PR follows up https://github.com/bitnami/charts/pull/19428 adopting the new "common.capabilities.psp.supported" helper to decided whether PodSecurityPolicy is supported or not.

### Benefits

Standardization

### Possible drawbacks

None

### Applicable issues

N/A

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
