### PR TITLE
[bitnami/*] Update Helm charts prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ Since the container image is an immutable artifact that is already analyzed, as 
 
 ### Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 
 ### Setup a Kubernetes Cluster
 

--- a/bitnami/airflow/README.md
+++ b/bitnami/airflow/README.md
@@ -24,8 +24,8 @@ Looking to use Apache Airflow in production? Try [VMware Application Catalog](ht
 
 ## Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 
 ## Installing the Chart
 

--- a/bitnami/apache/README.md
+++ b/bitnami/apache/README.md
@@ -28,8 +28,8 @@ Looking to use Apache in production? Try [VMware Application Catalog](https://bi
 
 ## Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 
 ## Installing the Chart
 

--- a/bitnami/apisix/README.md
+++ b/bitnami/apisix/README.md
@@ -24,8 +24,8 @@ Looking to use Apache APISIX in production? Try [VMware Application Catalog](htt
 
 ## Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 
 ## Installing the Chart
 

--- a/bitnami/appsmith/README.md
+++ b/bitnami/appsmith/README.md
@@ -28,8 +28,8 @@ Looking to use Appsmith in production? Try [VMware Application Catalog](https://
 
 ## Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 - PV provisioner support in the underlying infrastructure
 - ReadWriteMany volumes for deployment scaling
 

--- a/bitnami/argo-cd/README.md
+++ b/bitnami/argo-cd/README.md
@@ -24,8 +24,8 @@ Looking to use Argo CD in production? Try [VMware Application Catalog](https://b
 
 ## Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 - PV provisioner support in the underlying infrastructure
 - ReadWriteMany volumes for deployment scaling
 

--- a/bitnami/argo-workflows/README.md
+++ b/bitnami/argo-workflows/README.md
@@ -24,8 +24,8 @@ Looking to use Argo Workflows in production? Try [VMware Application Catalog](ht
 
 ## Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 - PV provisioner support in the underlying infrastructure
 - ReadWriteMany volumes for deployment scaling
 

--- a/bitnami/aspnet-core/README.md
+++ b/bitnami/aspnet-core/README.md
@@ -26,8 +26,8 @@ Looking to use ASP.NET in production? Try [VMware Application Catalog](https://b
 
 ## Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 
 ## Installing the Chart
 

--- a/bitnami/cassandra/README.md
+++ b/bitnami/cassandra/README.md
@@ -24,8 +24,8 @@ Looking to use Apache Cassandra in production? Try [VMware Application Catalog](
 
 ## Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 - PV provisioner support in the underlying infrastructure
 
 ## Installing the Chart

--- a/bitnami/cert-manager/README.md
+++ b/bitnami/cert-manager/README.md
@@ -26,8 +26,8 @@ Looking to use cert-manager in production? Try [VMware Application Catalog](http
 
 ## Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 - PV provisioner support in the underlying infrastructure
 
 ## Installing the Chart

--- a/bitnami/clickhouse/README.md
+++ b/bitnami/clickhouse/README.md
@@ -28,8 +28,8 @@ Looking to use ClickHouse in production? Try [VMware Application Catalog](https:
 
 ## Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 - PV provisioner support in the underlying infrastructure
 - ReadWriteMany volumes for deployment scaling
 

--- a/bitnami/common/README.md
+++ b/bitnami/common/README.md
@@ -34,8 +34,8 @@ Looking to use our applications in production? Try [VMware Application Catalog](
 
 ## Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 
 ## Parameters
 

--- a/bitnami/concourse/README.md
+++ b/bitnami/concourse/README.md
@@ -24,8 +24,8 @@ Looking to use Concourse in production? Try [VMware Application Catalog](https:/
 
 ## Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 - PV provisioner support in the underlying infrastructure
 - ReadWriteMany volumes for deployment scaling
 

--- a/bitnami/consul/README.md
+++ b/bitnami/consul/README.md
@@ -24,8 +24,8 @@ Looking to use HashiCorp Consul in production? Try [VMware Application Catalog](
 
 ## Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 - PV provisioner support in the underlying infrastructure
 
 ## Installing the Chart

--- a/bitnami/contour/README.md
+++ b/bitnami/contour/README.md
@@ -26,8 +26,8 @@ Looking to use Contour in production? Try [VMware Application Catalog](https://b
 
 ## Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 - An Operator for `ServiceType: LoadBalancer` like [MetalLB](https://github.com/bitnami/charts/tree/main/bitnami/metallb)
 
 ## Installing the Chart

--- a/bitnami/deepspeed/README.md
+++ b/bitnami/deepspeed/README.md
@@ -26,8 +26,8 @@ Looking to use DeepSpeed in production? Try [VMware Application Catalog](https:/
 
 ## Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 - PV provisioner support in the underlying infrastructure
 
 ## Installing the Chart

--- a/bitnami/discourse/README.md
+++ b/bitnami/discourse/README.md
@@ -26,8 +26,8 @@ Looking to use Discoursereg; in production? Try [VMware Application Catalog](htt
 
 ## Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 - PV provisioner support in the underlying infrastructure
 - ReadWriteMany volumes for deployment scaling
 

--- a/bitnami/dokuwiki/README.md
+++ b/bitnami/dokuwiki/README.md
@@ -24,8 +24,8 @@ Looking to use DokuWiki in production? Try [VMware Application Catalog](https://
 
 ## Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 - PV provisioner support in the underlying infrastructure
 - ReadWriteMany volumes for deployment scaling
 

--- a/bitnami/drupal/README.md
+++ b/bitnami/drupal/README.md
@@ -26,8 +26,8 @@ Looking to use Drupal in production? Try [VMware Application Catalog](https://bi
 
 ## Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 - PV provisioner support in the underlying infrastructure
 - ReadWriteMany volumes for deployment scaling
 

--- a/bitnami/ejbca/README.md
+++ b/bitnami/ejbca/README.md
@@ -26,8 +26,8 @@ Looking to use EJBCA in production? Try [VMware Application Catalog](https://bit
 
 ## Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 - PV provisioner support in the underlying infrastructure
 
 ## Installing the Chart

--- a/bitnami/elasticsearch/README.md
+++ b/bitnami/elasticsearch/README.md
@@ -24,8 +24,8 @@ Looking to use Elasticsearch in production? Try [VMware Application Catalog](htt
 
 ## Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 - PV provisioner support in the underlying infrastructure
 
 ## Installing the Chart

--- a/bitnami/etcd/README.md
+++ b/bitnami/etcd/README.md
@@ -24,8 +24,8 @@ Looking to use Etcd in production? Try [VMware Application Catalog](https://bitn
 
 ## Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 - PV provisioner support in the underlying infrastructure
 
 ## Installing the Chart

--- a/bitnami/external-dns/README.md
+++ b/bitnami/external-dns/README.md
@@ -24,8 +24,8 @@ Looking to use ExternalDNS in production? Try [VMware Application Catalog](https
 
 ## Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 
 ## Installing the Chart
 

--- a/bitnami/flink/README.md
+++ b/bitnami/flink/README.md
@@ -24,8 +24,8 @@ Looking to use Apache Flink in production? Try [VMware Application Catalog](http
 
 ## Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 - PV provisioner support in the underlying infrastructure
 - ReadWriteMany volumes for deployment scaling
 

--- a/bitnami/fluent-bit/README.md
+++ b/bitnami/fluent-bit/README.md
@@ -24,8 +24,8 @@ Looking to use Fluent Bit in production? Try [VMware Application Catalog](https:
 
 ## Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 - PV provisioner support in the underlying infrastructure
 - ReadWriteMany volumes for deployment scaling
 

--- a/bitnami/fluentd/README.md
+++ b/bitnami/fluentd/README.md
@@ -24,8 +24,8 @@ Looking to use Fluentd in production? Try [VMware Application Catalog](https://b
 
 ## Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 - PV provisioner support in the underlying infrastructure
 
 > Note: Please, note that the forwarder runs the container as root by default setting the `forwarder.securityContext.runAsUser` to `0` (_root_ user)

--- a/bitnami/flux/README.md
+++ b/bitnami/flux/README.md
@@ -24,8 +24,8 @@ Looking to use Flux in production? Try [VMware Application Catalog](https://bitn
 
 ## Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 
 ## Installing the Chart
 

--- a/bitnami/ghost/README.md
+++ b/bitnami/ghost/README.md
@@ -26,8 +26,8 @@ Looking to use Ghost in production? Try [VMware Application Catalog](https://bit
 
 ## Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 - PV provisioner support in the underlying infrastructure
 - ReadWriteMany volumes for deployment scaling
 

--- a/bitnami/gitea/README.md
+++ b/bitnami/gitea/README.md
@@ -26,8 +26,8 @@ Looking to use Gitea in production? Try [VMware Application Catalog](https://bit
 
 ## Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 - PV provisioner support in the underlying infrastructure
 - ReadWriteMany volumes for deployment scaling
 

--- a/bitnami/grafana-loki/README.md
+++ b/bitnami/grafana-loki/README.md
@@ -28,8 +28,8 @@ Looking to use Grafana Loki in production? Try [VMware Application Catalog](http
 
 ## Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 - PV provisioner support in the underlying infrastructure
 
 ## Installing the Chart

--- a/bitnami/grafana-mimir/README.md
+++ b/bitnami/grafana-mimir/README.md
@@ -28,8 +28,8 @@ Looking to use Grafana Mimir in production? Try [VMware Application Catalog](htt
 
 ## Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 - PV provisioner support in the underlying infrastructure
 
 ## Installing the Chart

--- a/bitnami/grafana-operator/README.md
+++ b/bitnami/grafana-operator/README.md
@@ -26,8 +26,8 @@ Looking to use Grafana Operator in production? Try [VMware Application Catalog](
 
 ## Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 
 ## Installing the Chart
 

--- a/bitnami/grafana-tempo/README.md
+++ b/bitnami/grafana-tempo/README.md
@@ -28,8 +28,8 @@ Looking to use Grafana Tempo in production? Try [VMware Application Catalog](htt
 
 ## Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 - PV provisioner support in the underlying infrastructure
 
 ## Installing the Chart

--- a/bitnami/grafana/README.md
+++ b/bitnami/grafana/README.md
@@ -24,8 +24,8 @@ Looking to use Grafana in production? Try [VMware Application Catalog](https://b
 
 ## Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 - PV provisioner support in the underlying infrastructure
 - ReadWriteMany volumes for deployment scaling
 

--- a/bitnami/haproxy/README.md
+++ b/bitnami/haproxy/README.md
@@ -28,8 +28,8 @@ Looking to use HAProxy in production? Try [VMware Application Catalog](https://b
 
 ## Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 
 ## Installing the Chart
 

--- a/bitnami/harbor/README.md
+++ b/bitnami/harbor/README.md
@@ -34,8 +34,8 @@ Looking to use Harbor in production? Try [VMware Application Catalog](https://bi
 
 ## Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 - PV provisioner support in the underlying infrastructure
 - ReadWriteMany volumes for deployment scaling
 

--- a/bitnami/influxdb/README.md
+++ b/bitnami/influxdb/README.md
@@ -24,8 +24,8 @@ Looking to use InfluxDB## Prerequisitestrade; in production? Try [VMware Applica
 
 ## Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 - PV provisioner support in the underlying infrastructure
 - ReadWriteMany volumes for deployment scaling
 

--- a/bitnami/jaeger/README.md
+++ b/bitnami/jaeger/README.md
@@ -24,8 +24,8 @@ Looking to use Jaeger in production? Try [VMware Application Catalog](https://bi
 
 ## Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 - PV provisioner support in the underlying infrastructure
 - ReadWriteMany volumes for deployment scaling
 

--- a/bitnami/jasperreports/README.md
+++ b/bitnami/jasperreports/README.md
@@ -26,8 +26,8 @@ Looking to use JasperReports in production? Try [VMware Application Catalog](htt
 
 ## Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 - PV provisioner support in the underlying infrastructure
 - ReadWriteMany volumes for deployment scaling
 

--- a/bitnami/jenkins/README.md
+++ b/bitnami/jenkins/README.md
@@ -24,8 +24,8 @@ Looking to use Jenkins in production? Try [VMware Application Catalog](https://b
 
 ## Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 - PV provisioner support in the underlying infrastructure
 - ReadWriteMany volumes for deployment scaling
 

--- a/bitnami/joomla/README.md
+++ b/bitnami/joomla/README.md
@@ -26,8 +26,8 @@ Looking to use Joomla! in production? Try [VMware Application Catalog](https://b
 
 ## Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 - PV provisioner support in the underlying infrastructure
 - ReadWriteMany volumes for deployment scaling
 

--- a/bitnami/jupyterhub/README.md
+++ b/bitnami/jupyterhub/README.md
@@ -28,8 +28,8 @@ Looking to use JupyterHub in production? Try [VMware Application Catalog](https:
 
 ## Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 - PV provisioner support in the underlying infrastructure
 
 ## Installing the Chart

--- a/bitnami/kafka/README.md
+++ b/bitnami/kafka/README.md
@@ -24,8 +24,8 @@ Looking to use Apache Kafka in production? Try [VMware Application Catalog](http
 
 ## Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 - PV provisioner support in the underlying infrastructure
 
 ## Installing the Chart

--- a/bitnami/keycloak/README.md
+++ b/bitnami/keycloak/README.md
@@ -26,8 +26,8 @@ Looking to use Keycloak in production? Try [VMware Application Catalog](https://
 
 ## Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 
 ## Installing the Chart
 

--- a/bitnami/kiam/README.md
+++ b/bitnami/kiam/README.md
@@ -28,8 +28,8 @@ Looking to use Kiam in production? Try [VMware Application Catalog](https://bitn
 
 ## Prerequisites
 
-- Kubernetes 1.19+ in AWS
-- Helm 3.2.0+
+- Kubernetes 1.23+ in AWS
+- Helm 3.8.0+
 
 ## Installing the Chart
 

--- a/bitnami/kibana/README.md
+++ b/bitnami/kibana/README.md
@@ -24,8 +24,8 @@ Looking to use Kibana in production? Try [VMware Application Catalog](https://bi
 
 ## Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 - PV provisioner support in the underlying infrastructure
 - ReadWriteMany volumes for deployment scaling
 

--- a/bitnami/kong/README.md
+++ b/bitnami/kong/README.md
@@ -26,8 +26,8 @@ Looking to use Kong in production? Try [VMware Application Catalog](https://bitn
 
 ## Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 - PV provisioner support in the underlying infrastructure
 
 ## Installing the Chart

--- a/bitnami/kube-prometheus/README.md
+++ b/bitnami/kube-prometheus/README.md
@@ -34,8 +34,8 @@ Looking to use Prometheus Operator in production? Try [VMware Application Catalo
 
 ## Prerequisites
 
-- Kubernetes 1.16+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 
 ## Installing the Chart
 

--- a/bitnami/kube-state-metrics/README.md
+++ b/bitnami/kube-state-metrics/README.md
@@ -24,8 +24,8 @@ Looking to use Kube State Metrics in production? Try [VMware Application Catalog
 
 ## Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 
 ## Installing the Chart
 

--- a/bitnami/kubeapps/README.md
+++ b/bitnami/kubeapps/README.md
@@ -35,8 +35,8 @@ Looking to use Kubeapps in production? Try [VMware Application Catalog](https://
 
 ## Prerequisites
 
-- Kubernetes 1.16+ (tested with both bare-metal and managed clusters, including EKS, AKS, GKE and Tanzu Kubernetes Grid, as well as dev clusters, such as Kind, Minikube and Docker for Desktop Kubernetes)
-- Helm 3.0.2+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 - Administrative access to the cluster to create Custom Resource Definitions (CRDs)
 - PV provisioner support in the underlying infrastructure (required for PostgreSQL database)
 

--- a/bitnami/kubernetes-event-exporter/README.md
+++ b/bitnami/kubernetes-event-exporter/README.md
@@ -24,8 +24,8 @@ Looking to use Kubernetes Event Exporter in production? Try [VMware Application 
 
 ## Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 
 ## Installing the Chart
 

--- a/bitnami/logstash/README.md
+++ b/bitnami/logstash/README.md
@@ -24,8 +24,8 @@ Looking to use Logstash in production? Try [VMware Application Catalog](https://
 
 ## Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 
 ## Installing the Chart
 

--- a/bitnami/magento/README.md
+++ b/bitnami/magento/README.md
@@ -26,8 +26,8 @@ Looking to use Magento in production? Try [VMware Application Catalog](https://b
 
 ## Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 - PV provisioner support in the underlying infrastructure
 - ReadWriteMany volumes for deployment scaling
 

--- a/bitnami/mariadb-galera/README.md
+++ b/bitnami/mariadb-galera/README.md
@@ -24,8 +24,8 @@ Looking to use MariaDB Galera in production? Try [VMware Application Catalog](ht
 
 ## Prerequisites
 
-- Kubernetes 1.10+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 - PV provisioner support in the underlying infrastructure
 
 ## Installing the Chart

--- a/bitnami/mariadb/README.md
+++ b/bitnami/mariadb/README.md
@@ -26,8 +26,8 @@ Looking to use MariaDB in production? Try [VMware Application Catalog](https://b
 
 ## Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 - PV provisioner support in the underlying infrastructure
 
 ## Installing the Chart

--- a/bitnami/mastodon/README.md
+++ b/bitnami/mastodon/README.md
@@ -28,8 +28,8 @@ Looking to use Mastodon in production? Try [VMware Application Catalog](https://
 
 ## Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 - PV provisioner support in the underlying infrastructure
 
 ## Installing the Chart

--- a/bitnami/matomo/README.md
+++ b/bitnami/matomo/README.md
@@ -26,8 +26,8 @@ Looking to use Matomo in production? Try [VMware Application Catalog](https://bi
 
 ## Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 - PV provisioner support in the underlying infrastructure
 - ReadWriteMany volumes for deployment scaling
 

--- a/bitnami/mediawiki/README.md
+++ b/bitnami/mediawiki/README.md
@@ -26,8 +26,8 @@ Looking to use MediaWiki in production? Try [VMware Application Catalog](https:/
 
 ## Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 - PV provisioner support in the underlying infrastructure
 - ReadWriteMany volumes for deployment scaling
 

--- a/bitnami/memcached/README.md
+++ b/bitnami/memcached/README.md
@@ -24,8 +24,8 @@ Looking to use Memcached in production? Try [VMware Application Catalog](https:/
 
 ## Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 
 ## Installing the Chart
 

--- a/bitnami/metallb/README.md
+++ b/bitnami/metallb/README.md
@@ -26,8 +26,8 @@ Looking to use MetalLB in production? Try [VMware Application Catalog](https://b
 
 ## Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 - Virtual IPs for Layer 2 or Route Reflector for BGP setup.
 
 ## Installing the Chart

--- a/bitnami/metrics-server/README.md
+++ b/bitnami/metrics-server/README.md
@@ -24,8 +24,8 @@ Looking to use Metrics Server in production? Try [VMware Application Catalog](ht
 
 ## Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 
 ## Installing the Chart
 

--- a/bitnami/milvus/README.md
+++ b/bitnami/milvus/README.md
@@ -28,8 +28,8 @@ Looking to use Milvus in production? Try [VMware Application Catalog](https://bi
 
 ## Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 - PV provisioner support in the underlying infrastructure
 
 ## Installing the Chart

--- a/bitnami/minio/README.md
+++ b/bitnami/minio/README.md
@@ -24,8 +24,8 @@ Looking to use Bitnami Object Storage based on MinIOreg; in production? Try [VMw
 
 ## Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 - PV provisioner support in the underlying infrastructure
 
 ## Installing the Chart

--- a/bitnami/mongodb-sharded/README.md
+++ b/bitnami/mongodb-sharded/README.md
@@ -28,8 +28,8 @@ Looking to use MongoDBreg; Sharded in production? Try [VMware Application Catalo
 
 ## Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 - PV provisioner support in the underlying infrastructure
 - ReadWriteMany volumes for deployment scaling
 

--- a/bitnami/mongodb/README.md
+++ b/bitnami/mongodb/README.md
@@ -24,8 +24,8 @@ Looking to use MongoDBreg; in production? Try [VMware Application Catalog](https
 
 ## Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 - PV provisioner support in the underlying infrastructure
 
 ## Installing the Chart

--- a/bitnami/moodle/README.md
+++ b/bitnami/moodle/README.md
@@ -26,8 +26,8 @@ Looking to use Bitnami LMS powered by Moodle## Prerequisitestrade; LMS in produc
 
 ## Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 - PV provisioner support in the underlying infrastructure
 - ReadWriteMany volumes for deployment scaling
 

--- a/bitnami/multus-cni/README.md
+++ b/bitnami/multus-cni/README.md
@@ -24,8 +24,8 @@ Looking to use Multus CNI in production? Try [VMware Application Catalog](https:
 
 ## Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 - PV provisioner support in the underlying infrastructure
 - ReadWriteMany volumes for deployment scaling
 

--- a/bitnami/mxnet/README.md
+++ b/bitnami/mxnet/README.md
@@ -24,8 +24,8 @@ Looking to use Apache MXNet (Incubating) in production? Try [VMware Application 
 
 ## Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 - PV provisioner support in the underlying infrastructure
 - ReadWriteMany volumes for deployment scaling
 

--- a/bitnami/mysql/README.md
+++ b/bitnami/mysql/README.md
@@ -24,8 +24,8 @@ Looking to use MySQL in production? Try [VMware Application Catalog](https://bit
 
 ## Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 - PV provisioner support in the underlying infrastructure
 
 ## Installing the Chart

--- a/bitnami/nats/README.md
+++ b/bitnami/nats/README.md
@@ -24,8 +24,8 @@ Looking to use NATS in production? Try [VMware Application Catalog](https://bitn
 
 ## Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 
 ## Installing the Chart
 

--- a/bitnami/nginx-ingress-controller/README.md
+++ b/bitnami/nginx-ingress-controller/README.md
@@ -26,8 +26,8 @@ Looking to use NGINX Ingress Controller in production? Try [VMware Application C
 
 ## Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 
 ## Installing the Chart
 

--- a/bitnami/nginx/README.md
+++ b/bitnami/nginx/README.md
@@ -26,8 +26,8 @@ Looking to use NGINX Open Source in production? Try [VMware Application Catalog]
 
 ## Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 
 ## Installing the Chart
 

--- a/bitnami/node-exporter/README.md
+++ b/bitnami/node-exporter/README.md
@@ -24,8 +24,8 @@ Looking to use Node Exporter in production? Try [VMware Application Catalog](htt
 
 ## Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 
 ## Installing the Chart
 

--- a/bitnami/oauth2-proxy/README.md
+++ b/bitnami/oauth2-proxy/README.md
@@ -26,8 +26,8 @@ Looking to use OAuth2 Proxy in production? Try [VMware Application Catalog](http
 
 ## Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 - PV provisioner support in the underlying infrastructure
 - ReadWriteMany volumes for deployment scaling
 

--- a/bitnami/odoo/README.md
+++ b/bitnami/odoo/README.md
@@ -26,8 +26,8 @@ Looking to use Odoo in production? Try [VMware Application Catalog](https://bitn
 
 ## Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 - PV provisioner support in the underlying infrastructure
 - ReadWriteMany volumes for deployment scaling
 

--- a/bitnami/opencart/README.md
+++ b/bitnami/opencart/README.md
@@ -26,8 +26,8 @@ Looking to use OpenCart in production? Try [VMware Application Catalog](https://
 
 ## Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 - PV provisioner support in the underlying infrastructure
 - ReadWriteMany volumes for deployment scaling
 

--- a/bitnami/opensearch/README.md
+++ b/bitnami/opensearch/README.md
@@ -24,8 +24,8 @@ Looking to use OpenSearch in production? Try [VMware Application Catalog](https:
 
 ## Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 - PV provisioner support in the underlying infrastructure
 
 ## Installing the Chart

--- a/bitnami/osclass/README.md
+++ b/bitnami/osclass/README.md
@@ -26,8 +26,8 @@ Looking to use Osclass in production? Try [VMware Application Catalog](https://b
 
 ## Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 - PV provisioner support in the underlying infrastructure
 - ReadWriteMany volumes for deployment scaling
 

--- a/bitnami/parse/README.md
+++ b/bitnami/parse/README.md
@@ -24,8 +24,8 @@ Looking to use Parse Server in production? Try [VMware Application Catalog](http
 
 ## Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 - PV provisioner support in the underlying infrastructure
 - ReadWriteMany volumes for deployment scaling
 

--- a/bitnami/phpbb/README.md
+++ b/bitnami/phpbb/README.md
@@ -26,8 +26,8 @@ Looking to use phpBB in production? Try [VMware Application Catalog](https://bit
 
 ## Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 - PV provisioner support in the underlying infrastructure
 - ReadWriteMany volumes for deployment scaling
 

--- a/bitnami/phpmyadmin/README.md
+++ b/bitnami/phpmyadmin/README.md
@@ -26,8 +26,8 @@ Looking to use phpMyAdmin in production? Try [VMware Application Catalog](https:
 
 ## Prerequisites
 
-- Kubernetes 1.8+ with Beta APIs enabled
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 
 ## Installing the Chart
 

--- a/bitnami/pinniped/README.md
+++ b/bitnami/pinniped/README.md
@@ -28,8 +28,8 @@ Looking to use Pinniped in production? Try [VMware Application Catalog](https://
 
 ## Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 
 ## Installing the Chart
 

--- a/bitnami/postgresql-ha/README.md
+++ b/bitnami/postgresql-ha/README.md
@@ -29,8 +29,8 @@ Looking to use PostgreSQL HA in production? Try [VMware Application Catalog](htt
 
 ## Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 
 ## Installing the Chart
 

--- a/bitnami/postgresql/README.md
+++ b/bitnami/postgresql/README.md
@@ -26,8 +26,8 @@ Looking to use PostgreSQL in production? Try [VMware Application Catalog](https:
 
 ## Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 - PV provisioner support in the underlying infrastructure
 
 ## Installing the Chart

--- a/bitnami/prestashop/README.md
+++ b/bitnami/prestashop/README.md
@@ -26,8 +26,8 @@ Looking to use PrestaShop in production? Try [VMware Application Catalog](https:
 
 ## Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 - PV provisioner support in the underlying infrastructure
 - ReadWriteMany volumes for deployment scaling
 

--- a/bitnami/prometheus/README.md
+++ b/bitnami/prometheus/README.md
@@ -28,8 +28,8 @@ Looking to use Prometheus in production? Try [VMware Application Catalog](https:
 
 ## Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 - PV provisioner support in the underlying infrastructure
 - ReadWriteMany volumes for deployment scaling
 

--- a/bitnami/pytorch/README.md
+++ b/bitnami/pytorch/README.md
@@ -26,8 +26,8 @@ Looking to use PyTorch in production? Try [VMware Application Catalog](https://b
 
 ## Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 - PV provisioner support in the underlying infrastructure
 - ReadWriteMany volumes for deployment scaling
 

--- a/bitnami/rabbitmq-cluster-operator/README.md
+++ b/bitnami/rabbitmq-cluster-operator/README.md
@@ -26,8 +26,8 @@ Looking to use RabbitMQ Cluster Operator in production? Try [VMware Application 
 
 ## Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 - PV provisioner support in the underlying infrastructure
 
 ## Installing the Chart

--- a/bitnami/rabbitmq/README.md
+++ b/bitnami/rabbitmq/README.md
@@ -24,8 +24,8 @@ Looking to use RabbitMQ in production? Try [VMware Application Catalog](https://
 
 ## Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 - PV provisioner support in the underlying infrastructure
 
 ## Installing the Chart

--- a/bitnami/redis-cluster/README.md
+++ b/bitnami/redis-cluster/README.md
@@ -36,8 +36,8 @@ Looking to use Redisreg; Cluster in production? Try [VMware Application Catalog]
 
 ## Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 - PV provisioner support in the underlying infrastructure
 
 ## Installing the Chart

--- a/bitnami/redis/README.md
+++ b/bitnami/redis/README.md
@@ -39,8 +39,8 @@ Looking to use Redisreg; in production? Try [VMware Application Catalog](https:/
 
 ## Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 - PV provisioner support in the underlying infrastructure
 
 ## Installing the Chart

--- a/bitnami/redmine/README.md
+++ b/bitnami/redmine/README.md
@@ -26,8 +26,8 @@ Looking to use Redmine in production? Try [VMware Application Catalog](https://b
 
 ## Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 - PV provisioner support in the underlying infrastructure
 - ReadWriteMany volumes for deployment scaling
 

--- a/bitnami/schema-registry/README.md
+++ b/bitnami/schema-registry/README.md
@@ -24,8 +24,8 @@ Looking to use Confluent Schema Registry in production? Try [VMware Application 
 
 ## Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 
 ## Installing the Chart
 

--- a/bitnami/sealed-secrets/README.md
+++ b/bitnami/sealed-secrets/README.md
@@ -25,7 +25,7 @@ Looking to use Sealed Secrets in production? Try [VMware Application Catalog](ht
 ## Prerequisites
 
 - Kubernetes 1.16+
-- Helm 3.1.0
+- Helm 3.8.0+
 
 ## Installing the Chart
 

--- a/bitnami/solr/README.md
+++ b/bitnami/solr/README.md
@@ -24,8 +24,8 @@ Looking to use Apache Solr in production? Try [VMware Application Catalog](https
 
 ## Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 - PV provisioner support in the underlying infrastructure
 - ReadWriteMany volumes for deployment scaling
 

--- a/bitnami/sonarqube/README.md
+++ b/bitnami/sonarqube/README.md
@@ -24,8 +24,8 @@ Looking to use SonarQube## Prerequisitestrade; in production? Try [VMware Applic
 
 ## Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 
 ## Installing the Chart
 

--- a/bitnami/spark/README.md
+++ b/bitnami/spark/README.md
@@ -26,8 +26,8 @@ Looking to use Apache Spark in production? Try [VMware Application Catalog](http
 
 ## Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 
 ## Installing the Chart
 

--- a/bitnami/spring-cloud-dataflow/README.md
+++ b/bitnami/spring-cloud-dataflow/README.md
@@ -22,8 +22,8 @@ Looking to use Spring Cloud Data Flow in production? Try [VMware Application Cat
 
 ## Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 - PV provisioner support in the underlying infrastructure
 
 ## Installing the Chart

--- a/bitnami/suitecrm/README.md
+++ b/bitnami/suitecrm/README.md
@@ -28,8 +28,8 @@ Looking to use SuiteCRM in production? Try [VMware Application Catalog](https://
 
 ## Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 - PV provisioner support in the underlying infrastructure
 - ReadWriteMany volumes for deployment scaling
 

--- a/bitnami/supabase/README.md
+++ b/bitnami/supabase/README.md
@@ -27,8 +27,8 @@ Looking to use Supabase in production? Try [VMware Application Catalog](https://
 
 ## Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 - PV provisioner support in the underlying infrastructure
 - ReadWriteMany volumes for deployment scaling
 

--- a/bitnami/tensorflow-resnet/README.md
+++ b/bitnami/tensorflow-resnet/README.md
@@ -24,8 +24,8 @@ Looking to use TensorFlow ResNet in production? Try [VMware Application Catalog]
 
 ## Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 
 ## Installing the Chart
 

--- a/bitnami/thanos/README.md
+++ b/bitnami/thanos/README.md
@@ -24,8 +24,8 @@ Looking to use Thanos in production? Try [VMware Application Catalog](https://bi
 
 ## Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 - PV provisioner support in the underlying infrastructure
 
 ## Installing the Chart

--- a/bitnami/tomcat/README.md
+++ b/bitnami/tomcat/README.md
@@ -26,8 +26,8 @@ Looking to use Apache Tomcat in production? Try [VMware Application Catalog](htt
 
 ## Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 - PV provisioner support in the underlying infrastructure
 - ReadWriteMany volumes for deployment scaling
 

--- a/bitnami/vault/README.md
+++ b/bitnami/vault/README.md
@@ -24,8 +24,8 @@ Looking to use HashiCorp Vault in production? Try [VMware Application Catalog](h
 
 ## Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 
 ## Installing the Chart
 

--- a/bitnami/whereabouts/README.md
+++ b/bitnami/whereabouts/README.md
@@ -24,8 +24,8 @@ Looking to use Whereabouts in production? Try [VMware Application Catalog](https
 
 ## Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 - PV provisioner support in the underlying infrastructure
 - ReadWriteMany volumes for deployment scaling
 

--- a/bitnami/wildfly/README.md
+++ b/bitnami/wildfly/README.md
@@ -26,8 +26,8 @@ Looking to use WildFly in production? Try [VMware Application Catalog](https://b
 
 ## Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 - PV provisioner support in the underlying infrastructure
 - ReadWriteMany volumes for deployment scaling
 

--- a/bitnami/wordpress/README.md
+++ b/bitnami/wordpress/README.md
@@ -24,8 +24,8 @@ Looking to use WordPress in production? Try [VMware Application Catalog](https:/
 
 ## Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 - PV provisioner support in the underlying infrastructure
 - ReadWriteMany volumes for deployment scaling
 

--- a/bitnami/zookeeper/README.md
+++ b/bitnami/zookeeper/README.md
@@ -24,8 +24,8 @@ Looking to use Apache ZooKeeper in production? Try [VMware Application Catalog](
 
 ## Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 - PV provisioner support in the underlying infrastructure
 
 ## Installing the Chart

--- a/template/CHART_NAME/README.md
+++ b/template/CHART_NAME/README.md
@@ -16,8 +16,8 @@ helm install my-release oci://registry-1.docker.io/bitnamicharts/%%CHART_NAME%%
 
 ## Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8.0+
 - PV provisioner support in the underlying infrastructure
 - ReadWriteMany volumes for deployment scaling
 


### PR DESCRIPTION
We are enhancing our installation prerequisites to align with the minimum version used by our automated test and release pipeline. While previous versions may still function, we cannot guarantee compatibility as our testing primarily focuses on the specified minimum version.

Additionally, we recommend using the OCI method for installing Bitnami Helm charts. To ensure compatibility and optimal functionality, please refer to the specific Helm version that introduced official OCI support, without relying on the experimental flag. For more details, please visit https://helm.sh/docs/topics/registries