### PR TITLE
bitnami/kafka configure clientUsers as SCRAM users

### DIFF
--- a/bitnami/kafka/templates/_helpers.tpl
+++ b/bitnami/kafka/templates/_helpers.tpl
@@ -452,14 +452,16 @@ Return the SASL mechanism to use for the Kafka exporter to access Kafka
 The exporter uses a different nomenclature so we need to do this hack
 */}}
 {{- define "kafka.metrics.kafka.saslMechanism" -}}
-{{- $saslMechanisms := .Values.sasl.enabledMechanisms }}
-{{- if contains "OAUTHBEARER" (upper $saslMechanisms) }}
+{{- $saslMechanisms := upper .Values.sasl.enabledMechanisms }}
+{{- if .Values.metrics.kafka.saslMechanism -}}
+  {{- print .Values.metrics.kafka.saslMechanism -}}
+{{- else if contains "OAUTHBEARER" $saslMechanisms }}
     {{- print "oauthbearer" -}}
-{{- else if contains "SCRAM-SHA-512" (upper $saslMechanisms) }}
+{{- else if contains "SCRAM-SHA-512" $saslMechanisms }}
     {{- print "scram-sha512" -}}
-{{- else if contains "SCRAM-SHA-256" (upper $saslMechanisms) }}
+{{- else if contains "SCRAM-SHA-256" $saslMechanisms }}
     {{- print "scram-sha256" -}}
-{{- else if contains "PLAIN" (upper $saslMechanisms) }}
+{{- else if contains "PLAIN" $saslMechanisms }}
     {{- print "plain" -}}
 {{- end -}}
 {{- end -}}
@@ -646,7 +648,7 @@ listener.name.{{lower $listener.name}}.oauthbearer.sasl.login.callback.handler.c
   {{- $saslJaasConfig = append $saslJaasConfig (print "password=\"interbroker-password-placeholder\"") }}
   {{- end }}
   {{- end }}
-  {{- if eq (upper $mechanism) "PLAIN" }}
+  {{- if or (eq "PLAIN" (upper $mechanism)) (regexFind "SCRAM" (upper $mechanism)) }}
   {{- if eq $listener.name $.Values.listeners.interbroker.name }}
   {{- $saslJaasConfig = append $saslJaasConfig (printf "user_%s=\"interbroker-password-placeholder\"" $.Values.sasl.interbroker.user) }}
   {{- end }}

--- a/bitnami/kafka/values.yaml
+++ b/bitnami/kafka/values.yaml
@@ -1691,6 +1691,9 @@ metrics:
     ## @param metrics.kafka.tlsCaCert The secret key from the certificatesSecret or tlsCaSecret if 'ca-cert' key different from the default (ca-file)
     ##
     tlsCaCert: ca-file
+    ## @param metrics.kafka.saslMechanism SASL mechanism for cluster communication
+    ##
+    saslMechanism: ""
     ## @param metrics.kafka.extraFlags Extra flags to be passed to Kafka exporter
     ## e.g:
     ## extraFlags:


### PR DESCRIPTION
### Description of the change

* configure clientUsers as SCRAM users
* allow to overwrite kafka-exporter saslMechanism

### Benefits

Allows to use the same credentials fo PLAIN and SCRAM-SHA-* mechanisms simultaneously.

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
