### PR TITLE
[bitnami/mastodon] Fix tootctl media management volume mount

### DIFF
--- a/bitnami/mastodon/Chart.yaml
+++ b/bitnami/mastodon/Chart.yaml
@@ -49,4 +49,4 @@ maintainers:
 name: mastodon
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/mastodon
-version: 3.2.4
+version: 3.2.5

--- a/bitnami/mastodon/templates/tootctlMediaManagement/cronjob.yaml
+++ b/bitnami/mastodon/templates/tootctlMediaManagement/cronjob.yaml
@@ -117,6 +117,6 @@ spec:
           volumes:
           - name: media-management
             configMap:
-              name: tootctl-media-management-configmap
+              name: {{ template "mastodon.tootctlMediaManagement.fullname" . }}
               defaultMode: 0555
 {{- end }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->
Fixes an error preventing the tootctlMediaManagement job from running due to a hard coded configmap name used in the cronjob template.
### Benefits

<!-- What benefits will be realized by the code change? -->
The container can initialize, run, and complete successfully.

### Possible drawbacks

<!-- Describe any known limitations with your change -->
None

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #21110

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
No changes were needed to README.md as this was bug fix for an issue introduced in https://github.com/bitnami/charts/commit/10711912ed2c3ab5840f1c8196de1ea413deeccd

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [ X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X ] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
