### PR TITLE
[bitnami/mlflow] Fix faulty type conversion in serviceMonitor

### DIFF
--- a/bitnami/mlflow/Chart.yaml
+++ b/bitnami/mlflow/Chart.yaml
@@ -43,4 +43,4 @@ name: mlflow
 sources:
 - https://github.com/bitnami/containers/tree/main/bitnami/mlflow
 - https://github.com/mlflow/mlflow
-version: 0.3.1
+version: 0.3.2

--- a/bitnami/mlflow/templates/_helpers.tpl
+++ b/bitnami/mlflow/templates/_helpers.tpl
@@ -78,7 +78,14 @@ Return the MLflow Tracking Secret key for the user
 Return the MLFlow Trakcing Port
 */}}
 {{- define "mlflow.v0.tracking.port" -}}
-{{- int ( ternary .Values.tracking.service.ports.https .Values.tracking.service.ports.http .Values.tracking.tls.enabled ) -}}
+{{- ternary .Values.tracking.service.ports.https .Values.tracking.service.ports.http .Values.tracking.tls.enabled -}}
+{{- end -}}
+
+{{/*
+Return the MLFlow Trakcing Port Name
+*/}}
+{{- define "mlflow.v0.tracking.portName" -}}
+{{- printf "%s-mlflow" (ternary "https" "http" .Values.tracking.tls.enabled) -}}
 {{- end -}}
 
 {{/*

--- a/bitnami/mlflow/templates/_helpers.tpl
+++ b/bitnami/mlflow/templates/_helpers.tpl
@@ -78,14 +78,14 @@ Return the MLflow Tracking Secret key for the user
 Return the MLFlow Trakcing Port
 */}}
 {{- define "mlflow.v0.tracking.port" -}}
-{{- ternary .Values.tracking.service.ports.https .Values.tracking.service.ports.http .Values.tracking.tls.enabled -}}
+{{- int ( ternary .Values.tracking.service.ports.https .Values.tracking.service.ports.http .Values.tracking.tls.enabled ) -}}
 {{- end -}}
 
 {{/*
 Return the MLFlow Trakcing Port Name
 */}}
 {{- define "mlflow.v0.tracking.portName" -}}
-{{- printf "%s-mlflow" (ternary "https" "http" .Values.tracking.tls.enabled) -}}
+{{- ternary "https" "http" .Values.tracking.tls.enabled -}}
 {{- end -}}
 
 {{/*

--- a/bitnami/mlflow/templates/_helpers.tpl
+++ b/bitnami/mlflow/templates/_helpers.tpl
@@ -75,28 +75,28 @@ Return the MLflow Tracking Secret key for the user
 {{- end -}}
 
 {{/*
-Return the MLFlow Trakcing Port
+Return the MLFlow Tracking Port
 */}}
 {{- define "mlflow.v0.tracking.port" -}}
 {{- int ( ternary .Values.tracking.service.ports.https .Values.tracking.service.ports.http .Values.tracking.tls.enabled ) -}}
 {{- end -}}
 
 {{/*
-Return the MLFlow Trakcing Port Name
+Return the MLFlow Tracking Port Name
 */}}
 {{- define "mlflow.v0.tracking.portName" -}}
 {{- ternary "https" "http" .Values.tracking.tls.enabled -}}
 {{- end -}}
 
 {{/*
-Return the MLFlow Trakcing Protocol
+Return the MLFlow Tracking Protocol
 */}}
 {{- define "mlflow.v0.tracking.protocol" -}}
 {{- ternary "https" "http" .Values.tracking.tls.enabled -}}
 {{- end -}}
 
 {{/*
-Return the MLFlow Trakcing URI
+Return the MLFlow Tracking URI
 */}}
 {{- define "mlflow.v0.tracking.uri" -}}
 {{ printf "%s://%s:%v" (include "mlflow.v0.tracking.protocol" .) (include "mlflow.v0.tracking.fullname" .) (include "mlflow.v0.tracking.port" .) }}

--- a/bitnami/mlflow/templates/tracking/deployment.yaml
+++ b/bitnami/mlflow/templates/tracking/deployment.yaml
@@ -201,7 +201,7 @@ spec:
           resources: {{- toYaml .Values.tracking.resources | nindent 12 }}
           {{- end }}
           ports:
