### PR TITLE
[bitnami/sonarqube] fix: :lock: Improve podSecurityContext and containerSecurityContext with essential security fields

### DIFF
--- a/bitnami/sonarqube/Chart.yaml
+++ b/bitnami/sonarqube/Chart.yaml
@@ -37,4 +37,4 @@ maintainers:
 name: sonarqube
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/sonarqube
-version: 4.1.7
+version: 4.2.0

--- a/bitnami/sonarqube/README.md
+++ b/bitnami/sonarqube/README.md
@@ -163,8 +163,12 @@ The command removes all the Kubernetes components associated with the chart and 
 | `resources.limits`                                  | The resources limits for the SonarQube&trade; containers                                       | `{}`             |
 | `resources.requests`                                | The requested resources for the SonarQube&trade; containers                                    | `{}`             |
 | `podSecurityContext.enabled`                        | Enabled SonarQube&trade; pods' Security Context                                                | `true`           |
+| `podSecurityContext.fsGroupChangePolicy`            | Set filesystem group change policy                                                             | `Always`         |
+| `podSecurityContext.sysctls`                        | Set kernel settings using the sysctl interface                                                 | `[]`             |
+| `podSecurityContext.supplementalGroups`             | Set filesystem extra groups                                                                    | `[]`             |
 | `podSecurityContext.fsGroup`                        | Set SonarQube&trade; pod's Security Context fsGroup                                            | `1001`           |
 | `containerSecurityContext.enabled`                  | Enabled containers' Security Context                                                           | `true`           |
+| `containerSecurityContext.seLinuxOptions`           | Set SELinux options in container                                                               | `{}`             |
 | `containerSecurityContext.runAsUser`                | Set containers' Security Context runAsUser                                                     | `1001`           |
 | `containerSecurityContext.runAsNonRoot`             | Set container's Security Context runAsNonRoot                                                  | `true`           |
 | `containerSecurityContext.privileged`               | Set container's Security Context privileged                                                    | `false`          |
@@ -227,55 +231,58 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### SonarQube caCerts provisioning parameters
 
-| Name                                         | Description                                                                                                        | Value                      |
-| -------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ | -------------------------- |
-| `caCerts.enabled`                            | Enable the use of caCerts                                                                                          | `false`                    |
-| `caCerts.image.registry`                     | OS Shell + Utility image registry                                                                                  | `REGISTRY_NAME`            |
-| `caCerts.image.repository`                   | OS Shell + Utility image repository                                                                                | `REPOSITORY_NAME/os-shell` |
-| `caCerts.image.digest`                       | OS Shell + Utility image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                       |
-| `caCerts.image.pullPolicy`                   | OS Shell + Utility image pull policy                                                                               | `IfNotPresent`             |
-| `caCerts.image.pullSecrets`                  | OS Shell + Utility image pull secrets                                                                              | `[]`                       |
-| `caCerts.secret`                             | Name of the secret containing the certificates                                                                     | `ca-certs-secret`          |
-| `caCerts.resources.limits`                   | The resources limits for the init container                                                                        | `{}`                       |
-| `caCerts.resources.requests`                 | The requested resources for the init container                                                                     | `{}`                       |
-| `caCerts.containerSecurityContext.runAsUser` | Set init container's Security Context runAsUser                                                                    | `0`                        |
+| Name                                              | Description                                                                                                        | Value                      |
+| ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ | -------------------------- |
+| `caCerts.enabled`                                 | Enable the use of caCerts                                                                                          | `false`                    |
+| `caCerts.image.registry`                          | OS Shell + Utility image registry                                                                                  | `REGISTRY_NAME`            |
+| `caCerts.image.repository`                        | OS Shell + Utility image repository                                                                                | `REPOSITORY_NAME/os-shell` |
+| `caCerts.image.digest`                            | OS Shell + Utility image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                       |
+| `caCerts.image.pullPolicy`                        | OS Shell + Utility image pull policy                                                                               | `IfNotPresent`             |
+| `caCerts.image.pullSecrets`                       | OS Shell + Utility image pull secrets                                                                              | `[]`                       |
+| `caCerts.secret`                                  | Name of the secret containing the certificates                                                                     | `ca-certs-secret`          |
+| `caCerts.resources.limits`                        | The resources limits for the init container                                                                        | `{}`                       |
+| `caCerts.resources.requests`                      | The requested resources for the init container                                                                     | `{}`                       |
+| `caCerts.containerSecurityContext.seLinuxOptions` | Set SELinux options in container                                                                                   | `{}`                       |
+| `caCerts.containerSecurityContext.runAsUser`      | Set init container's Security Context runAsUser                                                                    | `0`                        |
 
 ### SonarQube plugin provisioning parameters
 
