### PR TITLE
Adapt some tests to Goss 4

### DIFF
--- a/.vib/clickhouse/goss/goss.yaml
+++ b/.vib/clickhouse/goss/goss.yaml
@@ -32,7 +32,7 @@ command:
     exit-status: 0
     {{- $expectedCount := mul .Vars.shards .Vars.replicaCount }}
     stdout:
-      - {{ $expectedCount }}
+      - "{{ $expectedCount }}"
   create-database-in-cluster:
     {{- $database := printf "test_goss_%s" (randAlpha 5) }}
     {{- $table := printf "%s.table_%s" $database (randAlpha 5) }}
@@ -40,7 +40,7 @@ command:
     exec: clickhouse-client --host clickhouse --port {{ .Vars.service.ports.tcp }} --user '{{ .Vars.auth.username }}' --password '{{ .Vars.auth.password }}' --multiquery --query='CREATE DATABASE {{ $database }} ON CLUSTER default ENGINE = Memory; CREATE TABLE {{ $table }} (a UInt8) ENGINE = Memory;  INSERT INTO {{ $table }} VALUES({{ $insertValue }}); SELECT * FROM {{ $table }};'
     exit-status: 0
     stdout:
-      - {{ $insertValue }}
+      - "{{ $insertValue }}"
   {{ if .Vars.serviceAccount.automountServiceAccountToken }}
   check-sa:
     exec: cat /var/run/secrets/kubernetes.io/serviceaccount/token | cut -d '.' -f 2 | xargs -I '{}' echo '{}====' | fold -w 4 | sed '$ d' | tr -d '\n' | base64 -d

--- a/.vib/concourse/goss/worker/goss.yaml
+++ b/.vib/concourse/goss/worker/goss.yaml
@@ -16,7 +16,7 @@ command:
     exec: fly -t {{ $target }} login -c http://concourse-web:{{ $port }} -u {{ $user }} -p '{{ $pwd }}' && fly -t {{ $target }} workers | grep 'running' | wc -l
     exit-status: 0
     stdout:
-      - {{ .Vars.worker.replicaCount }}
+      - "{{ .Vars.worker.replicaCount }}"
   check-ports-config:
     exec: $(echo $CONCOURSE_BIND_PORT | grep -q {{ .Vars.worker.containerPorts.garden }}) && $(echo $CONCOURSE_HEALTHCHECK_BIND_PORT | grep -q {{ .Vars.worker.containerPorts.health }}) && $(echo $CONCOURSE_BAGGAGECLAIM_BIND_PORT | grep -q {{ .Vars.worker.containerPorts.baggageclaim }}) && $(echo $CONCOURSE_BAGGAGECLAIM_DEBUG_BIND_PORT | grep -q {{ .Vars.worker.containerPorts.pprof }})
     exit-status: 0

--- a/.vib/mariadb/goss/goss.yaml
+++ b/.vib/mariadb/goss/goss.yaml
@@ -19,10 +19,10 @@ command:
     exec: mariadb -h mariadb-primary -u root -P {{ .Vars.primary.service.ports.mysql }} -p'{{ .Vars.auth.rootPassword }}' {{ .Vars.auth.database }} -e 'DROP TABLE IF EXISTS TEST; create table TEST(test_id int auto_increment, test_value int, primary key(test_id)); INSERT INTO TEST (TEST_VALUE) VALUES (1989);SELECT * FROM TEST'
     exit-status: 0
     stdout:
-    - 1989
+    - "1989"
   replication-test:
     exec: mariadb -h mariadb-primary -u {{ .Vars.auth.username }} -P {{ .Vars.primary.service.ports.mysql }} -p'{{ .Vars.auth.password }}' {{ .Vars.auth.database }} -e 'DROP TABLE IF EXISTS TEST_REP; create table TEST_REP(test_id int auto_increment, test_value varchar(4), primary key(test_id)); INSERT INTO TEST_REP (TEST_VALUE) VALUES (2022)' && sleep 2 && mariadb -h mariadb-secondary -u {{ .Vars.auth.username }} -P {{ .Vars.secondary.service.ports.mysql }} -p'{{ .Vars.auth.password }}' {{ .Vars.auth.database }} -e 'SELECT * FROM TEST_REP'
     exit-status: 0
     stdout:
-    - 2022
+    - "2022"
     timeout: 9000

--- a/.vib/mysql/goss/goss.yaml
+++ b/.vib/mysql/goss/goss.yaml
@@ -6,12 +6,12 @@ command:
     exec: mysql -h mysql-primary -u root -P {{ .Vars.primary.service.ports.mysql }} -p'{{ .Vars.auth.rootPassword }}' {{ .Vars.auth.database }} -e 'DROP TABLE IF EXISTS TEST; create table TEST(test_id int auto_increment, test_value int, primary key(test_id)); INSERT INTO TEST (TEST_VALUE) VALUES (1993);SELECT * FROM TEST'
     exit-status: 0
     stdout:
-    - 1993
+    - "1993"
   replication-test:
     exec: mysql -h mysql-primary -u {{ .Vars.auth.username }} -P {{ .Vars.primary.service.ports.mysql }} -p'{{ .Vars.auth.password }}' {{ .Vars.auth.database }} -e 'DROP TABLE IF EXISTS TEST_REP; create table TEST_REP(test_id int auto_increment, test_value varchar(4), primary key(test_id)); INSERT INTO TEST_REP (TEST_VALUE) VALUES (2022)' && sleep 2 && mysql -h mysql-secondary -u {{ .Vars.auth.username }} -P {{ .Vars.secondary.service.ports.mysql }} -p'{{ .Vars.auth.password }}' {{ .Vars.auth.database }} -e 'SELECT * FROM TEST_REP'
     exit-status: 0
     stdout:
-    - 2022
+    - "2022"
     timeout: 9000
 file:
   /bitnami/mysql/data/{{ .Vars.auth.database }}:

--- a/.vib/postgresql/goss/goss.yaml
+++ b/.vib/postgresql/goss/goss.yaml
@@ -24,7 +24,7 @@ command:
     exec: PGPASSWORD='{{ .Vars.auth.postgresPassword }}' psql -tA -U postgres -p {{ $port }} -h postgresql-{{ .Vars.primary.name }} -c "SELECT COUNT(*) FROM pg_stat_replication WHERE usename='{{ .Vars.auth.replicationUsername }}';"
     exit-status: 0
     stdout:
-      - '2'
+      - "2"
   {{- $uid := .Vars.primary.containerSecurityContext.runAsUser }}
   {{- $gid := .Vars.primary.podSecurityContext.fsGroup }}
   check-user-info:


### PR DESCRIPTION
In this new version, the output is expected as a string instead of as an integer

Without quotes:
```console
$ goss --gossfile .vib/clickhouse/goss/goss.yaml --vars .vib/clickhouse/runtime-parameters.yaml render
...
  check-cluster-status:
    stdout:
    - 4
  create-database-in-cluster:
    stdout:
    - 23
```

Quoting the value:
```console
$ goss --gossfile .vib/clickhouse/goss/goss.yaml --vars .vib/clickhouse/runtime-parameters.yaml render
...
  check-cluster-status:
    stdout:
    - "4"
  create-database-in-cluster:
    stdout:
    - "23"
```