### PR TITLE
[bitnami/mastodon] fix: :lock: Do not automount the service account token unless necessary

### DIFF
--- a/bitnami/mastodon/Chart.yaml
+++ b/bitnami/mastodon/Chart.yaml
@@ -49,4 +49,4 @@ maintainers:
 name: mastodon
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/mastodon
-version: 4.0.3
+version: 4.0.4

--- a/bitnami/mastodon/README.md
+++ b/bitnami/mastodon/README.md
@@ -449,7 +449,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `serviceAccount.create`                       | Specifies whether a ServiceAccount should be created                    | `true`        |
 | `serviceAccount.name`                         | The name of the ServiceAccount to use.                                  | `""`          |
 | `serviceAccount.annotations`                  | Additional Service Account annotations (evaluated as a template)        | `{}`          |
-| `serviceAccount.automountServiceAccountToken` | Automount service account token for the server service account          | `true`        |
+| `serviceAccount.automountServiceAccountToken` | Automount service account token for the server service account          | `false`       |
 | `externalDatabase.host`                       | Database host                                                           | `""`          |
 | `externalDatabase.port`                       | Database port number                                                    | `5432`        |
 | `externalDatabase.user`                       | Non-root username for Mastodon                                          | `postgres`    |

--- a/bitnami/mastodon/values.yaml
+++ b/bitnami/mastodon/values.yaml
@@ -1276,7 +1276,7 @@ serviceAccount:
   annotations: {}
   ## @param serviceAccount.automountServiceAccountToken Automount service account token for the server service account
   ##
-  automountServiceAccountToken: true
+  automountServiceAccountToken: false
 
 ## External PostgreSQL configuration
 ## All of these values are only used when postgresql.enabled is set to false


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

This PR disables the automount of the service account token for those components that have no RBAC rules. This is to comply with Kubernetes security checklists.

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [ ] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [ ] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
