### PR TITLE
[bitnami/rabbitmq-cluster-operator] - Add support for PodMonitor

### DIFF
--- a/bitnami/rabbitmq-cluster-operator/Chart.yaml
+++ b/bitnami/rabbitmq-cluster-operator/Chart.yaml
@@ -37,4 +37,4 @@ maintainers:
 name: rabbitmq-cluster-operator
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/rabbitmq-cluster-operator
-version: 3.8.9
+version: 3.9.0

--- a/bitnami/rabbitmq-cluster-operator/README.md
+++ b/bitnami/rabbitmq-cluster-operator/README.md
@@ -242,32 +242,44 @@ This solution allows to easily deploy multiple RabbitMQ instances compared to th
 
 ### RabbitMQ Cluster Operator Metrics parameters
 
-| Name                                                       | Description                                                                 | Value                    |
-| ---------------------------------------------------------- | --------------------------------------------------------------------------- | ------------------------ |
-| `clusterOperator.metrics.enabled`                          | Create a service for accessing the metrics endpoint                         | `false`                  |
-| `clusterOperator.metrics.service.type`                     | RabbitMQ Cluster Operator metrics service type                              | `ClusterIP`              |
-| `clusterOperator.metrics.service.ports.http`               | RabbitMQ Cluster Operator metrics service HTTP port                         | `80`                     |
-| `clusterOperator.metrics.service.nodePorts.http`           | Node port for HTTP                                                          | `""`                     |
-| `clusterOperator.metrics.service.clusterIP`                | RabbitMQ Cluster Operator metrics service Cluster IP                        | `""`                     |
-| `clusterOperator.metrics.service.extraPorts`               | Extra ports to expose (normally used with the `sidecar` value)              | `[]`                     |
-| `clusterOperator.metrics.service.loadBalancerIP`           | RabbitMQ Cluster Operator metrics service Load Balancer IP                  | `""`                     |
-| `clusterOperator.metrics.service.loadBalancerSourceRanges` | RabbitMQ Cluster Operator metrics service Load Balancer sources             | `[]`                     |
-| `clusterOperator.metrics.service.externalTrafficPolicy`    | RabbitMQ Cluster Operator metrics service external traffic policy           | `Cluster`                |
-| `clusterOperator.metrics.service.annotations`              | Additional custom annotations for RabbitMQ Cluster Operator metrics service | `{}`                     |
-| `clusterOperator.metrics.service.sessionAffinity`          | Session Affinity for Kubernetes service, can be "None" or "ClientIP"        | `None`                   |
-| `clusterOperator.metrics.service.sessionAffinityConfig`    | Additional settings for the sessionAffinity                                 | `{}`                     |
-| `clusterOperator.metrics.serviceMonitor.enabled`           | Specify if a servicemonitor will be deployed for prometheus-operator        | `false`                  |
-| `clusterOperator.metrics.serviceMonitor.namespace`         | Namespace which Prometheus is running in                                    | `""`                     |
-| `clusterOperator.metrics.serviceMonitor.jobLabel`          | Specify the jobLabel to use for the prometheus-operator                     | `app.kubernetes.io/name` |
-| `clusterOperator.metrics.serviceMonitor.honorLabels`       | Honor metrics labels                                                        | `false`                  |
-| `clusterOperator.metrics.serviceMonitor.selector`          | Prometheus instance selector labels                                         | `{}`                     |
-| `clusterOperator.metrics.serviceMonitor.scrapeTimeout`     | Timeout after which the scrape is ended                                     | `""`                     |
-| `clusterOperator.metrics.serviceMonitor.interval`          | Scrape interval. If not set, the Prometheus default scrape interval is used | `""`                     |
-| `clusterOperator.metrics.serviceMonitor.metricRelabelings` | Specify additional relabeling of metrics                                    | `[]`                     |
-| `clusterOperator.metrics.serviceMonitor.relabelings`       | Specify general relabeling                                                  | `[]`                     |
-| `clusterOperator.metrics.serviceMonitor.labels`            | Extra labels for the ServiceMonitor                                         | `{}`                     |
-| `clusterOperator.metrics.serviceMonitor.path`              | Define the path used by ServiceMonitor to scrap metrics                     | `""`                     |
-| `clusterOperator.metrics.serviceMonitor.params`            | Define the HTTP URL parameters used by ServiceMonitor                       | `{}`                     |
+| Name                                                       | Description                                                                        | Value                    |
+| ---------------------------------------------------------- | ---------------------------------------------------------------------------------- | ------------------------ |
+| `clusterOperator.metrics.service.enabled`                  | Create a service for accessing the metrics endpoint                                | `false`                  |
+| `clusterOperator.metrics.service.type`                     | RabbitMQ Cluster Operator metrics service type                                     | `ClusterIP`              |
+| `clusterOperator.metrics.service.ports.http`               | RabbitMQ Cluster Operator metrics service HTTP port                                | `80`                     |
+| `clusterOperator.metrics.service.nodePorts.http`           | Node port for HTTP                                                                 | `""`                     |
+| `clusterOperator.metrics.service.clusterIP`                | RabbitMQ Cluster Operator metrics service Cluster IP                               | `""`                     |
+| `clusterOperator.metrics.service.extraPorts`               | Extra ports to expose (normally used with the `sidecar` value)                     | `[]`                     |
+| `clusterOperator.metrics.service.loadBalancerIP`           | RabbitMQ Cluster Operator metrics service Load Balancer IP                         | `""`                     |
+| `clusterOperator.metrics.service.loadBalancerSourceRanges` | RabbitMQ Cluster Operator metrics service Load Balancer sources                    | `[]`                     |
+| `clusterOperator.metrics.service.externalTrafficPolicy`    | RabbitMQ Cluster Operator metrics service external traffic policy                  | `Cluster`                |
+| `clusterOperator.metrics.service.annotations`              | Additional custom annotations for RabbitMQ Cluster Operator metrics service        | `{}`                     |
+| `clusterOperator.metrics.service.sessionAffinity`          | Session Affinity for Kubernetes service, can be "None" or "ClientIP"               | `None`                   |
+| `clusterOperator.metrics.service.sessionAffinityConfig`    | Additional settings for the sessionAffinity                                        | `{}`                     |
+| `clusterOperator.metrics.serviceMonitor.enabled`           | Specify if a servicemonitor will be deployed for prometheus-operator               | `false`                  |
+| `clusterOperator.metrics.serviceMonitor.namespace`         | Namespace which Prometheus is running in                                           | `""`                     |
+| `clusterOperator.metrics.serviceMonitor.jobLabel`          | Specify the jobLabel to use for the prometheus-operator                            | `app.kubernetes.io/name` |
+| `clusterOperator.metrics.serviceMonitor.honorLabels`       | Honor metrics labels                                                               | `false`                  |
+| `clusterOperator.metrics.serviceMonitor.selector`          | Prometheus instance selector labels                                                | `{}`                     |
+| `clusterOperator.metrics.serviceMonitor.scrapeTimeout`     | Timeout after which the scrape is ended                                            | `""`                     |
+| `clusterOperator.metrics.serviceMonitor.interval`          | Scrape interval. If not set, the Prometheus default scrape interval is used        | `""`                     |
+| `clusterOperator.metrics.serviceMonitor.metricRelabelings` | Specify additional relabeling of metrics                                           | `[]`                     |
+| `clusterOperator.metrics.serviceMonitor.relabelings`       | Specify general relabeling                                                         | `[]`                     |
+| `clusterOperator.metrics.serviceMonitor.labels`            | Extra labels for the ServiceMonitor                                                | `{}`                     |
+| `clusterOperator.metrics.serviceMonitor.path`              | Define the path used by ServiceMonitor to scrap metrics                            | `""`                     |
+| `clusterOperator.metrics.serviceMonitor.params`            | Define the HTTP URL parameters used by ServiceMonitor                              | `{}`                     |
+| `clusterOperator.metrics.podMonitor.enabled`               | Create PodMonitor Resource for scraping metrics using PrometheusOperator           | `false`                  |
+| `clusterOperator.metrics.podMonitor.jobLabel`              | Specify the jobLabel to use for the prometheus-operator                            | `app.kubernetes.io/name` |
+| `clusterOperator.metrics.podMonitor.namespace`             | Namespace which Prometheus is running in                                           | `""`                     |
+| `clusterOperator.metrics.podMonitor.honorLabels`           | Honor metrics labels                                                               | `false`                  |
+| `clusterOperator.metrics.podMonitor.selector`              | Prometheus instance selector labels                                                | `{}`                     |
+| `clusterOperator.metrics.podMonitor.interval`              | Specify the interval at which metrics should be scraped                            | `30s`                    |
+| `clusterOperator.metrics.podMonitor.scrapeTimeout`         | Specify the timeout after which the scrape is ended                                | `30s`                    |
+| `clusterOperator.metrics.podMonitor.additionalLabels`      | Additional labels that can be used so PodMonitors will be discovered by Prometheus | `{}`                     |
+| `clusterOperator.metrics.podMonitor.path`                  | Define HTTP path to scrape for metrics.                                            | `""`                     |
+| `clusterOperator.metrics.podMonitor.relabelings`           | Specify general relabeling                                                         | `[]`                     |
+| `clusterOperator.metrics.podMonitor.metricRelabelings`     | Specify additional relabeling of metrics                                           | `[]`                     |
+| `clusterOperator.metrics.podMonitor.params`                | Define the HTTP URL parameters used by PodMonitor                                  | `{}`                     |
 
 ### RabbitMQ Messaging Topology Operator Parameters
 
