### PR TITLE
[bitnami/redis] - Enable metrics-svc only when serviceMonitor enabled

### DIFF
--- a/bitnami/redis/Chart.yaml
+++ b/bitnami/redis/Chart.yaml
@@ -34,4 +34,4 @@ maintainers:
 name: redis
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/redis
-version: 18.2.0
+version: 18.2.1

--- a/bitnami/redis/Chart.yaml
+++ b/bitnami/redis/Chart.yaml
@@ -34,4 +34,4 @@ maintainers:
 name: redis
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/redis
-version: 18.2.1
+version: 18.2.0

--- a/bitnami/redis/templates/metrics-svc.yaml
+++ b/bitnami/redis/templates/metrics-svc.yaml
@@ -3,7 +3,7 @@ Copyright VMware, Inc.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- if .Values.metrics.enabled }}
+{{- if and .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled }}
 apiVersion: v1
 kind: Service
 metadata:


### PR DESCRIPTION
Description of the change
In addition to [#20409 ](https://github.com/bitnami/charts/pull/20409) enable metrics-svc only when serviceMonitor enabled since its not needed with podMonitor

Benefits
Removing the need for ClusterIP service when podMonitor enabled

Possible drawbacks

Applicable issues

Additional information