### PR TITLE
[bitnami/kubernetes-event-exporter] Increase ginkgo tests timeouts

### DIFF
--- a/.vib/kubernetes-event-exporter/ginkgo/kubernetes_event_exporter.go
+++ b/.vib/kubernetes-event-exporter/ginkgo/kubernetes_event_exporter.go
@@ -47,7 +47,7 @@ var _ = Describe("Kubernetes Event Exporter:", func() {
 				podLabel := "app.kubernetes.io/name=kubernetes-event-exporter"
 				containerName := "event-exporter"
 
-				containsPattern, _ := retry("containerLogsContainPattern", 5, 2*time.Second, func() (bool, error) {
+				containsPattern, _ := retry("containerLogsContainPattern", 12, 5*time.Second, func() (bool, error) {
 					return containerLogsContainPattern(ctx, coreclient, podLabel, containerName, pattern)
 				})
 				Expect(containsPattern).To(BeTrue())


### PR DESCRIPTION
### Description of the change

Increase the timeout for the test that checks whether a pod was created.

### Benefits

In some clusters, the pod may take more time to start. This makes tests more resilient by incrementing the timeout to a reasonable range (1 minute).

### Possible drawbacks

None

### Applicable issues

NA

### Additional information

NA

### Checklist

- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
