### PR TITLE
[bitnami/jasperreports] Upgrade MariaDB 11.2

### DIFF
--- a/bitnami/jasperreports/Chart.lock
+++ b/bitnami/jasperreports/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: mariadb
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 14.1.4
+  version: 15.0.0
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 2.14.1
-digest: sha256:a3c5a911d628ce29de05810e3e58e84843950e6cfac06f440cd6341a1e7f49ad
-generated: "2023-12-20T08:07:59.585686668Z"
+digest: sha256:f004beca8d3e9099f278fd0210edc0d1fec77f83bff9cddc888388f2119dd9c8
+generated: "2023-12-20T10:57:33.79013+01:00"

--- a/bitnami/jasperreports/Chart.yaml
+++ b/bitnami/jasperreports/Chart.yaml
@@ -13,7 +13,7 @@ dependencies:
 - condition: mariadb.enabled
   name: mariadb
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 14.x.x
+  version: 15.x.x
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
   tags:
@@ -35,4 +35,4 @@ maintainers:
 name: jasperreports
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/jasperreports
-version: 17.2.4
+version: 18.0.0

--- a/bitnami/jasperreports/README.md
+++ b/bitnami/jasperreports/README.md
@@ -333,6 +333,10 @@ Find more information about how to deal with common errors related to Bitnami's 
 
 ## Upgrading
 
+### To 18.0.0
+
+This major release bumps the MariaDB version to 11.2. No major issues are expected during the upgrade.
+
 ### To 17.0.0
 
 This major release bumps the MariaDB version to 11.1. No major issues are expected during the upgrade.


### PR DESCRIPTION
### Description of the change

This PR upgrades MariaDB subchart to version 15 (appVersion 11.2).

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)