### PR TITLE
Revert "Bump actions/download-artifact from 3.0.2 to 4.0.0"

### DIFF
--- a/.github/workflows/cd-pipeline.yml
+++ b/.github/workflows/cd-pipeline.yml
@@ -90,7 +90,7 @@ jobs:
       - vib-publish
     name: Update charts index
     steps:
-      - uses: actions/download-artifact@7a1cd3216ca9260cd8022db641d960b1db4d1be4
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
         with:
           path: ~/artifacts
       # If we perform a checkout of the main branch, we will find conflicts with the submodules


### PR DESCRIPTION
Reverts bitnami/charts#21612

There are several errors related to the above changes:
* https://github.com/bitnami/charts/actions/runs/7262227519/job/19785026092
* https://github.com/bitnami/charts/actions/runs/7261433171/job/19786370007