### PR TITLE
[bitnami/zookeeper] Make Zookeeper DefaultMode YAML 1.2 Compliant

### DIFF
--- a/bitnami/zookeeper/Chart.yaml
+++ b/bitnami/zookeeper/Chart.yaml
@@ -28,4 +28,4 @@ maintainers:
 name: zookeeper
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/zookeeper
-version: 12.3.3
+version: 12.3.4

--- a/bitnami/zookeeper/templates/statefulset.yaml
+++ b/bitnami/zookeeper/templates/statefulset.yaml
@@ -443,7 +443,7 @@ spec:
         - name: scripts
           configMap:
             name: {{ printf "%s-scripts" (include "common.names.fullname" .) }}
-            defaultMode: 0755
+            defaultMode: 0o755
         {{- if or .Values.configuration .Values.existingConfigmap }}
         - name: config
           configMap:

--- a/bitnami/zookeeper/templates/statefulset.yaml
+++ b/bitnami/zookeeper/templates/statefulset.yaml
@@ -443,7 +443,7 @@ spec:
         - name: scripts
           configMap:
             name: {{ printf "%s-scripts" (include "common.names.fullname" .) }}
-            defaultMode: 0o755
+            defaultMode: 493
         {{- if or .Values.configuration .Values.existingConfigmap }}
         - name: config
           configMap:


### PR DESCRIPTION
### Description of the change

With the YAML 1.2 spec octals must be prefixed with `0o` and not `0`. Parsers implementing the latest spec run into issues.

### Benefits

This commit makes the Zookeeper script mount compliant with YAML 1.2.

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

None at the moment

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

See background discussion here: https://github.com/dtolnay/serde-yaml/pull/225

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
