### PR TITLE
[bitnami/fluentd] Render extra volumes and volume mounts

### DIFF
--- a/bitnami/fluentd/Chart.yaml
+++ b/bitnami/fluentd/Chart.yaml
@@ -30,4 +30,4 @@ maintainers:
 name: fluentd
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/fluentd
-version: 5.9.12
+version: 5.10.0

--- a/bitnami/fluentd/templates/aggregator-statefulset.yaml
+++ b/bitnami/fluentd/templates/aggregator-statefulset.yaml
@@ -200,15 +200,12 @@ spec:
               mountPath: /docker-entrypoint-initdb.d/init-scripts-secret
             {{- end }}
             {{- if .Values.aggregator.extraVolumeMounts }}
-            {{- toYaml .Values.aggregator.extraVolumeMounts | nindent 12 }}
+            {{- include "common.tplvalues.render" ( dict "value" .Values.aggregator.extraVolumeMounts "context" $ ) | nindent 12 }}
             {{- end }}
         {{- if .Values.aggregator.sidecars }}
         {{- include "common.tplvalues.render" ( dict "value" .Values.aggregator.sidecars "context" $ ) | nindent 8 }}
         {{- end }}
       volumes:
-        {{- if .Values.aggregator.extraVolumes }}
-          {{- toYaml .Values.aggregator.extraVolumes | nindent 8 }}
-        {{- end }}
         {{- if .Values.tls.enabled }}
         - name: fluentd-aggregator-certificates
           secret:
@@ -237,6 +234,9 @@ spec:
           secret:
             secretName: {{ template "fluentd.aggregator.initScriptsSecret" . }}
             defaultMode: 0755
+        {{- end }}
+        {{- if .Values.aggregator.extraVolumes }}
+        {{- include "common.tplvalues.render" ( dict "value" .Values.aggregator.extraVolumes "context" $ ) | nindent 8 }}
         {{- end }}
 
   {{- if or .Values.aggregator.persistence.enabled .Values.aggregator.extraVolumeClaimTemplates }}

--- a/bitnami/fluentd/templates/forwarder-daemonset.yaml
+++ b/bitnami/fluentd/templates/forwarder-daemonset.yaml
@@ -201,15 +201,12 @@ spec:
               mountPath: /var/lib/docker/containers
               readOnly: true
             {{- if .Values.forwarder.extraVolumeMounts }}
-            {{- toYaml .Values.forwarder.extraVolumeMounts | nindent 12 }}
+            {{- include "common.tplvalues.render" ( dict "value" .Values.forwarder.extraVolumeMounts "context" $ ) | nindent 12 }}
             {{- end }}
         {{- if .Values.forwarder.sidecars }}
         {{- include "common.tplvalues.render" ( dict "value" .Values.forwarder.sidecars "context" $ ) | nindent 8 }}
         {{- end }}
       volumes:
-        {{- if .Values.forwarder.extraVolumes }}
-            {{- toYaml .Values.forwarder.extraVolumes | nindent 8 }}
-        {{- end }}
         {{- if .Values.tls.enabled }}
         - name: fluentd-forwarder-certificates
           secret:
@@ -250,4 +247,7 @@ spec:
         - name: varlibdockercontainers
           hostPath:
             path: /var/lib/docker/containers
+        {{- if .Values.forwarder.extraVolumes }}
+        {{- include "common.tplvalues.render" ( dict "value" .Values.forwarder.extraVolumes "context" $ ) | nindent 8 }}
+        {{- end }}
 {{- end }}


### PR DESCRIPTION
### Description of the change

Use the `common.tplvalues.render` partial to render volume and volume mount configs.

### Benefits

Volume and volume mount config can be templated.

### Possible drawbacks

None

### Applicable issues

None

### Additional information

None

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
