### PR TITLE
[bitnami/milvus] fix: :lock: Improve podSecurityContext and containerSecurityContext with essential security fields

### DIFF
--- a/bitnami/milvus/Chart.yaml
+++ b/bitnami/milvus/Chart.yaml
@@ -48,4 +48,4 @@ maintainers:
 name: milvus
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/milvus
-version: 5.1.6
+version: 5.2.0

--- a/bitnami/milvus/README.md
+++ b/bitnami/milvus/README.md
@@ -123,6 +123,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `initJob.extraVolumes`                                      | Optionally specify extra list of additional volumes for the credential init job                                           | `[]`             |
 | `initJob.extraCommands`                                     | Extra commands to pass to the generation job                                                                              | `""`             |
 | `initJob.containerSecurityContext.enabled`                  | Enabled containers' Security Context                                                                                      | `true`           |
+| `initJob.containerSecurityContext.seLinuxOptions`           | Set SELinux options in container                                                                                          | `{}`             |
 | `initJob.containerSecurityContext.runAsUser`                | Set containers' Security Context runAsUser                                                                                | `1001`           |
 | `initJob.containerSecurityContext.runAsNonRoot`             | Set container's Security Context runAsNonRoot                                                                             | `true`           |
 | `initJob.containerSecurityContext.privileged`               | Set container's Security Context privileged                                                                               | `false`          |
@@ -131,6 +132,9 @@ The command removes all the Kubernetes components associated with the chart and 
 | `initJob.containerSecurityContext.capabilities.drop`        | List of capabilities to be dropped                                                                                        | `["ALL"]`        |
 | `initJob.containerSecurityContext.seccompProfile.type`      | Set container's Security Context seccomp profile                                                                          | `RuntimeDefault` |
 | `initJob.podSecurityContext.enabled`                        | Enabled credential init job pods' Security Context                                                                        | `true`           |
+| `initJob.podSecurityContext.fsGroupChangePolicy`            | Set filesystem group change policy                                                                                        | `Always`         |
+| `initJob.podSecurityContext.sysctls`                        | Set kernel settings using the sysctl interface                                                                            | `[]`             |
+| `initJob.podSecurityContext.supplementalGroups`             | Set filesystem extra groups                                                                                               | `[]`             |
 | `initJob.podSecurityContext.fsGroup`                        | Set credential init job pod's Security Context fsGroup                                                                    | `1001`           |
 | `initJob.extraEnvVars`                                      | Array containing extra env vars to configure the credential init job                                                      | `[]`             |
 | `initJob.extraEnvVarsCM`                                    | ConfigMap containing extra env vars to configure the credential init job                                                  | `""`             |
@@ -184,8 +188,12 @@ The command removes all the Kubernetes components associated with the chart and 
 | `dataCoord.resources.limits`                                  | The resources limits for the data coordinator containers                                                   | `{}`             |
 | `dataCoord.resources.requests`                                | The requested resources for the data coordinator containers                                                | `{}`             |
 | `dataCoord.podSecurityContext.enabled`                        | Enabled Data Coordinator pods' Security Context                                                            | `true`           |
+| `dataCoord.podSecurityContext.fsGroupChangePolicy`            | Set filesystem group change policy                                                                         | `Always`         |
+| `dataCoord.podSecurityContext.sysctls`                        | Set kernel settings using the sysctl interface                                                             | `[]`             |
+| `dataCoord.podSecurityContext.supplementalGroups`             | Set filesystem extra groups                                                                                | `[]`             |
 | `dataCoord.podSecurityContext.fsGroup`                        | Set Data Coordinator pod's Security Context fsGroup                                                        | `1001`           |
 | `dataCoord.containerSecurityContext.enabled`                  | Enabled containers' Security Context                                                                       | `true`           |
+| `dataCoord.containerSecurityContext.seLinuxOptions`           | Set SELinux options in container                                                                           | `{}`             |
 | `dataCoord.containerSecurityContext.runAsUser`                | Set containers' Security Context runAsUser                                                                 | `1001`           |
 | `dataCoord.containerSecurityContext.runAsNonRoot`             | Set container's Security Context runAsNonRoot                                                              | `true`           |
 | `dataCoord.containerSecurityContext.privileged`               | Set container's Security Context privileged                                                                | `false`          |
