### PR TITLE
[bitnami/jaeger] fix: :lock: Do not automount the service account token unless necessary

### DIFF
--- a/bitnami/jaeger/Chart.yaml
+++ b/bitnami/jaeger/Chart.yaml
@@ -34,4 +34,4 @@ maintainers:
 name: jaeger
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/jaeger
-version: 1.5.7
+version: 1.5.8

--- a/bitnami/jaeger/README.md
+++ b/bitnami/jaeger/README.md
@@ -141,7 +141,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `query.serviceAccount.create`                             | Enables ServiceAccount                                                                    | `true`           |
 | `query.serviceAccount.name`                               | ServiceAccount name                                                                       | `""`             |
 | `query.serviceAccount.annotations`                        | Annotations to add to all deployed objects                                                | `{}`             |
-| `query.serviceAccount.automountServiceAccountToken`       | Automount API credentials for a service account.                                          | `true`           |
+| `query.serviceAccount.automountServiceAccountToken`       | Automount API credentials for a service account.                                          | `false`          |
 | `query.podSecurityContext.enabled`                        | Enabled Jaeger pods' Security Context                                                     | `true`           |
 | `query.podSecurityContext.fsGroup`                        | Set Jaeger pod's Security Context fsGroup                                                 | `1001`           |
 | `query.containerSecurityContext.enabled`                  | Enabled containers' Security Context                                                      | `true`           |
@@ -237,7 +237,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `collector.serviceAccount.create`                             | Enables ServiceAccount                                                                     | `true`           |
 | `collector.serviceAccount.name`                               | ServiceAccount name                                                                        | `""`             |
 | `collector.serviceAccount.annotations`                        | Annotations to add to all deployed objects                                                 | `{}`             |
-| `collector.serviceAccount.automountServiceAccountToken`       | Automount API credentials for a service account.                                           | `true`           |
+| `collector.serviceAccount.automountServiceAccountToken`       | Automount API credentials for a service account.                                           | `false`          |
 | `collector.podSecurityContext.enabled`                        | Enabled Jaeger pods' Security Context                                                      | `true`           |
 | `collector.podSecurityContext.fsGroup`                        | Set Jaeger pod's Security Context fsGroup                                                  | `1001`           |
 | `collector.containerSecurityContext.enabled`                  | Enabled containers' Security Context                                                       | `true`           |
@@ -330,7 +330,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `agent.serviceAccount.create`                                 | Enables ServiceAccount                                                                                         | `true`           |
 | `agent.serviceAccount.name`                                   | ServiceAccount name                                                                                            | `""`             |
 | `agent.serviceAccount.annotations`                            | Annotations to add to all deployed objects                                                                     | `{}`             |
-| `agent.serviceAccount.automountServiceAccountToken`           | Automount API credentials for a service account.                                                               | `true`           |
+| `agent.serviceAccount.automountServiceAccountToken`           | Automount API credentials for a service account.                                                               | `false`          |
 | `agent.podSecurityContext.enabled`                            | Enabled Jaeger pods' Security Context                                                                          | `true`           |
 | `agent.podSecurityContext.fsGroup`                            | Set Jaeger pod's Security Context fsGroup                                                                      | `1001`           |
 | `agent.containerSecurityContext.enabled`                      | Enabled containers' Security Context                                                                           | `true`           |

--- a/bitnami/jaeger/values.yaml
+++ b/bitnami/jaeger/values.yaml
@@ -290,7 +290,7 @@ query:
     annotations: {}
     ## @param query.serviceAccount.automountServiceAccountToken Automount API credentials for a service account.
     ##
-    automountServiceAccountToken: true
+    automountServiceAccountToken: false
   ## Pod security context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param query.podSecurityContext.enabled Enabled Jaeger pods' Security Context
@@ -644,7 +644,7 @@ collector:
     annotations: {}
     ## @param collector.serviceAccount.automountServiceAccountToken Automount API credentials for a service account.
     ##
-    automountServiceAccountToken: true
+    automountServiceAccountToken: false
   ## Pod security context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param collector.podSecurityContext.enabled Enabled Jaeger pods' Security Context
@@ -980,7 +980,7 @@ agent:
     annotations: {}
     ## @param agent.serviceAccount.automountServiceAccountToken Automount API credentials for a service account.
     ##
-    automountServiceAccountToken: true
+    automountServiceAccountToken: false
   ## Pod security context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param agent.podSecurityContext.enabled Enabled Jaeger pods' Security Context


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

This PR disables the automount of the service account token for those components that have no RBAC rules. This is to comply with Kubernetes security checklists.

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [ ] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [ ] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
