### PR TITLE
[bitnami/oauth2-proxy] feat: :sparkles: Add support for PSA restricted policy

### DIFF
--- a/bitnami/oauth2-proxy/Chart.lock
+++ b/bitnami/oauth2-proxy/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: redis
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 18.1.4
+  version: 18.2.0
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.13.2
-digest: sha256:fb6948a2b763f2b5d931a0b0f7e35ceb06ca1dcb7068627681e0a8016fe4774a
-generated: "2023-10-12T15:22:46.014524556Z"
+  version: 2.13.3
+digest: sha256:17b8aa46621b6c6df8eba8fa689f12e4998b19afd97cfebea2d30e5dbb2a018b
+generated: "2023-10-30T15:49:38.697347265+01:00"

--- a/bitnami/oauth2-proxy/Chart.yaml
+++ b/bitnami/oauth2-proxy/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: oauth2-proxy
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/oauth2-proxy
-version: 4.1.6
+version: 4.2.0

--- a/bitnami/oauth2-proxy/README.md
+++ b/bitnami/oauth2-proxy/README.md
@@ -151,73 +151,79 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### OAuth2 Proxy deployment parameters
 
-| Name                                          | Description                                                                                      | Value           |
-| --------------------------------------------- | ------------------------------------------------------------------------------------------------ | --------------- |
-| `containerPort`                               | OAuth2 Proxy port number                                                                         | `4180`          |
-| `extraContainerPorts`                         | Array of additional container ports for the OAuth2 Proxy container                               | `[]`            |
-| `replicaCount`                                | Number of OAuth2 Proxy replicas to deploy                                                        | `1`             |
-| `extraArgs`                                   | add extra args to the default command                                                            | `[]`            |
-| `startupProbe.enabled`                        | Enable startupProbe on OAuth2 Proxy nodes                                                        | `false`         |
-| `startupProbe.initialDelaySeconds`            | Initial delay seconds for startupProbe                                                           | `0`             |
-| `startupProbe.periodSeconds`                  | Period seconds for startupProbe                                                                  | `10`            |
-| `startupProbe.timeoutSeconds`                 | Timeout seconds for startupProbe                                                                 | `1`             |
-| `startupProbe.failureThreshold`               | Failure threshold for startupProbe                                                               | `5`             |
-| `startupProbe.successThreshold`               | Success threshold for startupProbe                                                               | `1`             |
-| `livenessProbe.enabled`                       | Enable livenessProbe on OAuth2 Proxy nodes                                                       | `true`          |
-| `livenessProbe.initialDelaySeconds`           | Initial delay seconds for livenessProbe                                                          | `0`             |
-| `livenessProbe.periodSeconds`                 | Period seconds for livenessProbe                                                                 | `10`            |
-| `livenessProbe.timeoutSeconds`                | Timeout seconds for livenessProbe                                                                | `1`             |
-| `livenessProbe.failureThreshold`              | Failure threshold for livenessProbe                                                              | `5`             |
-| `livenessProbe.successThreshold`              | Success threshold for livenessProbe                                                              | `1`             |
-| `readinessProbe.enabled`                      | Enable readinessProbe on OAuth2 Proxy nodes                                                      | `true`          |
-| `readinessProbe.initialDelaySeconds`          | Initial delay seconds for readinessProbe                                                         | `0`             |
-| `readinessProbe.periodSeconds`                | Period seconds for readinessProbe                                                                | `10`            |
-| `readinessProbe.timeoutSeconds`               | Timeout seconds for readinessProbe                                                               | `1`             |
-| `readinessProbe.failureThreshold`             | Failure threshold for readinessProbe                                                             | `5`             |
-| `readinessProbe.successThreshold`             | Success threshold for readinessProbe                                                             | `1`             |
-| `customStartupProbe`                          | Custom startupProbe that overrides the default one                                               | `{}`            |
-| `customLivenessProbe`                         | Custom livenessProbe that overrides the default one                                              | `{}`            |
-| `customReadinessProbe`                        | Custom readinessProbe that overrides the default one                                             | `{}`            |
-| `resources.limits`                            | The resources limits for the OAuth2 Proxy containers                                             | `{}`            |
-| `resources.requests`                          | The requested resources for the OAuth2 Proxy containers                                          | `{}`            |
-| `pdb.create`                                  | Enable a Pod Disruption Budget creation                                                          | `false`         |
-| `pdb.minAvailable`                            | Minimum number/percentage of pods that should remain scheduled                                   | `1`             |
-| `pdb.maxUnavailable`                          | Maximum number/percentage of pods that may be made unavailable                                   | `""`            |
-| `podSecurityContext.enabled`                  | Enabled OAuth2 Proxy pods' Security Context                                                      | `true`          |
-| `podSecurityContext.fsGroup`                  | Set OAuth2 Proxy pod's Security Context fsGroup                                                  | `1001`          |
-| `containerSecurityContext.enabled`            | Enabled OAuth2 Proxy containers' Security Context                                                | `true`          |
-| `containerSecurityContext.runAsUser`          | Set OAuth2 Proxy containers' Security Context runAsUser                                          | `1001`          |
-| `command`                                     | Override default container command (useful when using custom images)                             | `[]`            |
-| `args`                                        | Override default container args (useful when using custom images)                                | `[]`            |
-| `hostAliases`                                 | OAuth2 Proxy pods host aliases                                                                   | `[]`            |
-| `podLabels`                                   | Extra labels for OAuth2 Proxy pods                                                               | `{}`            |
-| `podAnnotations`                              | Annotations for OAuth2 Proxy pods                                                                | `{}`            |
-| `podAffinityPreset`                           | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`              | `""`            |
-| `podAntiAffinityPreset`                       | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`         | `soft`          |
-| `nodeAffinityPreset.type`                     | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`        | `""`            |
-| `nodeAffinityPreset.key`                      | Node label key to match. Ignored if `affinity` is set                                            | `""`            |
-| `nodeAffinityPreset.values`                   | Node label values to match. Ignored if `affinity` is set                                         | `[]`            |
-| `affinity`                                    | Affinity for OAuth2 Proxy pods assignment                                                        | `{}`            |
-| `nodeSelector`                                | Node labels for OAuth2 Proxy pods assignment                                                     | `{}`            |
-| `tolerations`                                 | Tolerations for OAuth2 Proxy pods assignment                                                     | `[]`            |
-| `updateStrategy.type`                         | OAuth2 Proxy statefulset strategy type                                                           | `RollingUpdate` |
-| `priorityClassName`                           | OAuth2 Proxy pods' priorityClassName                                                             | `""`            |
-| `schedulerName`                               | Name of the k8s scheduler (other than default)                                                   | `""`            |
-| `topologySpreadConstraints`                   | Topology Spread Constraints for pod assignment                                                   | `[]`            |
-| `lifecycleHooks`                              | for the OAuth2 Proxy container(s) to automate configuration before or after startup              | `{}`            |
-| `extraEnvVars`                                | Array with extra environment variables to add to OAuth2 Proxy nodes                              | `[]`            |
-| `extraEnvVarsCM`                              | Name of existing ConfigMap containing extra env vars for OAuth2 Proxy nodes                      | `""`            |
-| `extraEnvVarsSecret`                          | Name of existing Secret containing extra env vars for OAuth2 Proxy nodes                         | `""`            |
-| `extraVolumes`                                | Optionally specify extra list of additional volumes for the OAuth2 Proxy pod(s)                  | `[]`            |
-| `extraVolumeMounts`                           | Optionally specify extra list of additional volumeMounts for the OAuth2 Proxy container(s)       | `[]`            |
-| `sidecars`                                    | Add additional sidecar containers to the OAuth2 Proxy pod(s)                                     | `[]`            |
-| `initContainers`                              | Add additional init containers to the OAuth2 Proxy pod(s)                                        | `[]`            |
-| `dnsPolicy`                                   | Pod DNS policy. Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'. | `""`            |
-| `dnsConfig`                                   | Pod DNS configuration.                                                                           | `{}`            |
-| `serviceAccount.create`                       | Specifies whether a ServiceAccount should be created                                             | `true`          |
-| `serviceAccount.name`                         | The name of the ServiceAccount to use                                                            | `""`            |
-| `serviceAccount.automountServiceAccountToken` | Automount service account token for the server service account                                   | `true`          |
-| `serviceAccount.annotations`                  | Annotations for service account. Evaluated as a template. Only used if `create` is `true`.       | `{}`            |
+| Name                                                | Description                                                                                      | Value            |
+| --------------------------------------------------- | ------------------------------------------------------------------------------------------------ | ---------------- |
+| `containerPort`                                     | OAuth2 Proxy port number                                                                         | `4180`           |
+| `extraContainerPorts`                               | Array of additional container ports for the OAuth2 Proxy container                               | `[]`             |
+| `replicaCount`                                      | Number of OAuth2 Proxy replicas to deploy                                                        | `1`              |
+| `extraArgs`                                         | add extra args to the default command                                                            | `[]`             |
+| `startupProbe.enabled`                              | Enable startupProbe on OAuth2 Proxy nodes                                                        | `false`          |
+| `startupProbe.initialDelaySeconds`                  | Initial delay seconds for startupProbe                                                           | `0`              |
+| `startupProbe.periodSeconds`                        | Period seconds for startupProbe                                                                  | `10`             |
+| `startupProbe.timeoutSeconds`                       | Timeout seconds for startupProbe                                                                 | `1`              |
+| `startupProbe.failureThreshold`                     | Failure threshold for startupProbe                                                               | `5`              |
+| `startupProbe.successThreshold`                     | Success threshold for startupProbe                                                               | `1`              |
+| `livenessProbe.enabled`                             | Enable livenessProbe on OAuth2 Proxy nodes                                                       | `true`           |
+| `livenessProbe.initialDelaySeconds`                 | Initial delay seconds for livenessProbe                                                          | `0`              |
+| `livenessProbe.periodSeconds`                       | Period seconds for livenessProbe                                                                 | `10`             |
+| `livenessProbe.timeoutSeconds`                      | Timeout seconds for livenessProbe                                                                | `1`              |
+| `livenessProbe.failureThreshold`                    | Failure threshold for livenessProbe                                                              | `5`              |
+| `livenessProbe.successThreshold`                    | Success threshold for livenessProbe                                                              | `1`              |
+| `readinessProbe.enabled`                            | Enable readinessProbe on OAuth2 Proxy nodes                                                      | `true`           |
+| `readinessProbe.initialDelaySeconds`                | Initial delay seconds for readinessProbe                                                         | `0`              |
+| `readinessProbe.periodSeconds`                      | Period seconds for readinessProbe                                                                | `10`             |
+| `readinessProbe.timeoutSeconds`                     | Timeout seconds for readinessProbe                                                               | `1`              |
+| `readinessProbe.failureThreshold`                   | Failure threshold for readinessProbe                                                             | `5`              |
+| `readinessProbe.successThreshold`                   | Success threshold for readinessProbe                                                             | `1`              |
+| `customStartupProbe`                                | Custom startupProbe that overrides the default one                                               | `{}`             |
+| `customLivenessProbe`                               | Custom livenessProbe that overrides the default one                                              | `{}`             |
+| `customReadinessProbe`                              | Custom readinessProbe that overrides the default one                                             | `{}`             |
+| `resources.limits`                                  | The resources limits for the OAuth2 Proxy containers                                             | `{}`             |
+| `resources.requests`                                | The requested resources for the OAuth2 Proxy containers                                          | `{}`             |
+| `pdb.create`                                        | Enable a Pod Disruption Budget creation                                                          | `false`          |
+| `pdb.minAvailable`                                  | Minimum number/percentage of pods that should remain scheduled                                   | `1`              |
+| `pdb.maxUnavailable`                                | Maximum number/percentage of pods that may be made unavailable                                   | `""`             |
+| `podSecurityContext.enabled`                        | Enabled OAuth2 Proxy pods' Security Context                                                      | `true`           |
+| `podSecurityContext.fsGroup`                        | Set OAuth2 Proxy pod's Security Context fsGroup                                                  | `1001`           |
+| `containerSecurityContext.enabled`                  | Enabled containers' Security Context                                                             | `true`           |
+| `containerSecurityContext.runAsUser`                | Set containers' Security Context runAsUser                                                       | `1001`           |
+| `containerSecurityContext.runAsNonRoot`             | Set container's Security Context runAsNonRoot                                                    | `true`           |
+| `containerSecurityContext.privileged`               | Set container's Security Context privileged                                                      | `false`          |
+| `containerSecurityContext.readOnlyRootFilesystem`   | Set container's Security Context readOnlyRootFilesystem                                          | `false`          |
+| `containerSecurityContext.allowPrivilegeEscalation` | Set container's Security Context allowPrivilegeEscalation                                        | `false`          |
+| `containerSecurityContext.capabilities.drop`        | List of capabilities to be dropped                                                               | `["ALL"]`        |
+| `containerSecurityContext.seccompProfile.type`      | Set container's Security Context seccomp profile                                                 | `RuntimeDefault` |
+| `command`                                           | Override default container command (useful when using custom images)                             | `[]`             |
+| `args`                                              | Override default container args (useful when using custom images)                                | `[]`             |
+| `hostAliases`                                       | OAuth2 Proxy pods host aliases                                                                   | `[]`             |
+| `podLabels`                                         | Extra labels for OAuth2 Proxy pods                                                               | `{}`             |
+| `podAnnotations`                                    | Annotations for OAuth2 Proxy pods                                                                | `{}`             |
+| `podAffinityPreset`                                 | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`              | `""`             |
+| `podAntiAffinityPreset`                             | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`         | `soft`           |
+| `nodeAffinityPreset.type`                           | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`        | `""`             |
+| `nodeAffinityPreset.key`                            | Node label key to match. Ignored if `affinity` is set                                            | `""`             |
+| `nodeAffinityPreset.values`                         | Node label values to match. Ignored if `affinity` is set                                         | `[]`             |
+| `affinity`                                          | Affinity for OAuth2 Proxy pods assignment                                                        | `{}`             |
+| `nodeSelector`                                      | Node labels for OAuth2 Proxy pods assignment                                                     | `{}`             |
+| `tolerations`                                       | Tolerations for OAuth2 Proxy pods assignment                                                     | `[]`             |
+| `updateStrategy.type`                               | OAuth2 Proxy statefulset strategy type                                                           | `RollingUpdate`  |
+| `priorityClassName`                                 | OAuth2 Proxy pods' priorityClassName                                                             | `""`             |
+| `schedulerName`                                     | Name of the k8s scheduler (other than default)                                                   | `""`             |
+| `topologySpreadConstraints`                         | Topology Spread Constraints for pod assignment                                                   | `[]`             |
+| `lifecycleHooks`                                    | for the OAuth2 Proxy container(s) to automate configuration before or after startup              | `{}`             |
+| `extraEnvVars`                                      | Array with extra environment variables to add to OAuth2 Proxy nodes                              | `[]`             |
+| `extraEnvVarsCM`                                    | Name of existing ConfigMap containing extra env vars for OAuth2 Proxy nodes                      | `""`             |
+| `extraEnvVarsSecret`                                | Name of existing Secret containing extra env vars for OAuth2 Proxy nodes                         | `""`             |
+| `extraVolumes`                                      | Optionally specify extra list of additional volumes for the OAuth2 Proxy pod(s)                  | `[]`             |
+| `extraVolumeMounts`                                 | Optionally specify extra list of additional volumeMounts for the OAuth2 Proxy container(s)       | `[]`             |
+| `sidecars`                                          | Add additional sidecar containers to the OAuth2 Proxy pod(s)                                     | `[]`             |
+| `initContainers`                                    | Add additional init containers to the OAuth2 Proxy pod(s)                                        | `[]`             |
+| `dnsPolicy`                                         | Pod DNS policy. Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'. | `""`             |
+| `dnsConfig`                                         | Pod DNS configuration.                                                                           | `{}`             |
+| `serviceAccount.create`                             | Specifies whether a ServiceAccount should be created                                             | `true`           |
+| `serviceAccount.name`                               | The name of the ServiceAccount to use                                                            | `""`             |
+| `serviceAccount.automountServiceAccountToken`       | Automount service account token for the server service account                                   | `true`           |
+| `serviceAccount.annotations`                        | Annotations for service account. Evaluated as a template. Only used if `create` is `true`.       | `{}`             |
 
 ### External Redis&reg; parameters
 

