### PR TITLE
[bitnami/grafana-tempo] fix: :lock: Improve podSecurityContext and containerSecurityContext with essential security fields

### DIFF
--- a/bitnami/grafana-tempo/Chart.yaml
+++ b/bitnami/grafana-tempo/Chart.yaml
@@ -39,4 +39,4 @@ maintainers:
 name: grafana-tempo
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/grafana-tempo
-version: 2.5.10
+version: 2.6.0

--- a/bitnami/grafana-tempo/README.md
+++ b/bitnami/grafana-tempo/README.md
@@ -145,8 +145,12 @@ The command removes all the Kubernetes components associated with the chart and 
 | `compactor.resources.limits`                                  | The resources limits for the compactor containers                                                   | `{}`             |
 | `compactor.resources.requests`                                | The requested resources for the compactor containers                                                | `{}`             |
 | `compactor.podSecurityContext.enabled`                        | Enabled Compactor pods' Security Context                                                            | `true`           |
+| `compactor.podSecurityContext.fsGroupChangePolicy`            | Set filesystem group change policy                                                                  | `Always`         |
+| `compactor.podSecurityContext.sysctls`                        | Set kernel settings using the sysctl interface                                                      | `[]`             |
+| `compactor.podSecurityContext.supplementalGroups`             | Set filesystem extra groups                                                                         | `[]`             |
 | `compactor.podSecurityContext.fsGroup`                        | Set Compactor pod's Security Context fsGroup                                                        | `1001`           |
 | `compactor.containerSecurityContext.enabled`                  | Enabled containers' Security Context                                                                | `true`           |
+| `compactor.containerSecurityContext.seLinuxOptions`           | Set SELinux options in container                                                                    | `{}`             |
 | `compactor.containerSecurityContext.runAsUser`                | Set containers' Security Context runAsUser                                                          | `1001`           |
 | `compactor.containerSecurityContext.runAsNonRoot`             | Set container's Security Context runAsNonRoot                                                       | `true`           |
 | `compactor.containerSecurityContext.privileged`               | Set container's Security Context privileged                                                         | `false`          |
@@ -226,8 +230,12 @@ The command removes all the Kubernetes components associated with the chart and 
 | `distributor.resources.limits`                                  | The resources limits for the distributor containers                                                   | `{}`             |
 | `distributor.resources.requests`                                | The requested resources for the distributor containers                                                | `{}`             |
 | `distributor.podSecurityContext.enabled`                        | Enabled Distributor pods' Security Context                                                            | `true`           |
+| `distributor.podSecurityContext.fsGroupChangePolicy`            | Set filesystem group change policy                                                                    | `Always`         |
+| `distributor.podSecurityContext.sysctls`                        | Set kernel settings using the sysctl interface                                                        | `[]`             |
+| `distributor.podSecurityContext.supplementalGroups`             | Set filesystem extra groups                                                                           | `[]`             |
 | `distributor.podSecurityContext.fsGroup`                        | Set Distributor pod's Security Context fsGroup                                                        | `1001`           |
 | `distributor.containerSecurityContext.enabled`                  | Enabled containers' Security Context                                                                  | `true`           |
+| `distributor.containerSecurityContext.seLinuxOptions`           | Set SELinux options in container                                                                      | `{}`             |
 | `distributor.containerSecurityContext.runAsUser`                | Set containers' Security Context runAsUser                                                            | `1001`           |
 | `distributor.containerSecurityContext.runAsNonRoot`             | Set container's Security Context runAsNonRoot                                                         | `true`           |
 | `distributor.containerSecurityContext.privileged`               | Set container's Security Context privileged                                                           | `false`          |
@@ -310,8 +318,12 @@ The command removes all the Kubernetes components associated with the chart and 
 | `metricsGenerator.resources.limits`                                  | The resources limits for the metricsGenerator containers                                                   | `{}`             |
 | `metricsGenerator.resources.requests`                                | The requested resources for the metricsGenerator containers                                                | `{}`             |
 | `metricsGenerator.podSecurityContext.enabled`                        | Enabled metricsGenerator pods' Security Context                                                            | `true`           |
