### PR TITLE
[bitnami/solr] Add support for enableServiceLinks on solr chart

### DIFF
--- a/bitnami/solr/Chart.yaml
+++ b/bitnami/solr/Chart.yaml
@@ -34,4 +34,4 @@ maintainers:
 name: solr
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/solr
-version: 8.1.8
+version: 8.2.0

--- a/bitnami/solr/README.md
+++ b/bitnami/solr/README.md
@@ -166,6 +166,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `extraVolumeMounts`                     | Optionally specify extra list of additional volumeMounts for the Solr container(s)                                       | `[]`            |
 | `initContainers`                        | Add init containers to the Solr pod(s)                                                                                   | `[]`            |
 | `sidecars`                              | Add sidecars to the Solr pod(s)                                                                                          | `[]`            |
+| `enableServiceLinks`                    | Whether information about services should be injected into pod's environment variable                                    | `true`          |
 
 ### Traffic Exposure parameters
 

--- a/bitnami/solr/README.md
+++ b/bitnami/solr/README.md
@@ -159,6 +159,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `schedulerName`                         | Kubernetes pod scheduler registry                                                                                        | `""`            |
 | `updateStrategy.type`                   | Solr statefulset strategy type                                                                                           | `RollingUpdate` |
 | `updateStrategy.rollingUpdate`          | Solr statefulset rolling update configuration parameters                                                                 | `{}`            |
+| `enableServiceLinks`                    | Whether information about services should be injected into pod's environment variable                                    | `true`          |
 | `pdb.create`                            | Enable a Pod Disruption Budget creation                                                                                  | `false`         |
 | `pdb.minAvailable`                      | Minimum number/percentage of pods that should remain scheduled                                                           | `1`             |
 | `pdb.maxUnavailable`                    | Maximum number/percentage of pods that may be made unavailable                                                           | `""`            |
@@ -166,7 +167,6 @@ The command removes all the Kubernetes components associated with the chart and 
 | `extraVolumeMounts`                     | Optionally specify extra list of additional volumeMounts for the Solr container(s)                                       | `[]`            |
 | `initContainers`                        | Add init containers to the Solr pod(s)                                                                                   | `[]`            |
 | `sidecars`                              | Add sidecars to the Solr pod(s)                                                                                          | `[]`            |
-| `enableServiceLinks`                    | Whether information about services should be injected into pod's environment variable                                    | `true`          |
 
 ### Traffic Exposure parameters
 

--- a/bitnami/solr/templates/statefulset.yaml
+++ b/bitnami/solr/templates/statefulset.yaml
@@ -71,6 +71,7 @@ spec:
       {{- if .Values.podSecurityContext.enabled }}
       securityContext: {{- omit .Values.podSecurityContext "enabled" | toYaml | nindent 8 }}
       {{- end }}
+      enableServiceLinks: {{ .Values.enableServiceLinks }}
       initContainers:
         {{- if and .Values.volumePermissions.enabled .Values.persistence.enabled }}
         - name: volume-permissions

--- a/bitnami/solr/values.yaml
+++ b/bitnami/solr/values.yaml
@@ -327,6 +327,11 @@ schedulerName: ""
 updateStrategy:
   type: RollingUpdate
   rollingUpdate: {}
+## @param enableServiceLinks Whether information about services should be injected into pod's environment variable
+## The environment variables injected by service links are not used, but can lead to slow boot times or slow running of the scripts when there are many services in the current namespace.
+## If you experience slow pod startups or slow running of the scripts you probably want to set this to `false`.
+##
+enableServiceLinks: true
 
 ## Solr Pod Disruption Budget configuration
 ## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/


### PR DESCRIPTION
### Description of the change

This pull request adds support for `enableServiceLinks` parameter on Solr Helm chart.

### Benefits

- Reduce startup time for pods that run in a shared namespace with many services.

### Possible drawbacks

- None. Param has default value of `true`, which is standard k8s behaviour.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)