### PR TITLE
[bitnami/jaeger] Chart missing imagePullSecrets and otlp ports

### DIFF
--- a/bitnami/jaeger/Chart.yaml
+++ b/bitnami/jaeger/Chart.yaml
@@ -34,4 +34,4 @@ maintainers:
 name: jaeger
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/jaeger
-version: 1.4.3
+version: 1.4.4

--- a/bitnami/jaeger/Chart.yaml
+++ b/bitnami/jaeger/Chart.yaml
@@ -34,4 +34,4 @@ maintainers:
 name: jaeger
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/jaeger
-version: 1.4.4
+version: 1.5.0

--- a/bitnami/jaeger/README.md
+++ b/bitnami/jaeger/README.md
@@ -212,15 +212,21 @@ The command removes all the Kubernetes components associated with the chart and 
 | `collector.containerPorts.grpc`                               | used by jaeger-agent to send spans in model.proto format                                   | `14250`          |
 | `collector.containerPorts.binary`                             | can accept spans directly from clients in jaeger.thrift format over binary thrift protocol | `14268`          |
 | `collector.containerPorts.admin`                              | Admin port: health check at / and metrics at /metrics                                      | `14269`          |
+| `collector.containerPorts.otlp.grpc`                          | Accepts traces in OpenTelemetry OTLP format over gRPC                                      | `4317`           |
+| `collector.containerPorts.otlp.http`                          | Accepts traces in OpenTelemetry OTLP format over HTTP                                      | `4318`           |
 | `collector.service.type`                                      | Jaeger service type                                                                        | `ClusterIP`      |
 | `collector.service.ports.zipkin`                              | can accept Zipkin spans in Thrift, JSON and Proto (disabled by default)                    | `9411`           |
 | `collector.service.ports.grpc`                                | used by jaeger-agent to send spans in model.proto format                                   | `14250`          |
 | `collector.service.ports.binary`                              | can accept spans directly from clients in jaeger.thrift format over binary thrift protocol | `14268`          |
 | `collector.service.ports.admin`                               | Admin port: health check at / and metrics at /metrics                                      | `14269`          |
+| `collector.service.ports.otlp.grpc`                           | Accepts traces in OpenTelemetry OTLP format over gRPC                                      | `4317`           |
+| `collector.service.ports.otlp.http`                           | Accepts traces in OpenTelemetry OTLP format over HTTP                                      | `4318`           |
 | `collector.service.nodePorts.zipkin`                          | can accept Zipkin spans in Thrift, JSON and Proto (disabled by default)                    | `""`             |
 | `collector.service.nodePorts.grpc`                            | used by jaeger-agent to send spans in model.proto format                                   | `""`             |
 | `collector.service.nodePorts.binary`                          | can accept spans directly from clients in jaeger.thrift format over binary thrift protocol | `""`             |
 | `collector.service.nodePorts.admin`                           | Admin port: health check at / and metrics at /metrics                                      | `""`             |
+| `collector.service.nodePorts.otlp.grpc`                       | Accepts traces in OpenTelemetry OTLP format over gRPC                                      | `""`             |
+| `collector.service.nodePorts.otlp.http`                       | Accepts traces in OpenTelemetry OTLP format over HTTP                                      | `""`             |
 | `collector.service.extraPorts`                                | Extra ports to expose in the service (normally used with the `sidecar` value)              | `[]`             |
 | `collector.service.loadBalancerIP`                            | LoadBalancerIP if service type is `LoadBalancer`                                           | `""`             |
 | `collector.service.loadBalancerSourceRanges`                  | Service Load Balancer sources                                                              | `[]`             |

--- a/bitnami/jaeger/templates/_helpers.tpl
+++ b/bitnami/jaeger/templates/_helpers.tpl
@@ -29,6 +29,13 @@ Create the name of the query deployment
 {{- end -}}
 
 {{/*
+Return the proper Docker Image Registry Secret Names
+*/}}
+{{- define "jaeger.imagePullSecrets" -}}
+{{ include "common.images.pullSecrets" (dict "images" (list .Values.image .Values.cqlshImage) "global" .Values.global) }}
+{{- end -}}
+
+{{/*
 Create a container for checking cassandra availability
 */}}
 {{- define "jaeger.waitForDBInitContainer" -}}

--- a/bitnami/jaeger/templates/agent/deployment.yaml
+++ b/bitnami/jaeger/templates/agent/deployment.yaml
@@ -31,6 +31,7 @@ spec:
       annotations: {{- include "common.tplvalues.render" (dict "value" .Values.agent.podAnnotations "context" $) | nindent 8 }}
       {{- end }}
     spec:
+      {{- include "jaeger.imagePullSecrets" . | nindent 6 }}
       {{- if .Values.agent.schedulerName }}
       schedulerName: {{ .Values.agent.schedulerName }}
       {{- end }}

--- a/bitnami/jaeger/templates/collector/deployment.yaml
+++ b/bitnami/jaeger/templates/collector/deployment.yaml
@@ -31,6 +31,7 @@ spec:
       annotations: {{- include "common.tplvalues.render" (dict "value" .Values.collector.podAnnotations "context" $) | nindent 8 }}
       {{- end }}
     spec:
+      {{- include "jaeger.imagePullSecrets" . | nindent 6 }}
       {{- if .Values.collector.schedulerName }}
       schedulerName: {{ .Values.collector.schedulerName }}
       {{- end }}
@@ -115,6 +116,10 @@ spec:
               value: {{ printf ":%v" .Values.collector.containerPorts.grpc | quote }}
             - name: COLLECTOR_HTTP_SERVER_HOST_PORT
               value: {{ printf ":%v" .Values.collector.containerPorts.binary | quote }}
