### PR TITLE
[bitnami/redmine] fix: :lock: Improve podSecurityContext and containerSecurityContext with essential security fields

### DIFF
--- a/bitnami/redmine/Chart.yaml
+++ b/bitnami/redmine/Chart.yaml
@@ -43,4 +43,4 @@ maintainers:
 name: redmine
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/redmine
-version: 26.1.3
+version: 26.2.0

--- a/bitnami/redmine/README.md
+++ b/bitnami/redmine/README.md
@@ -128,8 +128,12 @@ helm install my-release oci://REGISTRY_NAME/REPOSITORY_NAME/redmine --set databa
 | `resources.limits`                             | The resources limits for the Redmine container                                                                           | `{}`             |
 | `resources.requests`                           | The requested resources for the Redmine container                                                                        | `{}`             |
 | `podSecurityContext.enabled`                   | Enabled Redmine pods' Security Context                                                                                   | `true`           |
+| `podSecurityContext.fsGroupChangePolicy`       | Set filesystem group change policy                                                                                       | `Always`         |
+| `podSecurityContext.sysctls`                   | Set kernel settings using the sysctl interface                                                                           | `[]`             |
+| `podSecurityContext.supplementalGroups`        | Set filesystem extra groups                                                                                              | `[]`             |
 | `podSecurityContext.fsGroup`                   | Set Redmine pod's Security Context fsGroup                                                                               | `0`              |
 | `containerSecurityContext.enabled`             | Enabled Redmine containers' Security Context                                                                             | `true`           |
+| `containerSecurityContext.seLinuxOptions`      | Set SELinux options in container                                                                                         | `{}`             |
 | `containerSecurityContext.runAsUser`           | Set Redmine container's Security Context runAsUser                                                                       | `0`              |
 | `containerSecurityContext.seccompProfile.type` | Set container's Security Context seccomp profile                                                                         | `RuntimeDefault` |
 | `livenessProbe.enabled`                        | Enable livenessProbe on Redmine containers                                                                               | `true`           |
@@ -211,21 +215,22 @@ helm install my-release oci://REGISTRY_NAME/REPOSITORY_NAME/redmine --set databa
 
 ### Persistence Parameters
 
-| Name                                                   | Description                                                                                     | Value   |
-| ------------------------------------------------------ | ----------------------------------------------------------------------------------------------- | ------- |
-| `persistence.enabled`                                  | Enable persistence using Persistent Volume Claims                                               | `true`  |
-| `persistence.storageClass`                             | Persistent Volume storage class                                                                 | `""`    |
-| `persistence.accessModes`                              | Persistent Volume access modes                                                                  | `[]`    |
-| `persistence.size`                                     | Persistent Volume size                                                                          | `8Gi`   |
-| `persistence.dataSource`                               | Custom PVC data source                                                                          | `{}`    |
-| `persistence.annotations`                              | Annotations for the PVC                                                                         | `{}`    |
-| `persistence.selector`                                 | Selector to match an existing Persistent Volume (this value is evaluated as a template)         | `{}`    |
-| `persistence.existingClaim`                            | The name of an existing PVC to use for persistence                                              | `""`    |
-| `volumePermissions.enabled`                            | Enable init container that changes the owner/group of the PV mount point to `runAsUser:fsGroup` | `false` |
-| `volumePermissions.resources.limits`                   | The resources limits for the init container                                                     | `{}`    |
-| `volumePermissions.resources.requests`                 | The requested resources for the init container                                                  | `{}`    |
-| `volumePermissions.containerSecurityContext.enabled`   | Enable init container's Security Context                                                        | `true`  |
-| `volumePermissions.containerSecurityContext.runAsUser` | Set init container's Security Context runAsUser                                                 | `0`     |
+| Name                                                        | Description                                                                                     | Value   |
+| ----------------------------------------------------------- | ----------------------------------------------------------------------------------------------- | ------- |
+| `persistence.enabled`                                       | Enable persistence using Persistent Volume Claims                                               | `true`  |
+| `persistence.storageClass`                                  | Persistent Volume storage class                                                                 | `""`    |
+| `persistence.accessModes`                                   | Persistent Volume access modes                                                                  | `[]`    |
+| `persistence.size`                                          | Persistent Volume size                                                                          | `8Gi`   |
+| `persistence.dataSource`                                    | Custom PVC data source                                                                          | `{}`    |
+| `persistence.annotations`                                   | Annotations for the PVC                                                                         | `{}`    |
+| `persistence.selector`                                      | Selector to match an existing Persistent Volume (this value is evaluated as a template)         | `{}`    |
+| `persistence.existingClaim`                                 | The name of an existing PVC to use for persistence                                              | `""`    |
+| `volumePermissions.enabled`                                 | Enable init container that changes the owner/group of the PV mount point to `runAsUser:fsGroup` | `false` |
+| `volumePermissions.resources.limits`                        | The resources limits for the init container                                                     | `{}`    |
+| `volumePermissions.resources.requests`                      | The requested resources for the init container                                                  | `{}`    |
+| `volumePermissions.containerSecurityContext.enabled`        | Enable init container's Security Context                                                        | `true`  |
+| `volumePermissions.containerSecurityContext.seLinuxOptions` | Set SELinux options in container                                                                | `{}`    |
+| `volumePermissions.containerSecurityContext.runAsUser`      | Set init container's Security Context runAsUser                                                 | `0`     |
 
 ### RBAC Parameters
 
