### PR TITLE
[bitnami/kafka]: clarify docs

### DIFF
--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -42,4 +42,4 @@ maintainers:
 name: kafka
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/kafka
-version: 26.2.0
+version: 26.2.1

--- a/bitnami/kafka/values.yaml
+++ b/bitnami/kafka/values.yaml
@@ -825,7 +825,6 @@ controller:
 ##
 broker:
   ## @param broker.replicaCount Number of Kafka broker-only nodes
-  ## Ignore this section if you are not running in Zookeeper mode.
   ##
   replicaCount: 0
   ## @param broker.minId Minimal node.id values for broker-only nodes. Do not change after first initialization.

--- a/bitnami/kafka/values.yaml
+++ b/bitnami/kafka/values.yaml
@@ -825,7 +825,7 @@ controller:
 ##
 broker:
   ## @param broker.replicaCount Number of Kafka broker-only nodes
-  ## Ignore this section if running in Zookeeper mode.
+  ## Ignore this section if you are not running in Zookeeper mode.
   ##
   replicaCount: 0
   ## @param broker.minId Minimal node.id values for broker-only nodes. Do not change after first initialization.


### PR DESCRIPTION

### Description of the change

Docs are specifying the opposite of the actual implementation:
```
{{- define "kafka.validateValues.zookeeperMissingBrokers" -}}
{{- if and (or .Values.zookeeper.enabled .Values.externalZookeeper.servers) (le (int .Values.broker.replicaCount) 0)}}
kafka: Zookeeper mode - No Kafka brokers configured
    Zookeper mode has been enabled, but no Kafka brokers nodes have been configured
```


### Checklist


- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
