### PR TITLE
[bitnami/opensearch] Modify liveness probes

### DIFF
--- a/bitnami/opensearch/Chart.yaml
+++ b/bitnami/opensearch/Chart.yaml
@@ -30,4 +30,4 @@ maintainers:
 name: opensearch
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/opensearch
-version: 0.2.3
+version: 0.3.0

--- a/bitnami/opensearch/templates/coordinating/statefulset.yaml
+++ b/bitnami/opensearch/templates/coordinating/statefulset.yaml
@@ -196,9 +196,8 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.coordinating.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.coordinating.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.coordinating.livenessProbe "enabled") "context" $) | nindent 12 }}
-            exec:
-              command:
-                - /opt/bitnami/scripts/opensearch/healthcheck.sh
+            tcpSocket:
+              port: rest-api
           {{- end }}
           {{- if .Values.coordinating.customReadinessProbe }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.coordinating.customReadinessProbe "context" $) | nindent 12 }}

--- a/bitnami/opensearch/templates/data/statefulset.yaml
+++ b/bitnami/opensearch/templates/data/statefulset.yaml
@@ -221,9 +221,8 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.data.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.data.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.data.livenessProbe "enabled") "context" $) | nindent 12 }}
-            exec:
-              command:
-                - /opt/bitnami/scripts/opensearch/healthcheck.sh
+            tcpSocket:
+              port: rest-api
           {{- end }}
           {{- if .Values.data.customReadinessProbe }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.data.customReadinessProbe "context" $) | nindent 12 }}

--- a/bitnami/opensearch/templates/ingest/statefulset.yaml
+++ b/bitnami/opensearch/templates/ingest/statefulset.yaml
@@ -197,9 +197,8 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.ingest.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.ingest.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.ingest.livenessProbe "enabled") "context" $) | nindent 12 }}
-            exec:
-              command:
-                - /opt/bitnami/scripts/opensearch/healthcheck.sh
+            tcpSocket:
+              port: rest-api
           {{- end }}
           {{- if .Values.ingest.customReadinessProbe }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.ingest.customReadinessProbe "context" $) | nindent 12 }}

--- a/bitnami/opensearch/templates/master/statefulset.yaml
+++ b/bitnami/opensearch/templates/master/statefulset.yaml
@@ -233,9 +233,8 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.master.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.master.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.master.livenessProbe "enabled") "context" $) | nindent 12 }}
-            exec:
-              command:
-                - /opt/bitnami/scripts/opensearch/healthcheck.sh
+            tcpSocket:
+              port: rest-api
           {{- end }}
           {{- if .Values.master.customReadinessProbe }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.master.customReadinessProbe "context" $) | nindent 12 }}


### PR DESCRIPTION
### Description of the change

Modify opensearch liveness probe to not rely on `/cluster/health` API call.

This change aims to improve chart stability by avoiding restarts if API endpoint is not reachable, and instead uses the rest-api port listening.

### Benefits

This change should help avoid restarts during the cluster bootstrap stage and reduce the number of accidental restarts due to other causes.

### Possible drawbacks

Change in the default livenessProbe behavior.

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
