### PR TITLE
[bitnami/pinniped] Configure impersonationProxy mode to run tests on clusters with PSA enabled

### DIFF
--- a/.vib/pinniped/ginkgo/scripts/pinniped-auth.sh
+++ b/.vib/pinniped/ginkgo/scripts/pinniped-auth.sh
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: APACHE-2.0
 
 # Run pinniped cli to obtain custom kubeconfig and auth into the cluster
-pinniped get kubeconfig --kubeconfig=<(echo $KUBECONFIG | base64 -d | sed "s%server:.*%server: https://${KUBERNETES_SERVICE_HOST}%g") > pinniped-config.yaml
+pinniped get kubeconfig --concierge-mode ImpersonationProxy --kubeconfig=<(echo $KUBECONFIG | base64 -d | sed "s%server:.*%server: https://${KUBERNETES_SERVICE_HOST}%g") > pinniped-config.yaml
 pinniped whoami --kubeconfig=pinniped-config.yaml
 
 echo 'Script finished correctly'

--- a/.vib/pinniped/runtime-parameters.yaml
+++ b/.vib/pinniped/runtime-parameters.yaml
@@ -14,6 +14,13 @@ concierge:
   enabled: true
   rbac:
     create: true
+  credentialIssuerConfig: |
+    impersonationProxy:
+      mode: enabled
+      service:
+        type: LoadBalancer
+        annotations:
+          service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "4000"
 extraDeploy:
 - |
   {{- $ca := genCA "pinniped-ca" 365 }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Configure `ImpersonationProxy` mode to run tests on clusters with PSA enabled.

### Benefits

Be able to run tests on PSA clusters.

### Possible drawbacks

None, this change affects to our tests.

### Applicable issues

With the default configuration (Token Credential Request API), concierge pods try to create a deployment whose pods need to run in the same node as the `kube-controller-manager` and they have to share particular volumes. So, by design, this configuration won't work on clusters with PSA unless pinniped is deployed in the `kube-system` namespace.

### Additional information

[vib execution](https://github.com/bitnami/charts/actions/runs/7347139444/job/20003059268?pr=21782)

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
