### PR TITLE
[bitnami/common] add params skipB64enc and skipQuote to common.secrets.passwords.manage

### DIFF
--- a/bitnami/common/Chart.yaml
+++ b/bitnami/common/Chart.yaml
@@ -23,4 +23,4 @@ name: common
 sources:
   - https://github.com/bitnami/charts
 type: library
-version: 2.13.4
+version: 2.14.0

--- a/bitnami/common/templates/_secrets.tpl
+++ b/bitnami/common/templates/_secrets.tpl
@@ -99,14 +99,14 @@ The order in which this function returns a secret password:
 {{- $secretData := (lookup "v1" "Secret" (include "common.names.namespace" .context) .secret).data }}
 {{- if $secretData }}
   {{- if hasKey $secretData .key }}
-    {{- $password = index $secretData .key }}
+    {{- $password = index $secretData .key | b64dec }}
   {{- else if not (eq .failOnNew false) }}
     {{- printf "\nPASSWORDS ERROR: The secret \"%s\" does not contain the key \"%s\"\n" .secret .key | fail -}}
   {{- else if $providedPasswordValue }}
-    {{- $password = $providedPasswordValue | toString | b64enc }}
+    {{- $password = $providedPasswordValue | toString }}
   {{- end -}}
 {{- else if $providedPasswordValue }}
-  {{- $password = $providedPasswordValue | toString | b64enc }}
+  {{- $password = $providedPasswordValue | toString }}
 {{- else }}
 
   {{- if .context.Values.enabled }}
@@ -122,11 +122,12 @@ The order in which this function returns a secret password:
     {{- $subStr := list (lower (randAlpha 1)) (randNumeric 1) (upper (randAlpha 1)) | join "_" }}
     {{- $password = randAscii $passwordLength }}
     {{- $password = regexReplaceAllLiteral "\\W" $password "@" | substr 5 $passwordLength }}
-    {{- $password = printf "%s%s" $subStr $password | toString | shuffle | b64enc }}
+    {{- $password = printf "%s%s" $subStr $password | toString | shuffle }}
   {{- else }}
-    {{- $password = randAlphaNum $passwordLength | b64enc }}
+    {{- $password = randAlphaNum $passwordLength }}
   {{- end }}
 {{- end -}}
+{{ $password = $password | b64enc }}
 {{- if .skipQuote -}}
 {{- printf "%s" $password -}}
 {{- else -}}

--- a/bitnami/common/templates/_secrets.tpl
+++ b/bitnami/common/templates/_secrets.tpl
@@ -78,6 +78,7 @@ Params:
   - chartName - String - Optional - Name of the chart used when said chart is deployed as a subchart.
   - context - Context - Required - Parent context.
   - failOnNew - Boolean - Optional - Default to true. If set to false, skip errors adding new keys to existing secrets.
+  - skipB64enc - Boolean - Optional - Default to false. If set to true, no the secret will not be base64 encrypted.
   - skipQuote - Boolean - Optional - Default to false. If set to true, no quotes will be added around the secret.
 The order in which this function returns a secret password:
   1. Already existing 'Secret' resource
@@ -127,7 +128,9 @@ The order in which this function returns a secret password:
     {{- $password = randAlphaNum $passwordLength }}
   {{- end }}
 {{- end -}}
+{{- if not .skipB64enc }}
 {{ $password = $password | b64enc }}
+{{- end -}}
 {{- if .skipQuote -}}
 {{- printf "%s" $password -}}
 {{- else -}}

--- a/bitnami/common/templates/_secrets.tpl
+++ b/bitnami/common/templates/_secrets.tpl
@@ -98,14 +98,14 @@ The order in which this function returns a secret password:
 {{- $secretData := (lookup "v1" "Secret" (include "common.names.namespace" .context) .secret).data }}
 {{- if $secretData }}
   {{- if hasKey $secretData .key }}
-    {{- $password = index $secretData .key | quote }}
+    {{- $password = index $secretData .key }}
   {{- else if not (eq .failOnNew false) }}
     {{- printf "\nPASSWORDS ERROR: The secret \"%s\" does not contain the key \"%s\"\n" .secret .key | fail -}}
   {{- else if $providedPasswordValue }}
