### PR TITLE
[bitnami/discourse] fix: :lock: Improve podSecurityContext and containerSecurityContext with essential security fields

### DIFF
--- a/bitnami/discourse/Chart.yaml
+++ b/bitnami/discourse/Chart.yaml
@@ -41,4 +41,4 @@ maintainers:
 name: discourse
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/discourse
-version: 12.2.1
+version: 12.3.0

--- a/bitnami/discourse/README.md
+++ b/bitnami/discourse/README.md
@@ -82,52 +82,55 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Discourse Common parameters
 
-| Name                            | Description                                                                                                              | Value                       |
-| ------------------------------- | ------------------------------------------------------------------------------------------------------------------------ | --------------------------- |
-| `image.registry`                | Discourse image registry                                                                                                 | `REGISTRY_NAME`             |
-| `image.repository`              | Discourse image repository                                                                                               | `REPOSITORY_NAME/discourse` |
-| `image.digest`                  | Discourse image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag                | `""`                        |
-| `image.pullPolicy`              | Discourse image pull policy                                                                                              | `IfNotPresent`              |
-| `image.pullSecrets`             | Discourse image pull secrets                                                                                             | `[]`                        |
-| `image.debug`                   | Enable image debug mode                                                                                                  | `false`                     |
-| `auth.email`                    | Discourse admin user email                                                                                               | `user@example.com`          |
-| `auth.username`                 | Discourse admin user                                                                                                     | `user`                      |
-| `auth.password`                 | Discourse admin password. WARNING: Minimum length of 10 characters                                                       | `""`                        |
-| `auth.existingSecret`           | Name of an existing secret to use for Discourse credentials                                                              | `""`                        |
-| `host`                          | Hostname to create application URLs (include the port if =/= 80)                                                         | `""`                        |
-| `siteName`                      | Discourse site name                                                                                                      | `My Site!`                  |
-| `smtp.enabled`                  | Enable/disable SMTP                                                                                                      | `false`                     |
-| `smtp.host`                     | SMTP host name                                                                                                           | `""`                        |
-| `smtp.port`                     | SMTP port number                                                                                                         | `""`                        |
-| `smtp.user`                     | SMTP account user name                                                                                                   | `""`                        |
-| `smtp.password`                 | SMTP account password                                                                                                    | `""`                        |
-| `smtp.protocol`                 | SMTP protocol (Allowed values: tls, ssl)                                                                                 | `""`                        |
-| `smtp.auth`                     | SMTP authentication method                                                                                               | `""`                        |
-| `smtp.existingSecret`           | Name of an existing Kubernetes secret. The secret must have the following key configured: `smtp-password`                | `""`                        |
-| `replicaCount`                  | Number of Discourse & Sidekiq replicas                                                                                   | `1`                         |
-| `podSecurityContext.enabled`    | Enabled Discourse pods' Security Context                                                                                 | `true`                      |
-| `podSecurityContext.fsGroup`    | Set Discourse pod's Security Context fsGroup                                                                             | `0`                         |
-| `hostAliases`                   | Add deployment host aliases                                                                                              | `[]`                        |
-| `podAnnotations`                | Additional pod annotations                                                                                               | `{}`                        |
-| `podLabels`                     | Additional pod labels                                                                                                    | `{}`                        |
-| `podAffinityPreset`             | Pod affinity preset. Allowed values: soft, hard                                                                          | `""`                        |
-| `podAntiAffinityPreset`         | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                 | `soft`                      |
-| `nodeAffinityPreset.type`       | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                | `""`                        |
-| `nodeAffinityPreset.key`        | Node label key to match Ignored if `affinity` is set.                                                                    | `""`                        |
-| `nodeAffinityPreset.values`     | Node label values to match. Ignored if `affinity` is set.                                                                | `[]`                        |
-| `affinity`                      | Affinity for pod assignment                                                                                              | `{}`                        |
-| `nodeSelector`                  | Node labels for pod assignment.                                                                                          | `{}`                        |
-| `tolerations`                   | Tolerations for pod assignment.                                                                                          | `[]`                        |
-| `topologySpreadConstraints`     | Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template | `[]`                        |
-| `priorityClassName`             | Priority Class Name                                                                                                      | `""`                        |
-| `schedulerName`                 | Use an alternate scheduler, e.g. "stork".                                                                                | `""`                        |
-| `terminationGracePeriodSeconds` | Seconds Discourse pod needs to terminate gracefully                                                                      | `""`                        |
-| `updateStrategy.type`           | Discourse deployment strategy type                                                                                       | `RollingUpdate`             |
-| `updateStrategy.rollingUpdate`  | Discourse deployment rolling update configuration parameters                                                             | `{}`                        |
-| `sidecars`                      | Add additional sidecar containers to the Discourse pods                                                                  | `[]`                        |
-| `initContainers`                | Add additional init containers to the Discourse pods                                                                     | `[]`                        |
-| `extraVolumeMounts`             | Optionally specify extra list of additional volumeMounts for the Discourse pods                                          | `[]`                        |
-| `extraVolumes`                  | Optionally specify extra list of additional volumes for the Discourse pods                                               | `[]`                        |
+| Name                                     | Description                                                                                                              | Value                       |
+| ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ | --------------------------- |
+| `image.registry`                         | Discourse image registry                                                                                                 | `REGISTRY_NAME`             |
+| `image.repository`                       | Discourse image repository                                                                                               | `REPOSITORY_NAME/discourse` |
+| `image.digest`                           | Discourse image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag                | `""`                        |
+| `image.pullPolicy`                       | Discourse image pull policy                                                                                              | `IfNotPresent`              |
+| `image.pullSecrets`                      | Discourse image pull secrets                                                                                             | `[]`                        |
+| `image.debug`                            | Enable image debug mode                                                                                                  | `false`                     |
+| `auth.email`                             | Discourse admin user email                                                                                               | `user@example.com`          |
+| `auth.username`                          | Discourse admin user                                                                                                     | `user`                      |
+| `auth.password`                          | Discourse admin password. WARNING: Minimum length of 10 characters                                                       | `""`                        |
+| `auth.existingSecret`                    | Name of an existing secret to use for Discourse credentials                                                              | `""`                        |
+| `host`                                   | Hostname to create application URLs (include the port if =/= 80)                                                         | `""`                        |
+| `siteName`                               | Discourse site name                                                                                                      | `My Site!`                  |
+| `smtp.enabled`                           | Enable/disable SMTP                                                                                                      | `false`                     |
+| `smtp.host`                              | SMTP host name                                                                                                           | `""`                        |
+| `smtp.port`                              | SMTP port number                                                                                                         | `""`                        |
+| `smtp.user`                              | SMTP account user name                                                                                                   | `""`                        |
+| `smtp.password`                          | SMTP account password                                                                                                    | `""`                        |
+| `smtp.protocol`                          | SMTP protocol (Allowed values: tls, ssl)                                                                                 | `""`                        |
+| `smtp.auth`                              | SMTP authentication method                                                                                               | `""`                        |
+| `smtp.existingSecret`                    | Name of an existing Kubernetes secret. The secret must have the following key configured: `smtp-password`                | `""`                        |
+| `replicaCount`                           | Number of Discourse & Sidekiq replicas                                                                                   | `1`                         |
+| `podSecurityContext.enabled`             | Enabled Discourse pods' Security Context                                                                                 | `true`                      |
+| `podSecurityContext.fsGroupChangePolicy` | Set filesystem group change policy                                                                                       | `Always`                    |
+| `podSecurityContext.sysctls`             | Set kernel settings using the sysctl interface                                                                           | `[]`                        |
+| `podSecurityContext.supplementalGroups`  | Set filesystem extra groups                                                                                              | `[]`                        |
+| `podSecurityContext.fsGroup`             | Set Discourse pod's Security Context fsGroup                                                                             | `0`                         |
+| `hostAliases`                            | Add deployment host aliases                                                                                              | `[]`                        |
+| `podAnnotations`                         | Additional pod annotations                                                                                               | `{}`                        |
+| `podLabels`                              | Additional pod labels                                                                                                    | `{}`                        |
+| `podAffinityPreset`                      | Pod affinity preset. Allowed values: soft, hard                                                                          | `""`                        |
+| `podAntiAffinityPreset`                  | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                 | `soft`                      |
+| `nodeAffinityPreset.type`                | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                | `""`                        |
+| `nodeAffinityPreset.key`                 | Node label key to match Ignored if `affinity` is set.                                                                    | `""`                        |
+| `nodeAffinityPreset.values`              | Node label values to match. Ignored if `affinity` is set.                                                                | `[]`                        |
+| `affinity`                               | Affinity for pod assignment                                                                                              | `{}`                        |
+| `nodeSelector`                           | Node labels for pod assignment.                                                                                          | `{}`                        |
+| `tolerations`                            | Tolerations for pod assignment.                                                                                          | `[]`                        |
+| `topologySpreadConstraints`              | Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template | `[]`                        |
+| `priorityClassName`                      | Priority Class Name                                                                                                      | `""`                        |
+| `schedulerName`                          | Use an alternate scheduler, e.g. "stork".                                                                                | `""`                        |
+| `terminationGracePeriodSeconds`          | Seconds Discourse pod needs to terminate gracefully                                                                      | `""`                        |
+| `updateStrategy.type`                    | Discourse deployment strategy type                                                                                       | `RollingUpdate`             |
+| `updateStrategy.rollingUpdate`           | Discourse deployment rolling update configuration parameters                                                             | `{}`                        |
+| `sidecars`                               | Add additional sidecar containers to the Discourse pods                                                                  | `[]`                        |
+| `initContainers`                         | Add additional init containers to the Discourse pods                                                                     | `[]`                        |
+| `extraVolumeMounts`                      | Optionally specify extra list of additional volumeMounts for the Discourse pods                                          | `[]`                        |
+| `extraVolumes`                           | Optionally specify extra list of additional volumes for the Discourse pods                                               | `[]`                        |
 
 ### Discourse container parameters
 
