### PR TITLE
[bitnami/matomo] Allow configuring CronJob pods affinity

### DIFF
--- a/bitnami/matomo/Chart.yaml
+++ b/bitnami/matomo/Chart.yaml
@@ -39,4 +39,4 @@ maintainers:
 name: matomo
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/matomo
-version: 3.2.3
+version: 3.3.0

--- a/bitnami/matomo/Chart.yaml
+++ b/bitnami/matomo/Chart.yaml
@@ -39,4 +39,4 @@ maintainers:
 name: matomo
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/matomo
-version: 3.2.2
+version: 3.2.3

--- a/bitnami/matomo/README.md
+++ b/bitnami/matomo/README.md
@@ -308,6 +308,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `cronjobs.taskScheduler.enabled`                                           | Whether to enable scheduled mail-to-task CronJob                     | `true`           |
 | `cronjobs.taskScheduler.schedule`                                          | Kubernetes CronJob schedule                                          | `*/5 * * * *`    |
 | `cronjobs.taskScheduler.suspend`                                           | Whether to create suspended CronJob                                  | `false`          |
+| `cronjobs.taskScheduler.affinity`                                          | Affinity for CronJob pod assignment                                  | `{}`             |
 | `cronjobs.taskScheduler.command`                                           | Override default container command (useful when using custom images) | `[]`             |
 | `cronjobs.taskScheduler.args`                                              | Override default container args (useful when using custom images)    | `[]`             |
 | `cronjobs.taskScheduler.containerSecurityContext.enabled`                  | Enabled containers' Security Context                                 | `true`           |
@@ -323,6 +324,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `cronjobs.archive.enabled`                                                 | Whether to enable scheduled mail-to-task CronJob                     | `true`           |
 | `cronjobs.archive.schedule`                                                | Kubernetes CronJob schedule                                          | `*/5 * * * *`    |
 | `cronjobs.archive.suspend`                                                 | Whether to create suspended CronJob                                  | `false`          |
+| `cronjobs.archive.affinity`                                                | Affinity for CronJob pod assignment                                  | `{}`             |
 | `cronjobs.archive.command`                                                 | Override default container command (useful when using custom images) | `[]`             |
 | `cronjobs.archive.args`                                                    | Override default container args (useful when using custom images)    | `[]`             |
 | `cronjobs.archive.containerSecurityContext.enabled`                        | Enabled containers' Security Context                                 | `true`           |

--- a/bitnami/matomo/templates/cronjob.yaml
+++ b/bitnami/matomo/templates/cronjob.yaml
@@ -35,6 +35,9 @@ spec:
         spec:
           {{- include "matomo.imagePullSecrets" . | nindent 10 }}
           restartPolicy: OnFailure
+          {{- if .Values.cronjobs.archive.affinity }}
+          affinity: {{- include "common.tplvalues.render" (dict "value" .Values.cronjobs.archive.affinity "context" $) | nindent 12 }}
+          {{- end }}
           initContainers:
             {{ include "matomo.initContainers" . | nindent 12 }}
           containers:
@@ -168,6 +171,9 @@ spec:
           {{- end }}
         spec:
           {{- include "matomo.imagePullSecrets" . | nindent 10 }}
+          {{- if .Values.cronjobs.taskScheduler.affinity }}
+          affinity: {{- include "common.tplvalues.render" (dict "value" .Values.cronjobs.taskScheduler.affinity "context" $) | nindent 12 }}
+          {{- end }}
           restartPolicy: OnFailure
           initContainers:
             {{ include "matomo.initContainers" . | nindent 12 }}

--- a/bitnami/matomo/values.yaml
+++ b/bitnami/matomo/values.yaml
@@ -945,6 +945,9 @@ cronjobs:
     ## @param cronjobs.taskScheduler.suspend Whether to create suspended CronJob
     ##
     suspend: false
+    ## @param cronjobs.taskScheduler.affinity Affinity for CronJob pod assignment
+    ##
+    affinity: {}
     ## @param cronjobs.taskScheduler.command Override default container command (useful when using custom images)
     ##
     command: []
@@ -991,6 +994,9 @@ cronjobs:
     ## @param cronjobs.archive.suspend Whether to create suspended CronJob
     ##
     suspend: false
+    ## @param cronjobs.archive.affinity Affinity for CronJob pod assignment
+    ##
+    affinity: {}
     ## @param cronjobs.archive.command Override default container command (useful when using custom images)
     ##
     command: []


### PR DESCRIPTION
### Description of the change

Allows to configure affinity for CronJobs.

### Benefits

Some k8s environments have limitations when attaching volume to more than one pod, eg. when using `rook-ceph` as storage driver you are not able to mount volume to pods assigned to different nodes: https://github.com/rook/rook/issues/4699

Allowing to configure CronJob pods affinity helps to resolve this issue by placing CronJob pods on the same node as Matomo pod.

### Possible drawbacks

No known drawbacks.

### Applicable issues

- workaround for [#20568](https://github.com/bitnami/charts/issues/20568)

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