-| Name                                         | Description                                                                                                        | Value                      |
-| -------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ | -------------------------- |
-| `plugins.install`                            | List of plugin URLS to download and install                                                                        | `[]`                       |
-| `plugins.netrcCreds`                         | .netrc secret file with a key "netrc" to use basic auth while downloading plugins                                  | `""`                       |
-| `plugins.noCheckCertificate`                 | Set to true to not validate the server's certificate to download plugin                                            | `true`                     |
-| `plugins.image.registry`                     | OS Shell + Utility image registry                                                                                  | `REGISTRY_NAME`            |
-| `plugins.image.repository`                   | OS Shell + Utility image repository                                                                                | `REPOSITORY_NAME/os-shell` |
-| `plugins.image.digest`                       | OS Shell + Utility image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                       |
-| `plugins.image.pullPolicy`                   | OS Shell + Utility image pull policy                                                                               | `IfNotPresent`             |
-| `plugins.image.pullSecrets`                  | OS Shell + Utility image pull secrets                                                                              | `[]`                       |
-| `plugins.resources.limits`                   | The resources limits for the init container                                                                        | `{}`                       |
-| `plugins.resources.requests`                 | The requested resources for the init container                                                                     | `{}`                       |
-| `plugins.containerSecurityContext.runAsUser` | Set init container's Security Context runAsUser                                                                    | `0`                        |
+| Name                                              | Description                                                                                                        | Value                      |
+| ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ | -------------------------- |
+| `plugins.install`                                 | List of plugin URLS to download and install                                                                        | `[]`                       |
+| `plugins.netrcCreds`                              | .netrc secret file with a key "netrc" to use basic auth while downloading plugins                                  | `""`                       |
+| `plugins.noCheckCertificate`                      | Set to true to not validate the server's certificate to download plugin                                            | `true`                     |
+| `plugins.image.registry`                          | OS Shell + Utility image registry                                                                                  | `REGISTRY_NAME`            |
+| `plugins.image.repository`                        | OS Shell + Utility image repository                                                                                | `REPOSITORY_NAME/os-shell` |
+| `plugins.image.digest`                            | OS Shell + Utility image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                       |
+| `plugins.image.pullPolicy`                        | OS Shell + Utility image pull policy                                                                               | `IfNotPresent`             |
+| `plugins.image.pullSecrets`                       | OS Shell + Utility image pull secrets                                                                              | `[]`                       |
+| `plugins.resources.limits`                        | The resources limits for the init container                                                                        | `{}`                       |
+| `plugins.resources.requests`                      | The requested resources for the init container                                                                     | `{}`                       |
+| `plugins.containerSecurityContext.seLinuxOptions` | Set SELinux options in container                                                                                   | `{}`                       |
+| `plugins.containerSecurityContext.runAsUser`      | Set init container's Security Context runAsUser                                                                    | `0`                        |
 
 ### Persistence Parameters
 
