### PR TITLE
[bitnami/grafana-operator]: fix grafana.serviceAccount

### DIFF
--- a/bitnami/grafana-operator/Chart.yaml
+++ b/bitnami/grafana-operator/Chart.yaml
@@ -30,4 +30,4 @@ maintainers:
 name: grafana-operator
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/grafana-operator
-version: 3.4.10
+version: 3.4.11

--- a/bitnami/grafana-operator/templates/grafana.yaml
+++ b/bitnami/grafana-operator/templates/grafana.yaml
@@ -50,7 +50,7 @@ spec:
       {{- end }}
   {{- if .Values.grafana.serviceAccount }}
   serviceAccount:
-    {{- include "common.tplvalues.render" ( dict "value" .Values.serviceAccount "context" $ ) | nindent 4 }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.grafana.serviceAccount "context" $ ) | nindent 4 }}
   {{- end }}
   deployment:
     metadata:


### PR DESCRIPTION
### Description of the change

Fixes a mistake in the grafana CR which broke serviceAccount configuration.

### Benefits

Makes additional `grafana.serviceAccount` configuration work as expected again. 

### Applicable issues

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
