### PR TITLE
[bitnami/matomo] fix wrong indent of extra volumes inside cronjobs

### DIFF
--- a/bitnami/matomo/Chart.yaml
+++ b/bitnami/matomo/Chart.yaml
@@ -39,4 +39,4 @@ maintainers:
 name: matomo
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/matomo
-version: 3.0.1
+version: 3.0.2

--- a/bitnami/matomo/README.md
+++ b/bitnami/matomo/README.md
@@ -280,43 +280,48 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### NetworkPolicy parameters
 
-| Name                                                           | Description                                                                                                                | Value         |
-| -------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- | ------------- |
-| `networkPolicy.enabled`                                        | Enable network policies                                                                                                    | `false`       |
-| `networkPolicy.metrics.enabled`                                | Enable network policy for metrics (prometheus)                                                                             | `false`       |
-| `networkPolicy.metrics.namespaceSelector`                      | Monitoring namespace selector labels. These labels will be used to identify the prometheus' namespace.                     | `{}`          |
-| `networkPolicy.metrics.podSelector`                            | Monitoring pod selector labels. These labels will be used to identify the Prometheus pods.                                 | `{}`          |
-| `networkPolicy.ingress.enabled`                                | Enable network policy for Ingress Proxies                                                                                  | `false`       |
-| `networkPolicy.ingress.namespaceSelector`                      | Ingress Proxy namespace selector labels. These labels will be used to identify the Ingress Proxy's namespace.              | `{}`          |
-| `networkPolicy.ingress.podSelector`                            | Ingress Proxy pods selector labels. These labels will be used to identify the Ingress Proxy pods.                          | `{}`          |
-| `networkPolicy.ingressRules.backendOnlyAccessibleByFrontend`   | Enable ingress rule that makes the backend (mariadb) only accessible by matomo's pods.                                     | `false`       |
-| `networkPolicy.ingressRules.customBackendSelector`             | Backend selector labels. These labels will be used to identify the backend pods.                                           | `{}`          |
-| `networkPolicy.ingressRules.accessOnlyFrom.enabled`            | Enable ingress rule that makes matomo only accessible from a particular origin                                             | `false`       |
-| `networkPolicy.ingressRules.accessOnlyFrom.namespaceSelector`  | Namespace selector label that is allowed to access matomo. This label will be used to identified the allowed namespace(s). | `{}`          |
-| `networkPolicy.ingressRules.accessOnlyFrom.podSelector`        | Pods selector label that is allowed to access matomo. This label will be used to identified the allowed pod(s).            | `{}`          |
-| `networkPolicy.ingressRules.customRules`                       | Custom network policy ingress rule                                                                                         | `{}`          |
-| `networkPolicy.egressRules.denyConnectionsToExternal`          | Enable egress rule that denies outgoing traffic outside the cluster, except for DNS (port 53).                             | `false`       |
-| `networkPolicy.egressRules.customRules`                        | Custom network policy rule                                                                                                 | `{}`          |
-| `cronjobs.enabled`                                             | Enables cronjobs for archive and scheduler tasks                                                                           | `true`        |
-| `cronjobs.taskScheduler.schedule`                              | Kubernetes CronJob schedule                                                                                                | `*/5 * * * *` |
-| `cronjobs.taskScheduler.suspend`                               | Whether to create suspended CronJob                                                                                        | `false`       |
-| `cronjobs.taskScheduler.command`                               | Override default container command (useful when using custom images)                                                       | `[]`          |
-| `cronjobs.taskScheduler.args`                                  | Override default container args (useful when using custom images)                                                          | `[]`          |
-| `cronjobs.taskScheduler.containerSecurityContext.enabled`      | archive Container securityContext                                                                                          | `false`       |
-| `cronjobs.taskScheduler.containerSecurityContext.runAsUser`    | User ID for the archive container                                                                                          | `1001`        |
-| `cronjobs.taskScheduler.containerSecurityContext.runAsNonRoot` | Whether to run the archive container as a non-root user                                                                    | `true`        |
-| `cronjobs.taskScheduler.podAnnotations`                        | Additional pod annotations                                                                                                 | `{}`          |
-| `cronjobs.taskScheduler.podLabels`                             | Additional pod labels                                                                                                      | `{}`          |
-| `cronjobs.archive.enabled`                                     | Whether to enable scheduled mail-to-task CronJob                                                                           | `false`       |
-| `cronjobs.archive.schedule`                                    | Kubernetes CronJob schedule                                                                                                | `*/5 * * * *` |
-| `cronjobs.archive.suspend`                                     | Whether to create suspended CronJob                                                                                        | `false`       |
-| `cronjobs.archive.command`                                     | Override default container command (useful when using custom images)                                                       | `[]`          |
-| `cronjobs.archive.args`                                        | Override default container args (useful when using custom images)                                                          | `[]`          |
-| `cronjobs.archive.containerSecurityContext.enabled`            | archive Container securityContext                                                                                          | `false`       |
-| `cronjobs.archive.containerSecurityContext.runAsUser`          | User ID for the archive container                                                                                          | `1001`        |
-| `cronjobs.archive.containerSecurityContext.runAsNonRoot`       | Whether to run the archive container as a non-root user                                                                    | `true`        |
-| `cronjobs.archive.podAnnotations`                              | Additional pod annotations                                                                                                 | `{}`          |
-| `cronjobs.archive.podLabels`                                   | Additional pod labels                                                                                                      | `{}`          |
+| Name                                                          | Description                                                                                                                | Value   |
+| ------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `networkPolicy.enabled`                                       | Enable network policies                                                                                                    | `false` |
+| `networkPolicy.metrics.enabled`                               | Enable network policy for metrics (prometheus)                                                                             | `false` |
+| `networkPolicy.metrics.namespaceSelector`                     | Monitoring namespace selector labels. These labels will be used to identify the prometheus' namespace.                     | `{}`    |
+| `networkPolicy.metrics.podSelector`                           | Monitoring pod selector labels. These labels will be used to identify the Prometheus pods.                                 | `{}`    |
+| `networkPolicy.ingress.enabled`                               | Enable network policy for Ingress Proxies                                                                                  | `false` |
+| `networkPolicy.ingress.namespaceSelector`                     | Ingress Proxy namespace selector labels. These labels will be used to identify the Ingress Proxy's namespace.              | `{}`    |
+| `networkPolicy.ingress.podSelector`                           | Ingress Proxy pods selector labels. These labels will be used to identify the Ingress Proxy pods.                          | `{}`    |
+| `networkPolicy.ingressRules.backendOnlyAccessibleByFrontend`  | Enable ingress rule that makes the backend (mariadb) only accessible by matomo's pods.                                     | `false` |
+| `networkPolicy.ingressRules.customBackendSelector`            | Backend selector labels. These labels will be used to identify the backend pods.                                           | `{}`    |
+| `networkPolicy.ingressRules.accessOnlyFrom.enabled`           | Enable ingress rule that makes matomo only accessible from a particular origin                                             | `false` |
+| `networkPolicy.ingressRules.accessOnlyFrom.namespaceSelector` | Namespace selector label that is allowed to access matomo. This label will be used to identified the allowed namespace(s). | `{}`    |
+| `networkPolicy.ingressRules.accessOnlyFrom.podSelector`       | Pods selector label that is allowed to access matomo. This label will be used to identified the allowed pod(s).            | `{}`    |
+| `networkPolicy.ingressRules.customRules`                      | Custom network policy ingress rule                                                                                         | `{}`    |
+| `networkPolicy.egressRules.denyConnectionsToExternal`         | Enable egress rule that denies outgoing traffic outside the cluster, except for DNS (port 53).                             | `false` |
+| `networkPolicy.egressRules.customRules`                       | Custom network policy rule                                                                                                 | `{}`    |
+
+### CronJob parameters
+
+| Name                                                           | Description                                                          | Value         |
+| -------------------------------------------------------------- | -------------------------------------------------------------------- | ------------- |
+| `cronjobs.enabled`                                             | Enables cronjobs for archive and scheduler tasks                     | `true`        |
+| `cronjobs.taskScheduler.schedule`                              | Kubernetes CronJob schedule                                          | `*/5 * * * *` |
+| `cronjobs.taskScheduler.suspend`                               | Whether to create suspended CronJob                                  | `false`       |
+| `cronjobs.taskScheduler.command`                               | Override default container command (useful when using custom images) | `[]`          |
+| `cronjobs.taskScheduler.args`                                  | Override default container args (useful when using custom images)    | `[]`          |
+| `cronjobs.taskScheduler.containerSecurityContext.enabled`      | archive Container securityContext                                    | `false`       |
+| `cronjobs.taskScheduler.containerSecurityContext.runAsUser`    | User ID for the archive container                                    | `1001`        |
+| `cronjobs.taskScheduler.containerSecurityContext.runAsNonRoot` | Whether to run the archive container as a non-root user              | `true`        |
+| `cronjobs.taskScheduler.podAnnotations`                        | Additional pod annotations                                           | `{}`          |
+| `cronjobs.taskScheduler.podLabels`                             | Additional pod labels                                                | `{}`          |
+| `cronjobs.archive.enabled`                                     | Whether to enable scheduled mail-to-task CronJob                     | `false`       |
+| `cronjobs.archive.schedule`                                    | Kubernetes CronJob schedule                                          | `*/5 * * * *` |
+| `cronjobs.archive.suspend`                                     | Whether to create suspended CronJob                                  | `false`       |
+| `cronjobs.archive.command`                                     | Override default container command (useful when using custom images) | `[]`          |
+| `cronjobs.archive.args`                                        | Override default container args (useful when using custom images)    | `[]`          |
+| `cronjobs.archive.containerSecurityContext.enabled`            | archive Container securityContext                                    | `false`       |
+| `cronjobs.archive.containerSecurityContext.runAsUser`          | User ID for the archive container                                    | `1001`        |
+| `cronjobs.archive.containerSecurityContext.runAsNonRoot`       | Whether to run the archive container as a non-root user              | `true`        |
+| `cronjobs.archive.podAnnotations`                              | Additional pod annotations                                           | `{}`          |
+| `cronjobs.archive.podLabels`                                   | Additional pod labels                                                | `{}`          |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/bitnami/matomo/templates/cronjob.yaml
+++ b/bitnami/matomo/templates/cronjob.yaml
@@ -133,7 +133,7 @@ spec:
                 defaultMode: 0755
             {{- end }}
             {{- if .Values.extraVolumes }}
-            {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumes "context" $) | nindent 8 }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumes "context" $) | nindent 12 }}
             {{- end }}
 ---
 apiVersion: {{ include "common.capabilities.cronjob.apiVersion" . }}
@@ -256,6 +256,6 @@ spec:
                 defaultMode: 0755
             {{- end }}
             {{- if .Values.extraVolumes }}
-            {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumes "context" $) | nindent 8 }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumes "context" $) | nindent 12 }}
             {{- end }}
 {{- end }}

--- a/bitnami/matomo/values.yaml
+++ b/bitnami/matomo/values.yaml
@@ -916,6 +916,9 @@ networkPolicy:
     ##
     customRules: {}
 
+## @section CronJob parameters
+##
+
 cronjobs:
   ## @param cronjobs.enabled Enables cronjobs for archive and scheduler tasks
   ##


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->

Fix the wrong indention of the `extraVolumes` inside the new cronjob. It's a regression of
- #18754

I've also fixed the heading for the cronjob parameters to not be included inside the network policy parameter table

### Benefits

Chart now works with extra volumes
<!-- What benefits will be realized by the code change? -->

### Possible drawbacks
none
<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
none

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
