### PR TITLE
[bitnami/matomo] Deprecates 'cronjobs.enabled'

### DIFF
--- a/bitnami/matomo/Chart.yaml
+++ b/bitnami/matomo/Chart.yaml
@@ -39,4 +39,4 @@ maintainers:
 name: matomo
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/matomo
-version: 3.1.4
+version: 3.2.0

--- a/bitnami/matomo/README.md
+++ b/bitnami/matomo/README.md
@@ -305,7 +305,7 @@ The command removes all the Kubernetes components associated with the chart and 
 
 | Name                                                                       | Description                                                          | Value            |
 | -------------------------------------------------------------------------- | -------------------------------------------------------------------- | ---------------- |
-| `cronjobs.enabled`                                                         | Enables cronjobs for archive and scheduler tasks                     | `true`           |
+| `cronjobs.taskScheduler.enabled`                                           | Whether to enable scheduled mail-to-task CronJob                     | `true`           |
 | `cronjobs.taskScheduler.schedule`                                          | Kubernetes CronJob schedule                                          | `*/5 * * * *`    |
 | `cronjobs.taskScheduler.suspend`                                           | Whether to create suspended CronJob                                  | `false`          |
 | `cronjobs.taskScheduler.command`                                           | Override default container command (useful when using custom images) | `[]`             |
@@ -320,7 +320,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `cronjobs.taskScheduler.containerSecurityContext.seccompProfile.type`      | Set container's Security Context seccomp profile                     | `RuntimeDefault` |
 | `cronjobs.taskScheduler.podAnnotations`                                    | Additional pod annotations                                           | `{}`             |
 | `cronjobs.taskScheduler.podLabels`                                         | Additional pod labels                                                | `{}`             |
-| `cronjobs.archive.enabled`                                                 | Whether to enable scheduled mail-to-task CronJob                     | `false`          |
+| `cronjobs.archive.enabled`                                                 | Whether to enable scheduled mail-to-task CronJob                     | `true`           |
 | `cronjobs.archive.schedule`                                                | Kubernetes CronJob schedule                                          | `*/5 * * * *`    |
 | `cronjobs.archive.suspend`                                                 | Whether to create suspended CronJob                                  | `false`          |
 | `cronjobs.archive.command`                                                 | Override default container command (useful when using custom images) | `[]`             |
@@ -436,6 +436,10 @@ helm install my-release --set persistence.existingClaim=PVC_NAME oci://REGISTRY_
 Find more information about how to deal with common errors related to Bitnami's Helm charts in [this troubleshooting guide](https://docs.bitnami.com/general/how-to/troubleshoot-helm-chart-issues).
 
 ## Upgrading
+
+### To 3.2.0
+
+This version deprecates `cronjobs.enabled` value in favor of `cronjobs.taskScheduler.enabled` and `cronjobs.archive.enabled` values.
 
 ### To 3.0.0
 

--- a/bitnami/matomo/templates/_helpers.tpl
+++ b/bitnami/matomo/templates/_helpers.tpl
@@ -215,3 +215,18 @@ Return the matomo pods needed initContainers
       readOnly: true
 {{- end }}
 {{- end }}
+{{/*
+Return if cronjob X is enabled. Takes into account the deprecated value 'cronjobs.enabled'.
+Use: include "matomo.cronjobs.enabled" (dict "context" $ "cronjob" "archive" )
+*/}}
+{{- define "matomo.cronjobs.enabled" -}}
+{{- if ( hasKey .context.Values.cronjobs "enabled" ) -}}
+  {{- if .context.Values.cronjobs.enabled -}}
+    {{- true -}}
+  {{- end -}}
+{{- else -}}
+  {{- if ( get .context.Values.cronjobs .cronjob ).enabled  -}}
+    {{- true -}}
+  {{- end -}}
+{{- end -}}
+{{- end }}

--- a/bitnami/matomo/templates/cronjob.yaml
+++ b/bitnami/matomo/templates/cronjob.yaml
@@ -135,9 +135,9 @@ spec:
             {{- if .Values.extraVolumes }}
             {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumes "context" $) | nindent 12 }}
             {{- end }}
----
 {{- end }}
 {{- if ( include "matomo.cronjobs.enabled" ( dict "context" $ "cronjob" "taskScheduler" ) ) -}}
+---
 apiVersion: {{ include "common.capabilities.cronjob.apiVersion" . }}
 kind: CronJob
 metadata:

--- a/bitnami/matomo/templates/cronjob.yaml
+++ b/bitnami/matomo/templates/cronjob.yaml
@@ -3,7 +3,7 @@ Copyright VMware, Inc.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- if .Values.cronjobs.enabled -}}
+{{- if ( include "matomo.cronjobs.enabled" ( dict "context" $ "cronjob" "archive" ) ) -}}
 apiVersion: {{ include "common.capabilities.cronjob.apiVersion" . }}
 kind: CronJob
 metadata:
@@ -136,6 +136,8 @@ spec:
             {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumes "context" $) | nindent 12 }}
             {{- end }}
 ---
+{{- end }}
+{{- if ( include "matomo.cronjobs.enabled" ( dict "context" $ "cronjob" "taskScheduler" ) ) -}}
 apiVersion: {{ include "common.capabilities.cronjob.apiVersion" . }}
 kind: CronJob
 metadata:

--- a/bitnami/matomo/values.yaml
+++ b/bitnami/matomo/values.yaml
@@ -932,10 +932,13 @@ networkPolicy:
 ##
 
 cronjobs:
-  ## @param cronjobs.enabled Enables cronjobs for archive and scheduler tasks
+  ## DEPRECATED @param cronjobs.enabled Please use cronjobs.taskScheduler.enabled and/or cronjobs.archive.enabled
   ##
-  enabled: true
+  # enabled: true
   taskScheduler:
+    ## @param cronjobs.taskScheduler.enabled Whether to enable scheduled mail-to-task CronJob
+    ##
+    enabled: true
     ## @param cronjobs.taskScheduler.schedule Kubernetes CronJob schedule
     ##
     schedule: "*/5 * * * *"
@@ -981,7 +984,7 @@ cronjobs:
   archive:
     ## @param cronjobs.archive.enabled Whether to enable scheduled mail-to-task CronJob
     ##
-    enabled: false
+    enabled: true
     ## @param cronjobs.archive.schedule Kubernetes CronJob schedule
     ##
     schedule: "*/5 * * * *"


### PR DESCRIPTION
### Description of the change

This version deprecates `cronjobs.enabled` value in favor of `cronjobs.taskScheduler.enabled` and `cronjobs.archive.enabled` values.

### Benefits

We can install each cronjob separately.

### Possible drawbacks

None identified

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #20567

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
