### PR TITLE
[bitnami/consul] fix: :lock: Improve podSecurityContext and containerSecurityContext with essential security fields

### DIFF
--- a/bitnami/consul/Chart.yaml
+++ b/bitnami/consul/Chart.yaml
@@ -32,4 +32,4 @@ maintainers:
 name: consul
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/consul
-version: 10.14.8
+version: 10.15.0

--- a/bitnami/consul/README.md
+++ b/bitnami/consul/README.md
@@ -135,8 +135,12 @@ helm delete --purge my-release
 | `nodeSelector`                                      | Node labels for pod assignment                                                            | `{}`             |
 | `tolerations`                                       | Tolerations for pod assignment                                                            | `[]`             |
 | `podSecurityContext.enabled`                        | Enable security context for HashiCorp Consul pods                                         | `true`           |
+| `podSecurityContext.fsGroupChangePolicy`            | Set filesystem group change policy                                                        | `Always`         |
+| `podSecurityContext.sysctls`                        | Set kernel settings using the sysctl interface                                            | `[]`             |
+| `podSecurityContext.supplementalGroups`             | Set filesystem extra groups                                                               | `[]`             |
 | `podSecurityContext.fsGroup`                        | Group ID for the volumes of the pod                                                       | `1001`           |
 | `containerSecurityContext.enabled`                  | Enabled Consul containers' Security Context                                               | `true`           |
+| `containerSecurityContext.seLinuxOptions`           | Set SELinux options in container                                                          | `{}`             |
 | `containerSecurityContext.runAsUser`                | Set Consul containers' Security Context runAsUser                                         | `1001`           |
 | `containerSecurityContext.allowPrivilegeEscalation` | Set Consul containers' Security Context allowPrivilegeEscalation                          | `false`          |
 | `containerSecurityContext.capabilities.drop`        | Set Argo CD containers' repo server Security Context capabilities to be dropped           | `["ALL"]`        |
@@ -233,33 +237,34 @@ helm delete --purge my-release
 
 ### Metrics parameters
 
-| Name                                            | Description                                                                                                                          | Value                             |
-| ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------- |
-| `metrics.enabled`                               | Start a side-car prometheus exporter                                                                                                 | `false`                           |
-| `metrics.image.registry`                        | HashiCorp Consul Prometheus Exporter image registry                                                                                  | `REGISTRY_NAME`                   |
-| `metrics.image.repository`                      | HashiCorp Consul Prometheus Exporter image repository                                                                                | `REPOSITORY_NAME/consul-exporter` |
-| `metrics.image.digest`                          | HashiCorp Consul Prometheus Exporter image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                              |
-| `metrics.image.pullPolicy`                      | HashiCorp Consul Prometheus Exporter image pull policy                                                                               | `IfNotPresent`                    |
-| `metrics.image.pullSecrets`                     | HashiCorp Consul Prometheus Exporter image pull secrets                                                                              | `[]`                              |
-| `metrics.containerSecurityContext.enabled`      | HashiCorp Consul Prometheus Exporter securityContext                                                                                 | `true`                            |
-| `metrics.containerSecurityContext.runAsUser`    | User ID for the HashiCorp Consul Prometheus Exporter                                                                                 | `1001`                            |
-| `metrics.containerSecurityContext.runAsNonRoot` | Force the container to be run as non root                                                                                            | `true`                            |
-| `metrics.service.type`                          | Kubernetes Service type                                                                                                              | `ClusterIP`                       |
-| `metrics.service.loadBalancerIP`                | Service Load Balancer IP                                                                                                             | `""`                              |
-| `metrics.service.annotations`                   | Provide any additional annotations which may be required.                                                                            | `{}`                              |
-| `metrics.podAnnotations`                        | Metrics exporter pod Annotation and Labels                                                                                           | `{}`                              |
-| `metrics.resources.limits`                      | The resources limits for the container                                                                                               | `{}`                              |
-| `metrics.resources.requests`                    | The requested resources for the container                                                                                            | `{}`                              |
-| `metrics.serviceMonitor.enabled`                | Create ServiceMonitor Resource for scraping metrics using PrometheusOperator, set to true to create a Service Monitor Entry          | `false`                           |
-| `metrics.serviceMonitor.namespace`              | The namespace in which the ServiceMonitor will be created                                                                            | `""`                              |
-| `metrics.serviceMonitor.interval`               | Interval at which metrics should be scraped                                                                                          | `30s`                             |
-| `metrics.serviceMonitor.scrapeTimeout`          | The timeout after which the scrape is ended                                                                                          | `""`                              |
-| `metrics.serviceMonitor.metricRelabelings`      | Metrics relabelings to add to the scrape endpoint                                                                                    | `[]`                              |
-| `metrics.serviceMonitor.relabelings`            | RelabelConfigs to apply to samples before scraping                                                                                   | `[]`                              |
-| `metrics.serviceMonitor.honorLabels`            | Specify honorLabels parameter to add the scrape endpoint                                                                             | `false`                           |
-| `metrics.serviceMonitor.jobLabel`               | The name of the label on the target service to use as the job name in prometheus.                                                    | `""`                              |
-| `metrics.serviceMonitor.selector`               | ServiceMonitor selector labels                                                                                                       | `{}`                              |
-| `metrics.serviceMonitor.labels`                 | Used to pass Labels that are used by the Prometheus installed in your cluster to select Service Monitors to work with                | `{}`                              |
+| Name                                              | Description                                                                                                                          | Value                             |
+| ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------- |
+| `metrics.enabled`                                 | Start a side-car prometheus exporter                                                                                                 | `false`                           |
+| `metrics.image.registry`                          | HashiCorp Consul Prometheus Exporter image registry                                                                                  | `REGISTRY_NAME`                   |
+| `metrics.image.repository`                        | HashiCorp Consul Prometheus Exporter image repository                                                                                | `REPOSITORY_NAME/consul-exporter` |
+| `metrics.image.digest`                            | HashiCorp Consul Prometheus Exporter image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                              |
+| `metrics.image.pullPolicy`                        | HashiCorp Consul Prometheus Exporter image pull policy                                                                               | `IfNotPresent`                    |
+| `metrics.image.pullSecrets`                       | HashiCorp Consul Prometheus Exporter image pull secrets                                                                              | `[]`                              |
+| `metrics.containerSecurityContext.enabled`        | HashiCorp Consul Prometheus Exporter securityContext                                                                                 | `true`                            |
+| `metrics.containerSecurityContext.seLinuxOptions` | Set SELinux options in container                                                                                                     | `{}`                              |
+| `metrics.containerSecurityContext.runAsUser`      | User ID for the HashiCorp Consul Prometheus Exporter                                                                                 | `1001`                            |
+| `metrics.containerSecurityContext.runAsNonRoot`   | Force the container to be run as non root                                                                                            | `true`                            |
+| `metrics.service.type`                            | Kubernetes Service type                                                                                                              | `ClusterIP`                       |
+| `metrics.service.loadBalancerIP`                  | Service Load Balancer IP                                                                                                             | `""`                              |
+| `metrics.service.annotations`                     | Provide any additional annotations which may be required.                                                                            | `{}`                              |
+| `metrics.podAnnotations`                          | Metrics exporter pod Annotation and Labels                                                                                           | `{}`                              |
+| `metrics.resources.limits`                        | The resources limits for the container                                                                                               | `{}`                              |
+| `metrics.resources.requests`                      | The requested resources for the container                                                                                            | `{}`                              |
+| `metrics.serviceMonitor.enabled`                  | Create ServiceMonitor Resource for scraping metrics using PrometheusOperator, set to true to create a Service Monitor Entry          | `false`                           |
+| `metrics.serviceMonitor.namespace`                | The namespace in which the ServiceMonitor will be created                                                                            | `""`                              |
+| `metrics.serviceMonitor.interval`                 | Interval at which metrics should be scraped                                                                                          | `30s`                             |
+| `metrics.serviceMonitor.scrapeTimeout`            | The timeout after which the scrape is ended                                                                                          | `""`                              |
+| `metrics.serviceMonitor.metricRelabelings`        | Metrics relabelings to add to the scrape endpoint                                                                                    | `[]`                              |
+| `metrics.serviceMonitor.relabelings`              | RelabelConfigs to apply to samples before scraping                                                                                   | `[]`                              |
+| `metrics.serviceMonitor.honorLabels`              | Specify honorLabels parameter to add the scrape endpoint                                                                             | `false`                           |
+| `metrics.serviceMonitor.jobLabel`                 | The name of the label on the target service to use as the job name in prometheus.                                                    | `""`                              |
+| `metrics.serviceMonitor.selector`                 | ServiceMonitor selector labels                                                                                                       | `{}`                              |
+| `metrics.serviceMonitor.labels`                   | Used to pass Labels that are used by the Prometheus installed in your cluster to select Service Monitors to work with                | `{}`                              |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/bitnami/consul/values.yaml
+++ b/bitnami/consul/values.yaml
@@ -275,14 +275,21 @@ tolerations: []
 ## Pod security context
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
 ## @param podSecurityContext.enabled Enable security context for HashiCorp Consul pods
