### PR TITLE
[bitnami/milvus] Fix externalEtcd settings

### DIFF
--- a/bitnami/milvus/Chart.yaml
+++ b/bitnami/milvus/Chart.yaml
@@ -48,4 +48,4 @@ maintainers:
 name: milvus
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/milvus
-version: 4.0.1
+version: 4.1.0

--- a/bitnami/milvus/Chart.yaml
+++ b/bitnami/milvus/Chart.yaml
@@ -48,4 +48,4 @@ maintainers:
 name: milvus
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/milvus
-version: 4.0.0
+version: 4.0.1

--- a/bitnami/milvus/README.md
+++ b/bitnami/milvus/README.md
@@ -1396,13 +1396,17 @@ The command removes all the Kubernetes components associated with the chart and 
 | `waitContainer.containerSecurityContext.allowPrivilegeEscalation` | Set Milvus container's privilege escalation                                                                                   | `false`                    |
 | `waitContainer.containerSecurityContext.capabilities.drop`        | Set Milvus container's Security Context runAsNonRoot                                                                          | `["ALL"]`                  |
 
-### External etcd parameters
+### External etcd settings
 
-| Name                           | Description                                 | Value   |
-| ------------------------------ | ------------------------------------------- | ------- |
-| `externalEtcd.servers`         | List of hostnames of the external etcd      | `[]`    |
-| `externalEtcd.port`            | Port of the external etcd instance          | `2379`  |
-| `externalEtcd.secureTransport` | Use TLS for client-to-server communications | `false` |
+| Name                                     | Description                                                 | Value                |
+| ---------------------------------------- | ----------------------------------------------------------- | -------------------- |
+| `externalEtcd.servers`                   | List of hostnames of the external etcd                      | `[]`                 |
+| `externalEtcd.port`                      | Port of the external etcd instance                          | `2379`               |
+| `externalEtcd.user`                      | User of the external etcd instance                          | `root`               |
+| `externalEtcd.password`                  | Password of the external etcd instance                      | `""`                 |
+| `externalEtcd.existingSecret`            | Name of a secret containing the external etcd password      | `""`                 |
+| `externalEtcd.existingSecretPasswordKey` | Key inside the secret containing the external etcd password | `etcd-root-password` |
+| `externalEtcd.secureTransport`           | Use TLS for client-to-server communications                 | `false`              |
 
 ### External S3 parameters
 

--- a/bitnami/milvus/values.yaml
+++ b/bitnami/milvus/values.yaml
@@ -4836,7 +4836,7 @@ waitContainer:
     capabilities:
       drop: ["ALL"]
 
-## @section External etcd parameters
+## @section External etcd settings
 ##
 externalEtcd:
   ## @param externalEtcd.servers List of hostnames of the external etcd
@@ -4845,6 +4845,18 @@ externalEtcd:
   ## @param externalEtcd.port Port of the external etcd instance
   ##
   port: 2379
+  ## @param externalEtcd.user User of the external etcd instance
+  ##
+  user: root
+  ## @param externalEtcd.password Password of the external etcd instance
+  ##
+  password: ""
+  ## @param externalEtcd.existingSecret Name of a secret containing the external etcd password
+  ##
+  existingSecret: ""
+  ## @param externalEtcd.existingSecretPasswordKey Key inside the secret containing the external etcd password
+  ##
+  existingSecretPasswordKey: "etcd-root-password"
   ## @param externalEtcd.secureTransport Use TLS for client-to-server communications
   ##
   secureTransport: false


### PR DESCRIPTION
### Description of the change

Set all the default values for externalEtcd.

### Benefits

The chart start using an external ETCD.

### Possible drawbacks

N/A

### Applicable issues

- fixes #20397

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
