### PR TITLE
[bitnami/mastodon] fix: :lock: Improve podSecurityContext and containerSecurityContext with essential security fields

### DIFF
--- a/bitnami/mastodon/Chart.yaml
+++ b/bitnami/mastodon/Chart.yaml
@@ -49,4 +49,4 @@ maintainers:
 name: mastodon
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/mastodon
-version: 4.0.4
+version: 4.1.0

--- a/bitnami/mastodon/README.md
+++ b/bitnami/mastodon/README.md
@@ -163,8 +163,12 @@ The command removes all the Kubernetes components associated with the chart and 
 | `web.resources.limits`                                  | The resources limits for the Mastodon web containers                                                                     | `{}`             |
 | `web.resources.requests`                                | The requested resources for the Mastodon web containers                                                                  | `{}`             |
 | `web.podSecurityContext.enabled`                        | Enabled Mastodon web pods' Security Context                                                                              | `true`           |
+| `web.podSecurityContext.fsGroupChangePolicy`            | Set filesystem group change policy                                                                                       | `Always`         |
+| `web.podSecurityContext.sysctls`                        | Set kernel settings using the sysctl interface                                                                           | `[]`             |
+| `web.podSecurityContext.supplementalGroups`             | Set filesystem extra groups                                                                                              | `[]`             |
 | `web.podSecurityContext.fsGroup`                        | Set Mastodon web pod's Security Context fsGroup                                                                          | `1001`           |
 | `web.containerSecurityContext.enabled`                  | Enabled containers' Security Context                                                                                     | `true`           |
+| `web.containerSecurityContext.seLinuxOptions`           | Set SELinux options in container                                                                                         | `{}`             |
 | `web.containerSecurityContext.runAsUser`                | Set containers' Security Context runAsUser                                                                               | `1001`           |
 | `web.containerSecurityContext.runAsNonRoot`             | Set container's Security Context runAsNonRoot                                                                            | `true`           |
 | `web.containerSecurityContext.privileged`               | Set container's Security Context privileged                                                                              | `false`          |
@@ -244,8 +248,12 @@ The command removes all the Kubernetes components associated with the chart and 
 | `sidekiq.resources.limits`                                  | The resources limits for the Mastodon sidekiq containers                                                                 | `{}`             |
 | `sidekiq.resources.requests`                                | The requested resources for the Mastodon sidekiq containers                                                              | `{}`             |
 | `sidekiq.podSecurityContext.enabled`                        | Enabled Mastodon sidekiq pods' Security Context                                                                          | `true`           |
+| `sidekiq.podSecurityContext.fsGroupChangePolicy`            | Set filesystem group change policy                                                                                       | `Always`         |
+| `sidekiq.podSecurityContext.sysctls`                        | Set kernel settings using the sysctl interface                                                                           | `[]`             |
+| `sidekiq.podSecurityContext.supplementalGroups`             | Set filesystem extra groups                                                                                              | `[]`             |
 | `sidekiq.podSecurityContext.fsGroup`                        | Set Mastodon sidekiq pod's Security Context fsGroup                                                                      | `1001`           |
 | `sidekiq.containerSecurityContext.enabled`                  | Enabled containers' Security Context                                                                                     | `true`           |
+| `sidekiq.containerSecurityContext.seLinuxOptions`           | Set SELinux options in container                                                                                         | `{}`             |
 | `sidekiq.containerSecurityContext.runAsUser`                | Set containers' Security Context runAsUser                                                                               | `1001`           |
 | `sidekiq.containerSecurityContext.runAsNonRoot`             | Set container's Security Context runAsNonRoot                                                                            | `true`           |
 | `sidekiq.containerSecurityContext.privileged`               | Set container's Security Context privileged                                                                              | `false`          |
@@ -310,8 +318,12 @@ The command removes all the Kubernetes components associated with the chart and 
 | `streaming.resources.limits`                                  | The resources limits for the Mastodon streaming containers                                                               | `{}`             |
 | `streaming.resources.requests`                                | The requested resources for the Mastodon streaming containers                                                            | `{}`             |
 | `streaming.podSecurityContext.enabled`                        | Enabled Mastodon streaming pods' Security Context                                                                        | `true`           |
