### PR TITLE
[bitnami/*] Add CI retriability for release PRs

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -27,7 +27,6 @@ jobs:
     name: Get modified charts
     permissions:
       contents: read
-    if: ${{ github.event.pull_request.state != 'closed' }}
     outputs:
       chart: ${{ steps.get-chart.outputs.chart }}
       result: ${{ steps.get-chart.outputs.result }}
@@ -50,7 +49,11 @@ jobs:
           num_version_bumps="$(filterdiff -s -i "*Chart.yaml" $TEMP_FILE | grep -c "+version" || true)"
           non_readme_files=$(echo "$files_changed" | grep -vc "\.md" || true)
 
-          if [[ "$non_readme_files" -le "0" ]]; then
+          if [[ $(curl -Lks ${{ github.event.pull_request.url }} | jq '.state | index("closed")') != *null* ]]; then
+            # The PR for which this workflow run was launched is now closed -> SKIP
+            echo "error=The PR for which this workflow run was launched is now closed. The tests will be skipped." >> $GITHUB_OUTPUT
+            echo "result=skip" >> $GITHUB_OUTPUT
+          elif [[ "$non_readme_files" -le "0" ]]; then
             # The only changes are .md files -> SKIP
             echo "result=skip" >> $GITHUB_OUTPUT
           elif [[ "$num_charts_changed" -ne "$num_version_bumps" ]]; then

--- a/.github/workflows/retry-failed-releases.yml
+++ b/.github/workflows/retry-failed-releases.yml
@@ -1,0 +1,28 @@
+# Copyright VMware, Inc.
+# SPDX-License-Identifier: APACHE-2.0
+
+name: '[CI/CD] Retry release PRs'
+on:
+  schedule:
+    # Every 2 hours
+    - cron: '0 */2 * * *'
+# Remove all permissions by default
+permissions: {}
+jobs:
+  retry-failed-pr-releases:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - name: Retry "CI Pipeline" failed runs in releases PRs
+        env:
+          TEMP_FILE: "${{runner.temp}}/failed_runs.json"
+          ACTIONS_API_ENDPOINT: "${{ github.api_url }}/repos/${{ github.repository }}/actions"
+        run: |
+          # Obtain "CI Pipeline" failed runs and filter those from release PRs with less than 3 attempts
+          curl -H 'Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' -X GET -Lkso ${{ env.TEMP_FILE }} ${{ env.ACTIONS_API_ENDPOINT }}/workflows/35553382/runs?status=failure
+          failed_runs_ids="$(jq '.workflow_runs[] | select((.run_attempt < 3) and (.display_title | contains("Release")) and (.head_commit.author.email=="bitnami-bot@vmware.com")).id' ${{ env.TEMP_FILE }})"
+
+          for run_id in ${failed_runs_ids}; do
+            curl -H 'Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' -X POST -Lks ${{ env.ACTIONS_API_ENDPOINT }}/runs/${run_id}/rerun
+          done

--- a/.github/workflows/retry-failed-releases.yml
+++ b/.github/workflows/retry-failed-releases.yml
@@ -16,13 +16,15 @@ jobs:
     steps:
       - name: Retry "CI Pipeline" failed runs in releases PRs
         env:
+          WORKFLOW_ID: "35553382"
           TEMP_FILE: "${{runner.temp}}/failed_runs.json"
           ACTIONS_API_ENDPOINT: "${{ github.api_url }}/repos/${{ github.repository }}/actions"
         run: |
           # Obtain "CI Pipeline" failed runs and filter those from release PRs with less than 3 attempts
-          curl -H 'Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' -X GET -Lkso ${{ env.TEMP_FILE }} ${{ env.ACTIONS_API_ENDPOINT }}/workflows/35553382/runs?status=failure
-          failed_runs_ids="$(jq '.workflow_runs[] | select((.run_attempt < 3) and (.display_title | contains("Release")) and (.head_commit.author.email=="bitnami-bot@vmware.com")).id' ${{ env.TEMP_FILE }})"
+          curl -H 'Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' -X GET -Lkso ${{ env.TEMP_FILE }} ${{ env.ACTIONS_API_ENDPOINT }}/workflows/${{ env.WORKFLOW_ID }}/runs?status=failure
+          readarray -t failed_runs_ids < <(jq '.workflow_runs[] | select((.run_attempt < 3) and (.display_title | contains("Release")) and (.head_commit.author.email=="bitnami-bot@vmware.com")).id' ${{ env.TEMP_FILE }})
 
-          for run_id in ${failed_runs_ids}; do
-            curl -H 'Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' -X POST -Lks ${{ env.ACTIONS_API_ENDPOINT }}/runs/${run_id}/rerun
+          for run_id in "${failed_runs_ids[@]:0:15}"; do
+            echo "Retrying workflow $(jq --argjson id $run_id '.workflow_runs[] | select(.id==$id) | .html_url' ${{ env.TEMP_FILE }})"
+            curl -H 'Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' -X POST -Lks ${{ env.ACTIONS_API_ENDPOINT }}/workflows/runs/${run_id}/rerun
           done


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Right now, our triage for failed PRs include retrying the `VIB Verify` workflow a couple of times to avoid any transient errors. This is a time-consuming manual process that should be automated.

### Benefits

Improved triage workflow

### Possible drawbacks

None

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
