### PR TITLE
[bitnami/kafka] Enable securityContext for autoDiscovery pods

### DIFF
--- a/.vib/kafka/runtime-parameters.yaml
+++ b/.vib/kafka/runtime-parameters.yaml
@@ -2,6 +2,9 @@ externalAccess:
   enabled: true
   autoDiscovery:
     enabled: true
+    containerSecurityContext:
+      enabled: true
+      runAsUser: 1002
   controller:
     service:
       ports:


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Enable explicitly in the `runtime-parameters.yaml` file the security context for the autoDiscovery pods.

### Benefits

For some of our internal tests this config has to be set.

### Possible drawbacks

None

### Applicable issues

### Additional information

[vib execution](https://github.com/bitnami/charts/actions/runs/7411422626/job/20165928475?pr=21853)

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
