### PR TITLE
[bitnami/dokuwiki] fix: :lock: Improve podSecurityContext and containerSecurityContext with essential security fields

### DIFF
--- a/bitnami/dokuwiki/Chart.yaml
+++ b/bitnami/dokuwiki/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: dokuwiki
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/dokuwiki
-version: 14.3.3
+version: 14.4.0

--- a/bitnami/dokuwiki/README.md
+++ b/bitnami/dokuwiki/README.md
@@ -102,8 +102,12 @@ The command removes all the Kubernetes components associated with the chart and 
 | `persistence.existingClaim`                         | Name of an existing PVC to be used                                                                                    | `""`                       |
 | `persistence.annotations`                           | Annotations to add to the PVC                                                                                         | `{}`                       |
 | `podSecurityContext.enabled`                        | Enable securityContext on for DokuWiki deployment                                                                     | `true`                     |
+| `podSecurityContext.fsGroupChangePolicy`            | Set filesystem group change policy                                                                                    | `Always`                   |
+| `podSecurityContext.sysctls`                        | Set kernel settings using the sysctl interface                                                                        | `[]`                       |
+| `podSecurityContext.supplementalGroups`             | Set filesystem extra groups                                                                                           | `[]`                       |
 | `podSecurityContext.fsGroup`                        | Group to configure permissions for volumes                                                                            | `1001`                     |
 | `containerSecurityContext.enabled`                  | Enabled Dokuwiki containers' Security Context                                                                         | `true`                     |
+| `containerSecurityContext.seLinuxOptions`           | Set SELinux options in container                                                                                      | `{}`                       |
 | `containerSecurityContext.runAsUser`                | Set Dokuwiki containers' Security Context runAsUser                                                                   | `1001`                     |
 | `containerSecurityContext.runAsNonRoot`             | Set Controller container's Security Context runAsNonRoot                                                              | `true`                     |
 | `containerSecurityContext.privileged`               | Set primary container's Security Context privileged                                                                   | `false`                    |

--- a/bitnami/dokuwiki/values.yaml
+++ b/bitnami/dokuwiki/values.yaml
@@ -165,13 +165,20 @@ persistence:
   existingClaim: ""
   annotations: {}
 ## @param podSecurityContext.enabled Enable securityContext on for DokuWiki deployment
+## @param podSecurityContext.fsGroupChangePolicy Set filesystem group change policy
+## @param podSecurityContext.sysctls Set kernel settings using the sysctl interface
+## @param podSecurityContext.supplementalGroups Set filesystem extra groups
 ## @param podSecurityContext.fsGroup Group to configure permissions for volumes
 ##
 podSecurityContext:
   enabled: true
+  fsGroupChangePolicy: Always
+  sysctls: []
+  supplementalGroups: []
   fsGroup: 1001
 ## SecurityContext configuration for the container
 ## @param containerSecurityContext.enabled Enabled Dokuwiki containers' Security Context
+## @param containerSecurityContext.seLinuxOptions Set SELinux options in container
 ## @param containerSecurityContext.runAsUser Set Dokuwiki containers' Security Context runAsUser
 ## @param containerSecurityContext.runAsNonRoot Set Controller container's Security Context runAsNonRoot
 ## @param containerSecurityContext.privileged Set primary container's Security Context privileged
@@ -182,6 +189,7 @@ podSecurityContext:
 ##
 containerSecurityContext:
   enabled: true
+  seLinuxOptions: {}
   runAsUser: 1001
   runAsNonRoot: true
   privileged: false


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

### Description of the change

This PR updates the podSecurityContext and containerSecurityContext fields by setting default values for essential security fields: seLinuxOptions, fsGroupChangePolicy, sysctls and supplementalGroups. These are required by security checklists. 

### Benefits

Charts become more security-compliant

### Possible drawbacks

n/a

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)

