### PR TITLE
[bitnami/metrics-server] Replace deprecated pull secret partial

### DIFF
--- a/bitnami/metrics-server/Chart.yaml
+++ b/bitnami/metrics-server/Chart.yaml
@@ -28,4 +28,4 @@ maintainers:
 name: metrics-server
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/metrics-server
-version: 6.6.3
+version: 6.6.4

--- a/bitnami/metrics-server/templates/_helpers.tpl
+++ b/bitnami/metrics-server/templates/_helpers.tpl
@@ -27,7 +27,7 @@ Return the proper metrics-server image name
 Return the proper Docker Image Registry Secret Names
 */}}
 {{- define "metrics-server.imagePullSecrets" -}}
-{{- include "common.images.pullSecrets" (dict "images" (list .Values.image ) "global" .Values.global) -}}
+{{- include "common.images.renderPullSecrets" (dict "images" (list .Values.image ) "context" $) -}}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
### Description of the change

The Metrics Server chart still uses the deprecated `common.images.pullSecrets` partial to render pull secrets. It was replaced with the recommended replacement `common.images.renderPullSecrets`.

### Benefits

The new helper adds support for templating of the name of the image pull secrets.

### Possible drawbacks

%

### Applicable issues

%

### Additional information

Tried to do a batch update in #21329

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