+| `metricsGenerator.podSecurityContext.fsGroupChangePolicy`            | Set filesystem group change policy                                                                         | `Always`         |
+| `metricsGenerator.podSecurityContext.sysctls`                        | Set kernel settings using the sysctl interface                                                             | `[]`             |
+| `metricsGenerator.podSecurityContext.supplementalGroups`             | Set filesystem extra groups                                                                                | `[]`             |
 | `metricsGenerator.podSecurityContext.fsGroup`                        | Set metricsGenerator pod's Security Context fsGroup                                                        | `1001`           |
 | `metricsGenerator.containerSecurityContext.enabled`                  | Enabled containers' Security Context                                                                       | `true`           |
+| `metricsGenerator.containerSecurityContext.seLinuxOptions`           | Set SELinux options in container                                                                           | `{}`             |
 | `metricsGenerator.containerSecurityContext.runAsUser`                | Set containers' Security Context runAsUser                                                                 | `1001`           |
 | `metricsGenerator.containerSecurityContext.runAsNonRoot`             | Set container's Security Context runAsNonRoot                                                              | `true`           |
 | `metricsGenerator.containerSecurityContext.privileged`               | Set container's Security Context privileged                                                                | `false`          |
@@ -393,8 +405,12 @@ The command removes all the Kubernetes components associated with the chart and 
 | `ingester.resources.limits`                                  | The resources limits for the Ingester containers                                                   | `{}`             |
 | `ingester.resources.requests`                                | The requested resources for the Ingester containers                                                | `{}`             |
 | `ingester.podSecurityContext.enabled`                        | Enabled Ingester pods' Security Context                                                            | `true`           |
+| `ingester.podSecurityContext.fsGroupChangePolicy`            | Set filesystem group change policy                                                                 | `Always`         |
+| `ingester.podSecurityContext.sysctls`                        | Set kernel settings using the sysctl interface                                                     | `[]`             |
+| `ingester.podSecurityContext.supplementalGroups`             | Set filesystem extra groups                                                                        | `[]`             |
 | `ingester.podSecurityContext.fsGroup`                        | Set Ingester pod's Security Context fsGroup                                                        | `1001`           |
 | `ingester.containerSecurityContext.enabled`                  | Enabled containers' Security Context                                                               | `true`           |
+| `ingester.containerSecurityContext.seLinuxOptions`           | Set SELinux options in container                                                                   | `{}`             |
 | `ingester.containerSecurityContext.runAsUser`                | Set containers' Security Context runAsUser                                                         | `1001`           |
 | `ingester.containerSecurityContext.runAsNonRoot`             | Set container's Security Context runAsNonRoot                                                      | `true`           |
 | `ingester.containerSecurityContext.privileged`               | Set container's Security Context privileged                                                        | `false`          |
@@ -488,8 +504,12 @@ The command removes all the Kubernetes components associated with the chart and 
 | `querier.resources.limits`                                  | The resources limits for the Querier containers                                                   | `{}`             |
 | `querier.resources.requests`                                | The requested resources for the Querier containers                                                | `{}`             |
 | `querier.podSecurityContext.enabled`                        | Enabled Querier pods' Security Context                                                            | `true`           |
+| `querier.podSecurityContext.fsGroupChangePolicy`            | Set filesystem group change policy                                                                | `Always`         |
+| `querier.podSecurityContext.sysctls`                        | Set kernel settings using the sysctl interface                                                    | `[]`             |
+| `querier.podSecurityContext.supplementalGroups`             | Set filesystem extra groups                                                                       | `[]`             |
 | `querier.podSecurityContext.fsGroup`                        | Set Querier pod's Security Context fsGroup                                                        | `1001`           |
 | `querier.containerSecurityContext.enabled`                  | Enabled containers' Security Context                                                              | `true`           |
