### PR TITLE
[bitnami/kafka] Update README's upgrade 24.0.0 notes (#17029)

### DIFF
--- a/bitnami/kafka/README.md
+++ b/bitnami/kafka/README.md
@@ -1169,9 +1169,9 @@ The changes introduced in this version are:
   - TLS settings have been moved from `auth.tls.*` to `tls.*`.
   - Zookeeper TLS settings have been moved from `auth.zookeeper*` to `tls.zookeeper.*`
 - Refactor externalAccess to support the new architecture:
-  - `externalAccess.service.*` have been renamed to `externalAccess.controller.service.*` and `externalAccess.controller.service.*`.
-  - Controller pods will not configure externalAccess unless:
-    - `controller.controllerOnly=false` (default), meaning the pods are running as 'controller+broker' nodes.
+  - `externalAccess.service.*` have been renamed to `externalAccess.controller.service.*` and `externalAccess.broker.service.*`.
+  - Controller pods will not configure externalAccess unless either:
+    - `controller.controllerOnly=false` (default), meaning the pods are running as 'controller+broker' nodes; or
     - `externalAccess.controller.service.forceExpose=true`, for use cases where controller-only nodes want to be exposed externally.
 
 #### Upgrading from Kraft mode


### PR DESCRIPTION
### Description of the change

Update a typo where `externalAccess.controller.*` was listed twice instead of `externalAccess.controller.*` and `externalAccess.broker.*`.

Be explicit about the fact that either condition mentioned is sufficient for controller pods to configure externalAccess.

Validated by reading
`bitnami/kafka/templates/controller-eligible/svc-external-access.yaml` and
`bitnami/kafka/templates/broker/svc-external-access.yaml`.

No code changes.

### Benefits

Clarity of README. 

### Possible drawbacks / Applicable issues

None

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
