### PR TITLE
[bitnami/grafana-loki] fix: :lock: Improve podSecurityContext and containerSecurityContext with essential security fields

### DIFF
--- a/bitnami/grafana-loki/Chart.yaml
+++ b/bitnami/grafana-loki/Chart.yaml
@@ -57,4 +57,4 @@ maintainers:
 name: grafana-loki
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/grafana-loki
-version: 2.12.1
+version: 2.13.0

--- a/bitnami/grafana-loki/README.md
+++ b/bitnami/grafana-loki/README.md
@@ -136,8 +136,12 @@ The command removes all the Kubernetes components associated with the chart and 
 | `compactor.resources.limits`                             | The resources limits for the compactor containers                                                   | `{}`                |
 | `compactor.resources.requests`                           | The requested resources for the compactor containers                                                | `{}`                |
 | `compactor.podSecurityContext.enabled`                   | Enabled Compactor pods' Security Context                                                            | `true`              |
+| `compactor.podSecurityContext.fsGroupChangePolicy`       | Set filesystem group change policy                                                                  | `Always`            |
+| `compactor.podSecurityContext.sysctls`                   | Set kernel settings using the sysctl interface                                                      | `[]`                |
+| `compactor.podSecurityContext.supplementalGroups`        | Set filesystem extra groups                                                                         | `[]`                |
 | `compactor.podSecurityContext.fsGroup`                   | Set Compactor pod's Security Context fsGroup                                                        | `1001`              |
 | `compactor.containerSecurityContext.enabled`             | Enabled Compactor containers' Security Context                                                      | `true`              |
+| `compactor.containerSecurityContext.seLinuxOptions`      | Set SELinux options in container                                                                    | `{}`                |
 | `compactor.containerSecurityContext.runAsUser`           | Set Compactor containers' Security Context runAsUser                                                | `1001`              |
 | `compactor.containerSecurityContext.runAsNonRoot`        | Set Compactor containers' Security Context runAsNonRoot                                             | `true`              |
 | `compactor.containerSecurityContext.seccompProfile.type` | Set container's Security Context seccomp profile                                                    | `RuntimeDefault`    |
@@ -235,8 +239,12 @@ The command removes all the Kubernetes components associated with the chart and 
 | `gateway.resources.limits`                             | The resources limits for the gateway containers                                                       | `{}`                    |
 | `gateway.resources.requests`                           | The requested resources for the gateway containers                                                    | `{}`                    |
 | `gateway.podSecurityContext.enabled`                   | Enabled Gateway pods' Security Context                                                                | `true`                  |
+| `gateway.podSecurityContext.fsGroupChangePolicy`       | Set filesystem group change policy                                                                    | `Always`                |
+| `gateway.podSecurityContext.sysctls`                   | Set kernel settings using the sysctl interface                                                        | `[]`                    |
+| `gateway.podSecurityContext.supplementalGroups`        | Set filesystem extra groups                                                                           | `[]`                    |
 | `gateway.podSecurityContext.fsGroup`                   | Set Gateway pod's Security Context fsGroup                                                            | `1001`                  |
 | `gateway.containerSecurityContext.enabled`             | Enabled Gateway containers' Security Context                                                          | `true`                  |
+| `gateway.containerSecurityContext.seLinuxOptions`      | Set SELinux options in container                                                                      | `{}`                    |
 | `gateway.containerSecurityContext.runAsUser`           | Set Gateway containers' Security Context runAsUser                                                    | `1001`                  |
 | `gateway.containerSecurityContext.runAsNonRoot`        | Set Gateway containers' Security Context runAsNonRoot                                                 | `true`                  |
 | `gateway.containerSecurityContext.seccompProfile.type` | Set container's Security Context seccomp profile                                                      | `RuntimeDefault`        |
@@ -328,8 +336,12 @@ The command removes all the Kubernetes components associated with the chart and 
 | `indexGateway.resources.limits`                             | The resources limits for the indexGateway containers                                                   | `{}`             |
 | `indexGateway.resources.requests`                           | The requested resources for the indexGateway containers                                                | `{}`             |
 | `indexGateway.podSecurityContext.enabled`                   | Enabled index-gateway pods' Security Context                                                           | `true`           |
+| `indexGateway.podSecurityContext.fsGroupChangePolicy`       | Set filesystem group change policy                                                                     | `Always`         |
+| `indexGateway.podSecurityContext.sysctls`                   | Set kernel settings using the sysctl interface                                                         | `[]`             |
+| `indexGateway.podSecurityContext.supplementalGroups`        | Set filesystem extra groups                                                                            | `[]`             |
 | `indexGateway.podSecurityContext.fsGroup`                   | Set index-gateway pod's Security Context fsGroup                                                       | `1001`           |
 | `indexGateway.containerSecurityContext.enabled`             | Enabled index-gateway containers' Security Context                                                     | `true`           |
