### PR TITLE
[bitnami/jasperreports] feat: :sparkles: Add support for PSA restricted policy

### DIFF
--- a/bitnami/jasperreports/Chart.lock
+++ b/bitnami/jasperreports/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: mariadb
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 14.0.1
+  version: 14.1.0
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.13.2
-digest: sha256:7617e01cd06d41043c65d55055935e5b34bfb7a55014a5c7d8da13a52b7f070c
-generated: "2023-10-10T16:45:08.692744267+02:00"
+  version: 2.13.3
+digest: sha256:ed18965f3ec543d94074f9ce7d71e9dd607ae50eac145184698b6cc1e1b175ef
+generated: "2023-10-26T15:09:50.347219025+02:00"

--- a/bitnami/jasperreports/Chart.yaml
+++ b/bitnami/jasperreports/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: jasperreports
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/jasperreports
-version: 17.1.0
+version: 17.2.0

--- a/bitnami/jasperreports/README.md
+++ b/bitnami/jasperreports/README.md
@@ -109,66 +109,71 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Jasperreports deployment parameters
 
-| Name                                    | Description                                                                               | Value                      |
-| --------------------------------------- | ----------------------------------------------------------------------------------------- | -------------------------- |
-| `hostAliases`                           | Add deployment host aliases                                                               | `[]`                       |
-| `containerPorts.http`                   | HTTP port to expose at container level                                                    | `8080`                     |
-| `dnsConfig`                             | Pod DNS configuration.                                                                    | `{}`                       |
-| `podSecurityContext.enabled`            | Enable pod's Security Context                                                             | `true`                     |
-| `podSecurityContext.fsGroup`            | Set pod's Security Context fsGroup                                                        | `1001`                     |
-| `containerSecurityContext.enabled`      | Enable container's Security Context                                                       | `true`                     |
-| `containerSecurityContext.runAsUser`    | Set container's Security Context runAsUser                                                | `1001`                     |
-| `containerSecurityContext.runAsNonRoot` | Set container's Security Context runAsNonRoot                                             | `true`                     |
-| `resources.limits`                      | The resources limits for the Jasperreports container                                      | `{}`                       |
-| `resources.requests`                    | The requested resources for the Jasperreports container                                   | `{}`                       |
-| `startupProbe.enabled`                  | Enable startupProbe                                                                       | `false`                    |
-| `startupProbe.path`                     | Request path for startupProbe                                                             | `/jasperserver/login.html` |
-| `startupProbe.initialDelaySeconds`      | Initial delay seconds for startupProbe                                                    | `450`                      |
-| `startupProbe.periodSeconds`            | Period seconds for startupProbe                                                           | `10`                       |
-| `startupProbe.timeoutSeconds`           | Timeout seconds for startupProbe                                                          | `5`                        |
-| `startupProbe.failureThreshold`         | Failure threshold for startupProbe                                                        | `6`                        |
-| `startupProbe.successThreshold`         | Success threshold for startupProbe                                                        | `1`                        |
-| `livenessProbe.enabled`                 | Enable livenessProbe                                                                      | `true`                     |
-| `livenessProbe.path`                    | Request path for livenessProbe                                                            | `/jasperserver/login.html` |
-| `livenessProbe.initialDelaySeconds`     | Initial delay seconds for livenessProbe                                                   | `450`                      |
-| `livenessProbe.periodSeconds`           | Period seconds for livenessProbe                                                          | `10`                       |
-| `livenessProbe.timeoutSeconds`          | Timeout seconds for livenessProbe                                                         | `5`                        |
-| `livenessProbe.failureThreshold`        | Failure threshold for livenessProbe                                                       | `6`                        |
-| `livenessProbe.successThreshold`        | Success threshold for livenessProbe                                                       | `1`                        |
-| `readinessProbe.enabled`                | Enable readinessProbe                                                                     | `true`                     |
-| `readinessProbe.path`                   | Request path for readinessProbe                                                           | `/jasperserver/login.html` |
-| `readinessProbe.initialDelaySeconds`    | Initial delay seconds for readinessProbe                                                  | `30`                       |
-| `readinessProbe.periodSeconds`          | Period seconds for readinessProbe                                                         | `10`                       |
-| `readinessProbe.timeoutSeconds`         | Timeout seconds for readinessProbe                                                        | `5`                        |
-| `readinessProbe.failureThreshold`       | Failure threshold for readinessProbe                                                      | `6`                        |
-| `readinessProbe.successThreshold`       | Success threshold for readinessProbe                                                      | `1`                        |
-| `customStartupProbe`                    | Override default startup probe                                                            | `{}`                       |
-| `customLivenessProbe`                   | Override default liveness probe                                                           | `{}`                       |
-| `customReadinessProbe`                  | Override default readiness probe                                                          | `{}`                       |
-| `podLabels`                             | Extra labels for Jasperreports pods                                                       | `{}`                       |
-| `podAnnotations`                        | Annotations for Jasperreports pods                                                        | `{}`                       |
-| `podAffinityPreset`                     | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`       | `""`                       |
-| `podAntiAffinityPreset`                 | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`  | `soft`                     |
-| `nodeAffinityPreset.type`               | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard` | `""`                       |
-| `nodeAffinityPreset.key`                | Node label key to match. Ignored if `affinity` is set.                                    | `""`                       |
-| `nodeAffinityPreset.values`             | Node label values to match. Ignored if `affinity` is set.                                 | `[]`                       |
-| `affinity`                              | Affinity for pod assignment                                                               | `{}`                       |
-| `nodeSelector`                          | Node labels for pod assignment                                                            | `{}`                       |
-| `tolerations`                           | Tolerations for pod assignment                                                            | `[]`                       |
-| `priorityClassName`                     | JasperReports pods' priorityClassName                                                     | `""`                       |
-| `schedulerName`                         | Name of the k8s scheduler (other than default)                                            | `""`                       |
-| `topologySpreadConstraints`             | Topology Spread Constraints for pod assignment                                            | `[]`                       |
-| `lifecycleHooks`                        | LifecycleHooks to set additional configuration at startup.                                | `{}`                       |
-| `extraVolumes`                          | Optionally specify extra list of additional volumes for Jasperreports pods                | `[]`                       |
-| `extraVolumeMounts`                     | Optionally specify extra list of additional volumeMounts for Jasperreports container(s)   | `[]`                       |
-| `initContainers`                        | Add additional init containers to the Jasperreports pods                                  | `[]`                       |
-| `sidecars`                              | Add additional sidecar containers to the Jasperreports pods                               | `[]`                       |
-| `persistence.enabled`                   | Enable persistence using PVC                                                              | `true`                     |
-| `persistence.storageClass`              | PVC Storage Class for Jasperreports volume                                                | `""`                       |
-| `persistence.accessModes`               | Persistent Volume Access Mode                                                             | `["ReadWriteOnce"]`        |
-| `persistence.size`                      | PVC Storage Request for Jasperreports volume                                              | `8Gi`                      |
-| `persistence.existingClaim`             | An Existing PVC name for Jasperreports volume                                             | `""`                       |
-| `persistence.annotations`               | Persistent Volume Claim annotations                                                       | `{}`                       |
+| Name                                                | Description                                                                               | Value                      |
+| --------------------------------------------------- | ----------------------------------------------------------------------------------------- | -------------------------- |
+| `hostAliases`                                       | Add deployment host aliases                                                               | `[]`                       |
+| `containerPorts.http`                               | HTTP port to expose at container level                                                    | `8080`                     |
+| `dnsConfig`                                         | Pod DNS configuration.                                                                    | `{}`                       |
+| `podSecurityContext.enabled`                        | Enable pod's Security Context                                                             | `true`                     |
+| `podSecurityContext.fsGroup`                        | Set pod's Security Context fsGroup                                                        | `1001`                     |
+| `containerSecurityContext.enabled`                  | Enabled containers' Security Context                                                      | `true`                     |
+| `containerSecurityContext.runAsUser`                | Set containers' Security Context runAsUser                                                | `1001`                     |
+| `containerSecurityContext.runAsNonRoot`             | Set container's Security Context runAsNonRoot                                             | `true`                     |
+| `containerSecurityContext.privileged`               | Set container's Security Context privileged                                               | `false`                    |
+| `containerSecurityContext.readOnlyRootFilesystem`   | Set container's Security Context readOnlyRootFilesystem                                   | `false`                    |
+| `containerSecurityContext.allowPrivilegeEscalation` | Set container's Security Context allowPrivilegeEscalation                                 | `false`                    |
+| `containerSecurityContext.capabilities.drop`        | List of capabilities to be dropped                                                        | `["ALL"]`                  |
+| `containerSecurityContext.seccompProfile.type`      | Set container's Security Context seccomp profile                                          | `RuntimeDefault`           |
+| `resources.limits`                                  | The resources limits for the Jasperreports container                                      | `{}`                       |
+| `resources.requests`                                | The requested resources for the Jasperreports container                                   | `{}`                       |
+| `startupProbe.enabled`                              | Enable startupProbe                                                                       | `false`                    |
+| `startupProbe.path`                                 | Request path for startupProbe                                                             | `/jasperserver/login.html` |
+| `startupProbe.initialDelaySeconds`                  | Initial delay seconds for startupProbe                                                    | `450`                      |
+| `startupProbe.periodSeconds`                        | Period seconds for startupProbe                                                           | `10`                       |
+| `startupProbe.timeoutSeconds`                       | Timeout seconds for startupProbe                                                          | `5`                        |
+| `startupProbe.failureThreshold`                     | Failure threshold for startupProbe                                                        | `6`                        |
+| `startupProbe.successThreshold`                     | Success threshold for startupProbe                                                        | `1`                        |
+| `livenessProbe.enabled`                             | Enable livenessProbe                                                                      | `true`                     |
+| `livenessProbe.path`                                | Request path for livenessProbe                                                            | `/jasperserver/login.html` |
+| `livenessProbe.initialDelaySeconds`                 | Initial delay seconds for livenessProbe                                                   | `450`                      |
+| `livenessProbe.periodSeconds`                       | Period seconds for livenessProbe                                                          | `10`                       |
+| `livenessProbe.timeoutSeconds`                      | Timeout seconds for livenessProbe                                                         | `5`                        |
+| `livenessProbe.failureThreshold`                    | Failure threshold for livenessProbe                                                       | `6`                        |
+| `livenessProbe.successThreshold`                    | Success threshold for livenessProbe                                                       | `1`                        |
+| `readinessProbe.enabled`                            | Enable readinessProbe                                                                     | `true`                     |
+| `readinessProbe.path`                               | Request path for readinessProbe                                                           | `/jasperserver/login.html` |
+| `readinessProbe.initialDelaySeconds`                | Initial delay seconds for readinessProbe                                                  | `30`                       |
+| `readinessProbe.periodSeconds`                      | Period seconds for readinessProbe                                                         | `10`                       |
+| `readinessProbe.timeoutSeconds`                     | Timeout seconds for readinessProbe                                                        | `5`                        |
+| `readinessProbe.failureThreshold`                   | Failure threshold for readinessProbe                                                      | `6`                        |
+| `readinessProbe.successThreshold`                   | Success threshold for readinessProbe                                                      | `1`                        |
+| `customStartupProbe`                                | Override default startup probe                                                            | `{}`                       |
+| `customLivenessProbe`                               | Override default liveness probe                                                           | `{}`                       |
+| `customReadinessProbe`                              | Override default readiness probe                                                          | `{}`                       |
+| `podLabels`                                         | Extra labels for Jasperreports pods                                                       | `{}`                       |
+| `podAnnotations`                                    | Annotations for Jasperreports pods                                                        | `{}`                       |
+| `podAffinityPreset`                                 | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`       | `""`                       |
+| `podAntiAffinityPreset`                             | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`  | `soft`                     |
+| `nodeAffinityPreset.type`                           | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard` | `""`                       |
+| `nodeAffinityPreset.key`                            | Node label key to match. Ignored if `affinity` is set.                                    | `""`                       |
+| `nodeAffinityPreset.values`                         | Node label values to match. Ignored if `affinity` is set.                                 | `[]`                       |
+| `affinity`                                          | Affinity for pod assignment                                                               | `{}`                       |
+| `nodeSelector`                                      | Node labels for pod assignment                                                            | `{}`                       |
+| `tolerations`                                       | Tolerations for pod assignment                                                            | `[]`                       |
+| `priorityClassName`                                 | JasperReports pods' priorityClassName                                                     | `""`                       |
+| `schedulerName`                                     | Name of the k8s scheduler (other than default)                                            | `""`                       |
+| `topologySpreadConstraints`                         | Topology Spread Constraints for pod assignment                                            | `[]`                       |
+| `lifecycleHooks`                                    | LifecycleHooks to set additional configuration at startup.                                | `{}`                       |
+| `extraVolumes`                                      | Optionally specify extra list of additional volumes for Jasperreports pods                | `[]`                       |
+| `extraVolumeMounts`                                 | Optionally specify extra list of additional volumeMounts for Jasperreports container(s)   | `[]`                       |
+| `initContainers`                                    | Add additional init containers to the Jasperreports pods                                  | `[]`                       |
+| `sidecars`                                          | Add additional sidecar containers to the Jasperreports pods                               | `[]`                       |
+| `persistence.enabled`                               | Enable persistence using PVC                                                              | `true`                     |
+| `persistence.storageClass`                          | PVC Storage Class for Jasperreports volume                                                | `""`                       |
+| `persistence.accessModes`                           | Persistent Volume Access Mode                                                             | `["ReadWriteOnce"]`        |
+| `persistence.size`                                  | PVC Storage Request for Jasperreports volume                                              | `8Gi`                      |
+| `persistence.existingClaim`                         | An Existing PVC name for Jasperreports volume                                             | `""`                       |
+| `persistence.annotations`                           | Persistent Volume Claim annotations                                                       | `{}`                       |
 
 ### Exposure parameters
 