+| `querier.containerSecurityContext.seLinuxOptions`           | Set SELinux options in container                                                                  | `{}`             |
 | `querier.containerSecurityContext.runAsUser`                | Set containers' Security Context runAsUser                                                        | `1001`           |
 | `querier.containerSecurityContext.runAsNonRoot`             | Set container's Security Context runAsNonRoot                                                     | `true`           |
 | `querier.containerSecurityContext.privileged`               | Set container's Security Context privileged                                                       | `false`          |
@@ -571,8 +591,12 @@ The command removes all the Kubernetes components associated with the chart and 
 | `queryFrontend.resources.limits`                                        | The resources limits for the queryFrontend containers                                                               | `{}`                                  |
 | `queryFrontend.resources.requests`                                      | The requested resources for the queryFrontend containers                                                            | `{}`                                  |
 | `queryFrontend.podSecurityContext.enabled`                              | Enabled queryFrontend pods' Security Context                                                                        | `true`                                |
+| `queryFrontend.podSecurityContext.fsGroupChangePolicy`                  | Set filesystem group change policy                                                                                  | `Always`                              |
+| `queryFrontend.podSecurityContext.sysctls`                              | Set kernel settings using the sysctl interface                                                                      | `[]`                                  |
+| `queryFrontend.podSecurityContext.supplementalGroups`                   | Set filesystem extra groups                                                                                         | `[]`                                  |
 | `queryFrontend.podSecurityContext.fsGroup`                              | Set queryFrontend pod's Security Context fsGroup                                                                    | `1001`                                |
 | `queryFrontend.containerSecurityContext.enabled`                        | Enabled containers' Security Context                                                                                | `true`                                |
+| `queryFrontend.containerSecurityContext.seLinuxOptions`                 | Set SELinux options in container                                                                                    | `{}`                                  |
 | `queryFrontend.containerSecurityContext.runAsUser`                      | Set containers' Security Context runAsUser                                                                          | `1001`                                |
 | `queryFrontend.containerSecurityContext.runAsNonRoot`                   | Set container's Security Context runAsNonRoot                                                                       | `true`                                |
 | `queryFrontend.containerSecurityContext.privileged`                     | Set container's Security Context privileged                                                                         | `false`                               |
@@ -638,6 +662,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `queryFrontend.query.customStartupProbe`                                | Custom startupProbe that overrides the default one                                                                  | `{}`                                  |
 | `queryFrontend.query.lifecycleHooks`                                    | for the query sidecar container(s) to automate configuration before or after startup                                | `{}`                                  |
 | `queryFrontend.query.containerSecurityContext.enabled`                  | Enabled containers' Security Context                                                                                | `true`                                |
+| `queryFrontend.query.containerSecurityContext.seLinuxOptions`           | Set SELinux options in container                                                                                    | `{}`                                  |
 | `queryFrontend.query.containerSecurityContext.runAsUser`                | Set containers' Security Context runAsUser                                                                          | `1001`                                |
 | `queryFrontend.query.containerSecurityContext.runAsNonRoot`             | Set container's Security Context runAsNonRoot                                                                       | `true`                                |
 | `queryFrontend.query.containerSecurityContext.privileged`               | Set container's Security Context privileged                                                                         | `false`                               |
@@ -708,8 +733,12 @@ The command removes all the Kubernetes components associated with the chart and 
 | `vulture.resources.limits`                                  | The resources limits for the Vulture containers                                                                 | `{}`                                    |
 | `vulture.resources.requests`                                | The requested resources for the Vulture containers                                                              | `{}`                                    |
 | `vulture.podSecurityContext.enabled`                        | Enabled Vulture pods' Security Context                                                                          | `true`                                  |
