### PR TITLE
[bitnami/grafana-operator] Fix Cypress tests

### DIFF
--- a/.vib/grafana-operator/cypress/cypress/support/commands.js
+++ b/.vib/grafana-operator/cypress/cypress/support/commands.js
@@ -22,8 +22,8 @@ Cypress.Commands.add(
   (username = Cypress.env('username'), password = Cypress.env('password')) => {
     cy.clearCookies();
     cy.visit('/login');
-    cy.get('[aria-label*="Username"]').type(username);
-    cy.get('[aria-label*="Password"]').type(password);
+    cy.get('input[name="user"]').type(username);
+    cy.get('input[name="password"]').type(password);
     cy.contains('Log in').click();
     cy.contains('Home');
   }


### PR DESCRIPTION
### Description of the change

We updated Cypress tests for Grafana at https://github.com/bitnami/charts/pull/21651/files since the "login" page changed, but we forgot to do the same for Grafana Operator.

### Benefits

Cypress tests to be updated for new Grafana release.

### Possible drawbacks

None

### Applicable issues

N/A

### Additional information

N/A

### Checklist


- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
