### PR TITLE
[bitnami/mlflow] fix the service monitor port name to match the service port name

### DIFF
--- a/bitnami/mlflow/Chart.yaml
+++ b/bitnami/mlflow/Chart.yaml
@@ -43,4 +43,4 @@ name: mlflow
 sources:
 - https://github.com/bitnami/containers/tree/main/bitnami/mlflow
 - https://github.com/mlflow/mlflow
-version: 0.3.0
+version: 0.3.1

--- a/bitnami/mlflow/templates/_helpers.tpl
+++ b/bitnami/mlflow/templates/_helpers.tpl
@@ -75,21 +75,21 @@ Return the MLflow Tracking Secret key for the user
 {{- end -}}
 
 {{/*
-Return the MLFlow Trakcing Port
+Return the MLFlow Tracking Port
 */}}
 {{- define "mlflow.v0.tracking.port" -}}
-{{- int ( ternary .Values.tracking.service.ports.https .Values.tracking.service.ports.http .Values.tracking.tls.enabled ) -}}
+{{- ternary .Values.tracking.service.ports.https .Values.tracking.service.ports.http .Values.tracking.tls.enabled -}}
 {{- end -}}
 
 {{/*
-Return the MLFlow Trakcing Protocol
+Return the MLFlow Tracking Protocol
 */}}
 {{- define "mlflow.v0.tracking.protocol" -}}
 {{- ternary "https" "http" .Values.tracking.tls.enabled -}}
 {{- end -}}
 
 {{/*
-Return the MLFlow Trakcing URI
+Return the MLFlow Tracking URI
 */}}
 {{- define "mlflow.v0.tracking.uri" -}}
 {{ printf "%s://%s:%v" (include "mlflow.v0.tracking.protocol" .) (include "mlflow.v0.tracking.fullname" .) (include "mlflow.v0.tracking.port" .) }}

--- a/bitnami/mlflow/templates/tracking/servicemonitor.yaml
+++ b/bitnami/mlflow/templates/tracking/servicemonitor.yaml
@@ -27,7 +27,7 @@ spec:
       {{- include "common.tplvalues.render" (dict "value" .Values.tracking.metrics.serviceMonitor.selector "context" $) | nindent 6 }}
       {{- end }}
   endpoints:
-    - port: {{ include "mlflow.v0.tracking.port" . }}
+    - port: {{ include "mlflow.v0.tracking.protocol" . }}
       {{- if .Values.tracking.auth.enabled }}
       basicAuth:
         password:


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->

This fixes the service monitor endpoint port to use the _name_ of the service port rather than the port number. Referring to the service monitor schema defined [here](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#monitoring.coreos.com/v1.Endpoint), the port field is the `Name of the Service port which this endpoint refers to.` rather than the port number.

The names are [here](https://github.com/bitnami/charts/blob/edfc97380c8edf4b4cc09882a3e797048fe1c1de/bitnami/mlflow/templates/tracking/service.yaml#L44) and [here](https://github.com/bitnami/charts/blob/edfc97380c8edf4b4cc09882a3e797048fe1c1de/bitnami/mlflow/templates/tracking/service.yaml#L54) which correspond to the `mlflow.v0.tracking.protocol` helper value, so we just use this instead.

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

Fixes #20668. This still seems to exist on Chart version 0.2.8 despite the change merged in #21235 which looks like it just coerces ints to ints for a field that expects a string.

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [ ] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [ ] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
