### PR TITLE
[bitnami/template] Update service.yaml

### DIFF
--- a/template/CHART_NAME/templates/service.yaml
+++ b/template/CHART_NAME/templates/service.yaml
@@ -49,6 +49,6 @@ spec:
     {{- if .Values.service.extraPorts }}
     {{- include "common.tplvalues.render" (dict "value" .Values.service.extraPorts "context" $) | nindent 4 }}
     {{- end }}
-  {{- $podLabels := include "common.tplvalues.merge (dict "values" .Values.%%MAIN_OBJECT_BLOCK%%.podLabels .Values.commonLabels "context" .) | fromYaml }}
+  {{- $podLabels := include "common.tplvalues.merge" (dict "values" (list .Values.%%MAIN_OBJECT_BLOCK%%.podLabels .Values.commonLabels) "context" .) | fromYaml }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: %%COMPONENT_NAME%%


### PR DESCRIPTION
[bitnami/template]  service.yaml syntax error

Should there be lint before push possibly? For example there could be two normalization steps before template linting:
- `.%%MAIN_OBJECT_BLOCK%%.` can be stripped
- `app.kubernetes.io/component: %%COMPONENT_NAME%%` removed
