### PR TITLE
[bitnami/schema-registry] Bump chart version and update deps

### DIFF
--- a/bitnami/schema-registry/Chart.lock
+++ b/bitnami/schema-registry/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: kafka
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 26.0.0
+  version: 26.2.0
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.13.2
-digest: sha256:72b18bcc3c023e732cec1f86c97b3d5b69c797e82d5966f0d442458474c874d2
-generated: "2023-10-17T11:47:31.677941622+02:00"
+  version: 2.13.3
+digest: sha256:9bc95e9574bfc62d94432609962a03bbd671d55135235225b9e9681b525f0db7
+generated: "2023-10-25T10:10:35.11785+02:00"

--- a/bitnami/schema-registry/Chart.yaml
+++ b/bitnami/schema-registry/Chart.yaml
@@ -34,4 +34,4 @@ maintainers:
 name: schema-registry
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/schema-registry
-version: 15.1.0
+version: 16.1.0


### PR DESCRIPTION
### Description of the change
The chart version was downgraded by mistake at https://github.com/bitnami/charts/pull/20074, this PR returned the Helm chart to the 16.x.x branch and updated the dependencies

15.0.1 ✅ -> 15.0.2 ✅ -> 16.0.0 ✅ -> 15.1.0 🔴 -> **16.1.0** ✅ 