@@ -276,58 +281,62 @@ helm install my-release oci://REGISTRY_NAME/REPOSITORY_NAME/redmine --set databa
 
 ### Mail Receiver/Cron Job Parameters
 
-| Name                                                 | Description                                                                                                                                   | Value         |
-| ---------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
-| `mailReceiver.enabled`                               | Whether to enable scheduled mail-to-task CronJob                                                                                              | `false`       |
-| `mailReceiver.schedule`                              | Kubernetes CronJob schedule                                                                                                                   | `*/5 * * * *` |
-| `mailReceiver.suspend`                               | Whether to create suspended CronJob                                                                                                           | `true`        |
-| `mailReceiver.mailProtocol`                          | Mail protocol to use for reading emails. Allowed values: `IMAP` and `POP3`                                                                    | `IMAP`        |
-| `mailReceiver.host`                                  | Server to receive emails from                                                                                                                 | `""`          |
-| `mailReceiver.port`                                  | TCP port on the `host`                                                                                                                        | `993`         |
-| `mailReceiver.username`                              | Login to authenticate on the `host`                                                                                                           | `""`          |
-| `mailReceiver.password`                              | Password to authenticate on the `host`                                                                                                        | `""`          |
-| `mailReceiver.ssl`                                   | Whether use SSL/TLS to connect to the `host`                                                                                                  | `true`        |
-| `mailReceiver.startTLS`                              | Whether use StartTLS to connect to the `host`                                                                                                 | `false`       |
-| `mailReceiver.imapFolder`                            | IMAP only. Folder to read emails from                                                                                                         | `INBOX`       |
-| `mailReceiver.moveOnSuccess`                         | IMAP only. Folder to move processed emails to                                                                                                 | `""`          |
-| `mailReceiver.moveOnFailure`                         | IMAP only. Folder to move emails with processing errors to                                                                                    | `""`          |
-| `mailReceiver.unknownUserAction`                     | Action to perform is an email received from unregistered user                                                                                 | `ignore`      |
-| `mailReceiver.noPermissionCheck`                     | Whether skip permission check during creating a new task                                                                                      | `0`           |
-| `mailReceiver.noAccountNotice`                       | Whether send an email to an unregistered user created during a new task creation                                                              | `1`           |
-| `mailReceiver.defaultGroup`                          | Defines a group list to add created user to                                                                                                   | `""`          |
-| `mailReceiver.project`                               | Defines identifier of the target project for a new task                                                                                       | `""`          |
-| `mailReceiver.projectFromSubaddress`                 | Defines email address to select project from subaddress                                                                                       | `""`          |
-| `mailReceiver.status`                                | Defines a new task status                                                                                                                     | `""`          |
-| `mailReceiver.tracker`                               | Defines a new task tracker                                                                                                                    | `""`          |
-| `mailReceiver.category`                              | Defines a new task category                                                                                                                   | `""`          |
-| `mailReceiver.priority`                              | Defines a new task priority                                                                                                                   | `""`          |
-| `mailReceiver.assignedTo`                            | Defines a new task assignee                                                                                                                   | `""`          |
-| `mailReceiver.allowOverride`                         | Defines if email content is allowed to set attributes values. Values is a comma separated list of attributes or `all` to allow all attributes | `""`          |
-| `mailReceiver.command`                               | Override default container command (useful when using custom images)                                                                          | `[]`          |
-| `mailReceiver.args`                                  | Override default container args (useful when using custom images)                                                                             | `[]`          |
-| `mailReceiver.extraEnvVars`                          | Extra environment variables to be set on mailReceiver container                                                                               | `[]`          |
-| `mailReceiver.extraEnvVarsCM`                        | Name of existing ConfigMap containing extra env vars                                                                                          | `""`          |
-| `mailReceiver.extraEnvVarsSecret`                    | Name of existing Secret containing extra env vars                                                                                             | `""`          |
-| `mailReceiver.podSecurityContext.enabled`            | Enabled Redmine pods' Security Context                                                                                                        | `true`        |
-| `mailReceiver.podSecurityContext.fsGroup`            | Set Redmine pod's Security Context fsGroup                                                                                                    | `1001`        |
-| `mailReceiver.containerSecurityContext.enabled`      | mailReceiver Container securityContext                                                                                                        | `false`       |
-| `mailReceiver.containerSecurityContext.runAsUser`    | User ID for the mailReceiver container                                                                                                        | `1001`        |
-| `mailReceiver.containerSecurityContext.runAsNonRoot` | Whether to run the mailReceiver container as a non-root user                                                                                  | `true`        |
-| `mailReceiver.podAnnotations`                        | Additional pod annotations                                                                                                                    | `{}`          |
-| `mailReceiver.podLabels`                             | Additional pod labels                                                                                                                         | `{}`          |
-| `mailReceiver.podAffinityPreset`                     | Pod affinity preset. Ignored if `mailReceiver.affinity` is set. Allowed values: `soft` or `hard`                                              | `""`          |
-| `mailReceiver.podAntiAffinityPreset`                 | Pod anti-affinity preset. Ignored if `mailReceiver.affinity` is set. Allowed values: `soft` or `hard`                                         | `soft`        |
-| `mailReceiver.nodeAffinityPreset.type`               | Node affinity preset. Ignored if `mailReceiver.affinity` is set. Allowed values: `soft` or `hard`                                             | `""`          |
-| `mailReceiver.nodeAffinityPreset.key`                | Node label key to match. Ignored if `mailReceiver.affinity` is set.                                                                           | `""`          |
-| `mailReceiver.nodeAffinityPreset.values`             | Node label values to match. Ignored if `mailReceiver.affinity` is set.                                                                        | `[]`          |
-| `mailReceiver.affinity`                              | Affinity for pod assignment                                                                                                                   | `{}`          |
-| `mailReceiver.nodeSelector`                          | Node labels for pod assignment                                                                                                                | `{}`          |
-| `mailReceiver.tolerations`                           | Tolerations for pod assignment                                                                                                                | `[]`          |
-| `mailReceiver.priorityClassName`                     | Redmine pods' priority.                                                                                                                       | `""`          |
-| `mailReceiver.initContainers`                        | Add additional init containers to the mailReceiver pods                                                                                       | `[]`          |
-| `mailReceiver.sidecars`                              | Add additional sidecar containers to the mailReceiver pods                                                                                    | `[]`          |
-| `mailReceiver.extraVolumes`                          | Optionally specify extra list of additional volumes for mailReceiver container                                                                | `[]`          |
-| `mailReceiver.extraVolumeMounts`                     | Optionally specify extra list of additional volumeMounts for mailReceiver container                                                           | `[]`          |
+| Name                                                   | Description                                                                                                                                   | Value         |
+| ------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| `mailReceiver.enabled`                                 | Whether to enable scheduled mail-to-task CronJob                                                                                              | `false`       |
+| `mailReceiver.schedule`                                | Kubernetes CronJob schedule                                                                                                                   | `*/5 * * * *` |
+| `mailReceiver.suspend`                                 | Whether to create suspended CronJob                                                                                                           | `true`        |
+| `mailReceiver.mailProtocol`                            | Mail protocol to use for reading emails. Allowed values: `IMAP` and `POP3`                                                                    | `IMAP`        |
+| `mailReceiver.host`                                    | Server to receive emails from                                                                                                                 | `""`          |
+| `mailReceiver.port`                                    | TCP port on the `host`                                                                                                                        | `993`         |
+| `mailReceiver.username`                                | Login to authenticate on the `host`                                                                                                           | `""`          |
+| `mailReceiver.password`                                | Password to authenticate on the `host`                                                                                                        | `""`          |
+| `mailReceiver.ssl`                                     | Whether use SSL/TLS to connect to the `host`                                                                                                  | `true`        |
+| `mailReceiver.startTLS`                                | Whether use StartTLS to connect to the `host`                                                                                                 | `false`       |
+| `mailReceiver.imapFolder`                              | IMAP only. Folder to read emails from                                                                                                         | `INBOX`       |
+| `mailReceiver.moveOnSuccess`                           | IMAP only. Folder to move processed emails to                                                                                                 | `""`          |
+| `mailReceiver.moveOnFailure`                           | IMAP only. Folder to move emails with processing errors to                                                                                    | `""`          |
+| `mailReceiver.unknownUserAction`                       | Action to perform is an email received from unregistered user                                                                                 | `ignore`      |
+| `mailReceiver.noPermissionCheck`                       | Whether skip permission check during creating a new task                                                                                      | `0`           |
+| `mailReceiver.noAccountNotice`                         | Whether send an email to an unregistered user created during a new task creation                                                              | `1`           |
+| `mailReceiver.defaultGroup`                            | Defines a group list to add created user to                                                                                                   | `""`          |
+| `mailReceiver.project`                                 | Defines identifier of the target project for a new task                                                                                       | `""`          |
+| `mailReceiver.projectFromSubaddress`                   | Defines email address to select project from subaddress                                                                                       | `""`          |
+| `mailReceiver.status`                                  | Defines a new task status                                                                                                                     | `""`          |
+| `mailReceiver.tracker`                                 | Defines a new task tracker                                                                                                                    | `""`          |
+| `mailReceiver.category`                                | Defines a new task category                                                                                                                   | `""`          |
+| `mailReceiver.priority`                                | Defines a new task priority                                                                                                                   | `""`          |
+| `mailReceiver.assignedTo`                              | Defines a new task assignee                                                                                                                   | `""`          |
+| `mailReceiver.allowOverride`                           | Defines if email content is allowed to set attributes values. Values is a comma separated list of attributes or `all` to allow all attributes | `""`          |
+| `mailReceiver.command`                                 | Override default container command (useful when using custom images)                                                                          | `[]`          |
+| `mailReceiver.args`                                    | Override default container args (useful when using custom images)                                                                             | `[]`          |
+| `mailReceiver.extraEnvVars`                            | Extra environment variables to be set on mailReceiver container                                                                               | `[]`          |
+| `mailReceiver.extraEnvVarsCM`                          | Name of existing ConfigMap containing extra env vars                                                                                          | `""`          |
+| `mailReceiver.extraEnvVarsSecret`                      | Name of existing Secret containing extra env vars                                                                                             | `""`          |
+| `mailReceiver.podSecurityContext.enabled`              | Enabled Redmine pods' Security Context                                                                                                        | `true`        |
+| `mailReceiver.podSecurityContext.fsGroupChangePolicy`  | Set filesystem group change policy                                                                                                            | `Always`      |
+| `mailReceiver.podSecurityContext.sysctls`              | Set kernel settings using the sysctl interface                                                                                                | `[]`          |
+| `mailReceiver.podSecurityContext.supplementalGroups`   | Set filesystem extra groups                                                                                                                   | `[]`          |
+| `mailReceiver.podSecurityContext.fsGroup`              | Set Redmine pod's Security Context fsGroup                                                                                                    | `1001`        |
+| `mailReceiver.containerSecurityContext.enabled`        | mailReceiver Container securityContext                                                                                                        | `false`       |
+| `mailReceiver.containerSecurityContext.seLinuxOptions` | Set SELinux options in container                                                                                                              | `{}`          |
+| `mailReceiver.containerSecurityContext.runAsUser`      | User ID for the mailReceiver container                                                                                                        | `1001`        |
+| `mailReceiver.containerSecurityContext.runAsNonRoot`   | Whether to run the mailReceiver container as a non-root user                                                                                  | `true`        |
+| `mailReceiver.podAnnotations`                          | Additional pod annotations                                                                                                                    | `{}`          |
+| `mailReceiver.podLabels`                               | Additional pod labels                                                                                                                         | `{}`          |
+| `mailReceiver.podAffinityPreset`                       | Pod affinity preset. Ignored if `mailReceiver.affinity` is set. Allowed values: `soft` or `hard`                                              | `""`          |
+| `mailReceiver.podAntiAffinityPreset`                   | Pod anti-affinity preset. Ignored if `mailReceiver.affinity` is set. Allowed values: `soft` or `hard`                                         | `soft`        |
+| `mailReceiver.nodeAffinityPreset.type`                 | Node affinity preset. Ignored if `mailReceiver.affinity` is set. Allowed values: `soft` or `hard`                                             | `""`          |
+| `mailReceiver.nodeAffinityPreset.key`                  | Node label key to match. Ignored if `mailReceiver.affinity` is set.                                                                           | `""`          |
+| `mailReceiver.nodeAffinityPreset.values`               | Node label values to match. Ignored if `mailReceiver.affinity` is set.                                                                        | `[]`          |
+| `mailReceiver.affinity`                                | Affinity for pod assignment                                                                                                                   | `{}`          |
+| `mailReceiver.nodeSelector`                            | Node labels for pod assignment                                                                                                                | `{}`          |
+| `mailReceiver.tolerations`                             | Tolerations for pod assignment                                                                                                                | `[]`          |
+| `mailReceiver.priorityClassName`                       | Redmine pods' priority.                                                                                                                       | `""`          |
+| `mailReceiver.initContainers`                          | Add additional init containers to the mailReceiver pods                                                                                       | `[]`          |
+| `mailReceiver.sidecars`                                | Add additional sidecar containers to the mailReceiver pods                                                                                    | `[]`          |
+| `mailReceiver.extraVolumes`                            | Optionally specify extra list of additional volumes for mailReceiver container                                                                | `[]`          |
+| `mailReceiver.extraVolumeMounts`                       | Optionally specify extra list of additional volumeMounts for mailReceiver container                                                           | `[]`          |
 
 ### Custom Certificates parameters
 

