### PR TITLE
[bitnami/influxdb] Allow separate persistence cfg for backups

### DIFF
--- a/bitnami/influxdb/Chart.yaml
+++ b/bitnami/influxdb/Chart.yaml
@@ -37,4 +37,4 @@ maintainers:
 name: influxdb
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/influxdb
-version: 5.11.1
+version: 5.12.0

--- a/bitnami/influxdb/README.md
+++ b/bitnami/influxdb/README.md
@@ -278,6 +278,12 @@ The command removes all the Kubernetes components associated with the chart and 
 | `backup.enabled`                                                   | Enable InfluxDB&trade; backup                                                                                    | `false`                            |
 | `backup.directory`                                                 | Directory where backups are stored                                                                               | `/backups`                         |
 | `backup.retentionDays`                                             | Retention time in days for backups (older backups are deleted)                                                   | `10`                               |
+| `backup.persistence.enabled`                                       | Enable data persistence for backup volume                                                                        | `true`                             |
+| `backup.persistence.existingClaim`                                 | Use a existing PVC which must be created manually before bound                                                   | `""`                               |
+| `backup.persistence.storageClass`                                  | Specify the `storageClass` used to provision the volume                                                          | `""`                               |
+| `backup.persistence.accessModes`                                   | Access mode of data volume                                                                                       | `["ReadWriteOnce"]`                |
+| `backup.persistence.size`                                          | Size of data volume                                                                                              | `8Gi`                              |
+| `backup.persistence.annotations`                                   | Persistent Volume Claim annotations                                                                              | `{}`                               |
 | `backup.cronjob.schedule`                                          | Schedule in Cron format to save snapshots                                                                        | `0 2 * * *`                        |
 | `backup.cronjob.historyLimit`                                      | Number of successful finished jobs to retain                                                                     | `1`                                |
 | `backup.cronjob.podAnnotations`                                    | Pod annotations                                                                                                  | `{}`                               |
@@ -443,6 +449,8 @@ As an alternative, you can use of the preset configurations for pod affinity, po
 
 The data is persisted by default using PVC(s). You can disable the persistence setting the `persistence.enabled` parameter to `false`.
 A default `StorageClass` is needed in the Kubernetes cluster to dynamically provision the volumes. Specify another StorageClass in the `persistence.storageClass` or set `persistence.existingClaim` if you have already existing persistent volumes to use.
+
+If you would like to define persistence settings for a backup volume that differ from the persistence settings for the database volume, you may do so under the `backup.persistence` section of the configuration. If this section is undefined, but `backup.enabled` is set to true, the backup volume will be defined using the `persistence` parameter section.
 
 ### Adjust permissions of persistent volume mountpoint
 

--- a/bitnami/influxdb/templates/cronjob-backup.yaml
+++ b/bitnami/influxdb/templates/cronjob-backup.yaml
@@ -27,7 +27,8 @@ spec:
           annotations: {{- include "common.tplvalues.render" (dict "value" .Values.backup.cronjob.podAnnotations "context" $) | nindent 12 }}
           {{- end }}
         spec:
-          {{- if .Values.backup.cronjob.securityContext.enabled }}
+          {{- /* .Values.backup.cronjob.securityContext default value is missing from values.yaml */ -}}
+          {{- if and .Values.backup.cronjob.securityContext .Values.backup.cronjob.securityContext.enabled }}
           # Deprecated, use backup.cronjob.podSecurityContext
           securityContext: {{- omit .Values.backup.cronjob.securityContext "enabled" | toYaml | nindent 12 }}
           {{- else if .Values.backup.cronjob.podSecurityContext.enabled }}

--- a/bitnami/influxdb/templates/cronjob-backup.yaml
+++ b/bitnami/influxdb/templates/cronjob-backup.yaml
@@ -50,7 +50,7 @@ spec:
             {{- end }}
             {{- end }}
             - name: {{ include "common.names.fullname" . }}-backups
-            {{- if .Values.persistence.enabled }}
+            {{- if or .Values.backup.persistence.enabled .Values.persistence.enabled }}
               persistentVolumeClaim:
                 claimName: {{ include "common.names.fullname" . }}-backups
             {{- else }}

--- a/bitnami/influxdb/templates/pvc-backup.yaml
+++ b/bitnami/influxdb/templates/pvc-backup.yaml
@@ -2,26 +2,17 @@
 Copyright VMware, Inc.
 SPDX-License-Identifier: APACHE-2.0
 */}}