+| `indexGateway.containerSecurityContext.seLinuxOptions`      | Set SELinux options in container                                                                       | `{}`             |
 | `indexGateway.containerSecurityContext.runAsUser`           | Set index-gateway containers' Security Context runAsUser                                               | `1001`           |
 | `indexGateway.containerSecurityContext.runAsNonRoot`        | Set index-gateway containers' Security Context runAsNonRoot                                            | `true`           |
 | `indexGateway.containerSecurityContext.seccompProfile.type` | Set container's Security Context seccomp profile                                                       | `RuntimeDefault` |
@@ -408,8 +420,12 @@ The command removes all the Kubernetes components associated with the chart and 
 | `distributor.resources.limits`                             | The resources limits for the distributor containers                                                   | `{}`             |
 | `distributor.resources.requests`                           | The requested resources for the distributor containers                                                | `{}`             |
 | `distributor.podSecurityContext.enabled`                   | Enabled Distributor pods' Security Context                                                            | `true`           |
+| `distributor.podSecurityContext.fsGroupChangePolicy`       | Set filesystem group change policy                                                                    | `Always`         |
+| `distributor.podSecurityContext.sysctls`                   | Set kernel settings using the sysctl interface                                                        | `[]`             |
+| `distributor.podSecurityContext.supplementalGroups`        | Set filesystem extra groups                                                                           | `[]`             |
 | `distributor.podSecurityContext.fsGroup`                   | Set Distributor pod's Security Context fsGroup                                                        | `1001`           |
 | `distributor.containerSecurityContext.enabled`             | Enabled Distributor containers' Security Context                                                      | `true`           |
+| `distributor.containerSecurityContext.seLinuxOptions`      | Set SELinux options in container                                                                      | `{}`             |
 | `distributor.containerSecurityContext.runAsUser`           | Set Distributor containers' Security Context runAsUser                                                | `1001`           |
 | `distributor.containerSecurityContext.runAsNonRoot`        | Set Distributor containers' Security Context runAsNonRoot                                             | `true`           |
 | `distributor.containerSecurityContext.seccompProfile.type` | Set container's Security Context seccomp profile                                                      | `RuntimeDefault` |
@@ -489,8 +505,12 @@ The command removes all the Kubernetes components associated with the chart and 
 | `ingester.resources.limits`                             | The resources limits for the Ingester containers                                                   | `{}`             |
 | `ingester.resources.requests`                           | The requested resources for the Ingester containers                                                | `{}`             |
 | `ingester.podSecurityContext.enabled`                   | Enabled Ingester pods' Security Context                                                            | `true`           |
+| `ingester.podSecurityContext.fsGroupChangePolicy`       | Set filesystem group change policy                                                                 | `Always`         |
+| `ingester.podSecurityContext.sysctls`                   | Set kernel settings using the sysctl interface                                                     | `[]`             |
+| `ingester.podSecurityContext.supplementalGroups`        | Set filesystem extra groups                                                                        | `[]`             |
 | `ingester.podSecurityContext.fsGroup`                   | Set Ingester pod's Security Context fsGroup                                                        | `1001`           |
 | `ingester.containerSecurityContext.enabled`             | Enabled Ingester containers' Security Context                                                      | `true`           |
+| `ingester.containerSecurityContext.seLinuxOptions`      | Set SELinux options in container                                                                   | `{}`             |
 | `ingester.containerSecurityContext.runAsUser`           | Set Ingester containers' Security Context runAsUser                                                | `1001`           |
 | `ingester.containerSecurityContext.runAsNonRoot`        | Set Ingester containers' Security Context runAsNonRoot                                             | `true`           |
 | `ingester.containerSecurityContext.seccompProfile.type` | Set container's Security Context seccomp profile                                                   | `RuntimeDefault` |
@@ -582,8 +602,12 @@ The command removes all the Kubernetes components associated with the chart and 
 | `querier.resources.limits`                             | The resources limits for the Querier containers                                                   | `{}`             |
 | `querier.resources.requests`                           | The requested resources for the Querier containers                                                | `{}`             |
 | `querier.podSecurityContext.enabled`                   | Enabled Querier pods' Security Context                                                            | `true`           |