--- a/bitnami/oauth2-proxy/values.yaml
+++ b/bitnami/oauth2-proxy/values.yaml
@@ -470,12 +470,26 @@ podSecurityContext:
   fsGroup: 1001
 ## Configure Container Security Context
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
-## @param containerSecurityContext.enabled Enabled OAuth2 Proxy containers' Security Context
-## @param containerSecurityContext.runAsUser Set OAuth2 Proxy containers' Security Context runAsUser
+## @param containerSecurityContext.enabled Enabled containers' Security Context
+## @param containerSecurityContext.runAsUser Set containers' Security Context runAsUser
+## @param containerSecurityContext.runAsNonRoot Set container's Security Context runAsNonRoot
+## @param containerSecurityContext.privileged Set container's Security Context privileged
+## @param containerSecurityContext.readOnlyRootFilesystem Set container's Security Context readOnlyRootFilesystem
+## @param containerSecurityContext.allowPrivilegeEscalation Set container's Security Context allowPrivilegeEscalation
+## @param containerSecurityContext.capabilities.drop List of capabilities to be dropped
+## @param containerSecurityContext.seccompProfile.type Set container's Security Context seccomp profile
 ##
 containerSecurityContext:
   enabled: true
   runAsUser: 1001
+  runAsNonRoot: true
+  privileged: false
+  readOnlyRootFilesystem: false
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop: ["ALL"]
+  seccompProfile:
+    type: "RuntimeDefault"
 
 ## @param command Override default container command (useful when using custom images)
 ##


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

This PR adds the necessary securityContext parameters to be run in the restricted Pod Security Admission level

https://kubernetes.io/docs/concepts/security/pod-security-admission/

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- Related to https://github.com/bitnami/charts/issues/20000

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
