### PR TITLE
[bitnami/jaeger] fix: :lock: Improve podSecurityContext and containerSecurityContext with essential security fields

### DIFF
--- a/bitnami/jaeger/Chart.yaml
+++ b/bitnami/jaeger/Chart.yaml
@@ -34,4 +34,4 @@ maintainers:
 name: jaeger
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/jaeger
-version: 1.5.8
+version: 1.6.0

--- a/bitnami/jaeger/README.md
+++ b/bitnami/jaeger/README.md
@@ -143,8 +143,12 @@ The command removes all the Kubernetes components associated with the chart and 
 | `query.serviceAccount.annotations`                        | Annotations to add to all deployed objects                                                | `{}`             |
 | `query.serviceAccount.automountServiceAccountToken`       | Automount API credentials for a service account.                                          | `false`          |
 | `query.podSecurityContext.enabled`                        | Enabled Jaeger pods' Security Context                                                     | `true`           |
+| `query.podSecurityContext.fsGroupChangePolicy`            | Set filesystem group change policy                                                        | `Always`         |
+| `query.podSecurityContext.sysctls`                        | Set kernel settings using the sysctl interface                                            | `[]`             |
+| `query.podSecurityContext.supplementalGroups`             | Set filesystem extra groups                                                               | `[]`             |
 | `query.podSecurityContext.fsGroup`                        | Set Jaeger pod's Security Context fsGroup                                                 | `1001`           |
 | `query.containerSecurityContext.enabled`                  | Enabled containers' Security Context                                                      | `true`           |
+| `query.containerSecurityContext.seLinuxOptions`           | Set SELinux options in container                                                          | `{}`             |
 | `query.containerSecurityContext.runAsUser`                | Set containers' Security Context runAsUser                                                | `1001`           |
 | `query.containerSecurityContext.runAsNonRoot`             | Set container's Security Context runAsNonRoot                                             | `true`           |
 | `query.containerSecurityContext.privileged`               | Set container's Security Context privileged                                               | `false`          |
@@ -239,8 +243,12 @@ The command removes all the Kubernetes components associated with the chart and 
 | `collector.serviceAccount.annotations`                        | Annotations to add to all deployed objects                                                 | `{}`             |
 | `collector.serviceAccount.automountServiceAccountToken`       | Automount API credentials for a service account.                                           | `false`          |
 | `collector.podSecurityContext.enabled`                        | Enabled Jaeger pods' Security Context                                                      | `true`           |
+| `collector.podSecurityContext.fsGroupChangePolicy`            | Set filesystem group change policy                                                         | `Always`         |
+| `collector.podSecurityContext.sysctls`                        | Set kernel settings using the sysctl interface                                             | `[]`             |
+| `collector.podSecurityContext.supplementalGroups`             | Set filesystem extra groups                                                                | `[]`             |
 | `collector.podSecurityContext.fsGroup`                        | Set Jaeger pod's Security Context fsGroup                                                  | `1001`           |
 | `collector.containerSecurityContext.enabled`                  | Enabled containers' Security Context                                                       | `true`           |
+| `collector.containerSecurityContext.seLinuxOptions`           | Set SELinux options in container                                                           | `{}`             |
 | `collector.containerSecurityContext.runAsUser`                | Set containers' Security Context runAsUser                                                 | `1001`           |
 | `collector.containerSecurityContext.runAsNonRoot`             | Set container's Security Context runAsNonRoot                                              | `true`           |
 | `collector.containerSecurityContext.privileged`               | Set container's Security Context privileged                                                | `false`          |
@@ -332,8 +340,12 @@ The command removes all the Kubernetes components associated with the chart and 
 | `agent.serviceAccount.annotations`                            | Annotations to add to all deployed objects                                                                     | `{}`             |
 | `agent.serviceAccount.automountServiceAccountToken`           | Automount API credentials for a service account.                                                               | `false`          |
 | `agent.podSecurityContext.enabled`                            | Enabled Jaeger pods' Security Context                                                                          | `true`           |
