### PR TITLE
[bitnami/etcd] Fix podLabels for disasterRecovery cronjob

### DIFF
--- a/bitnami/etcd/Chart.yaml
+++ b/bitnami/etcd/Chart.yaml
@@ -32,4 +32,4 @@ maintainers:
 name: etcd
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/etcd
-version: 9.7.2
+version: 9.7.3

--- a/bitnami/etcd/README.md
+++ b/bitnami/etcd/README.md
@@ -295,7 +295,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `disasterRecovery.cronjob.resources.requests`   | Cronjob container resource requests                                     | `{}`           |
 | `disasterRecovery.cronjob.nodeSelector`         | Node labels for cronjob pods assignment                                 | `{}`           |
 | `disasterRecovery.cronjob.tolerations`          | Tolerations for cronjob pods assignment                                 | `[]`           |
-| `disasterRecovery.cronjob.podLabels`            | List of labels that will be added to pods created by cronjob            | `[]`           |
+| `disasterRecovery.cronjob.podLabels`            | Labels that will be added to pods created by cronjob                    | `{}`           |
 | `disasterRecovery.pvc.existingClaim`            | A manually managed Persistent Volume and Claim                          | `""`           |
 | `disasterRecovery.pvc.size`                     | PVC Storage Request                                                     | `2Gi`          |
 | `disasterRecovery.pvc.storageClassName`         | Storage Class for snapshots volume                                      | `nfs`          |

--- a/bitnami/etcd/values.yaml
+++ b/bitnami/etcd/values.yaml
@@ -881,9 +881,9 @@ disasterRecovery:
     ## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
     ##
     tolerations: []
-    ## @param disasterRecovery.cronjob.podLabels List of labels that will be added to pods created by cronjob
+    ## @param disasterRecovery.cronjob.podLabels [object] Labels that will be added to pods created by cronjob
     ##
-    podLabels: []
+    podLabels: {}
 
   pvc:
     ## @param disasterRecovery.pvc.existingClaim A manually managed Persistent Volume and Claim


### PR DESCRIPTION

### Description of the change

Fix the type for the podlabels.

Otherwise it would result in error, when using the chart.
```bash
helm template etcd . --dependency-update --set disasterRecovery.enabled=true
Error: template: etcd/templates/cronjob.yaml:7:71: executing "etcd/templates/cronjob.yaml" at <.Values.disasterRecovery.cronjob.podLabels>: wrong type for value; expected map[string]interface {}; got []interface {}
```

### Benefits

Be able to use the chart without setting extra podLabels for the disasterRecovery cronjob.

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
