### PR TITLE
[bitnami/mlflow] fix  issue 20660 'error unmarshaling JSON: while decoding JSON:...' when merging annotations

### DIFF
--- a/bitnami/mlflow/Chart.yaml
+++ b/bitnami/mlflow/Chart.yaml
@@ -43,4 +43,4 @@ name: mlflow
 sources:
 - https://github.com/bitnami/containers/tree/main/bitnami/mlflow
 - https://github.com/mlflow/mlflow
-version: 0.2.2
+version: 0.2.3

--- a/bitnami/mlflow/templates/run/service-account.yaml
+++ b/bitnami/mlflow/templates/run/service-account.yaml
@@ -13,7 +13,7 @@ metadata:
     app.kubernetes.io/part-of: mlflow
     app.kubernetes.io/component: run
   {{- if or .Values.run.serviceAccount.annotations .Values.commonAnnotations }}
-  {{- $annotations := include "common.tplvalues.merge" (dict "values" .Values.run.serviceAccount.annotations .Values.commonAnnotations "context" .) | fromYaml }}
+  {{- $annotations := include "common.tplvalues.merge" (dict "values" ( list .Values.run.serviceAccount.annotations .Values.commonAnnotations ) "context" .) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $ ) | nindent 4 }}
   {{- end }}
 automountServiceAccountToken: {{ .Values.run.serviceAccount.automountServiceAccountToken }}

--- a/bitnami/mlflow/templates/tracking/ingress.yaml
+++ b/bitnami/mlflow/templates/tracking/ingress.yaml
@@ -13,7 +13,7 @@ metadata:
     app.kubernetes.io/part-of: mlflow
     app.kubernetes.io/component: tracking
   {{- if or .Values.tracking.ingress.annotations .Values.commonAnnotations }}
-  {{- $annotations := include "common.tplvalues.merge" (dict "values" .Values.tracking.ingress.annotations .Values.commonAnnotations "context" .) | fromYaml }}
+  {{- $annotations := include "common.tplvalues.merge" (dict "values" ( list .Values.tracking.ingress.annotations .Values.commonAnnotations ) "context" .) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:

--- a/bitnami/mlflow/templates/tracking/service-account.yaml
+++ b/bitnami/mlflow/templates/tracking/service-account.yaml
@@ -13,7 +13,7 @@ metadata:
     app.kubernetes.io/part-of: mlflow
     app.kubernetes.io/component: tracking
   {{- if or .Values.tracking.serviceAccount.annotations .Values.commonAnnotations }}
-  {{- $annotations := include "common.tplvalues.merge" (dict "values" .Values.tracking.serviceAccount.annotations .Values.commonAnnotations "context" .) | fromYaml }}
+  {{- $annotations := include "common.tplvalues.merge" (dict "values" ( list .Values.tracking.serviceAccount.annotations .Values.commonAnnotations ) "context" .) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $ ) | nindent 4 }}
   {{- end }}
 automountServiceAccountToken: {{ .Values.tracking.serviceAccount.automountServiceAccountToken }}

--- a/bitnami/mlflow/templates/tracking/service.yaml
+++ b/bitnami/mlflow/templates/tracking/service.yaml
@@ -16,7 +16,7 @@ metadata:
     {{- include "common.tplvalues.render" ( dict "value" .Values.tracking.service.labels "context" $ ) | nindent 4 }}
     {{- end }}
   {{- if or .Values.tracking.service.annotations .Values.commonAnnotations }}
-  {{- $annotations := include "common.tplvalues.merge" (dict "values" .Values.tracking.service.annotations .Values.commonAnnotations "context" .) | fromYaml }}
+  {{- $annotations := include "common.tplvalues.merge" (dict "values" ( list .Values.tracking.service.annotations .Values.commonAnnotations ) "context" .) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:


### PR DESCRIPTION
Closes https://github.com/bitnami/charts/issues/20660

### Description of the change

This changes address all instances in mlflow chart templates where annotations are incorrectly merged as 
```
{{- $annotations := include "common.tplvalues.merge" (dict "values" .Values.run.serviceAccount.annotations .Values.commonAnnotations "context" .) | fromYaml }}
```

### Benefits

Annotations can be specified via values and can be successfully merged with `commonAnnotations`

### Applicable issues

20660

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
