### PR TITLE
[bitnami/pinniped] Fix issue with kubeCertAgent pullSecrets

### DIFF
--- a/bitnami/pinniped/Chart.yaml
+++ b/bitnami/pinniped/Chart.yaml
@@ -27,4 +27,4 @@ maintainers:
 name: pinniped
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/pinniped
-version: 1.3.5
+version: 1.3.6

--- a/bitnami/pinniped/templates/_helpers.tpl
+++ b/bitnami/pinniped/templates/_helpers.tpl
@@ -18,6 +18,32 @@ Return the proper Docker Image Registry Secret Names
 {{- end -}}
 
 {{/*
+Return the proper Docker Image Registry Secret Names using the pinniped.yaml format
+{{ include "pinniped.config.imagePullSecrets" ( dict "images" (list .Values.path.to.the.image1, .Values.path.to.the.image2) "global" .Values.global) }}
+*/}}
+{{- define "pinniped.config.imagePullSecrets" -}}
+{{- $pullSecrets := list -}}
+{{- if .global -}}
+{{- range .global.imagePullSecrets -}}
+{{- $pullSecrets = append $pullSecrets . -}}
+{{- end -}}
+{{- end -}}
+
+{{- range .images -}}
+{{- range .pullSecrets -}}
+{{- $pullSecrets = append $pullSecrets . -}}
+{{- end -}}
+{{- end -}}
+
+{{- if (not (empty $pullSecrets)) -}}
+imagePullSecrets:
+{{- range $pullSecrets | uniq }}
+ - {{ . }}
+{{- end }}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Pinniped Concierge helpers
 */}}
 

--- a/bitnami/pinniped/values.yaml
+++ b/bitnami/pinniped/values.yaml
@@ -142,7 +142,7 @@ concierge:
     kubeCertAgent:
       namePrefix: {{ printf "%s-%s" (include "pinniped.concierge.fullname" .) "kube-cert-agent" | trunc 63 | trimSuffix "-" }}-
       image: {{ template "pinniped.image" . }}
-      {{- include "pinniped.imagePullSecrets" . | indent 2 }}
+      {{- include "pinniped.config.imagePullSecrets" (dict "images" (list .Values.image) "global" .Values.global) | nindent 2 }}
   ## @param concierge.credentialIssuerConfig [string] Configuration for the credential issuer
   ##
   credentialIssuerConfig: |


### PR DESCRIPTION
### Description of the change

Fixes an issue introduced at https://github.com/bitnami/charts/pull/19688

The pinniped.yaml config format does not match the Kubernetes spec format:

Wrong, using K8s format:
```
    kubeCertAgent:
      namePrefix: test-pinniped-concierge-kube-cert-agent-
      image: docker.io/bitnami/pinniped:0.26.0-debian-11-r0  
      imagePullSecrets:
        - name: testing
```

Correct:
```
    kubeCertAgent:
      namePrefix: test-pinniped-concierge-kube-cert-agent-
      image: docker.io/bitnami/pinniped:0.26.0-debian-11-r0  
      imagePullSecrets:
        - testing
```

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
