### PR TITLE
[bitnami/argo-cd] fix: :lock: Improve podSecurityContext and containerSecurityContext with essential security fields

### DIFF
--- a/bitnami/argo-cd/Chart.yaml
+++ b/bitnami/argo-cd/Chart.yaml
@@ -39,4 +39,4 @@ maintainers:
 name: argo-cd
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/argo-cd
-version: 5.3.0
+version: 5.4.0

--- a/bitnami/argo-cd/README.md
+++ b/bitnami/argo-cd/README.md
@@ -115,8 +115,12 @@ The command removes all the Kubernetes components associated with the chart and 
 | `controller.resources.limits`                                  | The resources limits for the Argo CD containers                                                      | `{}`             |
 | `controller.resources.requests`                                | The requested resources for the Argo CD containers                                                   | `{}`             |
 | `controller.podSecurityContext.enabled`                        | Enabled Argo CD pods' Security Context                                                               | `true`           |
+| `controller.podSecurityContext.fsGroupChangePolicy`            | Set filesystem group change policy                                                                   | `Always`         |
+| `controller.podSecurityContext.sysctls`                        | Set kernel settings using the sysctl interface                                                       | `[]`             |
+| `controller.podSecurityContext.supplementalGroups`             | Set filesystem extra groups                                                                          | `[]`             |
 | `controller.podSecurityContext.fsGroup`                        | Set Argo CD pod's Security Context fsGroup                                                           | `1001`           |
 | `controller.containerSecurityContext.enabled`                  | Enabled Argo CD containers' Security Context                                                         | `true`           |
+| `controller.containerSecurityContext.seLinuxOptions`           | Set SELinux options in container                                                                     | `{}`             |
 | `controller.containerSecurityContext.runAsUser`                | Set Argo CD containers' Security Context runAsUser                                                   | `1001`           |
 | `controller.containerSecurityContext.allowPrivilegeEscalation` | Set Argo CD containers' Security Context allowPrivilegeEscalation                                    | `false`          |
 | `controller.containerSecurityContext.capabilities.drop`        | Set Argo CD containers' Security Context capabilities to be dropped                                  | `["ALL"]`        |
@@ -264,6 +268,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `applicationSet.podAnnotations`                                    | Annotations for Argo CD applicationSet controller pods                                                          | `{}`             |
 | `applicationSet.podLabels`                                         | Extra labels for Argo CD applicationSet controller pods                                                         | `{}`             |
 | `applicationSet.containerSecurityContext.enabled`                  | Enabled Argo CD applicationSet controller containers' Security Context                                          | `true`           |
+| `applicationSet.containerSecurityContext.seLinuxOptions`           | Set SELinux options in container                                                                                | `{}`             |
 | `applicationSet.containerSecurityContext.runAsUser`                | Set Argo CD applicationSet controller containers' Security Context runAsUser                                    | `1001`           |
 | `applicationSet.containerSecurityContext.allowPrivilegeEscalation` | Set Argo CD applicationSet controller containers' Security Context allowPrivilegeEscalation                     | `false`          |
 | `applicationSet.containerSecurityContext.capabilities.drop`        | Set Argo CD applicationSet controller containers' Security Context capabilities to be dropped                   | `["ALL"]`        |
@@ -288,6 +293,9 @@ The command removes all the Kubernetes components associated with the chart and 
 | `applicationSet.resources.limits`                                  | The resources limits for the Argo CD applicationSet controller containers                                       | `{}`             |
 | `applicationSet.resources.requests`                                | The requested resources for the Argo CD applicationSet controller containers                                    | `{}`             |
 | `applicationSet.podSecurityContext.enabled`                        | Enabled Argo CD applicationSet controller pods' Security Context                                                | `true`           |