-| Name                                                   | Description                                                                                                        | Value                      |
-| ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------ | -------------------------- |
-| `persistence.enabled`                                  | Enable persistence using Persistent Volume Claims                                                                  | `false`                    |
-| `persistence.storageClass`                             | Persistent Volume storage class                                                                                    | `""`                       |
-| `persistence.accessModes`                              | Persistent Volume access modes                                                                                     | `[]`                       |
-| `persistence.size`                                     | Persistent Volume size                                                                                             | `10Gi`                     |
-| `persistence.dataSource`                               | Custom PVC data source                                                                                             | `{}`                       |
-| `persistence.existingClaim`                            | The name of an existing PVC to use for persistence                                                                 | `""`                       |
-| `persistence.annotations`                              | Persistent Volume Claim annotations                                                                                | `{}`                       |
-| `volumePermissions.enabled`                            | Enable init container that changes the owner/group of the PV mount point to `runAsUser:fsGroup`                    | `false`                    |
-| `volumePermissions.image.registry`                     | OS Shell + Utility image registry                                                                                  | `REGISTRY_NAME`            |
-| `volumePermissions.image.repository`                   | OS Shell + Utility image repository                                                                                | `REPOSITORY_NAME/os-shell` |
-| `volumePermissions.image.digest`                       | OS Shell + Utility image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                       |
-| `volumePermissions.image.pullPolicy`                   | OS Shell + Utility image pull policy                                                                               | `IfNotPresent`             |
-| `volumePermissions.image.pullSecrets`                  | OS Shell + Utility image pull secrets                                                                              | `[]`                       |
-| `volumePermissions.resources.limits`                   | The resources limits for the init container                                                                        | `{}`                       |
-| `volumePermissions.resources.requests`                 | The requested resources for the init container                                                                     | `{}`                       |
-| `volumePermissions.containerSecurityContext.runAsUser` | Set init container's Security Context runAsUser                                                                    | `0`                        |
+| Name                                                        | Description                                                                                                        | Value                      |
+| ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ | -------------------------- |
+| `persistence.enabled`                                       | Enable persistence using Persistent Volume Claims                                                                  | `false`                    |
+| `persistence.storageClass`                                  | Persistent Volume storage class                                                                                    | `""`                       |
+| `persistence.accessModes`                                   | Persistent Volume access modes                                                                                     | `[]`                       |
+| `persistence.size`                                          | Persistent Volume size                                                                                             | `10Gi`                     |
+| `persistence.dataSource`                                    | Custom PVC data source                                                                                             | `{}`                       |
+| `persistence.existingClaim`                                 | The name of an existing PVC to use for persistence                                                                 | `""`                       |
+| `persistence.annotations`                                   | Persistent Volume Claim annotations                                                                                | `{}`                       |
+| `volumePermissions.enabled`                                 | Enable init container that changes the owner/group of the PV mount point to `runAsUser:fsGroup`                    | `false`                    |
+| `volumePermissions.image.registry`                          | OS Shell + Utility image registry                                                                                  | `REGISTRY_NAME`            |
+| `volumePermissions.image.repository`                        | OS Shell + Utility image repository                                                                                | `REPOSITORY_NAME/os-shell` |
+| `volumePermissions.image.digest`                            | OS Shell + Utility image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                       |
+| `volumePermissions.image.pullPolicy`                        | OS Shell + Utility image pull policy                                                                               | `IfNotPresent`             |
+| `volumePermissions.image.pullSecrets`                       | OS Shell + Utility image pull secrets                                                                              | `[]`                       |
+| `volumePermissions.resources.limits`                        | The resources limits for the init container                                                                        | `{}`                       |
+| `volumePermissions.resources.requests`                      | The requested resources for the init container                                                                     | `{}`                       |
+| `volumePermissions.containerSecurityContext.seLinuxOptions` | Set SELinux options in container                                                                                   | `{}`                       |
+| `volumePermissions.containerSecurityContext.runAsUser`      | Set init container's Security Context runAsUser                                                                    | `0`                        |
 
 ### Sysctl Image parameters
 
@@ -307,33 +314,34 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Metrics parameters
 
