### PR TITLE
[bitnami/pinniped] Fix pinniped supervisor references

### DIFF
--- a/.vib/pinniped/runtime-parameters.yaml
+++ b/.vib/pinniped/runtime-parameters.yaml
@@ -10,11 +10,6 @@ supervisor:
     type: LoadBalancer
     ports:
       https: 443
-  hostAliases:
-    - ip: 127.0.0.1
-      hostnames:
-        - pinniped-supervisor
-  hostname: pinniped-supervisor
 concierge:
   enabled: true
   rbac:
@@ -22,12 +17,12 @@ concierge:
 extraDeploy:
 - |
   {{- $ca := genCA "pinniped-ca" 365 }}
-  {{- $pinniped_hostname := "pinniped-supervisor" }}
+  {{- $pinniped_hostname := include "pinniped.supervisor.fullname" . }}
   {{- $pinniped_cert := genSignedCert $pinniped_hostname nil (list $pinniped_hostname) 365 $ca }}
   apiVersion: v1
   kind: Secret
   metadata:
-    name: pinniped-supervisor-default-tls-certificate
+    name: {{ printf "%s-%s" (include "pinniped.supervisor.fullname" .) "default-tls-certificate" | trunc 63 | trimSuffix "-" }}
     namespace: {{ include "common.names.namespace" $ | quote }}
   type: kubernetes.io/tls
   data:
@@ -107,7 +102,7 @@ extraDeploy:
               - name: LDAP_ADMIN_PASSWORD
                 value: "admin123"
               - name: LDAP_ROOT
-                value: "dc=pinniped-supervisor"
+                value: {{ printf "dc=%s" (include "pinniped.supervisor.fullname" . ) }}
               - name: LDAP_USER_DC
                 value: "users"
               - name: LDAP_USERS
@@ -188,7 +183,7 @@ extraDeploy:
     name: supervisor-jwt-authenticator
     namespace: {{ include "common.names.namespace" $ | quote }}
   spec:
-    issuer: "https://pinniped-supervisor/demo-issuer"
+    issuer: {{ printf "https://%s/demo-issuer" ( include "pinniped.supervisor.fullname" . ) }}
     audience: vib-ed9de33c370981f61e9c
     tls:
       certificateAuthorityData: {{ $ca.Cert | b64enc | quote }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Create secrets and certificates using a name based on the deployment name.

### Benefits

We can run tests using any name. With previous configuration tests only worked if the deployment is called `pinniped`.

### Possible drawbacks

None

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
