### PR TITLE
[bitnami/mongodb] fix: :lock: Improve podSecurityContext and containerSecurityContext with essential security fields

### DIFF
--- a/bitnami/mongodb/Chart.yaml
+++ b/bitnami/mongodb/Chart.yaml
@@ -39,4 +39,4 @@ maintainers:
 name: mongodb
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/mongodb
-version: 14.5.1
+version: 14.6.0

--- a/bitnami/mongodb/README.md
+++ b/bitnami/mongodb/README.md
@@ -189,9 +189,12 @@ Refer to the [chart documentation for more information on each of these architec
 | `priorityClassName`                                 | Name of the existing priority class to be used by MongoDB(&reg;) pod(s)                                         | `""`             |
 | `runtimeClassName`                                  | Name of the runtime class to be used by MongoDB(&reg;) pod(s)                                                   | `""`             |
 | `podSecurityContext.enabled`                        | Enable MongoDB(&reg;) pod(s)' Security Context                                                                  | `true`           |
+| `podSecurityContext.fsGroupChangePolicy`            | Set filesystem group change policy                                                                              | `Always`         |
+| `podSecurityContext.supplementalGroups`             | Set filesystem extra groups                                                                                     | `[]`             |
 | `podSecurityContext.fsGroup`                        | Group ID for the volumes of the MongoDB(&reg;) pod(s)                                                           | `1001`           |
 | `podSecurityContext.sysctls`                        | sysctl settings of the MongoDB(&reg;) pod(s)'                                                                   | `[]`             |
 | `containerSecurityContext.enabled`                  | Enabled containers' Security Context                                                                            | `true`           |
+| `containerSecurityContext.seLinuxOptions`           | Set SELinux options in container                                                                                | `{}`             |
 | `containerSecurityContext.runAsUser`                | Set containers' Security Context runAsUser                                                                      | `1001`           |
 | `containerSecurityContext.runAsNonRoot`             | Set container's Security Context runAsNonRoot                                                                   | `true`           |
 | `containerSecurityContext.privileged`               | Set container's Security Context privileged                                                                     | `false`          |
@@ -339,6 +342,7 @@ Refer to the [chart documentation for more information on each of these architec
 | `backup.cronjob.ttlSecondsAfterFinished`                           | Set the cronjob parameter ttlSecondsAfterFinished                                                                                     | `""`                |
 | `backup.cronjob.restartPolicy`                                     | Set the cronjob parameter restartPolicy                                                                                               | `OnFailure`         |
 | `backup.cronjob.containerSecurityContext.enabled`                  | Enabled containers' Security Context                                                                                                  | `true`              |
+| `backup.cronjob.containerSecurityContext.seLinuxOptions`           | Set SELinux options in container                                                                                                      | `{}`                |
 | `backup.cronjob.containerSecurityContext.runAsUser`                | Set containers' Security Context runAsUser                                                                                            | `1001`              |
 | `backup.cronjob.containerSecurityContext.runAsNonRoot`             | Set container's Security Context runAsNonRoot                                                                                         | `true`              |
 | `backup.cronjob.containerSecurityContext.privileged`               | Set container's Security Context privileged                                                                                           | `false`             |
@@ -376,17 +380,18 @@ Refer to the [chart documentation for more information on each of these architec
 
 ### Volume Permissions parameters
 
-| Name                                          | Description                                                                                                                       | Value                      |
-| --------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- | -------------------------- |
-| `volumePermissions.enabled`                   | Enable init container that changes the owner and group of the persistent volume(s) mountpoint to `runAsUser:fsGroup`              | `false`                    |
-| `volumePermissions.image.registry`            | Init container volume-permissions image registry                                                                                  | `REGISTRY_NAME`            |
-| `volumePermissions.image.repository`          | Init container volume-permissions image repository                                                                                | `REPOSITORY_NAME/os-shell` |
-| `volumePermissions.image.digest`              | Init container volume-permissions image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                       |
-| `volumePermissions.image.pullPolicy`          | Init container volume-permissions image pull policy                                                                               | `IfNotPresent`             |
-| `volumePermissions.image.pullSecrets`         | Specify docker-registry secret names as an array                                                                                  | `[]`                       |
-| `volumePermissions.resources.limits`          | Init container volume-permissions resource limits                                                                                 | `{}`                       |
-| `volumePermissions.resources.requests`        | Init container volume-permissions resource requests                                                                               | `{}`                       |
-| `volumePermissions.securityContext.runAsUser` | User ID for the volumePermissions container                                                                                       | `0`                        |
+| Name                                               | Description                                                                                                                       | Value                      |
+| -------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- | -------------------------- |
+| `volumePermissions.enabled`                        | Enable init container that changes the owner and group of the persistent volume(s) mountpoint to `runAsUser:fsGroup`              | `false`                    |
+| `volumePermissions.image.registry`                 | Init container volume-permissions image registry                                                                                  | `REGISTRY_NAME`            |
+| `volumePermissions.image.repository`               | Init container volume-permissions image repository                                                                                | `REPOSITORY_NAME/os-shell` |
+| `volumePermissions.image.digest`                   | Init container volume-permissions image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                       |
+| `volumePermissions.image.pullPolicy`               | Init container volume-permissions image pull policy                                                                               | `IfNotPresent`             |
+| `volumePermissions.image.pullSecrets`              | Specify docker-registry secret names as an array                                                                                  | `[]`                       |
+| `volumePermissions.resources.limits`               | Init container volume-permissions resource limits                                                                                 | `{}`                       |
+| `volumePermissions.resources.requests`             | Init container volume-permissions resource requests                                                                               | `{}`                       |
+| `volumePermissions.securityContext.seLinuxOptions` | Set SELinux options in container                                                                                                  | `{}`                       |
+| `volumePermissions.securityContext.runAsUser`      | User ID for the volumePermissions container                                                                                       | `0`                        |
 
 ### Arbiter parameters
 
@@ -423,9 +428,12 @@ Refer to the [chart documentation for more information on each of these architec
 | `arbiter.priorityClassName`                                 | Name of the existing priority class to be used by Arbiter pod(s)                                  | `""`             |
 | `arbiter.runtimeClassName`                                  | Name of the runtime class to be used by Arbiter pod(s)                                            | `""`             |
 | `arbiter.podSecurityContext.enabled`                        | Enable Arbiter pod(s)' Security Context                                                           | `true`           |
+| `arbiter.podSecurityContext.fsGroupChangePolicy`            | Set filesystem group change policy                                                                | `Always`         |
+| `arbiter.podSecurityContext.supplementalGroups`             | Set filesystem extra groups                                                                       | `[]`             |
 | `arbiter.podSecurityContext.fsGroup`                        | Group ID for the volumes of the Arbiter pod(s)                                                    | `1001`           |
 | `arbiter.podSecurityContext.sysctls`                        | sysctl settings of the Arbiter pod(s)'                                                            | `[]`             |
 | `arbiter.containerSecurityContext.enabled`                  | Enabled containers' Security Context                                                              | `true`           |
+| `arbiter.containerSecurityContext.seLinuxOptions`           | Set SELinux options in container                                                                  | `{}`             |
 | `arbiter.containerSecurityContext.runAsUser`                | Set containers' Security Context runAsUser                                                        | `1001`           |
 | `arbiter.containerSecurityContext.runAsNonRoot`             | Set container's Security Context runAsNonRoot                                                     | `true`           |
 | `arbiter.containerSecurityContext.privileged`               | Set container's Security Context privileged                                                       | `false`          |
@@ -506,9 +514,12 @@ Refer to the [chart documentation for more information on each of these architec
 | `hidden.priorityClassName`                                 | Name of the existing priority class to be used by hidden node pod(s)                                 | `""`                |
 | `hidden.runtimeClassName`                                  | Name of the runtime class to be used by hidden node pod(s)                                           | `""`                |
 | `hidden.podSecurityContext.enabled`                        | Enable Hidden pod(s)' Security Context                                                               | `true`              |
+| `hidden.podSecurityContext.fsGroupChangePolicy`            | Set filesystem group change policy                                                                   | `Always`            |
+| `hidden.podSecurityContext.supplementalGroups`             | Set filesystem extra groups                                                                          | `[]`                |
 | `hidden.podSecurityContext.fsGroup`                        | Group ID for the volumes of the Hidden pod(s)                                                        | `1001`              |
 | `hidden.podSecurityContext.sysctls`                        | sysctl settings of the Hidden pod(s)'                                                                | `[]`                |
 | `hidden.containerSecurityContext.enabled`                  | Enabled containers' Security Context                                                                 | `true`              |
+| `hidden.containerSecurityContext.seLinuxOptions`           | Set SELinux options in container                                                                     | `{}`                |
 | `hidden.containerSecurityContext.runAsUser`                | Set containers' Security Context runAsUser                                                           | `1001`              |
 | `hidden.containerSecurityContext.runAsNonRoot`             | Set container's Security Context runAsNonRoot                                                        | `true`              |
 | `hidden.containerSecurityContext.privileged`               | Set container's Security Context privileged                                                          | `false`             |

--- a/bitnami/mongodb/values.yaml
+++ b/bitnami/mongodb/values.yaml
@@ -536,7 +536,6 @@ runtimeClassName: ""
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
 ## @param podSecurityContext.enabled Enable MongoDB(&reg;) pod(s)' Security Context
 ## @param podSecurityContext.fsGroupChangePolicy Set filesystem group change policy
-## @param podSecurityContext.sysctls Set kernel settings using the sysctl interface
 ## @param podSecurityContext.supplementalGroups Set filesystem extra groups
 ## @param podSecurityContext.fsGroup Group ID for the volumes of the MongoDB(&reg;) pod(s)
 ## @param podSecurityContext.sysctls sysctl settings of the MongoDB(&reg;) pod(s)'
@@ -544,7 +543,6 @@ runtimeClassName: ""
 podSecurityContext:
   enabled: true
   fsGroupChangePolicy: Always
-  sysctls: []
   supplementalGroups: []
   fsGroup: 1001
   ## sysctl settings
@@ -1574,7 +1572,6 @@ arbiter:
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param arbiter.podSecurityContext.enabled Enable Arbiter pod(s)' Security Context
   ## @param arbiter.podSecurityContext.fsGroupChangePolicy Set filesystem group change policy
-  ## @param arbiter.podSecurityContext.sysctls Set kernel settings using the sysctl interface
   ## @param arbiter.podSecurityContext.supplementalGroups Set filesystem extra groups
   ## @param arbiter.podSecurityContext.fsGroup Group ID for the volumes of the Arbiter pod(s)
   ## @param arbiter.podSecurityContext.sysctls sysctl settings of the Arbiter pod(s)'
@@ -1582,7 +1579,6 @@ arbiter:
   podSecurityContext:
     enabled: true
     fsGroupChangePolicy: Always
-    sysctls: []
     supplementalGroups: []
     fsGroup: 1001
     ## sysctl settings
@@ -1917,7 +1913,6 @@ hidden:
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param hidden.podSecurityContext.enabled Enable Hidden pod(s)' Security Context
   ## @param hidden.podSecurityContext.fsGroupChangePolicy Set filesystem group change policy
-  ## @param hidden.podSecurityContext.sysctls Set kernel settings using the sysctl interface
   ## @param hidden.podSecurityContext.supplementalGroups Set filesystem extra groups
   ## @param hidden.podSecurityContext.fsGroup Group ID for the volumes of the Hidden pod(s)
   ## @param hidden.podSecurityContext.sysctls sysctl settings of the Hidden pod(s)'
@@ -1925,7 +1920,6 @@ hidden:
   podSecurityContext:
     enabled: true
     fsGroupChangePolicy: Always
-    sysctls: []
     supplementalGroups: []
     fsGroup: 1001
     ## sysctl settings

--- a/bitnami/mongodb/values.yaml
+++ b/bitnami/mongodb/values.yaml
@@ -535,11 +535,17 @@ runtimeClassName: ""
 ## MongoDB(&reg;) pods' Security Context.
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
 ## @param podSecurityContext.enabled Enable MongoDB(&reg;) pod(s)' Security Context
+## @param podSecurityContext.fsGroupChangePolicy Set filesystem group change policy
+## @param podSecurityContext.sysctls Set kernel settings using the sysctl interface
+## @param podSecurityContext.supplementalGroups Set filesystem extra groups
 ## @param podSecurityContext.fsGroup Group ID for the volumes of the MongoDB(&reg;) pod(s)
 ## @param podSecurityContext.sysctls sysctl settings of the MongoDB(&reg;) pod(s)'
 ##
 podSecurityContext:
   enabled: true
+  fsGroupChangePolicy: Always
+  sysctls: []
+  supplementalGroups: []
   fsGroup: 1001
   ## sysctl settings
   ## Example:
@@ -551,6 +557,7 @@ podSecurityContext:
 ## MongoDB(&reg;) containers' Security Context (main and metrics container).
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
 ## @param containerSecurityContext.enabled Enabled containers' Security Context
+## @param containerSecurityContext.seLinuxOptions Set SELinux options in container
 ## @param containerSecurityContext.runAsUser Set containers' Security Context runAsUser
 ## @param containerSecurityContext.runAsNonRoot Set container's Security Context runAsNonRoot
 ## @param containerSecurityContext.privileged Set container's Security Context privileged
@@ -561,6 +568,7 @@ podSecurityContext:
 ##
 containerSecurityContext:
   enabled: true
+  seLinuxOptions: {}
   runAsUser: 1001
   runAsNonRoot: true
   privileged: false
@@ -1185,6 +1193,7 @@ backup:
     ## backup container's Security Context
     ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
     ## @param backup.cronjob.containerSecurityContext.enabled Enabled containers' Security Context
+    ## @param backup.cronjob.containerSecurityContext.seLinuxOptions Set SELinux options in container
     ## @param backup.cronjob.containerSecurityContext.runAsUser Set containers' Security Context runAsUser
     ## @param backup.cronjob.containerSecurityContext.runAsNonRoot Set container's Security Context runAsNonRoot
     ## @param backup.cronjob.containerSecurityContext.privileged Set container's Security Context privileged
@@ -1195,6 +1204,7 @@ backup:
     ##
     containerSecurityContext:
       enabled: true
+      seLinuxOptions: {}
       runAsUser: 1001
       runAsNonRoot: true
       privileged: false
@@ -1418,9 +1428,11 @@ volumePermissions:
   ## "auto" is especially useful for OpenShift which has scc with dynamic userids (and 0 is not allowed).
   ## You may want to use this volumePermissions.securityContext.runAsUser="auto" in combination with
   ## podSecurityContext.enabled=false,containerSecurityContext.enabled=false and shmVolume.chmod.enabled=false
+  ## @param volumePermissions.securityContext.seLinuxOptions Set SELinux options in container
   ## @param volumePermissions.securityContext.runAsUser User ID for the volumePermissions container
   ##
   securityContext:
+    seLinuxOptions: {}
     runAsUser: 0
 
 ## @section Arbiter parameters
@@ -1561,11 +1573,17 @@ arbiter:
   ## MongoDB(&reg;) Arbiter pods' Security Context.
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param arbiter.podSecurityContext.enabled Enable Arbiter pod(s)' Security Context
+  ## @param arbiter.podSecurityContext.fsGroupChangePolicy Set filesystem group change policy
+  ## @param arbiter.podSecurityContext.sysctls Set kernel settings using the sysctl interface
+  ## @param arbiter.podSecurityContext.supplementalGroups Set filesystem extra groups
   ## @param arbiter.podSecurityContext.fsGroup Group ID for the volumes of the Arbiter pod(s)
   ## @param arbiter.podSecurityContext.sysctls sysctl settings of the Arbiter pod(s)'
   ##
   podSecurityContext:
     enabled: true
+    fsGroupChangePolicy: Always
+    sysctls: []
+    supplementalGroups: []
     fsGroup: 1001
     ## sysctl settings
     ## Example:
@@ -1577,6 +1595,7 @@ arbiter:
   ## MongoDB(&reg;) Arbiter containers' Security Context (only main container).
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
   ## @param arbiter.containerSecurityContext.enabled Enabled containers' Security Context
+  ## @param arbiter.containerSecurityContext.seLinuxOptions Set SELinux options in container
   ## @param arbiter.containerSecurityContext.runAsUser Set containers' Security Context runAsUser
   ## @param arbiter.containerSecurityContext.runAsNonRoot Set container's Security Context runAsNonRoot
   ## @param arbiter.containerSecurityContext.privileged Set container's Security Context privileged
@@ -1587,6 +1606,7 @@ arbiter:
   ##
   containerSecurityContext:
     enabled: true
+    seLinuxOptions: {}
     runAsUser: 1001
     runAsNonRoot: true
     privileged: false
@@ -1896,11 +1916,17 @@ hidden:
   ## MongoDB(&reg;) Hidden pods' Security Context.
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param hidden.podSecurityContext.enabled Enable Hidden pod(s)' Security Context
+  ## @param hidden.podSecurityContext.fsGroupChangePolicy Set filesystem group change policy
+  ## @param hidden.podSecurityContext.sysctls Set kernel settings using the sysctl interface
+  ## @param hidden.podSecurityContext.supplementalGroups Set filesystem extra groups
   ## @param hidden.podSecurityContext.fsGroup Group ID for the volumes of the Hidden pod(s)
   ## @param hidden.podSecurityContext.sysctls sysctl settings of the Hidden pod(s)'
   ##
   podSecurityContext:
     enabled: true
+    fsGroupChangePolicy: Always
+    sysctls: []
+    supplementalGroups: []
     fsGroup: 1001
     ## sysctl settings
     ## Example:
@@ -1912,6 +1938,7 @@ hidden:
   ## MongoDB(&reg;) Hidden containers' Security Context (only main container).
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
   ## @param hidden.containerSecurityContext.enabled Enabled containers' Security Context
+  ## @param hidden.containerSecurityContext.seLinuxOptions Set SELinux options in container
   ## @param hidden.containerSecurityContext.runAsUser Set containers' Security Context runAsUser
   ## @param hidden.containerSecurityContext.runAsNonRoot Set container's Security Context runAsNonRoot
   ## @param hidden.containerSecurityContext.privileged Set container's Security Context privileged
@@ -1922,6 +1949,7 @@ hidden:
   ##
   containerSecurityContext:
     enabled: true
+    seLinuxOptions: {}
     runAsUser: 1001
     runAsNonRoot: true
     privileged: false


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

### Description of the change

This PR updates the podSecurityContext and containerSecurityContext fields by setting default values for essential security fields: seLinuxOptions, fsGroupChangePolicy, sysctls and supplementalGroups. These are required by security checklists. 

### Benefits

Charts become more security-compliant

### Possible drawbacks

n/a

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)