@@ -166,6 +169,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `discourse.resources.limits`                             | The resources limits for the Discourse containers                                            | `{}`             |
 | `discourse.resources.requests`                           | The requested resources for the Discourse containers                                         | `{}`             |
 | `discourse.containerSecurityContext.enabled`             | Enabled Discourse containers' Security Context                                               | `true`           |
+| `discourse.containerSecurityContext.seLinuxOptions`      | Set SELinux options in container                                                             | `{}`             |
 | `discourse.containerSecurityContext.runAsUser`           | Set Discourse containers' Security Context runAsUser                                         | `0`              |
 | `discourse.containerSecurityContext.runAsNonRoot`        | Set Discourse containers' Security Context runAsNonRoot                                      | `false`          |
 | `discourse.containerSecurityContext.seccompProfile.type` | Set container's Security Context seccomp profile                                             | `RuntimeDefault` |
@@ -213,6 +217,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `sidekiq.resources.limits`                             | The resources limits for the Sidekiq containers                                            | `{}`                                                |
 | `sidekiq.resources.requests`                           | The requested resources for the Sidekiq containers                                         | `{}`                                                |
 | `sidekiq.containerSecurityContext.enabled`             | Enabled Sidekiq containers' Security Context                                               | `true`                                              |
+| `sidekiq.containerSecurityContext.seLinuxOptions`      | Set SELinux options in container                                                           | `{}`                                                |
 | `sidekiq.containerSecurityContext.runAsUser`           | Set Sidekiq containers' Security Context runAsUser                                         | `0`                                                 |
 | `sidekiq.containerSecurityContext.runAsNonRoot`        | Set Sidekiq containers' Security Context runAsNonRoot                                      | `false`                                             |
 | `sidekiq.containerSecurityContext.seccompProfile.type` | Set container's Security Context seccomp profile                                           | `RuntimeDefault`                                    |
