### PR TITLE
[bitnami/mysql] Allow to set a persistentVolumeClaimRetentionPolicy

### DIFF
--- a/bitnami/mysql/Chart.yaml
+++ b/bitnami/mysql/Chart.yaml
@@ -34,4 +34,4 @@ maintainers:
 name: mysql
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/mysql
-version: 9.14.4
+version: 9.15.0

--- a/bitnami/mysql/README.md
+++ b/bitnami/mysql/README.md
@@ -177,6 +177,9 @@ The command removes all the Kubernetes components associated with the chart and 
 | `primary.persistence.accessModes`                           | MySQL primary persistent volume access Modes                                                                    | `["ReadWriteOnce"]` |
 | `primary.persistence.size`                                  | MySQL primary persistent volume size                                                                            | `8Gi`               |
 | `primary.persistence.selector`                              | Selector to match an existing Persistent Volume                                                                 | `{}`                |
+| `primary.persistentVolumeClaimRetentionPolicy.enabled`      | Enable Persistent volume retention policy for Primary StatefulSet                                               | `false`             |
+| `primary.persistentVolumeClaimRetentionPolicy.whenScaled`   | Volume retention behavior when the replica count of the StatefulSet is reduced                                  | `Retain`            |
+| `primary.persistentVolumeClaimRetentionPolicy.whenDeleted`  | Volume retention behavior that applies when the StatefulSet is deleted                                          | `Retain`            |
 | `primary.extraVolumes`                                      | Optionally specify extra list of additional volumes to the MySQL Primary pod(s)                                 | `[]`                |
 | `primary.extraVolumeMounts`                                 | Optionally specify extra list of additional volumeMounts for the MySQL Primary container(s)                     | `[]`                |
 | `primary.initContainers`                                    | Add additional init containers for the MySQL Primary pod(s)                                                     | `[]`                |
@@ -270,6 +273,9 @@ The command removes all the Kubernetes components associated with the chart and 
 | `secondary.persistence.accessModes`                           | MySQL secondary persistent volume access Modes                                                                      | `["ReadWriteOnce"]` |
 | `secondary.persistence.size`                                  | MySQL secondary persistent volume size                                                                              | `8Gi`               |
 | `secondary.persistence.selector`                              | Selector to match an existing Persistent Volume                                                                     | `{}`                |
+| `secondary.persistentVolumeClaimRetentionPolicy.enabled`      | Enable Persistent volume retention policy for Secondary StatefulSet                                                 | `false`             |
+| `secondary.persistentVolumeClaimRetentionPolicy.whenScaled`   | Volume retention behavior when the replica count of the StatefulSet is reduced                                      | `Retain`            |
+| `secondary.persistentVolumeClaimRetentionPolicy.whenDeleted`  | Volume retention behavior that applies when the StatefulSet is deleted                                              | `Retain`            |
 | `secondary.extraVolumes`                                      | Optionally specify extra list of additional volumes to the MySQL secondary pod(s)                                   | `[]`                |
 | `secondary.extraVolumeMounts`                                 | Optionally specify extra list of additional volumeMounts for the MySQL secondary container(s)                       | `[]`                |
 | `secondary.initContainers`                                    | Add additional init containers for the MySQL secondary pod(s)                                                       | `[]`                |

--- a/bitnami/mysql/README.md
+++ b/bitnami/mysql/README.md
@@ -273,7 +273,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `secondary.persistence.accessModes`                           | MySQL secondary persistent volume access Modes                                                                      | `["ReadWriteOnce"]` |
 | `secondary.persistence.size`                                  | MySQL secondary persistent volume size                                                                              | `8Gi`               |
 | `secondary.persistence.selector`                              | Selector to match an existing Persistent Volume                                                                     | `{}`                |
-| `secondary.persistentVolumeClaimRetentionPolicy.enabled`      | Enable Persistent volume retention policy for Secondary StatefulSet                                                 | `false`             |
+| `secondary.persistentVolumeClaimRetentionPolicy.enabled`      | Enable Persistent volume retention policy for read only StatefulSet                                                 | `false`             |
 | `secondary.persistentVolumeClaimRetentionPolicy.whenScaled`   | Volume retention behavior when the replica count of the StatefulSet is reduced                                      | `Retain`            |
 | `secondary.persistentVolumeClaimRetentionPolicy.whenDeleted`  | Volume retention behavior that applies when the StatefulSet is deleted                                              | `Retain`            |
 | `secondary.extraVolumes`                                      | Optionally specify extra list of additional volumes to the MySQL secondary pod(s)                                   | `[]`                |

