### PR TITLE
[bitnami/cassandra] fix: :lock: Improve podSecurityContext and containerSecurityContext with essential security fields

### DIFF
--- a/bitnami/cassandra/Chart.yaml
+++ b/bitnami/cassandra/Chart.yaml
@@ -32,4 +32,4 @@ maintainers:
 name: cassandra
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/cassandra
-version: 10.6.9
+version: 10.7.0

--- a/bitnami/cassandra/README.md
+++ b/bitnami/cassandra/README.md
@@ -134,8 +134,12 @@ The command removes all the Kubernetes components associated with the chart and 
 | `tolerations`                                       | Tolerations for pod assignment                                                            | `[]`             |
 | `topologySpreadConstraints`                         | Topology Spread Constraints for pod assignment                                            | `[]`             |
 | `podSecurityContext.enabled`                        | Enabled Cassandra pods' Security Context                                                  | `true`           |
+| `podSecurityContext.fsGroupChangePolicy`            | Set filesystem group change policy                                                        | `Always`         |
+| `podSecurityContext.sysctls`                        | Set kernel settings using the sysctl interface                                            | `[]`             |
+| `podSecurityContext.supplementalGroups`             | Set filesystem extra groups                                                               | `[]`             |
 | `podSecurityContext.fsGroup`                        | Set Cassandra pod's Security Context fsGroup                                              | `1001`           |
 | `containerSecurityContext.enabled`                  | Enabled Cassandra containers' Security Context                                            | `true`           |
+| `containerSecurityContext.seLinuxOptions`           | Set SELinux options in container                                                          | `{}`             |
 | `containerSecurityContext.runAsUser`                | Set Cassandra containers' Security Context runAsUser                                      | `1001`           |
 | `containerSecurityContext.allowPrivilegeEscalation` | Set Cassandra containers' Security Context allowPrivilegeEscalation                       | `false`          |
 | `containerSecurityContext.capabilities.drop`        | Set Cassandra containers' Security Context capabilities to be dropped                     | `["ALL"]`        |
@@ -233,17 +237,18 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Volume Permissions parameters
 
-| Name                                          | Description                                                                                                           | Value                      |
-| --------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- | -------------------------- |
-| `volumePermissions.enabled`                   | Enable init container that changes the owner and group of the persistent volume                                       | `false`                    |
-| `volumePermissions.image.registry`            | Init container volume image registry                                                                                  | `REGISTRY_NAME`            |
-| `volumePermissions.image.repository`          | Init container volume image repository                                                                                | `REPOSITORY_NAME/os-shell` |
-| `volumePermissions.image.digest`              | Init container volume image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                       |
-| `volumePermissions.image.pullPolicy`          | Init container volume pull policy                                                                                     | `IfNotPresent`             |
-| `volumePermissions.image.pullSecrets`         | Specify docker-registry secret names as an array                                                                      | `[]`                       |
-| `volumePermissions.resources.limits`          | The resources limits for the container                                                                                | `{}`                       |
-| `volumePermissions.resources.requests`        | The requested resources for the container                                                                             | `{}`                       |
-| `volumePermissions.securityContext.runAsUser` | User ID for the init container                                                                                        | `0`                        |
+| Name                                               | Description                                                                                                           | Value                      |
+| -------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- | -------------------------- |
+| `volumePermissions.enabled`                        | Enable init container that changes the owner and group of the persistent volume                                       | `false`                    |
+| `volumePermissions.image.registry`                 | Init container volume image registry                                                                                  | `REGISTRY_NAME`            |
+| `volumePermissions.image.repository`               | Init container volume image repository                                                                                | `REPOSITORY_NAME/os-shell` |
+| `volumePermissions.image.digest`                   | Init container volume image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                       |
+| `volumePermissions.image.pullPolicy`               | Init container volume pull policy                                                                                     | `IfNotPresent`             |
+| `volumePermissions.image.pullSecrets`              | Specify docker-registry secret names as an array                                                                      | `[]`                       |
+| `volumePermissions.resources.limits`               | The resources limits for the container                                                                                | `{}`                       |
+| `volumePermissions.resources.requests`             | The requested resources for the container                                                                             | `{}`                       |
+| `volumePermissions.securityContext.seLinuxOptions` | Set SELinux options in container                                                                                      | `{}`                       |
+| `volumePermissions.securityContext.runAsUser`      | User ID for the init container                                                                                        | `0`                        |
 
 ### Metrics parameters
 

--- a/bitnami/cassandra/values.yaml
+++ b/bitnami/cassandra/values.yaml
@@ -279,14 +279,21 @@ topologySpreadConstraints: []
 ## Pod security context
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
 ## @param podSecurityContext.enabled Enabled Cassandra pods' Security Context
+## @param podSecurityContext.fsGroupChangePolicy Set filesystem group change policy
+## @param podSecurityContext.sysctls Set kernel settings using the sysctl interface
+## @param podSecurityContext.supplementalGroups Set filesystem extra groups
 ## @param podSecurityContext.fsGroup Set Cassandra pod's Security Context fsGroup
 ##
 podSecurityContext:
   enabled: true
+  fsGroupChangePolicy: Always
+  sysctls: []
+  supplementalGroups: []
   fsGroup: 1001
 ## Configure Container Security Context (only main container)
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
 ## @param containerSecurityContext.enabled Enabled Cassandra containers' Security Context
+## @param containerSecurityContext.seLinuxOptions Set SELinux options in container
 ## @param containerSecurityContext.runAsUser Set Cassandra containers' Security Context runAsUser
 ## @param containerSecurityContext.allowPrivilegeEscalation Set Cassandra containers' Security Context allowPrivilegeEscalation
 ## @param containerSecurityContext.capabilities.drop Set Cassandra containers' Security Context capabilities to be dropped
@@ -297,6 +304,7 @@ podSecurityContext:
 ##
 containerSecurityContext:
   enabled: true
+  seLinuxOptions: {}
   runAsUser: 1001
   runAsNonRoot: true
   privileged: false
@@ -664,6 +672,7 @@ volumePermissions:
   ## Init container Security Context
   ## Note: the chown of the data folder is done to securityContext.runAsUser
   ## and not the below volumePermissions.securityContext.runAsUser
+  ## @param volumePermissions.securityContext.seLinuxOptions Set SELinux options in container
   ## @param volumePermissions.securityContext.runAsUser User ID for the init container
   ##
   ## When runAsUser is set to special value "auto", init container will try to chwon the
@@ -673,6 +682,7 @@ volumePermissions:
   ## pod securityContext.enabled=false and shmVolume.chmod.enabled=false
   ##
   securityContext:
+    seLinuxOptions: {}
     runAsUser: 0
 
 ## @section Metrics parameters


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

### Description of the change

This PR updates the podSecurityContext and containerSecurityContext fields by setting default values for essential security fields: seLinuxOptions, fsGroupChangePolicy, sysctls and supplementalGroups. These are required by security checklists. 

### Benefits

Charts become more security-compliant

### Possible drawbacks

n/a

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)