+| `applicationSet.podSecurityContext.fsGroupChangePolicy`            | Set filesystem group change policy                                                                              | `Always`         |
+| `applicationSet.podSecurityContext.sysctls`                        | Set kernel settings using the sysctl interface                                                                  | `[]`             |
+| `applicationSet.podSecurityContext.supplementalGroups`             | Set filesystem extra groups                                                                                     | `[]`             |
 | `applicationSet.podSecurityContext.fsGroup`                        | Set Argo CD applicationSet controller pod's Security Context fsGroup                                            | `1001`           |
 | `applicationSet.nodeSelector`                                      | Node labels for Argo CD applicationSet controller pods assignment                                               | `{}`             |
 | `applicationSet.tolerations`                                       | Tolerations for Argo CD applicationSet controller pods assignment                                               | `[]`             |
@@ -365,6 +373,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `notifications.podAnnotations`                                               | Annotations for Argo CD notifications controller pods                                                              | `{}`             |
 | `notifications.podLabels`                                                    | Extra labels for Argo CD notifications controller pods                                                             | `{}`             |
 | `notifications.containerSecurityContext.enabled`                             | Enabled Argo CD notifications controller containers' Security Context                                              | `true`           |
+| `notifications.containerSecurityContext.seLinuxOptions`                      | Set SELinux options in container                                                                                   | `{}`             |
 | `notifications.containerSecurityContext.runAsUser`                           | Set Argo CD notifications controller containers' Security Context runAsUser                                        | `1001`           |
 | `notifications.containerSecurityContext.allowPrivilegeEscalation`            | Set Argo CD notifications controller containers' Security Context allowPrivilegeEscalation                         | `false`          |
 | `notifications.containerSecurityContext.capabilities.drop`                   | Set Argo CD notifications controller containers' Security Context capabilities to be dropped                       | `["ALL"]`        |
@@ -375,6 +384,9 @@ The command removes all the Kubernetes components associated with the chart and 
 | `notifications.resources.limits`                                             | The resources limits for the Argo CD notifications controller containers                                           | `{}`             |
 | `notifications.resources.requests`                                           | The requested resources for the Argo CD notifications controller containers                                        | `{}`             |
 | `notifications.podSecurityContext.enabled`                                   | Enabled Argo CD notifications controller pods' Security Context                                                    | `true`           |
+| `notifications.podSecurityContext.fsGroupChangePolicy`                       | Set filesystem group change policy                                                                                 | `Always`         |
+| `notifications.podSecurityContext.sysctls`                                   | Set kernel settings using the sysctl interface                                                                     | `[]`             |
+| `notifications.podSecurityContext.supplementalGroups`                        | Set filesystem extra groups                                                                                        | `[]`             |
 | `notifications.podSecurityContext.fsGroup`                                   | Set Argo CD notifications controller pod's Security Context fsGroup                                                | `1001`           |
 | `notifications.nodeSelector`                                                 | Node labels for Argo CD notifications controller pods assignment                                                   | `{}`             |
 | `notifications.tolerations`                                                  | Tolerations for Argo CD notifications controller pods assignment                                                   | `[]`             |
@@ -466,6 +478,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `notifications.bots.slack.podAnnotations`                                    | Annotations for Argo CD Slack bot pods                                                                             | `{}`             |
 | `notifications.bots.slack.podLabels`                                         | Extra labels for Argo CD Slack bot pods                                                                            | `{}`             |
 | `notifications.bots.slack.containerSecurityContext.enabled`                  | Enabled Argo CD Slack bot containers' Security Context                                                             | `true`           |
+| `notifications.bots.slack.containerSecurityContext.seLinuxOptions`           | Set SELinux options in container                                                                                   | `{}`             |
 | `notifications.bots.slack.containerSecurityContext.runAsUser`                | Set Argo CD Slack bot containers' Security Context runAsUser                                                       | `1001`           |
 | `notifications.bots.slack.containerSecurityContext.allowPrivilegeEscalation` | Set Argo CD Slack bot containers' Security Context allowPrivilegeEscalation                                        | `false`          |
 | `notifications.bots.slack.containerSecurityContext.capabilities.drop`        | Set Argo CD Slack bot containers' Security Context capabilities to be dropped                                      | `["ALL"]`        |
