### PR TITLE
[bitnami/mongodb] Fixed mongodb arbiter configmap

### DIFF
--- a/bitnami/mongodb/Chart.yaml
+++ b/bitnami/mongodb/Chart.yaml
@@ -39,4 +39,4 @@ maintainers:
 name: mongodb
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/mongodb
-version: 14.0.13
+version: 14.0.14

--- a/bitnami/mongodb/templates/arbiter/configmap.yaml
+++ b/bitnami/mongodb/templates/arbiter/configmap.yaml
@@ -7,7 +7,7 @@ SPDX-License-Identifier: APACHE-2.0
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ print "%s-arbiter" (include "mongodb.fullname" .) }}
+  name: {{ printf "%s-arbiter" (include "mongodb.fullname" .) }}
   namespace: {{ include "mongodb.namespace" . | quote }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: arbiter


### PR DESCRIPTION
### Description of the change

This is a bugfix for the issue #20255 (i.e. arbiter's configuration file cannot be customised).

### Benefits

MongoDB Arbiter `configmap.yaml` is correctly generated when custom configuration is provided.

### Possible drawbacks

n/a

### Applicable issues

- fixes #20255

### Additional information

n/a

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
