### PR TITLE
[bitnami/fluent-bit] fix: :lock: Improve podSecurityContext and containerSecurityContext with essential security fields

### DIFF
--- a/bitnami/fluent-bit/Chart.yaml
+++ b/bitnami/fluent-bit/Chart.yaml
@@ -28,4 +28,4 @@ maintainers:
 name: fluent-bit
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/fluent-bit
-version: 0.6.6
+version: 0.7.0

--- a/bitnami/fluent-bit/README.md
+++ b/bitnami/fluent-bit/README.md
@@ -93,8 +93,12 @@ The command removes all the Kubernetes components associated with the chart and 
 | --------------------------------------------------- | ----------------------------------------------------------------------------------------- | ---------------------------- |
 | `daemonset.enabled`                                 | Use a daemonset instead of a deployment. `replicaCount` will not take effect.             | `false`                      |
 | `daemonset.podSecurityContext.enabled`              | Enable security context for daemonset pods                                                | `true`                       |
+| `daemonset.podSecurityContext.seLinuxOptions`       | Set SELinux options in container                                                          | `{}`                         |
 | `daemonset.podSecurityContext.runAsUser`            | User ID for daemonset containers                                                          | `0`                          |
 | `daemonset.podSecurityContext.runAsGroup`           | Group ID for daemonset containers                                                         | `0`                          |
+| `daemonset.podSecurityContext.fsGroupChangePolicy`  | Set filesystem group change policy                                                        | `Always`                     |
+| `daemonset.podSecurityContext.sysctls`              | Set kernel settings using the sysctl interface                                            | `[]`                         |
+| `daemonset.podSecurityContext.supplementalGroups`   | Set filesystem extra groups                                                               | `[]`                         |
 | `daemonset.podSecurityContext.fsGroup`              | Group ID for daemonset containers filesystem                                              | `0`                          |
 | `daemonset.hostPaths.logs`                          | Path to the node logs dir                                                                 | `/var/log`                   |
 | `daemonset.hostPaths.containerLogs`                 | Path to the container logs dir                                                            | `/var/lib/docker/containers` |
@@ -150,8 +154,12 @@ The command removes all the Kubernetes components associated with the chart and 
 | `serviceAccount.annotations`                        | Annotations to add to all deployed objects                                                | `{}`                         |
 | `serviceAccount.automountServiceAccountToken`       | Automount API credentials for a service account.                                          | `true`                       |
 | `podSecurityContext.enabled`                        | Enabled Fluent Bit pods' Security Context                                                 | `true`                       |
+| `podSecurityContext.fsGroupChangePolicy`            | Set filesystem group change policy                                                        | `Always`                     |
+| `podSecurityContext.sysctls`                        | Set kernel settings using the sysctl interface                                            | `[]`                         |
+| `podSecurityContext.supplementalGroups`             | Set filesystem extra groups                                                               | `[]`                         |
 | `podSecurityContext.fsGroup`                        | Set Fluent Bit pod's Security Context fsGroup                                             | `1001`                       |
 | `containerSecurityContext.enabled`                  | Enabled Fluent Bit containers' Security Context                                           | `true`                       |
+| `containerSecurityContext.seLinuxOptions`           | Set SELinux options in container                                                          | `{}`                         |
 | `containerSecurityContext.runAsUser`                | Set Fluent Bit containers' Security Context runAsUser                                     | `1001`                       |
 | `containerSecurityContext.runAsNonRoot`             | Set Fluent Bit container's Security Context runAsNonRoot                                  | `true`                       |
 | `containerSecurityContext.readOnlyRootFilesystem`   | Set Fluent Bit container's Security Context runAsNonRoot                                  | `false`                      |

--- a/bitnami/fluent-bit/values.yaml
+++ b/bitnami/fluent-bit/values.yaml
@@ -99,14 +99,22 @@ daemonset:
   ## Pod security context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param daemonset.podSecurityContext.enabled Enable security context for daemonset pods
+  ## @param daemonset.podSecurityContext.seLinuxOptions Set SELinux options in container
   ## @param daemonset.podSecurityContext.runAsUser User ID for daemonset containers
   ## @param daemonset.podSecurityContext.runAsGroup Group ID for daemonset containers
+  ## @param daemonset.podSecurityContext.fsGroupChangePolicy Set filesystem group change policy
+  ## @param daemonset.podSecurityContext.sysctls Set kernel settings using the sysctl interface
+  ## @param daemonset.podSecurityContext.supplementalGroups Set filesystem extra groups
   ## @param daemonset.podSecurityContext.fsGroup Group ID for daemonset containers filesystem
   ##
   podSecurityContext:
     enabled: true
+    seLinuxOptions: {}
     runAsUser: 0
     runAsGroup: 0
+    fsGroupChangePolicy: Always
+    sysctls: []
+    supplementalGroups: []
     fsGroup: 0
   ## Pod host paths
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
@@ -316,14 +324,21 @@ serviceAccount:
 ## Pod security context
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
 ## @param podSecurityContext.enabled Enabled Fluent Bit pods' Security Context
+## @param podSecurityContext.fsGroupChangePolicy Set filesystem group change policy
+## @param podSecurityContext.sysctls Set kernel settings using the sysctl interface
+## @param podSecurityContext.supplementalGroups Set filesystem extra groups
 ## @param podSecurityContext.fsGroup Set Fluent Bit pod's Security Context fsGroup
 ##
 podSecurityContext:
   enabled: true
+  fsGroupChangePolicy: Always
+  sysctls: []
+  supplementalGroups: []
   fsGroup: 1001
 ## Configure Container Security Context (only main container)
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
 ## @param containerSecurityContext.enabled Enabled Fluent Bit containers' Security Context
+## @param containerSecurityContext.seLinuxOptions Set SELinux options in container
 ## @param containerSecurityContext.runAsUser Set Fluent Bit containers' Security Context runAsUser
 ## @param containerSecurityContext.runAsNonRoot Set Fluent Bit container's Security Context runAsNonRoot
 ## @param containerSecurityContext.readOnlyRootFilesystem Set Fluent Bit container's Security Context runAsNonRoot
@@ -334,6 +349,7 @@ podSecurityContext:
 ##
 containerSecurityContext:
   enabled: true
+  seLinuxOptions: {}
   runAsUser: 1001
   runAsNonRoot: true
   privileged: false


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

### Description of the change

This PR updates the podSecurityContext and containerSecurityContext fields by setting default values for essential security fields: seLinuxOptions, fsGroupChangePolicy, sysctls and supplementalGroups. These are required by security checklists. 

### Benefits

Charts become more security-compliant

### Possible drawbacks

n/a

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)

