### PR TITLE
[bitnami/ejbca] feat: :sparkles: Add support for PSA restricted policy

### DIFF
--- a/bitnami/ejbca/Chart.lock
+++ b/bitnami/ejbca/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: mariadb
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 14.0.1
+  version: 14.1.0
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.13.2
-digest: sha256:9daa7ebb5cc12099d97a22004fd1a97637feddb5fb42030cc24d89339f78a142
-generated: "2023-10-10T16:39:58.062063428+02:00"
+  version: 2.13.3
+digest: sha256:40cd1cb6fcd8cac3acd4521d4d46373c40bb728bc0dc7982c23b778d1ad5075c
+generated: "2023-10-25T15:51:24.65914703+02:00"

--- a/bitnami/ejbca/Chart.yaml
+++ b/bitnami/ejbca/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: ejbca
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/ejbca
-version: 10.0.0
+version: 10.1.0

--- a/bitnami/ejbca/README.md
+++ b/bitnami/ejbca/README.md
@@ -83,84 +83,88 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### EJBCA parameters
 
-| Name                                    | Description                                                                                                 | Value                   |
-| --------------------------------------- | ----------------------------------------------------------------------------------------------------------- | ----------------------- |
-| `image.registry`                        | EJBCA image registry                                                                                        | `REGISTRY_NAME`         |
-| `image.repository`                      | EJBCA image name                                                                                            | `REPOSITORY_NAME/ejbca` |
-| `image.digest`                          | EJBCA image image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                    |
-| `image.pullPolicy`                      | EJBCA image pull policy                                                                                     | `IfNotPresent`          |
-| `image.pullSecrets`                     | Specify docker-registry secret names as an array                                                            | `[]`                    |
-| `image.debug`                           | Enable image debug mode                                                                                     | `false`                 |
-| `replicaCount`                          | Number of EJBCA replicas to deploy                                                                          | `1`                     |
-| `extraVolumeMounts`                     | Additional volume mounts (used along with `extraVolumes`)                                                   | `[]`                    |
-| `extraVolumes`                          | Array of extra volumes to be added deployment. Requires setting `extraVolumeMounts`                         | `[]`                    |
-| `podAnnotations`                        | Additional pod annotations                                                                                  | `{}`                    |
-| `podLabels`                             | Additional pod labels                                                                                       | `{}`                    |
-| `podSecurityContext.enabled`            | Enable security context for EJBCA container                                                                 | `true`                  |
-| `podSecurityContext.fsGroup`            | Group ID for the volumes of the pod                                                                         | `1001`                  |
-| `podAffinityPreset`                     | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                         | `""`                    |
-| `podAntiAffinityPreset`                 | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                    | `soft`                  |
-| `nodeAffinityPreset.type`               | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                   | `""`                    |
-| `nodeAffinityPreset.key`                | Node label key to match Ignored if `affinity` is set.                                                       | `""`                    |
-| `nodeAffinityPreset.values`             | Node label values to match. Ignored if `affinity` is set.                                                   | `[]`                    |
-| `affinity`                              | Affinity for pod assignment                                                                                 | `{}`                    |
-| `nodeSelector`                          | Node labels for pod assignment                                                                              | `{}`                    |
-| `tolerations`                           | Tolerations for pod assignment                                                                              | `[]`                    |
-| `updateStrategy.type`                   | EJBCA deployment strategy type.                                                                             | `RollingUpdate`         |
-| `persistence.enabled`                   | Whether to enable persistence based on Persistent Volume Claims                                             | `true`                  |
-| `persistence.accessModes`               | Persistent Volume access modes                                                                              | `[]`                    |
-| `persistence.size`                      | Size of the PVC to request                                                                                  | `2Gi`                   |
-| `persistence.storageClass`              | PVC Storage Class                                                                                           | `""`                    |
-| `persistence.existingClaim`             | Name of an existing PVC to reuse                                                                            | `""`                    |
-| `persistence.annotations`               | Persistent Volume Claim annotations                                                                         | `{}`                    |
-| `sidecars`                              | Attach additional sidecar containers to the pod                                                             | `[]`                    |
-| `initContainers`                        | Additional init containers to add to the pods                                                               | `[]`                    |
-| `hostAliases`                           | Add deployment host aliases                                                                                 | `[]`                    |
-| `priorityClassName`                     | EJBCA pods' priorityClassName                                                                               | `""`                    |
-| `schedulerName`                         | Name of the k8s scheduler (other than default)                                                              | `""`                    |
-| `topologySpreadConstraints`             | Topology Spread Constraints for pod assignment                                                              | `[]`                    |
-| `ejbcaAdminUsername`                    | EJBCA administrator username                                                                                | `bitnami`               |
-| `ejbcaAdminPassword`                    | Password for the administrator account                                                                      | `""`                    |
-| `existingSecret`                        | Alternatively, you can provide the name of an existing secret containing                                    | `""`                    |
-| `ejbcaJavaOpts`                         | Options used to launch the WildFly server                                                                   | `""`                    |
-| `ejbcaCA.name`                          | Name of the CA EJBCA will instantiate by default                                                            | `ManagementCA`          |
-| `ejbcaCA.baseDN`                        | Base DomainName of the CA EJBCA will instantiate by default                                                 | `""`                    |
-| `ejbcaKeystoreExistingSecret`           | Name of an existing Secret containing a Keystore object                                                     | `""`                    |
-| `extraEnvVars`                          | Array with extra environment variables to add to EJBCA nodes                                                | `[]`                    |
-| `extraEnvVarsCM`                        | Name of existing ConfigMap containing extra env vars for EJBCA nodes                                        | `""`                    |
-| `extraEnvVarsSecret`                    | Name of existing Secret containing extra env vars for EJBCA nodes                                           | `""`                    |
-| `command`                               | Custom command to override image cmd                                                                        | `[]`                    |
-| `args`                                  | Custom args for the custom command                                                                          | `[]`                    |
-| `lifecycleHooks`                        | for the EJBCA container(s) to automate configuration before or after startup                                | `{}`                    |
-| `resources.requests`                    | The requested resources for the init container                                                              | `{}`                    |
-| `resources.limits`                      | The resources limits for the init container                                                                 | `{}`                    |
-| `resources.limits`                      | The resources limits for Ejbca containers                                                                   | `{}`                    |
-| `resources.requests`                    | The requested resources for Ejbca containers                                                                | `{}`                    |
-| `containerSecurityContext.enabled`      | Enabled EJBCA containers' Security Context                                                                  | `true`                  |
-| `containerSecurityContext.runAsUser`    | Set EJBCA containers' Security Context runAsUser                                                            | `1001`                  |
-| `containerSecurityContext.runAsNonRoot` | Set EJBCA container's Security Context runAsNonRoot                                                         | `true`                  |
-| `startupProbe.enabled`                  | Enable/disable startupProbe                                                                                 | `false`                 |
-| `startupProbe.initialDelaySeconds`      | Delay before startup probe is initiated                                                                     | `500`                   |
-| `startupProbe.periodSeconds`            | How often to perform the probe                                                                              | `10`                    |
-| `startupProbe.timeoutSeconds`           | When the probe times out                                                                                    | `5`                     |
-| `startupProbe.failureThreshold`         | Minimum consecutive failures for the probe                                                                  | `6`                     |
-| `startupProbe.successThreshold`         | Minimum consecutive successes for the probe                                                                 | `1`                     |
-| `livenessProbe.enabled`                 | Enable/disable livenessProbe                                                                                | `true`                  |
-| `livenessProbe.initialDelaySeconds`     | Delay before liveness probe is initiated                                                                    | `500`                   |
-| `livenessProbe.periodSeconds`           | How often to perform the probe                                                                              | `10`                    |
-| `livenessProbe.timeoutSeconds`          | When the probe times out                                                                                    | `5`                     |
-| `livenessProbe.failureThreshold`        | Minimum consecutive failures for the probe                                                                  | `6`                     |
-| `livenessProbe.successThreshold`        | Minimum consecutive successes for the probe                                                                 | `1`                     |
-| `readinessProbe.enabled`                | Enable/disable readinessProbe                                                                               | `true`                  |
-| `readinessProbe.initialDelaySeconds`    | Delay before readiness probe is initiated                                                                   | `500`                   |
-| `readinessProbe.periodSeconds`          | How often to perform the probe                                                                              | `10`                    |
-| `readinessProbe.timeoutSeconds`         | When the probe times out                                                                                    | `5`                     |
-| `readinessProbe.failureThreshold`       | Minimum consecutive failures for the probe                                                                  | `6`                     |
-| `readinessProbe.successThreshold`       | Minimum consecutive successes for the probe                                                                 | `1`                     |
-| `customStartupProbe`                    | Custom startup probe to execute (when the main one is disabled)                                             | `{}`                    |
-| `customLivenessProbe`                   | Custom liveness probe to execute (when the main one is disabled)                                            | `{}`                    |
-| `customReadinessProbe`                  | Custom readiness probe to execute (when the main one is disabled)                                           | `{}`                    |
-| `containerPorts`                        | EJBCA Container ports to open                                                                               | `{}`                    |
+| Name                                                | Description                                                                                                 | Value                   |
+| --------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- | ----------------------- |
+| `image.registry`                                    | EJBCA image registry                                                                                        | `REGISTRY_NAME`         |
+| `image.repository`                                  | EJBCA image name                                                                                            | `REPOSITORY_NAME/ejbca` |
+| `image.digest`                                      | EJBCA image image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                    |
+| `image.pullPolicy`                                  | EJBCA image pull policy                                                                                     | `IfNotPresent`          |
+| `image.pullSecrets`                                 | Specify docker-registry secret names as an array                                                            | `[]`                    |
+| `image.debug`                                       | Enable image debug mode                                                                                     | `false`                 |
+| `replicaCount`                                      | Number of EJBCA replicas to deploy                                                                          | `1`                     |
+| `extraVolumeMounts`                                 | Additional volume mounts (used along with `extraVolumes`)                                                   | `[]`                    |
+| `extraVolumes`                                      | Array of extra volumes to be added deployment. Requires setting `extraVolumeMounts`                         | `[]`                    |
+| `podAnnotations`                                    | Additional pod annotations                                                                                  | `{}`                    |
+| `podLabels`                                         | Additional pod labels                                                                                       | `{}`                    |
+| `podSecurityContext.enabled`                        | Enable security context for EJBCA container                                                                 | `true`                  |
+| `podSecurityContext.fsGroup`                        | Group ID for the volumes of the pod                                                                         | `1001`                  |
+| `podAffinityPreset`                                 | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                         | `""`                    |
+| `podAntiAffinityPreset`                             | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                    | `soft`                  |
+| `nodeAffinityPreset.type`                           | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                   | `""`                    |
+| `nodeAffinityPreset.key`                            | Node label key to match Ignored if `affinity` is set.                                                       | `""`                    |
+| `nodeAffinityPreset.values`                         | Node label values to match. Ignored if `affinity` is set.                                                   | `[]`                    |
+| `affinity`                                          | Affinity for pod assignment                                                                                 | `{}`                    |
+| `nodeSelector`                                      | Node labels for pod assignment                                                                              | `{}`                    |
+| `tolerations`                                       | Tolerations for pod assignment                                                                              | `[]`                    |
+| `updateStrategy.type`                               | EJBCA deployment strategy type.                                                                             | `RollingUpdate`         |
+| `persistence.enabled`                               | Whether to enable persistence based on Persistent Volume Claims                                             | `true`                  |
+| `persistence.accessModes`                           | Persistent Volume access modes                                                                              | `[]`                    |
+| `persistence.size`                                  | Size of the PVC to request                                                                                  | `2Gi`                   |
+| `persistence.storageClass`                          | PVC Storage Class                                                                                           | `""`                    |
+| `persistence.existingClaim`                         | Name of an existing PVC to reuse                                                                            | `""`                    |
+| `persistence.annotations`                           | Persistent Volume Claim annotations                                                                         | `{}`                    |
+| `sidecars`                                          | Attach additional sidecar containers to the pod                                                             | `[]`                    |
+| `initContainers`                                    | Additional init containers to add to the pods                                                               | `[]`                    |
+| `hostAliases`                                       | Add deployment host aliases                                                                                 | `[]`                    |
+| `priorityClassName`                                 | EJBCA pods' priorityClassName                                                                               | `""`                    |
+| `schedulerName`                                     | Name of the k8s scheduler (other than default)                                                              | `""`                    |
+| `topologySpreadConstraints`                         | Topology Spread Constraints for pod assignment                                                              | `[]`                    |
+| `ejbcaAdminUsername`                                | EJBCA administrator username                                                                                | `bitnami`               |
+| `ejbcaAdminPassword`                                | Password for the administrator account                                                                      | `""`                    |
+| `existingSecret`                                    | Alternatively, you can provide the name of an existing secret containing                                    | `""`                    |
+| `ejbcaJavaOpts`                                     | Options used to launch the WildFly server                                                                   | `""`                    |
+| `ejbcaCA.name`                                      | Name of the CA EJBCA will instantiate by default                                                            | `ManagementCA`          |
+| `ejbcaCA.baseDN`                                    | Base DomainName of the CA EJBCA will instantiate by default                                                 | `""`                    |
+| `ejbcaKeystoreExistingSecret`                       | Name of an existing Secret containing a Keystore object                                                     | `""`                    |
+| `extraEnvVars`                                      | Array with extra environment variables to add to EJBCA nodes                                                | `[]`                    |
+| `extraEnvVarsCM`                                    | Name of existing ConfigMap containing extra env vars for EJBCA nodes                                        | `""`                    |
+| `extraEnvVarsSecret`                                | Name of existing Secret containing extra env vars for EJBCA nodes                                           | `""`                    |
+| `command`                                           | Custom command to override image cmd                                                                        | `[]`                    |
+| `args`                                              | Custom args for the custom command                                                                          | `[]`                    |
+| `lifecycleHooks`                                    | for the EJBCA container(s) to automate configuration before or after startup                                | `{}`                    |
+| `resources.requests`                                | The requested resources for the init container                                                              | `{}`                    |
+| `resources.limits`                                  | The resources limits for the init container                                                                 | `{}`                    |
+| `resources.limits`                                  | The resources limits for Ejbca containers                                                                   | `{}`                    |
+| `resources.requests`                                | The requested resources for Ejbca containers                                                                | `{}`                    |
+| `containerSecurityContext.enabled`                  | Enabled EJBCA containers' Security Context                                                                  | `true`                  |
+| `containerSecurityContext.runAsUser`                | Set EJBCA containers' Security Context runAsUser                                                            | `1001`                  |
+| `containerSecurityContext.runAsNonRoot`             | Set Controller container's Security Context runAsNonRoot                                                    | `true`                  |
+| `containerSecurityContext.privileged`               | Set primary container's Security Context privileged                                                         | `false`                 |
+| `containerSecurityContext.allowPrivilegeEscalation` | Set primary container's Security Context allowPrivilegeEscalation                                           | `false`                 |
+| `containerSecurityContext.capabilities.drop`        | List of capabilities to be dropped                                                                          | `["ALL"]`               |
+| `containerSecurityContext.seccompProfile.type`      | Set container's Security Context seccomp profile                                                            | `RuntimeDefault`        |
+| `startupProbe.enabled`                              | Enable/disable startupProbe                                                                                 | `false`                 |
+| `startupProbe.initialDelaySeconds`                  | Delay before startup probe is initiated                                                                     | `500`                   |
+| `startupProbe.periodSeconds`                        | How often to perform the probe                                                                              | `10`                    |
+| `startupProbe.timeoutSeconds`                       | When the probe times out                                                                                    | `5`                     |
+| `startupProbe.failureThreshold`                     | Minimum consecutive failures for the probe                                                                  | `6`                     |
+| `startupProbe.successThreshold`                     | Minimum consecutive successes for the probe                                                                 | `1`                     |
+| `livenessProbe.enabled`                             | Enable/disable livenessProbe                                                                                | `true`                  |
+| `livenessProbe.initialDelaySeconds`                 | Delay before liveness probe is initiated                                                                    | `500`                   |
+| `livenessProbe.periodSeconds`                       | How often to perform the probe                                                                              | `10`                    |
+| `livenessProbe.timeoutSeconds`                      | When the probe times out                                                                                    | `5`                     |
+| `livenessProbe.failureThreshold`                    | Minimum consecutive failures for the probe                                                                  | `6`                     |
+| `livenessProbe.successThreshold`                    | Minimum consecutive successes for the probe                                                                 | `1`                     |
+| `readinessProbe.enabled`                            | Enable/disable readinessProbe                                                                               | `true`                  |
+| `readinessProbe.initialDelaySeconds`                | Delay before readiness probe is initiated                                                                   | `500`                   |
+| `readinessProbe.periodSeconds`                      | How often to perform the probe                                                                              | `10`                    |
+| `readinessProbe.timeoutSeconds`                     | When the probe times out                                                                                    | `5`                     |
+| `readinessProbe.failureThreshold`                   | Minimum consecutive failures for the probe                                                                  | `6`                     |
+| `readinessProbe.successThreshold`                   | Minimum consecutive successes for the probe                                                                 | `1`                     |
+| `customStartupProbe`                                | Custom startup probe to execute (when the main one is disabled)                                             | `{}`                    |
+| `customLivenessProbe`                               | Custom liveness probe to execute (when the main one is disabled)                                            | `{}`                    |
+| `customReadinessProbe`                              | Custom readiness probe to execute (when the main one is disabled)                                           | `{}`                    |
+| `containerPorts`                                    | EJBCA Container ports to open                                                                               | `{}`                    |
 
 ### Service parameters
 

