### PR TITLE
[bitnami/opensearch] fix: Use correct key for existing TLS secrets

### DIFF
--- a/bitnami/opensearch/Chart.yaml
+++ b/bitnami/opensearch/Chart.yaml
@@ -30,4 +30,4 @@ maintainers:
 name: opensearch
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/opensearch
-version: 0.6.0
+version: 0.6.1

--- a/bitnami/opensearch/templates/_helpers.tpl
+++ b/bitnami/opensearch/templates/_helpers.tpl
@@ -395,10 +395,10 @@ Return the opensearch TLS credentials secret key of the given type.
 */}}
 {{- define "opensearch.tlsSecretKey" -}}
 {{- $secretConfig := index .context.Values.security.tls .type -}}
-{{- if $secretConfig.externalSecret }}
-{{ index $secretConfig .secretKey | default .defaultKey }}
+{{- if $secretConfig.existingSecret }}
+{{- print (index $secretConfig .secretKey | default .defaultKey) }}
 {{- else }}
-{{- printf .defaultKey }}
+{{- print .defaultKey }}
 {{- end }}
 {{- end -}}
 


### PR DESCRIPTION
### Description of the change

In #21287 I introduced a way to configure the keys of the TLS secrets.

I was working a lot with ExternalSecrets operator at that time. And somehow after testing I changed the key from `existingSecret` to `externalSecret` in the helper.

### Benefits

Bugfix

### Possible drawbacks

None

### Applicable issues

None

### Additional information

Related PRs:
* #21287

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
