### PR TITLE
[bitnami/mysql] Allow undo secret generation when using secret injector like vault.

### DIFF
--- a/bitnami/mysql/Chart.yaml
+++ b/bitnami/mysql/Chart.yaml
@@ -34,4 +34,4 @@ maintainers:
 name: mysql
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/mysql
-version: 9.16.0
+version: 9.16.1

--- a/bitnami/mysql/README.md
+++ b/bitnami/mysql/README.md
@@ -82,7 +82,7 @@ The command removes all the Kubernetes components associated with the chart and 
 ### MySQL common parameters
 
 | Name                               | Description                                                                                                                                                                         | Value                   |
-| ---------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------- |
+|------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------|
 | `image.registry`                   | MySQL image registry                                                                                                                                                                | `REGISTRY_NAME`         |
 | `image.repository`                 | MySQL image repository                                                                                                                                                              | `REPOSITORY_NAME/mysql` |
 | `image.digest`                     | MySQL image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag                                                                               | `""`                    |
@@ -105,6 +105,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `initdbScriptsConfigMap`           | ConfigMap with the initdb scripts (Note: Overrides `initdbScripts`)                                                                                                                 | `""`                    |
 | `startdbScripts`                   | Dictionary of startdb scripts                                                                                                                                                       | `{}`                    |
 | `startdbScriptsConfigMap`          | ConfigMap with the startdb scripts (Note: Overrides `startdbScripts`)                                                                                                               | `""`                    |
+| `createSecret`                     | Create secrets for passwords according configuration. Set to false if you use secret injection like vault-injector.                                                                 | `true`                  |
 
 ### MySQL Primary parameters
 

--- a/bitnami/mysql/templates/secrets.yaml
+++ b/bitnami/mysql/templates/secrets.yaml
@@ -3,11 +3,11 @@ Copyright VMware, Inc.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
+{{- if eq (include "mysql.createSecret" .) "true" }}
 {{- $host := include "mysql.primary.fullname" . }}
 {{- $port := print .Values.primary.service.ports.mysql }}
 {{- $rootPassword := include "common.secrets.passwords.manage" (dict "secret" (include "mysql.secretName" .) "key" "mysql-root-password" "length" 10 "providedValues" (list "auth.rootPassword") "context" $) | trimAll "\"" | b64dec }}
 {{- $password := include "common.secrets.passwords.manage" (dict "secret" (include "mysql.secretName" .) "key" "mysql-password" "length" 10 "providedValues" (list "auth.password") "context" $) | trimAll "\"" | b64dec }}
-{{- if eq (include "mysql.createSecret" .) "true" }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -24,7 +24,6 @@ data:
   {{- if eq .Values.architecture "replication" }}
   mysql-replication-password: {{ include "common.secrets.passwords.manage" (dict "secret" (include "common.names.fullname" .) "key" "mysql-replication-password" "length" 10 "providedValues" (list "auth.replicationPassword") "context" $) }}
   {{- end }}
-{{- end }}
 {{- if .Values.serviceBindings.enabled }}
 ---
 apiVersion: v1
@@ -70,5 +69,6 @@ data:
   {{- end }}
   password: {{ print $password | b64enc | quote }}
   uri: {{ printf "mysql://%s:%s@%s:%s/%s" .Values.auth.username $password $host $port $database | b64enc | quote }}
+{{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
When using a vault to inject secrets in the pod, there is no need to create secrets with the password values.

In my case, secrets are injected as files by vault inside pods with the option below: 

```yaml
mysql:
  auth:
    usePasswordFiles: true
    customPasswordFiles:
    root: /vault/secrets/root-db-password.txt
    user: /vault/secrets/db-password.txt
```

And I use annotations to inject the files inside vault/secrets/. There is no secret generation.

But when I try to upgrade my chart, I get the following error:

```
PASSWORDS ERROR: You must provide your current passwords when upgrading the release.
                 Note that even after reinstallation, old credentials may be needed as they may be kept in persistent volume claims.
                 Further information can be obtained at https://docs.bitnami.com/general/how-to/troubleshoot-helm-chart-issues/#credential-errors-while-upgrading-chart-releases

    'auth.rootPassword' must not be empty, please add '--set auth.rootPassword=$MYSQL_ROOT_PASSWORD' to the command. To get the current value:

        export MYSQL_ROOT_PASSWORD=$(kubectl get secret --namespace "contrast-ui-xm-dev" contrast-mysql -o jsonpath="{.data.mysql-root-password}" | base64 -d)
```

This is because of the `template/secrets.yaml` file, we try to retrieve the password event if we don't need to store it in a secret.

file mysql/template/secret.yaml
```yaml
{{- /*
Copyright VMware, Inc.
SPDX-License-Identifier: APACHE-2.0
*/}}

{{- $host := include "mysql.primary.fullname" . }}
{{- $port := print .Values.primary.service.ports.mysql }}
{{/* This line is interpreted even if we don't need secret */ }}
{{- $rootPassword := include "common.secrets.passwords.manage" (dict "secret" (include "mysql.secretName" .) "key" "mysql-root-password" "length" 10 "providedValues" (list "auth.rootPassword") "context" $) | trimAll "\"" | b64dec }}
{{- $password := include "common.secrets.passwords.manage" (dict "secret" (include "mysql.secretName" .) "key" "mysql-password" "length" 10 "providedValues" (list "auth.password") "context" $) | trimAll "\"" | b64dec }}
{{/* even when false, the upgrade fail whit an error */ }}
{{- if eq (include "mysql.createSecret" .) "true" }}
```

 ### Description of the change

With this change, when the parameter createSecret is false, we do not try to get the secret and the rootPassword.

### Benefits

We can use the vault injector in a clean way and upgrade the chart without error.

### Possible drawbacks

When the parameter to false, the user is responsible for the secret management.

With this configuration, the behavior with the parameters : 
```
creteSecret: false
.Values.serviceBindings.enabled : true
```
Will change.

Before: secret mychart-svcbind-root is created
After: secret mychart-svcbind-root is not created

Same behavior when the username changes.

### Applicable issues

I think this will fix errors like this (but I can't test the same configuration): https://github.com/bitnami/charts/issues/7953

Maybe we can report this PR on issues like this: https://github.com/bitnami/charts/issues/21360

### Additional information

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)