@@ -476,6 +489,9 @@ The command removes all the Kubernetes components associated with the chart and 
 | `notifications.bots.slack.resources.limits`                                  | The resources limits for the Argo CD Slack bot containers                                                          | `{}`             |
 | `notifications.bots.slack.resources.requests`                                | The requested resources for the Argo CD Slack bot containers                                                       | `{}`             |
 | `notifications.bots.slack.podSecurityContext.enabled`                        | Enabled Argo CD Slack bot pods' Security Context                                                                   | `true`           |
+| `notifications.bots.slack.podSecurityContext.fsGroupChangePolicy`            | Set filesystem group change policy                                                                                 | `Always`         |
+| `notifications.bots.slack.podSecurityContext.sysctls`                        | Set kernel settings using the sysctl interface                                                                     | `[]`             |
+| `notifications.bots.slack.podSecurityContext.supplementalGroups`             | Set filesystem extra groups                                                                                        | `[]`             |
 | `notifications.bots.slack.podSecurityContext.fsGroup`                        | Set Argo CD Slack bot pod's Security Context fsGroup                                                               | `1001`           |
 | `notifications.bots.slack.nodeSelector`                                      | Node labels for Argo CD Slack bot pods assignment                                                                  | `{}`             |
 | `notifications.bots.slack.tolerations`                                       | Tolerations for Argo CD Slack bot pods assignment                                                                  | `[]`             |
@@ -515,8 +531,12 @@ The command removes all the Kubernetes components associated with the chart and 
 | `server.resources.limits`                                  | The resources limits for the Argo CD server containers                                                                          | `{}`                     |
 | `server.resources.requests`                                | The requested resources for the Argo CD server containers                                                                       | `{}`                     |
 | `server.podSecurityContext.enabled`                        | Enabled Argo CD server pods' Security Context                                                                                   | `true`                   |
+| `server.podSecurityContext.fsGroupChangePolicy`            | Set filesystem group change policy                                                                                              | `Always`                 |
+| `server.podSecurityContext.sysctls`                        | Set kernel settings using the sysctl interface                                                                                  | `[]`                     |
+| `server.podSecurityContext.supplementalGroups`             | Set filesystem extra groups                                                                                                     | `[]`                     |
 | `server.podSecurityContext.fsGroup`                        | Set Argo CD server pod's Security Context fsGroup                                                                               | `1001`                   |
 | `server.containerSecurityContext.enabled`                  | Enabled Argo CD server containers' Security Context                                                                             | `true`                   |
+| `server.containerSecurityContext.seLinuxOptions`           | Set SELinux options in container                                                                                                | `{}`                     |
 | `server.containerSecurityContext.runAsUser`                | Set Argo CD server containers' Security Context runAsUser                                                                       | `1001`                   |
 | `server.containerSecurityContext.allowPrivilegeEscalation` | Set Argo CD server containers' Security Context allowPrivilegeEscalation                                                        | `false`                  |
 | `server.containerSecurityContext.capabilities.drop`        | Set Argo CD containers' server Security Context capabilities to be dropped                                                      | `["ALL"]`                |
@@ -661,8 +681,12 @@ The command removes all the Kubernetes components associated with the chart and 
 | `repoServer.resources.limits`                                  | The resources limits for the Argo CD repo server containers                                          | `{}`             |
 | `repoServer.resources.requests`                                | The requested resources for the Argo CD repo server containers                                       | `{}`             |
 | `repoServer.podSecurityContext.enabled`                        | Enabled Argo CD repo server pods' Security Context                                                   | `true`           |
+| `repoServer.podSecurityContext.fsGroupChangePolicy`            | Set filesystem group change policy                                                                   | `Always`         |
+| `repoServer.podSecurityContext.sysctls`                        | Set kernel settings using the sysctl interface                                                       | `[]`             |
+| `repoServer.podSecurityContext.supplementalGroups`             | Set filesystem extra groups                                                                          | `[]`             |
 | `repoServer.podSecurityContext.fsGroup`                        | Set Argo CD repo server pod's Security Context fsGroup                                               | `1001`           |
 | `repoServer.containerSecurityContext.enabled`                  | Enabled Argo CD repo server containers' Security Context                                             | `true`           |
