### PR TITLE
[bitnami/cert-manager] feat: :lock: Allow limit access to secrets by namespace

### DIFF
--- a/bitnami/cert-manager/Chart.yaml
+++ b/bitnami/cert-manager/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: cert-manager
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/cert-manager
-version: 0.15.0
+version: 0.16.0

--- a/bitnami/cert-manager/README.md
+++ b/bitnami/cert-manager/README.md
@@ -350,9 +350,11 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Other Parameters
 
-| Name          | Description                                        | Value  |
-| ------------- | -------------------------------------------------- | ------ |
-| `rbac.create` | Specifies whether RBAC resources should be created | `true` |
+| Name                                | Description                                                                          | Value  |
+| ----------------------------------- | ------------------------------------------------------------------------------------ | ------ |
+| `rbac.create`                       | Specifies whether RBAC resources should be created                                   | `true` |
+| `rbac.accessSecretsInAllNamespaces` | Allow accessing secrets in all namespaces                                            | `true` |
+| `rbac.allowedSecretNamespaces`      | List of namespaces allowed to access secrets when accessSecretsInAllNamespaces=false | `[]`   |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/bitnami/cert-manager/templates/NOTES.txt
+++ b/bitnami/cert-manager/templates/NOTES.txt
@@ -11,3 +11,23 @@ https://cert-manager.io/docs/configuration/
 To configure a new ingress to automatically provision certificates, you will find some information in the following link:
 
 https://cert-manager.io/docs/usage/ingress/
+
+{{- if .Values.rbac.create }}
+{{- if .Values.rbac.accessSecretsInAllNamespaces }}
+
+WARNING: Cert Manager can access all secrets in the cluster. This could pose a security risk if the application gets compromised.
+
+You can limit allowed namespaces by setting rbac.accessSecretsInAllNamespaces = false and configuring 
+ rbac.allowedSecretNamespaces
+{{- else }}
+
+Cert Manager can ONLY access secrets in the following namespaces:
+{{ $namespaces := .Values.rbac.allowedSecretNamespaces | default (list (include "common.names.namespace" .)) }}
+{{- range $namespace := $namespaces }}
+  - {{ $namespace }}
+{{- end }}
+
+Cert Manager wont be able to access secrets in other namespaces. You can configure this behavior by setting rbac.allowedSecretNamespaces
+
+{{- end }}
+{{- end }}

--- a/bitnami/cert-manager/templates/cainjector/rbac.yaml
+++ b/bitnami/cert-manager/templates/cainjector/rbac.yaml
@@ -64,9 +64,11 @@ rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["certificates"]
     verbs: ["get", "list", "watch"]
+  {{- if .Values.rbac.accessSecretsInAllNamespaces }}
   - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["get", "list", "watch"]
+  {{- end }}
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["get", "create", "update", "patch"]

