### PR TITLE
[bitnami/airflow] Improve web.baseUrl helper

### DIFF
--- a/bitnami/airflow/Chart.yaml
+++ b/bitnami/airflow/Chart.yaml
@@ -47,4 +47,4 @@ maintainers:
 name: airflow
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/airflow
-version: 16.1.2
+version: 16.1.3

--- a/bitnami/airflow/templates/_helpers.tpl
+++ b/bitnami/airflow/templates/_helpers.tpl
@@ -432,23 +432,20 @@ Gets the host to be used for this application.
 If not using ClusterIP, or if a host or LoadBalancerIP is not defined, the value will be empty.
 */}}
 {{- define "airflow.baseUrl" -}}
-{{- $host := "" -}}
-{{- $port := "" -}}
-{{- $servicePortString := printf "%v" .Values.service.ports.http -}}
-{{- if and (not (eq $servicePortString "80")) (not (eq $servicePortString "443")) -}}
-  {{- $port = printf ":%s" $servicePortString -}}
+
+{{- $host := default (include "airflow.serviceIP" .) .Values.web.baseUrl -}}
+{{- $port := printf ":%v" .Values.service.ports.http -}}
+{{- $schema := "http://" -}}
+{{- if regexMatch "^https?://" .Values.web.baseUrl -}}
+  {{- $schema = "" -}}
 {{- end -}}
-{{- if .Values.ingress.enabled }}
-  {{- $host = .Values.ingress.hostname | default "" -}}
-{{- else -}}
-  {{- $host = .Values.web.baseUrl | default "" -}}
-{{- end }}
-{{- $host = default (include "airflow.serviceIP" .) $host -}}
-{{- if $host -}}
-  {{- printf "http://%s%s" $host $port -}}
-{{- else -}}
-  {{- default "" .Values.web.baseUrl -}}
+{{- if or (regexMatch ":\\d+$" .Values.web.baseUrl) (eq $port ":80") (eq $port ":443") -}}
+  {{- $port = "" -}}
 {{- end -}}
+{{- if and .Values.ingress.enabled .Values.ingress.hostname -}}
+  {{- $host = .Values.ingress.hostname -}}
+{{- end -}}
+{{- printf "%s%s%s" $schema $host $port -}}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
### Description of the change

This improves the `airflow.baseUrl` helper, which handles the `web.baseUrl` value, by introducing the following changes:

- Simplify existing logic.
- Detect when `web.baseUrl` includes schema and/or port.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #20573

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
