### PR TITLE
[bitnami/mysql] Fix reference to defaultAuthenticationPlugin

### DIFF
--- a/bitnami/mysql/Chart.yaml
+++ b/bitnami/mysql/Chart.yaml
@@ -34,4 +34,4 @@ maintainers:
 name: mysql
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/mysql
-version: 9.14.1
+version: 9.14.2

--- a/bitnami/mysql/values.yaml
+++ b/bitnami/mysql/values.yaml
@@ -204,7 +204,7 @@ primary:
   ##
   configuration: |-
     [mysqld]
-    default_authentication_plugin={{- .Values.auth.defaultAuthPlugin | default "mysql_native_password" }}
+    default_authentication_plugin={{- .Values.auth.defaultAuthenticationPlugin | default "mysql_native_password" }}
     skip-name-resolve
     explicit_defaults_for_timestamp
     basedir=/opt/bitnami/mysql


### PR DESCRIPTION
### Description of the change

In the mysql configuration section in values.yaml there is a reference to .Values.auth.defaultAuthPlugin which does not exist. The correct name is .Values.auth.defaultAuthenticationPlugin

### Benefits

Setting .Values.auth.defaultAuthenticationPlugin actually works.

### Possible drawbacks

Users which has compensated for the error by using a undocumented variable might need to adjust their configuration

### Applicable issues

- fixes #20574 

### Additional information

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
