### PR TITLE
[bitnami/mastodon] replace all instances of JupyterHub with Mastodon in values.yaml

### DIFF
--- a/bitnami/mastodon/Chart.yaml
+++ b/bitnami/mastodon/Chart.yaml
@@ -49,4 +49,4 @@ maintainers:
 name: mastodon
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/mastodon
-version: 3.2.2
+version: 3.2.3

--- a/bitnami/mastodon/Chart.yaml
+++ b/bitnami/mastodon/Chart.yaml
@@ -49,4 +49,4 @@ maintainers:
 name: mastodon
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/mastodon
-version: 3.2.3
+version: 3.2.2

--- a/bitnami/mastodon/README.md
+++ b/bitnami/mastodon/README.md
@@ -454,9 +454,9 @@ The command removes all the Kubernetes components associated with the chart and 
 | `serviceAccount.automountServiceAccountToken` | Automount service account token for the server service account          | `true`        |
 | `externalDatabase.host`                       | Database host                                                           | `""`          |
 | `externalDatabase.port`                       | Database port number                                                    | `5432`        |
-| `externalDatabase.user`                       | Non-root username for JupyterHub                                        | `postgres`    |
-| `externalDatabase.password`                   | Password for the non-root username for JupyterHub                       | `""`          |
-| `externalDatabase.database`                   | JupyterHub database name                                                | `mastodon`    |
+| `externalDatabase.user`                       | Non-root username for Mastodon                                          | `postgres`    |
+| `externalDatabase.password`                   | Password for the non-root username for Mastodon                         | `""`          |
+| `externalDatabase.database`                   | Mastodon database name                                                  | `mastodon`    |
 | `externalDatabase.existingSecret`             | Name of an existing secret resource containing the database credentials | `""`          |
 | `externalDatabase.existingSecretPasswordKey`  | Name of an existing secret key containing the database credentials      | `db-password` |
 

--- a/bitnami/mastodon/values.yaml
+++ b/bitnami/mastodon/values.yaml
@@ -1282,9 +1282,9 @@ serviceAccount:
 ## All of these values are only used when postgresql.enabled is set to false
 ## @param externalDatabase.host Database host
 ## @param externalDatabase.port Database port number
-## @param externalDatabase.user Non-root username for JupyterHub
-## @param externalDatabase.password Password for the non-root username for JupyterHub
-## @param externalDatabase.database JupyterHub database name
+## @param externalDatabase.user Non-root username for Mastodon
+## @param externalDatabase.password Password for the non-root username for Mastodon
+## @param externalDatabase.database Mastodon database name
 ## @param externalDatabase.existingSecret Name of an existing secret resource containing the database credentials
 ## @param externalDatabase.existingSecretPasswordKey Name of an existing secret key containing the database credentials
 ##


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

This replaces all instances of JupyterHub with Mastodon.

### Benefits

This makes the comments in the values.yaml and the README docs more clear. I believe this was just a copy paste cleanup issue. No biggie.

### Possible drawbacks

none that I can think of

### Applicable issues

no issues that I see immediately

### Additional information
let me know if you'd like me to remove the Chart.yaml version bump

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
