### PR TITLE
[bitname/schema-registry] fix extraHosts entry

### DIFF
--- a/bitnami/schema-registry/Chart.yaml
+++ b/bitnami/schema-registry/Chart.yaml
@@ -34,4 +34,4 @@ maintainers:
 name: schema-registry
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/schema-registry
-version: 16.2.3
+version: 16.2.4

--- a/bitnami/schema-registry/templates/ingress.yaml
+++ b/bitnami/schema-registry/templates/ingress.yaml
@@ -37,9 +37,10 @@ spec:
       http:
         paths:
           - path: {{ default "/" .path }}
-            backend:
-              serviceName: {{ include "common.names.fullname" . }}
-              servicePort: http
+            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
+            pathType: {{ $.Values.ingress.pathType }}
+            {{- end }}
+            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" $) "servicePort" "http" "context" $)  | nindent 14 }}
     {{- end }}
     {{- if .Values.ingress.extraRules }}
     {{- include "common.tplvalues.render" (dict "value" .Values.ingress.extraRules "context" $) | nindent 4 }}


### PR DESCRIPTION
Use `common.ingress` helpers to generate ingress `extraHosts` section

### Description of the change

use common.ingress helpers to generate extraHosts entries

### Benefits

Fixes compatibility with ingress syntax

### Applicable issues

- fixes #21221

### Checklist

- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
