### PR TITLE
[bitnami/postgresql] value to configure posgres_exporter collectors

### DIFF
--- a/bitnami/postgresql/Chart.yaml
+++ b/bitnami/postgresql/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: postgresql
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/postgresql
-version: 13.2.14
+version: 13.2.15

--- a/bitnami/postgresql/README.md
+++ b/bitnami/postgresql/README.md
@@ -466,6 +466,7 @@ kubectl delete pvc -l release=my-release
 | `metrics.image.digest`                                      | PostgreSQL image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                                |
 | `metrics.image.pullPolicy`                                  | PostgreSQL Prometheus Exporter image pull policy                                                           | `IfNotPresent`                      |
 | `metrics.image.pullSecrets`                                 | Specify image pull secrets                                                                                 | `[]`                                |
+| `metrics.collectors`                                        | Control enabled collectors                                                                                 | `{}`                                |
 | `metrics.customMetrics`                                     | Define additional custom metrics                                                                           | `{}`                                |
 | `metrics.extraEnvVars`                                      | Extra environment variables to add to PostgreSQL Prometheus exporter                                       | `[]`                                |
 | `metrics.containerSecurityContext.enabled`                  | Enabled containers' Security Context                                                                       | `true`                              |

--- a/bitnami/postgresql/templates/primary/statefulset.yaml
+++ b/bitnami/postgresql/templates/primary/statefulset.yaml
@@ -495,8 +495,15 @@ spec:
           {{- if .Values.diagnosticMode.enabled }}
           command: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.command "context" $) | nindent 12 }}
           args: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.args "context" $) | nindent 12 }}
-          {{- else if .Values.metrics.customMetrics }}
-          args: ["--extend.query-path", "/conf/custom-metrics.yaml"]
+          {{- else if or .Values.metrics.customMetrics .Values.metrics.collectors }}
+          args:
+            {{- if .Values.metrics.customMetrics }}
+            - --extend.query-path
+            - /conf/custom-metrics.yaml
+            {{- end }}
+            {{- range $name, $enabled := .Values.metrics.collectors }}
+            - --{{ if not $enabled }}no-{{ end }}collector.{{ $name }}
+            {{- end }}
           {{- end }}
           env:
             {{- $database := required "In order to enable metrics you need to specify a database (.Values.auth.database or .Values.global.postgresql.auth.database)" (include "postgresql.v1.database" .) }}

--- a/bitnami/postgresql/values.yaml
+++ b/bitnami/postgresql/values.yaml
@@ -1412,8 +1412,14 @@ metrics:
     ##   - myRegistryKeySecretName
     ##
     pullSecrets: []
+  ## @param metrics.collectors Control enabled collectors
+  ## ref: https://github.com/prometheus-community/postgres_exporter#flags
+  ## Example:
+  ## collectors:
+  ##   wal: false
+  collectors: {}
   ## @param metrics.customMetrics Define additional custom metrics
-  ## ref: https://github.com/wrouesnel/postgres_exporter#adding-new-metrics-via-a-config-file
+  ## ref: https://github.com/prometheus-community/postgres_exporter#adding-new-metrics-via-a-config-file-deprecated
   ## customMetrics:
   ##   pg_database:
   ##     query: "SELECT d.datname AS name, CASE WHEN pg_catalog.has_database_privilege(d.datname, 'CONNECT') THEN pg_catalog.pg_database_size(d.datname) ELSE 0 END AS size_bytes FROM pg_catalog.pg_database d where datname not in ('template0', 'template1', 'postgres')"
@@ -1427,7 +1433,7 @@ metrics:
   ##
   customMetrics: {}
   ## @param metrics.extraEnvVars Extra environment variables to add to PostgreSQL Prometheus exporter
-  ## see: https://github.com/wrouesnel/postgres_exporter#environment-variables
+  ## see: https://github.com/prometheus-community/postgres_exporter#environment-variables
   ## For example:
   ##  extraEnvVars:
   ##  - name: PG_EXPORTER_DISABLE_DEFAULT_METRICS


### PR DESCRIPTION
### Description of the change

add a new option to configure collectors of postgres exporter

### Benefits

allows to switch collectors on/off

for example, to disable wal collector for #20247 or enable collectors that are disabled by default

### Possible drawbacks

### Applicable issues

- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
