### PR TITLE
Quote everything inside stdout/contents except regexp

### DIFF
--- a/.vib/clickhouse/goss/goss.yaml
+++ b/.vib/clickhouse/goss/goss.yaml
@@ -7,9 +7,9 @@ file:
     filetype: file
     exists: true
     contents:
-      - zookeeper
-      - remote_servers
-      - logger
+      - "zookeeper"
+      - "remote_servers"
+      - "logger"
   /bitnami/clickhouse/data:
     mode: "2750"
     filetype: directory

--- a/.vib/consul/goss/goss.yaml
+++ b/.vib/consul/goss/goss.yaml
@@ -23,5 +23,5 @@ command:
     exit-status: 0
     stdout:
     {{ range $e, $i := until .Vars.replicaCount }}
-      - consul-{{ $i }}
+      - "consul-{{ $i }}"
     {{ end }}

--- a/.vib/discourse/goss/goss.yaml
+++ b/.vib/discourse/goss/goss.yaml
@@ -15,8 +15,8 @@ file:
     owner: root
     group: root
     contents:
-      - hostname = {{ .Vars.host }}
-      - db_username = {{ .Vars.postgresql.auth.username }}
+      - "hostname = {{ .Vars.host }}"
+      - "db_username = {{ .Vars.postgresql.auth.username }}"
 command:
   discourse-cli:
     exec: cd /opt/bitnami/discourse/ && RAILS_ENV=production bundle exec rake -T

--- a/.vib/etcd/goss/goss.yaml
+++ b/.vib/etcd/goss/goss.yaml
@@ -17,7 +17,7 @@ command:
     exit-status: 0
     stdout:
     {{- range $e, $i := until .Vars.replicaCount }}
-      - etcd-{{ $i }}
+      - "etcd-{{ $i }}"
     {{- end }}
   {{- range $e, $i := until .Vars.replicaCount }}
   {{- $key := printf "key_%s" (randAlpha 5) }}
@@ -26,7 +26,7 @@ command:
     exec: etcdctl {{ $auth }} {{ $svc_endpoint }} put {{ $key }} {{ $value }} && etcdctl {{ $auth }} --endpoints=etcd-{{ $i }}.etcd-headless:{{ $.Vars.containerPorts.client }} get {{ $key }}
     exit-status: 0
     stdout:
-    - {{ $key }}
+    - "{{ $key }}"
   {{- end }}
   {{- $uid := .Vars.containerSecurityContext.runAsUser }}
   {{- $gid := .Vars.podSecurityContext.fsGroup }}

--- a/.vib/influxdb/goss/goss.yaml
+++ b/.vib/influxdb/goss/goss.yaml
@@ -18,7 +18,7 @@ command:
     exec: export INFLUX_TOKEN='{{ $adminToken }}' && influx write --host http://influxdb:{{ $port }} --org {{ $org }} --bucket {{ $bucket }} 'cpu_error,host=bitnami-server value="{{ $msg }}"' && export INFLUX_TOKEN=$(influx auth list | grep {{ $user }} | awk '{print $2}') && influx query --host http://influxdb:{{ $port }} --org {{ $org }} 'from(bucket:"{{ $bucket }}") |> range(start:-2m)'
     exit-status: 0
     stdout:
-      - {{ $msg }}
+      - "{{ $msg }}"
   {{- $uid := .Vars.influxdb.containerSecurityContext.runAsUser }}
   {{- $gid := .Vars.influxdb.podSecurityContext.fsGroup }}
   check-user-info:

--- a/.vib/jupyterhub/goss/goss.yaml
+++ b/.vib/jupyterhub/goss/goss.yaml
@@ -27,7 +27,7 @@ file:
     mode: "0777"
     owner: root
     contents:
-    - postgresql://{{ .Vars.postgresql.auth.username }}@jupyterhub-postgresql:{{ .Vars.postgresql.service.ports.postgresql }}/{{ .Vars.postgresql.auth.database }}
+    - "postgresql://{{ .Vars.postgresql.auth.username }}@jupyterhub-postgresql:{{ .Vars.postgresql.service.ports.postgresql }}/{{ .Vars.postgresql.auth.database }}"
     - /type.*dynamic/
 command:
   {{- $uid := .Vars.hub.containerSecurityContext.runAsUser }}

