### PR TITLE
[bitnami/kubeapps] Add securityContext steps in Cypress testing

### DIFF
--- a/.vib/kubeapps/cypress/cypress/integration/kubeapps_spec.js
+++ b/.vib/kubeapps/cypress/cypress/integration/kubeapps_spec.js
@@ -22,6 +22,33 @@ it('allows managing a helm chart release', () => {
     cy.contains('Deploy').click();
 
     cy.get('#releaseName').type(releaseName);
+
+    // Disable securityContext parameters, as some platforms may not allow to enforce
+    // a specific UID/GID when installing
+    cy.get('input[title="Search"]').type('SecurityContext{enter}');
+
+    // 1. containerSecurity Context
+    cy.contains('td', 'containerSecurityContext').within(() => {
+      cy.get('cds-button').click();
+    });
+    cy.contains('tr', 'containerSecurityContext/enabled').within(() => {
+      cy.contains('cds-toggle', 'true').click('left');
+    });
+    cy.contains('td', 'containerSecurityContext').within(() => {
+      cy.get('cds-button').click();
+    });
+
+    // 2. podSecurityContext Context
+    cy.contains('td', 'podSecurityContext').within(() => {
+      cy.get('cds-button').click();
+    });
+    cy.contains('tr', 'podSecurityContext/enabled').within(() => {
+      cy.contains('cds-toggle', 'true').click('left');
+    });
+    cy.contains('td', 'containerSecurityContext').within(() => {
+      cy.get('cds-button').click();
+    });
+
     cy.contains('cds-button', 'Deploy').click();
     cy.get('.application-status-pie-chart-title', { timeout: (Cypress.config('defaultCommandTimeout') * 3) }).should(
       'have.text',


### PR DESCRIPTION
### Description of the change

Some clusters (e.g. OpenShift) do require random UID/GID for scheduled containers, so enforcing our default `1001` will result in problems while testing. This PR adds the steps in order to disable `securityContext` configuration while setting up the sample application to be installed in Cypress testing.

### Benefits

Cypress tests can be performed without issues in any kind of cluster.

### Possible drawbacks

More steps, which may increase the resiliency.

### Applicable issues

NA

### Additional information

NA

### Checklist

- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
