### PR TITLE
[bitnami/kong] fix: :lock: Improve podSecurityContext and containerSecurityContext with essential security fields

### DIFF
--- a/bitnami/kong/Chart.yaml
+++ b/bitnami/kong/Chart.yaml
@@ -45,4 +45,4 @@ maintainers:
 name: kong
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/kong
-version: 10.2.0
+version: 10.3.0

--- a/bitnami/kong/README.md
+++ b/bitnami/kong/README.md
@@ -96,6 +96,7 @@ helm delete my-release
 | `useDaemonset`                                      | Use a daemonset instead of a deployment. `replicaCount` will not take effect.                                                      | `false`          |
 | `replicaCount`                                      | Number of Kong replicas                                                                                                            | `2`              |
 | `containerSecurityContext.enabled`                  | Enabled containers' Security Context                                                                                               | `true`           |
+| `containerSecurityContext.seLinuxOptions`           | Set SELinux options in container                                                                                                   | `{}`             |
 | `containerSecurityContext.runAsUser`                | Set containers' Security Context runAsUser                                                                                         | `1001`           |
 | `containerSecurityContext.runAsNonRoot`             | Set container's Security Context runAsNonRoot                                                                                      | `true`           |
 | `containerSecurityContext.privileged`               | Set container's Security Context privileged                                                                                        | `false`          |
@@ -104,6 +105,9 @@ helm delete my-release
 | `containerSecurityContext.capabilities.drop`        | List of capabilities to be dropped                                                                                                 | `["ALL"]`        |
 | `containerSecurityContext.seccompProfile.type`      | Set container's Security Context seccomp profile                                                                                   | `RuntimeDefault` |
 | `podSecurityContext.enabled`                        | Enabled Kong pods' Security Context                                                                                                | `false`          |
+| `podSecurityContext.fsGroupChangePolicy`            | Set filesystem group change policy                                                                                                 | `Always`         |
+| `podSecurityContext.sysctls`                        | Set kernel settings using the sysctl interface                                                                                     | `[]`             |
+| `podSecurityContext.supplementalGroups`             | Set filesystem extra groups                                                                                                        | `[]`             |
 | `podSecurityContext.fsGroup`                        | Set Kong pod's Security Context fsGroup                                                                                            | `1001`           |
 | `updateStrategy.type`                               | Kong update strategy                                                                                                               | `RollingUpdate`  |
 | `updateStrategy.rollingUpdate`                      | Kong deployment rolling update configuration parameters                                                                            | `{}`             |

--- a/bitnami/kong/values.yaml
+++ b/bitnami/kong/values.yaml
@@ -109,6 +109,7 @@ replicaCount: 2
 ## Kong containers' Security Context
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
 ## @param containerSecurityContext.enabled Enabled containers' Security Context
+## @param containerSecurityContext.seLinuxOptions Set SELinux options in container
 ## @param containerSecurityContext.runAsUser Set containers' Security Context runAsUser
 ## @param containerSecurityContext.runAsNonRoot Set container's Security Context runAsNonRoot
 ## @param containerSecurityContext.privileged Set container's Security Context privileged
@@ -119,6 +120,7 @@ replicaCount: 2
 ##
 containerSecurityContext:
   enabled: true
+  seLinuxOptions: {}
   runAsUser: 1001
   runAsNonRoot: true
   privileged: false
@@ -131,10 +133,16 @@ containerSecurityContext:
 ## Kong pods' Security Context
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
 ## @param podSecurityContext.enabled Enabled Kong pods' Security Context
+## @param podSecurityContext.fsGroupChangePolicy Set filesystem group change policy
+## @param podSecurityContext.sysctls Set kernel settings using the sysctl interface
+## @param podSecurityContext.supplementalGroups Set filesystem extra groups
 ## @param podSecurityContext.fsGroup Set Kong pod's Security Context fsGroup
 ##
 podSecurityContext:
   enabled: false
+  fsGroupChangePolicy: Always
+  sysctls: []
+  supplementalGroups: []
   fsGroup: 1001
 ## @param updateStrategy.type Kong update strategy
 ## @param updateStrategy.rollingUpdate Kong deployment rolling update configuration parameters


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

### Description of the change

This PR updates the podSecurityContext and containerSecurityContext fields by setting default values for essential security fields: seLinuxOptions, fsGroupChangePolicy, sysctls and supplementalGroups. These are required by security checklists. 

### Benefits

Charts become more security-compliant

### Possible drawbacks

n/a

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)