--- a/bitnami/ejbca/values.yaml
+++ b/bitnami/ejbca/values.yaml
@@ -328,12 +328,22 @@ resources:
 ## K8s Security Context for EJBCA container
 ## @param containerSecurityContext.enabled Enabled EJBCA containers' Security Context
 ## @param containerSecurityContext.runAsUser Set EJBCA containers' Security Context runAsUser
-## @param containerSecurityContext.runAsNonRoot Set EJBCA container's Security Context runAsNonRoot
+## @param containerSecurityContext.runAsNonRoot Set Controller container's Security Context runAsNonRoot
+## @param containerSecurityContext.privileged Set primary container's Security Context privileged
+## @param containerSecurityContext.allowPrivilegeEscalation Set primary container's Security Context allowPrivilegeEscalation
+## @param containerSecurityContext.capabilities.drop List of capabilities to be dropped
+## @param containerSecurityContext.seccompProfile.type Set container's Security Context seccomp profile
 ##
 containerSecurityContext:
   enabled: true
   runAsUser: 1001
   runAsNonRoot: true
+  privileged: false
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop: ["ALL"]
+  seccompProfile:
+    type: "RuntimeDefault"
 ## EJBCA pod extra options for startup probe
 ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 ## @param startupProbe.enabled Enable/disable startupProbe


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

This PR adds the necessary securityContext parameters to be run in the restricted Pod Security Admission level

https://kubernetes.io/docs/concepts/security/pod-security-admission/

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- Related to https://github.com/bitnami/charts/issues/20000

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)

