### PR TITLE
[bitnami/rabbitmq] Add Persistent Volume Claim Retention Policy to Rabbitmq Statefulsets  

### DIFF
--- a/bitnami/rabbitmq/Chart.yaml
+++ b/bitnami/rabbitmq/Chart.yaml
@@ -10,7 +10,7 @@ annotations:
     - name: rabbitmq
       image: docker.io/bitnami/rabbitmq:3.12.8-debian-11-r1
 apiVersion: v2
-appVersion: 3.12.8
+appVersion: 3.12.9
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts

--- a/bitnami/rabbitmq/Chart.yaml
+++ b/bitnami/rabbitmq/Chart.yaml
@@ -10,7 +10,7 @@ annotations:
     - name: rabbitmq
       image: docker.io/bitnami/rabbitmq:3.12.8-debian-11-r1
 apiVersion: v2
-appVersion: 3.12.9
+appVersion: 3.12.8
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
@@ -30,4 +30,4 @@ maintainers:
 name: rabbitmq
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/rabbitmq
-version: 12.4.2
+version: 12.4.3

--- a/bitnami/rabbitmq/Chart.yaml
+++ b/bitnami/rabbitmq/Chart.yaml
@@ -30,4 +30,4 @@ maintainers:
 name: rabbitmq
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/rabbitmq
-version: 12.4.3
+version: 12.5.0

--- a/bitnami/rabbitmq/README.md
+++ b/bitnami/rabbitmq/README.md
@@ -260,18 +260,21 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Persistence parameters
 
-| Name                        | Description                                      | Value                      |
-| --------------------------- | ------------------------------------------------ | -------------------------- |
-| `persistence.enabled`       | Enable RabbitMQ data persistence using PVC       | `true`                     |
-| `persistence.storageClass`  | PVC Storage Class for RabbitMQ data volume       | `""`                       |
-| `persistence.selector`      | Selector to match an existing Persistent Volume  | `{}`                       |
-| `persistence.accessModes`   | PVC Access Modes for RabbitMQ data volume        | `["ReadWriteOnce"]`        |
-| `persistence.existingClaim` | Provide an existing PersistentVolumeClaims       | `""`                       |
-| `persistence.mountPath`     | The path the volume will be mounted at           | `/bitnami/rabbitmq/mnesia` |
-| `persistence.subPath`       | The subdirectory of the volume to mount to       | `""`                       |
-| `persistence.size`          | PVC Storage Request for RabbitMQ data volume     | `8Gi`                      |
-| `persistence.annotations`   | Persistence annotations. Evaluated as a template | `{}`                       |
-| `persistence.labels`        | Persistence labels. Evaluated as a template      | `{}`                       |
+| Name                                               | Description                                                                    | Value                      |
+| -------------------------------------------------- | ------------------------------------------------------------------------------ | -------------------------- |
+| `persistence.enabled`                              | Enable RabbitMQ data persistence using PVC                                     | `true`                     |
+| `persistence.storageClass`                         | PVC Storage Class for RabbitMQ data volume                                     | `""`                       |
+| `persistence.selector`                             | Selector to match an existing Persistent Volume                                | `{}`                       |
+| `persistence.accessModes`                          | PVC Access Modes for RabbitMQ data volume                                      | `["ReadWriteOnce"]`        |
+| `persistence.existingClaim`                        | Provide an existing PersistentVolumeClaims                                     | `""`                       |
+| `persistence.mountPath`                            | The path the volume will be mounted at                                         | `/bitnami/rabbitmq/mnesia` |
+| `persistence.subPath`                              | The subdirectory of the volume to mount to                                     | `""`                       |
+| `persistence.size`                                 | PVC Storage Request for RabbitMQ data volume                                   | `8Gi`                      |
+| `persistence.annotations`                          | Persistence annotations. Evaluated as a template                               | `{}`                       |
+| `persistence.labels`                               | Persistence labels. Evaluated as a template                                    | `{}`                       |
+| `persistentVolumeClaimRetentionPolicy.enabled`     | Enable Persistent volume retention policy for rabbitmq Statefulset             | `false`                    |
+| `persistentVolumeClaimRetentionPolicy.whenScaled`  | Volume retention behavior when the replica count of the StatefulSet is reduced | `Retain`                   |
+| `persistentVolumeClaimRetentionPolicy.whenDeleted` | Volume retention behavior that applies when the StatefulSet is deleted         | `Retain`                   |
 
 ### Exposure parameters
 

--- a/bitnami/rabbitmq/templates/statefulset.yaml
+++ b/bitnami/rabbitmq/templates/statefulset.yaml
@@ -433,7 +433,12 @@ spec:
             {{- with .Values.persistence.existingClaim }}
             claimName: {{ tpl . $ }}
             {{- end }}
-  {{- else }}
+  {{- else 
+  {{- if .Values.persistentVolumeClaimRetentionPolicy.enabled }}
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: {{ .Values.persistentVolumeClaimRetentionPolicy.whenDeleted }}
+    whenScaled: {{ .Values.persistentVolumeClaimRetentionPolicy.whenScaled }}
+  {{- end }}
   volumeClaimTemplates:
     - apiVersion: v1
       kind: PersistentVolumeClaim

--- a/bitnami/rabbitmq/templates/statefulset.yaml
+++ b/bitnami/rabbitmq/templates/statefulset.yaml
@@ -433,7 +433,7 @@ spec:
             {{- with .Values.persistence.existingClaim }}
             claimName: {{ tpl . $ }}
             {{- end }}
-  {{- else 
+  {{- else }} 
   {{- if .Values.persistentVolumeClaimRetentionPolicy.enabled }}
   persistentVolumeClaimRetentionPolicy:
     whenDeleted: {{ .Values.persistentVolumeClaimRetentionPolicy.whenDeleted }}

--- a/bitnami/rabbitmq/values.yaml
+++ b/bitnami/rabbitmq/values.yaml
@@ -964,6 +964,20 @@ persistence:
   ##   app: my-app
   labels: {}
 
+## Persistent Volume Claim Retention Policy
+## ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#persistentvolumeclaim-retention
+##
+persistentVolumeClaimRetentionPolicy:
+  ## @param persistentVolumeClaimRetentionPolicy.enabled Enable Persistent volume retention policy for rabbitmq Statefulset
+  ##
+  enabled: false
+  ## @param persistentVolumeClaimRetentionPolicy.whenScaled Volume retention behavior when the replica count of the StatefulSet is reduced
+  ##
+  whenScaled: Retain
+  ## @param persistentVolumeClaimRetentionPolicy.whenDeleted Volume retention behavior that applies when the StatefulSet is deleted
+  ##
+  whenDeleted: Retain
+
 ## @section Exposure parameters
 ##
 


### PR DESCRIPTION
### Description of the change

Supports PVC retention policy for rabbitmq statefulsets

### Benefits

Make use of persistentVolumeClaimRetentionPolicy to Delete or Retain the PVCs/PVs whenever the statefulset gets deleted or scaled down.


### Possible drawbacks

Nil

### Applicable issues

https://github.com/bitnami/charts/issues/13917

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