--- a/bitnami/jasperreports/values.yaml
+++ b/bitnami/jasperreports/values.yaml
@@ -176,14 +176,26 @@ podSecurityContext:
   fsGroup: 1001
 ## JasperReports containers' SecurityContext
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
-## @param containerSecurityContext.enabled Enable container's Security Context
-## @param containerSecurityContext.runAsUser Set container's Security Context runAsUser
+## @param containerSecurityContext.enabled Enabled containers' Security Context
+## @param containerSecurityContext.runAsUser Set containers' Security Context runAsUser
 ## @param containerSecurityContext.runAsNonRoot Set container's Security Context runAsNonRoot
+## @param containerSecurityContext.privileged Set container's Security Context privileged
+## @param containerSecurityContext.readOnlyRootFilesystem Set container's Security Context readOnlyRootFilesystem
+## @param containerSecurityContext.allowPrivilegeEscalation Set container's Security Context allowPrivilegeEscalation
+## @param containerSecurityContext.capabilities.drop List of capabilities to be dropped
+## @param containerSecurityContext.seccompProfile.type Set container's Security Context seccomp profile
 ##
 containerSecurityContext:
   enabled: true
   runAsUser: 1001
   runAsNonRoot: true
+  privileged: false
+  readOnlyRootFilesystem: false
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop: ["ALL"]
+  seccompProfile:
+    type: "RuntimeDefault"
 ## JasperReports resource requests and limits
 ## ref: https://kubernetes.io/docs/user-guide/compute-resources/
 ## We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

This PR adds the necessary securityContext parameters to be run in the restricted Pod Security Admission level

https://kubernetes.io/docs/concepts/security/pod-security-admission/

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- Related to https://github.com/bitnami/charts/issues/20000

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
