### PR TITLE
[bitnami/redmine] Upgrade MariaDB 11.2

### DIFF
--- a/bitnami/redmine/Chart.lock
+++ b/bitnami/redmine/Chart.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 13.2.24
 - name: mariadb
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 14.1.4
+  version: 15.0.0
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 2.14.1
-digest: sha256:24d1b4cfd5184950f1d07c465cdeea5a9177721d1afc199d13d21567f212c61c
-generated: "2023-12-20T08:09:05.229659526Z"
+digest: sha256:75818bc0d8cbac79a1723a6a69167898b6c85fde36536c229e5b8e6187fe2fa0
+generated: "2023-12-20T11:39:40.302946+01:00"

--- a/bitnami/redmine/Chart.yaml
+++ b/bitnami/redmine/Chart.yaml
@@ -19,7 +19,7 @@ dependencies:
 - condition: mariadb.enabled
   name: mariadb
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 14.x.x
+  version: 15.x.x
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
   tags:
@@ -43,4 +43,4 @@ maintainers:
 name: redmine
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/redmine
-version: 25.0.8
+version: 26.0.0

--- a/bitnami/redmine/README.md
+++ b/bitnami/redmine/README.md
@@ -563,6 +563,10 @@ Find more information about how to deal with common errors related to Bitnami's 
 
 ## Upgrading
 
+### To 26.0.0
+
+This major release bumps the MariaDB version to 11.2. No major issues are expected during the upgrade.
+
 ### To 25.0.0
 
 This major release bumps the MariaDB version to 11.1. No major issues are expected during the upgrade.


### PR DESCRIPTION
### Description of the change

This PR upgrades MariaDB subchart to version 15 (appVersion 11.2).

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)