+| `streaming.podSecurityContext.fsGroupChangePolicy`            | Set filesystem group change policy                                                                                       | `Always`         |
+| `streaming.podSecurityContext.sysctls`                        | Set kernel settings using the sysctl interface                                                                           | `[]`             |
+| `streaming.podSecurityContext.supplementalGroups`             | Set filesystem extra groups                                                                                              | `[]`             |
 | `streaming.podSecurityContext.fsGroup`                        | Set Mastodon streaming pod's Security Context fsGroup                                                                    | `1001`           |
 | `streaming.containerSecurityContext.enabled`                  | Enabled containers' Security Context                                                                                     | `true`           |
+| `streaming.containerSecurityContext.seLinuxOptions`           | Set SELinux options in container                                                                                         | `{}`             |
 | `streaming.containerSecurityContext.runAsUser`                | Set containers' Security Context runAsUser                                                                               | `1001`           |
 | `streaming.containerSecurityContext.runAsNonRoot`             | Set container's Security Context runAsNonRoot                                                                            | `true`           |
 | `streaming.containerSecurityContext.privileged`               | Set container's Security Context privileged                                                                              | `false`          |
@@ -394,6 +406,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `initJob.backoffLimit`                                      | set backoff limit of the job                                                                                                   | `10`             |
 | `initJob.extraVolumes`                                      | Optionally specify extra list of additional volumes for the Mastodon init job                                                  | `[]`             |
 | `initJob.containerSecurityContext.enabled`                  | Enabled containers' Security Context                                                                                           | `true`           |
+| `initJob.containerSecurityContext.seLinuxOptions`           | Set SELinux options in container                                                                                               | `{}`             |
 | `initJob.containerSecurityContext.runAsUser`                | Set containers' Security Context runAsUser                                                                                     | `1001`           |
 | `initJob.containerSecurityContext.runAsNonRoot`             | Set container's Security Context runAsNonRoot                                                                                  | `true`           |
 | `initJob.containerSecurityContext.privileged`               | Set container's Security Context privileged                                                                                    | `false`          |
@@ -402,6 +415,9 @@ The command removes all the Kubernetes components associated with the chart and 
 | `initJob.containerSecurityContext.capabilities.drop`        | List of capabilities to be dropped                                                                                             | `["ALL"]`        |
 | `initJob.containerSecurityContext.seccompProfile.type`      | Set container's Security Context seccomp profile                                                                               | `RuntimeDefault` |
 | `initJob.podSecurityContext.enabled`                        | Enabled Mastodon init job pods' Security Context                                                                               | `true`           |
+| `initJob.podSecurityContext.fsGroupChangePolicy`            | Set filesystem group change policy                                                                                             | `Always`         |
+| `initJob.podSecurityContext.sysctls`                        | Set kernel settings using the sysctl interface                                                                                 | `[]`             |
+| `initJob.podSecurityContext.supplementalGroups`             | Set filesystem extra groups                                                                                                    | `[]`             |
 | `initJob.podSecurityContext.fsGroup`                        | Set Mastodon init job pod's Security Context fsGroup                                                                           | `1001`           |
 | `initJob.extraEnvVars`                                      | Array containing extra env vars to configure the Mastodon init job                                                             | `[]`             |
 | `initJob.extraEnvVarsCM`                                    | ConfigMap containing extra env vars to configure the Mastodon init job                                                         | `""`             |
@@ -431,16 +447,17 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Init Container Parameters
 