+| `querier.podSecurityContext.fsGroupChangePolicy`       | Set filesystem group change policy                                                                | `Always`         |
+| `querier.podSecurityContext.sysctls`                   | Set kernel settings using the sysctl interface                                                    | `[]`             |
+| `querier.podSecurityContext.supplementalGroups`        | Set filesystem extra groups                                                                       | `[]`             |
 | `querier.podSecurityContext.fsGroup`                   | Set Querier pod's Security Context fsGroup                                                        | `1001`           |
 | `querier.containerSecurityContext.enabled`             | Enabled Querier containers' Security Context                                                      | `true`           |
+| `querier.containerSecurityContext.seLinuxOptions`      | Set SELinux options in container                                                                  | `{}`             |
 | `querier.containerSecurityContext.runAsUser`           | Set Querier containers' Security Context runAsUser                                                | `1001`           |
 | `querier.containerSecurityContext.runAsNonRoot`        | Set Querier containers' Security Context runAsNonRoot                                             | `true`           |
 | `querier.containerSecurityContext.seccompProfile.type` | Set container's Security Context seccomp profile                                                  | `RuntimeDefault` |
@@ -674,8 +698,12 @@ The command removes all the Kubernetes components associated with the chart and 
 | `queryFrontend.resources.limits`                             | The resources limits for the queryFrontend containers                                                   | `{}`             |
 | `queryFrontend.resources.requests`                           | The requested resources for the queryFrontend containers                                                | `{}`             |
 | `queryFrontend.podSecurityContext.enabled`                   | Enabled queryFrontend pods' Security Context                                                            | `true`           |
+| `queryFrontend.podSecurityContext.fsGroupChangePolicy`       | Set filesystem group change policy                                                                      | `Always`         |
+| `queryFrontend.podSecurityContext.sysctls`                   | Set kernel settings using the sysctl interface                                                          | `[]`             |
+| `queryFrontend.podSecurityContext.supplementalGroups`        | Set filesystem extra groups                                                                             | `[]`             |
 | `queryFrontend.podSecurityContext.fsGroup`                   | Set queryFrontend pod's Security Context fsGroup                                                        | `1001`           |
 | `queryFrontend.containerSecurityContext.enabled`             | Enabled queryFrontend containers' Security Context                                                      | `true`           |
+| `queryFrontend.containerSecurityContext.seLinuxOptions`      | Set SELinux options in container                                                                        | `{}`             |
 | `queryFrontend.containerSecurityContext.runAsUser`           | Set queryFrontend containers' Security Context runAsUser                                                | `1001`           |
 | `queryFrontend.containerSecurityContext.runAsNonRoot`        | Set queryFrontend containers' Security Context runAsNonRoot                                             | `true`           |
 | `queryFrontend.containerSecurityContext.seccompProfile.type` | Set container's Security Context seccomp profile                                                        | `RuntimeDefault` |
@@ -756,8 +784,12 @@ The command removes all the Kubernetes components associated with the chart and 
 | `queryScheduler.resources.limits`                             | The resources limits for the queryScheduler containers                                                   | `{}`             |
 | `queryScheduler.resources.requests`                           | The requested resources for the queryScheduler containers                                                | `{}`             |
 | `queryScheduler.podSecurityContext.enabled`                   | Enabled queryScheduler pods' Security Context                                                            | `true`           |
+| `queryScheduler.podSecurityContext.fsGroupChangePolicy`       | Set filesystem group change policy                                                                       | `Always`         |
+| `queryScheduler.podSecurityContext.sysctls`                   | Set kernel settings using the sysctl interface                                                           | `[]`             |
+| `queryScheduler.podSecurityContext.supplementalGroups`        | Set filesystem extra groups                                                                              | `[]`             |
 | `queryScheduler.podSecurityContext.fsGroup`                   | Set queryScheduler pod's Security Context fsGroup                                                        | `1001`           |
 | `queryScheduler.containerSecurityContext.enabled`             | Enabled queryScheduler containers' Security Context                                                      | `true`           |
+| `queryScheduler.containerSecurityContext.seLinuxOptions`      | Set SELinux options in container                                                                         | `{}`             |
 | `queryScheduler.containerSecurityContext.runAsUser`           | Set queryScheduler containers' Security Context runAsUser                                                | `1001`           |
 | `queryScheduler.containerSecurityContext.runAsNonRoot`        | Set queryScheduler containers' Security Context runAsNonRoot                                             | `true`           |
 | `queryScheduler.containerSecurityContext.seccompProfile.type` | Set container's Security Context seccomp profile                                                         | `RuntimeDefault` |
