### PR TITLE
[bitnami/flink] Fix pullSecrets and extraVolumeMounts

### DIFF
--- a/bitnami/flink/Chart.yaml
+++ b/bitnami/flink/Chart.yaml
@@ -28,4 +28,4 @@ maintainers:
 name: flink
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/flink
-version: 0.4.2
+version: 0.4.3

--- a/bitnami/flink/templates/_helpers.tpl
+++ b/bitnami/flink/templates/_helpers.tpl
@@ -13,6 +13,13 @@ Return the proper flink image name
 {{- end -}}
 
 {{/*
+Return the proper flink image name
+*/}}
+{{- define "flink.imagePullSecrets" -}}
+{{- include "common.images.pullSecrets" (dict "images" (dict "images" (list .Values.image) "global" .Values.global) -}}
+{{- end -}}
+
+{{/*
 Create the name of the jobmanager deployment
 */}}
 {{- define "flink.jobmanager.fullname" -}}

--- a/bitnami/flink/templates/_helpers.tpl
+++ b/bitnami/flink/templates/_helpers.tpl
@@ -16,7 +16,7 @@ Return the proper flink image name
 Return the proper Docker Image Registry Secret Names
 */}}
 {{- define "flink.imagePullSecrets" -}}
-{{- include "common.images.pullSecrets" (dict "images" (dict "images" (list .Values.image) "global" .Values.global) -}}
+{{- include "common.images.pullSecrets" (dict "images" (list .Values.image) "global" .Values.global) -}}
 {{- end -}}
 
 {{/*

--- a/bitnami/flink/templates/_helpers.tpl
+++ b/bitnami/flink/templates/_helpers.tpl
@@ -13,7 +13,7 @@ Return the proper flink image name
 {{- end -}}
 
 {{/*
-Return the proper flink image name
+Return the proper Docker Image Registry Secret Names
 */}}
 {{- define "flink.imagePullSecrets" -}}
 {{- include "common.images.pullSecrets" (dict "images" (dict "images" (list .Values.image) "global" .Values.global) -}}

--- a/bitnami/flink/templates/jobmanager/deployment.yaml
+++ b/bitnami/flink/templates/jobmanager/deployment.yaml
@@ -34,6 +34,7 @@ spec:
       annotations: {{- include "common.tplvalues.render" (dict "value" $podAnnotations "context" $) | nindent 8 }}
       {{- end }}
     spec:
+      {{- include "flink.imagePullSecrets" . | nindent 6 }}
       {{- if .Values.jobmanager.schedulerName }}
       schedulerName: {{ .Values.jobmanager.schedulerName }}
       {{- end }}
@@ -149,7 +150,7 @@ spec:
           resources: {{- toYaml .Values.jobmanager.resources | nindent 12 }}
           {{- end }}
           {{- if .Values.jobmanager.extraVolumeMounts }}
-            {{- include "common.tplvalues.render" ( dict "value" .Values.jobmanager.extraVolumeMounts "context" $) | nindent 12 }}
+          volumeMounts: {{- include "common.tplvalues.render" ( dict "value" .Values.jobmanager.extraVolumeMounts "context" $) | nindent 12 }}
           {{- end }}
         {{- if .Values.jobmanager.sidecars }}
         {{- include "common.tplvalues.render" ( dict "value" .Values.jobmanager.sidecars "context" $) | nindent 8 }}

--- a/bitnami/flink/templates/taskmanager/deployment.yaml
+++ b/bitnami/flink/templates/taskmanager/deployment.yaml
@@ -34,6 +34,7 @@ spec:
       annotations: {{- include "common.tplvalues.render" (dict "value" $podAnnotations "context" $) | nindent 8 }}
       {{- end }}
     spec:
+      {{- include "flink.imagePullSecrets" . | nindent 6 }}
       {{- if .Values.taskmanager.schedulerName }}
       schedulerName: {{ .Values.taskmanager.schedulerName }}
       {{- end }}
@@ -144,7 +145,7 @@ spec:
           resources: {{- toYaml .Values.taskmanager.resources | nindent 12 }}
           {{- end }}
           {{- if .Values.taskmanager.extraVolumeMounts }}
-            {{- include "common.tplvalues.render" ( dict "value" .Values.taskmanager.extraVolumeMounts "context" $) | nindent 12 }}
+          volumeMounts: {{- include "common.tplvalues.render" ( dict "value" .Values.taskmanager.extraVolumeMounts "context" $) | nindent 12 }}
           {{- end }}
         {{- if .Values.taskmanager.sidecars }}
         {{- include "common.tplvalues.render" ( dict "value" .Values.taskmanager.sidecars "context" $) | nindent 8 }}


### PR DESCRIPTION
### Description of the change

As reported in #19302, the chart was unable to pull images from private registries and/or use extra volumes. This PR addresses theses issues.

### Benefits

Both image pull secrets and extra volume features can be used, as originally intended.

### Possible drawbacks

None

### Applicable issues

- fixes #19302

### Additional information

None

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
