### PR TITLE
[bitnami/contour] Fix useHostPort backwards compatibility

### DIFF
--- a/bitnami/contour/Chart.yaml
+++ b/bitnami/contour/Chart.yaml
@@ -32,4 +32,4 @@ maintainers:
 name: contour
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/contour
-version: 14.2.2
+version: 14.2.3

--- a/bitnami/contour/templates/envoy/daemonset.yaml
+++ b/bitnami/contour/templates/envoy/daemonset.yaml
@@ -163,7 +163,7 @@ spec:
           ports:
             - containerPort: {{ .Values.envoy.containerPorts.http }}
               # Use of .Values.envoy.useHostPort as boolean is DEPRECATED. Support will be removed in upcoming versions.
-              {{- if or (and (kindIs "boolean" .Values.envoy.useHostPort) .Values.envoy.useHostPort) .Values.envoy.useHostPort.http }}
+              {{- if or (and (kindIs "boolean" .Values.envoy.useHostPort) .Values.envoy.useHostPort) (and (kindIs "map" .Values.envoy.useHostPort) .Values.envoy.useHostPort.http) }}
               hostPort: {{ .Values.envoy.hostPorts.http }}
               {{- end }}
               {{- if .Values.envoy.useHostIP }}
@@ -173,7 +173,7 @@ spec:
               protocol: TCP
             - containerPort: {{ .Values.envoy.containerPorts.https }}
               # Use of .Values.envoy.useHostPort as boolean is DEPRECATED. Support will be removed in upcoming versions.
-              {{- if or (and (kindIs "boolean" .Values.envoy.useHostPort) .Values.envoy.useHostPort) .Values.envoy.useHostPort.https }}
+              {{- if or (and (kindIs "boolean" .Values.envoy.useHostPort) .Values.envoy.useHostPort) (and (kindIs "map" .Values.envoy.useHostPort) .Values.envoy.useHostPort.https) }}
               hostPort: {{ .Values.envoy.hostPorts.https }}
               {{- end }}
               {{- if .Values.envoy.useHostIP }}
@@ -183,7 +183,7 @@ spec:
               protocol: TCP
             - containerPort: {{ .Values.envoy.containerPorts.metrics }}
               # Use of .Values.envoy.useHostPort as boolean is DEPRECATED. Support will be removed in upcoming versions.
-              {{- if or (and (kindIs "boolean" .Values.envoy.useHostPort) .Values.envoy.useHostPort) .Values.envoy.useHostPort.metrics }}
+              {{- if or (and (kindIs "boolean" .Values.envoy.useHostPort) .Values.envoy.useHostPort) (and (kindIs "map" .Values.envoy.useHostPort) .Values.envoy.useHostPort.metrics) }}
               hostPort: {{ .Values.envoy.hostPorts.metrics }}
               {{- end }}
               {{- if .Values.envoy.useHostIP }}

--- a/bitnami/contour/templates/envoy/deployment.yaml
+++ b/bitnami/contour/templates/envoy/deployment.yaml
@@ -183,7 +183,7 @@ spec:
               protocol: TCP
             - containerPort: {{ .Values.envoy.containerPorts.https }}
               # Use of .Values.envoy.useHostPort as boolean is DEPRECATED. Support will be removed in upcoming versions.
-              {{- if or (and (kindIs "boolean" .Values.envoy.useHostPort) .Values.envoy.useHostPort) (and (kindIs "map" .Values.envoy.useHostPort) .Values.envoy.useHostPort.http)s }}
+              {{- if or (and (kindIs "boolean" .Values.envoy.useHostPort) .Values.envoy.useHostPort) (and (kindIs "map" .Values.envoy.useHostPort) .Values.envoy.useHostPort.https) }}
               hostPort: {{ .Values.envoy.hostPorts.https }}
               {{- end }}
               {{- if .Values.envoy.useHostIP }}
@@ -193,7 +193,7 @@ spec:
               protocol: TCP
             - containerPort: {{ .Values.envoy.containerPorts.metrics }}
               # Use of .Values.envoy.useHostPort as boolean is DEPRECATED. Support will be removed in upcoming versions.
-              {{- if or (and (kindIs "boolean" .Values.envoy.useHostPort) .Values.envoy.useHostPort) (and (kindIs "map" .Values.envoy.useHostPort) .Values.envoy.useHostPort.metr)ics }}
+              {{- if or (and (kindIs "boolean" .Values.envoy.useHostPort) .Values.envoy.useHostPort) (and (kindIs "map" .Values.envoy.useHostPort) .Values.envoy.useHostPort.metrics) }}
               hostPort: {{ .Values.envoy.hostPorts.metrics }}
               {{- end }}
               {{- if .Values.envoy.useHostIP }}

--- a/bitnami/contour/templates/envoy/deployment.yaml
+++ b/bitnami/contour/templates/envoy/deployment.yaml
@@ -173,7 +173,7 @@ spec:
           ports:
             - containerPort: {{ .Values.envoy.containerPorts.http }}
               # Use of .Values.envoy.useHostPort as boolean is DEPRECATED. Support will be removed in upcoming versions.
-              {{- if or (and (kindIs "boolean" .Values.envoy.useHostPort) .Values.envoy.useHostPort) .Values.envoy.useHostPort.http }}
+              {{- if or (and (kindIs "boolean" .Values.envoy.useHostPort) .Values.envoy.useHostPort) (and (kindIs "map" .Values.envoy.useHostPort) .Values.envoy.useHostPort.http) }}
               hostPort: {{ .Values.envoy.hostPorts.http }}
               {{- end }}
               {{- if .Values.envoy.useHostIP }}
@@ -183,7 +183,7 @@ spec:
               protocol: TCP
             - containerPort: {{ .Values.envoy.containerPorts.https }}
               # Use of .Values.envoy.useHostPort as boolean is DEPRECATED. Support will be removed in upcoming versions.
-              {{- if or (and (kindIs "boolean" .Values.envoy.useHostPort) .Values.envoy.useHostPort) .Values.envoy.useHostPort.https }}
+              {{- if or (and (kindIs "boolean" .Values.envoy.useHostPort) .Values.envoy.useHostPort) (and (kindIs "map" .Values.envoy.useHostPort) .Values.envoy.useHostPort.http)s }}
               hostPort: {{ .Values.envoy.hostPorts.https }}
               {{- end }}
               {{- if .Values.envoy.useHostIP }}
@@ -193,7 +193,7 @@ spec:
               protocol: TCP
             - containerPort: {{ .Values.envoy.containerPorts.metrics }}
               # Use of .Values.envoy.useHostPort as boolean is DEPRECATED. Support will be removed in upcoming versions.
-              {{- if or (and (kindIs "boolean" .Values.envoy.useHostPort) .Values.envoy.useHostPort) .Values.envoy.useHostPort.metrics }}
+              {{- if or (and (kindIs "boolean" .Values.envoy.useHostPort) .Values.envoy.useHostPort) (and (kindIs "map" .Values.envoy.useHostPort) .Values.envoy.useHostPort.metr)ics }}
               hostPort: {{ .Values.envoy.hostPorts.metrics }}
               {{- end }}
               {{- if .Values.envoy.useHostIP }}


### PR DESCRIPTION
### Description of the change

Follow-up of #20492 to fix backwards compatibility.

### Benefits

When `.Values.envoy.useHostPort=false`, the backwards compatibility still works.

### Possible drawbacks

None

### Applicable issues

None

### Additional information

Follow-up of  #20492

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