--- a/.vib/kafka/goss/goss.yaml
+++ b/.vib/kafka/goss/goss.yaml
@@ -17,7 +17,7 @@ file:
     filetype: file
     mode: "0644"
     contents:
-      - listeners=CLIENT://:{{ .Vars.listeners.client.containerPort }},INTERNAL://:{{ .Vars.listeners.interbroker.containerPort }},EXTERNAL://:{{ .Vars.listeners.external.containerPort }},CONTROLLER://:{{ .Vars.listeners.controller.containerPort }}
+      - "listeners=CLIENT://:{{ .Vars.listeners.client.containerPort }},INTERNAL://:{{ .Vars.listeners.interbroker.containerPort }},EXTERNAL://:{{ .Vars.listeners.external.containerPort }},CONTROLLER://:{{ .Vars.listeners.controller.containerPort }}"
 command:
   create-kafka-topic:
     exec: kafka-topics.sh --create --topic quickstart-events{{randAlpha 5}} --bootstrap-server kafka:{{ .Vars.service.ports.client }}

--- a/.vib/logstash/goss/goss.yaml
+++ b/.vib/logstash/goss/goss.yaml
@@ -25,7 +25,7 @@ command:
     exec: echo '{{ $rnd_ip }} - - [18/May/2011:19:35:08 -0700] "GET /css/main.css HTTP/1.1" 200 55 "{{ $rnd_address }}" "Mozilla/5.0"' >> /tmp/test_input && sleep 20 && cat /tmp/test_log
     exit-status: 0
     stdout:
-      - {{ $rnd_ip }}
+      - "{{ $rnd_ip }}"
       - /status_code.*200/
       - /referrer.*{{ $rnd_address }}/
     timeout: 30000

--- a/.vib/mariadb-galera/goss/goss.yaml
+++ b/.vib/mariadb-galera/goss/goss.yaml
@@ -25,7 +25,7 @@ command:
     exec: mariadb -h mariadb-galera {{ $conn_opts }} -e 'DROP TABLE IF EXISTS TEST; create table TEST(test_id int auto_increment, test_value int, primary key(test_id)); INSERT INTO TEST (TEST_VALUE) VALUES ({{ $testValue }});SELECT * FROM TEST'
     exit-status: 0
     stdout:
-    - {{ $testValue }}
+    - "{{ $testValue }}"
   {{- $numNodes := .Vars.replicaCount }}
   {{- $testValue := "2022" }}
   {{- range $e, $i := until $numNodes }}
@@ -34,7 +34,7 @@ command:
     exec: mariadb -h mariadb-galera-{{ $i }}.mariadb-galera-headless {{ $conn_opts }} -e 'DROP TABLE IF EXISTS TEST_REP_{{ $i }}; create table TEST_REP_{{ $i }}(test_id int auto_increment, test_value varchar(4), primary key(test_id)); INSERT INTO TEST_REP_{{ $i }} (TEST_VALUE) VALUES ({{ $testValue }})' && sleep 2 {{ range $e, $j := until $numNodes }} && mariadb -h mariadb-galera-{{ $j }}.mariadb-galera-headless {{ $conn_opts }} -e 'SELECT * FROM TEST_REP_{{ $i }}'{{ end }}
     exit-status: 0
     stdout:
-    - {{ $testValue }}
+    - "{{ $testValue }}"
     timeout: 9000
   {{- end }}
   {{- $uid := .Vars.containerSecurityContext.runAsUser }}

--- a/.vib/memcached/goss/goss.yaml
+++ b/.vib/memcached/goss/goss.yaml
@@ -14,8 +14,8 @@ command:
     exec: bash -c 'printf "set {{ $key }} 0 300 11\r\n{{ $value }}\r\nquit\n" | {{ $server_connection }} && printf "get {{ $key }}\r\nquit\n" | {{ $server_connection }}'
     exit-status: 0
     stdout:
-    - STORED
-    - {{ $value }}
+    - "STORED"
+    - "{{ $value }}"
   {{- $uid := .Vars.containerSecurityContext.runAsUser }}
   {{- $gid := .Vars.podSecurityContext.fsGroup }}
   check-user-info:

