### PR TITLE
[bitnami/mariadb] Fix ServiceMonitor namespace value reference

### DIFF
--- a/bitnami/mariadb/Chart.yaml
+++ b/bitnami/mariadb/Chart.yaml
@@ -34,4 +34,4 @@ maintainers:
 name: mariadb
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/mariadb
-version: 14.1.2
+version: 14.1.3

--- a/bitnami/mariadb/templates/servicemonitor.yaml
+++ b/bitnami/mariadb/templates/servicemonitor.yaml
@@ -8,7 +8,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "common.names.fullname" . }}
-  namespace: {{ default .Release.Namespace .Values.metrics.prometheusRule.namespace | quote }}
+  namespace: {{ default .Release.Namespace .Values.metrics.serviceMonitor.namespace | quote }}
   {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.metrics.serviceMonitor.labels .Values.commonLabels ) "context" . ) }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
   {{- if .Values.commonAnnotations }}


### PR DESCRIPTION
### Description of the change

Chart has `metrics.serviceMonitor.namespace` value, but doesn't use it in templates. Moreover template for ServiceMonitor uses `metrics.prometheusRule.namespace` for namespace field instead of `metrics.serviceMonitor.namespace`.

### Benefits

Ability to set namespace for ServiceMonitor regardless of PrometheusRule.

### Possible drawbacks

None.

### Applicable issues

None.

### Additional information

The bug appeared with https://github.com/bitnami/charts/commit/ccb27d3cb70a4ccc645032fcb14e809da8ef1e80

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