@@ -324,8 +332,12 @@ The command removes all the Kubernetes components associated with the chart and 
 | `rootCoord.resources.limits`                                  | The resources limits for the data coordinator containers                                                   | `{}`             |
 | `rootCoord.resources.requests`                                | The requested resources for the data coordinator containers                                                | `{}`             |
 | `rootCoord.podSecurityContext.enabled`                        | Enabled Root Coordinator pods' Security Context                                                            | `true`           |
+| `rootCoord.podSecurityContext.fsGroupChangePolicy`            | Set filesystem group change policy                                                                         | `Always`         |
+| `rootCoord.podSecurityContext.sysctls`                        | Set kernel settings using the sysctl interface                                                             | `[]`             |
+| `rootCoord.podSecurityContext.supplementalGroups`             | Set filesystem extra groups                                                                                | `[]`             |
 | `rootCoord.podSecurityContext.fsGroup`                        | Set Root Coordinator pod's Security Context fsGroup                                                        | `1001`           |
 | `rootCoord.containerSecurityContext.enabled`                  | Enabled containers' Security Context                                                                       | `true`           |
+| `rootCoord.containerSecurityContext.seLinuxOptions`           | Set SELinux options in container                                                                           | `{}`             |
 | `rootCoord.containerSecurityContext.runAsUser`                | Set containers' Security Context runAsUser                                                                 | `1001`           |
 | `rootCoord.containerSecurityContext.runAsNonRoot`             | Set container's Security Context runAsNonRoot                                                              | `true`           |
 | `rootCoord.containerSecurityContext.privileged`               | Set container's Security Context privileged                                                                | `false`          |
@@ -464,8 +476,12 @@ The command removes all the Kubernetes components associated with the chart and 
 | `queryCoord.resources.limits`                                  | The resources limits for the data coordinator containers                                                   | `{}`             |
 | `queryCoord.resources.requests`                                | The requested resources for the data coordinator containers                                                | `{}`             |
 | `queryCoord.podSecurityContext.enabled`                        | Enabled Query Coordinator pods' Security Context                                                           | `true`           |
+| `queryCoord.podSecurityContext.fsGroupChangePolicy`            | Set filesystem group change policy                                                                         | `Always`         |
+| `queryCoord.podSecurityContext.sysctls`                        | Set kernel settings using the sysctl interface                                                             | `[]`             |
+| `queryCoord.podSecurityContext.supplementalGroups`             | Set filesystem extra groups                                                                                | `[]`             |
 | `queryCoord.podSecurityContext.fsGroup`                        | Set Query Coordinator pod's Security Context fsGroup                                                       | `1001`           |
 | `queryCoord.containerSecurityContext.enabled`                  | Enabled containers' Security Context                                                                       | `true`           |
+| `queryCoord.containerSecurityContext.seLinuxOptions`           | Set SELinux options in container                                                                           | `{}`             |
 | `queryCoord.containerSecurityContext.runAsUser`                | Set containers' Security Context runAsUser                                                                 | `1001`           |
 | `queryCoord.containerSecurityContext.runAsNonRoot`             | Set container's Security Context runAsNonRoot                                                              | `true`           |
 | `queryCoord.containerSecurityContext.privileged`               | Set container's Security Context privileged                                                                | `false`          |
@@ -604,8 +620,12 @@ The command removes all the Kubernetes components associated with the chart and 
 | `indexCoord.resources.limits`                                  | The resources limits for the data coordinator containers                                                   | `{}`             |
 | `indexCoord.resources.requests`                                | The requested resources for the data coordinator containers                                                | `{}`             |
 | `indexCoord.podSecurityContext.enabled`                        | Enabled Index Coordinator pods' Security Context                                                           | `true`           |
+| `indexCoord.podSecurityContext.fsGroupChangePolicy`            | Set filesystem group change policy                                                                         | `Always`         |
+| `indexCoord.podSecurityContext.sysctls`                        | Set kernel settings using the sysctl interface                                                             | `[]`             |
+| `indexCoord.podSecurityContext.supplementalGroups`             | Set filesystem extra groups                                                                                | `[]`             |
 | `indexCoord.podSecurityContext.fsGroup`                        | Set Index Coordinator pod's Security Context fsGroup                                                       | `1001`           |
 | `indexCoord.containerSecurityContext.enabled`                  | Enabled containers' Security Context                                                                       | `true`           |