+| `agent.podSecurityContext.fsGroupChangePolicy`                | Set filesystem group change policy                                                                             | `Always`         |
+| `agent.podSecurityContext.sysctls`                            | Set kernel settings using the sysctl interface                                                                 | `[]`             |
+| `agent.podSecurityContext.supplementalGroups`                 | Set filesystem extra groups                                                                                    | `[]`             |
 | `agent.podSecurityContext.fsGroup`                            | Set Jaeger pod's Security Context fsGroup                                                                      | `1001`           |
 | `agent.containerSecurityContext.enabled`                      | Enabled containers' Security Context                                                                           | `true`           |
+| `agent.containerSecurityContext.seLinuxOptions`               | Set SELinux options in container                                                                               | `{}`             |
 | `agent.containerSecurityContext.runAsUser`                    | Set containers' Security Context runAsUser                                                                     | `1001`           |
 | `agent.containerSecurityContext.runAsNonRoot`                 | Set container's Security Context runAsNonRoot                                                                  | `true`           |
 | `agent.containerSecurityContext.privileged`                   | Set container's Security Context privileged                                                                    | `false`          |
@@ -363,8 +375,12 @@ The command removes all the Kubernetes components associated with the chart and 
 | `migration.podAnnotations`                                    | Additional pod annotations                                                                                     | `{}`             |
 | `migration.annotations`                                       | Provide any additional annotations which may be required.                                                      | `{}`             |
 | `migration.podSecurityContext.enabled`                        | Enabled Jaeger pods' Security Context                                                                          | `true`           |
+| `migration.podSecurityContext.fsGroupChangePolicy`            | Set filesystem group change policy                                                                             | `Always`         |
+| `migration.podSecurityContext.sysctls`                        | Set kernel settings using the sysctl interface                                                                 | `[]`             |
+| `migration.podSecurityContext.supplementalGroups`             | Set filesystem extra groups                                                                                    | `[]`             |
 | `migration.podSecurityContext.fsGroup`                        | Set Jaeger pod's Security Context fsGroup                                                                      | `1001`           |
 | `migration.containerSecurityContext.enabled`                  | Enabled containers' Security Context                                                                           | `true`           |
+| `migration.containerSecurityContext.seLinuxOptions`           | Set SELinux options in container                                                                               | `{}`             |
 | `migration.containerSecurityContext.runAsUser`                | Set containers' Security Context runAsUser                                                                     | `1001`           |
 | `migration.containerSecurityContext.runAsNonRoot`             | Set container's Security Context runAsNonRoot                                                                  | `true`           |
 | `migration.containerSecurityContext.privileged`               | Set container's Security Context privileged                                                                    | `false`          |

--- a/bitnami/jaeger/values.yaml
+++ b/bitnami/jaeger/values.yaml
@@ -294,14 +294,21 @@ query:
   ## Pod security context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param query.podSecurityContext.enabled Enabled Jaeger pods' Security Context
+  ## @param query.podSecurityContext.fsGroupChangePolicy Set filesystem group change policy
+  ## @param query.podSecurityContext.sysctls Set kernel settings using the sysctl interface
+  ## @param query.podSecurityContext.supplementalGroups Set filesystem extra groups
   ## @param query.podSecurityContext.fsGroup Set Jaeger pod's Security Context fsGroup
   ##
   podSecurityContext:
     enabled: true
+    fsGroupChangePolicy: Always
+    sysctls: []
+    supplementalGroups: []
     fsGroup: 1001
   ## Configure Container Security Context (only main container)
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
   ## @param query.containerSecurityContext.enabled Enabled containers' Security Context
+  ## @param query.containerSecurityContext.seLinuxOptions Set SELinux options in container
   ## @param query.containerSecurityContext.runAsUser Set containers' Security Context runAsUser
   ## @param query.containerSecurityContext.runAsNonRoot Set container's Security Context runAsNonRoot
   ## @param query.containerSecurityContext.privileged Set container's Security Context privileged
@@ -312,6 +319,7 @@ query:
   ##
   containerSecurityContext:
     enabled: true
+    seLinuxOptions: {}
     runAsUser: 1001
     runAsNonRoot: true
     privileged: false
@@ -648,14 +656,21 @@ collector:
   ## Pod security context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param collector.podSecurityContext.enabled Enabled Jaeger pods' Security Context
+  ## @param collector.podSecurityContext.fsGroupChangePolicy Set filesystem group change policy
+  ## @param collector.podSecurityContext.sysctls Set kernel settings using the sysctl interface
+  ## @param collector.podSecurityContext.supplementalGroups Set filesystem extra groups
   ## @param collector.podSecurityContext.fsGroup Set Jaeger pod's Security Context fsGroup
   ##
   podSecurityContext:
     enabled: true