@@ -839,8 +871,12 @@ The command removes all the Kubernetes components associated with the chart and 
 | `ruler.resources.limits`                             | The resources limits for the Ruler containers                                                   | `{}`             |
 | `ruler.resources.requests`                           | The requested resources for the Ruler containers                                                | `{}`             |
 | `ruler.podSecurityContext.enabled`                   | Enabled Ruler pods' Security Context                                                            | `true`           |
+| `ruler.podSecurityContext.fsGroupChangePolicy`       | Set filesystem group change policy                                                              | `Always`         |
+| `ruler.podSecurityContext.sysctls`                   | Set kernel settings using the sysctl interface                                                  | `[]`             |
+| `ruler.podSecurityContext.supplementalGroups`        | Set filesystem extra groups                                                                     | `[]`             |
 | `ruler.podSecurityContext.fsGroup`                   | Set Ruler pod's Security Context fsGroup                                                        | `1001`           |
 | `ruler.containerSecurityContext.enabled`             | Enabled Ruler containers' Security Context                                                      | `true`           |
+| `ruler.containerSecurityContext.seLinuxOptions`      | Set SELinux options in container                                                                | `{}`             |
 | `ruler.containerSecurityContext.runAsUser`           | Set Ruler containers' Security Context runAsUser                                                | `1001`           |
 | `ruler.containerSecurityContext.runAsNonRoot`        | Set Ruler containers' Security Context runAsNonRoot                                             | `true`           |
 | `ruler.containerSecurityContext.seccompProfile.type` | Set container's Security Context seccomp profile                                                | `RuntimeDefault` |
@@ -931,8 +967,12 @@ The command removes all the Kubernetes components associated with the chart and 
 | `tableManager.resources.limits`                             | The resources limits for the tableManager containers                                                   | `{}`             |
 | `tableManager.resources.requests`                           | The requested resources for the tableManager containers                                                | `{}`             |
 | `tableManager.podSecurityContext.enabled`                   | Enabled table-manager pods' Security Context                                                           | `true`           |
+| `tableManager.podSecurityContext.fsGroupChangePolicy`       | Set filesystem group change policy                                                                     | `Always`         |
+| `tableManager.podSecurityContext.sysctls`                   | Set kernel settings using the sysctl interface                                                         | `[]`             |
+| `tableManager.podSecurityContext.supplementalGroups`        | Set filesystem extra groups                                                                            | `[]`             |
 | `tableManager.podSecurityContext.fsGroup`                   | Set table-manager pod's Security Context fsGroup                                                       | `1001`           |
 | `tableManager.containerSecurityContext.enabled`             | Enabled table-manager containers' Security Context                                                     | `true`           |
+| `tableManager.containerSecurityContext.seLinuxOptions`      | Set SELinux options in container                                                                       | `{}`             |
 | `tableManager.containerSecurityContext.runAsUser`           | Set table-manager containers' Security Context runAsUser                                               | `1001`           |
 | `tableManager.containerSecurityContext.runAsNonRoot`        | Set table-manager containers' Security Context runAsNonRoot                                            | `true`           |
 | `tableManager.containerSecurityContext.seccompProfile.type` | Set container's Security Context seccomp profile                                                       | `RuntimeDefault` |
@@ -1018,8 +1058,12 @@ The command removes all the Kubernetes components associated with the chart and 
 | `promtail.resources.limits`                             | The resources limits for the Promtail containers                                                                 | `{}`                       |
 | `promtail.resources.requests`                           | The requested resources for the Promtail containers                                                              | `{}`                       |
 | `promtail.podSecurityContext.enabled`                   | Enabled Promtail pods' Security Context                                                                          | `true`                     |
+| `promtail.podSecurityContext.fsGroupChangePolicy`       | Set filesystem group change policy                                                                               | `Always`                   |
+| `promtail.podSecurityContext.sysctls`                   | Set kernel settings using the sysctl interface                                                                   | `[]`                       |
+| `promtail.podSecurityContext.supplementalGroups`        | Set filesystem extra groups                                                                                      | `[]`                       |
 | `promtail.podSecurityContext.fsGroup`                   | Set Promtail pod's Security Context fsGroup                                                                      | `0`                        |
 | `promtail.containerSecurityContext.enabled`             | Enabled Promtail containers' Security Context                                                                    | `true`                     |
+| `promtail.containerSecurityContext.seLinuxOptions`      | Set SELinux options in container                                                                                 | `{}`                       |
 | `promtail.containerSecurityContext.runAsUser`           | Set Promtail containers' Security Context runAsUser                                                              | `0`                        |
 | `promtail.containerSecurityContext.runAsNonRoot`        | Set Promtail containers' Security Context runAsNonRoot                                                           | `false`                    |
 | `promtail.containerSecurityContext.seccompProfile.type` | Set container's Security Context seccomp profile                                                                 | `RuntimeDefault`           |
