### PR TITLE
[bitnami/kafka] embedded jmx exporter agent

### DIFF
--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -42,4 +42,4 @@ maintainers:
 name: kafka
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/kafka
-version: 26.5.0
+version: 27.0.0

--- a/bitnami/kafka/README.md
+++ b/bitnami/kafka/README.md
@@ -542,21 +542,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `metrics.kafka.serviceAccount.name`                               | The name of the service account to use. If not set and `create` is `true`, a name is generated                                   | `""`                                                                                    |
 | `metrics.kafka.serviceAccount.automountServiceAccountToken`       | Allows auto mount of ServiceAccountToken on the serviceAccount created                                                           | `true`                                                                                  |
 | `metrics.jmx.enabled`                                             | Whether or not to expose JMX metrics to Prometheus                                                                               | `false`                                                                                 |
-| `metrics.jmx.kafkaJmxPort`                                        | JMX port where the exporter will collect metrics, exposed in the Kafka container.                                                | `5555`                                                                                  |
-| `metrics.jmx.image.registry`                                      | JMX exporter image registry                                                                                                      | `REGISTRY_NAME`                                                                         |
-| `metrics.jmx.image.repository`                                    | JMX exporter image repository                                                                                                    | `REPOSITORY_NAME/jmx-exporter`                                                          |
-| `metrics.jmx.image.digest`                                        | JMX exporter image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag                     | `""`                                                                                    |
-| `metrics.jmx.image.pullPolicy`                                    | JMX exporter image pull policy                                                                                                   | `IfNotPresent`                                                                          |
-| `metrics.jmx.image.pullSecrets`                                   | Specify docker-registry secret names as an array                                                                                 | `[]`                                                                                    |
-| `metrics.jmx.containerSecurityContext.enabled`                    | Enable Prometheus JMX exporter containers' Security Context                                                                      | `true`                                                                                  |
-| `metrics.jmx.containerSecurityContext.runAsUser`                  | Set Prometheus JMX exporter containers' Security Context runAsUser                                                               | `1001`                                                                                  |
-| `metrics.jmx.containerSecurityContext.runAsNonRoot`               | Set Prometheus JMX exporter containers' Security Context runAsNonRoot                                                            | `true`                                                                                  |
-| `metrics.jmx.containerSecurityContext.allowPrivilegeEscalation`   | Set Prometheus JMX exporter containers' Security Context allowPrivilegeEscalation                                                | `false`                                                                                 |
-| `metrics.jmx.containerSecurityContext.readOnlyRootFilesystem`     | Set Prometheus JMX exporter containers' Security Context readOnlyRootFilesystem                                                  | `true`                                                                                  |
-| `metrics.jmx.containerSecurityContext.capabilities.drop`          | Set Prometheus JMX exporter containers' Security Context capabilities to be dropped                                              | `["ALL"]`                                                                               |
 | `metrics.jmx.containerPorts.metrics`                              | Prometheus JMX exporter metrics container port                                                                                   | `5556`                                                                                  |
-| `metrics.jmx.resources.limits`                                    | The resources limits for the JMX exporter container                                                                              | `{}`                                                                                    |
-| `metrics.jmx.resources.requests`                                  | The requested resources for the JMX exporter container                                                                           | `{}`                                                                                    |
 | `metrics.jmx.service.ports.metrics`                               | Prometheus JMX exporter metrics service port                                                                                     | `5556`                                                                                  |
 | `metrics.jmx.service.clusterIP`                                   | Static clusterIP or None for headless services                                                                                   | `""`                                                                                    |
 | `metrics.jmx.service.sessionAffinity`                             | Control where client requests go, to the same pod or round-robin                                                                 | `None`                                                                                  |
