### PR TITLE
[bitnami/nats] feat: :sparkles: Add support for PSA restricted policy

### DIFF
--- a/bitnami/nats/Chart.yaml
+++ b/bitnami/nats/Chart.yaml
@@ -31,4 +31,4 @@ maintainers:
 name: nats
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/nats
-version: 7.9.10
+version: 7.10.0

--- a/bitnami/nats/README.md
+++ b/bitnami/nats/README.md
@@ -119,61 +119,66 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### NATS deployment/statefulset parameters
 
-| Name                                    | Description                                                                                           | Value           |
-| --------------------------------------- | ----------------------------------------------------------------------------------------------------- | --------------- |
-| `resourceType`                          | NATS cluster resource type under Kubernetes. Allowed values: `statefulset` (default) or `deployment`  | `statefulset`   |
-| `replicaCount`                          | Number of NATS nodes                                                                                  | `1`             |
-| `schedulerName`                         | Use an alternate scheduler, e.g. "stork".                                                             | `""`            |
-| `priorityClassName`                     | Name of pod priority class                                                                            | `""`            |
-| `updateStrategy.type`                   | StrategyType. Can be set to RollingUpdate or OnDelete                                                 | `RollingUpdate` |
-| `containerPorts.client`                 | NATS client container port                                                                            | `4222`          |
-| `containerPorts.cluster`                | NATS cluster container port                                                                           | `6222`          |
-| `containerPorts.monitoring`             | NATS monitoring container port                                                                        | `8222`          |
-| `podSecurityContext.enabled`            | Enabled NATS pods' Security Context                                                                   | `false`         |
-| `podSecurityContext.fsGroup`            | Set NATS pod's Security Context fsGroup                                                               | `1001`          |
-| `containerSecurityContext.enabled`      | Enabled NATS containers' Security Context                                                             | `false`         |
-| `containerSecurityContext.runAsUser`    | Set NATS containers' Security Context runAsUser                                                       | `1001`          |
-| `containerSecurityContext.runAsNonRoot` | Set NATS containers' Security Context runAsNonRoot                                                    | `true`          |
-| `resources.limits`                      | The resources limits for the NATS containers                                                          | `{}`            |
-| `resources.requests`                    | The requested resources for the NATS containers                                                       | `{}`            |
-| `livenessProbe.enabled`                 | Enable livenessProbe                                                                                  | `true`          |
-| `livenessProbe.initialDelaySeconds`     | Initial delay seconds for livenessProbe                                                               | `30`            |
-| `livenessProbe.periodSeconds`           | Period seconds for livenessProbe                                                                      | `10`            |
-| `livenessProbe.timeoutSeconds`          | Timeout seconds for livenessProbe                                                                     | `5`             |
-| `livenessProbe.failureThreshold`        | Failure threshold for livenessProbe                                                                   | `6`             |
-| `livenessProbe.successThreshold`        | Success threshold for livenessProbe                                                                   | `1`             |
-| `readinessProbe.enabled`                | Enable readinessProbe                                                                                 | `true`          |
-| `readinessProbe.initialDelaySeconds`    | Initial delay seconds for readinessProbe                                                              | `5`             |
-| `readinessProbe.periodSeconds`          | Period seconds for readinessProbe                                                                     | `10`            |
-| `readinessProbe.timeoutSeconds`         | Timeout seconds for readinessProbe                                                                    | `5`             |
-| `readinessProbe.failureThreshold`       | Failure threshold for readinessProbe                                                                  | `6`             |
-| `readinessProbe.successThreshold`       | Success threshold for readinessProbe                                                                  | `1`             |
-| `startupProbe.enabled`                  | Enable startupProbe on NATS containers                                                                | `false`         |
-| `startupProbe.initialDelaySeconds`      | Initial delay seconds for startupProbe                                                                | `5`             |
-| `startupProbe.periodSeconds`            | Period seconds for startupProbe                                                                       | `10`            |
-| `startupProbe.timeoutSeconds`           | Timeout seconds for startupProbe                                                                      | `5`             |
-| `startupProbe.failureThreshold`         | Failure threshold for startupProbe                                                                    | `6`             |
-| `startupProbe.successThreshold`         | Success threshold for startupProbe                                                                    | `1`             |
-| `customLivenessProbe`                   | Override default liveness probe                                                                       | `{}`            |
-| `customReadinessProbe`                  | Override default readiness probe                                                                      | `{}`            |
-| `customStartupProbe`                    | Custom startupProbe that overrides the default one                                                    | `{}`            |
-| `hostAliases`                           | Deployment pod host aliases                                                                           | `[]`            |
-| `podLabels`                             | Extra labels for NATS pods                                                                            | `{}`            |
-| `podAnnotations`                        | Annotations for NATS pods                                                                             | `{}`            |
-| `podAffinityPreset`                     | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                   | `""`            |
-| `podAntiAffinityPreset`                 | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`              | `soft`          |
-| `nodeAffinityPreset.type`               | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`             | `""`            |
-| `nodeAffinityPreset.key`                | Node label key to match. Ignored if `affinity` is set.                                                | `""`            |
-| `nodeAffinityPreset.values`             | Node label values to match. Ignored if `affinity` is set.                                             | `[]`            |
-| `affinity`                              | Affinity for pod assignment. Evaluated as a template.                                                 | `{}`            |
-| `nodeSelector`                          | Node labels for pod assignment. Evaluated as a template.                                              | `{}`            |
-| `tolerations`                           | Tolerations for pod assignment. Evaluated as a template.                                              | `[]`            |
-| `topologySpreadConstraints`             | Topology Spread Constraints for NATS pods assignment spread across your cluster among failure-domains | `[]`            |
-| `lifecycleHooks`                        | for the NATS container(s) to automate configuration before or after startup                           | `{}`            |
-| `extraVolumes`                          | Optionally specify extra list of additional volumes for NATS pods                                     | `[]`            |
-| `extraVolumeMounts`                     | Optionally specify extra list of additional volumeMounts for NATS container(s)                        | `[]`            |
-| `initContainers`                        | Add additional init containers to the NATS pods                                                       | `[]`            |
-| `sidecars`                              | Add additional sidecar containers to the NATS pods                                                    | `[]`            |
+| Name                                                | Description                                                                                           | Value            |
+| --------------------------------------------------- | ----------------------------------------------------------------------------------------------------- | ---------------- |
+| `resourceType`                                      | NATS cluster resource type under Kubernetes. Allowed values: `statefulset` (default) or `deployment`  | `statefulset`    |
+| `replicaCount`                                      | Number of NATS nodes                                                                                  | `1`              |
+| `schedulerName`                                     | Use an alternate scheduler, e.g. "stork".                                                             | `""`             |
+| `priorityClassName`                                 | Name of pod priority class                                                                            | `""`             |
+| `updateStrategy.type`                               | StrategyType. Can be set to RollingUpdate or OnDelete                                                 | `RollingUpdate`  |
+| `containerPorts.client`                             | NATS client container port                                                                            | `4222`           |
+| `containerPorts.cluster`                            | NATS cluster container port                                                                           | `6222`           |
+| `containerPorts.monitoring`                         | NATS monitoring container port                                                                        | `8222`           |
+| `podSecurityContext.enabled`                        | Enabled NATS pods' Security Context                                                                   | `true`           |
+| `podSecurityContext.fsGroup`                        | Set NATS pod's Security Context fsGroup                                                               | `1001`           |
+| `containerSecurityContext.enabled`                  | Enabled containers' Security Context                                                                  | `true`           |
+| `containerSecurityContext.runAsUser`                | Set containers' Security Context runAsUser                                                            | `1001`           |
+| `containerSecurityContext.runAsNonRoot`             | Set container's Security Context runAsNonRoot                                                         | `true`           |
+| `containerSecurityContext.privileged`               | Set container's Security Context privileged                                                           | `false`          |
+| `containerSecurityContext.readOnlyRootFilesystem`   | Set container's Security Context readOnlyRootFilesystem                                               | `false`          |
+| `containerSecurityContext.allowPrivilegeEscalation` | Set container's Security Context allowPrivilegeEscalation                                             | `false`          |
+| `containerSecurityContext.capabilities.drop`        | List of capabilities to be dropped                                                                    | `["ALL"]`        |
+| `containerSecurityContext.seccompProfile.type`      | Set container's Security Context seccomp profile                                                      | `RuntimeDefault` |
+| `resources.limits`                                  | The resources limits for the NATS containers                                                          | `{}`             |
+| `resources.requests`                                | The requested resources for the NATS containers                                                       | `{}`             |
+| `livenessProbe.enabled`                             | Enable livenessProbe                                                                                  | `true`           |
+| `livenessProbe.initialDelaySeconds`                 | Initial delay seconds for livenessProbe                                                               | `30`             |
+| `livenessProbe.periodSeconds`                       | Period seconds for livenessProbe                                                                      | `10`             |
+| `livenessProbe.timeoutSeconds`                      | Timeout seconds for livenessProbe                                                                     | `5`              |
+| `livenessProbe.failureThreshold`                    | Failure threshold for livenessProbe                                                                   | `6`              |
+| `livenessProbe.successThreshold`                    | Success threshold for livenessProbe                                                                   | `1`              |
+| `readinessProbe.enabled`                            | Enable readinessProbe                                                                                 | `true`           |
+| `readinessProbe.initialDelaySeconds`                | Initial delay seconds for readinessProbe                                                              | `5`              |
+| `readinessProbe.periodSeconds`                      | Period seconds for readinessProbe                                                                     | `10`             |
+| `readinessProbe.timeoutSeconds`                     | Timeout seconds for readinessProbe                                                                    | `5`              |
+| `readinessProbe.failureThreshold`                   | Failure threshold for readinessProbe                                                                  | `6`              |
+| `readinessProbe.successThreshold`                   | Success threshold for readinessProbe                                                                  | `1`              |
+| `startupProbe.enabled`                              | Enable startupProbe on NATS containers                                                                | `false`          |
+| `startupProbe.initialDelaySeconds`                  | Initial delay seconds for startupProbe                                                                | `5`              |
+| `startupProbe.periodSeconds`                        | Period seconds for startupProbe                                                                       | `10`             |
+| `startupProbe.timeoutSeconds`                       | Timeout seconds for startupProbe                                                                      | `5`              |
+| `startupProbe.failureThreshold`                     | Failure threshold for startupProbe                                                                    | `6`              |
+| `startupProbe.successThreshold`                     | Success threshold for startupProbe                                                                    | `1`              |
+| `customLivenessProbe`                               | Override default liveness probe                                                                       | `{}`             |
+| `customReadinessProbe`                              | Override default readiness probe                                                                      | `{}`             |
+| `customStartupProbe`                                | Custom startupProbe that overrides the default one                                                    | `{}`             |
+| `hostAliases`                                       | Deployment pod host aliases                                                                           | `[]`             |
+| `podLabels`                                         | Extra labels for NATS pods                                                                            | `{}`             |
+| `podAnnotations`                                    | Annotations for NATS pods                                                                             | `{}`             |
+| `podAffinityPreset`                                 | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                   | `""`             |
+| `podAntiAffinityPreset`                             | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`              | `soft`           |
+| `nodeAffinityPreset.type`                           | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`             | `""`             |
+| `nodeAffinityPreset.key`                            | Node label key to match. Ignored if `affinity` is set.                                                | `""`             |
+| `nodeAffinityPreset.values`                         | Node label values to match. Ignored if `affinity` is set.                                             | `[]`             |
+| `affinity`                                          | Affinity for pod assignment. Evaluated as a template.                                                 | `{}`             |
+| `nodeSelector`                                      | Node labels for pod assignment. Evaluated as a template.                                              | `{}`             |
+| `tolerations`                                       | Tolerations for pod assignment. Evaluated as a template.                                              | `[]`             |
+| `topologySpreadConstraints`                         | Topology Spread Constraints for NATS pods assignment spread across your cluster among failure-domains | `[]`             |
+| `lifecycleHooks`                                    | for the NATS container(s) to automate configuration before or after startup                           | `{}`             |
+| `extraVolumes`                                      | Optionally specify extra list of additional volumes for NATS pods                                     | `[]`             |
+| `extraVolumeMounts`                                 | Optionally specify extra list of additional volumeMounts for NATS container(s)                        | `[]`             |
+| `initContainers`                                    | Add additional init containers to the NATS pods                                                       | `[]`             |
+| `sidecars`                                          | Add additional sidecar containers to the NATS pods                                                    | `[]`             |
 
 ### Traffic Exposure parameters
 