+| `indexCoord.containerSecurityContext.seLinuxOptions`           | Set SELinux options in container                                                                           | `{}`             |
 | `indexCoord.containerSecurityContext.runAsUser`                | Set containers' Security Context runAsUser                                                                 | `1001`           |
 | `indexCoord.containerSecurityContext.runAsNonRoot`             | Set container's Security Context runAsNonRoot                                                              | `true`           |
 | `indexCoord.containerSecurityContext.privileged`               | Set container's Security Context privileged                                                                | `false`          |
@@ -744,8 +764,12 @@ The command removes all the Kubernetes components associated with the chart and 
 | `dataNode.resources.limits`                                  | The resources limits for the data node containers                                                   | `{}`             |
 | `dataNode.resources.requests`                                | The requested resources for the data node containers                                                | `{}`             |
 | `dataNode.podSecurityContext.enabled`                        | Enabled Data Node pods' Security Context                                                            | `true`           |
+| `dataNode.podSecurityContext.fsGroupChangePolicy`            | Set filesystem group change policy                                                                  | `Always`         |
+| `dataNode.podSecurityContext.sysctls`                        | Set kernel settings using the sysctl interface                                                      | `[]`             |
+| `dataNode.podSecurityContext.supplementalGroups`             | Set filesystem extra groups                                                                         | `[]`             |
 | `dataNode.podSecurityContext.fsGroup`                        | Set Data Node pod's Security Context fsGroup                                                        | `1001`           |
 | `dataNode.containerSecurityContext.enabled`                  | Enabled containers' Security Context                                                                | `true`           |
+| `dataNode.containerSecurityContext.seLinuxOptions`           | Set SELinux options in container                                                                    | `{}`             |
 | `dataNode.containerSecurityContext.runAsUser`                | Set containers' Security Context runAsUser                                                          | `1001`           |
 | `dataNode.containerSecurityContext.runAsNonRoot`             | Set container's Security Context runAsNonRoot                                                       | `true`           |
 | `dataNode.containerSecurityContext.privileged`               | Set container's Security Context privileged                                                         | `false`          |
@@ -884,8 +908,12 @@ The command removes all the Kubernetes components associated with the chart and 
 | `queryNode.resources.limits`                                  | The resources limits for the data node containers                                                   | `{}`             |
 | `queryNode.resources.requests`                                | The requested resources for the data node containers                                                | `{}`             |
 | `queryNode.podSecurityContext.enabled`                        | Enabled Query Node pods' Security Context                                                           | `true`           |
+| `queryNode.podSecurityContext.fsGroupChangePolicy`            | Set filesystem group change policy                                                                  | `Always`         |
+| `queryNode.podSecurityContext.sysctls`                        | Set kernel settings using the sysctl interface                                                      | `[]`             |
+| `queryNode.podSecurityContext.supplementalGroups`             | Set filesystem extra groups                                                                         | `[]`             |
 | `queryNode.podSecurityContext.fsGroup`                        | Set Query Node pod's Security Context fsGroup                                                       | `1001`           |
 | `queryNode.containerSecurityContext.enabled`                  | Enabled containers' Security Context                                                                | `true`           |
+| `queryNode.containerSecurityContext.seLinuxOptions`           | Set SELinux options in container                                                                    | `{}`             |
 | `queryNode.containerSecurityContext.runAsUser`                | Set containers' Security Context runAsUser                                                          | `1001`           |
 | `queryNode.containerSecurityContext.runAsNonRoot`             | Set container's Security Context runAsNonRoot                                                       | `true`           |
 | `queryNode.containerSecurityContext.privileged`               | Set container's Security Context privileged                                                         | `false`          |
@@ -1024,8 +1052,12 @@ The command removes all the Kubernetes components associated with the chart and 
 | `indexNode.resources.limits`                                  | The resources limits for the data node containers                                                   | `{}`             |
 | `indexNode.resources.requests`                                | The requested resources for the data node containers                                                | `{}`             |
 | `indexNode.podSecurityContext.enabled`                        | Enabled Index Node pods' Security Context                                                           | `true`           |
