### PR TITLE
[template] Replace deprecated pull secret partial

### DIFF
--- a/template/CHART_NAME/templates/_helpers.tpl
+++ b/template/CHART_NAME/templates/_helpers.tpl
@@ -21,7 +21,7 @@ Return the proper image name (for the init container volume-permissions image)
 Return the proper Docker Image Registry Secret Names
 */}}
 {{- define "%%TEMPLATE_NAME%%.imagePullSecrets" -}}
-{{- include "common.images.pullSecrets" (dict "images" (list .Values.%%MAIN_OBJECT_BLOCK%%.image .Values.%%SECONDARY_OBJECT_BLOCK%%.image .Values.volumePermissions.image) "global" .Values.global) -}}
+{{- include "common.images.renderPullSecrets" (dict "images" (list .Values.%%MAIN_OBJECT_BLOCK%%.image .Values.%%SECONDARY_OBJECT_BLOCK%%.image .Values.volumePermissions.image) "context" $) -}}
 {{- end -}}
 
 {{/*
@@ -59,4 +59,3 @@ Compile all warnings into a single message.
 {{-   printf "\nVALUES VALIDATION:\n%s" $message -}}
 {{- end -}}
 {{- end -}}
-


### PR DESCRIPTION
### Description of the change

The chart template still uses the deprecated `common.images.pullSecrets` partial to render pull secrets. It was replaced with the recommended replacement `common.images.renderPullSecrets`.

### Benefits

The new helper adds support for templating of the name of the image pull secrets.

### Possible drawbacks

%

### Applicable issues

%

### Additional information

See also the following PRs for same similar changes:
* #20661 MetalLB
* #20662 CertManager
* #20665 MongoDB
* #20666 Redis

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)