### PR TITLE
[bitnami/cassandra] feat: :sparkles: Add support for PSA restricted policy

### DIFF
--- a/bitnami/cassandra/Chart.yaml
+++ b/bitnami/cassandra/Chart.yaml
@@ -32,4 +32,4 @@ maintainers:
 name: cassandra
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/cassandra
-version: 10.5.8
+version: 10.6.0

--- a/bitnami/cassandra/README.md
+++ b/bitnami/cassandra/README.md
@@ -117,71 +117,76 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Statefulset parameters
 
-| Name                                    | Description                                                                               | Value           |
-| --------------------------------------- | ----------------------------------------------------------------------------------------- | --------------- |
-| `replicaCount`                          | Number of Cassandra replicas                                                              | `1`             |
-| `updateStrategy.type`                   | updateStrategy for Cassandra statefulset                                                  | `RollingUpdate` |
-| `hostAliases`                           | Add deployment host aliases                                                               | `[]`            |
-| `podManagementPolicy`                   | StatefulSet pod management policy                                                         | `OrderedReady`  |
-| `priorityClassName`                     | Cassandra pods' priority.                                                                 | `""`            |
-| `podAnnotations`                        | Additional pod annotations                                                                | `{}`            |
-| `podLabels`                             | Additional pod labels                                                                     | `{}`            |
-| `podAffinityPreset`                     | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`       | `""`            |
-| `podAntiAffinityPreset`                 | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`  | `soft`          |
-| `nodeAffinityPreset.type`               | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard` | `""`            |
-| `nodeAffinityPreset.key`                | Node label key to match. Ignored if `affinity` is set                                     | `""`            |
-| `nodeAffinityPreset.values`             | Node label values to match. Ignored if `affinity` is set                                  | `[]`            |
-| `affinity`                              | Affinity for pod assignment                                                               | `{}`            |
-| `nodeSelector`                          | Node labels for pod assignment                                                            | `{}`            |
-| `tolerations`                           | Tolerations for pod assignment                                                            | `[]`            |
-| `topologySpreadConstraints`             | Topology Spread Constraints for pod assignment                                            | `[]`            |
-| `podSecurityContext.enabled`            | Enabled Cassandra pods' Security Context                                                  | `true`          |
-| `podSecurityContext.fsGroup`            | Set Cassandra pod's Security Context fsGroup                                              | `1001`          |
-| `containerSecurityContext.enabled`      | Enabled Cassandra containers' Security Context                                            | `true`          |
-| `containerSecurityContext.runAsUser`    | Set Cassandra container's Security Context runAsUser                                      | `1001`          |
-| `containerSecurityContext.runAsNonRoot` | Force the container to be run as non root                                                 | `true`          |
-| `resources.limits`                      | The resources limits for Cassandra containers                                             | `{}`            |
-| `resources.requests`                    | The requested resources for Cassandra containers                                          | `{}`            |
-| `livenessProbe.enabled`                 | Enable livenessProbe                                                                      | `true`          |
-| `livenessProbe.initialDelaySeconds`     | Initial delay seconds for livenessProbe                                                   | `60`            |
-| `livenessProbe.periodSeconds`           | Period seconds for livenessProbe                                                          | `30`            |
-| `livenessProbe.timeoutSeconds`          | Timeout seconds for livenessProbe                                                         | `30`            |
-| `livenessProbe.failureThreshold`        | Failure threshold for livenessProbe                                                       | `5`             |
-| `livenessProbe.successThreshold`        | Success threshold for livenessProbe                                                       | `1`             |
-| `readinessProbe.enabled`                | Enable readinessProbe                                                                     | `true`          |
-| `readinessProbe.initialDelaySeconds`    | Initial delay seconds for readinessProbe                                                  | `60`            |
-| `readinessProbe.periodSeconds`          | Period seconds for readinessProbe                                                         | `10`            |
-| `readinessProbe.timeoutSeconds`         | Timeout seconds for readinessProbe                                                        | `30`            |
-| `readinessProbe.failureThreshold`       | Failure threshold for readinessProbe                                                      | `5`             |
-| `readinessProbe.successThreshold`       | Success threshold for readinessProbe                                                      | `1`             |
-| `startupProbe.enabled`                  | Enable startupProbe                                                                       | `false`         |
-| `startupProbe.initialDelaySeconds`      | Initial delay seconds for startupProbe                                                    | `0`             |
-| `startupProbe.periodSeconds`            | Period seconds for startupProbe                                                           | `10`            |
-| `startupProbe.timeoutSeconds`           | Timeout seconds for startupProbe                                                          | `5`             |
-| `startupProbe.failureThreshold`         | Failure threshold for startupProbe                                                        | `60`            |
-| `startupProbe.successThreshold`         | Success threshold for startupProbe                                                        | `1`             |
-| `customLivenessProbe`                   | Custom livenessProbe that overrides the default one                                       | `{}`            |
-| `customReadinessProbe`                  | Custom readinessProbe that overrides the default one                                      | `{}`            |
-| `customStartupProbe`                    | Override default startup probe                                                            | `{}`            |
-| `lifecycleHooks`                        | Override default etcd container hooks                                                     | `{}`            |
-| `schedulerName`                         | Alternative scheduler                                                                     | `""`            |
-| `terminationGracePeriodSeconds`         | In seconds, time the given to the Cassandra pod needs to terminate gracefully             | `""`            |
-| `extraVolumes`                          | Optionally specify extra list of additional volumes for cassandra container               | `[]`            |
-| `extraVolumeMounts`                     | Optionally specify extra list of additional volumeMounts for cassandra container          | `[]`            |
-| `initContainers`                        | Add additional init containers to the cassandra pods                                      | `[]`            |
-| `sidecars`                              | Add additional sidecar containers to the cassandra pods                                   | `[]`            |
-| `pdb.create`                            | Enable/disable a Pod Disruption Budget creation                                           | `false`         |
-| `pdb.minAvailable`                      | Mininimum number of pods that must still be available after the eviction                  | `1`             |
-| `pdb.maxUnavailable`                    | Max number of pods that can be unavailable after the eviction                             | `""`            |
-| `hostNetwork`                           | Enable HOST Network                                                                       | `false`         |
-| `containerPorts.intra`                  | Intra Port on the Host and Container                                                      | `7000`          |
-| `containerPorts.tls`                    | TLS Port on the Host and Container                                                        | `7001`          |
-| `containerPorts.jmx`                    | JMX Port on the Host and Container                                                        | `7199`          |
-| `containerPorts.cql`                    | CQL Port on the Host and Container                                                        | `9042`          |
-| `hostPorts.intra`                       | Intra Port on the Host                                                                    | `""`            |
-| `hostPorts.tls`                         | TLS Port on the Host                                                                      | `""`            |
-| `hostPorts.jmx`                         | JMX Port on the Host                                                                      | `""`            |
-| `hostPorts.cql`                         | CQL Port on the Host                                                                      | `""`            |
+| Name                                                | Description                                                                               | Value            |
+| --------------------------------------------------- | ----------------------------------------------------------------------------------------- | ---------------- |
+| `replicaCount`                                      | Number of Cassandra replicas                                                              | `1`              |
+| `updateStrategy.type`                               | updateStrategy for Cassandra statefulset                                                  | `RollingUpdate`  |
+| `hostAliases`                                       | Add deployment host aliases                                                               | `[]`             |
+| `podManagementPolicy`                               | StatefulSet pod management policy                                                         | `OrderedReady`   |
+| `priorityClassName`                                 | Cassandra pods' priority.                                                                 | `""`             |
+| `podAnnotations`                                    | Additional pod annotations                                                                | `{}`             |
+| `podLabels`                                         | Additional pod labels                                                                     | `{}`             |
+| `podAffinityPreset`                                 | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`       | `""`             |
+| `podAntiAffinityPreset`                             | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`  | `soft`           |
+| `nodeAffinityPreset.type`                           | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard` | `""`             |
+| `nodeAffinityPreset.key`                            | Node label key to match. Ignored if `affinity` is set                                     | `""`             |
+| `nodeAffinityPreset.values`                         | Node label values to match. Ignored if `affinity` is set                                  | `[]`             |
+| `affinity`                                          | Affinity for pod assignment                                                               | `{}`             |
+| `nodeSelector`                                      | Node labels for pod assignment                                                            | `{}`             |
+| `tolerations`                                       | Tolerations for pod assignment                                                            | `[]`             |
+| `topologySpreadConstraints`                         | Topology Spread Constraints for pod assignment                                            | `[]`             |
+| `podSecurityContext.enabled`                        | Enabled Cassandra pods' Security Context                                                  | `true`           |
+| `podSecurityContext.fsGroup`                        | Set Cassandra pod's Security Context fsGroup                                              | `1001`           |
+| `containerSecurityContext.enabled`                  | Enabled Cassandra containers' Security Context                                            | `true`           |
+| `containerSecurityContext.runAsUser`                | Set Cassandra containers' Security Context runAsUser                                      | `1001`           |
+| `containerSecurityContext.allowPrivilegeEscalation` | Set Cassandra containers' Security Context allowPrivilegeEscalation                       | `false`          |
+| `containerSecurityContext.capabilities.drop`        | Set Cassandra containers' Security Context capabilities to be dropped                     | `["ALL"]`        |
+| `containerSecurityContext.readOnlyRootFilesystem`   | Set Cassandra containers' Security Context readOnlyRootFilesystem                         | `false`          |
+| `containerSecurityContext.runAsNonRoot`             | Set Cassandra containers' Security Context runAsNonRoot                                   | `true`           |
+| `containerSecurityContext.privileged`               | Set container's Security Context privileged                                               | `false`          |
+| `containerSecurityContext.seccompProfile.type`      | Set container's Security Context seccomp profile                                          | `RuntimeDefault` |
+| `resources.limits`                                  | The resources limits for Cassandra containers                                             | `{}`             |
+| `resources.requests`                                | The requested resources for Cassandra containers                                          | `{}`             |
+| `livenessProbe.enabled`                             | Enable livenessProbe                                                                      | `true`           |
+| `livenessProbe.initialDelaySeconds`                 | Initial delay seconds for livenessProbe                                                   | `60`             |
+| `livenessProbe.periodSeconds`                       | Period seconds for livenessProbe                                                          | `30`             |
+| `livenessProbe.timeoutSeconds`                      | Timeout seconds for livenessProbe                                                         | `30`             |
+| `livenessProbe.failureThreshold`                    | Failure threshold for livenessProbe                                                       | `5`              |
+| `livenessProbe.successThreshold`                    | Success threshold for livenessProbe                                                       | `1`              |
+| `readinessProbe.enabled`                            | Enable readinessProbe                                                                     | `true`           |
+| `readinessProbe.initialDelaySeconds`                | Initial delay seconds for readinessProbe                                                  | `60`             |
+| `readinessProbe.periodSeconds`                      | Period seconds for readinessProbe                                                         | `10`             |
+| `readinessProbe.timeoutSeconds`                     | Timeout seconds for readinessProbe                                                        | `30`             |
+| `readinessProbe.failureThreshold`                   | Failure threshold for readinessProbe                                                      | `5`              |
+| `readinessProbe.successThreshold`                   | Success threshold for readinessProbe                                                      | `1`              |
+| `startupProbe.enabled`                              | Enable startupProbe                                                                       | `false`          |
+| `startupProbe.initialDelaySeconds`                  | Initial delay seconds for startupProbe                                                    | `0`              |
+| `startupProbe.periodSeconds`                        | Period seconds for startupProbe                                                           | `10`             |
+| `startupProbe.timeoutSeconds`                       | Timeout seconds for startupProbe                                                          | `5`              |
+| `startupProbe.failureThreshold`                     | Failure threshold for startupProbe                                                        | `60`             |
+| `startupProbe.successThreshold`                     | Success threshold for startupProbe                                                        | `1`              |
+| `customLivenessProbe`                               | Custom livenessProbe that overrides the default one                                       | `{}`             |
+| `customReadinessProbe`                              | Custom readinessProbe that overrides the default one                                      | `{}`             |
+| `customStartupProbe`                                | Override default startup probe                                                            | `{}`             |
+| `lifecycleHooks`                                    | Override default etcd container hooks                                                     | `{}`             |
+| `schedulerName`                                     | Alternative scheduler                                                                     | `""`             |
+| `terminationGracePeriodSeconds`                     | In seconds, time the given to the Cassandra pod needs to terminate gracefully             | `""`             |
+| `extraVolumes`                                      | Optionally specify extra list of additional volumes for cassandra container               | `[]`             |
+| `extraVolumeMounts`                                 | Optionally specify extra list of additional volumeMounts for cassandra container          | `[]`             |
+| `initContainers`                                    | Add additional init containers to the cassandra pods                                      | `[]`             |
+| `sidecars`                                          | Add additional sidecar containers to the cassandra pods                                   | `[]`             |
+| `pdb.create`                                        | Enable/disable a Pod Disruption Budget creation                                           | `false`          |
+| `pdb.minAvailable`                                  | Mininimum number of pods that must still be available after the eviction                  | `1`              |
+| `pdb.maxUnavailable`                                | Max number of pods that can be unavailable after the eviction                             | `""`             |
+| `hostNetwork`                                       | Enable HOST Network                                                                       | `false`          |
+| `containerPorts.intra`                              | Intra Port on the Host and Container                                                      | `7000`           |
+| `containerPorts.tls`                                | TLS Port on the Host and Container                                                        | `7001`           |
+| `containerPorts.jmx`                                | JMX Port on the Host and Container                                                        | `7199`           |
+| `containerPorts.cql`                                | CQL Port on the Host and Container                                                        | `9042`           |
+| `hostPorts.intra`                                   | Intra Port on the Host                                                                    | `""`             |
+| `hostPorts.tls`                                     | TLS Port on the Host                                                                      | `""`             |
+| `hostPorts.jmx`                                     | JMX Port on the Host                                                                      | `""`             |
+| `hostPorts.cql`                                     | CQL Port on the Host                                                                      | `""`             |
 
 ### RBAC parameters
 

