### PR TITLE
[template] add support for non-equal service and container ports

### DIFF
--- a/template/CHART_NAME/templates/service.yaml
+++ b/template/CHART_NAME/templates/service.yaml
@@ -37,6 +37,9 @@ spec:
   ports:
     - name: %%PORT_NAME%%
       port: {{ .Values.service.ports.http }}
+      {{- if not (eq .Values.service.ports.http .Values.%%MAIN_OBJECT_BLOCK%%.containerPorts.http) }}
+      targetPort: {{ .Values.%%MAIN_OBJECT_BLOCK%%.containerPorts.http }}
+      {{- end }}
       protocol: bar
       {{- if and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) (not (empty .Values.service.nodePorts.http)) }}
       nodePort: {{ .Values.service.nodePorts.http }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

The template allows for container and service ports, that are not equal. But the created service is only taking the service port into consideration.

In case the container and service ports are different the target port of the service should be set to the container port.

### Benefits

Template will work, when both ports are set differently.

### Possible drawbacks

None, that I know of.

### Applicable issues

%

### Additional information

https://kubernetes.io/docs/concepts/services-networking/service/#field-spec-ports

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
