### PR TITLE
[bitnami/appsmith] Bump Chart.yaml version

### DIFF
--- a/bitnami/appsmith/Chart.yaml
+++ b/bitnami/appsmith/Chart.yaml
@@ -37,4 +37,4 @@ maintainers:
 name: appsmith
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/appsmith
-version: 2.0.1
+version: 2.0.2


### PR DESCRIPTION
### Description of the change

Adds missing Chart version bump in https://github.com/bitnami/charts/pull/19476

### Benefits

The chart is published

### Possible drawbacks

None

### Applicable issues

- NA

### Additional information

NA

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