@@ -361,30 +373,40 @@ This solution allows to easily deploy multiple RabbitMQ instances compared to th
 
 ### RabbitMQ Messaging Topology Operator parameters
 
-| Name                                                           | Description                                                                 | Value                    |
-| -------------------------------------------------------------- | --------------------------------------------------------------------------- | ------------------------ |
-| `msgTopologyOperator.metrics.enabled`                          | Create a service for accessing the metrics endpoint                         | `false`                  |
-| `msgTopologyOperator.metrics.service.type`                     | RabbitMQ Cluster Operator metrics service type                              | `ClusterIP`              |
-| `msgTopologyOperator.metrics.service.ports.http`               | RabbitMQ Cluster Operator metrics service HTTP port                         | `80`                     |
-| `msgTopologyOperator.metrics.service.nodePorts.http`           | Node port for HTTP                                                          | `""`                     |
-| `msgTopologyOperator.metrics.service.clusterIP`                | RabbitMQ Cluster Operator metrics service Cluster IP                        | `""`                     |
-| `msgTopologyOperator.metrics.service.extraPorts`               | Extra ports to expose (normally used with the `sidecar` value)              | `[]`                     |
-| `msgTopologyOperator.metrics.service.loadBalancerIP`           | RabbitMQ Cluster Operator metrics service Load Balancer IP                  | `""`                     |
-| `msgTopologyOperator.metrics.service.loadBalancerSourceRanges` | RabbitMQ Cluster Operator metrics service Load Balancer sources             | `[]`                     |
-| `msgTopologyOperator.metrics.service.externalTrafficPolicy`    | RabbitMQ Cluster Operator metrics service external traffic policy           | `Cluster`                |
-| `msgTopologyOperator.metrics.service.annotations`              | Additional custom annotations for RabbitMQ Cluster Operator metrics service | `{}`                     |
-| `msgTopologyOperator.metrics.service.sessionAffinity`          | Session Affinity for Kubernetes service, can be "None" or "ClientIP"        | `None`                   |
-| `msgTopologyOperator.metrics.service.sessionAffinityConfig`    | Additional settings for the sessionAffinity                                 | `{}`                     |
-| `msgTopologyOperator.metrics.serviceMonitor.enabled`           | Specify if a servicemonitor will be deployed for prometheus-operator        | `false`                  |
-| `msgTopologyOperator.metrics.serviceMonitor.namespace`         | Namespace which Prometheus is running in                                    | `""`                     |
-| `msgTopologyOperator.metrics.serviceMonitor.jobLabel`          | Specify the jobLabel to use for the prometheus-operator                     | `app.kubernetes.io/name` |
-| `msgTopologyOperator.metrics.serviceMonitor.selector`          | Prometheus instance selector labels                                         | `{}`                     |
-| `msgTopologyOperator.metrics.serviceMonitor.honorLabels`       | Honor metrics labels                                                        | `false`                  |
-| `msgTopologyOperator.metrics.serviceMonitor.scrapeTimeout`     | Timeout after which the scrape is ended                                     | `""`                     |
-| `msgTopologyOperator.metrics.serviceMonitor.interval`          | Scrape interval. If not set, the Prometheus default scrape interval is used | `""`                     |
-| `msgTopologyOperator.metrics.serviceMonitor.metricRelabelings` | Specify additional relabeling of metrics                                    | `[]`                     |
-| `msgTopologyOperator.metrics.serviceMonitor.relabelings`       | Specify general relabeling                                                  | `[]`                     |
-| `msgTopologyOperator.metrics.serviceMonitor.labels`            | Extra labels for the ServiceMonitor                                         | `{}`                     |
+| Name                                                           | Description                                                                        | Value                    |
+| -------------------------------------------------------------- | ---------------------------------------------------------------------------------- | ------------------------ |
+| `msgTopologyOperator.metrics.service.enabled`                  | Create a service for accessing the metrics endpoint                                | `false`                  |
+| `msgTopologyOperator.metrics.service.type`                     | RabbitMQ Cluster Operator metrics service type                                     | `ClusterIP`              |
+| `msgTopologyOperator.metrics.service.ports.http`               | RabbitMQ Cluster Operator metrics service HTTP port                                | `80`                     |
+| `msgTopologyOperator.metrics.service.nodePorts.http`           | Node port for HTTP                                                                 | `""`                     |
+| `msgTopologyOperator.metrics.service.clusterIP`                | RabbitMQ Cluster Operator metrics service Cluster IP                               | `""`                     |
+| `msgTopologyOperator.metrics.service.extraPorts`               | Extra ports to expose (normally used with the `sidecar` value)                     | `[]`                     |
+| `msgTopologyOperator.metrics.service.loadBalancerIP`           | RabbitMQ Cluster Operator metrics service Load Balancer IP                         | `""`                     |
+| `msgTopologyOperator.metrics.service.loadBalancerSourceRanges` | RabbitMQ Cluster Operator metrics service Load Balancer sources                    | `[]`                     |
+| `msgTopologyOperator.metrics.service.externalTrafficPolicy`    | RabbitMQ Cluster Operator metrics service external traffic policy                  | `Cluster`                |
+| `msgTopologyOperator.metrics.service.annotations`              | Additional custom annotations for RabbitMQ Cluster Operator metrics service        | `{}`                     |
+| `msgTopologyOperator.metrics.service.sessionAffinity`          | Session Affinity for Kubernetes service, can be "None" or "ClientIP"               | `None`                   |
+| `msgTopologyOperator.metrics.service.sessionAffinityConfig`    | Additional settings for the sessionAffinity                                        | `{}`                     |
+| `msgTopologyOperator.metrics.serviceMonitor.enabled`           | Specify if a servicemonitor will be deployed for prometheus-operator               | `false`                  |
+| `msgTopologyOperator.metrics.serviceMonitor.namespace`         | Namespace which Prometheus is running in                                           | `""`                     |
+| `msgTopologyOperator.metrics.serviceMonitor.jobLabel`          | Specify the jobLabel to use for the prometheus-operator                            | `app.kubernetes.io/name` |
+| `msgTopologyOperator.metrics.serviceMonitor.selector`          | Prometheus instance selector labels                                                | `{}`                     |
+| `msgTopologyOperator.metrics.serviceMonitor.honorLabels`       | Honor metrics labels                                                               | `false`                  |
+| `msgTopologyOperator.metrics.serviceMonitor.scrapeTimeout`     | Timeout after which the scrape is ended                                            | `""`                     |
+| `msgTopologyOperator.metrics.serviceMonitor.interval`          | Scrape interval. If not set, the Prometheus default scrape interval is used        | `""`                     |
+| `msgTopologyOperator.metrics.serviceMonitor.metricRelabelings` | Specify additional relabeling of metrics                                           | `[]`                     |
+| `msgTopologyOperator.metrics.serviceMonitor.relabelings`       | Specify general relabeling                                                         | `[]`                     |
+| `msgTopologyOperator.metrics.serviceMonitor.labels`            | Extra labels for the ServiceMonitor                                                | `{}`                     |
+| `msgTopologyOperator.metrics.podMonitor.enabled`               | Create PodMonitor Resource for scraping metrics using PrometheusOperator           | `false`                  |
+| `msgTopologyOperator.metrics.podMonitor.jobLabel`              | Specify the jobLabel to use for the prometheus-operator                            | `app.kubernetes.io/name` |
+| `msgTopologyOperator.metrics.podMonitor.namespace`             | Namespace which Prometheus is running in                                           | `""`                     |
+| `msgTopologyOperator.metrics.podMonitor.honorLabels`           | Honor metrics labels                                                               | `false`                  |
+| `msgTopologyOperator.metrics.podMonitor.selector`              | Prometheus instance selector labels                                                | `{}`                     |
+| `msgTopologyOperator.metrics.podMonitor.interval`              | Specify the interval at which metrics should be scraped                            | `30s`                    |
+| `msgTopologyOperator.metrics.podMonitor.scrapeTimeout`         | Specify the timeout after which the scrape is ended                                | `30s`                    |
+| `msgTopologyOperator.metrics.podMonitor.additionalLabels`      | Additional labels that can be used so PodMonitors will be discovered by Prometheus | `{}`                     |
+| `msgTopologyOperator.metrics.podMonitor.relabelings`           | Specify general relabeling                                                         | `[]`                     |
+| `msgTopologyOperator.metrics.podMonitor.metricRelabelings`     | Specify additional relabeling of metrics                                           | `[]`                     |
 
 ### cert-manager parameters
 

