### PR TITLE
[bitnami/redis] fix: :lock: Do not use the default service account

### DIFF
--- a/.vib/redis/goss/goss.yaml
+++ b/.vib/redis/goss/goss.yaml
@@ -38,7 +38,7 @@ command:
     # or the one randomly defined by openshift (larger values). Otherwise, the chart is still using the default value.
     exec: if [ $(id -u) -lt {{ $uid }} ] || [ $(id -G | awk '{print $2}') -lt {{ $gid }} ]; then exit 1; fi
     exit-status: 0
-  {{ if .Vars.serviceAccount.automountServiceAccountToken }}
+  {{ if .Vars.master.serviceAccount.automountServiceAccountToken }}
   check-sa:
     exec: cat /var/run/secrets/kubernetes.io/serviceaccount/token | cut -d '.' -f 2 | xargs -I '{}' echo '{}====' | fold -w 4 | sed '$ d' | tr -d '\n' | base64 -d
     exit-status: 0

--- a/.vib/redis/runtime-parameters.yaml
+++ b/.vib/redis/runtime-parameters.yaml
@@ -40,8 +40,8 @@ replica:
     ports:
       redis: 6378
     type: ClusterIP
+  serviceAccount:
+    create: true
+    automountServiceAccountToken: true
 sentinel:
   enabled: false
-serviceAccount:
-  create: true
-  automountServiceAccountToken: true

--- a/.vib/redis/runtime-parameters.yaml
+++ b/.vib/redis/runtime-parameters.yaml
@@ -23,6 +23,9 @@ master:
     ports:
       redis: 80
     type: LoadBalancer
+  serviceAccount:
+    create: true
+    automountServiceAccountToken: true
 replica:
   replicaCount: 3
   containerPorts:
@@ -40,8 +43,5 @@ replica:
     ports:
       redis: 6378
     type: ClusterIP
-  serviceAccount:
-    create: true
-    automountServiceAccountToken: true
 sentinel:
   enabled: false

--- a/bitnami/redis/Chart.yaml
+++ b/bitnami/redis/Chart.yaml
@@ -34,4 +34,4 @@ maintainers:
 name: redis
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/redis
-version: 18.6.3
+version: 18.6.4

--- a/bitnami/redis/README.md
+++ b/bitnami/redis/README.md
@@ -228,9 +228,9 @@ The command removes all the Kubernetes components associated with the chart and 
 | `master.service.sessionAffinity`                           | Session Affinity for Kubernetes service, can be "None" or "ClientIP"                                  | `None`                   |
 | `master.service.sessionAffinityConfig`                     | Additional settings for the sessionAffinity                                                           | `{}`                     |
 | `master.terminationGracePeriodSeconds`                     | Integer setting the termination grace period for the redis-master pods                                | `30`                     |
-| `master.serviceAccount.create`                             | Specifies whether a ServiceAccount should be created                                                  | `false`                  |
+| `master.serviceAccount.create`                             | Specifies whether a ServiceAccount should be created                                                  | `true`                   |
 | `master.serviceAccount.name`                               | The name of the ServiceAccount to use.                                                                | `""`                     |
-| `master.serviceAccount.automountServiceAccountToken`       | Whether to auto mount the service account token                                                       | `true`                   |
+| `master.serviceAccount.automountServiceAccountToken`       | Whether to auto mount the service account token                                                       | `false`                  |
 | `master.serviceAccount.annotations`                        | Additional custom annotations for the ServiceAccount                                                  | `{}`                     |
 
 ### Redis&reg; replicas configuration parameters
@@ -346,9 +346,9 @@ The command removes all the Kubernetes components associated with the chart and 
 | `replica.autoscaling.maxReplicas`                           | Maximum replicas for the pod autoscaling                                                                | `11`                     |
 | `replica.autoscaling.targetCPU`                             | Percentage of CPU to consider when autoscaling                                                          | `""`                     |
 | `replica.autoscaling.targetMemory`                          | Percentage of Memory to consider when autoscaling                                                       | `""`                     |
