### PR TITLE
[bitnami/jenkins] fix: :lock: Improve podSecurityContext and containerSecurityContext with essential security fields

### DIFF
--- a/bitnami/jenkins/Chart.yaml
+++ b/bitnami/jenkins/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: jenkins
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/jenkins
-version: 12.4.8
+version: 12.5.0

--- a/bitnami/jenkins/README.md
+++ b/bitnami/jenkins/README.md
@@ -155,6 +155,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `configAsCode.autoReload.extraEnvVarsCM`                                    |                                                                                                         | `""`                            |
 | `configAsCode.autoReload.extraVolumeMounts`                                 |                                                                                                         | `[]`                            |
 | `configAsCode.autoReload.containerSecurityContext.enabled`                  | Enabled containers' Security Context                                                                    | `true`                          |
+| `configAsCode.autoReload.containerSecurityContext.seLinuxOptions`           | Set SELinux options in container                                                                        | `{}`                            |
 | `configAsCode.autoReload.containerSecurityContext.runAsUser`                | Set containers' Security Context runAsUser                                                              | `1001`                          |
 | `configAsCode.autoReload.containerSecurityContext.runAsNonRoot`             | Set container's Security Context runAsNonRoot                                                           | `true`                          |
 | `configAsCode.autoReload.containerSecurityContext.privileged`               | Set container's Security Context privileged                                                             | `false`                         |
@@ -182,6 +183,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `agent.resources.limits`                                                    | The resources limits for the Jenkins container                                                          | `{}`                            |
 | `agent.resources.requests`                                                  | The requested resources for the Jenkins container                                                       | `{}`                            |
 | `agent.containerSecurityContext.enabled`                                    | Enable container security context                                                                       | `false`                         |
+| `agent.containerSecurityContext.seLinuxOptions`                             | Set SELinux options in container                                                                        | `{}`                            |
 | `agent.containerSecurityContext.runAsUser`                                  | User ID for the agent container                                                                         | `""`                            |
 | `agent.containerSecurityContext.runAsGroup`                                 | User ID for the agent container                                                                         | `""`                            |
 | `agent.containerSecurityContext.privileged`                                 | Decide if the container runs privileged.                                                                | `false`                         |
@@ -216,8 +218,12 @@ The command removes all the Kubernetes components associated with the chart and 
 | `containerPorts.https`                              | Jenkins HTTPS container port                                                              | `8443`           |
 | `containerPorts.agentListener`                      | Jenkins agent listener port, ignored if agent.enabled=false                               | `50000`          |
 | `podSecurityContext.enabled`                        | Enabled Jenkins pods' Security Context                                                    | `true`           |
+| `podSecurityContext.fsGroupChangePolicy`            | Set filesystem group change policy                                                        | `Always`         |
+| `podSecurityContext.sysctls`                        | Set kernel settings using the sysctl interface                                            | `[]`             |
+| `podSecurityContext.supplementalGroups`             | Set filesystem extra groups                                                               | `[]`             |
 | `podSecurityContext.fsGroup`                        | Set Jenkins pod's Security Context fsGroup                                                | `1001`           |
 | `containerSecurityContext.enabled`                  | Enabled containers' Security Context                                                      | `true`           |
+| `containerSecurityContext.seLinuxOptions`           | Set SELinux options in container                                                          | `{}`             |
 | `containerSecurityContext.runAsUser`                | Set containers' Security Context runAsUser                                                | `1001`           |
 | `containerSecurityContext.runAsNonRoot`             | Set container's Security Context runAsNonRoot                                             | `true`           |
 | `containerSecurityContext.privileged`               | Set container's Security Context privileged                                               | `false`          |
@@ -293,24 +299,25 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Persistence Parameters
 
