### PR TITLE
[bitnami/kafka] Fixed the EXTERNAL_ACCESS_HOST_USE_PUBLIC_IP issue

### DIFF
--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -42,4 +42,4 @@ maintainers:
 name: kafka
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/kafka
-version: 26.4.4
+version: 26.4.5

--- a/bitnami/kafka/templates/scripts-configmap.yaml
+++ b/bitnami/kafka/templates/scripts-configmap.yaml
@@ -157,7 +157,7 @@ data:
         read -r -a hosts <<<"$(tr ',' ' ' <<<"${EXTERNAL_ACCESS_HOSTS_LIST}")"
         host="${hosts[$POD_ID]}"
       elif [[ "$EXTERNAL_ACCESS_HOST_USE_PUBLIC_IP" =~ ^(yes|true)$ ]]; then
-        host=$(curl -s https://ipinfo.io/ip)
+        host=$(curl -s https://ifconfig.me)
       else
         error "External access hostname not provided"
       fi


### PR DESCRIPTION
<!--
Fixes the https://github.com/bitnami/charts/issues/21498
 -->

### Description of the change

Fixes the EXTERNAL_ACCESS_HOST_USE_PUBLIC_IP issue

### Benefits

Can retrieve  the public IP of the host

### Possible drawbacks

NA

### Applicable issues


- fixes # https://github.com/bitnami/charts/issues/21498

### Additional information

NA

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [ ] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [ ] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
