### PR TITLE
[charts/*] Hardening CI workflow

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -14,10 +14,6 @@ on: # rebuild any PRs and main branch changes
       - bitnami:main
 # Remove all permissions by default
 permissions: {}
-env:
-  CSP_API_URL: https://console.cloud.vmware.com
-  CSP_API_TOKEN: ${{ secrets.CSP_API_TESTING_TOKEN }}
-  VIB_PUBLIC_URL: https://cp.bromelia.vmware.com
 # Avoid concurrency over the same PR
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
@@ -26,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Get modified charts
     permissions:
-      contents: read
+      pull-requests: read
     outputs:
       chart: ${{ steps.get-chart.outputs.chart }}
       result: ${{ steps.get-chart.outputs.result }}
@@ -36,20 +32,21 @@ jobs:
       - id: get-chart
         name: Get modified charts
         env:
-          DIFF_URL: "${{github.event.pull_request.diff_url}}"
-          TEMP_FILE: "${{runner.temp}}/pr-${{github.event.number}}.diff"
+          PULL_REQUEST_NUMBER: "${{ github.event.pull_request.number }}"
+          PULL_REQUEST_URL: "${{ github.event.pull_request.url }}"
+          GITHUB_TOKEN: "${{ github.token }}"
         run: |
-          # This request doesn't consume API calls.
-          curl -Lkso $TEMP_FILE $DIFF_URL
-          files_changed="$(sed -nr 's/[\-\+]{3} [ab]\/(.*)/\1/p' $TEMP_FILE | sort | uniq)"
+          # Using the Github API to detect the files changed as git merge-base stops working when the branch is behind
+          files_changed_data="$(gh api --paginate /repos/${GITHUB_REPOSITORY}/pulls/${PULL_REQUEST_NUMBER}/files)"
+          files_changed="$(echo "$files_changed_data" | jq -r '.[] | .filename')"
           # Adding || true to avoid "Process exited with code 1" errors
           charts_dirs_changed="$(echo "$files_changed" | xargs dirname | grep -o "bitnami/[^/]*" | sort | uniq || true)"
           # Using grep -c as a better alternative to wc -l when dealing with empty strings."
           num_charts_changed="$(echo "$charts_dirs_changed" | grep -c "bitnami" || true)"
-          num_version_bumps="$(filterdiff -s -i "*Chart.yaml" $TEMP_FILE | grep -c "+version" || true)"
+          num_version_bumps="$(echo "$files_changed_data" | jq -r '[.[] | select(.filename|endswith("Chart.yaml")) | select(.patch|contains("+version")) ] | length' )"
           non_readme_files=$(echo "$files_changed" | grep -vc "\.md" || true)
 
-          if [[ $(curl -Lks ${{ github.event.pull_request.url }} | jq '.state | index("closed")') != *null* ]]; then
+          if [[ $(curl -Lks "${PULL_REQUEST_URL}" | jq '.state | index("closed")') != *null* ]]; then
             # The PR for which this workflow run was launched is now closed -> SKIP
             echo "error=The PR for which this workflow run was launched is now closed. The tests will be skipped." >> $GITHUB_OUTPUT
             echo "result=skip" >> $GITHUB_OUTPUT
@@ -58,8 +55,7 @@ jobs:
             echo "result=skip" >> $GITHUB_OUTPUT
           elif [[ "$num_charts_changed" -ne "$num_version_bumps" ]]; then
             # Changes done in charts but version not bumped -> ERROR
-            charts_changed_str="$(echo ${charts_dirs_changed[@]})"
-            echo "error=Detected changes in charts without version bump in Chart.yaml. Charts changed: ${num_charts_changed} ${charts_changed_str}. Version bumps detected: ${num_version_bumps}" >> $GITHUB_OUTPUT
+            echo "error=Detected changes in charts without version bump in Chart.yaml. Charts changed: ${num_charts_changed}. Version bumps detected: ${num_version_bumps}" >> $GITHUB_OUTPUT
             echo "result=fail" >> $GITHUB_OUTPUT
           elif [[ "$num_charts_changed" -eq "1" ]]; then
             # Changes done in only one chart -> OK
@@ -72,8 +68,7 @@ jobs:
             echo "result=skip" >> $GITHUB_OUTPUT
           else
             # Changes done in more than chart -> SKIP
-            charts_changed_str="$(echo ${charts_dirs_changed[@]})"
-            echo "error=Changes detected in more than one chart directory: ${charts_changed_str}. It is strongly advised to change only one chart in a PR. The rest of the tests will be skipped." >> $GITHUB_OUTPUT
+            echo "error=Changes detected in more than one chart directory. It is strongly advised to change only one chart in a PR. The rest of the tests will be skipped." >> $GITHUB_OUTPUT
             echo "result=skip" >> $GITHUB_OUTPUT
           fi
       # Using actions/github-scripts because using exit 1 in the script above would not provide any output
@@ -95,6 +90,10 @@ jobs:
     needs: get-chart
     permissions:
       contents: read
+    env:
+      CSP_API_URL: https://console.cloud.vmware.com
+      CSP_API_TOKEN: ${{ secrets.CSP_API_TESTING_TOKEN }}
+      VIB_PUBLIC_URL: https://cp.bromelia.vmware.com
     # Given performance issues of the action feature on GH's side, we need to be very restrictive in the job's triggers:
     # -> The 'Get modified charts' job suceededs AND
     #  ( ---> The pipeline was triggered due to a label addition and said label was the 'verify' one OR

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -27,8 +27,6 @@ jobs:
       chart: ${{ steps.get-chart.outputs.chart }}
       result: ${{ steps.get-chart.outputs.result }}
     steps:
-      - name: Install dependencies
-        run: sudo apt-get install -y patchutils
       - id: get-chart
         name: Get modified charts
         env:


### PR DESCRIPTION
### Description of the change

* Reduce exposure of the `CSP_API_TOKEN` secret.
* Reduce verbosity in the errors reported by `get-chart` step.
* Use GitHub API instead of custom scripts to retrieve modified files in a PR.

### Benefits

Avoid possible injections and reduce the exposure of the secrets.

### Possible drawbacks

None identified.

### Applicable issues

Malicious user could retrieve `CSP_API_TOKEN` using js scripts in its PR.

### Additional information

Thanks Benoit for sharing this issue.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
