### PR TITLE
[bitnami/nginx] fix: :lock: Do not use the default service account

### DIFF
--- a/bitnami/nginx/Chart.yaml
+++ b/bitnami/nginx/Chart.yaml
@@ -34,4 +34,4 @@ maintainers:
 name: nginx
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/nginx
-version: 15.6.1
+version: 15.6.2

--- a/bitnami/nginx/README.md
+++ b/bitnami/nginx/README.md
@@ -164,7 +164,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `autoscaling.targetMemory`                          | Target Memory utilization percentage                                                      | `""`             |
 | `extraVolumes`                                      | Array to add extra volumes                                                                | `[]`             |
 | `extraVolumeMounts`                                 | Array to add extra mount                                                                  | `[]`             |
-| `serviceAccount.create`                             | Enable creation of ServiceAccount for nginx pod                                           | `false`          |
+| `serviceAccount.create`                             | Enable creation of ServiceAccount for nginx pod                                           | `true`           |
 | `serviceAccount.name`                               | The name of the ServiceAccount to use.                                                    | `""`             |
 | `serviceAccount.annotations`                        | Annotations for service account. Evaluated as a template.                                 | `{}`             |
 | `serviceAccount.automountServiceAccountToken`       | Auto-mount the service account token in the pod                                           | `false`          |

--- a/bitnami/nginx/values.yaml
+++ b/bitnami/nginx/values.yaml
@@ -372,7 +372,7 @@ extraVolumeMounts: []
 serviceAccount:
   ## @param serviceAccount.create Enable creation of ServiceAccount for nginx pod
   ##
-  create: false
+  create: true
   ## @param serviceAccount.name The name of the ServiceAccount to use.
   ## If not set and create is true, a name is generated using the `common.names.fullname` template
   name: ""


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

This PR changes the service account creation so the default account is not used. Also disables the service account automounting.

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [ ] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [ ] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