+| `repoServer.containerSecurityContext.seLinuxOptions`           | Set SELinux options in container                                                                     | `{}`             |
 | `repoServer.containerSecurityContext.runAsUser`                | Set Argo CD repo server containers' Security Context runAsUser                                       | `1001`           |
 | `repoServer.containerSecurityContext.allowPrivilegeEscalation` | Set Argo CD repo server containers' Security Context allowPrivilegeEscalation                        | `false`          |
 | `repoServer.containerSecurityContext.capabilities.drop`        | Set Argo CD containers' repo server Security Context capabilities to be dropped                      | `["ALL"]`        |
@@ -779,8 +803,12 @@ The command removes all the Kubernetes components associated with the chart and 
 | `dex.resources.limits`                                  | The resources limits for the Dex containers                                                         | `{}`                  |
 | `dex.resources.requests`                                | The requested resources for the Dex containers                                                      | `{}`                  |
 | `dex.podSecurityContext.enabled`                        | Enabled Dex pods' Security Context                                                                  | `true`                |
+| `dex.podSecurityContext.fsGroupChangePolicy`            | Set filesystem group change policy                                                                  | `Always`              |
+| `dex.podSecurityContext.sysctls`                        | Set kernel settings using the sysctl interface                                                      | `[]`                  |
+| `dex.podSecurityContext.supplementalGroups`             | Set filesystem extra groups                                                                         | `[]`                  |
 | `dex.podSecurityContext.fsGroup`                        | Set Dex pod's Security Context fsGroup                                                              | `1001`                |
 | `dex.containerSecurityContext.enabled`                  | Enabled Dex containers' Security Context                                                            | `true`                |
+| `dex.containerSecurityContext.seLinuxOptions`           | Set SELinux options in container                                                                    | `{}`                  |
 | `dex.containerSecurityContext.runAsUser`                | Set Dex containers' Security Context runAsUser                                                      | `1001`                |
 | `dex.containerSecurityContext.allowPrivilegeEscalation` | Set Dex containers' Security Context allowPrivilegeEscalation                                       | `false`               |
 | `dex.containerSecurityContext.readOnlyRootFilesystem`   | Set Dex containers' server Security Context readOnlyRootFilesystem                                  | `false`               |
@@ -886,17 +914,18 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Init Container Parameters
 
-| Name                                                   | Description                                                                                                        | Value                      |
-| ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------ | -------------------------- |
-| `volumePermissions.enabled`                            | Enable init container that changes the owner/group of the PV mount point to `runAsUser:fsGroup`                    | `false`                    |
-| `volumePermissions.image.registry`                     | OS Shell + Utility image registry                                                                                  | `REGISTRY_NAME`            |
-| `volumePermissions.image.repository`                   | OS Shell + Utility image repository                                                                                | `REPOSITORY_NAME/os-shell` |
-| `volumePermissions.image.digest`                       | OS Shell + Utility image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                       |
-| `volumePermissions.image.pullPolicy`                   | OS Shell + Utility image pull policy                                                                               | `IfNotPresent`             |
-| `volumePermissions.image.pullSecrets`                  | OS Shell + Utility image pull secrets                                                                              | `[]`                       |
-| `volumePermissions.resources.limits`                   | The resources limits for the init container                                                                        | `{}`                       |
-| `volumePermissions.resources.requests`                 | The requested resources for the init container                                                                     | `{}`                       |
-| `volumePermissions.containerSecurityContext.runAsUser` | Set init container's Security Context runAsUser                                                                    | `0`                        |
+| Name                                                        | Description                                                                                                        | Value                      |
+| ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ | -------------------------- |
+| `volumePermissions.enabled`                                 | Enable init container that changes the owner/group of the PV mount point to `runAsUser:fsGroup`                    | `false`                    |
+| `volumePermissions.image.registry`                          | OS Shell + Utility image registry                                                                                  | `REGISTRY_NAME`            |
+| `volumePermissions.image.repository`                        | OS Shell + Utility image repository                                                                                | `REPOSITORY_NAME/os-shell` |
+| `volumePermissions.image.digest`                            | OS Shell + Utility image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                       |
+| `volumePermissions.image.pullPolicy`                        | OS Shell + Utility image pull policy                                                                               | `IfNotPresent`             |
+| `volumePermissions.image.pullSecrets`                       | OS Shell + Utility image pull secrets                                                                              | `[]`                       |
+| `volumePermissions.resources.limits`                        | The resources limits for the init container                                                                        | `{}`                       |
+| `volumePermissions.resources.requests`                      | The requested resources for the init container                                                                     | `{}`                       |
+| `volumePermissions.containerSecurityContext.seLinuxOptions` | Set SELinux options in container                                                                                   | `{}`                       |
+| `volumePermissions.containerSecurityContext.runAsUser`      | Set init container's Security Context runAsUser                                                                    | `0`                        |
 
 ### Other Parameters
 