-| Name                                                   | Description                                                                                     | Value                      |
-| ------------------------------------------------------ | ----------------------------------------------------------------------------------------------- | -------------------------- |
-| `volumePermissions.enabled`                            | Enable init container that changes the owner/group of the PV mount point to `runAsUser:fsGroup` | `false`                    |
-| `volumePermissions.image.registry`                     | OS Shell + Utility image registry                                                               | `REGISTRY_NAME`            |
-| `volumePermissions.image.repository`                   | OS Shell + Utility image repository                                                             | `REPOSITORY_NAME/os-shell` |
-| `volumePermissions.image.pullPolicy`                   | OS Shell + Utility image pull policy                                                            | `IfNotPresent`             |
-| `volumePermissions.image.pullSecrets`                  | OS Shell + Utility image pull secrets                                                           | `[]`                       |
-| `volumePermissions.resources.limits`                   | The resources limits for the init container                                                     | `{}`                       |
-| `volumePermissions.resources.requests`                 | The requested resources for the init container                                                  | `{}`                       |
-| `volumePermissions.containerSecurityContext.runAsUser` | Set init container's Security Context runAsUser                                                 | `0`                        |
+| Name                                                        | Description                                                                                     | Value                      |
+| ----------------------------------------------------------- | ----------------------------------------------------------------------------------------------- | -------------------------- |
+| `volumePermissions.enabled`                                 | Enable init container that changes the owner/group of the PV mount point to `runAsUser:fsGroup` | `false`                    |
+| `volumePermissions.image.registry`                          | OS Shell + Utility image registry                                                               | `REGISTRY_NAME`            |
+| `volumePermissions.image.repository`                        | OS Shell + Utility image repository                                                             | `REPOSITORY_NAME/os-shell` |
+| `volumePermissions.image.pullPolicy`                        | OS Shell + Utility image pull policy                                                            | `IfNotPresent`             |
+| `volumePermissions.image.pullSecrets`                       | OS Shell + Utility image pull secrets                                                           | `[]`                       |
+| `volumePermissions.resources.limits`                        | The resources limits for the init container                                                     | `{}`                       |
+| `volumePermissions.resources.requests`                      | The requested resources for the init container                                                  | `{}`                       |
+| `volumePermissions.containerSecurityContext.seLinuxOptions` | Set SELinux options in container                                                                | `{}`                       |
+| `volumePermissions.containerSecurityContext.runAsUser`      | Set init container's Security Context runAsUser                                                 | `0`                        |
 
 ### Other Parameters
 

--- a/bitnami/mastodon/values.yaml
+++ b/bitnami/mastodon/values.yaml
@@ -314,14 +314,21 @@ web:
   ## Configure Pods Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param web.podSecurityContext.enabled Enabled Mastodon web pods' Security Context
+  ## @param web.podSecurityContext.fsGroupChangePolicy Set filesystem group change policy
+  ## @param web.podSecurityContext.sysctls Set kernel settings using the sysctl interface
+  ## @param web.podSecurityContext.supplementalGroups Set filesystem extra groups
   ## @param web.podSecurityContext.fsGroup Set Mastodon web pod's Security Context fsGroup
   ##
   podSecurityContext:
     enabled: true
+    fsGroupChangePolicy: Always
+    sysctls: []
+    supplementalGroups: []
     fsGroup: 1001
   ## Configure Container Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
   ## @param web.containerSecurityContext.enabled Enabled containers' Security Context
+  ## @param web.containerSecurityContext.seLinuxOptions Set SELinux options in container
   ## @param web.containerSecurityContext.runAsUser Set containers' Security Context runAsUser
   ## @param web.containerSecurityContext.runAsNonRoot Set container's Security Context runAsNonRoot
   ## @param web.containerSecurityContext.privileged Set container's Security Context privileged
@@ -332,6 +339,7 @@ web:
   ##
   containerSecurityContext:
     enabled: true
+    seLinuxOptions: {}
     runAsUser: 1001
     runAsNonRoot: true
     privileged: false
@@ -592,14 +600,21 @@ sidekiq:
   ## Configure Pods Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param sidekiq.podSecurityContext.enabled Enabled Mastodon sidekiq pods' Security Context
+  ## @param sidekiq.podSecurityContext.fsGroupChangePolicy Set filesystem group change policy
+  ## @param sidekiq.podSecurityContext.sysctls Set kernel settings using the sysctl interface
+  ## @param sidekiq.podSecurityContext.supplementalGroups Set filesystem extra groups
   ## @param sidekiq.podSecurityContext.fsGroup Set Mastodon sidekiq pod's Security Context fsGroup
   ##
   podSecurityContext:
     enabled: true
+    fsGroupChangePolicy: Always
+    sysctls: []
+    supplementalGroups: []
     fsGroup: 1001
   ## Configure Container Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
   ## @param sidekiq.containerSecurityContext.enabled Enabled containers' Security Context
+  ## @param sidekiq.containerSecurityContext.seLinuxOptions Set SELinux options in container
   ## @param sidekiq.containerSecurityContext.runAsUser Set containers' Security Context runAsUser
   ## @param sidekiq.containerSecurityContext.runAsNonRoot Set container's Security Context runAsNonRoot
   ## @param sidekiq.containerSecurityContext.privileged Set container's Security Context privileged
