### PR TITLE
[bitnami/mysql] Remove the specified collation config to keep it as d…

### DIFF
--- a/bitnami/mysql/Chart.yaml
+++ b/bitnami/mysql/Chart.yaml
@@ -34,4 +34,4 @@ maintainers:
 name: mysql
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/mysql
-version: 9.12.3
+version: 9.12.4

--- a/bitnami/mysql/values.yaml
+++ b/bitnami/mysql/values.yaml
@@ -214,7 +214,6 @@ primary:
     pid-file=/opt/bitnami/mysql/tmp/mysqld.pid
     log-error=/opt/bitnami/mysql/logs/mysqld.log
     character-set-server=UTF8
-    collation-server=utf8_general_ci
     slow_query_log=0
     long_query_time=10.0
 
@@ -592,7 +591,6 @@ secondary:
     pid-file=/opt/bitnami/mysql/tmp/mysqld.pid
     log-error=/opt/bitnami/mysql/logs/mysqld.log
     character-set-server=UTF8
-    collation-server=utf8_general_ci
     slow_query_log=0
     long_query_time=10.0
 


### PR DESCRIPTION
### Description of the change

Removed one specified charset collation config in `primary.configuration` and `secondary.configuration`:

1. `collation-server=utf8_general_ci`

### Benefits

This chart has specified `collation-server=utf8_general_ci`, which might be useful for mysql-5.7, but since mysql-8.0, default collation has changed from `utf8mb4_general_ci` to `utf8mb4_0900_ai_ci`.

After this commit, if we want to use `utf8mb4`, we can just specify `--character-set-server=utf8mb4` in `extraFlags` and no need to override the entire `configuration`, mysql-server will detect the collation automatically.

### Possible drawbacks

There are some defaults:

1. mysql-5.7:

   ```sql
   mysql> show global variables like '%character_set_server%';
   +----------------------+--------+
   | Variable_name        | Value  |
   +----------------------+--------+
   | character_set_server | latin1 |
   +----------------------+--------+
   1 row in set (0.00 sec)

   mysql> show global variables like '%collation_server%';
   +------------------+-------------------+
   | Variable_name    | Value             |
   +------------------+-------------------+
   | collation_server | latin1_swedish_ci |
   +------------------+-------------------+
   1 row in set (0.00 sec)

   mysql> set character_set_server=utf8mb4;
   Query OK, 0 rows affected (0.00 sec)

   mysql> show variables like '%character_set_server%';
   +----------------------+---------+
   | Variable_name        | Value   |
   +----------------------+---------+
   | character_set_server | utf8mb4 |
   +----------------------+---------+
   1 row in set (0.00 sec)

   mysql> show variables like '%collation_server%';
   +------------------+--------------------+
   | Variable_name    | Value              |
   +------------------+--------------------+
   | collation_server | utf8mb4_general_ci |
   +------------------+--------------------+
   1 row in set (0.01 sec)
   ```

2. mysql-8.0:

   ```sql
   mysql> show global variables like '%character_set_server%';
   +----------------------+---------+
   | Variable_name        | Value   |
   +----------------------+---------+
   | character_set_server | utf8mb4 |
   +----------------------+---------+
   1 row in set (0.00 sec)

   mysql> show global variables like '%collation_server%';
   +------------------+--------------------+
   | Variable_name    | Value              |
   +------------------+--------------------+
   | collation_server | utf8mb4_0900_ai_ci |
   +------------------+--------------------+
   1 row in set (0.01 sec)
   ```

### Applicable issues

- fixes #19311

### Additional information

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
