### PR TITLE
[bitnami/discourse] Add support for skipping to persist plugins

### DIFF
--- a/bitnami/discourse/Chart.yaml
+++ b/bitnami/discourse/Chart.yaml
@@ -41,4 +41,4 @@ maintainers:
 name: discourse
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/discourse
-version: 12.0.7
+version: 12.1.0

--- a/bitnami/discourse/README.md
+++ b/bitnami/discourse/README.md
@@ -135,6 +135,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | ------------------------------------------------- | -------------------------------------------------------------------------------------------- | --------------- |
 | `discourse.skipInstall`                           | Do not run the Discourse installation wizard                                                 | `false`         |
 | `discourse.plugins`                               | List of plugins to be installed before the container initialization                          | `[]`            |
+| `discourse.persistPlugins`                        | Persist plugins across container restarts                                                    | `true`          |
 | `discourse.command`                               | Custom command to override image cmd                                                         | `[]`            |
 | `discourse.args`                                  | Custom args for the custom command                                                           | `[]`            |
 | `discourse.extraEnvVars`                          | Array with extra environment variables to add Discourse pods                                 | `[]`            |
@@ -399,6 +400,18 @@ By default, this Chart only deploys a single pod running Discourse. Should you w
     persistence.storageClass=nfs
     postgresql.primary.persistence.storageClass=nfs
     ```
+
+### Installing plugins
+
+You can install custom Discourse plugins during the release installation listing the desired plugin repositories via the `discourse.plugins` parameter. For example:
+
+```yaml
+discourse:
+  plugins:
+  - https://github.com/discourse/discourse-oauth2-basic
+```
+
+> Note: By default, plugins are persisted after the 1st installation, therefore it's not possible to update them on subsequent upgrades. If you want plugins to be updated on every upgrade, set the `discourse.persistPlugins` parameter to `false`.
 
 ### Sidecars
 

--- a/bitnami/discourse/templates/deployment.yaml
+++ b/bitnami/discourse/templates/deployment.yaml
@@ -163,6 +163,10 @@ spec:
                   name: {{ include "smtp.secretName" . }}
                   key: smtp-password
             {{- end }}
+            {{- if not .Values.discourse.persistPlugins }}
+            - name: DISCOURSE_DATA_TO_PERSIST
+              value: "public/backups public/uploads"
+            {{- end }}
             {{- if .Values.discourse.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.discourse.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}

--- a/bitnami/discourse/values.yaml
+++ b/bitnami/discourse/values.yaml
@@ -265,6 +265,9 @@ discourse:
   ##   - https://github.com/discourse/discourse-oauth2-basic
   ##
   plugins: []
+  ## @param discourse.persistPlugins Persist plugins across container restarts
+  ##
+  persistPlugins: true
   ## @param discourse.command Custom command to override image cmd
   ##
   command: []


### PR DESCRIPTION
### Description of the change

This PR add support for removing "plugins" from the data to persist so the installed plugins are updated based on the `discourse.plugins` parameters.

### Benefits

Easier for users to skip persisting plugins so they're updated on every container restart. 

### Possible drawbacks

None

### Applicable issues

- fixes https://github.com/bitnami/charts/issues/21320

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