@@ -261,6 +266,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `volumePermissions.image.pullSecrets`                            | Init container volume-permissions image pull secrets                                                                              | `[]`                       |
 | `volumePermissions.resources.limits`                             | Init container volume-permissions resource limits                                                                                 | `{}`                       |
 | `volumePermissions.resources.requests`                           | Init container volume-permissions resource requests                                                                               | `{}`                       |
+| `volumePermissions.containerSecurityContext.seLinuxOptions`      | Set SELinux options in container                                                                                                  | `{}`                       |
 | `volumePermissions.containerSecurityContext.runAsUser`           | User ID for the init container                                                                                                    | `0`                        |
 | `volumePermissions.containerSecurityContext.seccompProfile.type` | Set container's Security Context seccomp profile                                                                                  | `RuntimeDefault`           |
 

--- a/bitnami/discourse/values.yaml
+++ b/bitnami/discourse/values.yaml
@@ -142,10 +142,16 @@ replicaCount: 1
 ## Configure Discourse pods Security Context
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
 ## @param podSecurityContext.enabled Enabled Discourse pods' Security Context
+## @param podSecurityContext.fsGroupChangePolicy Set filesystem group change policy
+## @param podSecurityContext.sysctls Set kernel settings using the sysctl interface
+## @param podSecurityContext.supplementalGroups Set filesystem extra groups
 ## @param podSecurityContext.fsGroup Set Discourse pod's Security Context fsGroup
 ##
 podSecurityContext:
   enabled: true
