### PR TITLE
[bitnami/scdf] Add securityContext to init containers

### DIFF
--- a/bitnami/spring-cloud-dataflow/Chart.yaml
+++ b/bitnami/spring-cloud-dataflow/Chart.yaml
@@ -53,4 +53,4 @@ maintainers:
 name: spring-cloud-dataflow
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/spring-cloud-dataflow
-version: 26.1.1
+version: 26.1.2

--- a/bitnami/spring-cloud-dataflow/Chart.yaml
+++ b/bitnami/spring-cloud-dataflow/Chart.yaml
@@ -53,4 +53,4 @@ maintainers:
 name: spring-cloud-dataflow
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/spring-cloud-dataflow
-version: 26.1.2
+version: 26.2.0

--- a/bitnami/spring-cloud-dataflow/README.md
+++ b/bitnami/spring-cloud-dataflow/README.md
@@ -422,16 +422,24 @@ helm uninstall my-release
 
 ### Init Container parameters
 
-| Name                                 | Description                                                                                                                     | Value                     |
-| ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------- | ------------------------- |
-| `waitForBackends.enabled`            | Wait for the database and other services (such as Kafka or RabbitMQ) used when enabling streaming                               | `true`                    |
-| `waitForBackends.image.registry`     | Init container wait-for-backend image registry                                                                                  | `REGISTRY_NAME`           |
-| `waitForBackends.image.repository`   | Init container wait-for-backend image name                                                                                      | `REPOSITORY_NAME/kubectl` |
-| `waitForBackends.image.digest`       | Init container wait-for-backend image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                      |
-| `waitForBackends.image.pullPolicy`   | Init container wait-for-backend image pull policy                                                                               | `IfNotPresent`            |
-| `waitForBackends.image.pullSecrets`  | Specify docker-registry secret names as an array                                                                                | `[]`                      |
-| `waitForBackends.resources.limits`   | Init container wait-for-backend resource limits                                                                                 | `{}`                      |
-| `waitForBackends.resources.requests` | Init container wait-for-backend resource requests                                                                               | `{}`                      |
+| Name                                                                | Description                                                                                                                     | Value                     |
+| ------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- | ------------------------- |
+| `waitForBackends.enabled`                                           | Wait for the database and other services (such as Kafka or RabbitMQ) used when enabling streaming                               | `true`                    |
+| `waitForBackends.image.registry`                                    | Init container wait-for-backend image registry                                                                                  | `REGISTRY_NAME`           |
+| `waitForBackends.image.repository`                                  | Init container wait-for-backend image name                                                                                      | `REPOSITORY_NAME/kubectl` |
+| `waitForBackends.image.digest`                                      | Init container wait-for-backend image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                      |
+| `waitForBackends.image.pullPolicy`                                  | Init container wait-for-backend image pull policy                                                                               | `IfNotPresent`            |
+| `waitForBackends.image.pullSecrets`                                 | Specify docker-registry secret names as an array                                                                                | `[]`                      |
+| `waitForBackends.containerSecurityContext.enabled`                  | Enabled containers' Security Context                                                                                            | `true`                    |
+| `waitForBackends.containerSecurityContext.runAsUser`                | Set containers' Security Context runAsUser                                                                                      | `1001`                    |
+| `waitForBackends.containerSecurityContext.runAsNonRoot`             | Set container's Security Context runAsNonRoot                                                                                   | `true`                    |
+| `waitForBackends.containerSecurityContext.privileged`               | Set container's Security Context privileged                                                                                     | `false`                   |
+| `waitForBackends.containerSecurityContext.readOnlyRootFilesystem`   | Set container's Security Context readOnlyRootFilesystem                                                                         | `false`                   |
+| `waitForBackends.containerSecurityContext.allowPrivilegeEscalation` | Set container's Security Context allowPrivilegeEscalation                                                                       | `false`                   |
+| `waitForBackends.containerSecurityContext.capabilities.drop`        | List of capabilities to be dropped                                                                                              | `["ALL"]`                 |
+| `waitForBackends.containerSecurityContext.seccompProfile.type`      | Set container's Security Context seccomp profile                                                                                | `RuntimeDefault`          |
+| `waitForBackends.resources.limits`                                  | Init container wait-for-backend resource limits                                                                                 | `{}`                      |
+| `waitForBackends.resources.requests`                                | Init container wait-for-backend resource requests                                                                               | `{}`                      |
 
 ### Database parameters
 

--- a/bitnami/spring-cloud-dataflow/templates/server/deployment.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/server/deployment.yaml
@@ -80,6 +80,9 @@ spec:
           imagePullPolicy: {{ .Values.waitForBackends.image.pullPolicy | quote }}
           command:
             - /scripts/wait-for-backends.sh