+| `indexNode.podSecurityContext.fsGroupChangePolicy`            | Set filesystem group change policy                                                                  | `Always`         |
+| `indexNode.podSecurityContext.sysctls`                        | Set kernel settings using the sysctl interface                                                      | `[]`             |
+| `indexNode.podSecurityContext.supplementalGroups`             | Set filesystem extra groups                                                                         | `[]`             |
 | `indexNode.podSecurityContext.fsGroup`                        | Set Index Node pod's Security Context fsGroup                                                       | `1001`           |
 | `indexNode.containerSecurityContext.enabled`                  | Enabled containers' Security Context                                                                | `true`           |
+| `indexNode.containerSecurityContext.seLinuxOptions`           | Set SELinux options in container                                                                    | `{}`             |
 | `indexNode.containerSecurityContext.runAsUser`                | Set containers' Security Context runAsUser                                                          | `1001`           |
 | `indexNode.containerSecurityContext.runAsNonRoot`             | Set container's Security Context runAsNonRoot                                                       | `true`           |
 | `indexNode.containerSecurityContext.privileged`               | Set container's Security Context privileged                                                         | `false`          |
@@ -1176,8 +1208,12 @@ The command removes all the Kubernetes components associated with the chart and 
 | `proxy.resources.limits`                                  | The resources limits for the proxy containers                                                   | `{}`             |
 | `proxy.resources.requests`                                | The requested resources for the proxy containers                                                | `{}`             |
 | `proxy.podSecurityContext.enabled`                        | Enabled Proxy pods' Security Context                                                            | `true`           |
+| `proxy.podSecurityContext.fsGroupChangePolicy`            | Set filesystem group change policy                                                              | `Always`         |
+| `proxy.podSecurityContext.sysctls`                        | Set kernel settings using the sysctl interface                                                  | `[]`             |
+| `proxy.podSecurityContext.supplementalGroups`             | Set filesystem extra groups                                                                     | `[]`             |
 | `proxy.podSecurityContext.fsGroup`                        | Set Proxy pod's Security Context fsGroup                                                        | `1001`           |
 | `proxy.containerSecurityContext.enabled`                  | Enabled containers' Security Context                                                            | `true`           |
+| `proxy.containerSecurityContext.seLinuxOptions`           | Set SELinux options in container                                                                | `{}`             |
 | `proxy.containerSecurityContext.runAsUser`                | Set containers' Security Context runAsUser                                                      | `1001`           |
 | `proxy.containerSecurityContext.runAsNonRoot`             | Set container's Security Context runAsNonRoot                                                   | `true`           |
 | `proxy.containerSecurityContext.privileged`               | Set container's Security Context privileged                                                     | `false`          |
@@ -1317,8 +1353,12 @@ The command removes all the Kubernetes components associated with the chart and 
 | `attu.resources.limits`                                  | The resources limits for the attu containers                                                         | `{}`                   |
 | `attu.resources.requests`                                | The requested resources for the attu containers                                                      | `{}`                   |
 | `attu.podSecurityContext.enabled`                        | Enabled Attu pods' Security Context                                                                  | `true`                 |
+| `attu.podSecurityContext.fsGroupChangePolicy`            | Set filesystem group change policy                                                                   | `Always`               |
+| `attu.podSecurityContext.sysctls`                        | Set kernel settings using the sysctl interface                                                       | `[]`                   |
+| `attu.podSecurityContext.supplementalGroups`             | Set filesystem extra groups                                                                          | `[]`                   |
 | `attu.podSecurityContext.fsGroup`                        | Set Attu pod's Security Context fsGroup                                                              | `1001`                 |
 | `attu.containerSecurityContext.enabled`                  | Enabled containers' Security Context                                                                 | `true`                 |
+| `attu.containerSecurityContext.seLinuxOptions`           | Set SELinux options in container                                                                     | `{}`                   |
 | `attu.containerSecurityContext.runAsUser`                | Set containers' Security Context runAsUser                                                           | `1001`                 |
 | `attu.containerSecurityContext.runAsNonRoot`             | Set container's Security Context runAsNonRoot                                                        | `true`                 |
 | `attu.containerSecurityContext.privileged`               | Set container's Security Context privileged                                                          | `false`                |