+| `vulture.podSecurityContext.fsGroupChangePolicy`            | Set filesystem group change policy                                                                              | `Always`                                |
+| `vulture.podSecurityContext.sysctls`                        | Set kernel settings using the sysctl interface                                                                  | `[]`                                    |
+| `vulture.podSecurityContext.supplementalGroups`             | Set filesystem extra groups                                                                                     | `[]`                                    |
 | `vulture.podSecurityContext.fsGroup`                        | Set Vulture pod's Security Context fsGroup                                                                      | `1001`                                  |
 | `vulture.containerSecurityContext.enabled`                  | Enabled containers' Security Context                                                                            | `true`                                  |
+| `vulture.containerSecurityContext.seLinuxOptions`           | Set SELinux options in container                                                                                | `{}`                                    |
 | `vulture.containerSecurityContext.runAsUser`                | Set containers' Security Context runAsUser                                                                      | `1001`                                  |
 | `vulture.containerSecurityContext.runAsNonRoot`             | Set container's Security Context runAsNonRoot                                                                   | `true`                                  |
 | `vulture.containerSecurityContext.privileged`               | Set container's Security Context privileged                                                                     | `false`                                 |
@@ -758,17 +787,18 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Init Container Parameters
 
-| Name                                                   | Description                                                                                                        | Value                      |
-| ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------ | -------------------------- |
-| `volumePermissions.enabled`                            | Enable init container that changes the owner/group of the PV mount point to `runAsUser:fsGroup`                    | `false`                    |
-| `volumePermissions.image.registry`                     | OS Shell + Utility image registry                                                                                  | `REGISTRY_NAME`            |
-| `volumePermissions.image.repository`                   | OS Shell + Utility image repository                                                                                | `REPOSITORY_NAME/os-shell` |
-| `volumePermissions.image.digest`                       | OS Shell + Utility image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                       |
-| `volumePermissions.image.pullPolicy`                   | OS Shell + Utility image pull policy                                                                               | `IfNotPresent`             |
-| `volumePermissions.image.pullSecrets`                  | OS Shell + Utility image pull secrets                                                                              | `[]`                       |
-| `volumePermissions.resources.limits`                   | The resources limits for the init container                                                                        | `{}`                       |
-| `volumePermissions.resources.requests`                 | The requested resources for the init container                                                                     | `{}`                       |
-| `volumePermissions.containerSecurityContext.runAsUser` | Set init container's Security Context runAsUser                                                                    | `0`                        |
+| Name                                                        | Description                                                                                                        | Value                      |
+| ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ | -------------------------- |
+| `volumePermissions.enabled`                                 | Enable init container that changes the owner/group of the PV mount point to `runAsUser:fsGroup`                    | `false`                    |
+| `volumePermissions.image.registry`                          | OS Shell + Utility image registry                                                                                  | `REGISTRY_NAME`            |
+| `volumePermissions.image.repository`                        | OS Shell + Utility image repository                                                                                | `REPOSITORY_NAME/os-shell` |
+| `volumePermissions.image.digest`                            | OS Shell + Utility image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                       |
+| `volumePermissions.image.pullPolicy`                        | OS Shell + Utility image pull policy                                                                               | `IfNotPresent`             |
+| `volumePermissions.image.pullSecrets`                       | OS Shell + Utility image pull secrets                                                                              | `[]`                       |
+| `volumePermissions.resources.limits`                        | The resources limits for the init container                                                                        | `{}`                       |
+| `volumePermissions.resources.requests`                      | The requested resources for the init container                                                                     | `{}`                       |
+| `volumePermissions.containerSecurityContext.seLinuxOptions` | Set SELinux options in container                                                                                   | `{}`                       |
+| `volumePermissions.containerSecurityContext.runAsUser`      | Set init container's Security Context runAsUser                                                                    | `0`                        |
 
 ### Other Parameters
 

--- a/bitnami/grafana-tempo/values.yaml
+++ b/bitnami/grafana-tempo/values.yaml
@@ -343,14 +343,21 @@ compactor:
   ## Configure Pods Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param compactor.podSecurityContext.enabled Enabled Compactor pods' Security Context
