### PR TITLE
[bitnami/flink] fix: :lock: Improve podSecurityContext and containerSecurityContext with essential security fields

### DIFF
--- a/bitnami/flink/Chart.yaml
+++ b/bitnami/flink/Chart.yaml
@@ -28,4 +28,4 @@ maintainers:
 name: flink
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/flink
-version: 0.5.4
+version: 0.6.0

--- a/bitnami/flink/README.md
+++ b/bitnami/flink/README.md
@@ -146,8 +146,12 @@ The command removes all the Kubernetes components associated with the chart and 
 | `jobmanager.serviceAccount.annotations`                        | Annotations to add to all deployed objects                                                | `{}`             |
 | `jobmanager.serviceAccount.automountServiceAccountToken`       | Automount API credentials for a service account.                                          | `false`          |
 | `jobmanager.podSecurityContext.enabled`                        | Enabled Apache Flink pods' Security Context                                               | `true`           |
+| `jobmanager.podSecurityContext.fsGroupChangePolicy`            | Set filesystem group change policy                                                        | `Always`         |
+| `jobmanager.podSecurityContext.sysctls`                        | Set kernel settings using the sysctl interface                                            | `[]`             |
+| `jobmanager.podSecurityContext.supplementalGroups`             | Set filesystem extra groups                                                               | `[]`             |
 | `jobmanager.podSecurityContext.fsGroup`                        | Set Apache Flink pod's Security Context fsGroup                                           | `1001`           |
 | `jobmanager.containerSecurityContext.enabled`                  | Enabled Apache Flink containers' Security Context                                         | `true`           |
+| `jobmanager.containerSecurityContext.seLinuxOptions`           | Set SELinux options in container                                                          | `{}`             |
 | `jobmanager.containerSecurityContext.runAsUser`                | Set Apache Flink container's Security Context runAsUser                                   | `1001`           |
 | `jobmanager.containerSecurityContext.runAsNonRoot`             | Force the container to be run as non root                                                 | `true`           |
 | `jobmanager.containerSecurityContext.allowPrivilegeEscalation` | Allows privilege escalation                                                               | `false`          |
@@ -228,8 +232,12 @@ The command removes all the Kubernetes components associated with the chart and 
 | `taskmanager.serviceAccount.annotations`                        | Annotations to add to all deployed objects                                                | `{}`             |
 | `taskmanager.serviceAccount.automountServiceAccountToken`       | Automount API credentials for a service account.                                          | `false`          |
 | `taskmanager.podSecurityContext.enabled`                        | Enabled Apache Flink pods' Security Context                                               | `true`           |
+| `taskmanager.podSecurityContext.fsGroupChangePolicy`            | Set filesystem group change policy                                                        | `Always`         |
+| `taskmanager.podSecurityContext.sysctls`                        | Set kernel settings using the sysctl interface                                            | `[]`             |
+| `taskmanager.podSecurityContext.supplementalGroups`             | Set filesystem extra groups                                                               | `[]`             |
 | `taskmanager.podSecurityContext.fsGroup`                        | Set Apache Flink pod's Security Context fsGroup                                           | `1001`           |
 | `taskmanager.containerSecurityContext.enabled`                  | Enabled Apache Flink containers' Security Context                                         | `true`           |
+| `taskmanager.containerSecurityContext.seLinuxOptions`           | Set SELinux options in container                                                          | `{}`             |
 | `taskmanager.containerSecurityContext.runAsUser`                | Set Apache Flink container's Security Context runAsUser                                   | `1001`           |
 | `taskmanager.containerSecurityContext.runAsNonRoot`             | Force the container to be run as non root                                                 | `true`           |
 | `taskmanager.containerSecurityContext.privileged`               | Set primary container's Security Context privileged                                       | `false`          |

--- a/bitnami/flink/values.yaml
+++ b/bitnami/flink/values.yaml
@@ -301,14 +301,21 @@ jobmanager:
   ## Pod security context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param jobmanager.podSecurityContext.enabled Enabled Apache Flink pods' Security Context
+  ## @param jobmanager.podSecurityContext.fsGroupChangePolicy Set filesystem group change policy
+  ## @param jobmanager.podSecurityContext.sysctls Set kernel settings using the sysctl interface
+  ## @param jobmanager.podSecurityContext.supplementalGroups Set filesystem extra groups
   ## @param jobmanager.podSecurityContext.fsGroup Set Apache Flink pod's Security Context fsGroup
   ##
   podSecurityContext:
     enabled: true
+    fsGroupChangePolicy: Always
+    sysctls: []
+    supplementalGroups: []
     fsGroup: 1001
   ## Configure Container Security Context (only main container)
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
   ## @param jobmanager.containerSecurityContext.enabled Enabled Apache Flink containers' Security Context
+  ## @param jobmanager.containerSecurityContext.seLinuxOptions Set SELinux options in container
   ## @param jobmanager.containerSecurityContext.runAsUser Set Apache Flink container's Security Context runAsUser
   ## @param jobmanager.containerSecurityContext.runAsNonRoot Force the container to be run as non root
   ## @param jobmanager.containerSecurityContext.allowPrivilegeEscalation Allows privilege escalation
@@ -318,6 +325,7 @@ jobmanager:
   ##
   containerSecurityContext:
     enabled: true
+    seLinuxOptions: {}
     runAsUser: 1001
     runAsNonRoot: true
     allowPrivilegeEscalation: false
@@ -602,14 +610,21 @@ taskmanager:
   ## Pod security context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param taskmanager.podSecurityContext.enabled Enabled Apache Flink pods' Security Context
+  ## @param taskmanager.podSecurityContext.fsGroupChangePolicy Set filesystem group change policy
+  ## @param taskmanager.podSecurityContext.sysctls Set kernel settings using the sysctl interface
+  ## @param taskmanager.podSecurityContext.supplementalGroups Set filesystem extra groups
   ## @param taskmanager.podSecurityContext.fsGroup Set Apache Flink pod's Security Context fsGroup
   ##
   podSecurityContext:
     enabled: true
+    fsGroupChangePolicy: Always
+    sysctls: []
+    supplementalGroups: []
     fsGroup: 1001
   ## Configure Container Security Context (only main container)
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
   ## @param taskmanager.containerSecurityContext.enabled Enabled Apache Flink containers' Security Context
+  ## @param taskmanager.containerSecurityContext.seLinuxOptions Set SELinux options in container
   ## @param taskmanager.containerSecurityContext.runAsUser Set Apache Flink container's Security Context runAsUser
   ## @param taskmanager.containerSecurityContext.runAsNonRoot Force the container to be run as non root
   ## @param taskmanager.containerSecurityContext.privileged Set primary container's Security Context privileged
@@ -619,6 +634,7 @@ taskmanager:
   ##
   containerSecurityContext:
     enabled: true
+    seLinuxOptions: {}
     runAsUser: 1001
     runAsNonRoot: true
     privileged: false


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

### Description of the change

This PR updates the podSecurityContext and containerSecurityContext fields by setting default values for essential security fields: seLinuxOptions, fsGroupChangePolicy, sysctls and supplementalGroups. These are required by security checklists. 

### Benefits

Charts become more security-compliant

### Possible drawbacks

n/a

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)

