### PR TITLE
[bitnami/mxnet] Mark MXNet chart as deprecated

### DIFF
--- a/bitnami/mxnet/Chart.yaml
+++ b/bitnami/mxnet/Chart.yaml
@@ -21,7 +21,7 @@ dependencies:
   version: 2.x.x
 # The MXNet chart is deprecated and no longer maintained.
 deprecated: true
-description: DEPRECATED Collection of open source web applications that help software companies build better software.
+description: DEPRECATED Apache MXNet (Incubating) is a flexible and efficient library for deep learning designed to work as a neural network. Bitnami image ships OpenBLAS as math library.
 home: https://bitnami.com
 icon: https://bitnami.com/assets/stacks/mxnet/img/mxnet-stack-220x234.png
 keywords:

--- a/bitnami/mxnet/Chart.yaml
+++ b/bitnami/mxnet/Chart.yaml
@@ -19,7 +19,9 @@ dependencies:
   tags:
   - bitnami-common
   version: 2.x.x
-description: Apache MXNet (Incubating) is a flexible and efficient library for deep learning designed to work as a neural network. Bitnami image ships OpenBLAS as math library.
+# The MXNet chart is deprecated and no longer maintained.
+deprecated: true
+description: DEPRECATED Collection of open source web applications that help software companies build better software.
 home: https://bitnami.com
 icon: https://bitnami.com/assets/stacks/mxnet/img/mxnet-stack-220x234.png
 keywords:
@@ -27,10 +29,8 @@ keywords:
 - python
 - machine
 - learning
-maintainers:
-- name: VMware, Inc.
-  url: https://github.com/bitnami/charts
+maintainers: []
 name: mxnet
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/mxnet
-version: 3.5.1
+version: 3.5.2

--- a/bitnami/mxnet/README.md
+++ b/bitnami/mxnet/README.md
@@ -8,6 +8,10 @@ Apache MXNet (Incubating) is a flexible and efficient library for deep learning 
 
 Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
 
+## This Helm chart is deprecated
+
+The upstream project has been discontinued and no new features.
+
 ## TL;DR
 
 ```console

--- a/bitnami/mxnet/templates/NOTES.txt
+++ b/bitnami/mxnet/templates/NOTES.txt
@@ -1,12 +1,12 @@
+This Helm chart is deprecated
+
+The upstream project has been discontinued and no new features.
+
 CHART NAME: {{ .Chart.Name }}
 CHART VERSION: {{ .Chart.Version }}
 APP VERSION: {{ .Chart.AppVersion }}
 
 ** Please be patient while the chart is being deployed **
-
-This Helm chart is deprecated
-
-The upstream project has been discontinued and no new features.
 
 {{- if or .Values.configMap (.Files.Glob "files/*") .Values.cloneFilesFromGit.enabled }}
 {{- if .Values.entrypoint.file }}

--- a/bitnami/mxnet/templates/NOTES.txt
+++ b/bitnami/mxnet/templates/NOTES.txt
@@ -4,6 +4,10 @@ APP VERSION: {{ .Chart.AppVersion }}
 
 ** Please be patient while the chart is being deployed **
 
+This Helm chart is deprecated
+
+The upstream project has been discontinued and no new features.
+
 {{- if or .Values.configMap (.Files.Glob "files/*") .Values.cloneFilesFromGit.enabled }}
 {{- if .Values.entrypoint.file }}
 The provided file {{ .Values.entrypoint.file }} is being executed. You can see the logs of each running node with:


### PR DESCRIPTION
### Description of the change

Apache MXNet helm chart will be deprecated since the upstream project has been [discontinued](https://mxnet.apache.org/versions/1.9.1/).

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