--- a/bitnami/redmine/values.yaml
+++ b/bitnami/redmine/values.yaml
@@ -189,19 +189,27 @@ resources:
 ## Configure Pods Security Context
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
 ## @param podSecurityContext.enabled Enabled Redmine pods' Security Context
+## @param podSecurityContext.fsGroupChangePolicy Set filesystem group change policy
+## @param podSecurityContext.sysctls Set kernel settings using the sysctl interface
+## @param podSecurityContext.supplementalGroups Set filesystem extra groups
 ## @param podSecurityContext.fsGroup Set Redmine pod's Security Context fsGroup
 ##
 podSecurityContext:
   enabled: true
+  fsGroupChangePolicy: Always
+  sysctls: []
+  supplementalGroups: []
   fsGroup: 0
 ## Configure Container Security Context (only main container)
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
 ## @param containerSecurityContext.enabled Enabled Redmine containers' Security Context
+## @param containerSecurityContext.seLinuxOptions Set SELinux options in container
 ## @param containerSecurityContext.runAsUser Set Redmine container's Security Context runAsUser
 ## @param containerSecurityContext.seccompProfile.type Set container's Security Context seccomp profile
 ##
 containerSecurityContext:
   enabled: true
+  seLinuxOptions: {}
   runAsUser: 0
   seccompProfile:
     type: "RuntimeDefault"