-| `replica.serviceAccount.create`                             | Specifies whether a ServiceAccount should be created                                                    | `false`                  |
+| `replica.serviceAccount.create`                             | Specifies whether a ServiceAccount should be created                                                    | `true`                   |
 | `replica.serviceAccount.name`                               | The name of the ServiceAccount to use.                                                                  | `""`                     |
-| `replica.serviceAccount.automountServiceAccountToken`       | Whether to auto mount the service account token                                                         | `true`                   |
+| `replica.serviceAccount.automountServiceAccountToken`       | Whether to auto mount the service account token                                                         | `false`                  |
 | `replica.serviceAccount.annotations`                        | Additional custom annotations for the ServiceAccount                                                    | `{}`                     |
 
 ### Redis&reg; Sentinel configuration parameters
@@ -466,7 +466,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `rbac.rules`                                    | Custom RBAC rules to set                                                                                                                    | `[]`    |
 | `serviceAccount.create`                         | Specifies whether a ServiceAccount should be created                                                                                        | `true`  |
 | `serviceAccount.name`                           | The name of the ServiceAccount to use.                                                                                                      | `""`    |
-| `serviceAccount.automountServiceAccountToken`   | Whether to auto mount the service account token                                                                                             | `true`  |
+| `serviceAccount.automountServiceAccountToken`   | Whether to auto mount the service account token                                                                                             | `false` |
 | `serviceAccount.annotations`                    | Additional custom annotations for the ServiceAccount                                                                                        | `{}`    |
 | `pdb.create`                                    | Specifies whether a PodDisruptionBudget should be created                                                                                   | `false` |
 | `pdb.minAvailable`                              | Min number of pods that must still be available after the eviction                                                                          | `1`     |

--- a/bitnami/redis/values.yaml
+++ b/bitnami/redis/values.yaml
@@ -576,7 +576,7 @@ master:
   serviceAccount:
     ## @param master.serviceAccount.create Specifies whether a ServiceAccount should be created
     ##
-    create: false
+    create: true
     ## @param master.serviceAccount.name The name of the ServiceAccount to use.
     ## If not set and create is true, a name is generated using the common.names.fullname template
     ##
@@ -584,7 +584,7 @@ master:
     ## @param master.serviceAccount.automountServiceAccountToken Whether to auto mount the service account token
     ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#use-the-default-service-account-to-access-the-api-server
     ##
-    automountServiceAccountToken: true
+    automountServiceAccountToken: false
     ## @param master.serviceAccount.annotations Additional custom annotations for the ServiceAccount
     ##
     annotations: {}
@@ -1037,7 +1037,7 @@ replica:
   serviceAccount:
     ## @param replica.serviceAccount.create Specifies whether a ServiceAccount should be created
     ##
-    create: false
+    create: true
     ## @param replica.serviceAccount.name The name of the ServiceAccount to use.
     ## If not set and create is true, a name is generated using the common.names.fullname template
     ##
@@ -1045,7 +1045,7 @@ replica:
     ## @param replica.serviceAccount.automountServiceAccountToken Whether to auto mount the service account token
     ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#use-the-default-service-account-to-access-the-api-server
     ##
-    automountServiceAccountToken: true
+    automountServiceAccountToken: false
     ## @param replica.serviceAccount.annotations Additional custom annotations for the ServiceAccount
     ##
     annotations: {}
@@ -1487,7 +1487,7 @@ serviceAccount:
   ## @param serviceAccount.automountServiceAccountToken Whether to auto mount the service account token
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#use-the-default-service-account-to-access-the-api-server
   ##
-  automountServiceAccountToken: true
+  automountServiceAccountToken: false
   ## @param serviceAccount.annotations Additional custom annotations for the ServiceAccount
   ##
   annotations: {}


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

This PR changes the service account creation so the default account is not used. Also disables the service account automounting.

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [ ] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [ ] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
