### PR TITLE
[bitnami/spark] fix: :lock: Improve podSecurityContext and containerSecurityContext with essential security fields

### DIFF
--- a/bitnami/spark/Chart.yaml
+++ b/bitnami/spark/Chart.yaml
@@ -27,4 +27,4 @@ maintainers:
 name: spark
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/spark
-version: 8.1.8
+version: 8.2.0

--- a/bitnami/spark/README.md
+++ b/bitnami/spark/README.md
@@ -110,11 +110,15 @@ The command removes all the Kubernetes components associated with the chart and 
 | `master.extraEnvVarsCM`                                    | Name of existing ConfigMap containing extra env vars for master nodes                                                    | `""`             |
 | `master.extraEnvVarsSecret`                                | Name of existing Secret containing extra env vars for master nodes                                                       | `""`             |
 | `master.podSecurityContext.enabled`                        | Enable security context                                                                                                  | `true`           |
+| `master.podSecurityContext.fsGroupChangePolicy`            | Set filesystem group change policy                                                                                       | `Always`         |
+| `master.podSecurityContext.sysctls`                        | Set kernel settings using the sysctl interface                                                                           | `[]`             |
+| `master.podSecurityContext.supplementalGroups`             | Set filesystem extra groups                                                                                              | `[]`             |
 | `master.podSecurityContext.fsGroup`                        | Set master pod's Security Context Group ID                                                                               | `1001`           |
 | `master.podSecurityContext.runAsUser`                      | Set master pod's Security Context User ID                                                                                | `1001`           |
 | `master.podSecurityContext.runAsGroup`                     | Set master pod's Security Context Group ID                                                                               | `0`              |
 | `master.podSecurityContext.seLinuxOptions`                 | Set master pod's Security Context SELinux options                                                                        | `{}`             |
 | `master.containerSecurityContext.enabled`                  | Enabled containers' Security Context                                                                                     | `true`           |
+| `master.containerSecurityContext.seLinuxOptions`           | Set SELinux options in container                                                                                         | `{}`             |
 | `master.containerSecurityContext.runAsUser`                | Set containers' Security Context runAsUser                                                                               | `1001`           |
 | `master.containerSecurityContext.runAsNonRoot`             | Set container's Security Context runAsNonRoot                                                                            | `true`           |
 | `master.containerSecurityContext.privileged`               | Set container's Security Context privileged                                                                              | `false`          |
@@ -190,9 +194,13 @@ The command removes all the Kubernetes components associated with the chart and 
 | `worker.extraEnvVarsSecret`                                | Name of existing Secret containing extra env vars for worker nodes                                                       | `""`             |
 | `worker.replicaCount`                                      | Number of spark workers (will be the minimum number when autoscaling is enabled)                                         | `2`              |
 | `worker.podSecurityContext.enabled`                        | Enable security context                                                                                                  | `true`           |
+| `worker.podSecurityContext.fsGroupChangePolicy`            | Set filesystem group change policy                                                                                       | `Always`         |
+| `worker.podSecurityContext.sysctls`                        | Set kernel settings using the sysctl interface                                                                           | `[]`             |
+| `worker.podSecurityContext.supplementalGroups`             | Set filesystem extra groups                                                                                              | `[]`             |
 | `worker.podSecurityContext.fsGroup`                        | Group ID for the container                                                                                               | `1001`           |
 | `worker.podSecurityContext.seLinuxOptions`                 | SELinux options for the container                                                                                        | `{}`             |
 | `worker.containerSecurityContext.enabled`                  | Enabled containers' Security Context                                                                                     | `true`           |
+| `worker.containerSecurityContext.seLinuxOptions`           | Set SELinux options in container                                                                                         | `{}`             |
 | `worker.containerSecurityContext.runAsUser`                | Set containers' Security Context runAsUser                                                                               | `1001`           |
 | `worker.containerSecurityContext.runAsNonRoot`             | Set container's Security Context runAsNonRoot                                                                            | `true`           |
 | `worker.containerSecurityContext.privileged`               | Set container's Security Context privileged                                                                              | `false`          |

--- a/bitnami/spark/values.yaml
+++ b/bitnami/spark/values.yaml
@@ -174,7 +174,6 @@ master:
   ## @param master.podSecurityContext.sysctls Set kernel settings using the sysctl interface
   ## @param master.podSecurityContext.supplementalGroups Set filesystem extra groups
   ## @param master.podSecurityContext.fsGroup Set master pod's Security Context Group ID
-  ## @param master.podSecurityContext.seLinuxOptions Set SELinux options in container
   ## @param master.podSecurityContext.runAsUser Set master pod's Security Context User ID
   ## @param master.podSecurityContext.runAsGroup Set master pod's Security Context Group ID
   ## @param master.podSecurityContext.seLinuxOptions Set master pod's Security Context SELinux options
