### PR TITLE
Update deployment.yaml

### DIFF
--- a/bitnami/airflow/templates/web/deployment.yaml
+++ b/bitnami/airflow/templates/web/deployment.yaml
@@ -249,7 +249,7 @@ spec:
             {{- end }}
             {{- if .Values.web.existingConfigmap }}
             - name: custom-webserver-configuration-file
-              mountPath: /opt/bitnami/airflow/webserver_config.py
+              mountPath: /opt/bitnami/airflow/default_webserver_config.py
               subPath: webserver_config.py
             {{- end }}
             {{- if .Values.ldap.tls.enabled }}


### PR DESCRIPTION
### Description of the change

Fix this bug chart by change with this value default_webserver_config.py in the template file https://github.com/bitnami/charts/blob/main/bitnami/airflow/templates/web/deployment.yaml

### Benefits
This fix can make it work the option << existingConfigmap >> in the value of the airflow chart

### Possible drawbacks
not or low possible drawbacks

### Applicable issues
Please see the origin of the bug in line 189 of the file airflow folder scripts/libairflow.sh:
```bash
# Generate Airflow conf file
airflow_generate_config() {
    # Create Airflow confirguration from default files
    cp "$(find "$AIRFLOW_BASE_DIR" -name default_airflow.cfg)" "$AIRFLOW_CONF_FILE"
    [[ -n "$AIRFLOW_WEBSERVER_CONF_FILE" ]] && cp "$(find "$AIRFLOW_BASE_DIR" -name default_webserver_config.py)" "$AIRFLOW_WEBSERVER_CONF_FILE"
```
### Additional information
When we use the option << existingConfigmap >> in the values.yaml of the chart this bug makes this error: `cp: cannot create regular file '/opt/bitnami/airflow/webserver_config.py': Read-only file system`