@@ -610,6 +625,7 @@ sidekiq:
   ##
   containerSecurityContext:
     enabled: true
+    seLinuxOptions: {}
     runAsUser: 1001
     runAsNonRoot: true
     privileged: false
@@ -820,14 +836,21 @@ streaming:
   ## Configure Pods Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param streaming.podSecurityContext.enabled Enabled Mastodon streaming pods' Security Context
+  ## @param streaming.podSecurityContext.fsGroupChangePolicy Set filesystem group change policy
+  ## @param streaming.podSecurityContext.sysctls Set kernel settings using the sysctl interface
+  ## @param streaming.podSecurityContext.supplementalGroups Set filesystem extra groups
   ## @param streaming.podSecurityContext.fsGroup Set Mastodon streaming pod's Security Context fsGroup
   ##
   podSecurityContext:
     enabled: true
+    fsGroupChangePolicy: Always
+    sysctls: []
+    supplementalGroups: []
     fsGroup: 1001
   ## Configure Container Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
   ## @param streaming.containerSecurityContext.enabled Enabled containers' Security Context
+  ## @param streaming.containerSecurityContext.seLinuxOptions Set SELinux options in container
   ## @param streaming.containerSecurityContext.runAsUser Set containers' Security Context runAsUser
   ## @param streaming.containerSecurityContext.runAsNonRoot Set container's Security Context runAsNonRoot
   ## @param streaming.containerSecurityContext.privileged Set container's Security Context privileged
@@ -838,6 +861,7 @@ streaming:
   ##
   containerSecurityContext:
     enabled: true
+    seLinuxOptions: {}
     runAsUser: 1001
     runAsNonRoot: true
     privileged: false
@@ -1090,6 +1114,7 @@ initJob:
   ## Configure Container Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
   ## @param initJob.containerSecurityContext.enabled Enabled containers' Security Context
+  ## @param initJob.containerSecurityContext.seLinuxOptions Set SELinux options in container
   ## @param initJob.containerSecurityContext.runAsUser Set containers' Security Context runAsUser
   ## @param initJob.containerSecurityContext.runAsNonRoot Set container's Security Context runAsNonRoot
   ## @param initJob.containerSecurityContext.privileged Set container's Security Context privileged
@@ -1100,6 +1125,7 @@ initJob:
   ##
   containerSecurityContext:
     enabled: true
+    seLinuxOptions: {}
     runAsUser: 1001
     runAsNonRoot: true
     privileged: false
@@ -1112,10 +1138,16 @@ initJob:
   ## Configure Pods Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param initJob.podSecurityContext.enabled Enabled Mastodon init job pods' Security Context
+  ## @param initJob.podSecurityContext.fsGroupChangePolicy Set filesystem group change policy
+  ## @param initJob.podSecurityContext.sysctls Set kernel settings using the sysctl interface
+  ## @param initJob.podSecurityContext.supplementalGroups Set filesystem extra groups
   ## @param initJob.podSecurityContext.fsGroup Set Mastodon init job pod's Security Context fsGroup
   ##
   podSecurityContext:
     enabled: true
+    fsGroupChangePolicy: Always
+    sysctls: []
+    supplementalGroups: []
     fsGroup: 1001
   ## @param initJob.extraEnvVars Array containing extra env vars to configure the Mastodon init job
   ## For example:
@@ -1250,12 +1282,14 @@ volumePermissions:
     requests: {}
   ## Init container Container Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
+  ## @param volumePermissions.containerSecurityContext.seLinuxOptions Set SELinux options in container
   ## @param volumePermissions.containerSecurityContext.runAsUser Set init container's Security Context runAsUser
   ## NOTE: when runAsUser is set to special value "auto", init container will try to chown the
   ##   data folder to auto-determined user&group, using commands: `id -u`:`id -G | cut -d" " -f2`
   ##   "auto" is especially useful for OpenShift which has scc with dynamic user ids (and 0 is not allowed)
   ##
   containerSecurityContext:
+    seLinuxOptions: {}
     runAsUser: 0
 
 ## @section Other Parameters


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

### Description of the change

This PR updates the podSecurityContext and containerSecurityContext fields by setting default values for essential security fields: seLinuxOptions, fsGroupChangePolicy, sysctls and supplementalGroups. These are required by security checklists. 

### Benefits

Charts become more security-compliant

### Possible drawbacks

n/a

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)

