### PR TITLE
[bitnami/pinniped] Add kubeCertAgent imagePullSecrets

### DIFF
--- a/bitnami/pinniped/Chart.yaml
+++ b/bitnami/pinniped/Chart.yaml
@@ -27,4 +27,4 @@ maintainers:
 name: pinniped
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/pinniped
-version: 1.3.4
+version: 1.3.5

--- a/bitnami/pinniped/values.yaml
+++ b/bitnami/pinniped/values.yaml
@@ -142,6 +142,7 @@ concierge:
     kubeCertAgent:
       namePrefix: {{ printf "%s-%s" (include "pinniped.concierge.fullname" .) "kube-cert-agent" | trunc 63 | trimSuffix "-" }}-
       image: {{ template "pinniped.image" . }}
+      {{- include "pinniped.imagePullSecrets" . | indent 2 }}
   ## @param concierge.credentialIssuerConfig [string] Configuration for the credential issuer
   ##
   credentialIssuerConfig: |


### PR DESCRIPTION
### Description of the change

Adds pullSecrets for kubeCertAgent image.

Upstream ref: https://github.com/vmware-tanzu/pinniped/blob/78cb86215b83994a0950d57dd9ed08d06234009d/deploy/concierge/deployment.yaml#L93C24-L95

Tested locally:
```
$ helm install test bitnami/pinniped -f .vib/pinniped/runtime-parameters.yaml --dry-run --set "global.imagePullSecrets[0]=testing"
...
data:
  pinniped.yaml: |-
    discovery:
      url: null
    api:
      servingCertificate:
        durationSeconds: 2592000
        renewBeforeSeconds: 2160000
    apiGroupSuffix: pinniped.dev
    aggregatedAPIServerPort: 10250
    impersonationProxyServerPort: 8444
    names:
      servingCertificateSecret: test-pinniped-concierge-default-api-tls-serving-certificate
      credentialIssuer: test-pinniped-concierge
      apiService: test-pinniped-concierge-default-api
      impersonationLoadBalancerService: test-pinniped-concierge-impersonation-proxy-load-balancer
      impersonationClusterIPService: test-pinniped-concierge-impersonation-proxy-cluster-ip
      impersonationTLSCertificateSecret: test-pinniped-concierge-impersonation-proxy-tls-serving-certifi
      impersonationCACertificateSecret: test-pinniped-concierge-impersonation-proxy-ca-certificate
      impersonationSignerSecret: test-pinniped-concierge-impersonation-proxy-signer-ca-certifica
      agentServiceAccount: test-pinniped-concierge-kube-cert-agent-server
    labels: {"app":"pinniped-concierge","app.kubernetes.io/part-of":"pinniped", "app.kubernetes.io/component": "concierge", "app.kubernetes.io/instance": "test"}
    kubeCertAgent:
      namePrefix: test-pinniped-concierge-kube-cert-agent-
      image: docker.io/bitnami/pinniped:0.26.0-debian-11-r0  
      imagePullSecrets:
        - name: testing
```


### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
