### PR TITLE
[bitnami/supabase] Update supabase storage image

### DIFF
--- a/bitnami/supabase/Chart.yaml
+++ b/bitnami/supabase/Chart.yaml
@@ -22,7 +22,7 @@ annotations:
     - name: supabase-realtime
       image: docker.io/bitnami/supabase-realtime:2.25.56-debian-11-r0
     - name: supabase-storage
-      image: docker.io/bitnami/supabase-storage:0.44.0-debian-11-r0
+      image: docker.io/bitnami/supabase-storage:0.44.1-debian-11-r0
     - name: supabase-studio
       image: docker.io/bitnami/supabase-studio:0.23.11-debian-11-r0
 apiVersion: v2
@@ -53,4 +53,4 @@ maintainers:
 name: supabase
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/supabase
-version: 2.2.1
+version: 2.2.2

--- a/bitnami/supabase/values.yaml
+++ b/bitnami/supabase/values.yaml
@@ -1644,6 +1644,7 @@ storage:
     TENANT_ID: "stub"
     REGION: "stub"
     GLOBAL_S3_BUCKET: "stub"
+    DB_INSTALL_ROLES: "false"
     PORT: {{ .Values.storage.containerPorts.http | quote }}
 
   ## @param storage.extraConfig Extra configuration for Supabase storage
@@ -1669,7 +1670,7 @@ storage:
   image:
     registry: docker.io
     repository: bitnami/supabase-storage
-    tag: 0.44.0-debian-11-r0
+    tag: 0.44.1-debian-11-r0
     digest: ""
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'


### PR DESCRIPTION
### Description of the change

Update the supabase-storage image and set the default value for DB_INSTALL_ROLES variable to false, since those roles are created by supabase-postgres.

### Benefits

Use the latest available version for supabase-storage.

### Possible drawbacks

N/A

### Applicable issues

N/A

### Additional information

[Related change](https://github.com/supabase/storage/pull/409)

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