-            - name: {{ include "mlflow.v0.tracking.protocol" . }}
+            - name: {{ include "mlflow.v0.tracking.portName" . }}
               containerPort: {{ .Values.tracking.containerPorts.http }}
           {{- if not .Values.diagnosticMode.enabled }}
           {{- if .Values.tracking.customLivenessProbe }}
@@ -210,11 +210,11 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.tracking.livenessProbe "enabled") "context" $) | nindent 12 }}
             {{- if .Values.tracking.auth.enabled }}
             tcpSocket:
-              port: {{ include "mlflow.v0.tracking.protocol" . }}
+              port: {{ include "mlflow.v0.tracking.portName" . }}
             {{- else }}
             httpGet:
               path: /
-              port: {{ include "mlflow.v0.tracking.protocol" . }}
+              port: {{ include "mlflow.v0.tracking.portName" . }}
             {{- end }}
           {{- end }}
           {{- if .Values.tracking.customReadinessProbe }}
@@ -223,11 +223,11 @@ spec:
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.tracking.readinessProbe "enabled") "context" $) | nindent 12 }}
             {{- if .Values.tracking.auth.enabled }}
             tcpSocket:
-              port: {{ include "mlflow.v0.tracking.protocol" . }}
+              port: {{ include "mlflow.v0.tracking.portName" . }}
             {{- else }}
             httpGet:
               path: /
-              port: {{ include "mlflow.v0.tracking.protocol" . }}
+              port: {{ include "mlflow.v0.tracking.portName" . }}
             {{- end }}
           {{- end }}
           {{- if .Values.tracking.customStartupProbe }}
@@ -236,11 +236,11 @@ spec:
           startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.tracking.startupProbe "enabled") "context" $) | nindent 12 }}
             {{- if .Values.tracking.auth.enabled }}
             tcpSocket:
-              port: {{ include "mlflow.v0.tracking.protocol" . }}
+              port: {{ include "mlflow.v0.tracking.portName" . }}
             {{- else }}
             httpGet:
               path: /
-              port: {{ include "mlflow.v0.tracking.protocol" . }}
+              port: {{ include "mlflow.v0.tracking.portName" . }}
             {{- end }}
           {{- end }}
           {{- end }}

--- a/bitnami/mlflow/templates/tracking/ingress.yaml
+++ b/bitnami/mlflow/templates/tracking/ingress.yaml
@@ -32,7 +32,7 @@ spec:
             {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
             pathType: {{ .Values.tracking.ingress.pathType }}
             {{- end }}
-            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "mlflow.v0.tracking.fullname" .) "servicePort" (include "mlflow.v0.tracking.portName" $)  "context" $)  | nindent 14 }}
+            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "mlflow.v0.tracking.fullname" .) "servicePort" (include "mlflow.v0.tracking.protocol" $)  "context" $)  | nindent 14 }}
     {{- end }}
     {{- range .Values.tracking.ingress.extraHosts }}
     - host: {{ .name | quote }}
@@ -42,7 +42,7 @@ spec:
             {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
             pathType: {{ default "ImplementationSpecific" .pathType }}
             {{- end }}
-            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "mlflow.v0.tracking.fullname" $) "servicePort" (include "mlflow.v0.tracking.portName" $) "context" $) | nindent 14 }}
+            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "mlflow.v0.tracking.fullname" $) "servicePort" (include "mlflow.v0.tracking.protocol" $) "context" $) | nindent 14 }}
     {{- end }}
     {{- if .Values.tracking.ingress.extraRules }}
     {{- include "common.tplvalues.render" (dict "value" .Values.tracking.ingress.extraRules "context" $) | nindent 4 }}

--- a/bitnami/mlflow/templates/tracking/ingress.yaml
+++ b/bitnami/mlflow/templates/tracking/ingress.yaml
@@ -32,7 +32,7 @@ spec:
             {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
             pathType: {{ .Values.tracking.ingress.pathType }}
             {{- end }}
-            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "mlflow.v0.tracking.fullname" .) "servicePort" "http" "context" $)  | nindent 14 }}
+            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "mlflow.v0.tracking.fullname" .) "servicePort" (include "mlflow.v0.tracking.portName" $)  "context" $)  | nindent 14 }}
     {{- end }}
     {{- range .Values.tracking.ingress.extraHosts }}
     - host: {{ .name | quote }}