+  ## @param compactor.podSecurityContext.fsGroupChangePolicy Set filesystem group change policy
+  ## @param compactor.podSecurityContext.sysctls Set kernel settings using the sysctl interface
+  ## @param compactor.podSecurityContext.supplementalGroups Set filesystem extra groups
   ## @param compactor.podSecurityContext.fsGroup Set Compactor pod's Security Context fsGroup
   ##
   podSecurityContext:
     enabled: true
+    fsGroupChangePolicy: Always
+    sysctls: []
+    supplementalGroups: []
     fsGroup: 1001
   ## Configure Container Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param compactor.containerSecurityContext.enabled Enabled containers' Security Context
+  ## @param compactor.containerSecurityContext.seLinuxOptions Set SELinux options in container
   ## @param compactor.containerSecurityContext.runAsUser Set containers' Security Context runAsUser
   ## @param compactor.containerSecurityContext.runAsNonRoot Set container's Security Context runAsNonRoot
   ## @param compactor.containerSecurityContext.privileged Set container's Security Context privileged
@@ -361,6 +368,7 @@ compactor:
   ##
   containerSecurityContext:
     enabled: true
+    seLinuxOptions: {}
     runAsUser: 1001
     runAsNonRoot: true
     privileged: false
@@ -614,14 +622,21 @@ distributor:
   ## Configure Pods Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param distributor.podSecurityContext.enabled Enabled Distributor pods' Security Context
+  ## @param distributor.podSecurityContext.fsGroupChangePolicy Set filesystem group change policy
+  ## @param distributor.podSecurityContext.sysctls Set kernel settings using the sysctl interface
+  ## @param distributor.podSecurityContext.supplementalGroups Set filesystem extra groups
   ## @param distributor.podSecurityContext.fsGroup Set Distributor pod's Security Context fsGroup
   ##
   podSecurityContext:
     enabled: true
+    fsGroupChangePolicy: Always
+    sysctls: []
+    supplementalGroups: []
     fsGroup: 1001
   ## Configure Container Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param distributor.containerSecurityContext.enabled Enabled containers' Security Context
+  ## @param distributor.containerSecurityContext.seLinuxOptions Set SELinux options in container
   ## @param distributor.containerSecurityContext.runAsUser Set containers' Security Context runAsUser
   ## @param distributor.containerSecurityContext.runAsNonRoot Set container's Security Context runAsNonRoot
   ## @param distributor.containerSecurityContext.privileged Set container's Security Context privileged
@@ -632,6 +647,7 @@ distributor:
   ##
   containerSecurityContext:
     enabled: true
+    seLinuxOptions: {}
     runAsUser: 1001
     runAsNonRoot: true
     privileged: false
@@ -891,14 +907,21 @@ metricsGenerator:
   ## Configure Pods Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param metricsGenerator.podSecurityContext.enabled Enabled metricsGenerator pods' Security Context
+  ## @param metricsGenerator.podSecurityContext.fsGroupChangePolicy Set filesystem group change policy
+  ## @param metricsGenerator.podSecurityContext.sysctls Set kernel settings using the sysctl interface
+  ## @param metricsGenerator.podSecurityContext.supplementalGroups Set filesystem extra groups
   ## @param metricsGenerator.podSecurityContext.fsGroup Set metricsGenerator pod's Security Context fsGroup
   ##
   podSecurityContext:
     enabled: true
+    fsGroupChangePolicy: Always
+    sysctls: []
+    supplementalGroups: []
     fsGroup: 1001
   ## Configure Container Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param metricsGenerator.containerSecurityContext.enabled Enabled containers' Security Context
+  ## @param metricsGenerator.containerSecurityContext.seLinuxOptions Set SELinux options in container
   ## @param metricsGenerator.containerSecurityContext.runAsUser Set containers' Security Context runAsUser
   ## @param metricsGenerator.containerSecurityContext.runAsNonRoot Set container's Security Context runAsNonRoot
   ## @param metricsGenerator.containerSecurityContext.privileged Set container's Security Context privileged