+            - name: COLLECTOR_OTLP_GRPC_HOST_PORT
+              value: {{ printf ":%v" .Values.collector.containerPorts.otlp.grpc | quote }}
+            - name: COLLECTOR_OTLP_HTTP_HOST_PORT
+              value: {{ printf ":%v" .Values.collector.containerPorts.otlp.http | quote }}
             - name: BITNAMI_DEBUG
               value: {{ ternary "true" "false" .Values.image.debug | quote }}
             {{- if .Values.collector.extraEnvVars }}

--- a/bitnami/jaeger/templates/collector/service.yml
+++ b/bitnami/jaeger/templates/collector/service.yml
@@ -68,6 +68,22 @@ spec:
       {{- else if eq .Values.collector.service.type "ClusterIP" }}
       nodePort: null
       {{- end }}
+    - name: otlp-grpc
+      port: {{ .Values.collector.service.ports.otlp.grpc }}
+      targetPort: {{ .Values.collector.containerPorts.otlp.grpc }}
+      {{- if and (or (eq .Values.collector.service.type "NodePort") (eq .Values.collector.service.type "LoadBalancer")) (not (empty .Values.collector.service.nodePorts.otlp.grpc)) }}
+      nodePort: {{ .Values.collector.service.nodePorts.otlp.grpc }}
+      {{- else if eq .Values.collector.service.type "ClusterIP" }}
+      nodePort: null
+      {{- end }}
+    - name: otlp-http
+      port: {{ .Values.collector.service.ports.otlp.http }}
+      targetPort: {{ .Values.collector.containerPorts.otlp.http }}
+      {{- if and (or (eq .Values.collector.service.type "NodePort") (eq .Values.collector.service.type "LoadBalancer")) (not (empty .Values.collector.service.nodePorts.otlp.http)) }}
+      nodePort: {{ .Values.collector.service.nodePorts.otlp.http }}
+      {{- else if eq .Values.collector.service.type "ClusterIP" }}
+      nodePort: null
+      {{- end }}
     {{- if .Values.collector.service.extraPorts }}
     {{- include "common.tplvalues.render" (dict "value" .Values.collector.service.extraPorts "context" $) | nindent 4 }}
     {{- end }}

--- a/bitnami/jaeger/templates/migrate-job.yaml
+++ b/bitnami/jaeger/templates/migrate-job.yaml
@@ -25,6 +25,7 @@ spec:
       annotations: {{- include "common.tplvalues.render" (dict "value" .Values.migration.podAnnotations "context" $) | nindent 8 }}
       {{- end }}
     spec:
+      {{- include "jaeger.imagePullSecrets" . | nindent 6 }}
       restartPolicy: OnFailure
       {{- if .Values.migration.podSecurityContext.enabled }}
       securityContext: {{- omit .Values.migration.podSecurityContext "enabled" | toYaml | nindent 8 }}

--- a/bitnami/jaeger/templates/query/deployment.yaml
+++ b/bitnami/jaeger/templates/query/deployment.yaml
@@ -31,6 +31,7 @@ spec:
       annotations: {{- include "common.tplvalues.render" (dict "value" .Values.query.podAnnotations "context" $) | nindent 8 }}
       {{- end }}
     spec:
+      {{- include "jaeger.imagePullSecrets" . | nindent 6 }}
       {{- if .Values.query.schedulerName }}
       schedulerName: {{ .Values.query.schedulerName }}
       {{- end }}

--- a/bitnami/jaeger/values.yaml
+++ b/bitnami/jaeger/values.yaml
@@ -522,6 +522,15 @@ collector:
     ## @param collector.containerPorts.admin Admin port: health check at / and metrics at /metrics
     ##
     admin: 14269
+    ## Otlp ports to expose
+    ##
+    otlp:
+      ## @param collector.containerPorts.otlp.grpc Accepts traces in OpenTelemetry OTLP format over gRPC
+      ##
+      grpc: 4317
+      ## @param collector.containerPorts.otlp.http Accepts traces in OpenTelemetry OTLP format over HTTP
+      ##
+      http: 4318
   ## Jaeger collector.service parameters
   ##
   service:
@@ -543,6 +552,15 @@ collector:
       ## @param collector.service.ports.admin Admin port: health check at / and metrics at /metrics
       ##
       admin: 14269
+      ## Otlp ports to expose
+      ##
+      otlp:
+        ## @param collector.service.ports.otlp.grpc Accepts traces in OpenTelemetry OTLP format over gRPC
+        ##
+        grpc: 4317
+        ## @param collector.service.ports.otlp.http Accepts traces in OpenTelemetry OTLP format over HTTP
+        ##
+        http: 4318
     ## Node ports to expose
     ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
     nodePorts:
@@ -558,6 +576,15 @@ collector:
       ## @param collector.service.nodePorts.admin Admin port: health check at / and metrics at /metrics
       ##
       admin: ""
+      ## Otlp ports to expose
+      ##
+      otlp:
+        ## @param collector.service.nodePorts.otlp.grpc Accepts traces in OpenTelemetry OTLP format over gRPC
+        ##
+        grpc: ""
+        ## @param collector.service.nodePorts.otlp.http Accepts traces in OpenTelemetry OTLP format over HTTP
+        ##
+        http: ""
     ## @param collector.service.extraPorts Extra ports to expose in the service (normally used with the `sidecar` value)
     ##
     extraPorts: []


### PR DESCRIPTION
### Description of the change

- fix missing imagePullSecrets in templates
- expose missing otlp receiver ports in jaeger collector
  -  https://www.jaegertracing.io/docs/1.50/deployment/#collector ports 4317 and 4318 are now exposed 

### Benefits

- images can be pulled from private registry
- jaeger can receive traces using otlp protocol

### Additional Information

- this fixes #20318 

### Checklist

- [X ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [ X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [ X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