+  fsGroupChangePolicy: Always
+  sysctls: []
+  supplementalGroups: []
   fsGroup: 0
 ## @param hostAliases Add deployment host aliases
 ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
@@ -351,12 +357,14 @@ discourse:
   ## Configure Discourse containers (only main one) Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
   ## @param discourse.containerSecurityContext.enabled Enabled Discourse containers' Security Context
+  ## @param discourse.containerSecurityContext.seLinuxOptions Set SELinux options in container
   ## @param discourse.containerSecurityContext.runAsUser Set Discourse containers' Security Context runAsUser
   ## @param discourse.containerSecurityContext.runAsNonRoot Set Discourse containers' Security Context runAsNonRoot
   ## @param discourse.containerSecurityContext.seccompProfile.type Set container's Security Context seccomp profile
   ##
   containerSecurityContext:
     enabled: true
+    seLinuxOptions: {}
     runAsUser: 0
     runAsNonRoot: false
     seccompProfile:
@@ -489,12 +497,14 @@ sidekiq:
   ## Configure Sidekiq containers (only main one) Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
   ## @param sidekiq.containerSecurityContext.enabled Enabled Sidekiq containers' Security Context
+  ## @param sidekiq.containerSecurityContext.seLinuxOptions Set SELinux options in container
   ## @param sidekiq.containerSecurityContext.runAsUser Set Sidekiq containers' Security Context runAsUser
   ## @param sidekiq.containerSecurityContext.runAsNonRoot Set Sidekiq containers' Security Context runAsNonRoot
   ## @param sidekiq.containerSecurityContext.seccompProfile.type Set container's Security Context seccomp profile
   ##
   containerSecurityContext:
     enabled: true
+    seLinuxOptions: {}
     runAsUser: 0
     runAsNonRoot: false
     seccompProfile:
@@ -708,10 +718,12 @@ volumePermissions:
   ## Init container' Security Context
   ## Note: the chown of the data folder is done to containerSecurityContext.runAsUser
   ## and not the below volumePermissions.containerSecurityContext.runAsUser
+  ## @param volumePermissions.containerSecurityContext.seLinuxOptions Set SELinux options in container
   ## @param volumePermissions.containerSecurityContext.runAsUser User ID for the init container
   ## @param volumePermissions.containerSecurityContext.seccompProfile.type Set container's Security Context seccomp profile
   ##
   containerSecurityContext:
+    seLinuxOptions: {}
     runAsUser: 0
     seccompProfile:
       type: "RuntimeDefault"


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

### Description of the change

This PR updates the podSecurityContext and containerSecurityContext fields by setting default values for essential security fields: seLinuxOptions, fsGroupChangePolicy, sysctls and supplementalGroups. These are required by security checklists. 

### Benefits

Charts become more security-compliant

### Possible drawbacks

n/a

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)