@@ -588,10 +596,12 @@ volumePermissions:
   ## Init container Container Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
   ## @param volumePermissions.containerSecurityContext.enabled Enable init container's Security Context
+  ## @param volumePermissions.containerSecurityContext.seLinuxOptions Set SELinux options in container
   ## @param volumePermissions.containerSecurityContext.runAsUser Set init container's Security Context runAsUser
   ##
   containerSecurityContext:
     enabled: true
+    seLinuxOptions: {}
     runAsUser: 0
 
 ## @section RBAC Parameters
@@ -807,19 +817,27 @@ mailReceiver:
   ## Configure Pods Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param mailReceiver.podSecurityContext.enabled Enabled Redmine pods' Security Context
+  ## @param mailReceiver.podSecurityContext.fsGroupChangePolicy Set filesystem group change policy
+  ## @param mailReceiver.podSecurityContext.sysctls Set kernel settings using the sysctl interface
+  ## @param mailReceiver.podSecurityContext.supplementalGroups Set filesystem extra groups
   ## @param mailReceiver.podSecurityContext.fsGroup Set Redmine pod's Security Context fsGroup
   ##
   podSecurityContext:
     enabled: true
+    fsGroupChangePolicy: Always
+    sysctls: []
+    supplementalGroups: []
     fsGroup: 1001
   ## @param
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
   ## @param mailReceiver.containerSecurityContext.enabled mailReceiver Container securityContext
+  ## @param mailReceiver.containerSecurityContext.seLinuxOptions Set SELinux options in container
   ## @param mailReceiver.containerSecurityContext.runAsUser User ID for the mailReceiver container
   ## @param mailReceiver.containerSecurityContext.runAsNonRoot Whether to run the mailReceiver container as a non-root user
   ##
   containerSecurityContext:
     enabled: false
+    seLinuxOptions: {}
     runAsUser: 1001
     runAsNonRoot: true
   ## @param mailReceiver.podAnnotations Additional pod annotations


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

### Description of the change

This PR updates the podSecurityContext and containerSecurityContext fields by setting default values for essential security fields: seLinuxOptions, fsGroupChangePolicy, sysctls and supplementalGroups. These are required by security checklists. 

### Benefits

Charts become more security-compliant

### Possible drawbacks

n/a

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)