-| Name                                          | Description                                                                                                        | Value                      |
-| --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ | -------------------------- |
-| `persistence.enabled`                         | Enable persistence using Persistent Volume Claims                                                                  | `true`                     |
-| `persistence.storageClass`                    | Persistent Volume storage class                                                                                    | `""`                       |
-| `persistence.existingClaim`                   | Use a existing PVC which must be created manually before bound                                                     | `""`                       |
-| `persistence.annotations`                     | Additional custom annotations for the PVC                                                                          | `{}`                       |
-| `persistence.accessModes`                     | Persistent Volume access modes                                                                                     | `[]`                       |
-| `persistence.size`                            | Persistent Volume size                                                                                             | `8Gi`                      |
-| `persistence.selector`                        | Selector to match an existing Persistent Volume for Ingester's data PVC                                            | `{}`                       |
-| `volumePermissions.enabled`                   | Enable init container that changes the owner/group of the PV mount point to `runAsUser:fsGroup`                    | `false`                    |
-| `volumePermissions.image.registry`            | OS Shell + Utility image registry                                                                                  | `REGISTRY_NAME`            |
-| `volumePermissions.image.repository`          | OS Shell + Utility image repository                                                                                | `REPOSITORY_NAME/os-shell` |
-| `volumePermissions.image.digest`              | OS Shell + Utility image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                       |
-| `volumePermissions.image.pullPolicy`          | OS Shell + Utility image pull policy                                                                               | `IfNotPresent`             |
-| `volumePermissions.image.pullSecrets`         | OS Shell + Utility image pull secrets                                                                              | `[]`                       |
-| `volumePermissions.resources.limits`          | The resources limits for the init container                                                                        | `{}`                       |
-| `volumePermissions.resources.requests`        | The requested resources for the init container                                                                     | `{}`                       |
-| `volumePermissions.securityContext.runAsUser` | Set init container's Security Context runAsUser                                                                    | `0`                        |
+| Name                                               | Description                                                                                                        | Value                      |
+| -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ | -------------------------- |
+| `persistence.enabled`                              | Enable persistence using Persistent Volume Claims                                                                  | `true`                     |
+| `persistence.storageClass`                         | Persistent Volume storage class                                                                                    | `""`                       |
+| `persistence.existingClaim`                        | Use a existing PVC which must be created manually before bound                                                     | `""`                       |
+| `persistence.annotations`                          | Additional custom annotations for the PVC                                                                          | `{}`                       |
+| `persistence.accessModes`                          | Persistent Volume access modes                                                                                     | `[]`                       |
+| `persistence.size`                                 | Persistent Volume size                                                                                             | `8Gi`                      |
+| `persistence.selector`                             | Selector to match an existing Persistent Volume for Ingester's data PVC                                            | `{}`                       |
+| `volumePermissions.enabled`                        | Enable init container that changes the owner/group of the PV mount point to `runAsUser:fsGroup`                    | `false`                    |
+| `volumePermissions.image.registry`                 | OS Shell + Utility image registry                                                                                  | `REGISTRY_NAME`            |
+| `volumePermissions.image.repository`               | OS Shell + Utility image repository                                                                                | `REPOSITORY_NAME/os-shell` |
+| `volumePermissions.image.digest`                   | OS Shell + Utility image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                       |
+| `volumePermissions.image.pullPolicy`               | OS Shell + Utility image pull policy                                                                               | `IfNotPresent`             |
+| `volumePermissions.image.pullSecrets`              | OS Shell + Utility image pull secrets                                                                              | `[]`                       |
+| `volumePermissions.resources.limits`               | The resources limits for the init container                                                                        | `{}`                       |
+| `volumePermissions.resources.requests`             | The requested resources for the init container                                                                     | `{}`                       |
+| `volumePermissions.securityContext.seLinuxOptions` | Set SELinux options in container                                                                                   | `{}`                       |
+| `volumePermissions.securityContext.runAsUser`      | Set init container's Security Context runAsUser                                                                    | `0`                        |
 
 ### Other Parameters
 