+          {{- if .Values.waitForBackends.containerSecurityContext.enabled }}
+          securityContext: {{- omit .Values.waitForBackends.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+          {{- end }}
           {{- if .Values.waitForBackends.resources }}
           resources: {{- include "common.tplvalues.render" (dict "value" .Values.waitForBackends.resources "context" $) | nindent 12 }}
           {{- end }}

--- a/bitnami/spring-cloud-dataflow/templates/skipper/deployment.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/skipper/deployment.yaml
@@ -78,6 +78,9 @@ spec:
           imagePullPolicy: {{ .Values.waitForBackends.image.pullPolicy | quote }}
           command:
             - /scripts/wait-for-backends.sh
+          {{- if .Values.waitForBackends.containerSecurityContext.enabled }}
+          securityContext: {{- omit .Values.waitForBackends.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+          {{- end }}
           {{- if .Values.waitForBackends.resources }}
           resources: {{- include "common.tplvalues.render" (dict "value" .Values.waitForBackends.resources "context" $) | nindent 12 }}
           {{- end }}

--- a/bitnami/spring-cloud-dataflow/values.schema.json
+++ b/bitnami/spring-cloud-dataflow/values.schema.json
@@ -1,344 +1,2454 @@
 {
-  "$schema": "http://json-schema.org/schema#",
-  "type": "object",
-  "properties": {
-    "server": {
-      "type": "object",
-      "form": true,
-      "title": "Spring Cloud Dataflow Server configuration",
-      "properties": {
-        "configuration": {
-          "type": "object",
-          "title": "Spring Cloud Dataflow Server configuration",
-          "properties": {
-            "streamingEnabled": {
-              "type": "boolean",
-              "title": "Enable deploying streaming data",
-              "form": true,
-              "description": "Enable support for Stream processing using using RabbitMQ or Kafka"
-            },
-            "batchEnabled": {
-              "type": "boolean",
-              "title": "Enable deploying Batch data",
-              "form": true,
-              "description": "Enable support for Task and Schedules processing"
-            }
-          }
-        },
-        "replicaCount": {
-          "type": "integer",
-          "form": true,
-          "title": "Dataflow server replicas"
-        },
-        "resources": {
-          "type": "object",
-          "title": "Required Resources",
-          "description": "Configure resource requests",
-          "form": true,
-          "properties": {
-            "requests": {
-              "type": "object",
-              "properties": {
-                "memory": {
-                  "type": "string",
-                  "form": true,
-                  "render": "slider",
-                  "title": "Memory Request",
-                  "sliderMin": 10,
-                  "sliderMax": 2048,
-                  "sliderUnit": "Mi"
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "Global Docker image registry",
+                    "default": ""
                 },
-                "cpu": {
-                  "type": "string",
-                  "form": true,
-                  "render": "slider",
-                  "title": "CPU Request",
-                  "sliderMin": 10,
-                  "sliderMax": 2000,
-                  "sliderUnit": "m"
-                }
-              }
-            }
-          }
-        },
-        "ingress": {
-          "type": "object",
-          "form": true,
-          "title": "Ingress configuration",
-          "properties": {
-            "enabled": {
-              "type": "boolean",
-              "form": true,
-              "title": "Use a custom hostname",
-              "description": "Enable the ingress resource that allows you to access the Dataflow Server dashboard."
-            },
-            "hostname": {
-              "type": "string",
-              "form": true,
-              "title": "Hostname",
-              "hidden": {
-                "condition": false,
-                "value": "server/ingress/enabled"
-              }
-            },
-            "tls": {
-              "type": "boolean",
-              "form": true,
-              "title": "Create a TLS secret",
-              "hidden": {
-                "condition": false,
-                "value": "server/ingress/enabled"
-              }
-            }
-          }
-        },
-        "service": {
-          "type": "object",
-          "form": true,
-          "title": "Service Configuration",
-          "properties": {
-            "type": {
-              "type": "string",
-              "form": true,
-              "title": "Service Type",
-              "description": "Allowed values: \"ClusterIP\", \"NodePort\" and \"LoadBalancer\"" 
-            }
-          }
-        }
-      }
-    },
-    "skipper": {
-      "type": "object",
-      "form": true,
-      "title": "Spring Cloud Skipper Server configuration",
-      "properties": {
-        "enabled": {
-          "type": "boolean",
-          "form": true,
-          "title": "Enable Skipper",
-          "description": "Enable Spring Cloud Skipper component"
-        },
-        "replicaCount": {
-          "type": "integer",
-          "form": true,
-          "title": "Skipper server replicas",
-          "hidden": {
-            "condition": false,
-            "value": "skipper/enabled"
-          }
-        },
-        "resources": {
-          "type": "object",
-          "title": "Required Resources",
-          "description": "Configure resource requests",
-          "form": true,
-          "properties": {
-            "requests": {
-              "type": "object",
-              "properties": {
-                "memory": {
-                  "type": "string",
-                  "form": true,
-                  "render": "slider",
-                  "title": "Memory Request",
-                  "sliderMin": 10,
-                  "sliderMax": 2048,
-                  "sliderUnit": "Mi"
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Global Docker registry secret names as an array",
+                    "default": [],
+                    "items": {}
                 },
-                "cpu": {
-                  "type": "string",
-                  "form": true,
-                  "render": "slider",
-                  "title": "CPU Request",
-                  "sliderMin": 10,
-                  "sliderMax": 2000,
-                  "sliderUnit": "m"
+                "storageClass": {
+                    "type": "string",
+                    "description": "Global StorageClass for Persistent Volume(s)",
+                    "default": ""
                 }
-              }
             }
-          },
-          "hidden": {
-            "condition": false,
-            "value": "skipper/enabled"
-          }
-        }
-      }
-    },
-    "serviceAccount": {
-      "type": "object",
-      "title": "ServiceAccount configuration",
-      "form": true,
-      "properties": {
-        "create": {
-          "type": "boolean",
-          "form": true,
-          "title": "Create a ServiceAcccount",
-          "description": "Specify whether a ServiceAcccount for Spring Cloud pods should be created"
         },
-        "name": {
-          "type": "string",
-          "form": true,
-          "title": "ServiceAcccount name",
-          "description": "ServiceAcccount name to use. Auto-generated if not specified",
-          "hidden": {
-            "condition": false,
-            "value": "serviceAccount/create"
-          }
-        }
-      }
-    },
-    "rbac": {
-      "type": "object",
-      "title": "RBAC rules configuration",
-      "form": true,
-      "properties": {
-        "create": {
-          "type": "boolean",
-          "form": true,
-          "title": "Create RBAC rules",
-          "description": "Specify whether RBAC resources should be created and used"
-        }
-      }
-    },
-    "metrics": {
-      "type": "object",
-      "form": true,
-      "title": "Prometheus metrics details",
-      "properties": {
-        "enabled": {
-          "type": "boolean",
-          "title": "Create Prometheus metrics exporter",
-          "description": "Create a side-car container to expose Prometheus metrics",
-          "form": true
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override scdf.fullname template (will maintain the release name).",
+            "default": ""
         },
-        "serviceMonitor": {
-          "type": "object",
-          "properties": {
-            "enabled": {
-              "type": "boolean",
-              "title": "Create Prometheus Operator ServiceMonitor",
-              "description": "Create a ServiceMonitor to track metrics using Prometheus Operator",
-              "form": true,
-              "hidden": {
-                "condition": false,
-                "value": "metrics/enabled"
-              }
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override scdf.fullname template.",
+            "default": ""
+        },
+        "commonAnnotations": {
+            "type": "object",
+            "description": "Annotations to add to all deployed objects",
+            "default": {}
+        },
+        "commonLabels": {
+            "type": "object",
+            "description": "Labels to add to all deployed objects",
+            "default": {}
+        },
+        "kubeVersion": {
+            "type": "string",
+            "description": "Force target Kubernetes version (using Helm capabilities if not set)",
+            "default": ""
+        },
+        "clusterDomain": {
+            "type": "string",
+            "description": "Default Kubernetes cluster domain",
+            "default": "cluster.local"
+        },
+        "extraDeploy": {
+            "type": "array",
+            "description": "Array of extra objects to deploy with the release",
+            "default": [],
+            "items": {}
+        },
+        "server": {
+            "type": "object",
+            "properties": {
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Spring Cloud Dataflow image registry",
+                            "default": "REGISTRY_NAME"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Spring Cloud Dataflow image repository",
+                            "default": "REPOSITORY_NAME/spring-cloud-dataflow"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Spring Cloud Dataflow image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Spring Cloud Dataflow image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Specify docker-registry secret names as an array",
+                            "default": [],
+                            "items": {}
+                        },
+                        "debug": {
+                            "type": "boolean",
+                            "description": "Enable image debug mode",
+                            "default": false
+                        }
+                    }
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Deployment pod host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "composedTaskRunner": {
+                    "type": "object",
+                    "properties": {
+                        "image": {
+                            "type": "object",
+                            "properties": {
+                                "registry": {
+                                    "type": "string",
+                                    "description": "Spring Cloud Dataflow Composed Task Runner image registry",
+                                    "default": "REGISTRY_NAME"
+                                },
+                                "repository": {
+                                    "type": "string",
+                                    "description": "Spring Cloud Dataflow Composed Task Runner image repository",
+                                    "default": "REPOSITORY_NAME/spring-cloud-dataflow-composed-task-runner"
+                                },
+                                "digest": {
+                                    "type": "string",
+                                    "description": "Spring Cloud Dataflow Composed Task Runner image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                                    "default": ""
+                                }
+                            }
+                        }
+                    }
+                },
+                "configuration": {
+                    "type": "object",
+                    "properties": {
+                        "streamingEnabled": {
+                            "type": "boolean",
+                            "description": "Enables or disables streaming data processing",
+                            "default": true
+                        },
+                        "batchEnabled": {
+                            "type": "boolean",
+                            "description": "Enables or disables batch data (tasks and schedules) processing",
+                            "default": true
+                        },
+                        "accountName": {
+                            "type": "string",
+                            "description": "The name of the account to configure for the Kubernetes platform",
+                            "default": "default"
+                        },
+                        "trustK8sCerts": {
+                            "type": "boolean",
+                            "description": "Trust K8s certificates when querying the Kubernetes API",
+                            "default": false
+                        },
+                        "containerRegistries": {
+                            "type": "object",
+                            "description": "Container registries configuration",
+                            "default": {}
+                        },
+                        "grafanaInfo": {
+                            "type": "string",
+                            "description": "Endpoint to the grafana instance (Deprecated: use the metricsDashboard instead)",
+                            "default": ""
+                        },
+                        "metricsDashboard": {
+                            "type": "string",
+                            "description": "Endpoint to the metricsDashboard instance",
+                            "default": ""
+                        },
+                        "defaultSpringApplicationJSON": {
+                            "type": "boolean",
+                            "description": "Injects default values for environment variable SPRING_APPLICATION_JSON",
+                            "default": true
+                        }
+                    }
+                },
+                "existingConfigmap": {
+                    "type": "string",
+                    "description": "ConfigMap with Spring Cloud Dataflow Server Configuration",
+                    "default": ""
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the Dataflow server container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Extra environment variables to be set on Dataflow server container",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "ConfigMap with extra environment variables",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Secret with extra environment variables",
+                    "default": ""
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of Dataflow server replicas to deploy",
+                    "default": 1
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Dataflow server pod affinity preset. Ignored if `server.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Dataflow server pod anti-affinity preset. Ignored if `server.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "containerPort": {
+                    "type": "number",
+                    "description": "Dataflow server port",
+                    "default": 8080
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Dataflow server node affinity preset type. Ignored if `server.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Dataflow server node label key to match Ignored if `server.affinity` is set.",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Dataflow server node label values to match. Ignored if `server.affinity` is set.",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Dataflow server affinity for pod assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Dataflow server node labels for pod assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Dataflow server tolerations for pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for Dataflow server pods",
+                    "default": {}
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Deployment strategy type for Dataflow server pods.",
+                            "default": "RollingUpdate"
+                        }
+                    }
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for Dataflow Server pods",
+                    "default": {}
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Dataflow Server pods' priority",
+                    "default": ""
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Name of the k8s scheduler (other than default)",
+                    "default": ""
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Dataflow Server pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Group ID for the volumes of the pod",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set container's Security Context runAsNonRoot",
+                            "default": true
+                        },
+                        "privileged": {
+                            "type": "boolean",
+                            "description": "Set container's Security Context privileged",
+                            "default": false
+                        },
+                        "readOnlyRootFilesystem": {
+                            "type": "boolean",
+                            "description": "Set container's Security Context readOnlyRootFilesystem",
+                            "default": false
+                        },
+                        "allowPrivilegeEscalation": {
+                            "type": "boolean",
+                            "description": "Set container's Security Context allowPrivilegeEscalation",
+                            "default": false
+                        },
+                        "capabilities": {
+                            "type": "object",
+                            "properties": {
+                                "drop": {
+                                    "type": "array",
+                                    "description": "List of capabilities to be dropped",
+                                    "default": [
+                                        "ALL"
+                                    ],
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "seccompProfile": {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "description": "Set container's Security Context seccomp profile",
+                                    "default": "RuntimeDefault"
+                                }
+                            }
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the Dataflow server container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the Dataflow server container",
+                            "default": {}
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 120
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 20
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 120
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 20
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 120
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 20
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Override default startup probe",
+                    "default": {}
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Override default liveness probe",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Override default readiness probe",
+                    "default": {}
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Kubernetes service type",
+                            "default": "ClusterIP"
+                        },
+                        "port": {
+                            "type": "number",
+                            "description": "Service HTTP port",
+                            "default": 8080
+                        },
+                        "nodePort": {
+                            "type": "string",
+                            "description": "Specify the nodePort value for the LoadBalancer and NodePort service types",
+                            "default": ""
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "Dataflow server service cluster IP",
+                            "default": ""
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "Enable client source IP preservation",
+                            "default": "Cluster"
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "Load balancer IP if service type is `LoadBalancer`",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "Addresses that are allowed when service is LoadBalancer",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose (normally used with the `sidecar` value)",
+                            "default": [],
+                            "items": {}
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Provide any additional annotations which may be required. Evaluated as a template.",
+                            "default": {}
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                            "default": "None"
+                        },
+                        "sessionAffinityConfig": {
+                            "type": "object",
+                            "description": "Additional settings for the sessionAffinity",
+                            "default": {}
+                        }
+                    }
+                },
+                "ingress": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable ingress controller resource",
+                            "default": false
+                        },
+                        "path": {
+                            "type": "string",
+                            "description": "The Path to WordPress. You may need to set this to '/*' in order to use this with ALB ingress controllers.",
+                            "default": "/"
+                        },
+                        "apiVersion": {
+                            "type": "string",
+                            "description": "Force Ingress API version (automatically detected if not set)",
+                            "default": ""
+                        },
+                        "pathType": {
+                            "type": "string",
+                            "description": "Ingress path type",
+                            "default": "ImplementationSpecific"
+                        },
+                        "hostname": {
+                            "type": "string",
+                            "description": "Default host for the ingress resource",
+                            "default": "dataflow.local"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations.",
+                            "default": {}
+                        },
+                        "tls": {
+                            "type": "boolean",
+                            "description": "Enable TLS configuration for the hostname defined at ingress.hostname parameter",
+                            "default": false
+                        },
+                        "certManager": {
+                            "type": "boolean",
+                            "description": "Add the corresponding annotations for cert-manager integration",
+                            "default": false
+                        },
+                        "extraHosts": {
+                            "type": "array",
+                            "description": "The list of additional hostnames to be covered with this ingress record.",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraPaths": {
+                            "type": "array",
+                            "description": "An array with additional arbitrary paths that may need to be added to the ingress under the main host",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraTls": {
+                            "type": "array",
+                            "description": "The tls configuration for additional hostnames to be covered with this ingress record.",
+                            "default": [],
+                            "items": {}
+                        },
+                        "secrets": {
+                            "type": "array",
+                            "description": "If you're providing your own certificates, please use this to add the certificates as secrets",
+                            "default": [],
+                            "items": {}
+                        },
+                        "ingressClassName": {
+                            "type": "string",
+                            "description": "IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)",
+                            "default": ""
+                        },
+                        "extraRules": {
+                            "type": "array",
+                            "description": "Additional rules to be covered with this ingress record",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add init containers to the Dataflow Server pods",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add sidecars to the Dataflow Server pods",
+                    "default": [],
+                    "items": {}
+                },
+                "pdb": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Enable/disable a Pod Disruption Budget creation",
+                            "default": false
+                        },
+                        "minAvailable": {
+                            "type": "number",
+                            "description": "Minimum number/percentage of pods that should remain scheduled",
+                            "default": 1
+                        },
+                        "maxUnavailable": {
+                            "type": "string",
+                            "description": "Maximum number/percentage of pods that may be made unavailable",
+                            "default": ""
+                        }
+                    }
+                },
+                "autoscaling": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable autoscaling for Dataflow server",
+                            "default": false
+                        },
+                        "minReplicas": {
+                            "type": "string",
+                            "description": "Minimum number of Dataflow server replicas",
+                            "default": ""
+                        },
+                        "maxReplicas": {
+                            "type": "string",
+                            "description": "Maximum number of Dataflow server replicas",
+                            "default": ""
+                        },
+                        "targetCPU": {
+                            "type": "string",
+                            "description": "Target CPU utilization percentage",
+                            "default": ""
+                        },
+                        "targetMemory": {
+                            "type": "string",
+                            "description": "Target Memory utilization percentage",
+                            "default": ""
+                        }
+                    }
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Extra Volumes to be set on the Dataflow Server Pod",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Extra VolumeMounts to be set on the Dataflow Container",
+                    "default": [],
+                    "items": {}
+                },
+                "jdwp": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Set to true to enable Java debugger",
+                            "default": false
+                        },
+                        "port": {
+                            "type": "number",
+                            "description": "Specify port for remote debugging",
+                            "default": 5005
+                        }
+                    }
+                },
+                "proxy": {
+                    "type": "object",
+                    "description": "Add proxy configuration for SCDF server",
+                    "default": {}
+                },
+                "applicationProperties": {
+                    "type": "object",
+                    "description": "Specify common application properties added by SCDF server to streams and/or tasks",
+                    "default": {}
+                }
             }
-          }
-        }
-      }
-    },
-    "mariadb": {
-      "type": "object",
-      "title": "MariaDB Details",
-      "form": true,
-      "properties": {
-        "enabled": {
-          "type": "boolean",
-          "title": "Use a new MariaDB database hosted in the cluster",
-          "form": true,
-          "description": "Whether to deploy a MariaDB server to satisfy the Spring Cloud database requirements. To use an external database switch this off and configure the external database details"
-        }
-      }
-    },
-    "flyway": {
-      "type": "object",
-      "title": "Flyway Details",
-      "form": true,
-      "properties": {
-        "enabled": {
-          "type": "boolean",
-          "title": "Run or skip Database creation scripts on startup",
-          "form": true,
-          "description": "Whether to run or skip running Database creation scripts on startup. This feature can be used in scenario of Database schema and tables already present, when using Mariadb or external database"
-        }
-      }
-    },
-    "externalDatabase": {
-      "type": "object",
-      "title": "External Database Details",
-      "description": "If MariaDB is disabled. Use this section to specify the external database details",
-      "form": true,
-      "properties": {
-        "host": {
-          "type": "string",
-          "form": true,
-          "title": "Database Host",
-          "hidden": "mariadb/enabled"
-        },
-        "port": {
-          "type": "integer",
-          "form": true,
-          "title": "Database Port",
-          "hidden": "mariadb/enabled"
-        },
-        "password": {
-          "type": "string",
-          "form": true,
-          "title": "Database Password",
-          "hidden": "mariadb/enabled"
-        },
-        "dataflow": {
-          "type": "object",
-          "properties": {
-            "user": {
-              "type": "string",
-              "form": true,
-              "title": "Database Username for Dataflow server",
-              "hidden": "mariadb/enabled"
-            },
-            "database": {
-              "type": "string",
-              "form": true,
-              "title": "Database Name for Dataflow server",
-              "hidden": "mariadb/enabled"
-            }
-          }
         },
         "skipper": {
-          "type": "object",
-          "properties": {
-            "user": {
-              "type": "string",
-              "form": true,
-              "title": "Database Username for Skipper server",
-              "hidden": "mariadb/enabled"
-            },
-            "database": {
-              "type": "string",
-              "form": true,
-              "title": "Database Name for Skipper server",
-              "hidden": "mariadb/enabled"
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable Spring Cloud Skipper component",
+                    "default": true
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Deployment pod host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Spring Cloud Skipper image registry",
+                            "default": "REGISTRY_NAME"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Spring Cloud Skipper image repository",
+                            "default": "REPOSITORY_NAME/spring-cloud-skipper"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Spring Cloud Skipper image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Spring Cloud Skipper image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Specify docker-registry secret names as an array",
+                            "default": [],
+                            "items": {}
+                        },
+                        "debug": {
+                            "type": "boolean",
+                            "description": "Enable image debug mode",
+                            "default": false
+                        }
+                    }
+                },
+                "configuration": {
+                    "type": "object",
+                    "properties": {
+                        "accountName": {
+                            "type": "string",
+                            "description": "The name of the account to configure for the Kubernetes platform",
+                            "default": "default"
+                        },
+                        "trustK8sCerts": {
+                            "type": "boolean",
+                            "description": "Trust K8s certificates when querying the Kubernetes API",
+                            "default": false
+                        }
+                    }
+                },
+                "existingConfigmap": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap with Skipper server configuration",
+                    "default": ""
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the Skipper container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Extra environment variables to be set on Skipper server container",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra environment variables",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra environment variables",
+                    "default": ""
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of Skipper server replicas to deploy",
+                    "default": 1
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Skipper pod affinity preset. Ignored if `skipper.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Skipper pod anti-affinity preset. Ignored if `skipper.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Skipper node affinity preset type. Ignored if `skipper.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Skipper node label key to match Ignored if `skipper.affinity` is set.",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Skipper node label values to match. Ignored if `skipper.affinity` is set.",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Skipper affinity for pod assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Skipper node labels for pod assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Skipper tolerations for pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for Skipper server pods",
+                    "default": {}
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Deployment strategy type for Skipper server pods.",
+                            "default": "RollingUpdate"
+                        }
+                    }
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for Skipper pods",
+                    "default": {}
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Controller priorityClassName",
+                    "default": ""
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Name of the k8s scheduler (other than default)",
+                    "default": ""
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Skipper pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Group ID for the volumes of the pod",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set container's Security Context runAsNonRoot",
+                            "default": true
+                        },
+                        "privileged": {
+                            "type": "boolean",
+                            "description": "Set container's Security Context privileged",
+                            "default": false
+                        },
+                        "readOnlyRootFilesystem": {
+                            "type": "boolean",
+                            "description": "Set container's Security Context readOnlyRootFilesystem",
+                            "default": false
+                        },
+                        "allowPrivilegeEscalation": {
+                            "type": "boolean",
+                            "description": "Set container's Security Context allowPrivilegeEscalation",
+                            "default": false
+                        },
+                        "capabilities": {
+                            "type": "object",
+                            "properties": {
+                                "drop": {
+                                    "type": "array",
+                                    "description": "List of capabilities to be dropped",
+                                    "default": [
+                                        "ALL"
+                                    ],
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "seccompProfile": {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "description": "Set container's Security Context seccomp profile",
+                                    "default": "RuntimeDefault"
+                                }
+                            }
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the Skipper server container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the Skipper server container",
+                            "default": {}
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 120
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 20
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 120
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 20
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 120
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 20
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Override default startup probe",
+                    "default": {}
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Override default liveness probe",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Override default readiness probe",
+                    "default": {}
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Kubernetes service type",
+                            "default": "ClusterIP"
+                        },
+                        "port": {
+                            "type": "number",
+                            "description": "Service HTTP port",
+                            "default": 80
+                        },
+                        "nodePort": {
+                            "type": "string",
+                            "description": "Service HTTP node port",
+                            "default": ""
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "Skipper server service cluster IP",
+                            "default": ""
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "Enable client source IP preservation",
+                            "default": "Cluster"
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "Load balancer IP if service type is `LoadBalancer`",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "Address that are allowed when service is LoadBalancer",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose (normally used with the `sidecar` value)",
+                            "default": [],
+                            "items": {}
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Annotations for Skipper server service",
+                            "default": {}
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                            "default": "None"
+                        },
+                        "sessionAffinityConfig": {
+                            "type": "object",
+                            "description": "Additional settings for the sessionAffinity",
+                            "default": {}
+                        }
+                    }
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add init containers to the Dataflow Skipper pods",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add sidecars to the Skipper pods",
+                    "default": [],
+                    "items": {}
+                },
+                "pdb": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Enable/disable a Pod Disruption Budget creation",
+                            "default": false
+                        },
+                        "minAvailable": {
+                            "type": "number",
+                            "description": "Minimum number/percentage of pods that should remain scheduled",
+                            "default": 1
+                        },
+                        "maxUnavailable": {
+                            "type": "string",
+                            "description": "Maximum number/percentage of pods that may be made unavailable",
+                            "default": ""
+                        }
+                    }
+                },
+                "autoscaling": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable autoscaling for Skipper server",
+                            "default": false
+                        },
+                        "minReplicas": {
+                            "type": "string",
+                            "description": "Minimum number of Skipper server replicas",
+                            "default": ""
+                        },
+                        "maxReplicas": {
+                            "type": "string",
+                            "description": "Maximum number of Skipper server replicas",
+                            "default": ""
+                        },
+                        "targetCPU": {
+                            "type": "string",
+                            "description": "Target CPU utilization percentage",
+                            "default": ""
+                        },
+                        "targetMemory": {
+                            "type": "string",
+                            "description": "Target Memory utilization percentage",
+                            "default": ""
+                        }
+                    }
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Extra Volumes to be set on the Skipper Pod",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Extra VolumeMounts to be set on the Skipper Container",
+                    "default": [],
+                    "items": {}
+                },
+                "jdwp": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable Java Debug Wire Protocol (JDWP)",
+                            "default": false
+                        },
+                        "port": {
+                            "type": "number",
+                            "description": "JDWP TCP port for remote debugging",
+                            "default": 5005
+                        }
+                    }
+                }
             }
