### PR TITLE
[bitnami/*] Fix env issue for retry workflow

### DIFF
--- a/.github/workflows/retry-failed-releases.yml
+++ b/.github/workflows/retry-failed-releases.yml
@@ -20,7 +20,7 @@ jobs:
           MAX_RUNS_ATTEMPS: 3
           WORKFLOW_ID: "35553382"
           TEMP_FILE: "${{runner.temp}}/failed_runs.json"
-          WORKFLOW_RUNS_URL: "${{ github.api_url }}/repos/${{ github.repository }}/actions/workflows/${{ env.WORKFLOW_ID }}/runs"
+          WORKFLOW_RUNS_URL: "${{ github.api_url }}/repos/${{ github.repository }}/actions/workflows/35553382/runs"
           TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Obtain "CI Pipeline" failed runs executed by the bitnami-bot and filter those from release PRs with $MAX_RUNS_ATTEMPS or more attempts

--- a/.github/workflows/retry-failed-releases.yml
+++ b/.github/workflows/retry-failed-releases.yml
@@ -18,7 +18,6 @@ jobs:
         env:
           MAX_RETRY_SLOTS: 15
           MAX_RUNS_ATTEMPS: 3
-          WORKFLOW_ID: "35553382"
           TEMP_FILE: "${{runner.temp}}/failed_runs.json"
           WORKFLOW_RUNS_URL: "${{ github.api_url }}/repos/${{ github.repository }}/actions/workflows/35553382/runs"
           TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->
Github doesn't support the use of an envvar as a parameter for another envvar in the same `env` scope. To avoid this and maintain the hardening, we'll hardcode the `WORKFLOW_ID` env to avoid issues when creating the `env.WORKFLOW_RUNS_URL` one.
### Benefits

<!-- What benefits will be realized by the code change? -->
The workflow works as expected
### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
N/A
### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