@@ -923,6 +952,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `redisWait.enabled`                                           | Enables waiting for redis                                                                             | `true`                  |
 | `redisWait.extraArgs`                                         | Additional arguments for the redis-cli call, such as TLS                                              | `""`                    |
 | `redisWait.containerSecurityContext.enabled`                  | Enabled Argo CD repo server containers' Security Context                                              | `true`                  |
+| `redisWait.containerSecurityContext.seLinuxOptions`           | Set SELinux options in container                                                                      | `{}`                    |
 | `redisWait.containerSecurityContext.runAsUser`                | Set Argo CD repo server containers' Security Context runAsUser                                        | `1001`                  |
 | `redisWait.containerSecurityContext.allowPrivilegeEscalation` | Set Argo CD repo server containers' Security Context allowPrivilegeEscalation                         | `false`                 |
 | `redisWait.containerSecurityContext.capabilities.drop`        | Set Argo CD containers' repo server Security Context capabilities to be dropped                       | `["ALL"]`               |

--- a/bitnami/argo-cd/values.yaml
+++ b/bitnami/argo-cd/values.yaml
@@ -149,14 +149,21 @@ controller:
   ## Configure Pods Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param controller.podSecurityContext.enabled Enabled Argo CD pods' Security Context
+  ## @param controller.podSecurityContext.fsGroupChangePolicy Set filesystem group change policy
+  ## @param controller.podSecurityContext.sysctls Set kernel settings using the sysctl interface
+  ## @param controller.podSecurityContext.supplementalGroups Set filesystem extra groups
   ## @param controller.podSecurityContext.fsGroup Set Argo CD pod's Security Context fsGroup
   ##
   podSecurityContext:
     enabled: true
+    fsGroupChangePolicy: Always
+    sysctls: []
+    supplementalGroups: []
     fsGroup: 1001
   ## Configure Container Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param controller.containerSecurityContext.enabled Enabled Argo CD containers' Security Context
+  ## @param controller.containerSecurityContext.seLinuxOptions Set SELinux options in container
   ## @param controller.containerSecurityContext.runAsUser Set Argo CD containers' Security Context runAsUser
   ## @param controller.containerSecurityContext.allowPrivilegeEscalation Set Argo CD containers' Security Context allowPrivilegeEscalation
   ## @param controller.containerSecurityContext.capabilities.drop Set Argo CD containers' Security Context capabilities to be dropped
@@ -167,6 +174,7 @@ controller:
   ##
   containerSecurityContext:
     enabled: true
+    seLinuxOptions: {}
     runAsUser: 1001
     runAsNonRoot: true
     readOnlyRootFilesystem: false
@@ -809,6 +817,7 @@ applicationSet:
   ## Configure Container Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param applicationSet.containerSecurityContext.enabled Enabled Argo CD applicationSet controller containers' Security Context