-
-{{- if and .Values.backup.enabled .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
-kind: PersistentVolumeClaim
-apiVersion: v1
-metadata:
-  name: {{ include "common.names.fullname" . }}-backups
-  namespace: {{ .Release.Namespace | quote }}
-  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
-    app.kubernetes.io/component: influxdb
-  {{- if or .Values.persistence.annotations .Values.commonAnnotations }}
-  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.persistence.annotations .Values.commonAnnotations ) "context" . ) }}
-  annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
+{{-
+/*
+Prefer .Values.backup.persistence, but fall back to .Values.persistence if not present.
+*/
+-}}
+{{- if .Values.backup.enabled }}
+  {{- if and .Values.backup.persistence .Values.backup.persistence.enabled (not .Values.backup.persistence.existingClaim) }}
+    {{- include "influxdb.backup.pvc" (list $ .Values.backup.persistence) }}
+  {{- else if and .Values.persistence.enabled }}
+    {{- include "influxdb.backup.pvc" (list $ .Values.persistence) }}
+  {{- else }}
+  {{/* Should backups be supported without any persistence? */}}
   {{- end }}
-spec:
-  accessModes:
-  {{- range .Values.persistence.accessModes }}
-    - {{ . | quote }}
-  {{- end }}
-  resources:
-    requests:
-      storage: {{ .Values.persistence.size | quote }}
-  {{- include "common.storage.class" ( dict "persistence" .Values.persistence "global" $) | nindent 2 }}
 {{- end }}

--- a/bitnami/influxdb/values.yaml
+++ b/bitnami/influxdb/values.yaml
@@ -874,6 +874,36 @@ backup:
   ## @param backup.retentionDays Retention time in days for backups (older backups are deleted)
   ##
   retentionDays: 10
+
+  ## Persistence parameters
+  ##
+  persistence:
+    ## @param backup.persistence.enabled Enable data persistence for backup volume
+    ##
+    enabled: true
+    ## @param backup.persistence.existingClaim Use a existing PVC which must be created manually before bound
+    ## If defined, PVC must be created manually before volume will be bound
+    ## The value is evaluated as a template
+    ##
+    existingClaim: ""
+    ## @param backup.persistence.storageClass Specify the `storageClass` used to provision the volume
+    ## If defined, storageClassName: <storageClass>
+    ## If set to "-", storageClassName: "", which disables dynamic provisioning
+    ## If undefined (the default) or set to null, no storageClassName spec is
+    ## set, choosing the default provisioner.
+    ##
+    storageClass: ""
+    ## @param backup.persistence.accessModes Access mode of data volume
+    ##
+    accessModes:
+      - ReadWriteOnce
+    ## @param backup.persistence.size Size of data volume
+    ##
+    size: 8Gi
+    ## @param backup.persistence.annotations Persistent Volume Claim annotations
+    ##
+    annotations: {}
+
   ## Cronjob configuration
   ## This cronjob is used to create InfluxDB&trade; backups
   ##


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the changes
- Fix failure to render when .Values.cronjob.securityContext is undefined (which is the current default in values.yaml)
- Add an optional configuration section under backup that allows the specification of distinct values for persistence. If this configuration section is not provided, the template will default to rendering using the existing top-level persistence configuration section to maintain compatibility.

### Benefits
Users can now define volumes for the Deployment and their backups separately without needing Kustomize or manual post-deployment hacks.

Example usage could include:
- using different StorageClasses for their backup volumes vs. their active database volumes.
- using a larger volume for backups vs. the main database volume to accommodate multiple full backups

### Possible drawbacks

<!-- Describe any known limitations with your change -->
There should not be any drawbacks to this PR; I have attempted to maintain backwards compatibility with existing use cases in the event that someone provides a values.yaml file that does not include the new section.

### Additional information

I would've committed the bugfix as a separate PR, but the template was failing to render without any changes in-place, so this fix is required to ensure the other commit works as expected.

If Bitnami releases patches for previous minor versions, I would recommend cherry-picking the first commit into a `5.11.2` release.

I've dumped the template out using permutations of both persistence modes to confirm that the `backup.persistence` section will take precedence over `persistence` for the backup volume, as well as to confirm that the templates still correctly render in the complete absence of that configuration section.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
