### PR TITLE
[bitnami/redis] Implementing an option to define masters as DaemonSets

### DIFF
--- a/bitnami/redis/Chart.yaml
+++ b/bitnami/redis/Chart.yaml
@@ -34,4 +34,4 @@ maintainers:
 name: redis
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/redis
-version: 18.3.3
+version: 18.4.0

--- a/bitnami/redis/README.md
+++ b/bitnami/redis/README.md
@@ -172,7 +172,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `master.containerSecurityContext.allowPrivilegeEscalation` | Is it possible to escalate Redis&reg; pod(s) privileges                                               | `false`                  |
 | `master.containerSecurityContext.seccompProfile.type`      | Set Redis&reg; master containers' Security Context seccompProfile                                     | `RuntimeDefault`         |
 | `master.containerSecurityContext.capabilities.drop`        | Set Redis&reg; master containers' Security Context capabilities to drop                               | `["ALL"]`                |
-| `master.kind`                                              | Use either Deployment or StatefulSet (default)                                                        | `StatefulSet`            |
+| `master.kind`                                              | Use either Deployment, StatefulSet (default) or DaemonSet                                             | `StatefulSet`            |
 | `master.schedulerName`                                     | Alternate scheduler for Redis&reg; master pods                                                        | `""`                     |
 | `master.updateStrategy.type`                               | Redis&reg; master statefulset strategy type                                                           | `RollingUpdate`          |
 | `master.minReadySeconds`                                   | How many seconds a pod needs to be ready before killing the next, during update                       | `0`                      |

--- a/bitnami/redis/templates/master/application.yaml
+++ b/bitnami/redis/templates/master/application.yaml
@@ -16,7 +16,9 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
+  {{- if not (eq .Values.master.kind "DaemonSet") }}
   replicas: {{ .Values.master.count }}
+  {{- end }}
   {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.master.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
@@ -472,7 +474,7 @@ spec:
         {{- if .Values.metrics.extraVolumes }}
         {{- include "common.tplvalues.render" ( dict "value" .Values.metrics.extraVolumes "context" $ ) | nindent 8 }}
         {{- end }}
-  {{- if not .Values.master.persistence.enabled }}
+  {{- if or (not .Values.master.persistence.enabled) (eq .Values.master.kind "DaemonSet") }}
         - name: redis-data
           {{- if or .Values.master.persistence.medium .Values.master.persistence.sizeLimit }}
           emptyDir:

--- a/bitnami/redis/templates/replicas/application.yaml
+++ b/bitnami/redis/templates/replicas/application.yaml
@@ -135,7 +135,7 @@ spec:
             - name: REDIS_MASTER_HOST
             {{- if .Values.replica.externalMaster.enabled }}
               value: {{ .Values.replica.externalMaster.host | quote }}
-            {{- else if and (eq (int64 .Values.master.count) 1) (ne .Values.master.kind "Deployment") }}
+            {{- else if and (eq (int64 .Values.master.count) 1) (eq .Values.master.kind "StatefulSet") }}
               value: {{ template "common.names.fullname" . }}-master-0.{{ template "common.names.fullname" . }}-headless.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}
             {{- else }}
               value: {{ template "common.names.fullname" . }}-master.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}

--- a/bitnami/redis/values.schema.json
+++ b/bitnami/redis/values.schema.json
@@ -40,8 +40,8 @@
           "type": "string",
           "title": "Workload Kind",
           "form": true,
-          "description": "Allowed values: `Deployment` or `StatefulSet`",
-          "enum": ["Deployment", "StatefulSet"]
+          "description": "Allowed values: `Deployment`, `StatefulSet` or `DaemonSet`",
+          "enum": ["Deployment", "StatefulSet", "DaemonSet"]
         },
         "persistence": {
           "type": "object",

--- a/bitnami/redis/values.yaml
+++ b/bitnami/redis/values.yaml
@@ -299,7 +299,7 @@ master:
     capabilities:
       drop:
         - ALL
-  ## @param master.kind Use either Deployment or StatefulSet (default)
+  ## @param master.kind Use either Deployment, StatefulSet (default) or DaemonSet
   ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/
   ##
   kind: StatefulSet


### PR DESCRIPTION
### Description of the change

With this change it is possible to define master as the DaemonSet kind (defaults to StatefulSet) similar to how the master can already be defined as a Deployment.

master:
  kind: DaemonSet

### Benefits

<!-- What benefits will be realized by the code change? -->

Defining master as a DaemonSet has the advantage of being able to run directly on nodes so that applications can connect directly to a master running on the same node using file sockets. The master can be configured to expose the file socket like so

```yaml
commonConfiguration: |
  # create a unix domain socket to listen on
  unixsocket /host-tmp/redis.socket
  # set permissions for the socket
  unixsocketperm 775

master:
  kind: DaemonSet
  extraVolumes:
    - name: host-tmp
      hostPath:
        path: /tmp
        type: Directory
  extraVolumeMounts:
    - mountPath: /host-tmp
      name: host-tmp
```

the client app can then mount the socket and connect directly to the replica instead of going through TCP connections. In low-latency scenarios, this saves on the overhead of going through the network.

### Possible drawbacks

This feature does not work when the `sentinel` option is enabled. The reason is that these instances should always stay local. They are not intended to work together in any way, they are there so that applications on a node can share a local redis instance.

As [mentioned](https://github.com/bitnami/charts/pull/20003#issuecomment-1792650164) in the related [PR](https://github.com/bitnami/charts/pull/20003), this feature does not work with PVCs so when the kind is set to a DaemonSet the behavior is the same as disabling persistence - an `emptyDir` is used.

### Applicable issues

- relates to #20003

### Additional information

A similar [change](https://github.com/bitnami/charts/pull/20003) allowing replicas to run as DaemonSets has already been merged. This PR extends that feature to the master as well.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
