### PR TITLE
[bitnami/*] test: :white_check_mark: Fix race condition in ginkgo utils

### DIFF
--- a/.vib/common-tests/ginkgo-utils/k8s.go
+++ b/.vib/common-tests/ginkgo-utils/k8s.go
@@ -48,7 +48,7 @@ func StsScale(ctx context.Context, c kubernetes.Interface, ss *appsv1.StatefulSe
 		if err != nil {
 			return nil, fmt.Errorf("failed to get statefulset %q: %v", name, err)
 		}
-		if ss.Status.Replicas == count {
+		if ss.Status.Replicas == count && ss.Status.AvailableReplicas == count {
 			return ss, nil
 		}
 		*(ss.Spec.Replicas) = count

--- a/.vib/common-tests/ginkgo-utils/k8s.go
+++ b/.vib/common-tests/ginkgo-utils/k8s.go
@@ -89,7 +89,7 @@ func DplScale(ctx context.Context, c kubernetes.Interface, dpl *appsv1.Deploymen
 		if err != nil {
 			return nil, fmt.Errorf("failed to get deployment %q: %v", name, err)
 		}
-		if currentDpl.Status.Replicas == count {
+		if currentDpl.Status.Replicas == count && currentDpl.Status.AvailableReplicas == count {
 			return currentDpl, nil
 		}
 		*(currentDpl.Spec.Replicas) = count


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Currently, the scale function was incorrectly not running the update command because it was checking the Status.Replicas field. However, this was not enough because sometimes the Status field was not properly updated when scaling down. We now check that both Replicas and AvailableReplicas are set to `count` in order to ignore the update function.
### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [ ] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [ ] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