@@ -1420,6 +1460,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `waitContainer.image.pullPolicy`                                  | Init container wait-container image pull policy                                                                               | `IfNotPresent`             |
 | `waitContainer.image.pullSecrets`                                 | Specify docker-registry secret names as an array                                                                              | `[]`                       |
 | `waitContainer.containerSecurityContext.enabled`                  | Enabled containers' Security Context                                                                                          | `true`                     |
+| `waitContainer.containerSecurityContext.seLinuxOptions`           | Set SELinux options in container                                                                                              | `{}`                       |
 | `waitContainer.containerSecurityContext.runAsUser`                | Set containers' Security Context runAsUser                                                                                    | `1001`                     |
 | `waitContainer.containerSecurityContext.runAsNonRoot`             | Set container's Security Context runAsNonRoot                                                                                 | `true`                     |
 | `waitContainer.containerSecurityContext.privileged`               | Set container's Security Context privileged                                                                                   | `false`                    |

--- a/bitnami/milvus/values.yaml
+++ b/bitnami/milvus/values.yaml
@@ -319,6 +319,7 @@ initJob:
   ## Configure Container Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
   ## @param initJob.containerSecurityContext.enabled Enabled containers' Security Context
+  ## @param initJob.containerSecurityContext.seLinuxOptions Set SELinux options in container
   ## @param initJob.containerSecurityContext.runAsUser Set containers' Security Context runAsUser
   ## @param initJob.containerSecurityContext.runAsNonRoot Set container's Security Context runAsNonRoot
   ## @param initJob.containerSecurityContext.privileged Set container's Security Context privileged
@@ -329,6 +330,7 @@ initJob:
   ##
   containerSecurityContext:
     enabled: true
+    seLinuxOptions: {}
     runAsUser: 1001
     runAsNonRoot: true
     privileged: false
@@ -341,10 +343,16 @@ initJob:
   ## Configure Pods Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param initJob.podSecurityContext.enabled Enabled credential init job pods' Security Context
+  ## @param initJob.podSecurityContext.fsGroupChangePolicy Set filesystem group change policy
+  ## @param initJob.podSecurityContext.sysctls Set kernel settings using the sysctl interface
+  ## @param initJob.podSecurityContext.supplementalGroups Set filesystem extra groups
   ## @param initJob.podSecurityContext.fsGroup Set credential init job pod's Security Context fsGroup
   ##
   podSecurityContext:
     enabled: true
+    fsGroupChangePolicy: Always
+    sysctls: []
+    supplementalGroups: []
     fsGroup: 1001
   ## @param initJob.extraEnvVars Array containing extra env vars to configure the credential init job
   ## For example:
@@ -505,14 +513,21 @@ dataCoord:
   ## Configure Pods Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param dataCoord.podSecurityContext.enabled Enabled Data Coordinator pods' Security Context
+  ## @param dataCoord.podSecurityContext.fsGroupChangePolicy Set filesystem group change policy
+  ## @param dataCoord.podSecurityContext.sysctls Set kernel settings using the sysctl interface
+  ## @param dataCoord.podSecurityContext.supplementalGroups Set filesystem extra groups
   ## @param dataCoord.podSecurityContext.fsGroup Set Data Coordinator pod's Security Context fsGroup
   ##
   podSecurityContext:
     enabled: true
+    fsGroupChangePolicy: Always
+    sysctls: []
+    supplementalGroups: []
     fsGroup: 1001
   ## Configure Container Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param dataCoord.containerSecurityContext.enabled Enabled containers' Security Context
+  ## @param dataCoord.containerSecurityContext.seLinuxOptions Set SELinux options in container
   ## @param dataCoord.containerSecurityContext.runAsUser Set containers' Security Context runAsUser
   ## @param dataCoord.containerSecurityContext.runAsNonRoot Set container's Security Context runAsNonRoot
   ## @param dataCoord.containerSecurityContext.privileged Set container's Security Context privileged
@@ -523,6 +538,7 @@ dataCoord:
   ##
   containerSecurityContext:
     enabled: true
+    seLinuxOptions: {}
     runAsUser: 1001
     runAsNonRoot: true
     privileged: false
@@ -993,14 +1009,21 @@ rootCoord:
   ## Configure Pods Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param rootCoord.podSecurityContext.enabled Enabled Root Coordinator pods' Security Context
