### PR TITLE
Grafana loki unquoting secret data

### DIFF
--- a/bitnami/grafana-loki/Chart.yaml
+++ b/bitnami/grafana-loki/Chart.yaml
@@ -57,4 +57,4 @@ maintainers:
 name: grafana-loki
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/grafana-loki
-version: 2.11.16
+version: 2.11.17

--- a/bitnami/grafana-loki/templates/gateway/secret.yaml
+++ b/bitnami/grafana-loki/templates/gateway/secret.yaml
@@ -20,6 +20,6 @@ metadata:
 type: Opaque
 data:
   {{- $password := (include "common.secrets.passwords.manage" (dict "secret" (include "grafana-loki.gateway.fullname" .) "key" "password" "providedValues" (list "gateway.auth.password") "context" $)) }}
-  password: {{ $password | quote }}
+  password: {{ $password }}
   htpasswd: {{ htpasswd .Values.gateway.auth.username (b64dec $password) | b64enc | quote }}
 {{- end }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

When enabling the auth into the gateway a wrong secret is generated with the configured credentials.

Quotes have been set into the $password variable, so when filtering its value with quotes a nonvalid secret is generated.

### Benefits

Allowing to deploy a grafana-loki instance with the authentication enabled.

### Possible drawbacks

Just needs to revert commits

### Applicable issues

- fixes #21282

### Additional information

Maybe it is better to modify how is generated the $password variable and don't include there the quotes.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