-    {{- $password = $providedPasswordValue | toString | b64enc | quote }}
+    {{- $password = $providedPasswordValue | toString | b64enc }}
   {{- end -}}
 {{- else if $providedPasswordValue }}
-  {{- $password = $providedPasswordValue | toString | b64enc | quote }}
+  {{- $password = $providedPasswordValue | toString | b64enc }}
 {{- else }}
 
   {{- if .context.Values.enabled }}
@@ -121,12 +121,12 @@ The order in which this function returns a secret password:
     {{- $subStr := list (lower (randAlpha 1)) (randNumeric 1) (upper (randAlpha 1)) | join "_" }}
     {{- $password = randAscii $passwordLength }}
     {{- $password = regexReplaceAllLiteral "\\W" $password "@" | substr 5 $passwordLength }}
-    {{- $password = printf "%s%s" $subStr $password | toString | shuffle | b64enc | quote }}
+    {{- $password = printf "%s%s" $subStr $password | toString | shuffle | b64enc }}
   {{- else }}
-    {{- $password = randAlphaNum $passwordLength | b64enc | quote }}
+    {{- $password = randAlphaNum $passwordLength | b64enc }}
   {{- end }}
 {{- end -}}
-{{- printf "%s" $password -}}
+{{- printf "%s" $password | quote -}}
 {{- end -}}
 
 {{/*

--- a/bitnami/common/templates/_secrets.tpl
+++ b/bitnami/common/templates/_secrets.tpl
@@ -78,6 +78,7 @@ Params:
   - chartName - String - Optional - Name of the chart used when said chart is deployed as a subchart.
   - context - Context - Required - Parent context.
   - failOnNew - Boolean - Optional - Default to true. If set to false, skip errors adding new keys to existing secrets.
+  - skipQuote - Boolean - Optional - Default to false. If set to true, no quotes will be added around the secret.
 The order in which this function returns a secret password:
   1. Already existing 'Secret' resource
      (If a 'Secret' resource is found under the name provided to the 'secret' parameter to this function and that 'Secret' resource contains a key with the name passed as the 'key' parameter to this function then the value of this existing secret password will be returned)
@@ -126,7 +127,11 @@ The order in which this function returns a secret password:
     {{- $password = randAlphaNum $passwordLength | b64enc }}
   {{- end }}
 {{- end -}}
+{{- if .skipQuote -}}
+{{- printf "%s" $password -}}
+{{- else -}}
 {{- printf "%s" $password | quote -}}
+{{- end -}}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
### Description of the change

Adding two parameters to allow more specific usage of `common.secrets.passwords.manage`:

- **`skipB64enc`**: option to disable return already be converted to base64 encoded string
- **`skipQuote`**: option to disable return already wrapped with quotes

### Benefits

This will allow to further use the secret in other ways when the helper is used.

For example this will allow to use secret templating with [`stringData`](https://kubernetes.io/docs/concepts/configuration/secret/#basic-authentication-secret) instead of `data`:

```yaml
{{- $resName := "foo" }}
{{- $resKey := "bar" }}
kind: Secret
apiVersion: v1
metadata:
  name: {{ $resName }}
type: Opaque
stringData: # stringData instead of data
  {{ $resKey }}: {{ include "common.secrets.passwords.manage" (dict
    "secret" $resName
    "key" $resKey
    "providedValues" (list "valuesvalue")
    "skipB64enc" true
    "context" $
  )}}
```

### Possible drawbacks

unknown - As the default setting continues to use quotes and encoding as before this PR, there should be no changes.

### Additional information

I've added two params because they are related to each other - also a merge conflict would occur if separated in two PRs.

This change also reduces the duplication of `quote` and `b64enc` in the template.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)

<hr />

<sub>Marco Lecheler [marco.lecheler@mercedes-benz.com](mailto:marco.lecheler@mercedes-benz.com) Mercedes-Benz Tech Innovation GmbH ([ProviderInformation](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md))</sub>