-          }
+        },
+        "externalSkipper": {
+            "type": "object",
+            "properties": {
+                "host": {
+                    "type": "string",
+                    "description": "Host of a external Skipper Server",
+                    "default": "localhost"
+                },
+                "port": {
+                    "type": "number",
+                    "description": "External Skipper Server port number",
+                    "default": 7577
+                }
+            }
+        },
+        "deployer": {
+            "type": "object",
+            "properties": {
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "requests": {
+                            "type": "object",
+                            "description": "Streaming applications resource requests",
+                            "default": {}
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 120
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 90
+                        }
+                    }
+                },
+                "nodeSelector": {
+                    "type": "string",
+                    "description": "The node selectors to apply to the streaming applications deployments in \"key:value\" format",
+                    "default": ""
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Streaming applications tolerations",
+                    "default": [],
+                    "items": {}
+                },
+                "volumeMounts": {
+                    "type": "array",
+                    "description": "Streaming applications extra volume mounts",
+                    "default": [],
+                    "items": {}
+                },
+                "volumes": {
+                    "type": "array",
+                    "description": "Streaming applications extra volumes",
+                    "default": [],
+                    "items": {}
+                },
+                "environmentVariables": {
+                    "type": "array",
+                    "description": "Streaming applications environment variables",
+                    "default": [],
+                    "items": {}
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled pods' Security Context of the deployed pods batch or stream pods",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set Dataflow Streams container's Security Context runAsUser",
+                            "default": 1001
+                        }
+                    }
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Streaming applications imagePullSecrets",
+                    "default": [],
+                    "items": {}
+                },
+                "secretRefs": {
+                    "type": "array",
+                    "description": "Streaming applications secretRefs",
+                    "default": [],
+                    "items": {}
+                },
+                "entryPointStyle": {
+                    "type": "string",
+                    "description": "An entry point style affects how application properties are passed to the container to be deployed. Allowed values: exec (default), shell, boot",
+                    "default": "exec"
+                },
+                "imagePullPolicy": {
+                    "type": "string",
+                    "description": "An image pull policy defines when a Docker image should be pulled to the local registry. Allowed values: IfNotPresent (default), Always, Never",
+                    "default": "IfNotPresent"
+                }
+            }
+        },
+        "serviceAccount": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Enable the creation of a ServiceAccount for Dataflow server and Skipper server pods",
+                    "default": true
+                },
+                "name": {
+                    "type": "string",
+                    "description": "Name of the created serviceAccount. If not set and create is true, a name is generated using the scdf.fullname template",
+                    "default": ""
+                },
+                "automountServiceAccountToken": {
+                    "type": "boolean",
+                    "description": "Automount service account token for the server service account",
+                    "default": true
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Annotations for service account. Evaluated as a template. Only used if `create` is `true`.",
+                    "default": {}
+                }
+            }
+        },
+        "rbac": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Whether to create and use RBAC resources or not",
+                    "default": true
+                }
+            }
+        },
+        "metrics": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable Prometheus metrics",
+                    "default": false
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Prometheus Rsocket Proxy image registry",
+                            "default": "REGISTRY_NAME"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Prometheus Rsocket Proxy image repository",
+                            "default": "REPOSITORY_NAME/prometheus-rsocket-proxy"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Prometheus Rsocket Proxy image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Prometheus Rsocket Proxy image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Specify docker-registry secret names as an array",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the Prometheus Rsocket Proxy container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the Prometheus Rsocket Proxy container",
+                            "default": {}
+                        }
+                    }
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of Prometheus Rsocket Proxy replicas to deploy",
+                    "default": 1
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "Prometheus Rsocket Proxy pod affinity preset. Ignored if `metrics.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "Prometheus Rsocket Proxy pod anti-affinity preset. Ignored if `metrics.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Prometheus Rsocket Proxy node affinity preset type. Ignored if `metrics.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Prometheus Rsocket Proxy node label key to match Ignored if `metrics.affinity` is set.",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "Prometheus Rsocket Proxy node label values to match. Ignored if `metrics.affinity` is set.",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Prometheus Rsocket Proxy affinity for pod assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Prometheus Rsocket Proxy node labels for pod assignment",
+                    "default": {}
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "Prometheus Proxy pods host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Prometheus Rsocket Proxy tolerations for pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Annotations for Prometheus Rsocket Proxy pods",
+                    "default": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Extra labels for Prometheus Proxy pods",
+                    "default": {}
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled Prometheus Proxy pods' Security Context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Set Prometheus Proxy pod's Security Context fsGroup",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set container's Security Context runAsNonRoot",
+                            "default": true
+                        },
+                        "privileged": {
+                            "type": "boolean",
+                            "description": "Set container's Security Context privileged",
+                            "default": false
+                        },
+                        "readOnlyRootFilesystem": {
+                            "type": "boolean",
+                            "description": "Set container's Security Context readOnlyRootFilesystem",
+                            "default": false
+                        },
+                        "allowPrivilegeEscalation": {
+                            "type": "boolean",
+                            "description": "Set container's Security Context allowPrivilegeEscalation",
+                            "default": false
+                        },
+                        "capabilities": {
+                            "type": "object",
+                            "properties": {
+                                "drop": {
+                                    "type": "array",
+                                    "description": "List of capabilities to be dropped",
+                                    "default": [
+                                        "ALL"
+                                    ],
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "seccompProfile": {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "description": "Set container's Security Context seccomp profile",
+                                    "default": "RuntimeDefault"
+                                }
+                            }
+                        }
+                    }
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the Prometheus Proxy container(s) to automate configuration before or after startup",
+                    "default": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add to Prometheus Proxy nodes",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for Prometheus Proxy nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for Prometheus Proxy nodes",
+                    "default": ""
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the Prometheus Proxy pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the Prometheus Proxy container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "containerPorts": {
+                    "type": "object",
+                    "properties": {
+                        "http": {
+                            "type": "number",
+                            "description": "Prometheus Proxy HTTP container port",
+                            "default": 8080
+                        },
+                        "rsocket": {
+                            "type": "number",
+                            "description": "Prometheus Proxy Rsocket container port",
+                            "default": 7001
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on Prometheus Proxy nodes",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on Prometheus Proxy nodes",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe on Prometheus Proxy nodes",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 3
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the Prometheus Proxy pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the Prometheus Proxy pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Prometheus Proxy deployment strategy type.",
+                            "default": "RollingUpdate"
+                        }
+                    }
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Prometheus Rsocket Proxy pods' priority.",
+                    "default": ""
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Name of the k8s scheduler (other than default)",
+                    "default": ""
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Prometheus Proxy service type",
+                            "default": "ClusterIP"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "number",
+                                    "description": "Prometheus Rsocket Proxy HTTP port",
+                                    "default": 8080
+                                },
+                                "rsocket": {
+                                    "type": "number",
+                                    "description": "Prometheus Rsocket Proxy Rsocket port",
+                                    "default": 7001
+                                }
+                            }
+                        },
+                        "nodePorts": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "string",
+                                    "description": "Node port for HTTP",
+                                    "default": ""
+                                },
+                                "rsocket": {
+                                    "type": "string",
+                                    "description": "Node port for Rsocket",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "Prometheys Proxy service Cluster IP",
+                            "default": ""
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "Prometheys Proxy service Load Balancer IP",
+                            "default": ""
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "Prometheys Proxy service Load Balancer sources",
+                            "default": [],
+                            "items": {}
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "Prometheys Proxy service external traffic policy",
+                            "default": "Cluster"
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose (normally used with the `sidecar` value)",
+                            "default": [],
+                            "items": {}
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                            "default": "None"
+                        },
+                        "sessionAffinityConfig": {
+                            "type": "object",
+                            "description": "Additional settings for the sessionAffinity",
+                            "default": {}
+                        }
+                    }
+                },
+                "serviceMonitor": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "if `true`, creates a Prometheus Operator ServiceMonitor (also requires `metrics.enabled` to be `true`)",
+                            "default": false
+                        },
+                        "namespace": {
+                            "type": "string",
+                            "description": "Namespace in which ServiceMonitor is created if different from release",
+                            "default": ""
+                        },
+                        "jobLabel": {
+                            "type": "string",
+                            "description": "The name of the label on the target service to use as the job name in prometheus.",
+                            "default": ""
+                        },
+                        "interval": {
+                            "type": "string",
+                            "description": "Interval at which metrics should be scraped.",
+                            "default": ""
+                        },
+                        "scrapeTimeout": {
+                            "type": "string",
+                            "description": "Timeout after which the scrape is ended",
+                            "default": ""
+                        },
+                        "relabelings": {
+                            "type": "array",
+                            "description": "RelabelConfigs to apply to samples before scraping",
+                            "default": [],
+                            "items": {}
+                        },
+                        "metricRelabelings": {
+                            "type": "array",
+                            "description": "MetricRelabelConfigs to apply to samples before ingestion",
+                            "default": [],
+                            "items": {}
+                        },
+                        "selector": {
+                            "type": "object",
+                            "description": "ServiceMonitor selector labels",
+                            "default": {}
+                        },
+                        "labels": {
+                            "type": "object",
+                            "description": "Extra labels for the ServiceMonitor",
+                            "default": {}
+                        },
+                        "honorLabels": {
+                            "type": "boolean",
+                            "description": "honorLabels chooses the metric's labels on collisions with target labels",
+                            "default": false
+                        }
+                    }
+                },
+                "pdb": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "type": "boolean",
+                            "description": "Enable/disable a Pod Disruption Budget creation",
+                            "default": false
+                        },
+                        "minAvailable": {
+                            "type": "number",
+                            "description": "Minimum number/percentage of pods that should remain scheduled",
+                            "default": 1
+                        },
+                        "maxUnavailable": {
+                            "type": "string",
+                            "description": "Maximum number/percentage of pods that may be made unavailable",
+                            "default": ""
+                        }
+                    }
+                },
+                "autoscaling": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable autoscaling for Prometheus Rsocket Proxy",
+                            "default": false
+                        },
+                        "minReplicas": {
+                            "type": "string",
+                            "description": "Minimum number of Prometheus Rsocket Proxy replicas",
+                            "default": ""
+                        },
+                        "maxReplicas": {
+                            "type": "string",
+                            "description": "Maximum number of Prometheus Rsocket Proxy replicas",
+                            "default": ""
+                        },
+                        "targetCPU": {
+                            "type": "string",
+                            "description": "Target CPU utilization percentage",
+                            "default": ""
+                        },
+                        "targetMemory": {
+                            "type": "string",
+                            "description": "Target Memory utilization percentage",
+                            "default": ""
+                        }
+                    }
+                }
+            }
+        },
+        "waitForBackends": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Wait for the database and other services (such as Kafka or RabbitMQ) used when enabling streaming",
+                    "default": true
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Init container wait-for-backend image registry",
+                            "default": "REGISTRY_NAME"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Init container wait-for-backend image name",
+                            "default": "REPOSITORY_NAME/kubectl"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Init container wait-for-backend image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Init container wait-for-backend image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Specify docker-registry secret names as an array",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enabled containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set container's Security Context runAsNonRoot",
+                            "default": true
+                        },
+                        "privileged": {
+                            "type": "boolean",
+                            "description": "Set container's Security Context privileged",
+                            "default": false
+                        },
+                        "readOnlyRootFilesystem": {
+                            "type": "boolean",
+                            "description": "Set container's Security Context readOnlyRootFilesystem",
+                            "default": false
+                        },
+                        "allowPrivilegeEscalation": {
+                            "type": "boolean",
+                            "description": "Set container's Security Context allowPrivilegeEscalation",
+                            "default": false
+                        },
+                        "capabilities": {
+                            "type": "object",
+                            "properties": {
+                                "drop": {
+                                    "type": "array",
+                                    "description": "List of capabilities to be dropped",
+                                    "default": [
+                                        "ALL"
+                                    ],
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "seccompProfile": {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "description": "Set container's Security Context seccomp profile",
+                                    "default": "RuntimeDefault"
+                                }
+                            }
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "Init container wait-for-backend resource limits",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "Init container wait-for-backend resource requests",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        },
+        "mariadb": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable/disable MariaDB chart installation",
+                    "default": true
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "MariaDB image registry",
+                            "default": "REGISTRY_NAME"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "MariaDB image repository",
+                            "default": "REPOSITORY_NAME/mariadb"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "MariaDB image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        }
+                    }
+                },
+                "architecture": {
+                    "type": "string",
+                    "description": "MariaDB architecture. Allowed values: `standalone` or `replication`",
+                    "default": "standalone"
+                },
+                "auth": {
+                    "type": "object",
+                    "properties": {
+                        "rootPassword": {
+                            "type": "string",
+                            "description": "Password for the MariaDB `root` user",
+                            "default": ""
+                        },
+                        "username": {
+                            "type": "string",
+                            "description": "Username of new user to create",
+                            "default": "dataflow"
+                        },
+                        "password": {
+                            "type": "string",
+                            "description": "Password for the new user",
+                            "default": "change-me"
+                        },
+                        "database": {
+                            "type": "string",
+                            "description": "Database name to create",
+                            "default": "dataflow"
+                        },
+                        "forcePassword": {
+                            "type": "boolean",
+                            "description": "Force users to specify required passwords in the database",
+                            "default": false
+                        },
+                        "usePasswordFiles": {
+                            "type": "boolean",
+                            "description": "Mount credentials as a file instead of using an environment variable",
+                            "default": false
+                        }
+                    }
+                }
+            }
+        },
+        "flyway": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable/disable flyway running Dataflow and Skipper Database creation scripts on startup",
+                    "default": true
+                }
+            }
+        },
+        "externalDatabase": {
+            "type": "object",
+            "properties": {
+                "host": {
+                    "type": "string",
+                    "description": "Host of the external database",
+                    "default": "localhost"
+                },
+                "port": {
+                    "type": "number",
+                    "description": "External database port number",
+                    "default": 3306
+                },
+                "driver": {
+                    "type": "string",
+                    "description": "The fully qualified name of the JDBC Driver class",
+                    "default": ""
+                },
+                "scheme": {
+                    "type": "string",
+                    "description": "The scheme is a vendor-specific or shared protocol string that follows the \"jdbc:\" of the URL",
+                    "default": ""
+                },
+                "password": {
+                    "type": "string",
+                    "description": "Password for the above username",
+                    "default": ""
+                },
+                "existingPasswordSecret": {
+                    "type": "string",
+                    "description": "Existing secret with database password",
+                    "default": ""
+                },
+                "existingPasswordKey": {
+                    "type": "string",
+                    "description": "Key of the existing secret with database password, defaults to `datasource-password`",
+                    "default": ""
+                },
+                "dataflow": {
+                    "type": "object",
+                    "properties": {
+                        "url": {
+                            "type": "string",
+                            "description": "JDBC URL for dataflow server. Overrides external scheme, host, port, database, and jdbc parameters.",
+                            "default": ""
+                        },
+                        "database": {
+                            "type": "string",
+                            "description": "Name of the existing database to be used by Dataflow server",
+                            "default": "dataflow"
+                        },
+                        "username": {
+                            "type": "string",
+                            "description": "Existing username in the external db to be used by Dataflow server",
+                            "default": "dataflow"
+                        }
+                    }
+                },
+                "skipper": {
+                    "type": "object",
+                    "properties": {
+                        "url": {
+                            "type": "string",
+                            "description": "JDBC URL for skipper. Overrides external scheme, host, port, database, and jdbc parameters.",
+                            "default": ""
+                        },
+                        "database": {
+                            "type": "string",
+                            "description": "Name of the existing database to be used by Skipper server",
+                            "default": "skipper"
+                        },
+                        "username": {
+                            "type": "string",
+                            "description": "Existing username in the external db to be used by Skipper server",
+                            "default": "skipper"
+                        }
+                    }
+                },
+                "hibernateDialect": {
+                    "type": "string",
+                    "description": "Hibernate Dialect used by Dataflow/Skipper servers",
+                    "default": ""
+                }
+            }
+        },
+        "rabbitmq": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable/disable RabbitMQ chart installation",
+                    "default": true
+                },
+                "auth": {
+                    "type": "object",
+                    "properties": {
+                        "username": {
+                            "type": "string",
+                            "description": "RabbitMQ username",
+                            "default": "user"
+                        }
+                    }
+                }
+            }
+        },
+        "externalRabbitmq": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable/disable external RabbitMQ",
+                    "default": false
+                },
+                "host": {
+                    "type": "string",
+                    "description": "Host of the external RabbitMQ",
+                    "default": "localhost"
+                },
+                "port": {
+                    "type": "number",
+                    "description": "External RabbitMQ port number",
+                    "default": 5672
+                },
+                "username": {
+                    "type": "string",
+                    "description": "External RabbitMQ username",
+                    "default": "guest"
+                },
+                "password": {
+                    "type": "string",
+                    "description": "External RabbitMQ password. It will be saved in a kubernetes secret",
+                    "default": "guest"
+                },
+                "vhost": {
+                    "type": "string",
+                    "description": "External RabbitMQ virtual host. It will be saved in a kubernetes secret",
+                    "default": ""
+                },
+                "existingPasswordSecret": {
+                    "type": "string",
+                    "description": "Existing secret with RabbitMQ password. It will be saved in a kubernetes secret",
+                    "default": ""
+                }
+            }
+        },
+        "kafka": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable/disable Kafka chart installation",
+                    "default": false
+                },
+                "controller": {
+                    "type": "object",
+                    "properties": {
+                        "replicaCount": {
+                            "type": "number",
+                            "description": "Number of Kafka controller+brokers nodes",
+                            "default": 1
+                        }
+                    }
+                },
+                "extraConfig": {
+                    "type": "string",
+                    "description": "Kafka extra configuration to be appended to dynamic settings",
+                    "default": "offsets.topic.replication.factor=1"
+                }
+            }
+        },
+        "externalKafka": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable/disable external Kafka",
+                    "default": false
+                },
+                "brokers": {
+                    "type": "string",
+                    "description": "External Kafka brokers",
+                    "default": "localhost:9092"
+                },
+                "zkNodes": {
+                    "type": "string",
+                    "description": "External Zookeeper nodes",
+                    "default": "localhost:2181"
+                }
+            }
         }