--- a/bitnami/cert-manager/templates/cainjector/secret-namespaced-rbac.yaml
+++ b/bitnami/cert-manager/templates/cainjector/secret-namespaced-rbac.yaml
@@ -1,0 +1,46 @@
+{{- /*
+Copyright VMware, Inc.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+{{- if and .Values.rbac.create (not .Values.rbac.accessSecretsInAllNamespaces) }}
+kind: ClusterRole
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
+metadata:
+  name: {{ printf "%s-secrets" (include "certmanager.cainjector.fullname" .) | trunc 63 | trimSuffix "-" }}
+  {{- $versionLabel := dict "app.kubernetes.io/version" ( include "common.images.version" ( dict "imageRoot" .Values.cainjector.image "chart" .Chart ) ) }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.commonLabels $versionLabel ) "context" . ) }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
+    app.kubernetes.io/component: cainjector
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch"]
+{{ $namespaces := .Values.rbac.allowedSecretNamespaces | default (list (include "common.names.namespace" .)) }}
+{{- range $namespace := $namespaces }}
+---
+kind: RoleBinding
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" $ }}
+metadata:
+  name: {{ printf "%s-secrets" (include "certmanager.cainjector.fullname" $) | trunc 63 | trimSuffix "-" }}
+  namespace: {{ $namespace | quote }}
+  {{- $versionLabel := dict "app.kubernetes.io/version" ( include "common.images.version" ( dict "imageRoot" $.Values.cainjector.image "chart" $.Chart ) ) }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list $.Values.commonLabels $versionLabel ) "context" $ ) }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
+    app.kubernetes.io/component: cainjector
+  {{- if $.Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" $.Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ printf "%s-secrets" (include "certmanager.cainjector.fullname" $) | trunc 63 | trimSuffix "-" }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "certmanager.cainjector.serviceAccountName" $ }}
+    namespace: {{ include "common.names.namespace" $ | quote }}
+{{- end }}
+{{- end }}

--- a/bitnami/cert-manager/templates/controller/rbac.yaml
+++ b/bitnami/cert-manager/templates/controller/rbac.yaml
@@ -68,9 +68,11 @@ rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["issuers"]
     verbs: ["get", "list", "watch"]
+  {{- if .Values.rbac.accessSecretsInAllNamespaces }}
   - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  {{- end }}
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["create", "patch"]
@@ -91,9 +93,11 @@ rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["clusterissuers"]
     verbs: ["get", "list", "watch"]
+  {{- if .Values.rbac.accessSecretsInAllNamespaces }}
   - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  {{- end }}
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["create", "patch"]
@@ -120,9 +124,11 @@ rules:
   - apiGroups: ["acme.cert-manager.io"]
     resources: ["orders"]
     verbs: ["create", "delete", "get", "list", "watch"]
+  {{- if .Values.rbac.accessSecretsInAllNamespaces }}
   - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["get", "list", "watch", "create", "update", "delete"]
+  {{- end }}
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["create", "patch"]
@@ -152,9 +158,11 @@ rules:
   - apiGroups: ["acme.cert-manager.io"]
     resources: ["orders/finalizers"]
     verbs: ["update"]
+  {{- if .Values.rbac.accessSecretsInAllNamespaces }}
   - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["get", "list", "watch"]
+  {{- end }}
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["create", "patch"]
@@ -181,10 +189,12 @@ rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["issuers", "clusterissuers"]
     verbs: ["get", "list", "watch"]
+  {{- if .Values.rbac.accessSecretsInAllNamespaces }}
   # Need to be able to retrieve ACME account private key to complete challenges
   - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["get", "list", "watch"]
+  {{- end }}
   # Used to create events
   - apiGroups: [""]
     resources: ["events"]
@@ -202,10 +212,12 @@ rules:
   - apiGroups: ["acme.cert-manager.io"]
     resources: ["challenges/finalizers"]
     verbs: ["update"]
+  {{- if .Values.rbac.accessSecretsInAllNamespaces }}
   # DNS01 rules (duplicated above)
   - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["get", "list", "watch"]
+  {{- end }}
   - apiGroups: [ "gateway.networking.k8s.io" ]
     resources: [ "httproutes" ]
     verbs: ["get", "list", "watch", "create", "delete", "update"]

--- a/bitnami/cert-manager/templates/controller/secret-namespaced-rbac.yaml
+++ b/bitnami/cert-manager/templates/controller/secret-namespaced-rbac.yaml
@@ -1,0 +1,46 @@
+{{- /*
+Copyright VMware, Inc.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+{{- if and .Values.rbac.create (not .Values.rbac.accessSecretsInAllNamespaces) }}
+kind: ClusterRole
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
+metadata:
+  name: {{ printf "%s-secrets" (include "certmanager.controller.fullname" .) | trunc 63 | trimSuffix "-" }}
+  {{- $versionLabel := dict "app.kubernetes.io/version" ( include "common.images.version" ( dict "imageRoot" .Values.controller.image "chart" .Chart ) ) }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.commonLabels $versionLabel ) "context" . ) }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
+    app.kubernetes.io/component: controller
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+{{ $namespaces := .Values.rbac.allowedSecretNamespaces | default (list (include "common.names.namespace" .)) }}
+{{- range $namespace := $namespaces }}
+---
+kind: RoleBinding
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" $ }}
+metadata:
+  name: {{ printf "%s-secrets" (include "certmanager.controller.fullname" $) | trunc 63 | trimSuffix "-" }}
+  namespace: {{ $namespace | quote }}
+  {{- $versionLabel := dict "app.kubernetes.io/version" ( include "common.images.version" ( dict "imageRoot" $.Values.controller.image "chart" $.Chart ) ) }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list $.Values.commonLabels $versionLabel ) "context" $ ) }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
+    app.kubernetes.io/component: controller
+  {{- if $.Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" $.Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ printf "%s-secrets" (include "certmanager.controller.fullname" $) | trunc 63 | trimSuffix "-" }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "certmanager.controller.serviceAccountName" $ }}
+    namespace: {{ include "common.names.namespace" $ | quote }}
+{{- end }}
+{{- end }}

--- a/bitnami/cert-manager/values.yaml
+++ b/bitnami/cert-manager/values.yaml
@@ -1030,3 +1030,9 @@ metrics:
 ##
 rbac:
   create: true
+  ## @param rbac.accessSecretsInAllNamespaces Allow accessing secrets in all namespaces
+  ##
+  accessSecretsInAllNamespaces: true
+  ## @param rbac.allowedSecretNamespaces List of namespaces allowed to access secrets when accessSecretsInAllNamespaces=false
+  ##
+  allowedSecretNamespaces: []


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

The following PR allows limiting the namespaces that the application can check for secrets. By default, it is using a ClusterRole, which has security implications that should be taken into account by operators.

The default value is to allow secrets to in all namespaces so we don't break upgrades.

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
