### PR TITLE
[bitnami/kafka] Add minReadySeconds configuration

### DIFF
--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -42,4 +42,4 @@ maintainers:
 name: kafka
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/kafka
-version: 26.2.0
+version: 26.2.1

--- a/bitnami/kafka/README.md
+++ b/bitnami/kafka/README.md
@@ -282,6 +282,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `controller.logPersistence.annotations`                        | Annotations for the PVC                                                                                                                                                                       | `{}`                      |
 | `controller.logPersistence.selector`                           | Selector to match an existing Persistent Volume for Kafka log data PVC. If set, the PVC can't have a PV dynamically provisioned for it                                                        | `{}`                      |
 | `controller.logPersistence.mountPath`                          | Mount path of the Kafka logs volume                                                                                                                                                           | `/opt/bitnami/kafka/logs` |
+| `controller.minReadySeconds`                                   | How many seconds a pod needs to be ready before killing the next, during update                                                                                                               | `0`                       |
 
 ### Broker-only statefulset parameters
 
@@ -380,6 +381,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `broker.logPersistence.annotations`                        | Annotations for the PVC                                                                                                                                                                       | `{}`                      |
 | `broker.logPersistence.selector`                           | Selector to match an existing Persistent Volume for Kafka log data PVC. If set, the PVC can't have a PV dynamically provisioned for it                                                        | `{}`                      |
 | `broker.logPersistence.mountPath`                          | Mount path of the Kafka logs volume                                                                                                                                                           | `/opt/bitnami/kafka/logs` |
+| `broker.minReadySeconds`                                   | How many seconds a pod needs to be ready before killing the next, during update                                                                                                               | `0`                       |
 
 ### Traffic Exposure parameters
 

--- a/bitnami/kafka/templates/broker/statefulset.yaml
+++ b/bitnami/kafka/templates/broker/statefulset.yaml
@@ -26,6 +26,9 @@ spec:
       app.kubernetes.io/part-of: kafka
   serviceName: {{ printf "%s-broker-headless" (include "common.names.fullname" .) | trunc 63 | trimSuffix "-" }}
   updateStrategy: {{- include "common.tplvalues.render" (dict "value" .Values.broker.updateStrategy "context" $ ) | nindent 4 }}
+  {{- if and .Values.broker.minReadySeconds (semverCompare ">= 1.23" (include "common.capabilities.kubeVersion" .)) }}
+  minReadySeconds: {{ .Values.broker.minReadySeconds }}
+  {{- end }}
   template:
     metadata:
       labels: {{- include "common.labels.standard" ( dict "customLabels" $podLabels "context" $ ) | nindent 8 }}

--- a/bitnami/kafka/templates/controller-eligible/statefulset.yaml
+++ b/bitnami/kafka/templates/controller-eligible/statefulset.yaml
@@ -26,6 +26,9 @@ spec:
       app.kubernetes.io/part-of: kafka
   serviceName: {{ printf "%s-controller-headless" (include "common.names.fullname" .) | trunc 63 | trimSuffix "-" }}
   updateStrategy: {{- include "common.tplvalues.render" (dict "value" .Values.controller.updateStrategy "context" $ ) | nindent 4 }}
+  {{- if and .Values.controller.minReadySeconds (semverCompare ">= 1.23" (include "common.capabilities.kubeVersion" .)) }}
+  minReadySeconds: {{ .Values.controller.minReadySeconds }}
+  {{- end }}
   template:
     metadata:
       labels: {{- include "common.labels.standard" ( dict "customLabels" $podLabels "context" $ ) | nindent 8 }}

--- a/bitnami/kafka/values.yaml
+++ b/bitnami/kafka/values.yaml
@@ -673,6 +673,9 @@ controller:
   ## ref: https://kubernetes.io/docs/tutorials/stateful-application/basic-stateful-set/#pod-management-policy
   ##
   podManagementPolicy: Parallel
+  ## @param controller.minReadySeconds How many seconds a pod needs to be ready before killing the next, during update
+  ##
+  minReadySeconds: 0
   ## @param controller.priorityClassName Name of the existing priority class to be used by kafka pods
   ## Ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
   ##
@@ -1052,6 +1055,9 @@ broker:
   ## ref: https://kubernetes.io/docs/tutorials/stateful-application/basic-stateful-set/#pod-management-policy
   ##
   podManagementPolicy: Parallel
+  ## @param broker.minReadySeconds How many seconds a pod needs to be ready before killing the next, during update
+  ##
+  minReadySeconds: 0
   ## @param broker.priorityClassName Name of the existing priority class to be used by kafka pods
   ## Ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
   ##


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Allow setting [`minReadySeconds`](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#minimum-ready-seconds) to the Kafka chart, allowing for a pause during a restart between one pod being ready and the next one being taken down.

### Benefits

<!-- What benefits will be realized by the code change? -->
This helps clients stay connected to the cluster instead of reaching a point where they can't talk to any broker.

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #20540 

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
This is modeled after the `minReadySeconds` work done in #13596, #13783, and #15417

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
