### PR TITLE
[bitnami/gitea] Remove HA support

### DIFF
--- a/bitnami/gitea/Chart.yaml
+++ b/bitnami/gitea/Chart.yaml
@@ -37,4 +37,4 @@ maintainers:
 name: gitea
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/gitea
-version: 1.1.0
+version: 1.2.0

--- a/bitnami/gitea/README.md
+++ b/bitnami/gitea/README.md
@@ -88,7 +88,6 @@ The command removes all the Kubernetes components associated with the chart and 
 | `image.pullPolicy`                                  | Gitea image pull policy                                                                                               | `IfNotPresent`          |
 | `image.pullSecrets`                                 | Specify docker-registry secret names as an array                                                                      | `[]`                    |
 | `image.debug`                                       | Specify if debug logs should be enabled                                                                               | `false`                 |
-| `replicaCount`                                      | Number of Gitea Pods to run (requires ReadWriteMany PVC support)                                                      | `1`                     |
 | `adminUsername`                                     | User of the application                                                                                               | `bn_user`               |
 | `adminPassword`                                     | Application password                                                                                                  | `""`                    |
 | `adminEmail`                                        | Admin email                                                                                                           | `user@example.com`      |

--- a/bitnami/gitea/README.md
+++ b/bitnami/gitea/README.md
@@ -31,7 +31,6 @@ Looking to use Gitea in production? Try [VMware Tanzu Application Catalog](https
 - Kubernetes 1.23+
 - Helm 3.8.0+
 - PV provisioner support in the underlying infrastructure
-- ReadWriteMany volumes for deployment scaling
 
 ## Installing the Chart
 

--- a/bitnami/gitea/templates/deployment.yaml
+++ b/bitnami/gitea/templates/deployment.yaml
@@ -19,7 +19,7 @@ spec:
   {{- if .Values.updateStrategy }}
   strategy: {{- toYaml .Values.updateStrategy | nindent 4 }}
   {{- end }}
-  replicas: {{ .Values.replicaCount }}
+  replicas: 1
   template:
     metadata:
       labels: {{- include "common.labels.standard" ( dict "customLabels" $podLabels "context" $ ) | nindent 8 }}

--- a/bitnami/gitea/values.yaml
+++ b/bitnami/gitea/values.yaml
@@ -80,9 +80,6 @@ image:
   ## Set to true if you would like to see extra information on logs
   ##
   debug: false
-## @param replicaCount Number of Gitea Pods to run (requires ReadWriteMany PVC support)
-##
-replicaCount: 1
 ## @param adminUsername User of the application
 ## ref: https://github.com/bitnami/containers/tree/main/bitnami/gitea#configuration
 ##


### PR DESCRIPTION
### Description of the change

Remove the ability to increase the number of replicas. Running Gitea in HA mode is a experimental feature, as described in their [official documentation](https://gitea.com/gitea/helm-chart/src/branch/main/docs/ha-setup.md), and requires a management system for cache, session and queueing.

### Benefits

Removed support for `replicaCount > 1` deployments, which will result in failure.

### Possible drawbacks

None, deployments with `replicaCount > 1` should already fail.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- relates to #19834

### Additional information

An internal issue has been created in order to evaluate implementing the necessary changes for the chart to be HA-compatible.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
