### PR TITLE
[bitnami/osclass] Upgrade MariaDB 11.2

### DIFF
--- a/bitnami/osclass/Chart.lock
+++ b/bitnami/osclass/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: mariadb
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 14.1.4
+  version: 15.0.0
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 2.14.1
-digest: sha256:46d9004aef689ac67cf034a9f5fe7d7bfa3d163c7172833c23d7f9e40530c57a
-generated: "2023-12-20T08:09:04.171868499Z"
+digest: sha256:571662874455ffc7f8fe4e78489da7b143c51b165771b51a42ca9a0b8abb3de0
+generated: "2023-12-20T11:36:53.228608+01:00"

--- a/bitnami/osclass/Chart.yaml
+++ b/bitnami/osclass/Chart.yaml
@@ -19,7 +19,7 @@ dependencies:
   repository: oci://registry-1.docker.io/bitnamicharts
   tags:
   - osclass-database
-  version: 14.x.x
+  version: 15.x.x
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
   tags:
@@ -40,4 +40,4 @@ maintainers:
 name: osclass
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/osclass
-version: 17.1.4
+version: 18.0.0

--- a/bitnami/osclass/README.md
+++ b/bitnami/osclass/README.md
@@ -417,6 +417,10 @@ Find more information about how to deal with common errors related to Bitnami's 
 
 ## Upgrading
 
+### To 18.0.0
+
+This major release bumps the MariaDB version to 11.2. No major issues are expected during the upgrade.
+
 ### To 17.0.0
 
 This major release bumps the MariaDB version to 11.1. No major issues are expected during the upgrade.


### PR DESCRIPTION
### Description of the change

This PR upgrades MariaDB subchart to version 15 (appVersion 11.2).

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)