### PR TITLE
Remove explicit null assignment to nodePort in Kubernetes Service

### DIFF
--- a/bitnami/grafana-operator/Chart.yaml
+++ b/bitnami/grafana-operator/Chart.yaml
@@ -6,11 +6,11 @@ annotations:
   licenses: Apache-2.0
   images: |
     - name: grafana-operator
-      image: docker.io/bitnami/grafana-operator:5.5.2-debian-11-r1
+      image: docker.io/bitnami/grafana-operator:5.6.0-debian-11-r0
     - name: grafana
-      image: docker.io/bitnami/grafana:10.2.2-debian-11-r1
+      image: docker.io/bitnami/grafana:10.2.2-debian-11-r3
 apiVersion: v2
-appVersion: 5.5.2
+appVersion: 5.6.0
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
@@ -30,4 +30,4 @@ maintainers:
 name: grafana-operator
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/grafana-operator
-version: 3.5.10
+version: 3.5.11

--- a/bitnami/grafana-operator/values.yaml
+++ b/bitnami/grafana-operator/values.yaml
@@ -151,7 +151,7 @@ operator:
   image:
     registry: docker.io
     repository: bitnami/grafana-operator
-    tag: 5.5.2-debian-11-r1
+    tag: 5.6.0-debian-11-r0
     digest: ""
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
@@ -420,7 +420,7 @@ grafana:
   image:
     registry: docker.io
     repository: bitnami/grafana
-    tag: 10.2.2-debian-11-r1
+    tag: 10.2.2-debian-11-r3
     digest: ""
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'

--- a/bitnami/rabbitmq/Chart.yaml
+++ b/bitnami/rabbitmq/Chart.yaml
@@ -30,4 +30,4 @@ maintainers:
 name: rabbitmq
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/rabbitmq
-version: 12.5.6
+version: 12.5.7

--- a/bitnami/rabbitmq/templates/svc.yaml
+++ b/bitnami/rabbitmq/templates/svc.yaml
@@ -45,9 +45,7 @@ spec:
     - name: {{ .Values.service.portNames.amqp }}
       port: {{ .Values.service.ports.amqp }}
       targetPort: amqp
-      {{- if (eq .Values.service.type "ClusterIP") }}
-      nodePort: null
-      {{- else if and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) (not (empty .Values.service.nodePorts.amqp)) }}
+      {{- if and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) (not (empty .Values.service.nodePorts.amqp)) }}
       nodePort: {{ .Values.service.nodePorts.amqp }}
       {{- end }}
     {{- end }}
@@ -55,9 +53,7 @@ spec:
     - name: {{ .Values.service.portNames.amqpTls }}
       port: {{ .Values.service.ports.amqpTls }}
       targetPort: amqp-tls
-      {{- if (eq .Values.service.type "ClusterIP") }}
-      nodePort: null
-      {{- else if and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) (not (empty .Values.service.nodePorts.amqpTls)) }}
+      {{- if and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) (not (empty .Values.service.nodePorts.amqpTls)) }}
       nodePort: {{ .Values.service.nodePorts.amqpTls }}
       {{- end }}
     {{- end }}
@@ -65,9 +61,7 @@ spec:
     - name: {{ .Values.service.portNames.epmd }}
       port: {{ .Values.service.ports.epmd }}
       targetPort: epmd
-      {{- if (eq .Values.service.type "ClusterIP") }}
-      nodePort: null
-      {{- else if and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) (not (empty .Values.service.nodePorts.epmd)) }}
+      {{- if and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) (not (empty .Values.service.nodePorts.epmd)) }}
       nodePort: {{ .Values.service.nodePorts.epmd }}
       {{- end }}
     {{- end }}
@@ -75,9 +69,7 @@ spec:
     - name: {{ .Values.service.portNames.dist }}
       port: {{ .Values.service.ports.dist }}
       targetPort: dist
-      {{- if eq .Values.service.type "ClusterIP" }}
-      nodePort: null
-      {{- else if and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) (not (empty .Values.service.nodePorts.dist)) }}
+      {{- if and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) (not (empty .Values.service.nodePorts.dist)) }}
       nodePort: {{ .Values.service.nodePorts.dist }}
       {{- end }}
     {{- end }}
@@ -85,9 +77,7 @@ spec:
     - name: {{ .Values.service.portNames.manager }}
       port: {{ .Values.service.ports.manager  }}
       targetPort: stats
-      {{- if eq .Values.service.type "ClusterIP" }}
-      nodePort: null
-      {{- else if and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) (not (empty .Values.service.nodePorts.manager)) }}
+      {{- if and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) (not (empty .Values.service.nodePorts.manager)) }}
       nodePort: {{ .Values.service.nodePorts.manager }}
       {{- end }}
     {{- end }}
@@ -95,9 +85,7 @@ spec:
     - name: {{ .Values.service.portNames.metrics }}
       port: {{ .Values.service.ports.metrics }}
       targetPort: metrics
-      {{- if eq .Values.service.type "ClusterIP" }}
-      nodePort: null
-      {{- else if and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) (not (empty .Values.service.nodePorts.metrics)) }}
+      {{- if and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) (not (empty .Values.service.nodePorts.metrics)) }}
       nodePort: {{ .Values.service.nodePorts.metrics }}
       {{- end }}
     {{- end }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->
Remove explicit null assignment to nodePort in Kubernetes Service
### Benefits

<!-- What benefits will be realized by the code change? -->
In Kubernetes Service, it is not necessary to explicitly set nodePort to null. If nodePort is not set, its value defaults to null. This commit removes the explicit null assignment, simplifying the code.
### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #21501 

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
