### PR TITLE
[bitnami/rabbitmq] Fix bug reference to erlang cookie's environment variable in RabbitMQ's helm chart

### DIFF
--- a/bitnami/rabbitmq/Chart.yaml
+++ b/bitnami/rabbitmq/Chart.yaml
@@ -30,4 +30,4 @@ maintainers:
 name: rabbitmq
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/rabbitmq
-version: 12.2.2
+version: 12.2.3

--- a/bitnami/rabbitmq/templates/statefulset.yaml
+++ b/bitnami/rabbitmq/templates/statefulset.yaml
@@ -217,7 +217,7 @@ spec:
             {{- end }}
             - name: RABBITMQ_USE_LONGNAME
               value: "true"
-            - name: RABBITMQ_ERL_COOKIE
+            - name: RABBITMQ_ERLANG_COOKIE
               valueFrom:
                 secretKeyRef:
                   name: {{ template "rabbitmq.secretErlangName" . }}


### PR DESCRIPTION
### Description of the change

As described in RabbitMQ's documentation (see https://www.rabbitmq.com/clustering.html) the Docker community RabbitMQ image uses "RABBITMQ_ERLANG_COOKIE" (and not "RABBITMQ_ERL_COOKIE") environment variable value to populate the cookie file.

### Benefits

As of now, your environment variable "RABBITMQ_ERL_COOKIE" does not populate the cookie file, as it would be expected. On the contrary, the Docker community RabbitMQ image will generate a random cookie file when the container is started. As a consequence of this bug, when a cluster of RabbitMQ nodes is created (with .Values.clustering.enabled=true), the nodes fail to identify their peers as all of them have different cookie values.

### Possible drawbacks

Not known.

### Applicable issues

Not applicable.

### Additional information

I have tested that changing the environment variable from "RABBITMQ_ERL_COOKIE" to "RABBITMQ_ERLANG_COOKIE" fixes this problem. I have carried out my tests using the Docker community RabbitMQ "3.12.2-management"

You can also verify this in the RabbitMQ's K8s examples (e.g. https://github.com/rabbitmq/diy-kubernetes-examples/blob/master/minikube/statefulset.yaml#L86).

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)

Signed-off-by: Xavier del Pozo <xavier.delpozo@gmail.com>