--- a/bitnami/mysql/templates/primary/statefulset.yaml
+++ b/bitnami/mysql/templates/primary/statefulset.yaml
@@ -367,6 +367,11 @@ spec:
         - name: data
           emptyDir: {}
   {{- else if and .Values.primary.persistence.enabled (not .Values.primary.persistence.existingClaim) }}
+  {{- if .Values.primary.persistentVolumeClaimRetentionPolicy.enabled }}
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: {{ .Values.primary.persistentVolumeClaimRetentionPolicy.whenDeleted }}
+    whenScaled: {{ .Values.primary.persistentVolumeClaimRetentionPolicy.whenScaled }}
+  {{- end }}
   volumeClaimTemplates:
     - metadata:
         name: data

--- a/bitnami/mysql/templates/secondary/statefulset.yaml
+++ b/bitnami/mysql/templates/secondary/statefulset.yaml
@@ -347,6 +347,11 @@ spec:
         - name: data
           emptyDir: {}
   {{- else }}
+  {{- if .Values.secondary.persistentVolumeClaimRetentionPolicy.enabled }}
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: {{ .Values.secondary.persistentVolumeClaimRetentionPolicy.whenDeleted }}
+    whenScaled: {{ .Values.secondary.persistentVolumeClaimRetentionPolicy.whenScaled }}
+  {{- end }}
   volumeClaimTemplates:
     - metadata:
         name: data

--- a/bitnami/mysql/values.yaml
+++ b/bitnami/mysql/values.yaml
@@ -472,6 +472,19 @@ primary:
     ##     app: my-app
     ##
     selector: {}
+  ## Primary Persistent Volume Claim Retention Policy
+  ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#persistentvolumeclaim-retention
+  ##
+  persistentVolumeClaimRetentionPolicy:
+    ## @param primary.persistentVolumeClaimRetentionPolicy.enabled Enable Persistent volume retention policy for Primary StatefulSet
+    ##
+    enabled: false
+    ## @param primary.persistentVolumeClaimRetentionPolicy.whenScaled Volume retention behavior when the replica count of the StatefulSet is reduced
+    ##
+    whenScaled: Retain
+    ## @param primary.persistentVolumeClaimRetentionPolicy.whenDeleted Volume retention behavior that applies when the StatefulSet is deleted
+    ##
+    whenDeleted: Retain
   ## @param primary.extraVolumes Optionally specify extra list of additional volumes to the MySQL Primary pod(s)
   ##
   extraVolumes: []
@@ -858,6 +871,19 @@ secondary:
     ##     app: my-app
     ##
     selector: {}
+  ## Secondary Persistent Volume Claim Retention Policy
+  ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#persistentvolumeclaim-retention
+  ##
+  persistentVolumeClaimRetentionPolicy:
+    ## @param secondary.persistentVolumeClaimRetentionPolicy.enabled Enable Persistent volume retention policy for read only StatefulSet
+    ##
+    enabled: false
+    ## @param secondary.persistentVolumeClaimRetentionPolicy.whenScaled Volume retention behavior when the replica count of the StatefulSet is reduced
+    ##
+    whenScaled: Retain
+    ## @param secondary.persistentVolumeClaimRetentionPolicy.whenDeleted Volume retention behavior that applies when the StatefulSet is deleted
+    ##
+    whenDeleted: Retain
   ## @param secondary.extraVolumes Optionally specify extra list of additional volumes to the MySQL secondary pod(s)
   ##
   extraVolumes: []


### PR DESCRIPTION
### Description of the change

Allow to specify a persistentVolumeClaimRetentionPolicy in both the primary and secondary StatefulSet.

### Benefits

This allows for automatic cleanup of PVCs after deletion, etc. An example use case of this is for highly dynamic test environments, where cleaning up the PVCs after deletion of the helm chart is preferred.

### Possible drawbacks

None, it needs to be enabled, and the defaults are the same as Kubernetes specifies if it is not defined. 

### Applicable issues

None.

### Additional information

This is implemented following the same pattern as the postgresql helm chart. 

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md`
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)