+  ## @param rootCoord.podSecurityContext.fsGroupChangePolicy Set filesystem group change policy
+  ## @param rootCoord.podSecurityContext.sysctls Set kernel settings using the sysctl interface
+  ## @param rootCoord.podSecurityContext.supplementalGroups Set filesystem extra groups
   ## @param rootCoord.podSecurityContext.fsGroup Set Root Coordinator pod's Security Context fsGroup
   ##
   podSecurityContext:
     enabled: true
+    fsGroupChangePolicy: Always
+    sysctls: []
+    supplementalGroups: []
     fsGroup: 1001
   ## Configure Container Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param rootCoord.containerSecurityContext.enabled Enabled containers' Security Context
+  ## @param rootCoord.containerSecurityContext.seLinuxOptions Set SELinux options in container
   ## @param rootCoord.containerSecurityContext.runAsUser Set containers' Security Context runAsUser
   ## @param rootCoord.containerSecurityContext.runAsNonRoot Set container's Security Context runAsNonRoot
   ## @param rootCoord.containerSecurityContext.privileged Set container's Security Context privileged
@@ -1011,6 +1034,7 @@ rootCoord:
   ##
   containerSecurityContext:
     enabled: true
+    seLinuxOptions: {}
     runAsUser: 1001
     runAsNonRoot: true
     privileged: false
@@ -1480,14 +1504,21 @@ queryCoord:
   ## Configure Pods Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param queryCoord.podSecurityContext.enabled Enabled Query Coordinator pods' Security Context
+  ## @param queryCoord.podSecurityContext.fsGroupChangePolicy Set filesystem group change policy
+  ## @param queryCoord.podSecurityContext.sysctls Set kernel settings using the sysctl interface
+  ## @param queryCoord.podSecurityContext.supplementalGroups Set filesystem extra groups
   ## @param queryCoord.podSecurityContext.fsGroup Set Query Coordinator pod's Security Context fsGroup
   ##
   podSecurityContext:
     enabled: true
+    fsGroupChangePolicy: Always
+    sysctls: []
+    supplementalGroups: []
     fsGroup: 1001
   ## Configure Container Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param queryCoord.containerSecurityContext.enabled Enabled containers' Security Context
+  ## @param queryCoord.containerSecurityContext.seLinuxOptions Set SELinux options in container
   ## @param queryCoord.containerSecurityContext.runAsUser Set containers' Security Context runAsUser
   ## @param queryCoord.containerSecurityContext.runAsNonRoot Set container's Security Context runAsNonRoot
   ## @param queryCoord.containerSecurityContext.privileged Set container's Security Context privileged
@@ -1498,6 +1529,7 @@ queryCoord:
   ##
   containerSecurityContext:
     enabled: true
+    seLinuxOptions: {}
     runAsUser: 1001
     runAsNonRoot: true
     privileged: false
@@ -1968,14 +2000,21 @@ indexCoord:
   ## Configure Pods Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param indexCoord.podSecurityContext.enabled Enabled Index Coordinator pods' Security Context
+  ## @param indexCoord.podSecurityContext.fsGroupChangePolicy Set filesystem group change policy
+  ## @param indexCoord.podSecurityContext.sysctls Set kernel settings using the sysctl interface
+  ## @param indexCoord.podSecurityContext.supplementalGroups Set filesystem extra groups
   ## @param indexCoord.podSecurityContext.fsGroup Set Index Coordinator pod's Security Context fsGroup
   ##
   podSecurityContext:
     enabled: true
+    fsGroupChangePolicy: Always
+    sysctls: []
+    supplementalGroups: []
     fsGroup: 1001
   ## Configure Container Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param indexCoord.containerSecurityContext.enabled Enabled containers' Security Context
+  ## @param indexCoord.containerSecurityContext.seLinuxOptions Set SELinux options in container
   ## @param indexCoord.containerSecurityContext.runAsUser Set containers' Security Context runAsUser
   ## @param indexCoord.containerSecurityContext.runAsNonRoot Set container's Security Context runAsNonRoot
   ## @param indexCoord.containerSecurityContext.privileged Set container's Security Context privileged
@@ -1986,6 +2025,7 @@ indexCoord:
   ##
   containerSecurityContext:
     enabled: true