@@ -909,6 +932,7 @@ metricsGenerator:
   ##
   containerSecurityContext:
     enabled: true
+    seLinuxOptions: {}
     runAsUser: 1001
     runAsNonRoot: true
     privileged: false
@@ -1163,14 +1187,21 @@ ingester:
   ## Configure Pods Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param ingester.podSecurityContext.enabled Enabled Ingester pods' Security Context
+  ## @param ingester.podSecurityContext.fsGroupChangePolicy Set filesystem group change policy
+  ## @param ingester.podSecurityContext.sysctls Set kernel settings using the sysctl interface
+  ## @param ingester.podSecurityContext.supplementalGroups Set filesystem extra groups
   ## @param ingester.podSecurityContext.fsGroup Set Ingester pod's Security Context fsGroup
   ##
   podSecurityContext:
     enabled: true
+    fsGroupChangePolicy: Always
+    sysctls: []
+    supplementalGroups: []
     fsGroup: 1001
   ## Configure Container Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param ingester.containerSecurityContext.enabled Enabled containers' Security Context
+  ## @param ingester.containerSecurityContext.seLinuxOptions Set SELinux options in container
   ## @param ingester.containerSecurityContext.runAsUser Set containers' Security Context runAsUser
   ## @param ingester.containerSecurityContext.runAsNonRoot Set container's Security Context runAsNonRoot
   ## @param ingester.containerSecurityContext.privileged Set container's Security Context privileged
@@ -1181,6 +1212,7 @@ ingester:
   ##
   containerSecurityContext:
     enabled: true
+    seLinuxOptions: {}
     runAsUser: 1001
     runAsNonRoot: true
     privileged: false
@@ -1478,14 +1510,21 @@ querier:
   ## Configure Pods Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param querier.podSecurityContext.enabled Enabled Querier pods' Security Context
+  ## @param querier.podSecurityContext.fsGroupChangePolicy Set filesystem group change policy
+  ## @param querier.podSecurityContext.sysctls Set kernel settings using the sysctl interface
+  ## @param querier.podSecurityContext.supplementalGroups Set filesystem extra groups
   ## @param querier.podSecurityContext.fsGroup Set Querier pod's Security Context fsGroup
   ##
   podSecurityContext:
     enabled: true
+    fsGroupChangePolicy: Always
+    sysctls: []
+    supplementalGroups: []
     fsGroup: 1001
   ## Configure Container Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param querier.containerSecurityContext.enabled Enabled containers' Security Context
+  ## @param querier.containerSecurityContext.seLinuxOptions Set SELinux options in container
   ## @param querier.containerSecurityContext.runAsUser Set containers' Security Context runAsUser
   ## @param querier.containerSecurityContext.runAsNonRoot Set container's Security Context runAsNonRoot
   ## @param querier.containerSecurityContext.privileged Set container's Security Context privileged
@@ -1496,6 +1535,7 @@ querier:
   ##
   containerSecurityContext:
     enabled: true
+    seLinuxOptions: {}
     runAsUser: 1001
     runAsNonRoot: true
     privileged: false
@@ -1753,14 +1793,21 @@ queryFrontend:
   ## Configure Pods Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param queryFrontend.podSecurityContext.enabled Enabled queryFrontend pods' Security Context
+  ## @param queryFrontend.podSecurityContext.fsGroupChangePolicy Set filesystem group change policy
+  ## @param queryFrontend.podSecurityContext.sysctls Set kernel settings using the sysctl interface
+  ## @param queryFrontend.podSecurityContext.supplementalGroups Set filesystem extra groups
   ## @param queryFrontend.podSecurityContext.fsGroup Set queryFrontend pod's Security Context fsGroup
   ##
   podSecurityContext:
     enabled: true
+    fsGroupChangePolicy: Always
+    sysctls: []
+    supplementalGroups: []
     fsGroup: 1001
   ## Configure Container Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param queryFrontend.containerSecurityContext.enabled Enabled containers' Security Context