-| Name                                                | Description                                                                                                  | Value                          |
-| --------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ | ------------------------------ |
-| `metrics.jmx.enabled`                               | Whether or not to expose JMX metrics to Prometheus                                                           | `false`                        |
-| `metrics.jmx.image.registry`                        | JMX exporter image registry                                                                                  | `REGISTRY_NAME`                |
-| `metrics.jmx.image.repository`                      | JMX exporter image repository                                                                                | `REPOSITORY_NAME/jmx-exporter` |
-| `metrics.jmx.image.digest`                          | JMX exporter image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                           |
-| `metrics.jmx.image.pullPolicy`                      | JMX exporter image pull policy                                                                               | `IfNotPresent`                 |
-| `metrics.jmx.image.pullSecrets`                     | Specify docker-registry secret names as an array                                                             | `[]`                           |
-| `metrics.jmx.containerPorts.metrics`                | JMX Exporter metrics container port                                                                          | `10445`                        |
-| `metrics.jmx.resources.limits`                      | The resources limits for the init container                                                                  | `{}`                           |
-| `metrics.jmx.resources.requests`                    | The requested resources for the init container                                                               | `{}`                           |
-| `metrics.jmx.containerSecurityContext.enabled`      | Enabled JMX Exporter containers' Security Context                                                            | `true`                         |
-| `metrics.jmx.containerSecurityContext.runAsUser`    | Set JMX Exporter containers' Security Context runAsUser                                                      | `1001`                         |
-| `metrics.jmx.containerSecurityContext.runAsNonRoot` | Set JMX Exporter containers' Security Context runAsNonRoot                                                   | `true`                         |
-| `metrics.jmx.whitelistObjectNames`                  | Allows setting which JMX objects you want to expose to via JMX stats to JMX Exporter                         | `[]`                           |
-| `metrics.jmx.configuration`                         | Configuration file for JMX exporter                                                                          | `""`                           |
-| `metrics.jmx.service.ports.metrics`                 | JMX Exporter Prometheus port                                                                                 | `10443`                        |
-| `metrics.jmx.service.annotations`                   | Annotations for the JMX Exporter Prometheus metrics service                                                  | `{}`                           |
-| `metrics.serviceMonitor.enabled`                    | if `true`, creates a Prometheus Operator ServiceMonitor (requires `metrics.jmx.enabled` to be `true`)        | `false`                        |
-| `metrics.serviceMonitor.namespace`                  | Namespace in which Prometheus is running                                                                     | `""`                           |
-| `metrics.serviceMonitor.labels`                     | Extra labels for the ServiceMonitor                                                                          | `{}`                           |
-| `metrics.serviceMonitor.jobLabel`                   | The name of the label on the target service to use as the job name in Prometheus                             | `""`                           |
-| `metrics.serviceMonitor.interval`                   | How frequently to scrape metrics                                                                             | `""`                           |
-| `metrics.serviceMonitor.scrapeTimeout`              | Timeout after which the scrape is ended                                                                      | `""`                           |
-| `metrics.serviceMonitor.metricRelabelings`          | Specify additional relabeling of metrics                                                                     | `[]`                           |
-| `metrics.serviceMonitor.relabelings`                | Specify general relabeling                                                                                   | `[]`                           |
-| `metrics.serviceMonitor.selector`                   | Prometheus instance selector labels                                                                          | `{}`                           |
+| Name                                                  | Description                                                                                                  | Value                          |
+| ----------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ | ------------------------------ |
+| `metrics.jmx.enabled`                                 | Whether or not to expose JMX metrics to Prometheus                                                           | `false`                        |
+| `metrics.jmx.image.registry`                          | JMX exporter image registry                                                                                  | `REGISTRY_NAME`                |
+| `metrics.jmx.image.repository`                        | JMX exporter image repository                                                                                | `REPOSITORY_NAME/jmx-exporter` |
+| `metrics.jmx.image.digest`                            | JMX exporter image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                           |
+| `metrics.jmx.image.pullPolicy`                        | JMX exporter image pull policy                                                                               | `IfNotPresent`                 |
+| `metrics.jmx.image.pullSecrets`                       | Specify docker-registry secret names as an array                                                             | `[]`                           |
+| `metrics.jmx.containerPorts.metrics`                  | JMX Exporter metrics container port                                                                          | `10445`                        |
+| `metrics.jmx.resources.limits`                        | The resources limits for the init container                                                                  | `{}`                           |
+| `metrics.jmx.resources.requests`                      | The requested resources for the init container                                                               | `{}`                           |
+| `metrics.jmx.containerSecurityContext.enabled`        | Enabled JMX Exporter containers' Security Context                                                            | `true`                         |
+| `metrics.jmx.containerSecurityContext.seLinuxOptions` | Set SELinux options in container                                                                             | `{}`                           |
+| `metrics.jmx.containerSecurityContext.runAsUser`      | Set JMX Exporter containers' Security Context runAsUser                                                      | `1001`                         |
+| `metrics.jmx.containerSecurityContext.runAsNonRoot`   | Set JMX Exporter containers' Security Context runAsNonRoot                                                   | `true`                         |
+| `metrics.jmx.whitelistObjectNames`                    | Allows setting which JMX objects you want to expose to via JMX stats to JMX Exporter                         | `[]`                           |
+| `metrics.jmx.configuration`                           | Configuration file for JMX exporter                                                                          | `""`                           |
+| `metrics.jmx.service.ports.metrics`                   | JMX Exporter Prometheus port                                                                                 | `10443`                        |
+| `metrics.jmx.service.annotations`                     | Annotations for the JMX Exporter Prometheus metrics service                                                  | `{}`                           |
+| `metrics.serviceMonitor.enabled`                      | if `true`, creates a Prometheus Operator ServiceMonitor (requires `metrics.jmx.enabled` to be `true`)        | `false`                        |
+| `metrics.serviceMonitor.namespace`                    | Namespace in which Prometheus is running                                                                     | `""`                           |
+| `metrics.serviceMonitor.labels`                       | Extra labels for the ServiceMonitor                                                                          | `{}`                           |
+| `metrics.serviceMonitor.jobLabel`                     | The name of the label on the target service to use as the job name in Prometheus                             | `""`                           |
+| `metrics.serviceMonitor.interval`                     | How frequently to scrape metrics                                                                             | `""`                           |
+| `metrics.serviceMonitor.scrapeTimeout`                | Timeout after which the scrape is ended                                                                      | `""`                           |
+| `metrics.serviceMonitor.metricRelabelings`            | Specify additional relabeling of metrics                                                                     | `[]`                           |
+| `metrics.serviceMonitor.relabelings`                  | Specify general relabeling                                                                                   | `[]`                           |
+| `metrics.serviceMonitor.selector`                     | Prometheus instance selector labels                                                                          | `{}`                           |
 
 ### PostgreSQL subchart settings
 