+    seLinuxOptions: {}
     runAsUser: 1001
     runAsNonRoot: true
     privileged: false
@@ -2456,14 +2496,21 @@ dataNode:
   ## Configure Pods Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param dataNode.podSecurityContext.enabled Enabled Data Node pods' Security Context
+  ## @param dataNode.podSecurityContext.fsGroupChangePolicy Set filesystem group change policy
+  ## @param dataNode.podSecurityContext.sysctls Set kernel settings using the sysctl interface
+  ## @param dataNode.podSecurityContext.supplementalGroups Set filesystem extra groups
   ## @param dataNode.podSecurityContext.fsGroup Set Data Node pod's Security Context fsGroup
   ##
   podSecurityContext:
     enabled: true
+    fsGroupChangePolicy: Always
+    sysctls: []
+    supplementalGroups: []
     fsGroup: 1001
   ## Configure Container Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param dataNode.containerSecurityContext.enabled Enabled containers' Security Context
+  ## @param dataNode.containerSecurityContext.seLinuxOptions Set SELinux options in container
   ## @param dataNode.containerSecurityContext.runAsUser Set containers' Security Context runAsUser
   ## @param dataNode.containerSecurityContext.runAsNonRoot Set container's Security Context runAsNonRoot
   ## @param dataNode.containerSecurityContext.privileged Set container's Security Context privileged
@@ -2474,6 +2521,7 @@ dataNode:
   ##
   containerSecurityContext:
     enabled: true
+    seLinuxOptions: {}
     runAsUser: 1001
     runAsNonRoot: true
     privileged: false
@@ -2944,14 +2992,21 @@ queryNode:
   ## Configure Pods Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param queryNode.podSecurityContext.enabled Enabled Query Node pods' Security Context
+  ## @param queryNode.podSecurityContext.fsGroupChangePolicy Set filesystem group change policy
+  ## @param queryNode.podSecurityContext.sysctls Set kernel settings using the sysctl interface
+  ## @param queryNode.podSecurityContext.supplementalGroups Set filesystem extra groups
   ## @param queryNode.podSecurityContext.fsGroup Set Query Node pod's Security Context fsGroup
   ##
   podSecurityContext:
     enabled: true
+    fsGroupChangePolicy: Always
+    sysctls: []
+    supplementalGroups: []
     fsGroup: 1001
   ## Configure Container Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param queryNode.containerSecurityContext.enabled Enabled containers' Security Context
+  ## @param queryNode.containerSecurityContext.seLinuxOptions Set SELinux options in container
   ## @param queryNode.containerSecurityContext.runAsUser Set containers' Security Context runAsUser
   ## @param queryNode.containerSecurityContext.runAsNonRoot Set container's Security Context runAsNonRoot
   ## @param queryNode.containerSecurityContext.privileged Set container's Security Context privileged
@@ -2962,6 +3017,7 @@ queryNode:
   ##
   containerSecurityContext:
     enabled: true
+    seLinuxOptions: {}
     runAsUser: 1001
     runAsNonRoot: true
     privileged: false
@@ -3432,14 +3488,21 @@ indexNode:
   ## Configure Pods Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param indexNode.podSecurityContext.enabled Enabled Index Node pods' Security Context
+  ## @param indexNode.podSecurityContext.fsGroupChangePolicy Set filesystem group change policy
+  ## @param indexNode.podSecurityContext.sysctls Set kernel settings using the sysctl interface
+  ## @param indexNode.podSecurityContext.supplementalGroups Set filesystem extra groups
   ## @param indexNode.podSecurityContext.fsGroup Set Index Node pod's Security Context fsGroup
   ##
   podSecurityContext:
     enabled: true
+    fsGroupChangePolicy: Always
+    sysctls: []
+    supplementalGroups: []
     fsGroup: 1001
   ## Configure Container Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param indexNode.containerSecurityContext.enabled Enabled containers' Security Context
+  ## @param indexNode.containerSecurityContext.seLinuxOptions Set SELinux options in container
   ## @param indexNode.containerSecurityContext.runAsUser Set containers' Security Context runAsUser
   ## @param indexNode.containerSecurityContext.runAsNonRoot Set container's Security Context runAsNonRoot
   ## @param indexNode.containerSecurityContext.privileged Set container's Security Context privileged