@@ -1080,6 +1124,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `volumePermissions.image.pullSecrets`                            | OS Shell + Utility image pull secrets                                                                              | `[]`                       |
 | `volumePermissions.resources.limits`                             | The resources limits for the init container                                                                        | `{}`                       |
 | `volumePermissions.resources.requests`                           | The requested resources for the init container                                                                     | `{}`                       |
+| `volumePermissions.containerSecurityContext.seLinuxOptions`      | Set SELinux options in container                                                                                   | `{}`                       |
 | `volumePermissions.containerSecurityContext.runAsUser`           | Set init container's Security Context runAsUser                                                                    | `0`                        |
 | `volumePermissions.containerSecurityContext.seccompProfile.type` | Set container's Security Context seccomp profile                                                                   | `RuntimeDefault`           |
 

--- a/bitnami/grafana-loki/values.yaml
+++ b/bitnami/grafana-loki/values.yaml
@@ -364,20 +364,28 @@ compactor:
   ## Configure Pods Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param compactor.podSecurityContext.enabled Enabled Compactor pods' Security Context
+  ## @param compactor.podSecurityContext.fsGroupChangePolicy Set filesystem group change policy
+  ## @param compactor.podSecurityContext.sysctls Set kernel settings using the sysctl interface
+  ## @param compactor.podSecurityContext.supplementalGroups Set filesystem extra groups
   ## @param compactor.podSecurityContext.fsGroup Set Compactor pod's Security Context fsGroup
   ##
   podSecurityContext:
     enabled: true
+    fsGroupChangePolicy: Always
+    sysctls: []
+    supplementalGroups: []
     fsGroup: 1001
   ## Configure Container Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param compactor.containerSecurityContext.enabled Enabled Compactor containers' Security Context
+  ## @param compactor.containerSecurityContext.seLinuxOptions Set SELinux options in container
   ## @param compactor.containerSecurityContext.runAsUser Set Compactor containers' Security Context runAsUser
   ## @param compactor.containerSecurityContext.runAsNonRoot Set Compactor containers' Security Context runAsNonRoot
   ## @param compactor.containerSecurityContext.seccompProfile.type Set container's Security Context seccomp profile
   ##
   containerSecurityContext:
     enabled: true
+    seLinuxOptions: {}
     runAsUser: 1001
     runAsNonRoot: true
     seccompProfile:
@@ -721,20 +729,28 @@ gateway:
   ## Configure Pods Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param gateway.podSecurityContext.enabled Enabled Gateway pods' Security Context
+  ## @param gateway.podSecurityContext.fsGroupChangePolicy Set filesystem group change policy
+  ## @param gateway.podSecurityContext.sysctls Set kernel settings using the sysctl interface
+  ## @param gateway.podSecurityContext.supplementalGroups Set filesystem extra groups
   ## @param gateway.podSecurityContext.fsGroup Set Gateway pod's Security Context fsGroup
   ##
   podSecurityContext:
     enabled: true
+    fsGroupChangePolicy: Always
+    sysctls: []
+    supplementalGroups: []
     fsGroup: 1001
   ## Configure Container Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param gateway.containerSecurityContext.enabled Enabled Gateway containers' Security Context
+  ## @param gateway.containerSecurityContext.seLinuxOptions Set SELinux options in container
   ## @param gateway.containerSecurityContext.runAsUser Set Gateway containers' Security Context runAsUser
   ## @param gateway.containerSecurityContext.runAsNonRoot Set Gateway containers' Security Context runAsNonRoot
   ## @param gateway.containerSecurityContext.seccompProfile.type Set container's Security Context seccomp profile
   ##
   containerSecurityContext:
     enabled: true
+    seLinuxOptions: {}
     runAsUser: 1001
     runAsNonRoot: true
     seccompProfile:
@@ -1088,20 +1104,28 @@ indexGateway:
   ## Configure Pods Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param indexGateway.podSecurityContext.enabled Enabled index-gateway pods' Security Context
+  ## @param indexGateway.podSecurityContext.fsGroupChangePolicy Set filesystem group change policy
+  ## @param indexGateway.podSecurityContext.sysctls Set kernel settings using the sysctl interface
+  ## @param indexGateway.podSecurityContext.supplementalGroups Set filesystem extra groups
   ## @param indexGateway.podSecurityContext.fsGroup Set index-gateway pod's Security Context fsGroup
   ##
   podSecurityContext:
     enabled: true