--- a/bitnami/nats/values.yaml
+++ b/bitnami/nats/values.yaml
@@ -327,18 +327,30 @@ containerPorts:
 ## @param podSecurityContext.fsGroup Set NATS pod's Security Context fsGroup
 ##
 podSecurityContext:
-  enabled: false
+  enabled: true
   fsGroup: 1001
 ## Configure Container Security Context
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
-## @param containerSecurityContext.enabled Enabled NATS containers' Security Context
-## @param containerSecurityContext.runAsUser Set NATS containers' Security Context runAsUser
-## @param containerSecurityContext.runAsNonRoot Set NATS containers' Security Context runAsNonRoot
+## @param containerSecurityContext.enabled Enabled containers' Security Context
+## @param containerSecurityContext.runAsUser Set containers' Security Context runAsUser
+## @param containerSecurityContext.runAsNonRoot Set container's Security Context runAsNonRoot
+## @param containerSecurityContext.privileged Set container's Security Context privileged
+## @param containerSecurityContext.readOnlyRootFilesystem Set container's Security Context readOnlyRootFilesystem
+## @param containerSecurityContext.allowPrivilegeEscalation Set container's Security Context allowPrivilegeEscalation
+## @param containerSecurityContext.capabilities.drop List of capabilities to be dropped
+## @param containerSecurityContext.seccompProfile.type Set container's Security Context seccomp profile
 ##
 containerSecurityContext:
-  enabled: false
+  enabled: true
   runAsUser: 1001
   runAsNonRoot: true
+  privileged: false
+  readOnlyRootFilesystem: false
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop: ["ALL"]
+  seccompProfile:
+    type: "RuntimeDefault"
 ## NATS resource requests and limits
 ## ref: https://kubernetes.io/docs/user-guide/compute-resources/
 ## @param resources.limits The resources limits for the NATS containers


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

This PR adds the necessary securityContext parameters to be run in the restricted Pod Security Admission level

https://kubernetes.io/docs/concepts/security/pod-security-admission/

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- Related to https://github.com/bitnami/charts/issues/20000

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