--- a/bitnami/cassandra/values.yaml
+++ b/bitnami/cassandra/values.yaml
@@ -287,13 +287,25 @@ podSecurityContext:
 ## Configure Container Security Context (only main container)
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
 ## @param containerSecurityContext.enabled Enabled Cassandra containers' Security Context
-## @param containerSecurityContext.runAsUser Set Cassandra container's Security Context runAsUser
-## @param containerSecurityContext.runAsNonRoot Force the container to be run as non root
+## @param containerSecurityContext.runAsUser Set Cassandra containers' Security Context runAsUser
+## @param containerSecurityContext.allowPrivilegeEscalation Set Cassandra containers' Security Context allowPrivilegeEscalation
+## @param containerSecurityContext.capabilities.drop Set Cassandra containers' Security Context capabilities to be dropped
+## @param containerSecurityContext.readOnlyRootFilesystem Set Cassandra containers' Security Context readOnlyRootFilesystem
+## @param containerSecurityContext.runAsNonRoot Set Cassandra containers' Security Context runAsNonRoot
+## @param containerSecurityContext.privileged Set container's Security Context privileged
+## @param containerSecurityContext.seccompProfile.type Set container's Security Context seccomp profile
 ##
 containerSecurityContext:
   enabled: true
   runAsUser: 1001
   runAsNonRoot: true
+  privileged: false
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop: ["ALL"]
+  seccompProfile:
+    type: "RuntimeDefault"
+  readOnlyRootFilesystem: false
 ## Cassandra pods' resource requests and limits
 ## ref: https://kubernetes.io/docs/user-guide/compute-resources/
 ## Minimum memory for development is 4GB and 2 CPU cores


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

This PR adds the necessary securityContext parameters to be run in the restricted Pod Security Admission level

https://kubernetes.io/docs/concepts/security/pod-security-admission/

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- Related to https://github.com/bitnami/charts/issues/20000

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