--- a/bitnami/sonarqube/values.yaml
+++ b/bitnami/sonarqube/values.yaml
@@ -314,14 +314,21 @@ resources:
 ## Configure Pods Security Context
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
 ## @param podSecurityContext.enabled Enabled SonarQube&trade; pods' Security Context
+## @param podSecurityContext.fsGroupChangePolicy Set filesystem group change policy
+## @param podSecurityContext.sysctls Set kernel settings using the sysctl interface
+## @param podSecurityContext.supplementalGroups Set filesystem extra groups
 ## @param podSecurityContext.fsGroup Set SonarQube&trade; pod's Security Context fsGroup
 ##
 podSecurityContext:
   enabled: true
+  fsGroupChangePolicy: Always
+  sysctls: []
+  supplementalGroups: []
   fsGroup: 1001
 ## Configure Container Security Context
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
 ## @param containerSecurityContext.enabled Enabled containers' Security Context
+## @param containerSecurityContext.seLinuxOptions Set SELinux options in container
 ## @param containerSecurityContext.runAsUser Set containers' Security Context runAsUser
 ## @param containerSecurityContext.runAsNonRoot Set container's Security Context runAsNonRoot
 ## @param containerSecurityContext.privileged Set container's Security Context privileged
@@ -332,6 +339,7 @@ podSecurityContext:
 ##
 containerSecurityContext:
   enabled: true
