### PR TITLE
[bitnami/opensearch] Use dedicated TLS secrets in nodes

### DIFF
--- a/bitnami/opensearch/Chart.yaml
+++ b/bitnami/opensearch/Chart.yaml
@@ -30,4 +30,4 @@ maintainers:
 name: opensearch
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/opensearch
-version: 0.5.2
+version: 0.5.3

--- a/bitnami/opensearch/templates/_helpers.tpl
+++ b/bitnami/opensearch/templates/_helpers.tpl
@@ -335,6 +335,42 @@ Return the opensearch admin TLS credentials secret for all nodes.
 {{- end -}}
 
 {{/*
+Return the opensearch TLS credentials secret for coordinating nodes.
+*/}}
+{{- define "opensearch.coordinating.tlsSecretName" -}}
+{{- $secretName := .Values.security.tls.coordinating.existingSecret -}}
+{{- if $secretName -}}
+    {{- printf "%s" (tpl $secretName $) -}}
+{{- else -}}
+    {{- printf "%s-crt" (include "opensearch.coordinating.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the opensearch TLS credentials secret for data nodes.
+*/}}
+{{- define "opensearch.data.tlsSecretName" -}}
+{{- $secretName := .Values.security.tls.data.existingSecret -}}
+{{- if $secretName -}}
+    {{- printf "%s" (tpl $secretName $) -}}
+{{- else -}}
+    {{- printf "%s-crt" (include "opensearch.data.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the opensearch TLS credentials secret for ingest nodes.
+*/}}
+{{- define "opensearch.ingest.tlsSecretName" -}}
+{{- $secretName := .Values.security.tls.ingest.existingSecret -}}
+{{- if $secretName -}}
+    {{- printf "%s" (tpl $secretName $) -}}
+{{- else -}}
+    {{- printf "%s-crt" (include "opensearch.ingest.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Return true if a TLS credentials secret object should be created
 */}}
 {{- define "opensearch.createTlsSecret" -}}

--- a/bitnami/opensearch/templates/coordinating/statefulset.yaml
+++ b/bitnami/opensearch/templates/coordinating/statefulset.yaml
@@ -267,7 +267,7 @@ spec:
             defaultMode: 256
             sources:
               - secret:
-                  name: {{ include "opensearch.master.tlsSecretName" . }}
+                  name: {{ include "opensearch.coordinating.tlsSecretName" . }}
               - secret:
                   name: {{ include "opensearch.admin.tlsSecretName" . }}
         {{- end }}

--- a/bitnami/opensearch/templates/data/statefulset.yaml
+++ b/bitnami/opensearch/templates/data/statefulset.yaml
@@ -290,7 +290,7 @@ spec:
             defaultMode: 256
             sources:
               - secret:
-                  name: {{ include "opensearch.master.tlsSecretName" . }}
+                  name: {{ include "opensearch.data.tlsSecretName" . }}
               - secret:
                   name: {{ include "opensearch.admin.tlsSecretName" . }}
         {{- end }}

--- a/bitnami/opensearch/templates/ingest/statefulset.yaml
+++ b/bitnami/opensearch/templates/ingest/statefulset.yaml
@@ -268,7 +268,7 @@ spec:
             defaultMode: 256
             sources:
               - secret:
-                  name: {{ include "opensearch.master.tlsSecretName" . }}
+                  name: {{ include "opensearch.ingest.tlsSecretName" . }}
               - secret:
                   name: {{ include "opensearch.admin.tlsSecretName" . }}
         {{- end }}


### PR DESCRIPTION
### Description of the change

For each type of OpenSearch node a dedicated certificate is created.

The nodes always mount the master nodes certificates.

### Benefits

Bugfix!

* The nodes now use their dedicated TLS certificate.
* Dashboards container can now communicate TLS encrypted with Opensearch

### Possible drawbacks

None, that I'm aware of.

### Applicable issues

None

### Additional information

Related PR #21287 

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