@@ -42,7 +42,7 @@ spec:
             {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
             pathType: {{ default "ImplementationSpecific" .pathType }}
             {{- end }}
-            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "mlflow.v0.tracking.fullname" $) "servicePort" "http" "context" $) | nindent 14 }}
+            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "mlflow.v0.tracking.fullname" $) "servicePort" (include "mlflow.v0.tracking.portName" $) "context" $) | nindent 14 }}
     {{- end }}
     {{- if .Values.tracking.ingress.extraRules }}
     {{- include "common.tplvalues.render" (dict "value" .Values.tracking.ingress.extraRules "context" $) | nindent 4 }}

--- a/bitnami/mlflow/templates/tracking/service.yaml
+++ b/bitnami/mlflow/templates/tracking/service.yaml
@@ -40,27 +40,15 @@ spec:
   loadBalancerIP: {{ .Values.tracking.service.loadBalancerIP }}
   {{- end }}
   ports:
-    {{- if .Values.tracking.tls.enabled }}
-    - name: https
-      port: {{ .Values.tracking.service.ports.https }}
+    - name: {{ include "mlflow.v0.tracking.portName" . }}
+      port: {{ get .Values.tracking.service.ports (include "mlflow.v0.tracking.protocol" .) }}
       protocol: TCP
-      {{- if and (or (eq .Values.tracking.service.type "NodePort") (eq .Values.tracking.service.type "LoadBalancer")) (not (empty .Values.tracking.service.nodePorts.https)) }}
-      nodePort: {{ .Values.tracking.service.nodePorts.https }}
+      {{- if and (or (eq .Values.tracking.service.type "NodePort") (eq .Values.tracking.service.type "LoadBalancer")) (not (empty (get .Values.tracking.service.nodePorts (include "mlflow.v0.tracking.protocol" .)))) }}
+      nodePort: {{ get .Values.tracking.service.nodePorts (include "mlflow.v0.tracking.protocol" .) }}
       {{- else if eq .Values.tracking.service.type "ClusterIP" }}
       nodePort: null
       {{- end }}
-      targetPort: https
-    {{- else }}
-    - name: http
-      port: {{ .Values.tracking.service.ports.http }}
-      protocol: TCP
-      {{- if and (or (eq .Values.tracking.service.type "NodePort") (eq .Values.tracking.service.type "LoadBalancer")) (not (empty .Values.tracking.service.nodePorts.http)) }}
-      nodePort: {{ .Values.tracking.service.nodePorts.http }}
-      {{- else if eq .Values.tracking.service.type "ClusterIP" }}
-      nodePort: null
-      {{- end }}
-      targetPort: http
-    {{- end }}
+      targetPort: {{ include "mlflow.v0.tracking.portName" . }}
     {{- if .Values.tracking.service.extraPorts }}
     {{- include "common.tplvalues.render" (dict "value" .Values.tracking.service.extraPorts "context" $) | nindent 4 }}
     {{- end }}

--- a/bitnami/mlflow/templates/tracking/servicemonitor.yaml
+++ b/bitnami/mlflow/templates/tracking/servicemonitor.yaml
@@ -27,7 +27,7 @@ spec:
       {{- include "common.tplvalues.render" (dict "value" .Values.tracking.metrics.serviceMonitor.selector "context" $) | nindent 6 }}
       {{- end }}
   endpoints:
-    - port: {{ include "mlflow.v0.tracking.port" . }}
+    - port: {{ include "mlflow.v0.tracking.portName" . }}
       {{- if .Values.tracking.auth.enabled }}
       basicAuth:
         password:


### PR DESCRIPTION
### Description of the change

Follow up #21235, fix wrong type conversion in serviceMonitor.

### Benefits

Fix issue reported in #20668

### Possible drawbacks

None

### Applicable issues

- fixes #20668
- related to #21316

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