-      }
-    },
-    "rabbitmq": {
-      "type": "object",
-      "title": "RabbitMQ Details",
-      "form": true,
-      "properties": {
-        "enabled": {
-          "type": "boolean",
-          "title": "Use a new RabbitMQ server hosted in the cluster",
-          "form": true,
-          "description": "Whether to deploy a RabbitMQ server to satisfy the Spring Cloud Skipper messaging middleware requirements."
-        }
-      }
-    },
-    "kafka": {
-      "type": "object",
-      "title": "Kafka Details",
-      "form": true,
-      "properties": {
-        "enabled": {
-          "type": "boolean",
-          "title": "Use a new Kafka server hosted in the cluster",
-          "form": true,
-          "description": "Whether to deploy a Kafka server to satisfy the Spring Cloud Skipper messaging middleware requirements."
-        }
-      }
     }
-  }
 }

--- a/bitnami/spring-cloud-dataflow/values.schema.json
+++ b/bitnami/spring-cloud-dataflow/values.schema.json
@@ -1,2454 +1,344 @@
 {
-    "title": "Chart Values",
-    "type": "object",
-    "properties": {
-        "global": {
-            "type": "object",
-            "properties": {
-                "imageRegistry": {
-                    "type": "string",
-                    "description": "Global Docker image registry",
-                    "default": ""
-                },
-                "imagePullSecrets": {
-                    "type": "array",
-                    "description": "Global Docker registry secret names as an array",
-                    "default": [],
-                    "items": {}
-                },
-                "storageClass": {
-                    "type": "string",
-                    "description": "Global StorageClass for Persistent Volume(s)",
-                    "default": ""
-                }
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object",
+  "properties": {
+    "server": {
+      "type": "object",
+      "form": true,
+      "title": "Spring Cloud Dataflow Server configuration",
+      "properties": {
+        "configuration": {
+          "type": "object",
+          "title": "Spring Cloud Dataflow Server configuration",
+          "properties": {
+            "streamingEnabled": {
+              "type": "boolean",
+              "title": "Enable deploying streaming data",
+              "form": true,
+              "description": "Enable support for Stream processing using using RabbitMQ or Kafka"
+            },
+            "batchEnabled": {
+              "type": "boolean",
+              "title": "Enable deploying Batch data",
+              "form": true,
+              "description": "Enable support for Task and Schedules processing"
             }
+          }
         },
-        "nameOverride": {
-            "type": "string",
-            "description": "String to partially override scdf.fullname template (will maintain the release name).",
-            "default": ""
+        "replicaCount": {
+          "type": "integer",
+          "form": true,
+          "title": "Dataflow server replicas"
         },
-        "fullnameOverride": {
-            "type": "string",
-            "description": "String to fully override scdf.fullname template.",
-            "default": ""
-        },
-        "commonAnnotations": {
-            "type": "object",
-            "description": "Annotations to add to all deployed objects",
-            "default": {}
-        },
-        "commonLabels": {
-            "type": "object",
-            "description": "Labels to add to all deployed objects",
-            "default": {}
-        },
-        "kubeVersion": {
-            "type": "string",
-            "description": "Force target Kubernetes version (using Helm capabilities if not set)",
-            "default": ""
-        },
-        "clusterDomain": {
-            "type": "string",
-            "description": "Default Kubernetes cluster domain",
-            "default": "cluster.local"
-        },
-        "extraDeploy": {
-            "type": "array",
-            "description": "Array of extra objects to deploy with the release",
-            "default": [],
-            "items": {}
-        },
-        "server": {
-            "type": "object",
-            "properties": {
-                "image": {
-                    "type": "object",
-                    "properties": {
-                        "registry": {
-                            "type": "string",
-                            "description": "Spring Cloud Dataflow image registry",
-                            "default": "REGISTRY_NAME"
-                        },
-                        "repository": {
-                            "type": "string",
-                            "description": "Spring Cloud Dataflow image repository",
-                            "default": "REPOSITORY_NAME/spring-cloud-dataflow"
-                        },
-                        "digest": {
-                            "type": "string",
-                            "description": "Spring Cloud Dataflow image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
-                            "default": ""
-                        },
-                        "pullPolicy": {
-                            "type": "string",
-                            "description": "Spring Cloud Dataflow image pull policy",
-                            "default": "IfNotPresent"
-                        },
-                        "pullSecrets": {
-                            "type": "array",
-                            "description": "Specify docker-registry secret names as an array",
-                            "default": [],
-                            "items": {}
-                        },
-                        "debug": {
-                            "type": "boolean",
-                            "description": "Enable image debug mode",
-                            "default": false
-                        }
-                    }
+        "resources": {
+          "type": "object",
+          "title": "Required Resources",
+          "description": "Configure resource requests",
+          "form": true,
+          "properties": {
+            "requests": {
+              "type": "object",
+              "properties": {
+                "memory": {
+                  "type": "string",
+                  "form": true,
+                  "render": "slider",
+                  "title": "Memory Request",
+                  "sliderMin": 10,
+                  "sliderMax": 2048,
+                  "sliderUnit": "Mi"
                 },
-                "hostAliases": {
-                    "type": "array",
-                    "description": "Deployment pod host aliases",
-                    "default": [],
-                    "items": {}
-                },
-                "composedTaskRunner": {
-                    "type": "object",
-                    "properties": {
-                        "image": {
-                            "type": "object",
-                            "properties": {
-                                "registry": {
-                                    "type": "string",
-                                    "description": "Spring Cloud Dataflow Composed Task Runner image registry",
-                                    "default": "REGISTRY_NAME"
-                                },
-                                "repository": {
-                                    "type": "string",
-                                    "description": "Spring Cloud Dataflow Composed Task Runner image repository",
-                                    "default": "REPOSITORY_NAME/spring-cloud-dataflow-composed-task-runner"
-                                },
-                                "digest": {
-                                    "type": "string",
-                                    "description": "Spring Cloud Dataflow Composed Task Runner image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
-                                    "default": ""
-                                }
-                            }
-                        }
-                    }
-                },
-                "configuration": {
-                    "type": "object",
-                    "properties": {
-                        "streamingEnabled": {
-                            "type": "boolean",
-                            "description": "Enables or disables streaming data processing",
-                            "default": true
-                        },
-                        "batchEnabled": {
-                            "type": "boolean",
-                            "description": "Enables or disables batch data (tasks and schedules) processing",
-                            "default": true
-                        },
-                        "accountName": {
-                            "type": "string",
-                            "description": "The name of the account to configure for the Kubernetes platform",
-                            "default": "default"
-                        },
-                        "trustK8sCerts": {
-                            "type": "boolean",
-                            "description": "Trust K8s certificates when querying the Kubernetes API",
-                            "default": false
-                        },
-                        "containerRegistries": {
-                            "type": "object",
-                            "description": "Container registries configuration",
-                            "default": {}
-                        },
-                        "grafanaInfo": {
-                            "type": "string",
-                            "description": "Endpoint to the grafana instance (Deprecated: use the metricsDashboard instead)",
-                            "default": ""
-                        },
-                        "metricsDashboard": {
-                            "type": "string",
-                            "description": "Endpoint to the metricsDashboard instance",
-                            "default": ""
-                        },
-                        "defaultSpringApplicationJSON": {
-                            "type": "boolean",
-                            "description": "Injects default values for environment variable SPRING_APPLICATION_JSON",
-                            "default": true
-                        }
-                    }
-                },
-                "existingConfigmap": {
-                    "type": "string",
-                    "description": "ConfigMap with Spring Cloud Dataflow Server Configuration",
-                    "default": ""
-                },
-                "command": {
-                    "type": "array",
-                    "description": "Override default container command (useful when using custom images)",
-                    "default": [],
-                    "items": {}
-                },
-                "args": {
-                    "type": "array",
-                    "description": "Override default container args (useful when using custom images)",
-                    "default": [],
-                    "items": {}
-                },
-                "lifecycleHooks": {
-                    "type": "object",
-                    "description": "for the Dataflow server container(s) to automate configuration before or after startup",
-                    "default": {}
-                },
-                "extraEnvVars": {
-                    "type": "array",
-                    "description": "Extra environment variables to be set on Dataflow server container",
-                    "default": [],
-                    "items": {}
-                },
-                "extraEnvVarsCM": {
-                    "type": "string",
-                    "description": "ConfigMap with extra environment variables",
-                    "default": ""
-                },
-                "extraEnvVarsSecret": {
-                    "type": "string",
-                    "description": "Secret with extra environment variables",
-                    "default": ""
-                },
-                "replicaCount": {
-                    "type": "number",
-                    "description": "Number of Dataflow server replicas to deploy",
-                    "default": 1
-                },
-                "podAffinityPreset": {
-                    "type": "string",
-                    "description": "Dataflow server pod affinity preset. Ignored if `server.affinity` is set. Allowed values: `soft` or `hard`",
-                    "default": ""
-                },
-                "podAntiAffinityPreset": {
-                    "type": "string",
-                    "description": "Dataflow server pod anti-affinity preset. Ignored if `server.affinity` is set. Allowed values: `soft` or `hard`",
-                    "default": "soft"
-                },
-                "containerPort": {
-                    "type": "number",
-                    "description": "Dataflow server port",
-                    "default": 8080
-                },
-                "nodeAffinityPreset": {
-                    "type": "object",
-                    "properties": {
-                        "type": {
-                            "type": "string",
-                            "description": "Dataflow server node affinity preset type. Ignored if `server.affinity` is set. Allowed values: `soft` or `hard`",
-                            "default": ""
-                        },
-                        "key": {
-                            "type": "string",
-                            "description": "Dataflow server node label key to match Ignored if `server.affinity` is set.",
-                            "default": ""
-                        },
-                        "values": {
-                            "type": "array",
-                            "description": "Dataflow server node label values to match. Ignored if `server.affinity` is set.",
-                            "default": [],
-                            "items": {}
-                        }
-                    }
-                },
-                "affinity": {
-                    "type": "object",
-                    "description": "Dataflow server affinity for pod assignment",
-                    "default": {}
-                },
-                "nodeSelector": {
-                    "type": "object",
-                    "description": "Dataflow server node labels for pod assignment",
-                    "default": {}
-                },
-                "tolerations": {
-                    "type": "array",
-                    "description": "Dataflow server tolerations for pod assignment",
-                    "default": [],
-                    "items": {}
-                },
-                "podAnnotations": {
-                    "type": "object",
-                    "description": "Annotations for Dataflow server pods",
-                    "default": {}
-                },
-                "updateStrategy": {
-                    "type": "object",
-                    "properties": {
-                        "type": {
-                            "type": "string",
-                            "description": "Deployment strategy type for Dataflow server pods.",
-                            "default": "RollingUpdate"
-                        }
-                    }
-                },
-                "podLabels": {
-                    "type": "object",
-                    "description": "Extra labels for Dataflow Server pods",
-                    "default": {}
-                },
-                "priorityClassName": {
-                    "type": "string",
-                    "description": "Dataflow Server pods' priority",
-                    "default": ""
-                },
-                "schedulerName": {
-                    "type": "string",
-                    "description": "Name of the k8s scheduler (other than default)",
-                    "default": ""
-                },
-                "topologySpreadConstraints": {
-                    "type": "array",
-                    "description": "Topology Spread Constraints for pod assignment",
-                    "default": [],
-                    "items": {}
-                },
-                "podSecurityContext": {
-                    "type": "object",
-                    "properties": {
-                        "enabled": {
-                            "type": "boolean",
-                            "description": "Enabled Dataflow Server pods' Security Context",
-                            "default": true
-                        },
-                        "fsGroup": {
-                            "type": "number",
-                            "description": "Group ID for the volumes of the pod",
-                            "default": 1001
-                        }
-                    }
-                },
-                "containerSecurityContext": {
-                    "type": "object",
-                    "properties": {
-                        "enabled": {
-                            "type": "boolean",
-                            "description": "Enabled containers' Security Context",
-                            "default": true
-                        },
-                        "runAsUser": {
-                            "type": "number",
-                            "description": "Set containers' Security Context runAsUser",
-                            "default": 1001
-                        },
-                        "runAsNonRoot": {
-                            "type": "boolean",
-                            "description": "Set container's Security Context runAsNonRoot",
-                            "default": true
-                        },
-                        "privileged": {
-                            "type": "boolean",
-                            "description": "Set container's Security Context privileged",
-                            "default": false
-                        },
-                        "readOnlyRootFilesystem": {
-                            "type": "boolean",
-                            "description": "Set container's Security Context readOnlyRootFilesystem",
-                            "default": false
-                        },
-                        "allowPrivilegeEscalation": {
-                            "type": "boolean",
-                            "description": "Set container's Security Context allowPrivilegeEscalation",
-                            "default": false
-                        },
-                        "capabilities": {
-                            "type": "object",
-                            "properties": {
-                                "drop": {
-                                    "type": "array",
-                                    "description": "List of capabilities to be dropped",
-                                    "default": [
-                                        "ALL"
-                                    ],
-                                    "items": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "seccompProfile": {
-                            "type": "object",
-                            "properties": {
-                                "type": {
-                                    "type": "string",
-                                    "description": "Set container's Security Context seccomp profile",
-                                    "default": "RuntimeDefault"
-                                }
-                            }
-                        }
-                    }
-                },
-                "resources": {
-                    "type": "object",
-                    "properties": {
-                        "limits": {
-                            "type": "object",
-                            "description": "The resources limits for the Dataflow server container",
-                            "default": {}
-                        },
-                        "requests": {
-                            "type": "object",
-                            "description": "The requested resources for the Dataflow server container",
-                            "default": {}
-                        }
-                    }
-                },
-                "startupProbe": {
-                    "type": "object",
-                    "properties": {
-                        "enabled": {
-                            "type": "boolean",
-                            "description": "Enable startupProbe",
-                            "default": false
-                        },
-                        "initialDelaySeconds": {
-                            "type": "number",
-                            "description": "Initial delay seconds for startupProbe",
-                            "default": 120
-                        },
-                        "periodSeconds": {
-                            "type": "number",
-                            "description": "Period seconds for startupProbe",
-                            "default": 20
-                        },
-                        "timeoutSeconds": {
-                            "type": "number",
-                            "description": "Timeout seconds for startupProbe",
-                            "default": 1
-                        },
-                        "failureThreshold": {
-                            "type": "number",
-                            "description": "Failure threshold for startupProbe",
-                            "default": 6
-                        },
-                        "successThreshold": {
-                            "type": "number",
-                            "description": "Success threshold for startupProbe",
-                            "default": 1
-                        }
-                    }
-                },
-                "livenessProbe": {
-                    "type": "object",
-                    "properties": {
-                        "enabled": {
-                            "type": "boolean",
-                            "description": "Enable livenessProbe",
-                            "default": true
-                        },
-                        "initialDelaySeconds": {
-                            "type": "number",
-                            "description": "Initial delay seconds for livenessProbe",
-                            "default": 120
-                        },
-                        "periodSeconds": {
-                            "type": "number",
-                            "description": "Period seconds for livenessProbe",
-                            "default": 20
-                        },
-                        "timeoutSeconds": {
-                            "type": "number",
-                            "description": "Timeout seconds for livenessProbe",
-                            "default": 1
-                        },
-                        "failureThreshold": {
-                            "type": "number",
-                            "description": "Failure threshold for livenessProbe",
-                            "default": 6
-                        },
-                        "successThreshold": {
-                            "type": "number",
-                            "description": "Success threshold for livenessProbe",
-                            "default": 1
-                        }
-                    }
-                },
-                "readinessProbe": {
-                    "type": "object",
-                    "properties": {
-                        "enabled": {
-                            "type": "boolean",
-                            "description": "Enable readinessProbe",
-                            "default": true
-                        },
-                        "initialDelaySeconds": {
-                            "type": "number",
-                            "description": "Initial delay seconds for readinessProbe",
-                            "default": 120
-                        },
-                        "periodSeconds": {
-                            "type": "number",
-                            "description": "Period seconds for readinessProbe",
-                            "default": 20
-                        },
-                        "timeoutSeconds": {
-                            "type": "number",
-                            "description": "Timeout seconds for readinessProbe",
-                            "default": 1
-                        },
-                        "failureThreshold": {
-                            "type": "number",
-                            "description": "Failure threshold for readinessProbe",
-                            "default": 6
-                        },
-                        "successThreshold": {
-                            "type": "number",
-                            "description": "Success threshold for readinessProbe",
-                            "default": 1
-                        }
-                    }
-                },
-                "customStartupProbe": {
-                    "type": "object",
-                    "description": "Override default startup probe",
-                    "default": {}
-                },
-                "customLivenessProbe": {
-                    "type": "object",
-                    "description": "Override default liveness probe",
-                    "default": {}
-                },
-                "customReadinessProbe": {
-                    "type": "object",
-                    "description": "Override default readiness probe",
-                    "default": {}
-                },
-                "service": {
-                    "type": "object",
-                    "properties": {
-                        "type": {
-                            "type": "string",
-                            "description": "Kubernetes service type",
-                            "default": "ClusterIP"
-                        },
-                        "port": {
-                            "type": "number",
-                            "description": "Service HTTP port",
-                            "default": 8080
-                        },
-                        "nodePort": {
-                            "type": "string",
-                            "description": "Specify the nodePort value for the LoadBalancer and NodePort service types",
-                            "default": ""
-                        },
-                        "clusterIP": {
-                            "type": "string",
-                            "description": "Dataflow server service cluster IP",
-                            "default": ""
-                        },
-                        "externalTrafficPolicy": {
-                            "type": "string",
-                            "description": "Enable client source IP preservation",
-                            "default": "Cluster"
-                        },
-                        "loadBalancerIP": {
-                            "type": "string",
-                            "description": "Load balancer IP if service type is `LoadBalancer`",
-                            "default": ""
-                        },
-                        "loadBalancerSourceRanges": {
-                            "type": "array",
-                            "description": "Addresses that are allowed when service is LoadBalancer",
-                            "default": [],
-                            "items": {}
-                        },
-                        "extraPorts": {
-                            "type": "array",
-                            "description": "Extra ports to expose (normally used with the `sidecar` value)",
-                            "default": [],
-                            "items": {}
-                        },
-                        "annotations": {
-                            "type": "object",
-                            "description": "Provide any additional annotations which may be required. Evaluated as a template.",
-                            "default": {}
-                        },
-                        "sessionAffinity": {
-                            "type": "string",
-                            "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
-                            "default": "None"
-                        },
-                        "sessionAffinityConfig": {
-                            "type": "object",
-                            "description": "Additional settings for the sessionAffinity",
-                            "default": {}
-                        }
-                    }
-                },
-                "ingress": {
-                    "type": "object",
-                    "properties": {
-                        "enabled": {
-                            "type": "boolean",
-                            "description": "Enable ingress controller resource",
-                            "default": false
-                        },
-                        "path": {
-                            "type": "string",
-                            "description": "The Path to WordPress. You may need to set this to '/*' in order to use this with ALB ingress controllers.",
-                            "default": "/"
-                        },
-                        "apiVersion": {
-                            "type": "string",
-                            "description": "Force Ingress API version (automatically detected if not set)",
-                            "default": ""
-                        },
-                        "pathType": {
-                            "type": "string",
-                            "description": "Ingress path type",
-                            "default": "ImplementationSpecific"
-                        },
-                        "hostname": {
-                            "type": "string",
-                            "description": "Default host for the ingress resource",
-                            "default": "dataflow.local"
-                        },
-                        "annotations": {
-                            "type": "object",
-                            "description": "Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations.",
-                            "default": {}
-                        },
-                        "tls": {
-                            "type": "boolean",
-                            "description": "Enable TLS configuration for the hostname defined at ingress.hostname parameter",
-                            "default": false
-                        },
-                        "certManager": {
-                            "type": "boolean",
-                            "description": "Add the corresponding annotations for cert-manager integration",
-                            "default": false
-                        },
-                        "extraHosts": {
-                            "type": "array",
-                            "description": "The list of additional hostnames to be covered with this ingress record.",
-                            "default": [],
-                            "items": {}
-                        },
-                        "extraPaths": {
-                            "type": "array",
-                            "description": "An array with additional arbitrary paths that may need to be added to the ingress under the main host",
-                            "default": [],
-                            "items": {}
-                        },
-                        "extraTls": {
-                            "type": "array",
-                            "description": "The tls configuration for additional hostnames to be covered with this ingress record.",
-                            "default": [],
-                            "items": {}
-                        },
-                        "secrets": {
-                            "type": "array",
-                            "description": "If you're providing your own certificates, please use this to add the certificates as secrets",
-                            "default": [],
-                            "items": {}
-                        },
-                        "ingressClassName": {
-                            "type": "string",
-                            "description": "IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)",
-                            "default": ""
-                        },
-                        "extraRules": {
-                            "type": "array",
-                            "description": "Additional rules to be covered with this ingress record",
-                            "default": [],
-                            "items": {}
-                        }
-                    }
-                },
-                "initContainers": {
-                    "type": "array",
-                    "description": "Add init containers to the Dataflow Server pods",
-                    "default": [],
-                    "items": {}
-                },
-                "sidecars": {
-                    "type": "array",
-                    "description": "Add sidecars to the Dataflow Server pods",
-                    "default": [],
-                    "items": {}
-                },
-                "pdb": {
-                    "type": "object",
-                    "properties": {
-                        "create": {
-                            "type": "boolean",
-                            "description": "Enable/disable a Pod Disruption Budget creation",
-                            "default": false
-                        },
-                        "minAvailable": {
-                            "type": "number",
-                            "description": "Minimum number/percentage of pods that should remain scheduled",
-                            "default": 1
-                        },
-                        "maxUnavailable": {
-                            "type": "string",
-                            "description": "Maximum number/percentage of pods that may be made unavailable",
-                            "default": ""
-                        }
-                    }
-                },
-                "autoscaling": {
-                    "type": "object",
-                    "properties": {
-                        "enabled": {
-                            "type": "boolean",
-                            "description": "Enable autoscaling for Dataflow server",
-                            "default": false
-                        },
-                        "minReplicas": {
-                            "type": "string",
-                            "description": "Minimum number of Dataflow server replicas",
-                            "default": ""
-                        },
-                        "maxReplicas": {
-                            "type": "string",
-                            "description": "Maximum number of Dataflow server replicas",
-                            "default": ""
-                        },
-                        "targetCPU": {
-                            "type": "string",
-                            "description": "Target CPU utilization percentage",
-                            "default": ""
-                        },
-                        "targetMemory": {
-                            "type": "string",
-                            "description": "Target Memory utilization percentage",
-                            "default": ""
-                        }
-                    }
-                },
-                "extraVolumes": {
-                    "type": "array",
-                    "description": "Extra Volumes to be set on the Dataflow Server Pod",
-                    "default": [],
-                    "items": {}
-                },
-                "extraVolumeMounts": {
-                    "type": "array",
-                    "description": "Extra VolumeMounts to be set on the Dataflow Container",
-                    "default": [],
-                    "items": {}
-                },
-                "jdwp": {
-                    "type": "object",
-                    "properties": {
-                        "enabled": {
-                            "type": "boolean",
-                            "description": "Set to true to enable Java debugger",
-                            "default": false
-                        },
-                        "port": {
-                            "type": "number",
-                            "description": "Specify port for remote debugging",
-                            "default": 5005
-                        }
-                    }
-                },
-                "proxy": {
-                    "type": "object",
-                    "description": "Add proxy configuration for SCDF server",
-                    "default": {}
-                },
-                "applicationProperties": {
-                    "type": "object",
-                    "description": "Specify common application properties added by SCDF server to streams and/or tasks",
-                    "default": {}
+                "cpu": {
+                  "type": "string",
+                  "form": true,
+                  "render": "slider",
+                  "title": "CPU Request",
+                  "sliderMin": 10,
+                  "sliderMax": 2000,
+                  "sliderUnit": "m"
                 }
+              }
             }
+          }
+        },
+        "ingress": {
+          "type": "object",
+          "form": true,
+          "title": "Ingress configuration",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "form": true,
+              "title": "Use a custom hostname",
+              "description": "Enable the ingress resource that allows you to access the Dataflow Server dashboard."
+            },
+            "hostname": {
+              "type": "string",
+              "form": true,
+              "title": "Hostname",
+              "hidden": {
+                "condition": false,
+                "value": "server/ingress/enabled"
+              }
+            },
+            "tls": {
+              "type": "boolean",
+              "form": true,
+              "title": "Create a TLS secret",
+              "hidden": {
+                "condition": false,
+                "value": "server/ingress/enabled"
+              }
+            }
+          }
+        },
+        "service": {
+          "type": "object",
+          "form": true,
+          "title": "Service Configuration",
+          "properties": {
+            "type": {
+              "type": "string",
+              "form": true,
+              "title": "Service Type",
+              "description": "Allowed values: \"ClusterIP\", \"NodePort\" and \"LoadBalancer\"" 
+            }
+          }
+        }
+      }
+    },
+    "skipper": {
+      "type": "object",
+      "form": true,
+      "title": "Spring Cloud Skipper Server configuration",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "form": true,
+          "title": "Enable Skipper",
+          "description": "Enable Spring Cloud Skipper component"
+        },
+        "replicaCount": {
+          "type": "integer",
+          "form": true,
+          "title": "Skipper server replicas",
+          "hidden": {
+            "condition": false,
+            "value": "skipper/enabled"
+          }
+        },
+        "resources": {
+          "type": "object",
+          "title": "Required Resources",
+          "description": "Configure resource requests",
+          "form": true,
+          "properties": {
+            "requests": {
+              "type": "object",
+              "properties": {
+                "memory": {
+                  "type": "string",
+                  "form": true,
+                  "render": "slider",
+                  "title": "Memory Request",
+                  "sliderMin": 10,
+                  "sliderMax": 2048,
+                  "sliderUnit": "Mi"
+                },
+                "cpu": {
+                  "type": "string",
+                  "form": true,
+                  "render": "slider",
+                  "title": "CPU Request",
+                  "sliderMin": 10,
+                  "sliderMax": 2000,
+                  "sliderUnit": "m"
+                }
+              }
+            }
+          },
+          "hidden": {
+            "condition": false,
+            "value": "skipper/enabled"
+          }
+        }
+      }
+    },
+    "serviceAccount": {
+      "type": "object",
+      "title": "ServiceAccount configuration",
+      "form": true,
+      "properties": {
+        "create": {
+          "type": "boolean",
+          "form": true,
+          "title": "Create a ServiceAcccount",
+          "description": "Specify whether a ServiceAcccount for Spring Cloud pods should be created"
+        },
+        "name": {
+          "type": "string",
+          "form": true,
+          "title": "ServiceAcccount name",
+          "description": "ServiceAcccount name to use. Auto-generated if not specified",
+          "hidden": {
+            "condition": false,
+            "value": "serviceAccount/create"
+          }
+        }
+      }
+    },
+    "rbac": {
+      "type": "object",
+      "title": "RBAC rules configuration",
+      "form": true,
+      "properties": {
+        "create": {
+          "type": "boolean",
+          "form": true,
+          "title": "Create RBAC rules",
+          "description": "Specify whether RBAC resources should be created and used"
+        }
+      }
+    },
+    "metrics": {
+      "type": "object",
+      "form": true,
+      "title": "Prometheus metrics details",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "title": "Create Prometheus metrics exporter",
+          "description": "Create a side-car container to expose Prometheus metrics",
+          "form": true
+        },
+        "serviceMonitor": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "title": "Create Prometheus Operator ServiceMonitor",
+              "description": "Create a ServiceMonitor to track metrics using Prometheus Operator",
+              "form": true,
+              "hidden": {
+                "condition": false,
+                "value": "metrics/enabled"
+              }
+            }
+          }
+        }
+      }
+    },
+    "mariadb": {
+      "type": "object",
+      "title": "MariaDB Details",
+      "form": true,
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "title": "Use a new MariaDB database hosted in the cluster",
+          "form": true,
+          "description": "Whether to deploy a MariaDB server to satisfy the Spring Cloud database requirements. To use an external database switch this off and configure the external database details"
+        }
+      }
+    },
+    "flyway": {
+      "type": "object",
+      "title": "Flyway Details",
+      "form": true,
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "title": "Run or skip Database creation scripts on startup",
+          "form": true,
+          "description": "Whether to run or skip running Database creation scripts on startup. This feature can be used in scenario of Database schema and tables already present, when using Mariadb or external database"
+        }
+      }
+    },
+    "externalDatabase": {
+      "type": "object",
+      "title": "External Database Details",
+      "description": "If MariaDB is disabled. Use this section to specify the external database details",
+      "form": true,
+      "properties": {
+        "host": {
+          "type": "string",
+          "form": true,
+          "title": "Database Host",
+          "hidden": "mariadb/enabled"
+        },
+        "port": {
+          "type": "integer",
+          "form": true,
+          "title": "Database Port",
+          "hidden": "mariadb/enabled"
+        },
+        "password": {
+          "type": "string",
+          "form": true,
+          "title": "Database Password",
+          "hidden": "mariadb/enabled"
+        },
+        "dataflow": {
+          "type": "object",
+          "properties": {
+            "user": {
+              "type": "string",
+              "form": true,
+              "title": "Database Username for Dataflow server",
+              "hidden": "mariadb/enabled"
+            },
+            "database": {
+              "type": "string",
+              "form": true,
+              "title": "Database Name for Dataflow server",
+              "hidden": "mariadb/enabled"
+            }
+          }
         },
         "skipper": {
-            "type": "object",
-            "properties": {
-                "enabled": {
-                    "type": "boolean",
-                    "description": "Enable Spring Cloud Skipper component",
-                    "default": true
-                },
-                "hostAliases": {
-                    "type": "array",
-                    "description": "Deployment pod host aliases",
-                    "default": [],
-                    "items": {}
-                },
-                "image": {
-                    "type": "object",
-                    "properties": {
-                        "registry": {
-                            "type": "string",
-                            "description": "Spring Cloud Skipper image registry",
-                            "default": "REGISTRY_NAME"
-                        },
-                        "repository": {
-                            "type": "string",
-                            "description": "Spring Cloud Skipper image repository",
-                            "default": "REPOSITORY_NAME/spring-cloud-skipper"
-                        },
-                        "digest": {
-                            "type": "string",
-                            "description": "Spring Cloud Skipper image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
-                            "default": ""
-                        },
-                        "pullPolicy": {
-                            "type": "string",
-                            "description": "Spring Cloud Skipper image pull policy",
-                            "default": "IfNotPresent"
-                        },
-                        "pullSecrets": {
-                            "type": "array",
-                            "description": "Specify docker-registry secret names as an array",
-                            "default": [],
-                            "items": {}
-                        },
-                        "debug": {
-                            "type": "boolean",
-                            "description": "Enable image debug mode",
-                            "default": false
-                        }
-                    }
-                },
-                "configuration": {
-                    "type": "object",
-                    "properties": {
-                        "accountName": {
-                            "type": "string",
-                            "description": "The name of the account to configure for the Kubernetes platform",
-                            "default": "default"
-                        },
-                        "trustK8sCerts": {
-                            "type": "boolean",
-                            "description": "Trust K8s certificates when querying the Kubernetes API",
-                            "default": false
-                        }
-                    }
-                },
-                "existingConfigmap": {
-                    "type": "string",
-                    "description": "Name of existing ConfigMap with Skipper server configuration",
-                    "default": ""
-                },
-                "command": {
-                    "type": "array",
-                    "description": "Override default container command (useful when using custom images)",
-                    "default": [],
-                    "items": {}
-                },
-                "args": {
-                    "type": "array",
-                    "description": "Override default container args (useful when using custom images)",
-                    "default": [],
-                    "items": {}
-                },
-                "lifecycleHooks": {
-                    "type": "object",
-                    "description": "for the Skipper container(s) to automate configuration before or after startup",
-                    "default": {}
-                },
-                "extraEnvVars": {
-                    "type": "array",
-                    "description": "Extra environment variables to be set on Skipper server container",
-                    "default": [],
-                    "items": {}
-                },
-                "extraEnvVarsCM": {
-                    "type": "string",
-                    "description": "Name of existing ConfigMap containing extra environment variables",
-                    "default": ""
-                },
-                "extraEnvVarsSecret": {
-                    "type": "string",
-                    "description": "Name of existing Secret containing extra environment variables",
-                    "default": ""
-                },
-                "replicaCount": {
-                    "type": "number",
-                    "description": "Number of Skipper server replicas to deploy",
-                    "default": 1
-                },
-                "podAffinityPreset": {
-                    "type": "string",
-                    "description": "Skipper pod affinity preset. Ignored if `skipper.affinity` is set. Allowed values: `soft` or `hard`",
-                    "default": ""
-                },
-                "podAntiAffinityPreset": {
-                    "type": "string",
-                    "description": "Skipper pod anti-affinity preset. Ignored if `skipper.affinity` is set. Allowed values: `soft` or `hard`",
-                    "default": "soft"
-                },
-                "nodeAffinityPreset": {
-                    "type": "object",
-                    "properties": {
-                        "type": {
-                            "type": "string",
-                            "description": "Skipper node affinity preset type. Ignored if `skipper.affinity` is set. Allowed values: `soft` or `hard`",
-                            "default": ""
-                        },
-                        "key": {
-                            "type": "string",
-                            "description": "Skipper node label key to match Ignored if `skipper.affinity` is set.",
-                            "default": ""
-                        },
-                        "values": {
-                            "type": "array",
-                            "description": "Skipper node label values to match. Ignored if `skipper.affinity` is set.",
-                            "default": [],
-                            "items": {}
-                        }
-                    }
-                },
-                "affinity": {
-                    "type": "object",
-                    "description": "Skipper affinity for pod assignment",
-                    "default": {}
-                },
-                "nodeSelector": {
-                    "type": "object",
-                    "description": "Skipper node labels for pod assignment",
-                    "default": {}
-                },
-                "tolerations": {
-                    "type": "array",
-                    "description": "Skipper tolerations for pod assignment",
-                    "default": [],
-                    "items": {}
-                },
-                "podAnnotations": {
-                    "type": "object",
-                    "description": "Annotations for Skipper server pods",
-                    "default": {}
-                },
-                "updateStrategy": {
-                    "type": "object",
-                    "properties": {
-                        "type": {
-                            "type": "string",
-                            "description": "Deployment strategy type for Skipper server pods.",
-                            "default": "RollingUpdate"
-                        }
-                    }
-                },
-                "podLabels": {
-                    "type": "object",
-                    "description": "Extra labels for Skipper pods",
-                    "default": {}
-                },
-                "priorityClassName": {
-                    "type": "string",
-                    "description": "Controller priorityClassName",
-                    "default": ""
-                },
-                "schedulerName": {
-                    "type": "string",
-                    "description": "Name of the k8s scheduler (other than default)",
-                    "default": ""
-                },
-                "topologySpreadConstraints": {
-                    "type": "array",
-                    "description": "Topology Spread Constraints for pod assignment",
-                    "default": [],
-                    "items": {}
-                },
-                "podSecurityContext": {
-                    "type": "object",
-                    "properties": {
-                        "enabled": {
-                            "type": "boolean",
-                            "description": "Enabled Skipper pods' Security Context",
-                            "default": true
-                        },
-                        "fsGroup": {
-                            "type": "number",
-                            "description": "Group ID for the volumes of the pod",
-                            "default": 1001
-                        }
-                    }
-                },
-                "containerSecurityContext": {
-                    "type": "object",
-                    "properties": {
-                        "enabled": {
-                            "type": "boolean",
-                            "description": "Enabled containers' Security Context",
-                            "default": true
-                        },
-                        "runAsUser": {
-                            "type": "number",
-                            "description": "Set containers' Security Context runAsUser",
-                            "default": 1001
-                        },
-                        "runAsNonRoot": {
-                            "type": "boolean",
-                            "description": "Set container's Security Context runAsNonRoot",
-                            "default": true
-                        },
-                        "privileged": {
-                            "type": "boolean",
-                            "description": "Set container's Security Context privileged",
-                            "default": false
-                        },
-                        "readOnlyRootFilesystem": {
-                            "type": "boolean",
-                            "description": "Set container's Security Context readOnlyRootFilesystem",
-                            "default": false
-                        },
-                        "allowPrivilegeEscalation": {
-                            "type": "boolean",
-                            "description": "Set container's Security Context allowPrivilegeEscalation",
-                            "default": false
-                        },
-                        "capabilities": {
-                            "type": "object",
-                            "properties": {
-                                "drop": {
-                                    "type": "array",
-                                    "description": "List of capabilities to be dropped",
-                                    "default": [
-                                        "ALL"
-                                    ],
-                                    "items": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "seccompProfile": {
-                            "type": "object",
-                            "properties": {
-                                "type": {
-                                    "type": "string",
-                                    "description": "Set container's Security Context seccomp profile",
-                                    "default": "RuntimeDefault"
-                                }
-                            }
-                        }
-                    }
-                },
-                "resources": {
-                    "type": "object",
-                    "properties": {
-                        "limits": {
-                            "type": "object",
-                            "description": "The resources limits for the Skipper server container",
-                            "default": {}
-                        },
-                        "requests": {
-                            "type": "object",
-                            "description": "The requested resources for the Skipper server container",
-                            "default": {}
-                        }
-                    }
-                },
-                "startupProbe": {
-                    "type": "object",
-                    "properties": {
-                        "enabled": {
-                            "type": "boolean",
-                            "description": "Enable startupProbe",
-                            "default": false
-                        },
-                        "initialDelaySeconds": {
-                            "type": "number",
-                            "description": "Initial delay seconds for startupProbe",
-                            "default": 120
-                        },
-                        "periodSeconds": {
-                            "type": "number",
-                            "description": "Period seconds for startupProbe",
-                            "default": 20
-                        },
-                        "timeoutSeconds": {
-                            "type": "number",
-                            "description": "Timeout seconds for startupProbe",
-                            "default": 1
-                        },
-                        "failureThreshold": {
-                            "type": "number",
-                            "description": "Failure threshold for startupProbe",
-                            "default": 6
-                        },
-                        "successThreshold": {
-                            "type": "number",
-                            "description": "Success threshold for startupProbe",
-                            "default": 1
-                        }
-                    }
-                },
-                "livenessProbe": {
-                    "type": "object",
-                    "properties": {
-                        "enabled": {
-                            "type": "boolean",
-                            "description": "Enable livenessProbe",
-                            "default": true
-                        },
-                        "initialDelaySeconds": {
-                            "type": "number",
-                            "description": "Initial delay seconds for livenessProbe",
-                            "default": 120
-                        },
-                        "periodSeconds": {
-                            "type": "number",
-                            "description": "Period seconds for livenessProbe",
-                            "default": 20
-                        },
-                        "timeoutSeconds": {
-                            "type": "number",
-                            "description": "Timeout seconds for livenessProbe",
-                            "default": 1
-                        },
-                        "failureThreshold": {
-                            "type": "number",
-                            "description": "Failure threshold for livenessProbe",
-                            "default": 6
-                        },
-                        "successThreshold": {
-                            "type": "number",
-                            "description": "Success threshold for livenessProbe",
-                            "default": 1
-                        }
-                    }
-                },
-                "readinessProbe": {
-                    "type": "object",
-                    "properties": {
-                        "enabled": {
-                            "type": "boolean",
-                            "description": "Enable readinessProbe",
-                            "default": true
-                        },
-                        "initialDelaySeconds": {
-                            "type": "number",
-                            "description": "Initial delay seconds for readinessProbe",
-                            "default": 120
-                        },
-                        "periodSeconds": {
-                            "type": "number",
-                            "description": "Period seconds for readinessProbe",
-                            "default": 20
-                        },
-                        "timeoutSeconds": {
-                            "type": "number",
-                            "description": "Timeout seconds for readinessProbe",
-                            "default": 1
-                        },
-                        "failureThreshold": {
-                            "type": "number",
-                            "description": "Failure threshold for readinessProbe",
-                            "default": 6
-                        },
-                        "successThreshold": {
-                            "type": "number",
-                            "description": "Success threshold for readinessProbe",
-                            "default": 1
-                        }
-                    }
-                },
-                "customStartupProbe": {
-                    "type": "object",
-                    "description": "Override default startup probe",
-                    "default": {}
-                },
-                "customLivenessProbe": {
-                    "type": "object",
-                    "description": "Override default liveness probe",
-                    "default": {}
-                },
-                "customReadinessProbe": {
-                    "type": "object",
-                    "description": "Override default readiness probe",
-                    "default": {}
-                },
-                "service": {
-                    "type": "object",
-                    "properties": {
-                        "type": {
-                            "type": "string",
-                            "description": "Kubernetes service type",
-                            "default": "ClusterIP"
-                        },
-                        "port": {
-                            "type": "number",
-                            "description": "Service HTTP port",
-                            "default": 80
-                        },
-                        "nodePort": {
-                            "type": "string",
-                            "description": "Service HTTP node port",
-                            "default": ""
-                        },
-                        "clusterIP": {
-                            "type": "string",
-                            "description": "Skipper server service cluster IP",
-                            "default": ""
-                        },
-                        "externalTrafficPolicy": {
-                            "type": "string",
-                            "description": "Enable client source IP preservation",
-                            "default": "Cluster"
-                        },
-                        "loadBalancerIP": {
-                            "type": "string",
-                            "description": "Load balancer IP if service type is `LoadBalancer`",
-                            "default": ""
-                        },
-                        "loadBalancerSourceRanges": {
-                            "type": "array",
-                            "description": "Address that are allowed when service is LoadBalancer",
-                            "default": [],
-                            "items": {}
-                        },
-                        "extraPorts": {
-                            "type": "array",
-                            "description": "Extra ports to expose (normally used with the `sidecar` value)",
-                            "default": [],
-                            "items": {}
-                        },
-                        "annotations": {
-                            "type": "object",
-                            "description": "Annotations for Skipper server service",
-                            "default": {}
-                        },
-                        "sessionAffinity": {
-                            "type": "string",
-                            "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
-                            "default": "None"
-                        },
-                        "sessionAffinityConfig": {
-                            "type": "object",
-                            "description": "Additional settings for the sessionAffinity",
-                            "default": {}
-                        }
-                    }
-                },
-                "initContainers": {
-                    "type": "array",
-                    "description": "Add init containers to the Dataflow Skipper pods",
-                    "default": [],
-                    "items": {}
-                },
-                "sidecars": {
-                    "type": "array",
-                    "description": "Add sidecars to the Skipper pods",
-                    "default": [],
-                    "items": {}
-                },
-                "pdb": {
-                    "type": "object",
-                    "properties": {
-                        "create": {
-                            "type": "boolean",
-                            "description": "Enable/disable a Pod Disruption Budget creation",
-                            "default": false
-                        },
-                        "minAvailable": {
-                            "type": "number",
-                            "description": "Minimum number/percentage of pods that should remain scheduled",
-                            "default": 1
-                        },
-                        "maxUnavailable": {
-                            "type": "string",
-                            "description": "Maximum number/percentage of pods that may be made unavailable",
-                            "default": ""
-                        }
-                    }
-                },
-                "autoscaling": {
-                    "type": "object",
-                    "properties": {
-                        "enabled": {
-                            "type": "boolean",
-                            "description": "Enable autoscaling for Skipper server",
-                            "default": false
-                        },
-                        "minReplicas": {
-                            "type": "string",
-                            "description": "Minimum number of Skipper server replicas",
-                            "default": ""
-                        },
-                        "maxReplicas": {
-                            "type": "string",
-                            "description": "Maximum number of Skipper server replicas",
-                            "default": ""
-                        },
-                        "targetCPU": {
-                            "type": "string",
-                            "description": "Target CPU utilization percentage",
-                            "default": ""
-                        },
-                        "targetMemory": {
-                            "type": "string",
-                            "description": "Target Memory utilization percentage",
-                            "default": ""
-                        }
-                    }
-                },
-                "extraVolumes": {
-                    "type": "array",
-                    "description": "Extra Volumes to be set on the Skipper Pod",
-                    "default": [],
-                    "items": {}
-                },
-                "extraVolumeMounts": {
-                    "type": "array",
-                    "description": "Extra VolumeMounts to be set on the Skipper Container",
-                    "default": [],
-                    "items": {}
-                },
-                "jdwp": {
-                    "type": "object",
-                    "properties": {
-                        "enabled": {
-                            "type": "boolean",
-                            "description": "Enable Java Debug Wire Protocol (JDWP)",
-                            "default": false
-                        },
-                        "port": {
-                            "type": "number",
-                            "description": "JDWP TCP port for remote debugging",
-                            "default": 5005
-                        }
-                    }
-                }
+          "type": "object",
+          "properties": {
+            "user": {
+              "type": "string",
+              "form": true,
+              "title": "Database Username for Skipper server",
+              "hidden": "mariadb/enabled"
+            },
+            "database": {
+              "type": "string",
+              "form": true,
+              "title": "Database Name for Skipper server",
+              "hidden": "mariadb/enabled"
             }
-        },
-        "externalSkipper": {
-            "type": "object",
-            "properties": {
-                "host": {
-                    "type": "string",
-                    "description": "Host of a external Skipper Server",
-                    "default": "localhost"
-                },
-                "port": {
-                    "type": "number",
-                    "description": "External Skipper Server port number",
-                    "default": 7577
-                }
-            }
-        },
-        "deployer": {
-            "type": "object",
-            "properties": {
-                "resources": {
-                    "type": "object",
-                    "properties": {
-                        "requests": {
-                            "type": "object",
-                            "description": "Streaming applications resource requests",
-                            "default": {}
-                        }
-                    }
-                },
-                "readinessProbe": {
-                    "type": "object",
-                    "properties": {
-                        "initialDelaySeconds": {
-                            "type": "number",
-                            "description": "Initial delay seconds for readinessProbe",
-                            "default": 120
-                        }
-                    }
-                },
-                "livenessProbe": {
-                    "type": "object",
-                    "properties": {
-                        "initialDelaySeconds": {
-                            "type": "number",
-                            "description": "Initial delay seconds for livenessProbe",
-                            "default": 90
-                        }
-                    }
-                },
-                "nodeSelector": {
-                    "type": "string",
-                    "description": "The node selectors to apply to the streaming applications deployments in \"key:value\" format",
-                    "default": ""
-                },
-                "tolerations": {
-                    "type": "array",
-                    "description": "Streaming applications tolerations",
-                    "default": [],
-                    "items": {}
-                },
-                "volumeMounts": {
-                    "type": "array",
-                    "description": "Streaming applications extra volume mounts",
-                    "default": [],
-                    "items": {}
-                },
-                "volumes": {
-                    "type": "array",
-                    "description": "Streaming applications extra volumes",
-                    "default": [],
-                    "items": {}
-                },
-                "environmentVariables": {
-                    "type": "array",
-                    "description": "Streaming applications environment variables",
-                    "default": [],
-                    "items": {}
-                },
-                "podSecurityContext": {
-                    "type": "object",
-                    "properties": {
-                        "enabled": {
-                            "type": "boolean",
-                            "description": "Enabled pods' Security Context of the deployed pods batch or stream pods",
-                            "default": true
-                        },
-                        "runAsUser": {
-                            "type": "number",
-                            "description": "Set Dataflow Streams container's Security Context runAsUser",
-                            "default": 1001
-                        }
-                    }
-                },
-                "imagePullSecrets": {
-                    "type": "array",
-                    "description": "Streaming applications imagePullSecrets",
-                    "default": [],
-                    "items": {}
-                },
-                "secretRefs": {
-                    "type": "array",
-                    "description": "Streaming applications secretRefs",
-                    "default": [],
-                    "items": {}
-                },
-                "entryPointStyle": {
-                    "type": "string",
-                    "description": "An entry point style affects how application properties are passed to the container to be deployed. Allowed values: exec (default), shell, boot",
-                    "default": "exec"
-                },
-                "imagePullPolicy": {
-                    "type": "string",
-                    "description": "An image pull policy defines when a Docker image should be pulled to the local registry. Allowed values: IfNotPresent (default), Always, Never",
-                    "default": "IfNotPresent"
-                }
-            }
-        },
-        "serviceAccount": {
-            "type": "object",
-            "properties": {
-                "create": {
-                    "type": "boolean",
-                    "description": "Enable the creation of a ServiceAccount for Dataflow server and Skipper server pods",
-                    "default": true
-                },
-                "name": {
-                    "type": "string",
-                    "description": "Name of the created serviceAccount. If not set and create is true, a name is generated using the scdf.fullname template",
-                    "default": ""
-                },
-                "automountServiceAccountToken": {
-                    "type": "boolean",
-                    "description": "Automount service account token for the server service account",
-                    "default": true
-                },
-                "annotations": {
-                    "type": "object",
-                    "description": "Annotations for service account. Evaluated as a template. Only used if `create` is `true`.",
-                    "default": {}
-                }
-            }
-        },
-        "rbac": {
-            "type": "object",
-            "properties": {
-                "create": {
-                    "type": "boolean",
-                    "description": "Whether to create and use RBAC resources or not",
-                    "default": true
-                }
-            }
-        },
-        "metrics": {
-            "type": "object",
-            "properties": {
-                "enabled": {
-                    "type": "boolean",
-                    "description": "Enable Prometheus metrics",
-                    "default": false
-                },
-                "image": {
-                    "type": "object",
-                    "properties": {
-                        "registry": {
-                            "type": "string",
-                            "description": "Prometheus Rsocket Proxy image registry",
-                            "default": "REGISTRY_NAME"
-                        },
-                        "repository": {
-                            "type": "string",
-                            "description": "Prometheus Rsocket Proxy image repository",
-                            "default": "REPOSITORY_NAME/prometheus-rsocket-proxy"
-                        },
-                        "digest": {
-                            "type": "string",
-                            "description": "Prometheus Rsocket Proxy image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
-                            "default": ""
-                        },
-                        "pullPolicy": {
-                            "type": "string",
-                            "description": "Prometheus Rsocket Proxy image pull policy",
-                            "default": "IfNotPresent"
-                        },
-                        "pullSecrets": {
-                            "type": "array",
-                            "description": "Specify docker-registry secret names as an array",
-                            "default": [],
-                            "items": {}
-                        }
-                    }
-                },
-                "resources": {
-                    "type": "object",
-                    "properties": {
-                        "limits": {
-                            "type": "object",
-                            "description": "The resources limits for the Prometheus Rsocket Proxy container",
-                            "default": {}
-                        },
-                        "requests": {
-                            "type": "object",
-                            "description": "The requested resources for the Prometheus Rsocket Proxy container",
-                            "default": {}
-                        }
-                    }
-                },
-                "replicaCount": {
-                    "type": "number",
-                    "description": "Number of Prometheus Rsocket Proxy replicas to deploy",
-                    "default": 1
-                },
-                "podAffinityPreset": {
-                    "type": "string",
-                    "description": "Prometheus Rsocket Proxy pod affinity preset. Ignored if `metrics.affinity` is set. Allowed values: `soft` or `hard`",
-                    "default": ""
-                },
-                "podAntiAffinityPreset": {
-                    "type": "string",
-                    "description": "Prometheus Rsocket Proxy pod anti-affinity preset. Ignored if `metrics.affinity` is set. Allowed values: `soft` or `hard`",
-                    "default": "soft"
-                },
-                "nodeAffinityPreset": {
-                    "type": "object",
-                    "properties": {
-                        "type": {
-                            "type": "string",
-                            "description": "Prometheus Rsocket Proxy node affinity preset type. Ignored if `metrics.affinity` is set. Allowed values: `soft` or `hard`",
-                            "default": ""
-                        },
-                        "key": {
-                            "type": "string",
-                            "description": "Prometheus Rsocket Proxy node label key to match Ignored if `metrics.affinity` is set.",
-                            "default": ""
-                        },
-                        "values": {
-                            "type": "array",
-                            "description": "Prometheus Rsocket Proxy node label values to match. Ignored if `metrics.affinity` is set.",
-                            "default": [],
-                            "items": {}
-                        }
-                    }
-                },
-                "affinity": {
-                    "type": "object",
-                    "description": "Prometheus Rsocket Proxy affinity for pod assignment",
-                    "default": {}
-                },
-                "nodeSelector": {
-                    "type": "object",
-                    "description": "Prometheus Rsocket Proxy node labels for pod assignment",
-                    "default": {}
-                },
-                "hostAliases": {
-                    "type": "array",
-                    "description": "Prometheus Proxy pods host aliases",
-                    "default": [],
-                    "items": {}
-                },
-                "tolerations": {
-                    "type": "array",
-                    "description": "Prometheus Rsocket Proxy tolerations for pod assignment",
-                    "default": [],
-                    "items": {}
-                },
-                "podAnnotations": {
-                    "type": "object",
-                    "description": "Annotations for Prometheus Rsocket Proxy pods",
-                    "default": {}
-                },
-                "podLabels": {
-                    "type": "object",
-                    "description": "Extra labels for Prometheus Proxy pods",
-                    "default": {}
-                },
-                "podSecurityContext": {
-                    "type": "object",
-                    "properties": {
-                        "enabled": {
-                            "type": "boolean",
-                            "description": "Enabled Prometheus Proxy pods' Security Context",
-                            "default": true
-                        },
-                        "fsGroup": {
-                            "type": "number",
-                            "description": "Set Prometheus Proxy pod's Security Context fsGroup",
-                            "default": 1001
-                        }
-                    }
-                },
-                "containerSecurityContext": {
-                    "type": "object",
-                    "properties": {
-                        "enabled": {
-                            "type": "boolean",
-                            "description": "Enabled containers' Security Context",
-                            "default": true
-                        },
-                        "runAsUser": {
-                            "type": "number",
-                            "description": "Set containers' Security Context runAsUser",
-                            "default": 1001
-                        },
-                        "runAsNonRoot": {
-                            "type": "boolean",
-                            "description": "Set container's Security Context runAsNonRoot",
-                            "default": true
-                        },
-                        "privileged": {
-                            "type": "boolean",
-                            "description": "Set container's Security Context privileged",
-                            "default": false
-                        },
-                        "readOnlyRootFilesystem": {
-                            "type": "boolean",
-                            "description": "Set container's Security Context readOnlyRootFilesystem",
-                            "default": false
-                        },
-                        "allowPrivilegeEscalation": {
-                            "type": "boolean",
-                            "description": "Set container's Security Context allowPrivilegeEscalation",
-                            "default": false
-                        },
-                        "capabilities": {
-                            "type": "object",
-                            "properties": {
-                                "drop": {
-                                    "type": "array",
-                                    "description": "List of capabilities to be dropped",
-                                    "default": [
-                                        "ALL"
-                                    ],
-                                    "items": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "seccompProfile": {
-                            "type": "object",
-                            "properties": {
-                                "type": {
-                                    "type": "string",
-                                    "description": "Set container's Security Context seccomp profile",
-                                    "default": "RuntimeDefault"
-                                }
-                            }
-                        }
-                    }
-                },
-                "command": {
-                    "type": "array",
-                    "description": "Override default container command (useful when using custom images)",
-                    "default": [],
-                    "items": {}
-                },
-                "args": {
-                    "type": "array",
-                    "description": "Override default container args (useful when using custom images)",
-                    "default": [],
-                    "items": {}
-                },
-                "lifecycleHooks": {
-                    "type": "object",
-                    "description": "for the Prometheus Proxy container(s) to automate configuration before or after startup",
-                    "default": {}
-                },
-                "extraEnvVars": {
-                    "type": "array",
-                    "description": "Array with extra environment variables to add to Prometheus Proxy nodes",
-                    "default": [],
-                    "items": {}
-                },
-                "extraEnvVarsCM": {
-                    "type": "string",
-                    "description": "Name of existing ConfigMap containing extra env vars for Prometheus Proxy nodes",
-                    "default": ""
-                },
-                "extraEnvVarsSecret": {
-                    "type": "string",
-                    "description": "Name of existing Secret containing extra env vars for Prometheus Proxy nodes",
-                    "default": ""
-                },
-                "extraVolumes": {
-                    "type": "array",
-                    "description": "Optionally specify extra list of additional volumes for the Prometheus Proxy pod(s)",
-                    "default": [],
-                    "items": {}
-                },
-                "extraVolumeMounts": {
-                    "type": "array",
-                    "description": "Optionally specify extra list of additional volumeMounts for the Prometheus Proxy container(s)",
-                    "default": [],
-                    "items": {}
-                },
-                "containerPorts": {
-                    "type": "object",
-                    "properties": {
-                        "http": {
-                            "type": "number",
-                            "description": "Prometheus Proxy HTTP container port",
-                            "default": 8080
-                        },
-                        "rsocket": {
-                            "type": "number",
-                            "description": "Prometheus Proxy Rsocket container port",
-                            "default": 7001
-                        }
-                    }
-                },
-                "startupProbe": {
-                    "type": "object",
-                    "properties": {
-                        "enabled": {
-                            "type": "boolean",
-                            "description": "Enable startupProbe on Prometheus Proxy nodes",
-                            "default": false
-                        },
-                        "initialDelaySeconds": {
-                            "type": "number",
-                            "description": "Initial delay seconds for startupProbe",
-                            "default": 10
-                        },
-                        "periodSeconds": {
-                            "type": "number",
-                            "description": "Period seconds for startupProbe",
-                            "default": 10
-                        },
-                        "timeoutSeconds": {
-                            "type": "number",
-                            "description": "Timeout seconds for startupProbe",
-                            "default": 1
-                        },
-                        "failureThreshold": {
-                            "type": "number",
-                            "description": "Failure threshold for startupProbe",
-                            "default": 3
-                        },
-                        "successThreshold": {
-                            "type": "number",
-                            "description": "Success threshold for startupProbe",
-                            "default": 1
-                        }
-                    }
-                },
-                "livenessProbe": {
-                    "type": "object",
-                    "properties": {
-                        "enabled": {
-                            "type": "boolean",
-                            "description": "Enable livenessProbe on Prometheus Proxy nodes",
-                            "default": true
-                        },
-                        "initialDelaySeconds": {
-                            "type": "number",
-                            "description": "Initial delay seconds for livenessProbe",
-                            "default": 10
-                        },
-                        "periodSeconds": {
-                            "type": "number",
-                            "description": "Period seconds for livenessProbe",
-                            "default": 10
-                        },
-                        "timeoutSeconds": {
-                            "type": "number",
-                            "description": "Timeout seconds for livenessProbe",
-                            "default": 1
-                        },
-                        "failureThreshold": {
-                            "type": "number",
-                            "description": "Failure threshold for livenessProbe",
-                            "default": 3
-                        },
-                        "successThreshold": {
-                            "type": "number",
-                            "description": "Success threshold for livenessProbe",
-                            "default": 1
-                        }
-                    }
-                },
-                "readinessProbe": {
-                    "type": "object",
-                    "properties": {
-                        "enabled": {
-                            "type": "boolean",
-                            "description": "Enable readinessProbe on Prometheus Proxy nodes",
-                            "default": true
-                        },
-                        "initialDelaySeconds": {
-                            "type": "number",
-                            "description": "Initial delay seconds for readinessProbe",
-                            "default": 10
-                        },
-                        "periodSeconds": {
-                            "type": "number",
-                            "description": "Period seconds for readinessProbe",
-                            "default": 10
-                        },
-                        "timeoutSeconds": {
-                            "type": "number",
-                            "description": "Timeout seconds for readinessProbe",
-                            "default": 1
-                        },
-                        "failureThreshold": {
-                            "type": "number",
-                            "description": "Failure threshold for readinessProbe",
-                            "default": 3
-                        },
-                        "successThreshold": {
-                            "type": "number",
-                            "description": "Success threshold for readinessProbe",
-                            "default": 1
-                        }
-                    }
-                },
-                "customStartupProbe": {
-                    "type": "object",
-                    "description": "Custom startupProbe that overrides the default one",
-                    "default": {}
-                },
-                "customLivenessProbe": {
-                    "type": "object",
-                    "description": "Custom livenessProbe that overrides the default one",
-                    "default": {}
-                },
-                "customReadinessProbe": {
-                    "type": "object",
-                    "description": "Custom readinessProbe that overrides the default one",
-                    "default": {}
-                },
-                "sidecars": {
-                    "type": "array",
-                    "description": "Add additional sidecar containers to the Prometheus Proxy pod(s)",
-                    "default": [],
-                    "items": {}
-                },
-                "initContainers": {
-                    "type": "array",
-                    "description": "Add additional init containers to the Prometheus Proxy pod(s)",
-                    "default": [],
-                    "items": {}
-                },
-                "updateStrategy": {
-                    "type": "object",
-                    "properties": {
-                        "type": {
-                            "type": "string",
-                            "description": "Prometheus Proxy deployment strategy type.",
-                            "default": "RollingUpdate"
-                        }
-                    }
-                },
-                "priorityClassName": {
-                    "type": "string",
-                    "description": "Prometheus Rsocket Proxy pods' priority.",
-                    "default": ""
-                },
-                "schedulerName": {
-                    "type": "string",
-                    "description": "Name of the k8s scheduler (other than default)",
-                    "default": ""
-                },
-                "topologySpreadConstraints": {
-                    "type": "array",
-                    "description": "Topology Spread Constraints for pod assignment",
-                    "default": [],
-                    "items": {}
-                },
-                "service": {
-                    "type": "object",
-                    "properties": {
-                        "type": {
-                            "type": "string",
-                            "description": "Prometheus Proxy service type",
-                            "default": "ClusterIP"
-                        },
-                        "ports": {
-                            "type": "object",
-                            "properties": {
-                                "http": {
-                                    "type": "number",
-                                    "description": "Prometheus Rsocket Proxy HTTP port",
-                                    "default": 8080
-                                },
-                                "rsocket": {
-                                    "type": "number",
-                                    "description": "Prometheus Rsocket Proxy Rsocket port",
-                                    "default": 7001
-                                }
-                            }
-                        },
-                        "nodePorts": {
-                            "type": "object",
-                            "properties": {
-                                "http": {
-                                    "type": "string",
-                                    "description": "Node port for HTTP",
-                                    "default": ""
-                                },
-                                "rsocket": {
-                                    "type": "string",
-                                    "description": "Node port for Rsocket",
-                                    "default": ""
-                                }
-                            }
-                        },
-                        "clusterIP": {
-                            "type": "string",
-                            "description": "Prometheys Proxy service Cluster IP",
-                            "default": ""
-                        },
-                        "loadBalancerIP": {
-                            "type": "string",
-                            "description": "Prometheys Proxy service Load Balancer IP",
-                            "default": ""
-                        },
-                        "loadBalancerSourceRanges": {
-                            "type": "array",
-                            "description": "Prometheys Proxy service Load Balancer sources",
-                            "default": [],
-                            "items": {}
-                        },
-                        "externalTrafficPolicy": {
-                            "type": "string",
-                            "description": "Prometheys Proxy service external traffic policy",
-                            "default": "Cluster"
-                        },
-                        "extraPorts": {
-                            "type": "array",
-                            "description": "Extra ports to expose (normally used with the `sidecar` value)",
-                            "default": [],
-                            "items": {}
-                        },
-                        "sessionAffinity": {
-                            "type": "string",
-                            "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
-                            "default": "None"
-                        },
-                        "sessionAffinityConfig": {
-                            "type": "object",
-                            "description": "Additional settings for the sessionAffinity",
-                            "default": {}
-                        }
-                    }
-                },
-                "serviceMonitor": {
-                    "type": "object",
-                    "properties": {
-                        "enabled": {
-                            "type": "boolean",
-                            "description": "if `true`, creates a Prometheus Operator ServiceMonitor (also requires `metrics.enabled` to be `true`)",
-                            "default": false
-                        },
-                        "namespace": {
-                            "type": "string",
-                            "description": "Namespace in which ServiceMonitor is created if different from release",
-                            "default": ""
-                        },
-                        "jobLabel": {
-                            "type": "string",
-                            "description": "The name of the label on the target service to use as the job name in prometheus.",
-                            "default": ""
-                        },
-                        "interval": {
-                            "type": "string",
-                            "description": "Interval at which metrics should be scraped.",
-                            "default": ""
-                        },
-                        "scrapeTimeout": {
-                            "type": "string",
-                            "description": "Timeout after which the scrape is ended",
-                            "default": ""
-                        },
-                        "relabelings": {
-                            "type": "array",
-                            "description": "RelabelConfigs to apply to samples before scraping",
-                            "default": [],
-                            "items": {}
-                        },
-                        "metricRelabelings": {
-                            "type": "array",
-                            "description": "MetricRelabelConfigs to apply to samples before ingestion",
-                            "default": [],
-                            "items": {}
-                        },
-                        "selector": {
-                            "type": "object",
-                            "description": "ServiceMonitor selector labels",
-                            "default": {}
-                        },
-                        "labels": {
-                            "type": "object",
-                            "description": "Extra labels for the ServiceMonitor",
-                            "default": {}
-                        },
-                        "honorLabels": {
-                            "type": "boolean",
-                            "description": "honorLabels chooses the metric's labels on collisions with target labels",
-                            "default": false
-                        }
-                    }
-                },
-                "pdb": {
-                    "type": "object",
-                    "properties": {
-                        "create": {
-                            "type": "boolean",
-                            "description": "Enable/disable a Pod Disruption Budget creation",
-                            "default": false
-                        },
-                        "minAvailable": {
-                            "type": "number",
-                            "description": "Minimum number/percentage of pods that should remain scheduled",
-                            "default": 1
-                        },
-                        "maxUnavailable": {
-                            "type": "string",
-                            "description": "Maximum number/percentage of pods that may be made unavailable",
-                            "default": ""
-                        }
-                    }
-                },
-                "autoscaling": {
-                    "type": "object",
-                    "properties": {
-                        "enabled": {
-                            "type": "boolean",
-                            "description": "Enable autoscaling for Prometheus Rsocket Proxy",
-                            "default": false
-                        },
-                        "minReplicas": {
-                            "type": "string",
-                            "description": "Minimum number of Prometheus Rsocket Proxy replicas",
-                            "default": ""
-                        },
-                        "maxReplicas": {
-                            "type": "string",
-                            "description": "Maximum number of Prometheus Rsocket Proxy replicas",
-                            "default": ""
-                        },
-                        "targetCPU": {
-                            "type": "string",
-                            "description": "Target CPU utilization percentage",
-                            "default": ""
-                        },
-                        "targetMemory": {
-                            "type": "string",
-                            "description": "Target Memory utilization percentage",
-                            "default": ""
-                        }
-                    }
-                }
-            }
-        },
-        "waitForBackends": {
-            "type": "object",
-            "properties": {
-                "enabled": {
-                    "type": "boolean",
-                    "description": "Wait for the database and other services (such as Kafka or RabbitMQ) used when enabling streaming",
-                    "default": true
-                },
-                "image": {
-                    "type": "object",
-                    "properties": {
-                        "registry": {
-                            "type": "string",
-                            "description": "Init container wait-for-backend image registry",
-                            "default": "REGISTRY_NAME"
-                        },
-                        "repository": {
-                            "type": "string",
-                            "description": "Init container wait-for-backend image name",
-                            "default": "REPOSITORY_NAME/kubectl"
-                        },
-                        "digest": {
-                            "type": "string",
-                            "description": "Init container wait-for-backend image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
-                            "default": ""
-                        },
-                        "pullPolicy": {
-                            "type": "string",
-                            "description": "Init container wait-for-backend image pull policy",
-                            "default": "IfNotPresent"
-                        },
-                        "pullSecrets": {
-                            "type": "array",
-                            "description": "Specify docker-registry secret names as an array",
-                            "default": [],
-                            "items": {}
-                        }
-                    }
-                },
-                "containerSecurityContext": {
-                    "type": "object",
-                    "properties": {
-                        "enabled": {
-                            "type": "boolean",
-                            "description": "Enabled containers' Security Context",
-                            "default": true
-                        },
-                        "runAsUser": {
-                            "type": "number",
-                            "description": "Set containers' Security Context runAsUser",
-                            "default": 1001
-                        },
-                        "runAsNonRoot": {
-                            "type": "boolean",
-                            "description": "Set container's Security Context runAsNonRoot",
-                            "default": true
-                        },
-                        "privileged": {
-                            "type": "boolean",
-                            "description": "Set container's Security Context privileged",
-                            "default": false
-                        },
-                        "readOnlyRootFilesystem": {
-                            "type": "boolean",
-                            "description": "Set container's Security Context readOnlyRootFilesystem",
-                            "default": false
-                        },
-                        "allowPrivilegeEscalation": {
-                            "type": "boolean",
-                            "description": "Set container's Security Context allowPrivilegeEscalation",
-                            "default": false
-                        },
-                        "capabilities": {
-                            "type": "object",
-                            "properties": {
-                                "drop": {
-                                    "type": "array",
-                                    "description": "List of capabilities to be dropped",
-                                    "default": [
-                                        "ALL"
-                                    ],
-                                    "items": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "seccompProfile": {
-                            "type": "object",
-                            "properties": {
-                                "type": {
-                                    "type": "string",
-                                    "description": "Set container's Security Context seccomp profile",
-                                    "default": "RuntimeDefault"
-                                }
-                            }
-                        }
-                    }
-                },
-                "resources": {
-                    "type": "object",
-                    "properties": {
-                        "limits": {
-                            "type": "object",
-                            "description": "Init container wait-for-backend resource limits",
-                            "default": {}
-                        },
-                        "requests": {
-                            "type": "object",
-                            "description": "Init container wait-for-backend resource requests",
-                            "default": {}
-                        }
-                    }
-                }
-            }
-        },
-        "mariadb": {
-            "type": "object",
-            "properties": {
-                "enabled": {
-                    "type": "boolean",
-                    "description": "Enable/disable MariaDB chart installation",
-                    "default": true
-                },
-                "image": {
-                    "type": "object",
-                    "properties": {
-                        "registry": {
-                            "type": "string",
-                            "description": "MariaDB image registry",
-                            "default": "REGISTRY_NAME"
-                        },
-                        "repository": {
-                            "type": "string",
-                            "description": "MariaDB image repository",
-                            "default": "REPOSITORY_NAME/mariadb"
-                        },
-                        "digest": {
-                            "type": "string",
-                            "description": "MariaDB image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
-                            "default": ""
-                        }
-                    }
-                },
-                "architecture": {
-                    "type": "string",
-                    "description": "MariaDB architecture. Allowed values: `standalone` or `replication`",
-                    "default": "standalone"
-                },
-                "auth": {
-                    "type": "object",
-                    "properties": {
-                        "rootPassword": {
-                            "type": "string",
-                            "description": "Password for the MariaDB `root` user",
-                            "default": ""
-                        },
-                        "username": {
-                            "type": "string",
-                            "description": "Username of new user to create",
-                            "default": "dataflow"
-                        },
-                        "password": {
-                            "type": "string",
-                            "description": "Password for the new user",
-                            "default": "change-me"
-                        },
-                        "database": {
-                            "type": "string",
-                            "description": "Database name to create",
-                            "default": "dataflow"
-                        },
-                        "forcePassword": {
-                            "type": "boolean",
-                            "description": "Force users to specify required passwords in the database",
-                            "default": false
-                        },
-                        "usePasswordFiles": {
-                            "type": "boolean",
-                            "description": "Mount credentials as a file instead of using an environment variable",
-                            "default": false
-                        }
-                    }
-                }
-            }
-        },
-        "flyway": {
-            "type": "object",
-            "properties": {
-                "enabled": {
-                    "type": "boolean",
-                    "description": "Enable/disable flyway running Dataflow and Skipper Database creation scripts on startup",
-                    "default": true
-                }
-            }
-        },
-        "externalDatabase": {
-            "type": "object",
-            "properties": {
-                "host": {
-                    "type": "string",
-                    "description": "Host of the external database",
-                    "default": "localhost"
-                },
-                "port": {
-                    "type": "number",
-                    "description": "External database port number",
-                    "default": 3306
-                },
-                "driver": {
-                    "type": "string",
-                    "description": "The fully qualified name of the JDBC Driver class",
-                    "default": ""
-                },
-                "scheme": {
-                    "type": "string",
-                    "description": "The scheme is a vendor-specific or shared protocol string that follows the \"jdbc:\" of the URL",
-                    "default": ""
-                },
-                "password": {
-                    "type": "string",
-                    "description": "Password for the above username",
-                    "default": ""
-                },
-                "existingPasswordSecret": {
-                    "type": "string",
-                    "description": "Existing secret with database password",
-                    "default": ""
-                },
-                "existingPasswordKey": {
-                    "type": "string",
-                    "description": "Key of the existing secret with database password, defaults to `datasource-password`",
-                    "default": ""
-                },
-                "dataflow": {
-                    "type": "object",
-                    "properties": {
-                        "url": {
-                            "type": "string",
-                            "description": "JDBC URL for dataflow server. Overrides external scheme, host, port, database, and jdbc parameters.",
-                            "default": ""
-                        },
-                        "database": {
-                            "type": "string",
-                            "description": "Name of the existing database to be used by Dataflow server",
-                            "default": "dataflow"
-                        },
-                        "username": {
-                            "type": "string",
-                            "description": "Existing username in the external db to be used by Dataflow server",
-                            "default": "dataflow"
-                        }
-                    }
-                },
-                "skipper": {
-                    "type": "object",
-                    "properties": {
-                        "url": {
-                            "type": "string",
-                            "description": "JDBC URL for skipper. Overrides external scheme, host, port, database, and jdbc parameters.",
-                            "default": ""
-                        },
-                        "database": {
-                            "type": "string",
-                            "description": "Name of the existing database to be used by Skipper server",
-                            "default": "skipper"
-                        },
-                        "username": {
-                            "type": "string",
-                            "description": "Existing username in the external db to be used by Skipper server",
-                            "default": "skipper"
-                        }
-                    }
-                },
-                "hibernateDialect": {
-                    "type": "string",
-                    "description": "Hibernate Dialect used by Dataflow/Skipper servers",
-                    "default": ""
-                }
-            }
-        },
-        "rabbitmq": {
-            "type": "object",
-            "properties": {
-                "enabled": {
-                    "type": "boolean",
-                    "description": "Enable/disable RabbitMQ chart installation",
-                    "default": true
-                },
-                "auth": {
-                    "type": "object",
-                    "properties": {
-                        "username": {
-                            "type": "string",
-                            "description": "RabbitMQ username",
-                            "default": "user"
-                        }
-                    }
-                }
-            }
-        },
-        "externalRabbitmq": {
-            "type": "object",
-            "properties": {
-                "enabled": {
-                    "type": "boolean",
-                    "description": "Enable/disable external RabbitMQ",
-                    "default": false
-                },
-                "host": {
-                    "type": "string",
-                    "description": "Host of the external RabbitMQ",
-                    "default": "localhost"
-                },
-                "port": {
-                    "type": "number",
-                    "description": "External RabbitMQ port number",
-                    "default": 5672
-                },
-                "username": {
-                    "type": "string",
-                    "description": "External RabbitMQ username",
-                    "default": "guest"
-                },
-                "password": {
-                    "type": "string",
-                    "description": "External RabbitMQ password. It will be saved in a kubernetes secret",
-                    "default": "guest"
-                },
-                "vhost": {
-                    "type": "string",
-                    "description": "External RabbitMQ virtual host. It will be saved in a kubernetes secret",
-                    "default": ""
-                },
-                "existingPasswordSecret": {
-                    "type": "string",
-                    "description": "Existing secret with RabbitMQ password. It will be saved in a kubernetes secret",
-                    "default": ""
-                }
-            }
-        },
-        "kafka": {
-            "type": "object",
-            "properties": {
-                "enabled": {
-                    "type": "boolean",
-                    "description": "Enable/disable Kafka chart installation",
-                    "default": false
-                },
-                "controller": {
-                    "type": "object",
-                    "properties": {
-                        "replicaCount": {
-                            "type": "number",
-                            "description": "Number of Kafka controller+brokers nodes",
-                            "default": 1
-                        }
-                    }
-                },
-                "extraConfig": {
-                    "type": "string",
-                    "description": "Kafka extra configuration to be appended to dynamic settings",
-                    "default": "offsets.topic.replication.factor=1"
-                }
-            }
-        },
-        "externalKafka": {
-            "type": "object",
-            "properties": {
-                "enabled": {
-                    "type": "boolean",
-                    "description": "Enable/disable external Kafka",
-                    "default": false
-                },
-                "brokers": {
-                    "type": "string",
-                    "description": "External Kafka brokers",
-                    "default": "localhost:9092"
-                },
-                "zkNodes": {
-                    "type": "string",
-                    "description": "External Zookeeper nodes",
-                    "default": "localhost:2181"
-                }
-            }
+          }
         }
+      }
+    },
+    "rabbitmq": {
+      "type": "object",
+      "title": "RabbitMQ Details",
+      "form": true,
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "title": "Use a new RabbitMQ server hosted in the cluster",
+          "form": true,
+          "description": "Whether to deploy a RabbitMQ server to satisfy the Spring Cloud Skipper messaging middleware requirements."
+        }
+      }
+    },
+    "kafka": {
+      "type": "object",
+      "title": "Kafka Details",
+      "form": true,
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "title": "Use a new Kafka server hosted in the cluster",
+          "form": true,
+          "description": "Whether to deploy a Kafka server to satisfy the Spring Cloud Skipper messaging middleware requirements."
+        }
+      }
     }
+  }
 }

--- a/bitnami/spring-cloud-dataflow/values.yaml
+++ b/bitnami/spring-cloud-dataflow/values.yaml
@@ -1511,6 +1511,28 @@ waitForBackends:
     ##   - myRegistryKeySecretName
     ##
     pullSecrets: []
+  ## waitForBackends containers' Security Context (init container).
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
+  ## @param waitForBackends.containerSecurityContext.enabled Enabled containers' Security Context
+  ## @param waitForBackends.containerSecurityContext.runAsUser Set containers' Security Context runAsUser
+  ## @param waitForBackends.containerSecurityContext.runAsNonRoot Set container's Security Context runAsNonRoot
+  ## @param waitForBackends.containerSecurityContext.privileged Set container's Security Context privileged
+  ## @param waitForBackends.containerSecurityContext.readOnlyRootFilesystem Set container's Security Context readOnlyRootFilesystem
+  ## @param waitForBackends.containerSecurityContext.allowPrivilegeEscalation Set container's Security Context allowPrivilegeEscalation
+  ## @param waitForBackends.containerSecurityContext.capabilities.drop List of capabilities to be dropped
+  ## @param waitForBackends.containerSecurityContext.seccompProfile.type Set container's Security Context seccomp profile
+  ##
+  containerSecurityContext:
+    enabled: true
+    runAsUser: 1001
+    runAsNonRoot: true
+    privileged: false
+    readOnlyRootFilesystem: false
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop: ["ALL"]
+    seccompProfile:
+      type: "RuntimeDefault"
   ## Init container resource requests and limits.
   ## ref: https://kubernetes.io/docs/user-guide/compute-resources/
   ## We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Add securityContext to init containers.

### Benefits

Chart can be deployed on clusters with PSA enabled.

### Possible drawbacks

None.

### Additional information

https://kubernetes.io/docs/concepts/security/pod-security-admission/

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