+  ## @param applicationSet.containerSecurityContext.seLinuxOptions Set SELinux options in container
   ## @param applicationSet.containerSecurityContext.runAsUser Set Argo CD applicationSet controller containers' Security Context runAsUser
   ## @param applicationSet.containerSecurityContext.allowPrivilegeEscalation Set Argo CD applicationSet controller containers' Security Context allowPrivilegeEscalation
   ## @param applicationSet.containerSecurityContext.capabilities.drop Set Argo CD applicationSet controller containers' Security Context capabilities to be dropped
@@ -819,6 +828,7 @@ applicationSet:
   ##
   containerSecurityContext:
     enabled: true
+    seLinuxOptions: {}
     runAsUser: 1001
     runAsNonRoot: true
     readOnlyRootFilesystem: false
@@ -873,10 +883,16 @@ applicationSet:
   ## Configure Pods Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param applicationSet.podSecurityContext.enabled Enabled Argo CD applicationSet controller pods' Security Context
+  ## @param applicationSet.podSecurityContext.fsGroupChangePolicy Set filesystem group change policy
+  ## @param applicationSet.podSecurityContext.sysctls Set kernel settings using the sysctl interface
+  ## @param applicationSet.podSecurityContext.supplementalGroups Set filesystem extra groups
   ## @param applicationSet.podSecurityContext.fsGroup Set Argo CD applicationSet controller pod's Security Context fsGroup
   ##
   podSecurityContext:
     enabled: true
+    fsGroupChangePolicy: Always
+    sysctls: []
+    supplementalGroups: []
     fsGroup: 1001
   ## @param applicationSet.nodeSelector Node labels for Argo CD applicationSet controller pods assignment
   ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/
@@ -1205,6 +1221,7 @@ notifications:
   ## Configure Container Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param notifications.containerSecurityContext.enabled Enabled Argo CD notifications controller containers' Security Context
+  ## @param notifications.containerSecurityContext.seLinuxOptions Set SELinux options in container
   ## @param notifications.containerSecurityContext.runAsUser Set Argo CD notifications controller containers' Security Context runAsUser
   ## @param notifications.containerSecurityContext.allowPrivilegeEscalation Set Argo CD notifications controller containers' Security Context allowPrivilegeEscalation
   ## @param notifications.containerSecurityContext.capabilities.drop Set Argo CD notifications controller containers' Security Context capabilities to be dropped
@@ -1215,6 +1232,7 @@ notifications:
   ##
   containerSecurityContext:
     enabled: true
+    seLinuxOptions: {}
     runAsUser: 1001
     runAsNonRoot: true
     readOnlyRootFilesystem: false
@@ -1235,10 +1253,16 @@ notifications:
   ## Configure Pods Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param notifications.podSecurityContext.enabled Enabled Argo CD notifications controller pods' Security Context
+  ## @param notifications.podSecurityContext.fsGroupChangePolicy Set filesystem group change policy
+  ## @param notifications.podSecurityContext.sysctls Set kernel settings using the sysctl interface
+  ## @param notifications.podSecurityContext.supplementalGroups Set filesystem extra groups
   ## @param notifications.podSecurityContext.fsGroup Set Argo CD notifications controller pod's Security Context fsGroup
   ##
   podSecurityContext:
     enabled: true
+    fsGroupChangePolicy: Always
+    sysctls: []
+    supplementalGroups: []
     fsGroup: 1001
   ## @param notifications.nodeSelector Node labels for Argo CD notifications controller pods assignment
   ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/
@@ -1572,6 +1596,7 @@ notifications:
       ## Configure Container Security Context
       ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
       ## @param notifications.bots.slack.containerSecurityContext.enabled Enabled Argo CD Slack bot containers' Security Context
+      ## @param notifications.bots.slack.containerSecurityContext.seLinuxOptions Set SELinux options in container
       ## @param notifications.bots.slack.containerSecurityContext.runAsUser Set Argo CD Slack bot containers' Security Context runAsUser
       ## @param notifications.bots.slack.containerSecurityContext.allowPrivilegeEscalation Set Argo CD Slack bot containers' Security Context allowPrivilegeEscalation
       ## @param notifications.bots.slack.containerSecurityContext.capabilities.drop Set Argo CD Slack bot containers' Security Context capabilities to be dropped