@@ -188,7 +187,6 @@ master:
     seLinuxOptions: {}
     runAsUser: 1001
     runAsGroup: 0
-    seLinuxOptions: {}
   ## Configure Container Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
   ## @param master.containerSecurityContext.enabled Enabled containers' Security Context

--- a/bitnami/spark/values.yaml
+++ b/bitnami/spark/values.yaml
@@ -170,20 +170,29 @@ master:
   ## Kubernetes Pods Security Context
   ## https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
   ## @param master.podSecurityContext.enabled Enable security context
+  ## @param master.podSecurityContext.fsGroupChangePolicy Set filesystem group change policy
+  ## @param master.podSecurityContext.sysctls Set kernel settings using the sysctl interface
+  ## @param master.podSecurityContext.supplementalGroups Set filesystem extra groups
   ## @param master.podSecurityContext.fsGroup Set master pod's Security Context Group ID
+  ## @param master.podSecurityContext.seLinuxOptions Set SELinux options in container
   ## @param master.podSecurityContext.runAsUser Set master pod's Security Context User ID
   ## @param master.podSecurityContext.runAsGroup Set master pod's Security Context Group ID
   ## @param master.podSecurityContext.seLinuxOptions Set master pod's Security Context SELinux options
   ##
   podSecurityContext:
     enabled: true
+    fsGroupChangePolicy: Always
+    sysctls: []
+    supplementalGroups: []
     fsGroup: 1001
+    seLinuxOptions: {}
     runAsUser: 1001
     runAsGroup: 0
     seLinuxOptions: {}
   ## Configure Container Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
   ## @param master.containerSecurityContext.enabled Enabled containers' Security Context
+  ## @param master.containerSecurityContext.seLinuxOptions Set SELinux options in container
   ## @param master.containerSecurityContext.runAsUser Set containers' Security Context runAsUser
   ## @param master.containerSecurityContext.runAsNonRoot Set container's Security Context runAsNonRoot
   ## @param master.containerSecurityContext.privileged Set container's Security Context privileged
@@ -194,6 +203,7 @@ master:
   ##
   containerSecurityContext:
     enabled: true
+    seLinuxOptions: {}
     runAsUser: 1001
     runAsNonRoot: true
     privileged: false
@@ -460,16 +470,23 @@ worker:
   ## Kubernetes Pods Security Context
   ## https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
   ## @param worker.podSecurityContext.enabled Enable security context
+  ## @param worker.podSecurityContext.fsGroupChangePolicy Set filesystem group change policy
+  ## @param worker.podSecurityContext.sysctls Set kernel settings using the sysctl interface
+  ## @param worker.podSecurityContext.supplementalGroups Set filesystem extra groups
   ## @param worker.podSecurityContext.fsGroup Group ID for the container
   ## @param worker.podSecurityContext.seLinuxOptions SELinux options for the container
   ##
   podSecurityContext:
     enabled: true
+    fsGroupChangePolicy: Always
+    sysctls: []
+    supplementalGroups: []
     fsGroup: 1001
     seLinuxOptions: {}
   ## Configure Container Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
   ## @param worker.containerSecurityContext.enabled Enabled containers' Security Context
+  ## @param worker.containerSecurityContext.seLinuxOptions Set SELinux options in container
   ## @param worker.containerSecurityContext.runAsUser Set containers' Security Context runAsUser
   ## @param worker.containerSecurityContext.runAsNonRoot Set container's Security Context runAsNonRoot
   ## @param worker.containerSecurityContext.privileged Set container's Security Context privileged
@@ -480,6 +497,7 @@ worker:
   ##
   containerSecurityContext:
     enabled: true
+    seLinuxOptions: {}
     runAsUser: 1001
     runAsNonRoot: true
     privileged: false

--- a/bitnami/spark/values.yaml
+++ b/bitnami/spark/values.yaml
@@ -184,9 +184,9 @@ master:
     sysctls: []
     supplementalGroups: []
     fsGroup: 1001
-    seLinuxOptions: {}
     runAsUser: 1001
     runAsGroup: 0
+    seLinuxOptions: {}
   ## Configure Container Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
   ## @param master.containerSecurityContext.enabled Enabled containers' Security Context


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

### Description of the change

This PR updates the podSecurityContext and containerSecurityContext fields by setting default values for essential security fields: seLinuxOptions, fsGroupChangePolicy, sysctls and supplementalGroups. These are required by security checklists. 

### Benefits

Charts become more security-compliant

### Possible drawbacks

n/a

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)

