### PR TITLE
[bitnami/keycloak] Increase Keycloak Cypress test timeout

### DIFF
--- a/.vib/keycloak/cypress/cypress.json
+++ b/.vib/keycloak/cypress/cypress.json
@@ -1,7 +1,7 @@
 {
   "baseUrl": "http://localhost",
   "pageLoadTimeout": 240000,
-  "defaultCommandTimeout": 40000,
+  "defaultCommandTimeout": 90000,
   "viewportWidth": 1920,
   "viewportHeight": 1080,
   "env": {


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Increasing timeout for Keycloak Cypress test as it is currently failing on GKE.

- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