@@ -1582,6 +1607,7 @@ notifications:
       ##
       containerSecurityContext:
         enabled: true
+        seLinuxOptions: {}
         runAsUser: 1001
         runAsNonRoot: true
         readOnlyRootFilesystem: false
@@ -1602,10 +1628,16 @@ notifications:
       ## Configure Pods Security Context
       ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
       ## @param notifications.bots.slack.podSecurityContext.enabled Enabled Argo CD Slack bot pods' Security Context
+      ## @param notifications.bots.slack.podSecurityContext.fsGroupChangePolicy Set filesystem group change policy
+      ## @param notifications.bots.slack.podSecurityContext.sysctls Set kernel settings using the sysctl interface
+      ## @param notifications.bots.slack.podSecurityContext.supplementalGroups Set filesystem extra groups
       ## @param notifications.bots.slack.podSecurityContext.fsGroup Set Argo CD Slack bot pod's Security Context fsGroup
       ##
       podSecurityContext:
         enabled: true
+        fsGroupChangePolicy: Always
+        sysctls: []
+        supplementalGroups: []
         fsGroup: 1001
       ## @param notifications.bots.slack.nodeSelector Node labels for Argo CD Slack bot pods assignment
       ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/
@@ -1711,14 +1743,21 @@ server:
   ## Configure Pods Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param server.podSecurityContext.enabled Enabled Argo CD server pods' Security Context
+  ## @param server.podSecurityContext.fsGroupChangePolicy Set filesystem group change policy
+  ## @param server.podSecurityContext.sysctls Set kernel settings using the sysctl interface
+  ## @param server.podSecurityContext.supplementalGroups Set filesystem extra groups
   ## @param server.podSecurityContext.fsGroup Set Argo CD server pod's Security Context fsGroup
   ##
   podSecurityContext:
     enabled: true
+    fsGroupChangePolicy: Always
+    sysctls: []
+    supplementalGroups: []
     fsGroup: 1001
   ## Configure Container Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param server.containerSecurityContext.enabled Enabled Argo CD server containers' Security Context
+  ## @param server.containerSecurityContext.seLinuxOptions Set SELinux options in container
   ## @param server.containerSecurityContext.runAsUser Set Argo CD server containers' Security Context runAsUser
   ## @param server.containerSecurityContext.allowPrivilegeEscalation Set Argo CD server containers' Security Context allowPrivilegeEscalation
   ## @param server.containerSecurityContext.capabilities.drop Set Argo CD containers' server Security Context capabilities to be dropped
@@ -1729,6 +1768,7 @@ server:
   ##
   containerSecurityContext:
     enabled: true
+    seLinuxOptions: {}
     runAsUser: 1001
     runAsNonRoot: true
     readOnlyRootFilesystem: false
@@ -2462,14 +2502,21 @@ repoServer:
   ## Configure Pods Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param repoServer.podSecurityContext.enabled Enabled Argo CD repo server pods' Security Context
+  ## @param repoServer.podSecurityContext.fsGroupChangePolicy Set filesystem group change policy
+  ## @param repoServer.podSecurityContext.sysctls Set kernel settings using the sysctl interface
+  ## @param repoServer.podSecurityContext.supplementalGroups Set filesystem extra groups
   ## @param repoServer.podSecurityContext.fsGroup Set Argo CD repo server pod's Security Context fsGroup
   ##
   podSecurityContext:
     enabled: true
+    fsGroupChangePolicy: Always
+    sysctls: []
+    supplementalGroups: []
     fsGroup: 1001
   ## Configure Container Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param repoServer.containerSecurityContext.enabled Enabled Argo CD repo server containers' Security Context
+  ## @param repoServer.containerSecurityContext.seLinuxOptions Set SELinux options in container
   ## @param repoServer.containerSecurityContext.runAsUser Set Argo CD repo server containers' Security Context runAsUser
   ## @param repoServer.containerSecurityContext.allowPrivilegeEscalation Set Argo CD repo server containers' Security Context allowPrivilegeEscalation
   ## @param repoServer.containerSecurityContext.capabilities.drop Set Argo CD containers' repo server Security Context capabilities to be dropped