+    fsGroupChangePolicy: Always
+    sysctls: []
+    supplementalGroups: []
     fsGroup: 1001
   ## Configure Container Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param indexGateway.containerSecurityContext.enabled Enabled index-gateway containers' Security Context
+  ## @param indexGateway.containerSecurityContext.seLinuxOptions Set SELinux options in container
   ## @param indexGateway.containerSecurityContext.runAsUser Set index-gateway containers' Security Context runAsUser
   ## @param indexGateway.containerSecurityContext.runAsNonRoot Set index-gateway containers' Security Context runAsNonRoot
   ## @param indexGateway.containerSecurityContext.seccompProfile.type Set container's Security Context seccomp profile
   ##
   containerSecurityContext:
     enabled: true
+    seLinuxOptions: {}
     runAsUser: 1001
     runAsNonRoot: true
     seccompProfile:
@@ -1358,20 +1382,28 @@ distributor:
   ## Configure Pods Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param distributor.podSecurityContext.enabled Enabled Distributor pods' Security Context
+  ## @param distributor.podSecurityContext.fsGroupChangePolicy Set filesystem group change policy
+  ## @param distributor.podSecurityContext.sysctls Set kernel settings using the sysctl interface
+  ## @param distributor.podSecurityContext.supplementalGroups Set filesystem extra groups
   ## @param distributor.podSecurityContext.fsGroup Set Distributor pod's Security Context fsGroup
   ##
   podSecurityContext:
     enabled: true
+    fsGroupChangePolicy: Always
+    sysctls: []
+    supplementalGroups: []
     fsGroup: 1001
   ## Configure Container Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param distributor.containerSecurityContext.enabled Enabled Distributor containers' Security Context
+  ## @param distributor.containerSecurityContext.seLinuxOptions Set SELinux options in container
   ## @param distributor.containerSecurityContext.runAsUser Set Distributor containers' Security Context runAsUser
   ## @param distributor.containerSecurityContext.runAsNonRoot Set Distributor containers' Security Context runAsNonRoot
   ## @param distributor.containerSecurityContext.seccompProfile.type Set container's Security Context seccomp profile
   ##
   containerSecurityContext:
     enabled: true
+    seLinuxOptions: {}
     runAsUser: 1001
     runAsNonRoot: true
     seccompProfile:
@@ -1631,20 +1663,28 @@ ingester:
   ## Configure Pods Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param ingester.podSecurityContext.enabled Enabled Ingester pods' Security Context
+  ## @param ingester.podSecurityContext.fsGroupChangePolicy Set filesystem group change policy
+  ## @param ingester.podSecurityContext.sysctls Set kernel settings using the sysctl interface
+  ## @param ingester.podSecurityContext.supplementalGroups Set filesystem extra groups
   ## @param ingester.podSecurityContext.fsGroup Set Ingester pod's Security Context fsGroup
   ##
   podSecurityContext:
     enabled: true
+    fsGroupChangePolicy: Always
+    sysctls: []
+    supplementalGroups: []
     fsGroup: 1001
   ## Configure Container Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param ingester.containerSecurityContext.enabled Enabled Ingester containers' Security Context
+  ## @param ingester.containerSecurityContext.seLinuxOptions Set SELinux options in container
   ## @param ingester.containerSecurityContext.runAsUser Set Ingester containers' Security Context runAsUser
   ## @param ingester.containerSecurityContext.runAsNonRoot Set Ingester containers' Security Context runAsNonRoot
   ## @param ingester.containerSecurityContext.seccompProfile.type Set container's Security Context seccomp profile
   ##
   containerSecurityContext:
     enabled: true
+    seLinuxOptions: {}
     runAsUser: 1001
     runAsNonRoot: true
     seccompProfile:
@@ -1946,20 +1986,28 @@ querier:
   ## Configure Pods Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param querier.podSecurityContext.enabled Enabled Querier pods' Security Context
+  ## @param querier.podSecurityContext.fsGroupChangePolicy Set filesystem group change policy
+  ## @param querier.podSecurityContext.sysctls Set kernel settings using the sysctl interface
+  ## @param querier.podSecurityContext.supplementalGroups Set filesystem extra groups
   ## @param querier.podSecurityContext.fsGroup Set Querier pod's Security Context fsGroup
   ##
   podSecurityContext:
     enabled: true
+    fsGroupChangePolicy: Always
+    sysctls: []
+    supplementalGroups: []
     fsGroup: 1001
   ## Configure Container Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param querier.containerSecurityContext.enabled Enabled Querier containers' Security Context
