### PR TITLE
[bitnami/whereabouts] fix: :lock: Improve podSecurityContext and containerSecurityContext with essential security fields

### DIFF
--- a/bitnami/whereabouts/Chart.yaml
+++ b/bitnami/whereabouts/Chart.yaml
@@ -29,4 +29,4 @@ maintainers:
 name: whereabouts
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/whereabouts
-version: 0.6.1
+version: 0.7.0

--- a/bitnami/whereabouts/README.md
+++ b/bitnami/whereabouts/README.md
@@ -116,8 +116,12 @@ The command removes all the Kubernetes components associated with the chart and 
 | `resources.requests`                           | The requested resources for the init container                                                                        | `{}`                          |
 | `resources.limits`                             | The resources limits for the init container                                                                           | `{}`                          |
 | `podSecurityContext.enabled`                   | Enable Whereabouts pods' Security Context                                                                             | `true`                        |
+| `podSecurityContext.fsGroupChangePolicy`       | Set filesystem group change policy                                                                                    | `Always`                      |
+| `podSecurityContext.sysctls`                   | Set kernel settings using the sysctl interface                                                                        | `[]`                          |
+| `podSecurityContext.supplementalGroups`        | Set filesystem extra groups                                                                                           | `[]`                          |
 | `podSecurityContext.fsGroup`                   | Whereabouts pods' group ID                                                                                            | `0`                           |
 | `containerSecurityContext.enabled`             | Enable Whereabouts containers' Security Context                                                                       | `true`                        |
+| `containerSecurityContext.seLinuxOptions`      | Set SELinux options in container                                                                                      | `{}`                          |
 | `containerSecurityContext.runAsUser`           | Whereabouts containers' Security Context                                                                              | `0`                           |
 | `containerSecurityContext.runAsNonRoot`        | Set Whereabouts container's Security Context runAsNonRoot                                                             | `false`                       |
 | `containerSecurityContext.privileged`          | Set Whereabouts container's Security Context privileged                                                               | `true`                        |

--- a/bitnami/whereabouts/values.yaml
+++ b/bitnami/whereabouts/values.yaml
@@ -211,14 +211,21 @@ resources:
 ## Configure Pods Security Context
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
 ## @param podSecurityContext.enabled Enable Whereabouts pods' Security Context
+## @param podSecurityContext.fsGroupChangePolicy Set filesystem group change policy
+## @param podSecurityContext.sysctls Set kernel settings using the sysctl interface
+## @param podSecurityContext.supplementalGroups Set filesystem extra groups
 ## @param podSecurityContext.fsGroup Whereabouts pods' group ID
 ##
 podSecurityContext:
   enabled: true
+  fsGroupChangePolicy: Always
+  sysctls: []
+  supplementalGroups: []
   fsGroup: 0
 ## Configure Container Security Context (only main container)
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
 ## @param containerSecurityContext.enabled Enable Whereabouts containers' Security Context
+## @param containerSecurityContext.seLinuxOptions Set SELinux options in container
 ## @param containerSecurityContext.runAsUser Whereabouts containers' Security Context
 ## @param containerSecurityContext.runAsNonRoot Set Whereabouts container's Security Context runAsNonRoot
 ## @param containerSecurityContext.privileged Set Whereabouts container's Security Context privileged
@@ -226,6 +233,7 @@ podSecurityContext:
 ##
 containerSecurityContext:
   enabled: true
+  seLinuxOptions: {}
   runAsUser: 0
   runAsNonRoot: false
   privileged: true


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

### Description of the change

This PR updates the podSecurityContext and containerSecurityContext fields by setting default values for essential security fields: seLinuxOptions, fsGroupChangePolicy, sysctls and supplementalGroups. These are required by security checklists. 

### Benefits

Charts become more security-compliant

### Possible drawbacks

n/a

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)

