### PR TITLE
[bitnami/wordpress] Omit wp-config.php from data to persist if provided via secret

### DIFF
--- a/bitnami/wordpress/Chart.yaml
+++ b/bitnami/wordpress/Chart.yaml
@@ -44,4 +44,4 @@ maintainers:
 name: wordpress
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/wordpress
-version: 18.1.27
+version: 18.1.28

--- a/bitnami/wordpress/templates/deployment.yaml
+++ b/bitnami/wordpress/templates/deployment.yaml
@@ -130,6 +130,14 @@ spec:
               value: {{ ternary "true" "false" (or .Values.image.debug .Values.diagnosticMode.enabled) | quote }}
             - name: ALLOW_EMPTY_PASSWORD
               value: {{ ternary "yes" "no" .Values.allowEmptyPassword | quote }}
+            - name: WORDPRESS_SKIP_BOOTSTRAP
+              value: {{ ternary "yes" "no" .Values.wordpressSkipInstall | quote }}
+            {{- if or .Values.wordpressConfiguration .Values.existingWordPressConfigurationSecret }}
+            # Override the default data to persist omiting wp-config.php from the list since
+            # it is mounted as a read-only file from a Secret
+            - name: WORDPRESS_DATA_TO_PERSIST
+              value: "wp-content"
+            {{- else }}
             - name: MARIADB_HOST
               value: {{ include "wordpress.databaseHost" . | quote }}
             - name: MARIADB_PORT_NUMBER
@@ -162,8 +170,6 @@ spec:
               value: {{ ternary "yes" "no" .Values.htaccessPersistenceEnabled | quote }}
             - name: WORDPRESS_BLOG_NAME
               value: {{ .Values.wordpressBlogName | quote }}
-            - name: WORDPRESS_SKIP_BOOTSTRAP
-              value: {{ ternary "yes" "no" .Values.wordpressSkipInstall | quote }}
             - name: WORDPRESS_TABLE_PREFIX
               value: {{ .Values.wordpressTablePrefix | quote }}
             - name: WORDPRESS_SCHEME
@@ -172,13 +178,8 @@ spec:
               value: {{ .Values.wordpressExtraConfigContent | quote }}
             - name: WORDPRESS_PLUGINS
               value: {{ join "," .Values.wordpressPlugins | quote }}
-            - name: APACHE_HTTP_PORT_NUMBER
-              value: {{ .Values.containerPorts.http | quote }}
-            - name: APACHE_HTTPS_PORT_NUMBER
-              value: {{ .Values.containerPorts.https | quote }}
-            {{- if .Values.overrideDatabaseSettings }}
             - name: WORDPRESS_OVERRIDE_DATABASE_SETTINGS
-              value: "yes"
+              value: {{ ternary "yes" "no" .Values.overrideDatabaseSettings | quote }}
             {{- end }}
             {{- if .Values.multisite.enable }}
             - name: WORDPRESS_ENABLE_MULTISITE
@@ -217,6 +218,10 @@ spec:
             - name: SMTP_PROTOCOL
               value: {{ .Values.smtpProtocol | quote }}
             {{- end }}
+            - name: APACHE_HTTP_PORT_NUMBER
+              value: {{ .Values.containerPorts.http | quote }}
+            - name: APACHE_HTTPS_PORT_NUMBER
+              value: {{ .Values.containerPorts.https | quote }}
             {{- if .Values.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}


### PR DESCRIPTION
### Description of the change

This PR ensures we omit `wp-config.php` from the default data to persist (specified via `WORDPRESS_DATA_TO_PERSIST` environment variable) when it's mounted as a read-only file from a secret.

### Benefits

Fixes the workflow below:

```bash
# Install chart
helm install wordpress oci://registry-1.docker.io/bitnamicharts/wordpress
# Wait for pods to be ready and extract wp-config.php
kubectl cp "$(kubectl get pod -o jsonpath='{.items[0].metadata.name}' -l app.kubernetes.io/name=wordpress)":/bitnami/wordpress/wp-config.php wp-config.php
# Edit wp-config.php and create secret with customizations
kubectl create secret generic wordpress-config --from-file=wp-config.php
# Upgrade chart
helm upgrade wordpress oci://registry-1.docker.io/bitnamicharts/wordpress --set existingWordPressConfigurationSecret=wordpress-config --set wordpressSkipInstall=true
```

### Possible drawbacks

None

### Applicable issues

- fixes https://github.com/bitnami/charts/issues/20880

### Additional information

Default value for `WORDPRESS_DATA_TO_PERSIST` environment variable can be found below:

- https://github.com/bitnami/containers/blob/main/bitnami/wordpress/6/debian-11/rootfs/opt/bitnami/scripts/wordpress-env.sh#L121

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