+  ## @param querier.containerSecurityContext.seLinuxOptions Set SELinux options in container
   ## @param querier.containerSecurityContext.runAsUser Set Querier containers' Security Context runAsUser
   ## @param querier.containerSecurityContext.runAsNonRoot Set Querier containers' Security Context runAsNonRoot
   ## @param querier.containerSecurityContext.seccompProfile.type Set container's Security Context seccomp profile
   ##
   containerSecurityContext:
     enabled: true
+    seLinuxOptions: {}
     runAsUser: 1001
     runAsNonRoot: true
     seccompProfile:
@@ -2256,20 +2304,28 @@ queryFrontend:
   ## Configure Pods Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param queryFrontend.podSecurityContext.enabled Enabled queryFrontend pods' Security Context
+  ## @param queryFrontend.podSecurityContext.fsGroupChangePolicy Set filesystem group change policy
+  ## @param queryFrontend.podSecurityContext.sysctls Set kernel settings using the sysctl interface
+  ## @param queryFrontend.podSecurityContext.supplementalGroups Set filesystem extra groups
   ## @param queryFrontend.podSecurityContext.fsGroup Set queryFrontend pod's Security Context fsGroup
   ##
   podSecurityContext:
     enabled: true
+    fsGroupChangePolicy: Always
+    sysctls: []
+    supplementalGroups: []
     fsGroup: 1001
   ## Configure Container Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param queryFrontend.containerSecurityContext.enabled Enabled queryFrontend containers' Security Context
+  ## @param queryFrontend.containerSecurityContext.seLinuxOptions Set SELinux options in container
   ## @param queryFrontend.containerSecurityContext.runAsUser Set queryFrontend containers' Security Context runAsUser
   ## @param queryFrontend.containerSecurityContext.runAsNonRoot Set queryFrontend containers' Security Context runAsNonRoot
   ## @param queryFrontend.containerSecurityContext.seccompProfile.type Set container's Security Context seccomp profile
   ##
   containerSecurityContext:
     enabled: true
+    seLinuxOptions: {}
     runAsUser: 1001
     runAsNonRoot: true
     seccompProfile:
@@ -2536,20 +2592,28 @@ queryScheduler:
   ## Configure Pods Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param queryScheduler.podSecurityContext.enabled Enabled queryScheduler pods' Security Context
+  ## @param queryScheduler.podSecurityContext.fsGroupChangePolicy Set filesystem group change policy
+  ## @param queryScheduler.podSecurityContext.sysctls Set kernel settings using the sysctl interface
+  ## @param queryScheduler.podSecurityContext.supplementalGroups Set filesystem extra groups
   ## @param queryScheduler.podSecurityContext.fsGroup Set queryScheduler pod's Security Context fsGroup
   ##
   podSecurityContext:
     enabled: true
+    fsGroupChangePolicy: Always
+    sysctls: []
+    supplementalGroups: []
     fsGroup: 1001
   ## Configure Container Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param queryScheduler.containerSecurityContext.enabled Enabled queryScheduler containers' Security Context
+  ## @param queryScheduler.containerSecurityContext.seLinuxOptions Set SELinux options in container
   ## @param queryScheduler.containerSecurityContext.runAsUser Set queryScheduler containers' Security Context runAsUser
   ## @param queryScheduler.containerSecurityContext.runAsNonRoot Set queryScheduler containers' Security Context runAsNonRoot
   ## @param queryScheduler.containerSecurityContext.seccompProfile.type Set container's Security Context seccomp profile
   ##
   containerSecurityContext:
     enabled: true
+    seLinuxOptions: {}
     runAsUser: 1001
     runAsNonRoot: true
     seccompProfile:
@@ -2816,20 +2880,28 @@ ruler:
   ## Configure Pods Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param ruler.podSecurityContext.enabled Enabled Ruler pods' Security Context
+  ## @param ruler.podSecurityContext.fsGroupChangePolicy Set filesystem group change policy
+  ## @param ruler.podSecurityContext.sysctls Set kernel settings using the sysctl interface
+  ## @param ruler.podSecurityContext.supplementalGroups Set filesystem extra groups
   ## @param ruler.podSecurityContext.fsGroup Set Ruler pod's Security Context fsGroup
   ##
   podSecurityContext:
     enabled: true
+    fsGroupChangePolicy: Always
+    sysctls: []
+    supplementalGroups: []
     fsGroup: 1001
   ## Configure Container Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param ruler.containerSecurityContext.enabled Enabled Ruler containers' Security Context
