### PR TITLE
[bitnami/cert-manager] Replace deprecated pull secret partial

### DIFF
--- a/bitnami/cert-manager/Chart.yaml
+++ b/bitnami/cert-manager/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: cert-manager
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/cert-manager
-version: 0.13.2
+version: 0.13.3

--- a/bitnami/cert-manager/templates/_helpers.tpl
+++ b/bitnami/cert-manager/templates/_helpers.tpl
@@ -28,7 +28,7 @@ Return the proper image name (for the init container volume-permissions image)
 Return the proper Docker Image Registry Secret Names
 */}}
 {{- define "certmanager.imagePullSecrets" -}}
-{{ include "common.images.pullSecrets" (dict "images" (list .Values.controller.image) "global" .Values.global) }}
+{{ include "common.images.renderPullSecrets" (dict "images" (list .Values.controller.image) "context" $) }}
 {{- end -}}
 
 {{/*
@@ -68,7 +68,7 @@ Return the proper certmanager.webhook image name
 Return the proper Docker Image Registry Secret Names
 */}}
 {{- define "certmanager.webhook.imagePullSecrets" -}}
-{{ include "common.images.pullSecrets" (dict "images" (list .Values.webhook.image) "global" .Values.global) }}
+{{ include "common.images.renderPullSecrets" (dict "images" (list .Values.webhook.image) "context" $) }}
 {{- end -}}
 
 {{/*
@@ -108,7 +108,7 @@ Return the proper cainjector image name
 Return the proper Docker Image Registry Secret Names
 */}}
 {{- define "certmanager.cainjector.imagePullSecrets" -}}
-{{ include "common.images.pullSecrets" (dict "images" (list .Values.cainjector.image) "global" .Values.global) }}
+{{ include "common.images.renderPullSecrets" (dict "images" (list .Values.cainjector.image) "context" $) }}
 {{- end -}}
 
 {{/*
@@ -163,4 +163,3 @@ cert-manager: CRDs
     If you want to include our CRD resources, please install the cert-manager using the crd flags (--set .Values.installCRDs=true).
 {{- end -}}
 {{- end -}}
-


### PR DESCRIPTION
### Description of the change

The CertManager chart still uses the deprecated `common.images.pullSecrets` partial to render pull secrets. It was replaced with the recommended replacement `common.images.renderPullSecrets`.

### Benefits

The new helper adds support for templating of the name of the image pull secrets.

### Possible drawbacks

%

### Applicable issues

%

### Additional information

See also #20661 for same change in MetalLB.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)