--- a/.vib/mongodb-sharded/goss/goss.yaml
+++ b/.vib/mongodb-sharded/goss/goss.yaml
@@ -41,5 +41,5 @@ file:
     mode: "0600"
     filetype: file
     contents:
-      - {{ .Vars.auth.replicaSetKey }}
+      - "{{ .Vars.auth.replicaSetKey }}"
     exists: true

--- a/.vib/mongodb/goss/goss.yaml
+++ b/.vib/mongodb/goss/goss.yaml
@@ -24,7 +24,7 @@ command:
     exec: mongosh {{ $conn_opts }} --eval "db.{{ $testCollection }}.drop(); db.createCollection('{{ $testCollection }}'); db.getCollectionNames()" {{ (index .Vars.auth.databases 0) }}
     exit-status: 0
     stdout:
-      - {{ $testCollection }}
+      - "{{ $testCollection }}"
   {{- $uid := .Vars.containerSecurityContext.runAsUser }}
   {{- $gid := .Vars.podSecurityContext.fsGroup }}
   check-user-info:

--- a/.vib/nginx-ingress-controller/goss/goss.yaml
+++ b/.vib/nginx-ingress-controller/goss/goss.yaml
@@ -17,7 +17,7 @@ command:
     exec: capsh --print
     exit-status: 0
     stdout:
-      - Bounding set =cap_{{ index .Vars.containerSecurityContext.capabilities.add 0 | toLower }}
+      - "Bounding set =cap_{{ index .Vars.containerSecurityContext.capabilities.add 0 | toLower }}"
   {{ if .Vars.serviceAccount.automountServiceAccountToken }}
   check-sa:
     exec: cat /var/run/secrets/kubernetes.io/serviceaccount/token | cut -d '.' -f 2 | xargs -I '{}' echo '{}====' | fold -w 4 | sed '$ d' | tr -d '\n' | base64 -d

--- a/.vib/odoo/goss/goss.yaml
+++ b/.vib/odoo/goss/goss.yaml
@@ -15,5 +15,5 @@ file:
     owner: root
     group: root
     contents:
-     - db_user = {{ .Vars.postgresql.auth.username }}
-     - http_port = {{ .Vars.containerPorts.http }}
+     - "db_user = {{ .Vars.postgresql.auth.username }}"
+     - "http_port = {{ .Vars.containerPorts.http }}"

--- a/.vib/postgresql-ha/goss/repmgr/goss.yaml
+++ b/.vib/postgresql-ha/goss/repmgr/goss.yaml
@@ -18,11 +18,11 @@ command:
     exec: PGPASSWORD={{ $repmgr_password }} psql -U {{ $repmgr_user }} -d {{ $repmgr_database }} {{ $repmgr_endpoint }} -c "SELECT conninfo FROM repmgr.nodes WHERE type = 'primary'"
     exit-status: 0
     stdout:
-    - user={{ $repmgr_user }}
-    - password={{ $repmgr_password }}
-    - dbname={{ $repmgr_database }}
-    - port={{ $repmgr_port }}
-    - connect_timeout={{ .Vars.postgresql.repmgrConnectTimeout }}
+    - "user={{ $repmgr_user }}"
+    - "password={{ $repmgr_password }}"
+    - "dbname={{ $repmgr_database }}"
+    - "port={{ $repmgr_port }}"
+    - "connect_timeout={{ .Vars.postgresql.repmgrConnectTimeout }}"
   test-replication:
     # We need to first obtain the primary's host to perform write operations
     {{- $database := printf "db_%s" (randAlpha 5 | lower) }}

--- a/.vib/prometheus/goss/goss.yaml
+++ b/.vib/prometheus/goss/goss.yaml
@@ -70,7 +70,7 @@ command:
     exec: promtool check config /opt/bitnami/prometheus/conf/{{ .Vars.server.existingConfigmapKey }}
     exit-status: 0
     stdout:
-    - SUCCESS
+    - "SUCCESS"
   check-metrics:
     exec: promtool query instant http://localhost:{{ .Vars.server.containerPorts.http }} prometheus_http_requests_total
     exit-status: 0

--- a/.vib/rabbitmq/goss/goss.yaml
+++ b/.vib/rabbitmq/goss/goss.yaml
@@ -37,7 +37,7 @@ command:
     exit-status: 0
     stdout:
     {{ range $plugin := (split " " .Vars.extraPlugins) }}
