### PR TITLE
[bitnami/matomo] Add `existingSecretPasswordKey`

### DIFF
--- a/bitnami/matomo/Chart.yaml
+++ b/bitnami/matomo/Chart.yaml
@@ -39,4 +39,4 @@ maintainers:
 name: matomo
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/matomo
-version: 5.1.0
+version: 5.2.0

--- a/bitnami/matomo/README.md
+++ b/bitnami/matomo/README.md
@@ -217,26 +217,27 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Database parameters
 
-| Name                                        | Description                                                                              | Value               |
-| ------------------------------------------- | ---------------------------------------------------------------------------------------- | ------------------- |
-| `mariadb.enabled`                           | Whether to deploy a mariadb server to satisfy the applications database requirements     | `true`              |
-| `mariadb.architecture`                      | MariaDB architecture (`standalone` or `replication`)                                     | `standalone`        |
-| `mariadb.auth.rootPassword`                 | Password for the MariaDB `root` user                                                     | `""`                |
-| `mariadb.auth.database`                     | Database name to create                                                                  | `bitnami_matomo`    |
-| `mariadb.auth.username`                     | Database user to create                                                                  | `bn_matomo`         |
-| `mariadb.auth.password`                     | Password for the database                                                                | `""`                |
-| `mariadb.primary.persistence.enabled`       | Enable database persistence using PVC                                                    | `true`              |
-| `mariadb.primary.persistence.storageClass`  | MariaDB primary persistent volume storage Class                                          | `""`                |
-| `mariadb.primary.persistence.accessModes`   | Database Persistent Volume Access Modes                                                  | `["ReadWriteOnce"]` |
-| `mariadb.primary.persistence.size`          | Database Persistent Volume Size                                                          | `8Gi`               |
-| `mariadb.primary.persistence.hostPath`      | Set path in case you want to use local host path volumes (not recommended in production) | `""`                |
-| `mariadb.primary.persistence.existingClaim` | Name of an existing `PersistentVolumeClaim` for MariaDB primary replicas                 | `""`                |
-| `externalDatabase.host`                     | Host of the existing database                                                            | `""`                |
-| `externalDatabase.port`                     | Port of the existing database                                                            | `3306`              |
-| `externalDatabase.user`                     | Existing username in the external db                                                     | `bn_matomo`         |
-| `externalDatabase.password`                 | Password for the above username                                                          | `""`                |
-| `externalDatabase.database`                 | Name of the existing database                                                            | `bitnami_matomo`    |
-| `externalDatabase.existingSecret`           | Name of a secret containing the database credentials                                     | `""`                |
+| Name                                         | Description                                                                              | Value               |
+| -------------------------------------------- | ---------------------------------------------------------------------------------------- | ------------------- |
+| `mariadb.enabled`                            | Whether to deploy a mariadb server to satisfy the applications database requirements     | `true`              |
+| `mariadb.architecture`                       | MariaDB architecture (`standalone` or `replication`)                                     | `standalone`        |
+| `mariadb.auth.rootPassword`                  | Password for the MariaDB `root` user                                                     | `""`                |
+| `mariadb.auth.database`                      | Database name to create                                                                  | `bitnami_matomo`    |
+| `mariadb.auth.username`                      | Database user to create                                                                  | `bn_matomo`         |
+| `mariadb.auth.password`                      | Password for the database                                                                | `""`                |
+| `mariadb.primary.persistence.enabled`        | Enable database persistence using PVC                                                    | `true`              |
+| `mariadb.primary.persistence.storageClass`   | MariaDB primary persistent volume storage Class                                          | `""`                |
+| `mariadb.primary.persistence.accessModes`    | Database Persistent Volume Access Modes                                                  | `["ReadWriteOnce"]` |
+| `mariadb.primary.persistence.size`           | Database Persistent Volume Size                                                          | `8Gi`               |
+| `mariadb.primary.persistence.hostPath`       | Set path in case you want to use local host path volumes (not recommended in production) | `""`                |
+| `mariadb.primary.persistence.existingClaim`  | Name of an existing `PersistentVolumeClaim` for MariaDB primary replicas                 | `""`                |
+| `externalDatabase.host`                      | Host of the existing database                                                            | `""`                |
+| `externalDatabase.port`                      | Port of the existing database                                                            | `3306`              |
+| `externalDatabase.user`                      | Existing username in the external db                                                     | `bn_matomo`         |
+| `externalDatabase.password`                  | Password for the above username                                                          | `""`                |
+| `externalDatabase.database`                  | Name of the existing database                                                            | `bitnami_matomo`    |
+| `externalDatabase.existingSecret`            | Name of a secret containing the database credentials                                     | `""`                |
+| `externalDatabase.existingSecretPasswordKey` | Key of the password in the existing secret                                               | `db-password`       |
 
 ### Volume Permissions parameters
 

--- a/bitnami/matomo/templates/_helpers.tpl
+++ b/bitnami/matomo/templates/_helpers.tpl
@@ -139,7 +139,7 @@ Return the database password key
 {{- if .Values.mariadb.enabled -}}
 mariadb-password
 {{- else -}}
-db-password
+    {{- printf "%s" .Values.externalDatabase.existingSecretPasswordKey -}}
 {{- end -}}
 {{- end -}}
 

--- a/bitnami/matomo/values.yaml
+++ b/bitnami/matomo/values.yaml
@@ -680,6 +680,7 @@ mariadb:
 ## @param externalDatabase.password Password for the above username
 ## @param externalDatabase.database Name of the existing database
 ## @param externalDatabase.existingSecret Name of a secret containing the database credentials
+## @param externalDatabase.existingSecretPasswordKey Key of the password in the existing secret
 ##
 externalDatabase:
   host: ""
@@ -688,6 +689,7 @@ externalDatabase:
   password: ""
   database: bitnami_matomo
   existingSecret: ""
+  existingSecretPasswordKey: db-password
 
 ## @section Volume Permissions parameters
 ##


### PR DESCRIPTION
### Description of the change

Add `externalDatabase.existingSecretPasswordKey` to be able to customize the key of the password in the existing secret.

### Benefits

The secret key might be injected into various other tools/charts. Not all will need the secret to be "db-password".

### Possible drawbacks

Can't think of any.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
