### PR TITLE
[bitnami/kafka] Make Kafka DefaultMode YAML 1.2 Compliant

### DIFF
--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -42,4 +42,4 @@ maintainers:
 name: kafka
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/kafka
-version: 26.4.3
+version: 26.4.4

--- a/bitnami/kafka/templates/broker/statefulset.yaml
+++ b/bitnami/kafka/templates/broker/statefulset.yaml
@@ -374,7 +374,7 @@ spec:
         - name: scripts
           configMap:
             name: {{ include "common.names.fullname" . }}-scripts
-            defaultMode: 0755
+            defaultMode: 493
         {{- if and .Values.externalAccess.enabled .Values.externalAccess.autoDiscovery.enabled }}
         - name: kafka-autodiscovery-shared
           emptyDir: {}

--- a/bitnami/kafka/templates/controller-eligible/statefulset.yaml
+++ b/bitnami/kafka/templates/controller-eligible/statefulset.yaml
@@ -367,7 +367,7 @@ spec:
         - name: scripts
           configMap:
             name: {{ include "common.names.fullname" . }}-scripts
-            defaultMode: 0755
+            defaultMode: 493
         {{- if and .Values.externalAccess.enabled .Values.externalAccess.autoDiscovery.enabled }}
         - name: kafka-autodiscovery-shared
           emptyDir: {}


### PR DESCRIPTION
### Description of the change

With the YAML 1.2 spec octals must be prefixed with `0o` and not `0`. Parsers implementing the latest spec run into issues. 

### Benefits

This commit makes the Kafka script mounts compliant with YAML 1.2.

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

None at the moment.

### Additional information

See background discussion here: dtolnay/serde-yaml#225

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