+## @param podSecurityContext.fsGroupChangePolicy Set filesystem group change policy
+## @param podSecurityContext.sysctls Set kernel settings using the sysctl interface
+## @param podSecurityContext.supplementalGroups Set filesystem extra groups
 ## @param podSecurityContext.fsGroup Group ID for the volumes of the pod
 ##
 podSecurityContext:
   enabled: true
+  fsGroupChangePolicy: Always
+  sysctls: []
+  supplementalGroups: []
   fsGroup: 1001
 ## Container security context
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
 ## @param containerSecurityContext.enabled Enabled Consul containers' Security Context
+## @param containerSecurityContext.seLinuxOptions Set SELinux options in container
 ## @param containerSecurityContext.runAsUser Set Consul containers' Security Context runAsUser
 ## @param containerSecurityContext.allowPrivilegeEscalation Set Consul containers' Security Context allowPrivilegeEscalation
 ## @param containerSecurityContext.capabilities.drop Set Argo CD containers' repo server Security Context capabilities to be dropped
@@ -293,6 +300,7 @@ podSecurityContext:
 ##
 containerSecurityContext:
   enabled: true
+  seLinuxOptions: {}
   runAsUser: 1001
   runAsNonRoot: true
   privileged: false
@@ -697,11 +705,13 @@ metrics:
   ## Container security context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
   ## @param metrics.containerSecurityContext.enabled HashiCorp Consul Prometheus Exporter securityContext
+  ## @param metrics.containerSecurityContext.seLinuxOptions Set SELinux options in container
   ## @param metrics.containerSecurityContext.runAsUser User ID for the HashiCorp Consul Prometheus Exporter
   ## @param metrics.containerSecurityContext.runAsNonRoot Force the container to be run as non root
   ##
   containerSecurityContext:
     enabled: true
+    seLinuxOptions: {}
     runAsUser: 1001
     runAsNonRoot: true
   ## Consul Prometheus exporter service type


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

### Description of the change

This PR updates the podSecurityContext and containerSecurityContext fields by setting default values for essential security fields: seLinuxOptions, fsGroupChangePolicy, sysctls and supplementalGroups. These are required by security checklists. 

### Benefits

Charts become more security-compliant

### Possible drawbacks

n/a

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)

