### PR TITLE
[bitnami/mongodb]  feat: add node configuration

### DIFF
--- a/bitnami/mongodb/Chart.yaml
+++ b/bitnami/mongodb/Chart.yaml
@@ -39,4 +39,4 @@ maintainers:
 name: mongodb
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/mongodb
-version: 14.4.2
+version: 14.4.0

--- a/bitnami/mongodb/Chart.yaml
+++ b/bitnami/mongodb/Chart.yaml
@@ -39,4 +39,4 @@ maintainers:
 name: mongodb
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/mongodb
-version: 14.3.2
+version: 14.4.2

--- a/bitnami/mongodb/templates/replicaset/scripts-configmap.yaml
+++ b/bitnami/mongodb/templates/replicaset/scripts-configmap.yaml
@@ -261,8 +261,14 @@ data:
       for key in ${!desiredRsConf[@]}; do
         value=${desiredRsConf[$key]}
         if ! $(echo "\"${currentRsConf}"\" | grep -q -e "${key}: ${value},"); then
-           logger "rs conf setting: ${key} value will be set to: ${value}"
-           settingsToConfigure="${settingsToConfigure}cfg.settings.${key} = ${value}; "
+           if [[ $key =~ ^members\[[0-9]+\]\..+ ]]; then
+            memberIndex=$(echo $key | grep -o -E '[0-9]+')
+            nodeConfigKey=${key#*.}
+            settingsToConfigure="${settingsToConfigure}cfg.members[${memberIndex}].${nodeConfigKey} = ${value}; "
+          else
+            # General rs settings
+            settingsToConfigure="${settingsToConfigure}cfg.settings.${key} = ${value}; "
+          fi
            desiredEqualsactual=false
         else
           logger "rs conf: ${key} is already at desired value: ${value}"

--- a/bitnami/mongodb/values.yaml
+++ b/bitnami/mongodb/values.yaml
@@ -384,6 +384,7 @@ configuration: ""
 replicaSetConfigurationSettings:
   enabled: false
   configuration: {}
+##    members[0].priority: 3
 ##    chainingAllowed : false
 ##    heartbeatTimeoutSecs : 10
 ##    heartbeatIntervalMillis : 2000

--- a/bitnami/mongodb/values.yaml
+++ b/bitnami/mongodb/values.yaml
@@ -384,6 +384,10 @@ configuration: ""
 replicaSetConfigurationSettings:
   enabled: false
   configuration: {}
+## Custom configurations for individual replica set members.
+## Use the prefix 'members[X].' to apply settings to the member X of the replica set.
+## Example: 'members[0].priority: 3' sets the priority of the first replica set member to 3.
+## The index X in 'members[X]' corresponds to the member's position in the replica set.
 ##    members[0].priority: 3
 ##    chainingAllowed : false
 ##    heartbeatTimeoutSecs : 10


### PR DESCRIPTION

### Description of the change

The modifications allow for more granular control of replica set member settings, such as priority levels, directly through Helm values.


### Benefits

This makes it easier to manage and tune the replica set according to specific requirements and scenarios directly from the Helm chart, without needing manual interventions post-deployment.


### Possible drawbacks

<!-- Describe any known limitations with your change -->
The modifications allow for more granular control of replica set member settings, such as priority levels, directly through Helm values.
### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes https://github.com/bitnami/charts/issues/21291

### Additional information


### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