--- a/bitnami/jenkins/values.yaml
+++ b/bitnami/jenkins/values.yaml
@@ -313,6 +313,7 @@ configAsCode:
     ## Configure Container Security Context
     ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
     ## @param configAsCode.autoReload.containerSecurityContext.enabled Enabled containers' Security Context
+    ## @param configAsCode.autoReload.containerSecurityContext.seLinuxOptions Set SELinux options in container
     ## @param configAsCode.autoReload.containerSecurityContext.runAsUser Set containers' Security Context runAsUser
     ## @param configAsCode.autoReload.containerSecurityContext.runAsNonRoot Set container's Security Context runAsNonRoot
     ## @param configAsCode.autoReload.containerSecurityContext.privileged Set container's Security Context privileged
@@ -323,6 +324,7 @@ configAsCode:
     ##
     containerSecurityContext:
       enabled: true
+      seLinuxOptions: {}
       runAsUser: 1001
       runAsNonRoot: true
       privileged: false
@@ -416,12 +418,14 @@ agent:
   ## Container securityContext
   ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
   ## @param agent.containerSecurityContext.enabled Enable container security context
+  ## @param agent.containerSecurityContext.seLinuxOptions Set SELinux options in container
   ## @param agent.containerSecurityContext.runAsUser User ID for the agent container
   ## @param agent.containerSecurityContext.runAsGroup User ID for the agent container
   ## @param agent.containerSecurityContext.privileged Decide if the container runs privileged.
   ##
   containerSecurityContext:
     enabled: false
+    seLinuxOptions: {}
     runAsUser: ""
     runAsGroup: ""
     privileged: false
@@ -557,14 +561,21 @@ containerPorts:
 ## Configure Pods Security Context
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
 ## @param podSecurityContext.enabled Enabled Jenkins pods' Security Context
+## @param podSecurityContext.fsGroupChangePolicy Set filesystem group change policy
+## @param podSecurityContext.sysctls Set kernel settings using the sysctl interface
+## @param podSecurityContext.supplementalGroups Set filesystem extra groups
 ## @param podSecurityContext.fsGroup Set Jenkins pod's Security Context fsGroup
 ##
 podSecurityContext:
   enabled: true
+  fsGroupChangePolicy: Always
+  sysctls: []
+  supplementalGroups: []
   fsGroup: 1001
 ## Configure Container Security Context (only main container)
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
 ## @param containerSecurityContext.enabled Enabled containers' Security Context
+## @param containerSecurityContext.seLinuxOptions Set SELinux options in container
 ## @param containerSecurityContext.runAsUser Set containers' Security Context runAsUser
 ## @param containerSecurityContext.runAsNonRoot Set container's Security Context runAsNonRoot
 ## @param containerSecurityContext.privileged Set container's Security Context privileged
@@ -575,6 +586,7 @@ podSecurityContext:
 ##
 containerSecurityContext:
   enabled: true
+  seLinuxOptions: {}
   runAsUser: 1001
   runAsNonRoot: true
   privileged: false
@@ -941,12 +953,14 @@ volumePermissions:
     requests: {}
   ## Init container Container Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
+  ## @param volumePermissions.securityContext.seLinuxOptions Set SELinux options in container
   ## @param volumePermissions.securityContext.runAsUser Set init container's Security Context runAsUser
   ## NOTE: when runAsUser is set to special value "auto", init container will try to chown the
   ##   data folder to auto-determined user&group, using commands: `id -u`:`id -G | cut -d" " -f2`
   ##   "auto" is especially useful for OpenShift which has scc with dynamic user ids (and 0 is not allowed)
   ##
   securityContext:
+    seLinuxOptions: {}
     runAsUser: 0
 
 ## @section Other Parameters


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

### Description of the change

This PR updates the podSecurityContext and containerSecurityContext fields by setting default values for essential security fields: seLinuxOptions, fsGroupChangePolicy, sysctls and supplementalGroups. These are required by security checklists. 

### Benefits

Charts become more security-compliant

### Possible drawbacks

n/a

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)