+  seLinuxOptions: {}
   runAsUser: 1001
   runAsNonRoot: true
   privileged: false
@@ -652,12 +660,14 @@ caCerts:
     requests: {}
   ## Init container Container Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
+  ## @param caCerts.containerSecurityContext.seLinuxOptions Set SELinux options in container
   ## @param caCerts.containerSecurityContext.runAsUser Set init container's Security Context runAsUser
   ## NOTE: when runAsUser is set to special value "auto", init container will try to chown the
   ##   data folder to auto-determined user&group, using commands: `id -u`:`id -G | cut -d" " -f2`
   ##   "auto" is especially useful for OpenShift which has scc with dynamic user ids (and 0 is not allowed)
   ##
   containerSecurityContext:
+    seLinuxOptions: {}
     runAsUser: 0
 
 ## @section SonarQube plugin provisioning parameters
@@ -710,12 +720,14 @@ plugins:
     requests: {}
   ## Init container Container Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
+  ## @param plugins.containerSecurityContext.seLinuxOptions Set SELinux options in container
   ## @param plugins.containerSecurityContext.runAsUser Set init container's Security Context runAsUser
   ## NOTE: when runAsUser is set to special value "auto", init container will try to chown the
   ##   data folder to auto-determined user&group, using commands: `id -u`:`id -G | cut -d" " -f2`
   ##   "auto" is especially useful for OpenShift which has scc with dynamic user ids (and 0 is not allowed)
   ##
   containerSecurityContext:
+    seLinuxOptions: {}
     runAsUser: 0
 
 ## @section Persistence Parameters
@@ -791,12 +803,14 @@ volumePermissions:
     requests: {}
   ## Init container Container Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
+  ## @param volumePermissions.containerSecurityContext.seLinuxOptions Set SELinux options in container
   ## @param volumePermissions.containerSecurityContext.runAsUser Set init container's Security Context runAsUser
   ## NOTE: when runAsUser is set to special value "auto", init container will try to chown the
   ##   data folder to auto-determined user&group, using commands: `id -u`:`id -G | cut -d" " -f2`
   ##   "auto" is especially useful for OpenShift which has scc with dynamic user ids (and 0 is not allowed)
   ##
   containerSecurityContext:
+    seLinuxOptions: {}
     runAsUser: 0
 
 ## @section Sysctl Image parameters
@@ -926,11 +940,13 @@ metrics:
     ## Configure Container Security Context
     ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
     ## @param metrics.jmx.containerSecurityContext.enabled Enabled JMX Exporter containers' Security Context
+    ## @param metrics.jmx.containerSecurityContext.seLinuxOptions Set SELinux options in container
     ## @param metrics.jmx.containerSecurityContext.runAsUser Set JMX Exporter containers' Security Context runAsUser
     ## @param metrics.jmx.containerSecurityContext.runAsNonRoot Set JMX Exporter containers' Security Context runAsNonRoot
     ##
     containerSecurityContext:
       enabled: true
+      seLinuxOptions: {}
       runAsUser: 1001
       runAsNonRoot: true
     ## @param metrics.jmx.whitelistObjectNames [array] Allows setting which JMX objects you want to expose to via JMX stats to JMX Exporter


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

### Description of the change

This PR updates the podSecurityContext and containerSecurityContext fields by setting default values for essential security fields: seLinuxOptions, fsGroupChangePolicy, sysctls and supplementalGroups. These are required by security checklists. 

### Benefits

Charts become more security-compliant

### Possible drawbacks

n/a

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)