@@ -2480,6 +2527,7 @@ repoServer:
   ##
   containerSecurityContext:
     enabled: true
+    seLinuxOptions: {}
     runAsUser: 1001
     runAsNonRoot: true
     readOnlyRootFilesystem: false
@@ -2929,14 +2977,21 @@ dex:
   ## Configure Pods Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param dex.podSecurityContext.enabled Enabled Dex pods' Security Context
+  ## @param dex.podSecurityContext.fsGroupChangePolicy Set filesystem group change policy
+  ## @param dex.podSecurityContext.sysctls Set kernel settings using the sysctl interface
+  ## @param dex.podSecurityContext.supplementalGroups Set filesystem extra groups
   ## @param dex.podSecurityContext.fsGroup Set Dex pod's Security Context fsGroup
   ##
   podSecurityContext:
     enabled: true
+    fsGroupChangePolicy: Always
+    sysctls: []
+    supplementalGroups: []
     fsGroup: 1001
   ## Configure Container Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param dex.containerSecurityContext.enabled Enabled Dex containers' Security Context
+  ## @param dex.containerSecurityContext.seLinuxOptions Set SELinux options in container
   ## @param dex.containerSecurityContext.runAsUser Set Dex containers' Security Context runAsUser
   ## @param dex.containerSecurityContext.allowPrivilegeEscalation Set Dex containers' Security Context allowPrivilegeEscalation
   ## @param dex.containerSecurityContext.readOnlyRootFilesystem Set Dex containers' server Security Context readOnlyRootFilesystem
@@ -2947,6 +3002,7 @@ dex:
   ##
   containerSecurityContext:
     enabled: true
+    seLinuxOptions: {}
     runAsUser: 1001
     runAsNonRoot: true
     readOnlyRootFilesystem: false
@@ -3491,12 +3547,14 @@ volumePermissions:
     requests: {}
   ## Init container Container Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
+  ## @param volumePermissions.containerSecurityContext.seLinuxOptions Set SELinux options in container
   ## @param volumePermissions.containerSecurityContext.runAsUser Set init container's Security Context runAsUser
   ## NOTE: when runAsUser is set to special value "auto", init container will try to chown the
   ##   data folder to auto-determined user&group, using commands: `id -u`:`id -G | cut -d" " -f2`
   ##   "auto" is especially useful for OpenShift which has scc with dynamic user ids (and 0 is not allowed)
   ##
   containerSecurityContext:
+    seLinuxOptions: {}
     runAsUser: 0
 
 ## @section Other Parameters
@@ -3608,6 +3666,7 @@ redisWait:
   ##
   extraArgs: ''
   ## @param redisWait.containerSecurityContext.enabled Enabled Argo CD repo server containers' Security Context
+  ## @param redisWait.containerSecurityContext.seLinuxOptions Set SELinux options in container
   ## @param redisWait.containerSecurityContext.runAsUser Set Argo CD repo server containers' Security Context runAsUser
   ## @param redisWait.containerSecurityContext.allowPrivilegeEscalation Set Argo CD repo server containers' Security Context allowPrivilegeEscalation
   ## @param redisWait.containerSecurityContext.capabilities.drop Set Argo CD containers' repo server Security Context capabilities to be dropped
@@ -3618,6 +3677,7 @@ redisWait:
   ##
   containerSecurityContext:
     enabled: true
+    seLinuxOptions: {}
     runAsUser: 1001
     runAsNonRoot: true
     readOnlyRootFilesystem: false


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

### Description of the change

This PR updates the podSecurityContext and containerSecurityContext fields by setting default values for essential security fields: seLinuxOptions, fsGroupChangePolicy, sysctls and supplementalGroups. These are required by security checklists. 

### Benefits

Charts become more security-compliant

### Possible drawbacks

n/a

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)

