### PR TITLE
[bitnami/redis-cluster] Use common capabilities for PSP

### DIFF
--- a/bitnami/redis-cluster/Chart.lock
+++ b/bitnami/redis-cluster/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.10.0
-digest: sha256:023ded170632d04528f30332370f34fc8fb96efb2886a01d934cb3bd6e6d2e09
-generated: "2023-09-07T00:17:57.260504224Z"
+  version: 2.13.0
+digest: sha256:6b6084c51b6a028a651f6e8539d0197487ee807c5bae44867d4ea6ccd1f9ae93
+generated: "2023-09-29T11:05:39.24661+02:00"

--- a/bitnami/redis-cluster/Chart.yaml
+++ b/bitnami/redis-cluster/Chart.yaml
@@ -32,4 +32,4 @@ maintainers:
 name: redis-cluster
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/redis-cluster
-version: 9.0.6
+version: 9.0.7

--- a/bitnami/redis-cluster/templates/psp.yaml
+++ b/bitnami/redis-cluster/templates/psp.yaml
@@ -3,8 +3,7 @@ Copyright VMware, Inc.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- $pspAvailable := (semverCompare "<1.25-0" (include "common.capabilities.kubeVersion" .)) -}}
-{{- if and $pspAvailable .Values.podSecurityPolicy.create }}
+{{- if and (include "common.capabilities.psp.supported" .) .Values.podSecurityPolicy.create }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:

--- a/bitnami/redis-cluster/templates/redis-role.yaml
+++ b/bitnami/redis-cluster/templates/redis-role.yaml
@@ -14,8 +14,7 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 rules:
-  {{- $pspAvailable := (semverCompare "<1.25-0" (include "common.capabilities.kubeVersion" .)) -}}
-  {{- if and $pspAvailable .Values.podSecurityPolicy.create }}
+  {{- if and (include "common.capabilities.psp.supported" .) .Values.podSecurityPolicy.create }}
   - apiGroups: ['{{ template "podSecurityPolicy.apiGroup" . }}']
     resources: ['podsecuritypolicies']
     verbs: ['use']


### PR DESCRIPTION
### Description of the change

This PR follows up https://github.com/bitnami/charts/pull/19428 adopting the new "common.capabilities.psp.supported" helper to decided whether PodSecurityPolicy is supported or not.

### Benefits

Standardization

### Possible drawbacks

None

### Applicable issues

N/A

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
