### PR TITLE
[bitnami/spring-cloud-dataflow] Upgrade MariaDB 11.2

### DIFF
--- a/bitnami/spring-cloud-dataflow/Chart.lock
+++ b/bitnami/spring-cloud-dataflow/Chart.lock
@@ -4,12 +4,12 @@ dependencies:
   version: 12.6.0
 - name: mariadb
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 14.1.4
+  version: 15.0.0
 - name: kafka
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 26.5.1
+  version: 26.6.0
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 2.14.1
-digest: sha256:10b619f34cec8194baca13358abf033c4f8aabc1634e45a2f17e343bb677500d
-generated: "2023-12-20T08:09:08.531916737Z"
+digest: sha256:535b4cfdb9ced30ac3179308daad489aced53c95f87a42695b17e4ceb83d17d5
+generated: "2023-12-20T12:06:17.539049+01:00"

--- a/bitnami/spring-cloud-dataflow/Chart.yaml
+++ b/bitnami/spring-cloud-dataflow/Chart.yaml
@@ -29,7 +29,7 @@ dependencies:
   repository: oci://registry-1.docker.io/bitnamicharts
   tags:
   - dataflow-database
-  version: 14.x.x
+  version: 15.x.x
 - condition: kafka.enabled
   name: kafka
   repository: oci://registry-1.docker.io/bitnamicharts
@@ -53,4 +53,4 @@ maintainers:
 name: spring-cloud-dataflow
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/spring-cloud-dataflow
-version: 25.1.4
+version: 26.0.0


### PR DESCRIPTION
### Description of the change

This PR upgrades MariaDB subchart to version 15 (appVersion 11.2).

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)