### PR TITLE
[bitnami/suitecrm] Mark SuiteCRM helm chart as deprecated

### DIFF
--- a/bitnami/suitecrm/Chart.yaml
+++ b/bitnami/suitecrm/Chart.yaml
@@ -23,7 +23,9 @@ dependencies:
     tags:
       - bitnami-common
     version: 2.x.x
-description: SuiteCRM is a completely open source, enterprise-grade Customer Relationship Management (CRM) application. SuiteCRM is a fork of the popular SugarCRM application.
+# The SuiteCRM chart is deprecated and no longer maintained.
+deprecated: true
+description: DEPRECATED SuiteCRM is a completely open source, enterprise-grade Customer Relationship Management (CRM) application. SuiteCRM is a fork of the popular SugarCRM application.
 home: https://bitnami.com
 icon: https://bitnami.com/assets/stacks/suitecrm/img/suitecrm-stack-220x234.png
 keywords:
@@ -32,10 +34,8 @@ keywords:
   - http
   - web
   - php
-maintainers:
-  - name: VMware, Inc.
-    url: https://github.com/bitnami/charts
+maintainers: []
 name: suitecrm
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/suitecrm
-version: 14.1.0
+version: 14.1.1

--- a/bitnami/suitecrm/README.md
+++ b/bitnami/suitecrm/README.md
@@ -8,6 +8,10 @@ SuiteCRM is a completely open source, enterprise-grade Customer Relationship Man
 
 Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
 
+## This Helm chart is deprecated
+
+The upstream project has been discontinued and no new features.
+
 ## TL;DR
 
 ```console

--- a/bitnami/suitecrm/README.md
+++ b/bitnami/suitecrm/README.md
@@ -10,7 +10,7 @@ Trademarks: This software listing is packaged by Bitnami. The respective tradema
 
 ## This Helm chart is deprecated
 
-The upstream project has been discontinued and no new features.
+The latest branch of SuiteCRM 8 has a bug that makes it incompatible with the chart deployment.
 
 ## TL;DR
 

--- a/bitnami/suitecrm/templates/NOTES.txt
+++ b/bitnami/suitecrm/templates/NOTES.txt
@@ -1,3 +1,7 @@
+This Helm chart is deprecated
+
+The upstream project has been discontinued and no new features.
+
 CHART NAME: {{ .Chart.Name }}
 CHART VERSION: {{ .Chart.Version }}
 APP VERSION: {{ .Chart.AppVersion }}

--- a/bitnami/suitecrm/templates/NOTES.txt
+++ b/bitnami/suitecrm/templates/NOTES.txt
@@ -1,4 +1,4 @@
-This Helm chart is deprecated
+This Helm chart is deprecated on our side and will not receive new updates.
 
 CHART NAME: {{ .Chart.Name }}
 CHART VERSION: {{ .Chart.Version }}

--- a/bitnami/suitecrm/templates/NOTES.txt
+++ b/bitnami/suitecrm/templates/NOTES.txt
@@ -1,7 +1,5 @@
 This Helm chart is deprecated
 
-The upstream project has been discontinued and no new features.
-
 CHART NAME: {{ .Chart.Name }}
 CHART VERSION: {{ .Chart.Version }}
 APP VERSION: {{ .Chart.AppVersion }}


### PR DESCRIPTION

### Description of the change

SuiteCRM helm chart will be deprecated. 

The latest branch of SuiteCRM 8 has a bug that makes it incompatible with the chart deployment.

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
