### PR TITLE
[bitnami/mlflow] Issue 20581 - fix external DB secret template name

### DIFF
--- a/bitnami/mlflow/Chart.yaml
+++ b/bitnami/mlflow/Chart.yaml
@@ -43,4 +43,4 @@ name: mlflow
 sources:
 - https://github.com/bitnami/containers/tree/main/bitnami/mlflow
 - https://github.com/mlflow/mlflow
-version: 0.1.5
+version: 0.1.6

--- a/bitnami/mlflow/templates/tracking/externaldb-secret.yaml
+++ b/bitnami/mlflow/templates/tracking/externaldb-secret.yaml
@@ -7,7 +7,7 @@ SPDX-License-Identifier: APACHE-2.0
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ printf "%s-externaldb" (include "mlflow.v0.tracking.fullname" .) | trunc 63 | trimSuffix "-" }}
+  name: {{ include "mlflow.v0.database.secretName" . }}
   namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: mlflow


### PR DESCRIPTION
See https://github.com/bitnami/charts/issues/20581

### Description of the change

The name of the external-dbs secret manifest should have the name defined in helpers and used by other manifests.

### Benefits

Fixes deployment with external DBs

### Possible drawbacks

N/A

### Applicable issues

- Fixes https://github.com/bitnami/charts/issues/20581

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