+  ## @param ruler.containerSecurityContext.seLinuxOptions Set SELinux options in container
   ## @param ruler.containerSecurityContext.runAsUser Set Ruler containers' Security Context runAsUser
   ## @param ruler.containerSecurityContext.runAsNonRoot Set Ruler containers' Security Context runAsNonRoot
   ## @param ruler.containerSecurityContext.seccompProfile.type Set container's Security Context seccomp profile
   ##
   containerSecurityContext:
     enabled: true
+    seLinuxOptions: {}
     runAsUser: 1001
     runAsNonRoot: true
     seccompProfile:
@@ -3126,20 +3198,28 @@ tableManager:
   ## Configure Pods Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param tableManager.podSecurityContext.enabled Enabled table-manager pods' Security Context
+  ## @param tableManager.podSecurityContext.fsGroupChangePolicy Set filesystem group change policy
+  ## @param tableManager.podSecurityContext.sysctls Set kernel settings using the sysctl interface
+  ## @param tableManager.podSecurityContext.supplementalGroups Set filesystem extra groups
   ## @param tableManager.podSecurityContext.fsGroup Set table-manager pod's Security Context fsGroup
   ##
   podSecurityContext:
     enabled: true
+    fsGroupChangePolicy: Always
+    sysctls: []
+    supplementalGroups: []
     fsGroup: 1001
   ## Configure Container Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param tableManager.containerSecurityContext.enabled Enabled table-manager containers' Security Context
+  ## @param tableManager.containerSecurityContext.seLinuxOptions Set SELinux options in container
   ## @param tableManager.containerSecurityContext.runAsUser Set table-manager containers' Security Context runAsUser
   ## @param tableManager.containerSecurityContext.runAsNonRoot Set table-manager containers' Security Context runAsNonRoot
   ## @param tableManager.containerSecurityContext.seccompProfile.type Set container's Security Context seccomp profile
   ##
   containerSecurityContext:
     enabled: true
+    seLinuxOptions: {}
     runAsUser: 1001
     runAsNonRoot: true
     seccompProfile:
@@ -3433,20 +3513,28 @@ promtail:
   ## Configure Pods Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param promtail.podSecurityContext.enabled Enabled Promtail pods' Security Context
+  ## @param promtail.podSecurityContext.fsGroupChangePolicy Set filesystem group change policy
+  ## @param promtail.podSecurityContext.sysctls Set kernel settings using the sysctl interface
+  ## @param promtail.podSecurityContext.supplementalGroups Set filesystem extra groups
   ## @param promtail.podSecurityContext.fsGroup Set Promtail pod's Security Context fsGroup
   ##
   podSecurityContext:
     enabled: true
+    fsGroupChangePolicy: Always
+    sysctls: []
+    supplementalGroups: []
     fsGroup: 0
   ## Configure Container Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param promtail.containerSecurityContext.enabled Enabled Promtail containers' Security Context
+  ## @param promtail.containerSecurityContext.seLinuxOptions Set SELinux options in container
   ## @param promtail.containerSecurityContext.runAsUser Set Promtail containers' Security Context runAsUser
   ## @param promtail.containerSecurityContext.runAsNonRoot Set Promtail containers' Security Context runAsNonRoot
   ## @param promtail.containerSecurityContext.seccompProfile.type Set container's Security Context seccomp profile
   ##
   containerSecurityContext:
     enabled: true
+    seLinuxOptions: {}
     runAsUser: 0
     runAsNonRoot: false
     seccompProfile:
@@ -3764,6 +3852,7 @@ volumePermissions:
     requests: {}
   ## Init container Container Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
+  ## @param volumePermissions.containerSecurityContext.seLinuxOptions Set SELinux options in container
   ## @param volumePermissions.containerSecurityContext.runAsUser Set init container's Security Context runAsUser
   ## @param volumePermissions.containerSecurityContext.seccompProfile.type Set container's Security Context seccomp profile
   ## NOTE: when runAsUser is set to special value "auto", init container will try to chown the
@@ -3771,6 +3860,7 @@ volumePermissions:
   ##   "auto" is especially useful for OpenShift which has scc with dynamic user ids (and 0 is not allowed)
   ##
   containerSecurityContext:
+    seLinuxOptions: {}
     runAsUser: 0
     seccompProfile:
       type: "RuntimeDefault"


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

### Description of the change

This PR updates the podSecurityContext and containerSecurityContext fields by setting default values for essential security fields: seLinuxOptions, fsGroupChangePolicy, sysctls and supplementalGroups. These are required by security checklists. 

### Benefits

Charts become more security-compliant

### Possible drawbacks

n/a

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)

