### PR TITLE
[bitnami/opensearch] Replace deprecated pull secret partial

### DIFF
--- a/bitnami/opensearch/Chart.yaml
+++ b/bitnami/opensearch/Chart.yaml
@@ -30,4 +30,4 @@ maintainers:
 name: opensearch
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/opensearch
-version: 0.5.1
+version: 0.5.2

--- a/bitnami/opensearch/templates/_helpers.tpl
+++ b/bitnami/opensearch/templates/_helpers.tpl
@@ -16,7 +16,7 @@ Return the proper OS image name
 Return the proper Docker Image Registry Secret Names
 */}}
 {{- define "opensearch.imagePullSecrets" -}}
-{{ include "common.images.pullSecrets" (dict "images" (list .Values.image .Values.sysctlImage .Values.volumePermissions.image) "global" .Values.global) }}
+{{ include "common.images.renderPullSecrets" (dict "images" (list .Values.image .Values.sysctlImage .Values.volumePermissions.image) "context" $) }}
 {{- end -}}
 
 {{/*
@@ -662,4 +662,3 @@ Return true if a TLS credentials secret object should be created
     {{- true -}}
 {{- end -}}
 {{- end -}}
-


### PR DESCRIPTION
### Description of the change

The OpenSearch chart still uses the deprecated `common.images.pullSecrets` partial to render pull secrets. It was replaced with the recommended replacement `common.images.renderPullSecrets`.

### Benefits

The new helper adds support for templating of the name of the image pull secrets.

### Possible drawbacks

%

### Applicable issues

%

### Additional information

Tried to do a batch update in #21329

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