@@ -3450,6 +3513,7 @@ indexNode:
   ##
   containerSecurityContext:
     enabled: true
+    seLinuxOptions: {}
     runAsUser: 1001
     runAsNonRoot: true
     privileged: false
@@ -3949,14 +4013,21 @@ proxy:
   ## Configure Pods Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param proxy.podSecurityContext.enabled Enabled Proxy pods' Security Context
+  ## @param proxy.podSecurityContext.fsGroupChangePolicy Set filesystem group change policy
+  ## @param proxy.podSecurityContext.sysctls Set kernel settings using the sysctl interface
+  ## @param proxy.podSecurityContext.supplementalGroups Set filesystem extra groups
   ## @param proxy.podSecurityContext.fsGroup Set Proxy pod's Security Context fsGroup
   ##
   podSecurityContext:
     enabled: true
+    fsGroupChangePolicy: Always
+    sysctls: []
+    supplementalGroups: []
     fsGroup: 1001
   ## Configure Container Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param proxy.containerSecurityContext.enabled Enabled containers' Security Context
+  ## @param proxy.containerSecurityContext.seLinuxOptions Set SELinux options in container
   ## @param proxy.containerSecurityContext.runAsUser Set containers' Security Context runAsUser
   ## @param proxy.containerSecurityContext.runAsNonRoot Set container's Security Context runAsNonRoot
   ## @param proxy.containerSecurityContext.privileged Set container's Security Context privileged
@@ -3967,6 +4038,7 @@ proxy:
   ##
   containerSecurityContext:
     enabled: true
+    seLinuxOptions: {}
     runAsUser: 1001
     runAsNonRoot: true
     privileged: false
@@ -4449,14 +4521,21 @@ attu:
   ## Configure Pods Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param attu.podSecurityContext.enabled Enabled Attu pods' Security Context
+  ## @param attu.podSecurityContext.fsGroupChangePolicy Set filesystem group change policy
+  ## @param attu.podSecurityContext.sysctls Set kernel settings using the sysctl interface
+  ## @param attu.podSecurityContext.supplementalGroups Set filesystem extra groups
   ## @param attu.podSecurityContext.fsGroup Set Attu pod's Security Context fsGroup
   ##
   podSecurityContext:
     enabled: true
+    fsGroupChangePolicy: Always
+    sysctls: []
+    supplementalGroups: []
     fsGroup: 1001
   ## Configure Container Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param attu.containerSecurityContext.enabled Enabled containers' Security Context
+  ## @param attu.containerSecurityContext.seLinuxOptions Set SELinux options in container
   ## @param attu.containerSecurityContext.runAsUser Set containers' Security Context runAsUser
   ## @param attu.containerSecurityContext.runAsNonRoot Set container's Security Context runAsNonRoot
   ## @param attu.containerSecurityContext.privileged Set container's Security Context privileged
@@ -4467,6 +4546,7 @@ attu:
   ##
   containerSecurityContext:
     enabled: true
+    seLinuxOptions: {}
     runAsUser: 1001
     runAsNonRoot: true
     privileged: false
@@ -4901,6 +4981,7 @@ waitContainer:
   ## Configure Container Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
   ## @param waitContainer.containerSecurityContext.enabled Enabled containers' Security Context
+  ## @param waitContainer.containerSecurityContext.seLinuxOptions Set SELinux options in container
   ## @param waitContainer.containerSecurityContext.runAsUser Set containers' Security Context runAsUser
   ## @param waitContainer.containerSecurityContext.runAsNonRoot Set container's Security Context runAsNonRoot
   ## @param waitContainer.containerSecurityContext.privileged Set container's Security Context privileged
@@ -4911,6 +4992,7 @@ waitContainer:
   ##
   containerSecurityContext:
     enabled: true
+    seLinuxOptions: {}
     runAsUser: 1001
     runAsNonRoot: true
     privileged: false


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

### Description of the change

This PR updates the podSecurityContext and containerSecurityContext fields by setting default values for essential security fields: seLinuxOptions, fsGroupChangePolicy, sysctls and supplementalGroups. These are required by security checklists. 

### Benefits

Charts become more security-compliant

### Possible drawbacks

n/a

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)