@@ -1108,6 +1094,23 @@ This guide is an adaptation from upstream documentation: [Migrate from ZooKeeper
     For more information about decommissioning kafka broker check the [Kafka documentation](https://www.confluent.io/blog/remove-kafka-brokers-from-any-cluster-the-easy-way/).
 
 ## Upgrading
+
+### To 27.0.0
+
+This major release drops the jmx-exporter container (if `metrics.jmx.enabled`) in favor of embedding the exporter as a Java agent directly in the JVM that runs the Kafka controller or broker.
+This implies the follow values are no longer relevant because there is no longer a separate jmx-exporter container or image:
+
+- `metrics.jmx.image.registry`
+- `metrics.jmx.image.repository`
+- `metrics.jmx.image.tag`
+- `metrics.jmx.image.pullPolicy`
+- `metrics.jmx.image.pullSecrets`
+- `metrics.jmx.containerSecurityContext.enabled`
+- `metrics.jmx.containerSecurityContext.runAsUser`
+- `metrics.jmx.containerSecurityContext.runAsNonRoot`
+- `metrics.jmx.resources.limits`
+- `metrics.jmx.resources.requests`
+- `metrics.jmx.kafkaJmxPort`
 
 ### To 26.0.0
 

--- a/bitnami/kafka/templates/_helpers.tpl
+++ b/bitnami/kafka/templates/_helpers.tpl
@@ -65,17 +65,10 @@ Return the proper Kafka exporter image name
 {{- end -}}
 
 {{/*
-Return the proper JMX exporter image name
-*/}}
-{{- define "kafka.metrics.jmx.image" -}}
-{{ include "common.images.image" (dict "imageRoot" .Values.metrics.jmx.image "global" .Values.global) }}
-{{- end -}}
-
-{{/*
 Return the proper Docker Image Registry Secret Names
 */}}
 {{- define "kafka.imagePullSecrets" -}}
-{{ include "common.images.pullSecrets" (dict "images" (list .Values.image .Values.externalAccess.autoDiscovery.image .Values.volumePermissions.image .Values.metrics.kafka.image .Values.metrics.jmx.image) "global" .Values.global) }}
+{{ include "common.images.pullSecrets" (dict "images" (list .Values.image .Values.externalAccess.autoDiscovery.image .Values.volumePermissions.image .Values.metrics.kafka.image) "global" .Values.global) }}
 {{- end -}}
 
 {{/*
@@ -986,7 +979,6 @@ Check if there are rolling tags in the images
 {{- include "common.warnings.rollingTag" .Values.image }}
 {{- include "common.warnings.rollingTag" .Values.externalAccess.autoDiscovery.image }}
 {{- include "common.warnings.rollingTag" .Values.metrics.kafka.image }}
-{{- include "common.warnings.rollingTag" .Values.metrics.jmx.image }}
 {{- include "common.warnings.rollingTag" .Values.volumePermissions.image }}
 {{- end -}}
 

--- a/bitnami/kafka/templates/broker/statefulset.yaml
+++ b/bitnami/kafka/templates/broker/statefulset.yaml
@@ -221,8 +221,8 @@ spec:
             {{- end }}
             {{- end }}
             {{- if .Values.metrics.jmx.enabled }}
-            - name: JMX_PORT
-              value: {{ .Values.metrics.jmx.kafkaJmxPort | quote }}
+            - name: KAFKA_JMX_OPTS
+              value: "-javaagent:/opt/bitnami/jmx-exporter/jmx_prometheus_javaagent.jar={{ .Values.metrics.jmx.containerPorts.metrics }}:/etc/jmx-kafka/jmx-kafka-prometheus.yml"
             {{- end }}
             {{- if .Values.broker.extraEnvVars }}
             {{- include "common.tplvalues.render" ( dict "value" .Values.broker.extraEnvVars "context" $) | nindent 12 }}
@@ -257,6 +257,10 @@ spec:
             {{- if .Values.externalAccess.enabled }}
             - name: external
               containerPort: {{ .Values.listeners.external.containerPort }}
+            {{- end }}
+            {{- if .Values.metrics.jmx.enabled }}
+            - name: metrics
+              containerPort: {{ .Values.metrics.jmx.containerPorts.metrics }}
             {{- end }}
             {{- if .Values.listeners.extraListeners }}
             {{- include "kafka.extraListeners.containerPorts" . | nindent 12 }}
@@ -308,6 +312,10 @@ spec:
               mountPath: /opt/bitnami/kafka/config/log4j.properties
               subPath: log4j.properties
             {{- end }}
+            {{- if .Values.metrics.jmx.enabled }}
+            - name: jmx-config
+              mountPath: /etc/jmx-kafka
+            {{- end }}
             {{- if or .Values.tls.zookeeper.enabled (include "kafka.sslEnabled" .) }}
             - name: kafka-shared-certs
               mountPath: /opt/bitnami/kafka/config/certs
@@ -319,37 +327,6 @@ spec:
             {{- if .Values.broker.extraVolumeMounts }}
             {{- include "common.tplvalues.render" (dict "value" .Values.broker.extraVolumeMounts "context" $) | nindent 12 }}
             {{- end }}
-        {{- if .Values.metrics.jmx.enabled }}
-        - name: jmx-exporter
-          image: {{ include "kafka.metrics.jmx.image" . }}
-          imagePullPolicy: {{ .Values.metrics.jmx.image.pullPolicy | quote }}
-          {{- if .Values.metrics.jmx.containerSecurityContext.enabled }}
-          securityContext: {{- omit .Values.metrics.jmx.containerSecurityContext "enabled" | toYaml | nindent 12 }}
-          {{- end }}
-          {{- if .Values.diagnosticMode.enabled }}
-          command: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.command "context" $) | nindent 12 }}
-          args: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.args "context" $) | nindent 12 }}
-          {{- else }}
-          command:
-            - java
-          args:
-            - -XX:MaxRAMPercentage=100
-            - -XshowSettings:vm
-            - -jar
-            - jmx_prometheus_httpserver.jar
-            - "5556"
-            - /etc/jmx-kafka/jmx-kafka-prometheus.yml
-          {{- end }}
-          ports:
-            - name: metrics
-              containerPort: {{ .Values.metrics.jmx.containerPorts.metrics }}
-          {{- if .Values.metrics.jmx.resources }}
-          resources: {{- toYaml .Values.metrics.jmx.resources | nindent 12 }}
-          {{- end }}
-          volumeMounts:
-            - name: jmx-config
-              mountPath: /etc/jmx-kafka
-        {{- end }}
         {{- if .Values.broker.sidecars }}
         {{- include "common.tplvalues.render" (dict "value" .Values.broker.sidecars "context" $) | nindent 8 }}
         {{- end }}

--- a/bitnami/kafka/templates/controller-eligible/statefulset.yaml
+++ b/bitnami/kafka/templates/controller-eligible/statefulset.yaml
@@ -210,8 +210,8 @@ spec:
             {{- end }}
             {{- end }}
             {{- if .Values.metrics.jmx.enabled }}
-            - name: JMX_PORT
-              value: {{ .Values.metrics.jmx.kafkaJmxPort | quote }}
+            - name: KAFKA_JMX_OPTS
+              value: "-javaagent:/opt/bitnami/jmx-exporter/jmx_prometheus_javaagent.jar={{ .Values.metrics.jmx.containerPorts.metrics }}:/etc/jmx-kafka/jmx-kafka-prometheus.yml"
             {{- end }}
             {{- if .Values.controller.extraEnvVars }}
             {{- include "common.tplvalues.render" ( dict "value" .Values.controller.extraEnvVars "context" $) | nindent 12 }}
@@ -249,6 +249,10 @@ spec:
             {{- if .Values.externalAccess.enabled }}
             - name: external
               containerPort: {{ .Values.listeners.external.containerPort }}
+            {{- end }}
+            {{- if .Values.metrics.jmx.enabled }}
+            - name: metrics
+              containerPort: {{ .Values.metrics.jmx.containerPorts.metrics }}
             {{- end }}
             {{- if .Values.listeners.extraListeners }}
             {{- include "kafka.extraListeners.containerPorts" . | nindent 12 }}
@@ -301,6 +305,10 @@ spec:
               mountPath: /opt/bitnami/kafka/config/log4j.properties
               subPath: log4j.properties
             {{- end }}
+            {{- if .Values.metrics.jmx.enabled }}
+            - name: jmx-config
+              mountPath: /etc/jmx-kafka
+            {{- end }}
             {{- if or .Values.tls.zookeeper.enabled (include "kafka.sslEnabled" .) }}
             - name: kafka-shared-certs
               mountPath: /opt/bitnami/kafka/config/certs
@@ -312,37 +320,6 @@ spec:
             {{- if .Values.controller.extraVolumeMounts }}
             {{- include "common.tplvalues.render" (dict "value" .Values.controller.extraVolumeMounts "context" $) | nindent 12 }}
             {{- end }}
-        {{- if .Values.metrics.jmx.enabled }}
-        - name: jmx-exporter
-          image: {{ include "kafka.metrics.jmx.image" . }}
-          imagePullPolicy: {{ .Values.metrics.jmx.image.pullPolicy | quote }}
-          {{- if .Values.metrics.jmx.containerSecurityContext.enabled }}
-          securityContext: {{- omit .Values.metrics.jmx.containerSecurityContext "enabled" | toYaml | nindent 12 }}
-          {{- end }}
-          {{- if .Values.diagnosticMode.enabled }}
-          command: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.command "context" $) | nindent 12 }}
-          args: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.args "context" $) | nindent 12 }}
-          {{- else }}
-          command:
-            - java
-          args:
-            - -XX:MaxRAMPercentage=100
-            - -XshowSettings:vm
-            - -jar
-            - jmx_prometheus_httpserver.jar
-            - "5556"
-            - /etc/jmx-kafka/jmx-kafka-prometheus.yml
-          {{- end }}
-          ports:
-            - name: metrics
-              containerPort: {{ .Values.metrics.jmx.containerPorts.metrics }}
-          {{- if .Values.metrics.jmx.resources }}
-          resources: {{- toYaml .Values.metrics.jmx.resources | nindent 12 }}
-          {{- end }}
-          volumeMounts:
-            - name: jmx-config
-              mountPath: /etc/jmx-kafka
-        {{- end }}
         {{- if .Values.controller.sidecars }}
         {{- include "common.tplvalues.render" (dict "value" .Values.controller.sidecars "context" $) | nindent 8 }}
         {{- end }}

--- a/bitnami/kafka/values.yaml
+++ b/bitnami/kafka/values.yaml
@@ -1925,70 +1925,10 @@ metrics:
     ## @param metrics.jmx.enabled Whether or not to expose JMX metrics to Prometheus
     ##
     enabled: false
-    ## @param metrics.jmx.kafkaJmxPort JMX port where the exporter will collect metrics, exposed in the Kafka container.
-    ##
-    kafkaJmxPort: 5555
-    ## Bitnami JMX exporter image
-    ## ref: https://hub.docker.com/r/bitnami/jmx-exporter/tags/
-    ## @param metrics.jmx.image.registry [default: REGISTRY_NAME] JMX exporter image registry
-    ## @param metrics.jmx.image.repository [default: REPOSITORY_NAME/jmx-exporter] JMX exporter image repository
-    ## @skip metrics.jmx.image.tag JMX exporter image tag (immutable tags are recommended)
-    ## @param metrics.jmx.image.digest JMX exporter image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
-    ## @param metrics.jmx.image.pullPolicy JMX exporter image pull policy
-    ## @param metrics.jmx.image.pullSecrets Specify docker-registry secret names as an array
-    ##
-    image:
-      registry: docker.io
-      repository: bitnami/jmx-exporter
-      tag: 0.20.0-debian-11-r1
-      digest: ""
-      ## Specify a imagePullPolicy
-      ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
-      ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
-      ##
-      pullPolicy: IfNotPresent
-      ## Optionally specify an array of imagePullSecrets (secrets must be manually created in the namespace)
-      ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
-      ## e.g:
-      ## pullSecrets:
-      ##   - myRegistryKeySecretName
-      ##
-      pullSecrets: []
-    ## Prometheus JMX exporter containers' Security Context
-    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
-    ## @param metrics.jmx.containerSecurityContext.enabled Enable Prometheus JMX exporter containers' Security Context
-    ## @param metrics.jmx.containerSecurityContext.runAsUser Set Prometheus JMX exporter containers' Security Context runAsUser
-    ## @param metrics.jmx.containerSecurityContext.runAsNonRoot Set Prometheus JMX exporter containers' Security Context runAsNonRoot
-    ## @param metrics.jmx.containerSecurityContext.allowPrivilegeEscalation Set Prometheus JMX exporter containers' Security Context allowPrivilegeEscalation
-    ## @param metrics.jmx.containerSecurityContext.readOnlyRootFilesystem Set Prometheus JMX exporter containers' Security Context readOnlyRootFilesystem
-    ## @param metrics.jmx.containerSecurityContext.capabilities.drop Set Prometheus JMX exporter containers' Security Context capabilities to be dropped
-    ## e.g:
-    ##   containerSecurityContext:
-    ##     enabled: true
-    ##     capabilities:
-    ##       drop: ["NET_RAW"]
-    ##     readOnlyRootFilesystem: true
-    ##
-    containerSecurityContext:
-      enabled: true
-      runAsUser: 1001
-      runAsNonRoot: true
-      allowPrivilegeEscalation: false
-      readOnlyRootFilesystem: true
-      capabilities:
-        drop: ["ALL"]
     ## @param metrics.jmx.containerPorts.metrics Prometheus JMX exporter metrics container port
     ##
     containerPorts:
       metrics: 5556
-    ## Prometheus JMX exporter resource requests and limits
-    ## ref: https://kubernetes.io/docs/user-guide/compute-resources/
-    ## @param metrics.jmx.resources.limits The resources limits for the JMX exporter container
-    ## @param metrics.jmx.resources.requests The requested resources for the JMX exporter container
-    ##
-    resources:
-      limits: {}
-      requests: {}
     ## Prometheus JMX exporter service configuration
     ##
     service:
@@ -2029,7 +1969,6 @@ metrics:
     ## https://github.com/helm/charts/tree/master/incubator/kafka
     ##
     config: |-
-      jmxUrl: service:jmx:rmi:///jndi/rmi://127.0.0.1:{{ .Values.metrics.jmx.kafkaJmxPort }}/jmxrmi
       lowercaseOutputName: true
       lowercaseOutputLabelNames: true
       ssl: false


### PR DESCRIPTION
### Description of the change

Run the jmx exporter for prometheus as an embedded agent in the Kafka broker JVM, rather than as a standalone process.

### Benefits

As explained in https://github.com/prometheus/jmx_exporter, this is the preferred approach. The most obvious benefit is that it then also exposes JVM process metrics (e.g. about memory usage etc).

fixes #21309 

### Possible drawbacks

None that I am aware of.

### Applicable issues

None

### Additional information

N/A

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
