### PR TITLE
[bitnami/keycloak] Correct `http-relative-path` and cache related environment variables

### DIFF
--- a/bitnami/keycloak/Chart.yaml
+++ b/bitnami/keycloak/Chart.yaml
@@ -33,4 +33,4 @@ maintainers:
 name: keycloak
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/keycloak
-version: 17.2.1
+version: 17.2.2

--- a/bitnami/keycloak/templates/configmap-env-vars.yaml
+++ b/bitnami/keycloak/templates/configmap-env-vars.yaml
@@ -50,9 +50,9 @@ data:
   KEYCLOAK_SPI_TRUSTSTORE_FILE: {{ printf "/opt/bitnami/keycloak/spi-certs/%s" .Values.spi.truststoreFilename }}
   {{- end }}
   {{- if .Values.cache.enabled }}
-  KEYCLOAK_CACHE_TYPE: "ispn"
+  KC_CACHE: "ispn"
   {{- if .Values.cache.stackName }}
-  KEYCLOAK_CACHE_STACK: {{ .Values.cache.stackName | quote }} 
+  KC_CACHE_STACK: {{ .Values.cache.stackName | quote }} 
   {{- end }}
   {{- if .Values.cache.stackFile }}
   KEYCLOAK_CACHE_CONFIG_FILE: {{ .Values.cache.stackFile | quote }} 

--- a/bitnami/keycloak/templates/statefulset.yaml
+++ b/bitnami/keycloak/templates/statefulset.yaml
@@ -175,7 +175,7 @@ spec:
                   name: {{ include "keycloak.spiPasswordsSecretName" . }}
                   key: "spi-truststore-password"
             {{- end }}
-            - name: KEYCLOAK_HTTP_RELATIVE_PATH
+            - name: KC_HTTP_RELATIVE_PATH
               value: {{ .Values.httpRelativePath | quote }}
             {{- if .Values.extraStartupArgs }}
             - name: KEYCLOAK_EXTRA_ARGS


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Keycloak chart templates some values to env vars Keycloak does not recognize. This PR corrects those variables.

### Benefits

Values `httpRelativePath`, `cache.enabled` and `cache.stackName` will actually get applied to Keycloak's configuration as expected.

### Additional information

These env vars should probably also be corrected in the [container image](https://github.com/bitnami/containers/tree/main/bitnami/keycloak) as well, though these changes should fix the issues in the chart. This issue in `bitnami/containers` may be related: https://github.com/bitnami/containers/issues/33282

I haven't looked into other `KEYCLOAK_...` env vars, but some of those might be invalid too.  

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