--- a/bitnami/rabbitmq-cluster-operator/templates/cluster-operator/metrics-service.yaml
+++ b/bitnami/rabbitmq-cluster-operator/templates/cluster-operator/metrics-service.yaml
@@ -3,7 +3,7 @@ Copyright VMware, Inc.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- if .Values.clusterOperator.metrics.enabled }}
+{{- if .Values.clusterOperator.metrics.service.enabled }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/bitnami/rabbitmq-cluster-operator/templates/cluster-operator/podmonitor.yaml
+++ b/bitnami/rabbitmq-cluster-operator/templates/cluster-operator/podmonitor.yaml
@@ -1,0 +1,73 @@
+{{- /*
+Copyright VMware, Inc.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+{{- if .Values.clusterOperator.metrics.podMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+    app.kubernetes.io/component: rabbitmq-operator
+    app.kubernetes.io/part-of: rabbitmq
+    {{- if .Values.clusterOperator.metrics.podMonitor.additionalLabels }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.clusterOperator.metrics.podMonitor.additionalLabels "context" $) | nindent 4 }}
+    {{- end }}
+  name: {{ printf "%s-metrics" (include "rmqco.clusterOperator.fullname" .) }}
+  namespace: {{ default (include "common.names.namespace" .) .Values.msgTopologyOperator.metrics.podMonitor.namespace | quote }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $) | nindent 4 }}
+  {{- end }}
+spec:
+  jobLabel: {{ .Values.clusterOperator.metrics.podMonitor.jobLabel }}
+  selector:
+    matchLabels:
+      {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.clusterOperator.podLabels .Values.commonLabels ) "context" . ) }}
+      {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
+      {{- if .Values.clusterOperator.metrics.podMonitor.selector }}
+      {{- include "common.tplvalues.render" ( dict "value" .Values.clusterOperator.metrics.podMonitor.selector "context" $ ) | nindent 6 }}
+      {{- end }}
+      app.kubernetes.io/component: rabbitmq-operator
+  namespaceSelector:
+    matchNames:
+      - {{ include "common.names.namespace" . | quote }}
+  podMetricsEndpoints:
+    - port: http
+      {{- if .Values.clusterOperator.metrics.podMonitor.interval }}
+      interval: {{ .Values.clusterOperator.metrics.podMonitor.interval }}
+      {{- end }}
+      {{- if .Values.clusterOperator.metrics.podMonitor.honorLabels }}
+      honorLabels: {{ .Values.clusterOperator.metrics.podMonitor.honorLabels }}
+      {{- end }}
+      {{- if .Values.clusterOperator.metrics.podMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ .Values.clusterOperator.metrics.podMonitor.scrapeTimeout }}
+      {{- end }}
+      {{- if .Values.clusterOperator.metrics.podMonitor.relabelings }}
+      relabelings: {{ toYaml .Values.clusterOperator.metrics.podMonitor.relabelings | nindent 8 }}
+      {{- end }}
+      {{- if .Values.clusterOperator.metrics.podMonitor.metricRelabelings }}
+      metricRelabelings: {{ toYaml .Values.clusterOperator.metrics.podMonitor.metricRelabelings | nindent 8 }}
+      {{- end }}
+    - port: metrics
+      {{- if .Values.clusterOperator.metrics.podMonitor.path }}
+      path: {{ .Values.clusterOperator.metrics.podMonitor.path }}
+      {{- end }}
+      {{- if .Values.clusterOperator.metrics.podMonitor.params }}
+      params: {{ toYaml .Values.clusterOperator.metrics.podMonitor.params | nindent 8 }}
+      {{- end }}
+      {{- if .Values.clusterOperator.metrics.podMonitor.interval }}
+      interval: {{ .Values.clusterOperator.metrics.podMonitor.interval }}
+      {{- end }}
+      {{- if .Values.clusterOperator.metrics.podMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ .Values.clusterOperator.metrics.podMonitor.scrapeTimeout }}
+      {{- end }}
+      {{- if .Values.clusterOperator.metrics.podMonitor.honorLabels }}
+      honorLabels: {{ .Values.clusterOperator.metrics.podMonitor.honorLabels }}
+      {{- end }}
+      {{- if .Values.clusterOperator.metrics.podMonitor.relabelings }}
+      relabelings: {{- include "common.tplvalues.render" ( dict "value" .Values.clusterOperator.metrics.podMonitor.relabelings "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.clusterOperator.metrics.podMonitor.metricRelabelings }}
+      metricRelabelings: {{- include "common.tplvalues.render" ( dict "value" .Values.clusterOperator.metrics.podMonitor.metricRelabelings "context" $) | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/bitnami/rabbitmq-cluster-operator/templates/cluster-operator/servicemonitor.yaml
+++ b/bitnami/rabbitmq-cluster-operator/templates/cluster-operator/servicemonitor.yaml
@@ -3,7 +3,7 @@ Copyright VMware, Inc.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- if and .Values.clusterOperator.metrics.serviceMonitor.enabled .Values.clusterOperator.metrics.enabled }}
+{{- if and .Values.clusterOperator.metrics.serviceMonitor.enabled .Values.clusterOperator.metrics.service.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/metrics-service.yaml
+++ b/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/metrics-service.yaml
@@ -3,7 +3,7 @@ Copyright VMware, Inc.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- if and .Values.msgTopologyOperator.enabled .Values.msgTopologyOperator.metrics.enabled }}
+{{- if and .Values.msgTopologyOperator.enabled .Values.msgTopologyOperator.metrics.service.enabled }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/podmonitor.yaml
+++ b/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/podmonitor.yaml
@@ -1,0 +1,53 @@
+{{- /*
+Copyright VMware, Inc.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+{{- if and .Values.msgTopologyOperator.enabled  .Values.msgTopologyOperator.metrics.podMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ template "rmqco.msgTopologyOperator.fullname" . }}
+  {{- $versionLabel := dict "app.kubernetes.io/version" ( include "common.images.version" ( dict "imageRoot" .Values.msgTopologyOperator.image "chart" .Chart ) ) }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.msgTopologyOperator.metrics.podMonitor.labels .Values.commonLabels $versionLabel ) "context" . ) }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
+    app.kubernetes.io/component: messaging-topology-operator
+    app.kubernetes.io/part-of: rabbitmq
+    {{- if .Values.msgTopologyOperator.metrics.podMonitor.additionalLabels }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.msgTopologyOperator.metrics.podMonitor.additionalLabels "context" $) | nindent 4 }}
+    {{- end }}
+  namespace: {{ default (include "common.names.namespace" .) .Values.msgTopologyOperator.metrics.podMonitor.namespace | quote }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+  jobLabel: {{ .Values.msgTopologyOperator.metrics.podMonitor.jobLabel }}
+  selector:
+    matchLabels:
+      {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.msgTopologyOperator.podLabels .Values.commonLabels ) "context" . ) }}
+      {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
+      {{- if .Values.msgTopologyOperator.metrics.podMonitor.selector }}
+      {{- include "common.tplvalues.render" ( dict "value" .Values.msgTopologyOperator.metrics.podMonitor.selector "context" $ ) | nindent 6 }}
+      {{- end }}
+      app.kubernetes.io/component: rabbitmq-operator
+  namespaceSelector:
+    matchNames:
+      - {{ include "common.names.namespace" . | quote }}
+  podMetricsEndpoints:
+    - port: http
+      {{- if .Values.msgTopologyOperator.metrics.podMonitor.interval }}
+      interval: {{ .Values.msgTopologyOperator.metrics.podMonitor.interval }}
+      {{- end }}
+      {{- if .Values.msgTopologyOperator.metrics.podMonitor.honorLabels }}
+      honorLabels: {{ .Values.msgTopologyOperator.metrics.podMonitor.honorLabels }}
+      {{- end }}
+      {{- if .Values.msgTopologyOperator.metrics.podMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ .Values.msgTopologyOperator.metrics.podMonitor.scrapeTimeout }}
+      {{- end }}
+      {{- if .Values.msgTopologyOperator.metrics.podMonitor.relabelings }}
+      relabelings: {{ toYaml .Values.msgTopologyOperator.metrics.podMonitor.relabelings | nindent 8 }}
+      {{- end }}
+      {{- if .Values.msgTopologyOperator.metrics.podMonitor.metricRelabelings }}
+      metricRelabelings: {{ toYaml .Values.msgTopologyOperator.metrics.podMonitor.metricRelabelings | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/servicemonitor.yaml
+++ b/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/servicemonitor.yaml
@@ -3,7 +3,7 @@ Copyright VMware, Inc.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- if and .Values.msgTopologyOperator.enabled .Values.msgTopologyOperator.metrics.serviceMonitor.enabled .Values.msgTopologyOperator.metrics.enabled }}
+{{- if and .Values.msgTopologyOperator.enabled .Values.msgTopologyOperator.metrics.serviceMonitor.enabled .Values.msgTopologyOperator.metrics.service.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/bitnami/rabbitmq-cluster-operator/values.yaml
+++ b/bitnami/rabbitmq-cluster-operator/values.yaml
@@ -505,7 +505,7 @@ clusterOperator:
       ##
       params: {}
     podMonitor:
-      ## @param clusterOperator.metrics.enabled Create PodMonitor Resource for scraping metrics using PrometheusOperator
+      ## @param clusterOperator.metrics.podMonitor.enabled Create PodMonitor Resource for scraping metrics using PrometheusOperator
       ##
       enabled: false
       ## @param clusterOperator.metrics.podMonitor.jobLabel Specify the jobLabel to use for the prometheus-operator
@@ -535,10 +535,10 @@ clusterOperator:
       ## @param clusterOperator.metrics.podMonitor.relabelings Specify general relabeling
       ##
       relabelings: []
-      ## @param clusterOperator.metrics.serviceMonitor.metricRelabelings Specify additional relabeling of metrics
+      ## @param clusterOperator.metrics.podMonitor.metricRelabelings Specify additional relabeling of metrics
       ##
       metricRelabelings: []
-      ## @param clusterOperator.metrics.serviceMonitor.params Define the HTTP URL parameters used by PodMonitor
+      ## @param clusterOperator.metrics.podMonitor.params Define the HTTP URL parameters used by PodMonitor
       ##
       params: {}
 ## @section RabbitMQ Messaging Topology Operator Parameters
@@ -894,7 +894,7 @@ msgTopologyOperator:
     ## Metrics service parameters
     ##
     service:
-      ## @param msgTopologyOperator.metrics.enabled Create a service for accessing the metrics endpoint
+      ## @param msgTopologyOperator.metrics.service.enabled Create a service for accessing the metrics endpoint
       ##
       enabled: false
       ## @param msgTopologyOperator.metrics.service.type RabbitMQ Cluster Operator metrics service type
@@ -996,7 +996,7 @@ msgTopologyOperator:
       ##
       labels: {}
     podMonitor:
-      ## @param msgTopologyOperator.metrics.enabled Create PodMonitor Resource for scraping metrics using PrometheusOperator
+      ## @param msgTopologyOperator.metrics.podMonitor.enabled Create PodMonitor Resource for scraping metrics using PrometheusOperator
       ##
       enabled: false
       ## @param msgTopologyOperator.metrics.podMonitor.jobLabel Specify the jobLabel to use for the prometheus-operator
@@ -1008,7 +1008,7 @@ msgTopologyOperator:
       ## @param msgTopologyOperator.metrics.podMonitor.honorLabels Honor metrics labels
       ##
       honorLabels: false
-      ## @param clusterOperator.metrics.podMonitor.selector Prometheus instance selector labels
+      ## @param msgTopologyOperator.metrics.podMonitor.selector Prometheus instance selector labels
       ## ref: https://github.com/bitnami/charts/tree/main/bitnami/prometheus-operator#prometheus-configuration
       selector: {}
       ## @param msgTopologyOperator.metrics.podMonitor.interval Specify the interval at which metrics should be scraped
@@ -1023,7 +1023,7 @@ msgTopologyOperator:
       ## @param msgTopologyOperator.metrics.podMonitor.relabelings Specify general relabeling
       ##
       relabelings: []
-      ## @param msgTopologyOperator.metrics.serviceMonitor.metricRelabelings Specify additional relabeling of metrics
+      ## @param msgTopologyOperator.metrics.podMonitor.metricRelabelings Specify additional relabeling of metrics
       ##
       metricRelabelings: []
 ## @section cert-manager parameters

--- a/bitnami/rabbitmq-cluster-operator/values.yaml
+++ b/bitnami/rabbitmq-cluster-operator/values.yaml
@@ -393,12 +393,12 @@ clusterOperator:
   ## @section RabbitMQ Cluster Operator Metrics parameters
   ##
   metrics:
-    ## @param clusterOperator.metrics.enabled Create a service for accessing the metrics endpoint
-    ##
-    enabled: false
     ## Metrics service parameters
     ##
     service:
+      ## @param clusterOperator.metrics.service.enabled Create a service for accessing the metrics endpoint
+      ##
+      enabled: false
       ## @param clusterOperator.metrics.service.type RabbitMQ Cluster Operator metrics service type
       ##
       type: ClusterIP
@@ -504,7 +504,43 @@ clusterOperator:
       ## @param clusterOperator.metrics.serviceMonitor.params Define the HTTP URL parameters used by ServiceMonitor
       ##
       params: {}
-
+    podMonitor:
+      ## @param clusterOperator.metrics.enabled Create PodMonitor Resource for scraping metrics using PrometheusOperator
+      ##
+      enabled: false
+      ## @param clusterOperator.metrics.podMonitor.jobLabel Specify the jobLabel to use for the prometheus-operator
+      ##
+      jobLabel: app.kubernetes.io/name
+      ## @param clusterOperator.metrics.podMonitor.namespace Namespace which Prometheus is running in
+      ##
+      namespace: ""
+      ## @param clusterOperator.metrics.podMonitor.honorLabels Honor metrics labels
+      ##
+      honorLabels: false
+      ## @param clusterOperator.metrics.podMonitor.selector Prometheus instance selector labels
+      ## ref: https://github.com/bitnami/charts/tree/main/bitnami/prometheus-operator#prometheus-configuration
+      selector: {}
+      ## @param clusterOperator.metrics.podMonitor.interval Specify the interval at which metrics should be scraped
+      ##
+      interval: 30s
+      ## @param clusterOperator.metrics.podMonitor.scrapeTimeout Specify the timeout after which the scrape is ended
+      ##
+      scrapeTimeout: 30s
+      ## @param clusterOperator.metrics.podMonitor.additionalLabels [object] Additional labels that can be used so PodMonitors will be discovered by Prometheus
+      ##
+      additionalLabels: {}
+      ## @param clusterOperator.metrics.podMonitor.path Define HTTP path to scrape for metrics.
+      ##
+      path: ""
+      ## @param clusterOperator.metrics.podMonitor.relabelings Specify general relabeling
+      ##
+      relabelings: []
+      ## @param clusterOperator.metrics.serviceMonitor.metricRelabelings Specify additional relabeling of metrics
+      ##
+      metricRelabelings: []
+      ## @param clusterOperator.metrics.serviceMonitor.params Define the HTTP URL parameters used by PodMonitor
+      ##
+      params: {}
 ## @section RabbitMQ Messaging Topology Operator Parameters
 ##
 msgTopologyOperator:
@@ -855,12 +891,12 @@ msgTopologyOperator:
   ## @section RabbitMQ Messaging Topology Operator parameters
   ##
   metrics:
-    ## @param msgTopologyOperator.metrics.enabled Create a service for accessing the metrics endpoint
-    ##
-    enabled: false
     ## Metrics service parameters
     ##
     service:
+      ## @param msgTopologyOperator.metrics.enabled Create a service for accessing the metrics endpoint
+      ##
+      enabled: false
       ## @param msgTopologyOperator.metrics.service.type RabbitMQ Cluster Operator metrics service type
       ##
       type: ClusterIP
@@ -959,7 +995,37 @@ msgTopologyOperator:
       ## @param msgTopologyOperator.metrics.serviceMonitor.labels Extra labels for the ServiceMonitor
       ##
       labels: {}
-
+    podMonitor:
+      ## @param msgTopologyOperator.metrics.enabled Create PodMonitor Resource for scraping metrics using PrometheusOperator
+      ##
+      enabled: false
+      ## @param msgTopologyOperator.metrics.podMonitor.jobLabel Specify the jobLabel to use for the prometheus-operator
+      ##
+      jobLabel: app.kubernetes.io/name
+      ## @param msgTopologyOperator.metrics.podMonitor.namespace Namespace which Prometheus is running in
+      ##
+      namespace: ""
+      ## @param msgTopologyOperator.metrics.podMonitor.honorLabels Honor metrics labels
+      ##
+      honorLabels: false
+      ## @param clusterOperator.metrics.podMonitor.selector Prometheus instance selector labels
+      ## ref: https://github.com/bitnami/charts/tree/main/bitnami/prometheus-operator#prometheus-configuration
+      selector: {}
+      ## @param msgTopologyOperator.metrics.podMonitor.interval Specify the interval at which metrics should be scraped
+      ##
+      interval: 30s
+      ## @param msgTopologyOperator.metrics.podMonitor.scrapeTimeout Specify the timeout after which the scrape is ended
+      ##
+      scrapeTimeout: 30s
+      ## @param msgTopologyOperator.metrics.podMonitor.additionalLabels [object] Additional labels that can be used so PodMonitors will be discovered by Prometheus
+      ##
+      additionalLabels: {}
+      ## @param msgTopologyOperator.metrics.podMonitor.relabelings Specify general relabeling
+      ##
+      relabelings: []
+      ## @param msgTopologyOperator.metrics.serviceMonitor.metricRelabelings Specify additional relabeling of metrics
+      ##
+      metricRelabelings: []
 ## @section cert-manager parameters
 ##
 


### PR DESCRIPTION
**Description of the change**
Adding PodMonitor support for rabbitmq-cluster-operator

**Benefits**
Removing the need for ClusterIP service that solely exist for gathering metrics

**Possible drawbacks**

**Applicable issues**

**Additional information**