+  ## @param queryFrontend.containerSecurityContext.seLinuxOptions Set SELinux options in container
   ## @param queryFrontend.containerSecurityContext.runAsUser Set containers' Security Context runAsUser
   ## @param queryFrontend.containerSecurityContext.runAsNonRoot Set container's Security Context runAsNonRoot
   ## @param queryFrontend.containerSecurityContext.privileged Set container's Security Context privileged
@@ -1771,6 +1818,7 @@ queryFrontend:
   ##
   containerSecurityContext:
     enabled: true
+    seLinuxOptions: {}
     runAsUser: 1001
     runAsNonRoot: true
     privileged: false
@@ -2000,6 +2048,7 @@ queryFrontend:
     ## Configure Container Security Context
     ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
     ## @param queryFrontend.query.containerSecurityContext.enabled Enabled containers' Security Context
+    ## @param queryFrontend.query.containerSecurityContext.seLinuxOptions Set SELinux options in container
     ## @param queryFrontend.query.containerSecurityContext.runAsUser Set containers' Security Context runAsUser
     ## @param queryFrontend.query.containerSecurityContext.runAsNonRoot Set container's Security Context runAsNonRoot
     ## @param queryFrontend.query.containerSecurityContext.privileged Set container's Security Context privileged
@@ -2010,6 +2059,7 @@ queryFrontend:
     ##
     containerSecurityContext:
       enabled: true
+      seLinuxOptions: {}
       runAsUser: 1001
       runAsNonRoot: true
       privileged: false
@@ -2218,14 +2268,21 @@ vulture:
   ## Configure Pods Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param vulture.podSecurityContext.enabled Enabled Vulture pods' Security Context
+  ## @param vulture.podSecurityContext.fsGroupChangePolicy Set filesystem group change policy
+  ## @param vulture.podSecurityContext.sysctls Set kernel settings using the sysctl interface
+  ## @param vulture.podSecurityContext.supplementalGroups Set filesystem extra groups
   ## @param vulture.podSecurityContext.fsGroup Set Vulture pod's Security Context fsGroup
   ##
   podSecurityContext:
     enabled: true
+    fsGroupChangePolicy: Always
+    sysctls: []
+    supplementalGroups: []
     fsGroup: 1001
   ## Configure Container Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param vulture.containerSecurityContext.enabled Enabled containers' Security Context
+  ## @param vulture.containerSecurityContext.seLinuxOptions Set SELinux options in container
   ## @param vulture.containerSecurityContext.runAsUser Set containers' Security Context runAsUser
   ## @param vulture.containerSecurityContext.runAsNonRoot Set container's Security Context runAsNonRoot
   ## @param vulture.containerSecurityContext.privileged Set container's Security Context privileged
@@ -2236,6 +2293,7 @@ vulture:
   ##
   containerSecurityContext:
     enabled: true
+    seLinuxOptions: {}
     runAsUser: 1001
     runAsNonRoot: true
     privileged: false
@@ -2448,12 +2506,14 @@ volumePermissions:
     requests: {}
   ## Init container Container Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
+  ## @param volumePermissions.containerSecurityContext.seLinuxOptions Set SELinux options in container
   ## @param volumePermissions.containerSecurityContext.runAsUser Set init container's Security Context runAsUser
   ## NOTE: when runAsUser is set to special value "auto", init container will try to chown the
   ##   data folder to auto-determined user&group, using commands: `id -u`:`id -G | cut -d" " -f2`
   ##   "auto" is especially useful for OpenShift which has scc with dynamic user ids (and 0 is not allowed)
   ##
   containerSecurityContext:
+    seLinuxOptions: {}
     runAsUser: 0
 
 ## @section Other Parameters


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

### Description of the change

This PR updates the podSecurityContext and containerSecurityContext fields by setting default values for essential security fields: seLinuxOptions, fsGroupChangePolicy, sysctls and supplementalGroups. These are required by security checklists. 

### Benefits

Charts become more security-compliant

### Possible drawbacks

n/a

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)