+    fsGroupChangePolicy: Always
+    sysctls: []
+    supplementalGroups: []
     fsGroup: 1001
   ## Configure Container Security Context (only main container)
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
   ## @param collector.containerSecurityContext.enabled Enabled containers' Security Context
+  ## @param collector.containerSecurityContext.seLinuxOptions Set SELinux options in container
   ## @param collector.containerSecurityContext.runAsUser Set containers' Security Context runAsUser
   ## @param collector.containerSecurityContext.runAsNonRoot Set container's Security Context runAsNonRoot
   ## @param collector.containerSecurityContext.privileged Set container's Security Context privileged
@@ -666,6 +681,7 @@ collector:
   ##
   containerSecurityContext:
     enabled: true
+    seLinuxOptions: {}
     runAsUser: 1001
     runAsNonRoot: true
     privileged: false
@@ -984,14 +1000,21 @@ agent:
   ## Pod security context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param agent.podSecurityContext.enabled Enabled Jaeger pods' Security Context
+  ## @param agent.podSecurityContext.fsGroupChangePolicy Set filesystem group change policy
+  ## @param agent.podSecurityContext.sysctls Set kernel settings using the sysctl interface
+  ## @param agent.podSecurityContext.supplementalGroups Set filesystem extra groups
   ## @param agent.podSecurityContext.fsGroup Set Jaeger pod's Security Context fsGroup
   ##
   podSecurityContext:
     enabled: true
+    fsGroupChangePolicy: Always
+    sysctls: []
+    supplementalGroups: []
     fsGroup: 1001
   ## Configure Container Security Context (only main container)
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
   ## @param agent.containerSecurityContext.enabled Enabled containers' Security Context
+  ## @param agent.containerSecurityContext.seLinuxOptions Set SELinux options in container
   ## @param agent.containerSecurityContext.runAsUser Set containers' Security Context runAsUser
   ## @param agent.containerSecurityContext.runAsNonRoot Set container's Security Context runAsNonRoot
   ## @param agent.containerSecurityContext.privileged Set container's Security Context privileged
@@ -1002,6 +1025,7 @@ agent:
   ##
   containerSecurityContext:
     enabled: true
+    seLinuxOptions: {}
     runAsUser: 1001
     runAsNonRoot: true
     privileged: false
@@ -1105,13 +1129,20 @@ migration:
   ## Pod security context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param migration.podSecurityContext.enabled Enabled Jaeger pods' Security Context
+  ## @param migration.podSecurityContext.fsGroupChangePolicy Set filesystem group change policy
+  ## @param migration.podSecurityContext.sysctls Set kernel settings using the sysctl interface
+  ## @param migration.podSecurityContext.supplementalGroups Set filesystem extra groups
   ## @param migration.podSecurityContext.fsGroup Set Jaeger pod's Security Context fsGroup
   ##
   podSecurityContext:
     enabled: true
+    fsGroupChangePolicy: Always
+    sysctls: []
+    supplementalGroups: []
     fsGroup: 1001
 
   ## @param migration.containerSecurityContext.enabled Enabled containers' Security Context
+  ## @param migration.containerSecurityContext.seLinuxOptions Set SELinux options in container
   ## @param migration.containerSecurityContext.runAsUser Set containers' Security Context runAsUser
   ## @param migration.containerSecurityContext.runAsNonRoot Set container's Security Context runAsNonRoot
   ## @param migration.containerSecurityContext.privileged Set container's Security Context privileged
@@ -1121,6 +1152,7 @@ migration:
   ## @param migration.containerSecurityContext.seccompProfile.type Set container's Security Context seccomp profile
   containerSecurityContext:
     enabled: true
+    seLinuxOptions: {}
     runAsUser: 1001
     runAsNonRoot: true
     privileged: false


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

### Description of the change

This PR updates the podSecurityContext and containerSecurityContext fields by setting default values for essential security fields: seLinuxOptions, fsGroupChangePolicy, sysctls and supplementalGroups. These are required by security checklists. 

### Benefits

Charts become more security-compliant

### Possible drawbacks

n/a

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)