-      - {{ $plugin }}
+      - "{{ $plugin }}"
     {{ end }}
   {{- $uid := .Vars.containerSecurityContext.runAsUser }}
   {{- $gid := .Vars.podSecurityContext.fsGroup }}

--- a/.vib/redis/goss/goss.yaml
+++ b/.vib/redis/goss/goss.yaml
@@ -16,21 +16,21 @@ command:
     exec: {{ $auth }} redis-cli {{ $master_endpoint }} {{ $command }}
     exit-status: 0
     stdout:
-      - ERR unknown command
+      - "ERR unknown command"
   {{ end }}
   redis-master-role:
     exec: {{ $auth }} redis-cli {{ $master_endpoint }} ROLE
     exit-status: 0
     stdout:
-      - master
+      - "master"
       {{ range $e, $i := until $replicas }}
-      - redis-replicas-{{ $i }}
+      - "redis-replicas-{{ $i }}"
       {{ end }}
   redis-replicas-role:
     exec: {{ $auth }} redis-cli {{ $replicas_endpoint }} ROLE
     exit-status: 0
     stdout:
-      - slave
+      - "slave"
   {{- $uid := .Vars.master.containerSecurityContext.runAsUser }}
   {{- $gid := .Vars.master.podSecurityContext.fsGroup }}
   check-user-info:

--- a/.vib/solr/goss/goss.yaml
+++ b/.vib/solr/goss/goss.yaml
@@ -12,7 +12,7 @@ command:
       solr healthcheck -z solr-zookeeper:2181/solr -c {{ $collection }}
     exit-status: 0
     stdout:
-      - healthy
+      - "healthy"
     {{ range $e, $i := until $replicas }}
       - /solr-{{ $i }}/
     {{ end }}
@@ -35,4 +35,4 @@ file:
     filetype: file
     exists: true
     contents:
-    - SOLR_CLOUD_BOOTSTRAP={{ if .Vars.cloudBootstrap }}yes{{ else }}no{{ end }}
+    - "SOLR_CLOUD_BOOTSTRAP={{ if .Vars.cloudBootstrap }}yes{{ else }}no{{ end }}"

--- a/.vib/spring-cloud-dataflow/goss/goss.yaml
+++ b/.vib/spring-cloud-dataflow/goss/goss.yaml
@@ -11,7 +11,7 @@ file:
     mode: "0777"
     owner: root
     contents:
-    - {{ .Vars.server.configuration.accountName }}
+    - "{{ .Vars.server.configuration.accountName }}"
     - /url.*jdbc:mariadb.*{{ .Vars.mariadb.auth.database }}/
     - /username.*{{ .Vars.mariadb.auth.username }}/
   /etc/secrets/database:

--- a/.vib/wordpress/goss/goss.yaml
+++ b/.vib/wordpress/goss/goss.yaml
@@ -22,7 +22,7 @@ command:
     exec: wp option list --search="admin_email"
     exit-status: 0
     stdout:
-      - {{ .Vars.wordpressEmail }}
+      - "{{ .Vars.wordpressEmail }}"
   {{- $uid := .Vars.containerSecurityContext.runAsUser }}
   {{- $gid := .Vars.podSecurityContext.fsGroup }}
   check-user-info:

--- a/.vib/zookeeper/goss/goss.yaml
+++ b/.vib/zookeeper/goss/goss.yaml
@@ -10,8 +10,8 @@ file:
     filetype: file
     mode: "0644"
     contents:
-      - {{ .Vars.containerPorts.client }}
-      - preAllocSize={{ .Vars.preAllocSize }}
+      - "{{ .Vars.containerPorts.client }}"
+      - "preAllocSize={{ .Vars.preAllocSize }}"
 command:
   zookeeper-create-znode:
     exec: zkCli.sh -server zookeeper-0:{{ .Vars.containerPorts.client }} create /my_key_{{randAlpha 5}} my_data


### PR DESCRIPTION
This is a follow-up of https://github.com/bitnami/charts/pull/20305. Since any integer in `contents:` and `stdout:` is expected to be treated as a string, we opted for quoting any variable or hardcoded value except regexps so we don't need to care about the type.