### PR TITLE
[bitnami/grafana-operator]  Fix namespace reference

### DIFF
--- a/bitnami/grafana-operator/Chart.yaml
+++ b/bitnami/grafana-operator/Chart.yaml
@@ -30,4 +30,4 @@ maintainers:
 name: grafana-operator
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/grafana-operator
-version: 3.5.4
+version: 3.5.5

--- a/bitnami/grafana-operator/templates/deployment.yaml
+++ b/bitnami/grafana-operator/templates/deployment.yaml
@@ -120,8 +120,8 @@ spec:
             - name: TEMPLATE_PATH
               value: /usr/local/bin/templates
             - name: WATCH_NAMESPACE
-              {{- if .Values.namespaceScope }}
-              value: {{ default (include "common.names.namespace" .) .Values.watchNamespace | quote }}
+              {{- if .Values.operator.namespaceScope }}
+              value: {{ default (include "common.names.namespace" .) .Values.operator.watchNamespace | quote }}
               {{- else }}
               value: ""
               {{- end }}


### PR DESCRIPTION
The keys `namespaceScope` and `watchNamespace` are inside `operator` section but they are being referenced from root in the deployment template
