### PR TITLE
[bitnami/grafana-operator] update crds

### DIFF
--- a/bitnami/grafana-operator/Chart.yaml
+++ b/bitnami/grafana-operator/Chart.yaml
@@ -30,4 +30,4 @@ maintainers:
 name: grafana-operator
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/grafana-operator
-version: 3.6.0
+version: 3.6.1

--- a/bitnami/grafana-operator/crds/grafanadashboards.integreatly.org.yaml
+++ b/bitnami/grafana-operator/crds/grafanadashboards.integreatly.org.yaml
@@ -1,4 +1,4 @@
-# !kustomize build https://github.com/grafana-operator/grafana-operator/blob/v5.0.2/deploy/helm/grafana-operator/crds/
+# kustomize build https://github.com/grafana/grafana-operator//config/crd?ref=v5.6.0
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -14,204 +14,222 @@ spec:
     singular: grafanadashboard
   scope: Namespaced
   versions:
-    - additionalPrinterColumns:
-        - jsonPath: .status.NoMatchingInstances
-          name: No matching instances
-          type: boolean
-        - format: date-time
-          jsonPath: .status.lastResync
-          name: Last resync
-          type: date
-        - jsonPath: .metadata.creationTimestamp
-          name: Age
-          type: date
-      name: v1beta1
-      schema:
-        openAPIV3Schema:
-          properties:
-            apiVersion:
-              type: string
-            kind:
-              type: string
-            metadata:
-              type: object
-            spec:
-              properties:
-                allowCrossNamespaceImport:
-                  type: boolean
-                configMapRef:
+  - additionalPrinterColumns:
+    - jsonPath: .status.NoMatchingInstances
+      name: No matching instances
+      type: boolean
+    - format: date-time
+      jsonPath: .status.lastResync
+      name: Last resync
+      type: date
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              allowCrossNamespaceImport:
+                type: boolean
+              configMapRef:
+                properties:
+                  key:
+                    type: string
+                  name:
+                    type: string
+                  optional:
+                    type: boolean
+                required:
+                - key
+                type: object
+                x-kubernetes-map-type: atomic
+              contentCacheDuration:
+                type: string
+              datasources:
+                items:
                   properties:
-                    key:
+                    datasourceName:
                       type: string
+                    inputName:
+                      type: string
+                  required:
+                  - datasourceName
+                  - inputName
+                  type: object
+                type: array
+              envFrom:
+                items:
+                  properties:
+                    configMapKeyRef:
+                      properties:
+                        key:
+                          type: string
+                        name:
+                          type: string
+                        optional:
+                          type: boolean
+                      required:
+                      - key
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    secretKeyRef:
+                      properties:
+                        key:
+                          type: string
+                        name:
+                          type: string
+                        optional:
+                          type: boolean
+                      required:
+                      - key
+                      type: object
+                      x-kubernetes-map-type: atomic
+                  type: object
+                type: array
+              envs:
+                items:
+                  properties:
                     name:
                       type: string
-                    optional:
-                      type: boolean
-                  required:
-                    - key
-                  type: object
-                  x-kubernetes-map-type: atomic
-                contentCacheDuration:
-                  type: string
-                datasources:
-                  items:
-                    properties:
-                      datasourceName:
-                        type: string
-                      inputName:
-                        type: string
-                    required:
-                      - datasourceName
-                      - inputName
-                    type: object
-                  type: array
-                envFrom:
-                  items:
-                    properties:
-                      configMapKeyRef:
-                        properties:
-                          key:
-                            type: string
-                          name:
-                            type: string
-                          optional:
-                            type: boolean
-                        required:
-                          - key
-                        type: object
-                        x-kubernetes-map-type: atomic
-                      secretKeyRef:
-                        properties:
-                          key:
-                            type: string
-                          name:
-                            type: string
-                          optional:
-                            type: boolean
-                        required:
-                          - key
-                        type: object
-                        x-kubernetes-map-type: atomic
-                    type: object
-                  type: array
-                envs:
-                  items:
-                    properties:
-                      configMapKeyRef:
-                        properties:
-                          key:
-                            type: string
-                          name:
-                            type: string
-                          optional:
-                            type: boolean
-                        required:
-                          - key
-                        type: object
-                        x-kubernetes-map-type: atomic
-                      name:
-                        type: string
-                      secretKeyRef:
-                        properties:
-                          key:
-                            type: string
-                          name:
-                            type: string
-                          optional:
-                            type: boolean
-                        required:
-                          - key
-                        type: object
-                        x-kubernetes-map-type: atomic
-                      value:omitempty:
-                        type: string
-                    required:
-                      - name
-                    type: object
-                  type: array
-                folder:
-                  type: string
-                grafanaCom:
-                  properties:
-                    id:
-                      type: integer
-                    revision:
-                      type: integer
-                  required:
-                    - id
-                  type: object
-                gzipJson:
-                  format: byte
-                  type: string
-                instanceSelector:
-                  properties:
-                    matchExpressions:
-                      items:
-                        properties:
-                          key:
-                            type: string
-                          operator:
-                            type: string
-                          values:
-                            items:
+                    value:
+                      type: string
+                    valueFrom:
+                      properties:
+                        configMapKeyRef:
+                          properties:
+                            key:
                               type: string
-                            type: array
-                        required:
+                            name:
+                              type: string
+                            optional:
+                              type: boolean
+                          required:
                           - key
-                          - operator
-                        type: object
-                      type: array
-                    matchLabels:
-                      additionalProperties:
-                        type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        secretKeyRef:
+                          properties:
+                            key:
+                              type: string
+                            name:
+                              type: string
+                            optional:
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
                       type: object
+                  required:
+                  - name
                   type: object
-                  x-kubernetes-map-type: atomic
-                json:
-                  type: string
-                jsonnet:
-                  type: string
-                plugins:
-                  items:
-                    properties:
-                      name:
-                        type: string
-                      version:
-                        type: string
-                    required:
-                      - name
-                      - version
+                type: array
+              folder:
+                type: string
+              grafanaCom:
+                properties:
+                  id:
+                    type: integer
+                  revision:
+                    type: integer
+                required:
+                - id
+                type: object
+              gzipJson:
+                format: byte
+                type: string
+              instanceSelector:
+                properties:
+                  matchExpressions:
+                    items:
+                      properties:
+                        key:
+                          type: string
+                        operator:
+                          type: string
+                        values:
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
                     type: object
-                  type: array
-                resyncPeriod:
-                  type: string
-                url:
-                  type: string
-              required:
-                - instanceSelector
-              type: object
-            status:
-              properties:
-                NoMatchingInstances:
-                  type: boolean
-                contentCache:
-                  format: byte
-                  type: string
-                contentTimestamp:
-                  format: date-time
-                  type: string
-                contentUrl:
-                  type: string
-                hash:
-                  type: string
-                lastResync:
-                  format: date-time
-                  type: string
-                uid:
-                  type: string
-              type: object
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
+                type: object
+                x-kubernetes-map-type: atomic
+              json:
+                type: string
+              jsonnet:
+                type: string
+              jsonnetLib:
+                properties:
+                  fileName:
+                    type: string
+                  gzipJsonnetProject:
+                    format: byte
+                    type: string
+                  jPath:
+                    items:
+                      type: string
+                    type: array
+                required:
+                - fileName
+                - gzipJsonnetProject
+                type: object
+              plugins:
+                items:
+                  properties:
+                    name:
+                      type: string
+                    version:
+                      type: string
+                  required:
+                  - name
+                  - version
+                  type: object
+                type: array
+              resyncPeriod:
+                type: string
+              url:
+                type: string
+            required:
+            - instanceSelector
+            type: object
+          status:
+            properties:
+              NoMatchingInstances:
+                type: boolean
+              contentCache:
+                format: byte
+                type: string
+              contentTimestamp:
+                format: date-time
+                type: string
+              contentUrl:
+                type: string
+              hash:
+                type: string
+              lastResync:
+                format: date-time
+                type: string
+              uid:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/bitnami/grafana-operator/crds/grafanadatasources.integreatly.org.yaml
+++ b/bitnami/grafana-operator/crds/grafanadatasources.integreatly.org.yaml
@@ -1,4 +1,4 @@
-# !kustomize build https://github.com/grafana-operator/grafana-operator/blob/v5.0.2/deploy/helm/grafana-operator/crds/
+# kustomize build https://github.com/grafana/grafana-operator//config/crd?ref=v5.6.0
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -14,159 +14,165 @@ spec:
     singular: grafanadatasource
   scope: Namespaced
   versions:
-    - additionalPrinterColumns:
-        - jsonPath: .status.NoMatchingInstances
-          name: No matching instances
-          type: boolean
-        - format: date-time
-          jsonPath: .status.lastResync
-          name: Last resync
-          type: date
-        - jsonPath: .metadata.creationTimestamp
-          name: Age
-          type: date
-      name: v1beta1
-      schema:
-        openAPIV3Schema:
-          properties:
-            apiVersion:
-              type: string
-            kind:
-              type: string
-            metadata:
-              type: object
-            spec:
-              properties:
-                allowCrossNamespaceImport:
-                  type: boolean
-                datasource:
-                  properties:
-                    access:
-                      type: string
-                    basicAuth:
-                      type: boolean
-                    basicAuthUser:
-                      type: string
-                    database:
-                      type: string
-                    editable:
-                      type: boolean
-                    isDefault:
-                      type: boolean
-                    jsonData:
+  - additionalPrinterColumns:
+    - jsonPath: .status.NoMatchingInstances
+      name: No matching instances
+      type: boolean
+    - format: date-time
+      jsonPath: .status.lastResync
+      name: Last resync
+      type: date
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              allowCrossNamespaceImport:
+                type: boolean
+              datasource:
+                properties:
+                  access:
+                    type: string
+                  basicAuth:
+                    type: boolean
+                  basicAuthUser:
+                    type: string
+                  database:
+                    type: string
+                  editable:
+                    type: boolean
+                  isDefault:
+                    type: boolean
+                  jsonData:
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                  name:
+                    type: string
+                  orgId:
+                    format: int64
+                    type: integer
+                  secureJsonData:
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                  type:
+                    type: string
+                  uid:
+                    type: string
+                  url:
+                    type: string
+                  user:
+                    type: string
+                required:
+                - access
+                - name
+                - type
+                - url
+                type: object
+              instanceSelector:
+                properties:
+                  matchExpressions:
+                    items:
+                      properties:
+                        key:
+                          type: string
+                        operator:
+                          type: string
+                        values:
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
                       type: object
-                      x-kubernetes-preserve-unknown-fields: true
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              plugins:
+                items:
+                  properties:
                     name:
                       type: string
-                    orgId:
-                      format: int64
-                      type: integer
-                    secureJsonData:
-                      type: object
-                      x-kubernetes-preserve-unknown-fields: true
-                    type:
+                    version:
                       type: string
-                    uid:
-                      type: string
-                    url:
-                      type: string
-                    user:
-                      type: string
+                  required:
+                  - name
+                  - version
                   type: object
-                instanceSelector:
+                type: array
+              resyncPeriod:
+                type: string
+              valuesFrom:
+                items:
                   properties:
-                    matchExpressions:
-                      items:
-                        properties:
-                          key:
-                            type: string
-                          operator:
-                            type: string
-                          values:
-                            items:
+                    targetPath:
+                      type: string
+                    valueFrom:
+                      properties:
+                        configMapKeyRef:
+                          properties:
+                            key:
                               type: string
-                            type: array
-                        required:
+                            name:
+                              type: string
+                            optional:
+                              type: boolean
+                          required:
                           - key
-                          - operator
-                        type: object
-                      type: array
-                    matchLabels:
-                      additionalProperties:
-                        type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        secretKeyRef:
+                          properties:
+                            key:
+                              type: string
+                            name:
+                              type: string
+                            optional:
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
                       type: object
+                  required:
+                  - targetPath
+                  - valueFrom
                   type: object
-                  x-kubernetes-map-type: atomic
-                plugins:
-                  items:
-                    properties:
-                      name:
-                        type: string
-                      version:
-                        type: string
-                    required:
-                      - name
-                      - version
-                    type: object
-                  type: array
-                resyncPeriod:
-                  type: string
-                valuesFrom:
-                  items:
-                    properties:
-                      targetPath:
-                        type: string
-                      valueFrom:
-                        properties:
-                          configMapKeyRef:
-                            properties:
-                              key:
-                                type: string
-                              name:
-                                type: string
-                              optional:
-                                type: boolean
-                            required:
-                              - key
-                            type: object
-                            x-kubernetes-map-type: atomic
-                          secretKeyRef:
-                            properties:
-                              key:
-                                type: string
-                              name:
-                                type: string
-                              optional:
-                                type: boolean
-                            required:
-                              - key
-                            type: object
-                            x-kubernetes-map-type: atomic
-                        type: object
-                    required:
-                      - targetPath
-                      - valueFrom
-                    type: object
-                  type: array
-              required:
-                - instanceSelector
-              type: object
-            status:
-              properties:
-                NoMatchingInstances:
-                  type: boolean
-                hash:
-                  type: string
-                lastMessage:
-                  type: string
-                lastResync:
-                  format: date-time
-                  type: string
-                uid:
-                  type: string
-              type: object
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
+                type: array
+            required:
+            - datasource
+            - instanceSelector
+            type: object
+          status:
+            properties:
+              NoMatchingInstances:
+                type: boolean
+              hash:
+                type: string
+              lastMessage:
+                type: string
+              lastResync:
+                format: date-time
+                type: string
+              uid:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/bitnami/grafana-operator/crds/grafanafolders.integreatly.org.yaml
+++ b/bitnami/grafana-operator/crds/grafanafolders.integreatly.org.yaml
@@ -1,4 +1,4 @@
-# !kustomize build https://github.com/grafana-operator/grafana-operator/blob/v5.0.2/deploy/helm/grafana-operator/crds/
+# kustomize build https://github.com/grafana/grafana-operator//config/crd?ref=v5.6.0
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -14,72 +14,72 @@ spec:
     singular: grafanafolder
   scope: Namespaced
   versions:
-    - additionalPrinterColumns:
-        - jsonPath: .status.NoMatchingInstances
-          name: No matching instances
-          type: boolean
-        - jsonPath: .metadata.creationTimestamp
-          name: Age
-          type: date
-      name: v1beta1
-      schema:
-        openAPIV3Schema:
-          properties:
-            apiVersion:
-              type: string
-            kind:
-              type: string
-            metadata:
-              type: object
-            spec:
-              properties:
-                allowCrossNamespaceImport:
-                  type: boolean
-                instanceSelector:
-                  properties:
-                    matchExpressions:
-                      items:
-                        properties:
-                          key:
+  - additionalPrinterColumns:
+    - jsonPath: .status.NoMatchingInstances
+      name: No matching instances
+      type: boolean
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              allowCrossNamespaceImport:
+                type: boolean
+              instanceSelector:
+                properties:
+                  matchExpressions:
+                    items:
+                      properties:
+                        key:
+                          type: string
+                        operator:
+                          type: string
+                        values:
+                          items:
                             type: string
-                          operator:
-                            type: string
-                          values:
-                            items:
-                              type: string
-                            type: array
-                        required:
-                          - key
-                          - operator
-                        type: object
-                      type: array
-                    matchLabels:
-                      additionalProperties:
-                        type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
                       type: object
-                  type: object
-                  x-kubernetes-map-type: atomic
-                permissions:
-                  type: string
-                resyncPeriod:
-                  type: string
-                title:
-                  type: string
-              required:
-                - instanceSelector
-              type: object
-            status:
-              properties:
-                NoMatchingInstances:
-                  type: boolean
-                hash:
-                  type: string
-                lastResync:
-                  format: date-time
-                  type: string
-              type: object
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              permissions:
+                type: string
+              resyncPeriod:
+                type: string
+              title:
+                type: string
+            required:
+            - instanceSelector
+            type: object
+          status:
+            properties:
+              NoMatchingInstances:
+                type: boolean
+              hash:
+                type: string
+              lastResync:
+                format: date-time
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/bitnami/grafana-operator/crds/grafanas.integreatly.org.yaml
+++ b/bitnami/grafana-operator/crds/grafanas.integreatly.org.yaml
@@ -1,4 +1,4 @@
-# !kustomize build https://github.com/grafana-operator/grafana-operator/tree/v4.9.0/config/crd
+# kustomize build https://github.com/grafana/grafana-operator//config/crd?ref=v5.6.0
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -14,3578 +14,3643 @@ spec:
     singular: grafana
   scope: Namespaced
   versions:
-    - additionalPrinterColumns:
-        - jsonPath: .status.stage
-          name: Stage
-          type: string
-        - jsonPath: .status.stageStatus
-          name: Stage status
-          type: string
-        - jsonPath: .metadata.creationTimestamp
-          name: Age
-          type: date
-      name: v1beta1
-      schema:
-        openAPIV3Schema:
-          properties:
-            apiVersion:
-              type: string
-            kind:
-              type: string
-            metadata:
-              type: object
-            spec:
-              properties:
-                client:
-                  properties:
-                    preferIngress:
-                      nullable: true
-                      type: boolean
-                    timeout:
-                      nullable: true
-                      type: integer
-                  type: object
-                config:
+  - additionalPrinterColumns:
+    - jsonPath: .status.stage
+      name: Stage
+      type: string
+    - jsonPath: .status.stageStatus
+      name: Stage status
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              client:
+                properties:
+                  preferIngress:
+                    nullable: true
+                    type: boolean
+                  timeout:
+                    nullable: true
+                    type: integer
+                type: object
+              config:
+                additionalProperties:
                   additionalProperties:
-                    additionalProperties:
-                      type: string
-                    type: object
+                    type: string
                   type: object
-                  x-kubernetes-preserve-unknown-fields: true
-                deployment:
-                  properties:
-                    metadata:
-                      properties:
-                        annotations:
-                          additionalProperties:
-                            type: string
-                          type: object
-                        labels:
-                          additionalProperties:
-                            type: string
-                          type: object
-                      type: object
-                    spec:
-                      properties:
-                        minReadySeconds:
-                          format: int32
-                          type: integer
-                        paused:
-                          type: boolean
-                        progressDeadlineSeconds:
-                          format: int32
-                          type: integer
-                        replicas:
-                          format: int32
-                          type: integer
-                        revisionHistoryLimit:
-                          format: int32
-                          type: integer
-                        selector:
-                          properties:
-                            matchExpressions:
-                              items:
-                                properties:
-                                  key:
-                                    type: string
-                                  operator:
-                                    type: string
-                                  values:
-                                    items:
-                                      type: string
-                                    type: array
-                                required:
-                                  - key
-                                  - operator
-                                type: object
-                              type: array
-                            matchLabels:
-                              additionalProperties:
-                                type: string
-                              type: object
-                          type: object
-                          x-kubernetes-map-type: atomic
-                        strategy:
-                          properties:
-                            rollingUpdate:
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              deployment:
+                properties:
+                  metadata:
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                    type: object
+                  spec:
+                    properties:
+                      minReadySeconds:
+                        format: int32
+                        type: integer
+                      paused:
+                        type: boolean
+                      progressDeadlineSeconds:
+                        format: int32
+                        type: integer
+                      replicas:
+                        format: int32
+                        type: integer
+                      revisionHistoryLimit:
+                        format: int32
+                        type: integer
+                      selector:
+                        properties:
+                          matchExpressions:
+                            items:
                               properties:
-                                maxSurge:
-                                  anyOf:
-                                    - type: integer
-                                    - type: string
-                                  x-kubernetes-int-or-string: true
-                                maxUnavailable:
-                                  anyOf:
-                                    - type: integer
-                                    - type: string
-                                  x-kubernetes-int-or-string: true
+                                key:
+                                  type: string
+                                operator:
+                                  type: string
+                                values:
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - key
+                              - operator
                               type: object
-                            type:
+                            type: array
+                          matchLabels:
+                            additionalProperties:
                               type: string
-                          type: object
-                        template:
-                          properties:
-                            metadata:
-                              properties:
-                                annotations:
-                                  additionalProperties:
-                                    type: string
-                                  type: object
-                                labels:
-                                  additionalProperties:
-                                    type: string
-                                  type: object
-                              type: object
-                            spec:
-                              properties:
-                                activeDeadlineSeconds:
-                                  format: int64
-                                  type: integer
-                                affinity:
-                                  properties:
-                                    nodeAffinity:
-                                      properties:
-                                        preferredDuringSchedulingIgnoredDuringExecution:
-                                          items:
-                                            properties:
-                                              preference:
-                                                properties:
-                                                  matchExpressions:
-                                                    items:
-                                                      properties:
-                                                        key:
-                                                          type: string
-                                                        operator:
-                                                          type: string
-                                                        values:
-                                                          items:
-                                                            type: string
-                                                          type: array
-                                                      required:
-                                                        - key
-                                                        - operator
-                                                      type: object
-                                                    type: array
-                                                  matchFields:
-                                                    items:
-                                                      properties:
-                                                        key:
-                                                          type: string
-                                                        operator:
-                                                          type: string
-                                                        values:
-                                                          items:
-                                                            type: string
-                                                          type: array
-                                                      required:
-                                                        - key
-                                                        - operator
-                                                      type: object
-                                                    type: array
-                                                type: object
-                                                x-kubernetes-map-type: atomic
-                                              weight:
-                                                format: int32
-                                                type: integer
-                                            required:
-                                              - preference
-                                              - weight
-                                            type: object
-                                          type: array
-                                        requiredDuringSchedulingIgnoredDuringExecution:
+                            type: object
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      strategy:
+                        properties:
+                          rollingUpdate:
+                            properties:
+                              maxSurge:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                x-kubernetes-int-or-string: true
+                              maxUnavailable:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                x-kubernetes-int-or-string: true
+                            type: object
+                          type:
+                            type: string
+                        type: object
+                      template:
+                        properties:
+                          metadata:
+                            properties:
+                              annotations:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              labels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                            type: object
+                          spec:
+                            properties:
+                              activeDeadlineSeconds:
+                                format: int64
+                                type: integer
+                              affinity:
+                                properties:
+                                  nodeAffinity:
+                                    properties:
+                                      preferredDuringSchedulingIgnoredDuringExecution:
+                                        items:
                                           properties:
-                                            nodeSelectorTerms:
-                                              items:
-                                                properties:
-                                                  matchExpressions:
-                                                    items:
-                                                      properties:
-                                                        key:
-                                                          type: string
-                                                        operator:
-                                                          type: string
-                                                        values:
-                                                          items:
-                                                            type: string
-                                                          type: array
-                                                      required:
-                                                        - key
-                                                        - operator
-                                                      type: object
-                                                    type: array
-                                                  matchFields:
-                                                    items:
-                                                      properties:
-                                                        key:
-                                                          type: string
-                                                        operator:
-                                                          type: string
-                                                        values:
-                                                          items:
-                                                            type: string
-                                                          type: array
-                                                      required:
-                                                        - key
-                                                        - operator
-                                                      type: object
-                                                    type: array
-                                                type: object
-                                                x-kubernetes-map-type: atomic
-                                              type: array
-                                          required:
-                                            - nodeSelectorTerms
-                                          type: object
-                                          x-kubernetes-map-type: atomic
-                                      type: object
-                                    podAffinity:
-                                      properties:
-                                        preferredDuringSchedulingIgnoredDuringExecution:
-                                          items:
-                                            properties:
-                                              podAffinityTerm:
-                                                properties:
-                                                  labelSelector:
+                                            preference:
+                                              properties:
+                                                matchExpressions:
+                                                  items:
                                                     properties:
-                                                      matchExpressions:
+                                                      key:
+                                                        type: string
+                                                      operator:
+                                                        type: string
+                                                      values:
                                                         items:
-                                                          properties:
-                                                            key:
-                                                              type: string
-                                                            operator:
-                                                              type: string
-                                                            values:
-                                                              items:
-                                                                type: string
-                                                              type: array
-                                                          required:
-                                                            - key
-                                                            - operator
-                                                          type: object
-                                                        type: array
-                                                      matchLabels:
-                                                        additionalProperties:
                                                           type: string
-                                                        type: object
+                                                        type: array
+                                                    required:
+                                                    - key
+                                                    - operator
                                                     type: object
-                                                    x-kubernetes-map-type: atomic
-                                                  namespaceSelector:
+                                                  type: array
+                                                matchFields:
+                                                  items:
                                                     properties:
-                                                      matchExpressions:
+                                                      key:
+                                                        type: string
+                                                      operator:
+                                                        type: string
+                                                      values:
                                                         items:
-                                                          properties:
-                                                            key:
-                                                              type: string
-                                                            operator:
-                                                              type: string
-                                                            values:
-                                                              items:
-                                                                type: string
-                                                              type: array
-                                                          required:
-                                                            - key
-                                                            - operator
-                                                          type: object
+                                                          type: string
                                                         type: array
-                                                      matchLabels:
-                                                        additionalProperties:
-                                                          type: string
-                                                        type: object
-                                                    type: object
-                                                    x-kubernetes-map-type: atomic
-                                                  namespaces:
-                                                    items:
-                                                      type: string
-                                                    type: array
-                                                  topologyKey:
-                                                    type: string
-                                                required:
-                                                  - topologyKey
-                                                type: object
-                                              weight:
-                                                format: int32
-                                                type: integer
-                                            required:
-                                              - podAffinityTerm
-                                              - weight
-                                            type: object
-                                          type: array
-                                        requiredDuringSchedulingIgnoredDuringExecution:
-                                          items:
-                                            properties:
-                                              labelSelector:
-                                                properties:
-                                                  matchExpressions:
-                                                    items:
-                                                      properties:
-                                                        key:
-                                                          type: string
-                                                        operator:
-                                                          type: string
-                                                        values:
-                                                          items:
-                                                            type: string
-                                                          type: array
-                                                      required:
-                                                        - key
-                                                        - operator
-                                                      type: object
-                                                    type: array
-                                                  matchLabels:
-                                                    additionalProperties:
-                                                      type: string
-                                                    type: object
-                                                type: object
-                                                x-kubernetes-map-type: atomic
-                                              namespaceSelector:
-                                                properties:
-                                                  matchExpressions:
-                                                    items:
-                                                      properties:
-                                                        key:
-                                                          type: string
-                                                        operator:
-                                                          type: string
-                                                        values:
-                                                          items:
-                                                            type: string
-                                                          type: array
-                                                      required:
-                                                        - key
-                                                        - operator
-                                                      type: object
-                                                    type: array
-                                                  matchLabels:
-                                                    additionalProperties:
-                                                      type: string
-                                                    type: object
-                                                type: object
-                                                x-kubernetes-map-type: atomic
-                                              namespaces:
-                                                items:
-                                                  type: string
-                                                type: array
-                                              topologyKey:
-                                                type: string
-                                            required:
-                                              - topologyKey
-                                            type: object
-                                          type: array
-                                      type: object
-                                    podAntiAffinity:
-                                      properties:
-                                        preferredDuringSchedulingIgnoredDuringExecution:
-                                          items:
-                                            properties:
-                                              podAffinityTerm:
-                                                properties:
-                                                  labelSelector:
-                                                    properties:
-                                                      matchExpressions:
-                                                        items:
-                                                          properties:
-                                                            key:
-                                                              type: string
-                                                            operator:
-                                                              type: string
-                                                            values:
-                                                              items:
-                                                                type: string
-                                                              type: array
-                                                          required:
-                                                            - key
-                                                            - operator
-                                                          type: object
-                                                        type: array
-                                                      matchLabels:
-                                                        additionalProperties:
-                                                          type: string
-                                                        type: object
-                                                    type: object
-                                                    x-kubernetes-map-type: atomic
-                                                  namespaceSelector:
-                                                    properties:
-                                                      matchExpressions:
-                                                        items:
-                                                          properties:
-                                                            key:
-                                                              type: string
-                                                            operator:
-                                                              type: string
-                                                            values:
-                                                              items:
-                                                                type: string
-                                                              type: array
-                                                          required:
-                                                            - key
-                                                            - operator
-                                                          type: object
-                                                        type: array
-                                                      matchLabels:
-                                                        additionalProperties:
-                                                          type: string
-                                                        type: object
-                                                    type: object
-                                                    x-kubernetes-map-type: atomic
-                                                  namespaces:
-                                                    items:
-                                                      type: string
-                                                    type: array
-                                                  topologyKey:
-                                                    type: string
-                                                required:
-                                                  - topologyKey
-                                                type: object
-                                              weight:
-                                                format: int32
-                                                type: integer
-                                            required:
-                                              - podAffinityTerm
-                                              - weight
-                                            type: object
-                                          type: array
-                                        requiredDuringSchedulingIgnoredDuringExecution:
-                                          items:
-                                            properties:
-                                              labelSelector:
-                                                properties:
-                                                  matchExpressions:
-                                                    items:
-                                                      properties:
-                                                        key:
-                                                          type: string
-                                                        operator:
-                                                          type: string
-                                                        values:
-                                                          items:
-                                                            type: string
-                                                          type: array
-                                                      required:
-                                                        - key
-                                                        - operator
-                                                      type: object
-                                                    type: array
-                                                  matchLabels:
-                                                    additionalProperties:
-                                                      type: string
-                                                    type: object
-                                                type: object
-                                                x-kubernetes-map-type: atomic
-                                              namespaceSelector:
-                                                properties:
-                                                  matchExpressions:
-                                                    items:
-                                                      properties:
-                                                        key:
-                                                          type: string
-                                                        operator:
-                                                          type: string
-                                                        values:
-                                                          items:
-                                                            type: string
-                                                          type: array
-                                                      required:
-                                                        - key
-                                                        - operator
-                                                      type: object
-                                                    type: array
-                                                  matchLabels:
-                                                    additionalProperties:
-                                                      type: string
-                                                    type: object
-                                                type: object
-                                                x-kubernetes-map-type: atomic
-                                              namespaces:
-                                                items:
-                                                  type: string
-                                                type: array
-                                              topologyKey:
-                                                type: string
-                                            required:
-                                              - topologyKey
-                                            type: object
-                                          type: array
-                                      type: object
-                                  type: object
-                                automountServiceAccountToken:
-                                  type: boolean
-                                containers:
-                                  items:
-                                    properties:
-                                      args:
-                                        items:
-                                          type: string
-                                        type: array
-                                      command:
-                                        items:
-                                          type: string
-                                        type: array
-                                      env:
-                                        items:
-                                          properties:
-                                            name:
-                                              type: string
-                                            value:
-                                              type: string
-                                            valueFrom:
-                                              properties:
-                                                configMapKeyRef:
-                                                  properties:
-                                                    key:
-                                                      type: string
-                                                    name:
-                                                      type: string
-                                                    optional:
-                                                      type: boolean
-                                                  required:
+                                                    required:
                                                     - key
-                                                  type: object
-                                                  x-kubernetes-map-type: atomic
-                                                fieldRef:
-                                                  properties:
-                                                    apiVersion:
-                                                      type: string
-                                                    fieldPath:
-                                                      type: string
-                                                  required:
-                                                    - fieldPath
-                                                  type: object
-                                                  x-kubernetes-map-type: atomic
-                                                resourceFieldRef:
-                                                  properties:
-                                                    containerName:
-                                                      type: string
-                                                    divisor:
-                                                      anyOf:
-                                                        - type: integer
-                                                        - type: string
-                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                      x-kubernetes-int-or-string: true
-                                                    resource:
-                                                      type: string
-                                                  required:
-                                                    - resource
-                                                  type: object
-                                                  x-kubernetes-map-type: atomic
-                                                secretKeyRef:
-                                                  properties:
-                                                    key:
-                                                      type: string
-                                                    name:
-                                                      type: string
-                                                    optional:
-                                                      type: boolean
-                                                  required:
-                                                    - key
-                                                  type: object
-                                                  x-kubernetes-map-type: atomic
-                                              type: object
-                                          required:
-                                            - name
-                                          type: object
-                                        type: array
-                                      envFrom:
-                                        items:
-                                          properties:
-                                            configMapRef:
-                                              properties:
-                                                name:
-                                                  type: string
-                                                optional:
-                                                  type: boolean
+                                                    - operator
+                                                    type: object
+                                                  type: array
                                               type: object
                                               x-kubernetes-map-type: atomic
-                                            prefix:
-                                              type: string
-                                            secretRef:
-                                              properties:
-                                                name:
-                                                  type: string
-                                                optional:
-                                                  type: boolean
-                                              type: object
-                                              x-kubernetes-map-type: atomic
-                                          type: object
-                                        type: array
-                                      image:
-                                        type: string
-                                      imagePullPolicy:
-                                        type: string
-                                      lifecycle:
-                                        properties:
-                                          postStart:
-                                            properties:
-                                              exec:
-                                                properties:
-                                                  command:
-                                                    items:
-                                                      type: string
-                                                    type: array
-                                                type: object
-                                              httpGet:
-                                                properties:
-                                                  host:
-                                                    type: string
-                                                  httpHeaders:
-                                                    items:
-                                                      properties:
-                                                        name:
-                                                          type: string
-                                                        value:
-                                                          type: string
-                                                      required:
-                                                        - name
-                                                        - value
-                                                      type: object
-                                                    type: array
-                                                  path:
-                                                    type: string
-                                                  port:
-                                                    anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                    x-kubernetes-int-or-string: true
-                                                  scheme:
-                                                    type: string
-                                                required:
-                                                  - port
-                                                type: object
-                                              tcpSocket:
-                                                properties:
-                                                  host:
-                                                    type: string
-                                                  port:
-                                                    anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                    x-kubernetes-int-or-string: true
-                                                required:
-                                                  - port
-                                                type: object
-                                            type: object
-                                          preStop:
-                                            properties:
-                                              exec:
-                                                properties:
-                                                  command:
-                                                    items:
-                                                      type: string
-                                                    type: array
-                                                type: object
-                                              httpGet:
-                                                properties:
-                                                  host:
-                                                    type: string
-                                                  httpHeaders:
-                                                    items:
-                                                      properties:
-                                                        name:
-                                                          type: string
-                                                        value:
-                                                          type: string
-                                                      required:
-                                                        - name
-                                                        - value
-                                                      type: object
-                                                    type: array
-                                                  path:
-                                                    type: string
-                                                  port:
-                                                    anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                    x-kubernetes-int-or-string: true
-                                                  scheme:
-                                                    type: string
-                                                required:
-                                                  - port
-                                                type: object
-                                              tcpSocket:
-                                                properties:
-                                                  host:
-                                                    type: string
-                                                  port:
-                                                    anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                    x-kubernetes-int-or-string: true
-                                                required:
-                                                  - port
-                                                type: object
-                                            type: object
-                                        type: object
-                                      livenessProbe:
-                                        properties:
-                                          exec:
-                                            properties:
-                                              command:
-                                                items:
-                                                  type: string
-                                                type: array
-                                            type: object
-                                          failureThreshold:
-                                            format: int32
-                                            type: integer
-                                          grpc:
-                                            properties:
-                                              port:
-                                                format: int32
-                                                type: integer
-                                              service:
-                                                type: string
-                                            required:
-                                              - port
-                                            type: object
-                                          httpGet:
-                                            properties:
-                                              host:
-                                                type: string
-                                              httpHeaders:
-                                                items:
-                                                  properties:
-                                                    name:
-                                                      type: string
-                                                    value:
-                                                      type: string
-                                                  required:
-                                                    - name
-                                                    - value
-                                                  type: object
-                                                type: array
-                                              path:
-                                                type: string
-                                              port:
-                                                anyOf:
-                                                  - type: integer
-                                                  - type: string
-                                                x-kubernetes-int-or-string: true
-                                              scheme:
-                                                type: string
-                                            required:
-                                              - port
-                                            type: object
-                                          initialDelaySeconds:
-                                            format: int32
-                                            type: integer
-                                          periodSeconds:
-                                            format: int32
-                                            type: integer
-                                          successThreshold:
-                                            format: int32
-                                            type: integer
-                                          tcpSocket:
-                                            properties:
-                                              host:
-                                                type: string
-                                              port:
-                                                anyOf:
-                                                  - type: integer
-                                                  - type: string
-                                                x-kubernetes-int-or-string: true
-                                            required:
-                                              - port
-                                            type: object
-                                          terminationGracePeriodSeconds:
-                                            format: int64
-                                            type: integer
-                                          timeoutSeconds:
-                                            format: int32
-                                            type: integer
-                                        type: object
-                                      name:
-                                        type: string
-                                      ports:
-                                        items:
-                                          properties:
-                                            containerPort:
+                                            weight:
                                               format: int32
                                               type: integer
-                                            hostIP:
-                                              type: string
-                                            hostPort:
-                                              format: int32
-                                              type: integer
-                                            name:
-                                              type: string
-                                            protocol:
-                                              default: TCP
-                                              type: string
                                           required:
-                                            - containerPort
+                                          - preference
+                                          - weight
                                           type: object
                                         type: array
-                                        x-kubernetes-list-map-keys:
-                                          - containerPort
-                                          - protocol
-                                        x-kubernetes-list-type: map
-                                      readinessProbe:
+                                      requiredDuringSchedulingIgnoredDuringExecution:
                                         properties:
-                                          exec:
-                                            properties:
-                                              command:
-                                                items:
-                                                  type: string
-                                                type: array
-                                            type: object
-                                          failureThreshold:
-                                            format: int32
-                                            type: integer
-                                          grpc:
-                                            properties:
-                                              port:
-                                                format: int32
-                                                type: integer
-                                              service:
-                                                type: string
-                                            required:
-                                              - port
-                                            type: object
-                                          httpGet:
-                                            properties:
-                                              host:
-                                                type: string
-                                              httpHeaders:
-                                                items:
-                                                  properties:
-                                                    name:
-                                                      type: string
-                                                    value:
-                                                      type: string
-                                                  required:
-                                                    - name
-                                                    - value
-                                                  type: object
-                                                type: array
-                                              path:
-                                                type: string
-                                              port:
-                                                anyOf:
-                                                  - type: integer
-                                                  - type: string
-                                                x-kubernetes-int-or-string: true
-                                              scheme:
-                                                type: string
-                                            required:
-                                              - port
-                                            type: object
-                                          initialDelaySeconds:
-                                            format: int32
-                                            type: integer
-                                          periodSeconds:
-                                            format: int32
-                                            type: integer
-                                          successThreshold:
-                                            format: int32
-                                            type: integer
-                                          tcpSocket:
-                                            properties:
-                                              host:
-                                                type: string
-                                              port:
-                                                anyOf:
-                                                  - type: integer
-                                                  - type: string
-                                                x-kubernetes-int-or-string: true
-                                            required:
-                                              - port
-                                            type: object
-                                          terminationGracePeriodSeconds:
-                                            format: int64
-                                            type: integer
-                                          timeoutSeconds:
-                                            format: int32
-                                            type: integer
-                                        type: object
-                                      resources:
-                                        properties:
-                                          limits:
-                                            additionalProperties:
-                                              anyOf:
-                                                - type: integer
-                                                - type: string
-                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                              x-kubernetes-int-or-string: true
-                                            type: object
-                                          requests:
-                                            additionalProperties:
-                                              anyOf:
-                                                - type: integer
-                                                - type: string
-                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                              x-kubernetes-int-or-string: true
-                                            type: object
-                                        type: object
-                                      securityContext:
-                                        properties:
-                                          allowPrivilegeEscalation:
-                                            type: boolean
-                                          capabilities:
-                                            properties:
-                                              add:
-                                                items:
-                                                  type: string
-                                                type: array
-                                              drop:
-                                                items:
-                                                  type: string
-                                                type: array
-                                            type: object
-                                          privileged:
-                                            type: boolean
-                                          procMount:
-                                            type: string
-                                          readOnlyRootFilesystem:
-                                            type: boolean
-                                          runAsGroup:
-                                            format: int64
-                                            type: integer
-                                          runAsNonRoot:
-                                            type: boolean
-                                          runAsUser:
-                                            format: int64
-                                            type: integer
-                                          seLinuxOptions:
-                                            properties:
-                                              level:
-                                                type: string
-                                              role:
-                                                type: string
-                                              type:
-                                                type: string
-                                              user:
-                                                type: string
-                                            type: object
-                                          seccompProfile:
-                                            properties:
-                                              localhostProfile:
-                                                type: string
-                                              type:
-                                                type: string
-                                            required:
-                                              - type
-                                            type: object
-                                          windowsOptions:
-                                            properties:
-                                              gmsaCredentialSpec:
-                                                type: string
-                                              gmsaCredentialSpecName:
-                                                type: string
-                                              hostProcess:
-                                                type: boolean
-                                              runAsUserName:
-                                                type: string
-                                            type: object
-                                        type: object
-                                      startupProbe:
-                                        properties:
-                                          exec:
-                                            properties:
-                                              command:
-                                                items:
-                                                  type: string
-                                                type: array
-                                            type: object
-                                          failureThreshold:
-                                            format: int32
-                                            type: integer
-                                          grpc:
-                                            properties:
-                                              port:
-                                                format: int32
-                                                type: integer
-                                              service:
-                                                type: string
-                                            required:
-                                              - port
-                                            type: object
-                                          httpGet:
-                                            properties:
-                                              host:
-                                                type: string
-                                              httpHeaders:
-                                                items:
-                                                  properties:
-                                                    name:
-                                                      type: string
-                                                    value:
-                                                      type: string
-                                                  required:
-                                                    - name
-                                                    - value
-                                                  type: object
-                                                type: array
-                                              path:
-                                                type: string
-                                              port:
-                                                anyOf:
-                                                  - type: integer
-                                                  - type: string
-                                                x-kubernetes-int-or-string: true
-                                              scheme:
-                                                type: string
-                                            required:
-                                              - port
-                                            type: object
-                                          initialDelaySeconds:
-                                            format: int32
-                                            type: integer
-                                          periodSeconds:
-                                            format: int32
-                                            type: integer
-                                          successThreshold:
-                                            format: int32
-                                            type: integer
-                                          tcpSocket:
-                                            properties:
-                                              host:
-                                                type: string
-                                              port:
-                                                anyOf:
-                                                  - type: integer
-                                                  - type: string
-                                                x-kubernetes-int-or-string: true
-                                            required:
-                                              - port
-                                            type: object
-                                          terminationGracePeriodSeconds:
-                                            format: int64
-                                            type: integer
-                                          timeoutSeconds:
-                                            format: int32
-                                            type: integer
-                                        type: object
-                                      stdin:
-                                        type: boolean
-                                      stdinOnce:
-                                        type: boolean
-                                      terminationMessagePath:
-                                        type: string
-                                      terminationMessagePolicy:
-                                        type: string
-                                      tty:
-                                        type: boolean
-                                      volumeDevices:
-                                        items:
-                                          properties:
-                                            devicePath:
-                                              type: string
-                                            name:
-                                              type: string
-                                          required:
-                                            - devicePath
-                                            - name
-                                          type: object
-                                        type: array
-                                      volumeMounts:
-                                        items:
-                                          properties:
-                                            mountPath:
-                                              type: string
-                                            mountPropagation:
-                                              type: string
-                                            name:
-                                              type: string
-                                            readOnly:
-                                              type: boolean
-                                            subPath:
-                                              type: string
-                                            subPathExpr:
-                                              type: string
-                                          required:
-                                            - mountPath
-                                            - name
-                                          type: object
-                                        type: array
-                                      workingDir:
-                                        type: string
-                                    required:
-                                      - name
-                                    type: object
-                                  type: array
-                                dnsConfig:
-                                  properties:
-                                    nameservers:
-                                      items:
-                                        type: string
-                                      type: array
-                                    options:
-                                      items:
-                                        properties:
-                                          name:
-                                            type: string
-                                          value:
-                                            type: string
-                                        type: object
-                                      type: array
-                                    searches:
-                                      items:
-                                        type: string
-                                      type: array
-                                  type: object
-                                dnsPolicy:
-                                  type: string
-                                enableServiceLinks:
-                                  type: boolean
-                                ephemeralContainers:
-                                  items:
-                                    properties:
-                                      args:
-                                        items:
-                                          type: string
-                                        type: array
-                                      command:
-                                        items:
-                                          type: string
-                                        type: array
-                                      env:
-                                        items:
-                                          properties:
-                                            name:
-                                              type: string
-                                            value:
-                                              type: string
-                                            valueFrom:
-                                              properties:
-                                                configMapKeyRef:
-                                                  properties:
-                                                    key:
-                                                      type: string
-                                                    name:
-                                                      type: string
-                                                    optional:
-                                                      type: boolean
-                                                  required:
-                                                    - key
-                                                  type: object
-                                                  x-kubernetes-map-type: atomic
-                                                fieldRef:
-                                                  properties:
-                                                    apiVersion:
-                                                      type: string
-                                                    fieldPath:
-                                                      type: string
-                                                  required:
-                                                    - fieldPath
-                                                  type: object
-                                                  x-kubernetes-map-type: atomic
-                                                resourceFieldRef:
-                                                  properties:
-                                                    containerName:
-                                                      type: string
-                                                    divisor:
-                                                      anyOf:
-                                                        - type: integer
-                                                        - type: string
-                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                      x-kubernetes-int-or-string: true
-                                                    resource:
-                                                      type: string
-                                                  required:
-                                                    - resource
-                                                  type: object
-                                                  x-kubernetes-map-type: atomic
-                                                secretKeyRef:
-                                                  properties:
-                                                    key:
-                                                      type: string
-                                                    name:
-                                                      type: string
-                                                    optional:
-                                                      type: boolean
-                                                  required:
-                                                    - key
-                                                  type: object
-                                                  x-kubernetes-map-type: atomic
-                                              type: object
-                                          required:
-                                            - name
-                                          type: object
-                                        type: array
-                                      envFrom:
-                                        items:
-                                          properties:
-                                            configMapRef:
-                                              properties:
-                                                name:
-                                                  type: string
-                                                optional:
-                                                  type: boolean
-                                              type: object
-                                              x-kubernetes-map-type: atomic
-                                            prefix:
-                                              type: string
-                                            secretRef:
-                                              properties:
-                                                name:
-                                                  type: string
-                                                optional:
-                                                  type: boolean
-                                              type: object
-                                              x-kubernetes-map-type: atomic
-                                          type: object
-                                        type: array
-                                      image:
-                                        type: string
-                                      imagePullPolicy:
-                                        type: string
-                                      lifecycle:
-                                        properties:
-                                          postStart:
-                                            properties:
-                                              exec:
-                                                properties:
-                                                  command:
-                                                    items:
-                                                      type: string
-                                                    type: array
-                                                type: object
-                                              httpGet:
-                                                properties:
-                                                  host:
-                                                    type: string
-                                                  httpHeaders:
-                                                    items:
-                                                      properties:
-                                                        name:
-                                                          type: string
-                                                        value:
-                                                          type: string
-                                                      required:
-                                                        - name
-                                                        - value
-                                                      type: object
-                                                    type: array
-                                                  path:
-                                                    type: string
-                                                  port:
-                                                    anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                    x-kubernetes-int-or-string: true
-                                                  scheme:
-                                                    type: string
-                                                required:
-                                                  - port
-                                                type: object
-                                              tcpSocket:
-                                                properties:
-                                                  host:
-                                                    type: string
-                                                  port:
-                                                    anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                    x-kubernetes-int-or-string: true
-                                                required:
-                                                  - port
-                                                type: object
-                                            type: object
-                                          preStop:
-                                            properties:
-                                              exec:
-                                                properties:
-                                                  command:
-                                                    items:
-                                                      type: string
-                                                    type: array
-                                                type: object
-                                              httpGet:
-                                                properties:
-                                                  host:
-                                                    type: string
-                                                  httpHeaders:
-                                                    items:
-                                                      properties:
-                                                        name:
-                                                          type: string
-                                                        value:
-                                                          type: string
-                                                      required:
-                                                        - name
-                                                        - value
-                                                      type: object
-                                                    type: array
-                                                  path:
-                                                    type: string
-                                                  port:
-                                                    anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                    x-kubernetes-int-or-string: true
-                                                  scheme:
-                                                    type: string
-                                                required:
-                                                  - port
-                                                type: object
-                                              tcpSocket:
-                                                properties:
-                                                  host:
-                                                    type: string
-                                                  port:
-                                                    anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                    x-kubernetes-int-or-string: true
-                                                required:
-                                                  - port
-                                                type: object
-                                            type: object
-                                        type: object
-                                      livenessProbe:
-                                        properties:
-                                          exec:
-                                            properties:
-                                              command:
-                                                items:
-                                                  type: string
-                                                type: array
-                                            type: object
-                                          failureThreshold:
-                                            format: int32
-                                            type: integer
-                                          grpc:
-                                            properties:
-                                              port:
-                                                format: int32
-                                                type: integer
-                                              service:
-                                                type: string
-                                            required:
-                                              - port
-                                            type: object
-                                          httpGet:
-                                            properties:
-                                              host:
-                                                type: string
-                                              httpHeaders:
-                                                items:
-                                                  properties:
-                                                    name:
-                                                      type: string
-                                                    value:
-                                                      type: string
-                                                  required:
-                                                    - name
-                                                    - value
-                                                  type: object
-                                                type: array
-                                              path:
-                                                type: string
-                                              port:
-                                                anyOf:
-                                                  - type: integer
-                                                  - type: string
-                                                x-kubernetes-int-or-string: true
-                                              scheme:
-                                                type: string
-                                            required:
-                                              - port
-                                            type: object
-                                          initialDelaySeconds:
-                                            format: int32
-                                            type: integer
-                                          periodSeconds:
-                                            format: int32
-                                            type: integer
-                                          successThreshold:
-                                            format: int32
-                                            type: integer
-                                          tcpSocket:
-                                            properties:
-                                              host:
-                                                type: string
-                                              port:
-                                                anyOf:
-                                                  - type: integer
-                                                  - type: string
-                                                x-kubernetes-int-or-string: true
-                                            required:
-                                              - port
-                                            type: object
-                                          terminationGracePeriodSeconds:
-                                            format: int64
-                                            type: integer
-                                          timeoutSeconds:
-                                            format: int32
-                                            type: integer
-                                        type: object
-                                      name:
-                                        type: string
-                                      ports:
-                                        items:
-                                          properties:
-                                            containerPort:
-                                              format: int32
-                                              type: integer
-                                            hostIP:
-                                              type: string
-                                            hostPort:
-                                              format: int32
-                                              type: integer
-                                            name:
-                                              type: string
-                                            protocol:
-                                              default: TCP
-                                              type: string
-                                          required:
-                                            - containerPort
-                                          type: object
-                                        type: array
-                                        x-kubernetes-list-map-keys:
-                                          - containerPort
-                                          - protocol
-                                        x-kubernetes-list-type: map
-                                      readinessProbe:
-                                        properties:
-                                          exec:
-                                            properties:
-                                              command:
-                                                items:
-                                                  type: string
-                                                type: array
-                                            type: object
-                                          failureThreshold:
-                                            format: int32
-                                            type: integer
-                                          grpc:
-                                            properties:
-                                              port:
-                                                format: int32
-                                                type: integer
-                                              service:
-                                                type: string
-                                            required:
-                                              - port
-                                            type: object
-                                          httpGet:
-                                            properties:
-                                              host:
-                                                type: string
-                                              httpHeaders:
-                                                items:
-                                                  properties:
-                                                    name:
-                                                      type: string
-                                                    value:
-                                                      type: string
-                                                  required:
-                                                    - name
-                                                    - value
-                                                  type: object
-                                                type: array
-                                              path:
-                                                type: string
-                                              port:
-                                                anyOf:
-                                                  - type: integer
-                                                  - type: string
-                                                x-kubernetes-int-or-string: true
-                                              scheme:
-                                                type: string
-                                            required:
-                                              - port
-                                            type: object
-                                          initialDelaySeconds:
-                                            format: int32
-                                            type: integer
-                                          periodSeconds:
-                                            format: int32
-                                            type: integer
-                                          successThreshold:
-                                            format: int32
-                                            type: integer
-                                          tcpSocket:
-                                            properties:
-                                              host:
-                                                type: string
-                                              port:
-                                                anyOf:
-                                                  - type: integer
-                                                  - type: string
-                                                x-kubernetes-int-or-string: true
-                                            required:
-                                              - port
-                                            type: object
-                                          terminationGracePeriodSeconds:
-                                            format: int64
-                                            type: integer
-                                          timeoutSeconds:
-                                            format: int32
-                                            type: integer
-                                        type: object
-                                      resources:
-                                        properties:
-                                          limits:
-                                            additionalProperties:
-                                              anyOf:
-                                                - type: integer
-                                                - type: string
-                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                              x-kubernetes-int-or-string: true
-                                            type: object
-                                          requests:
-                                            additionalProperties:
-                                              anyOf:
-                                                - type: integer
-                                                - type: string
-                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                              x-kubernetes-int-or-string: true
-                                            type: object
-                                        type: object
-                                      securityContext:
-                                        properties:
-                                          allowPrivilegeEscalation:
-                                            type: boolean
-                                          capabilities:
-                                            properties:
-                                              add:
-                                                items:
-                                                  type: string
-                                                type: array
-                                              drop:
-                                                items:
-                                                  type: string
-                                                type: array
-                                            type: object
-                                          privileged:
-                                            type: boolean
-                                          procMount:
-                                            type: string
-                                          readOnlyRootFilesystem:
-                                            type: boolean
-                                          runAsGroup:
-                                            format: int64
-                                            type: integer
-                                          runAsNonRoot:
-                                            type: boolean
-                                          runAsUser:
-                                            format: int64
-                                            type: integer
-                                          seLinuxOptions:
-                                            properties:
-                                              level:
-                                                type: string
-                                              role:
-                                                type: string
-                                              type:
-                                                type: string
-                                              user:
-                                                type: string
-                                            type: object
-                                          seccompProfile:
-                                            properties:
-                                              localhostProfile:
-                                                type: string
-                                              type:
-                                                type: string
-                                            required:
-                                              - type
-                                            type: object
-                                          windowsOptions:
-                                            properties:
-                                              gmsaCredentialSpec:
-                                                type: string
-                                              gmsaCredentialSpecName:
-                                                type: string
-                                              hostProcess:
-                                                type: boolean
-                                              runAsUserName:
-                                                type: string
-                                            type: object
-                                        type: object
-                                      startupProbe:
-                                        properties:
-                                          exec:
-                                            properties:
-                                              command:
-                                                items:
-                                                  type: string
-                                                type: array
-                                            type: object
-                                          failureThreshold:
-                                            format: int32
-                                            type: integer
-                                          grpc:
-                                            properties:
-                                              port:
-                                                format: int32
-                                                type: integer
-                                              service:
-                                                type: string
-                                            required:
-                                              - port
-                                            type: object
-                                          httpGet:
-                                            properties:
-                                              host:
-                                                type: string
-                                              httpHeaders:
-                                                items:
-                                                  properties:
-                                                    name:
-                                                      type: string
-                                                    value:
-                                                      type: string
-                                                  required:
-                                                    - name
-                                                    - value
-                                                  type: object
-                                                type: array
-                                              path:
-                                                type: string
-                                              port:
-                                                anyOf:
-                                                  - type: integer
-                                                  - type: string
-                                                x-kubernetes-int-or-string: true
-                                              scheme:
-                                                type: string
-                                            required:
-                                              - port
-                                            type: object
-                                          initialDelaySeconds:
-                                            format: int32
-                                            type: integer
-                                          periodSeconds:
-                                            format: int32
-                                            type: integer
-                                          successThreshold:
-                                            format: int32
-                                            type: integer
-                                          tcpSocket:
-                                            properties:
-                                              host:
-                                                type: string
-                                              port:
-                                                anyOf:
-                                                  - type: integer
-                                                  - type: string
-                                                x-kubernetes-int-or-string: true
-                                            required:
-                                              - port
-                                            type: object
-                                          terminationGracePeriodSeconds:
-                                            format: int64
-                                            type: integer
-                                          timeoutSeconds:
-                                            format: int32
-                                            type: integer
-                                        type: object
-                                      stdin:
-                                        type: boolean
-                                      stdinOnce:
-                                        type: boolean
-                                      targetContainerName:
-                                        type: string
-                                      terminationMessagePath:
-                                        type: string
-                                      terminationMessagePolicy:
-                                        type: string
-                                      tty:
-                                        type: boolean
-                                      volumeDevices:
-                                        items:
-                                          properties:
-                                            devicePath:
-                                              type: string
-                                            name:
-                                              type: string
-                                          required:
-                                            - devicePath
-                                            - name
-                                          type: object
-                                        type: array
-                                      volumeMounts:
-                                        items:
-                                          properties:
-                                            mountPath:
-                                              type: string
-                                            mountPropagation:
-                                              type: string
-                                            name:
-                                              type: string
-                                            readOnly:
-                                              type: boolean
-                                            subPath:
-                                              type: string
-                                            subPathExpr:
-                                              type: string
-                                          required:
-                                            - mountPath
-                                            - name
-                                          type: object
-                                        type: array
-                                      workingDir:
-                                        type: string
-                                    required:
-                                      - name
-                                    type: object
-                                  type: array
-                                hostAliases:
-                                  items:
-                                    properties:
-                                      hostnames:
-                                        items:
-                                          type: string
-                                        type: array
-                                      ip:
-                                        type: string
-                                    type: object
-                                  type: array
-                                hostIPC:
-                                  type: boolean
-                                hostNetwork:
-                                  type: boolean
-                                hostPID:
-                                  type: boolean
-                                hostUsers:
-                                  type: boolean
-                                hostname:
-                                  type: string
-                                imagePullSecrets:
-                                  items:
-                                    properties:
-                                      name:
-                                        type: string
-                                    type: object
-                                    x-kubernetes-map-type: atomic
-                                  type: array
-                                initContainers:
-                                  items:
-                                    properties:
-                                      args:
-                                        items:
-                                          type: string
-                                        type: array
-                                      command:
-                                        items:
-                                          type: string
-                                        type: array
-                                      env:
-                                        items:
-                                          properties:
-                                            name:
-                                              type: string
-                                            value:
-                                              type: string
-                                            valueFrom:
-                                              properties:
-                                                configMapKeyRef:
-                                                  properties:
-                                                    key:
-                                                      type: string
-                                                    name:
-                                                      type: string
-                                                    optional:
-                                                      type: boolean
-                                                  required:
-                                                    - key
-                                                  type: object
-                                                  x-kubernetes-map-type: atomic
-                                                fieldRef:
-                                                  properties:
-                                                    apiVersion:
-                                                      type: string
-                                                    fieldPath:
-                                                      type: string
-                                                  required:
-                                                    - fieldPath
-                                                  type: object
-                                                  x-kubernetes-map-type: atomic
-                                                resourceFieldRef:
-                                                  properties:
-                                                    containerName:
-                                                      type: string
-                                                    divisor:
-                                                      anyOf:
-                                                        - type: integer
-                                                        - type: string
-                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                      x-kubernetes-int-or-string: true
-                                                    resource:
-                                                      type: string
-                                                  required:
-                                                    - resource
-                                                  type: object
-                                                  x-kubernetes-map-type: atomic
-                                                secretKeyRef:
-                                                  properties:
-                                                    key:
-                                                      type: string
-                                                    name:
-                                                      type: string
-                                                    optional:
-                                                      type: boolean
-                                                  required:
-                                                    - key
-                                                  type: object
-                                                  x-kubernetes-map-type: atomic
-                                              type: object
-                                          required:
-                                            - name
-                                          type: object
-                                        type: array
-                                      envFrom:
-                                        items:
-                                          properties:
-                                            configMapRef:
-                                              properties:
-                                                name:
-                                                  type: string
-                                                optional:
-                                                  type: boolean
-                                              type: object
-                                              x-kubernetes-map-type: atomic
-                                            prefix:
-                                              type: string
-                                            secretRef:
-                                              properties:
-                                                name:
-                                                  type: string
-                                                optional:
-                                                  type: boolean
-                                              type: object
-                                              x-kubernetes-map-type: atomic
-                                          type: object
-                                        type: array
-                                      image:
-                                        type: string
-                                      imagePullPolicy:
-                                        type: string
-                                      lifecycle:
-                                        properties:
-                                          postStart:
-                                            properties:
-                                              exec:
-                                                properties:
-                                                  command:
-                                                    items:
-                                                      type: string
-                                                    type: array
-                                                type: object
-                                              httpGet:
-                                                properties:
-                                                  host:
-                                                    type: string
-                                                  httpHeaders:
-                                                    items:
-                                                      properties:
-                                                        name:
-                                                          type: string
-                                                        value:
-                                                          type: string
-                                                      required:
-                                                        - name
-                                                        - value
-                                                      type: object
-                                                    type: array
-                                                  path:
-                                                    type: string
-                                                  port:
-                                                    anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                    x-kubernetes-int-or-string: true
-                                                  scheme:
-                                                    type: string
-                                                required:
-                                                  - port
-                                                type: object
-                                              tcpSocket:
-                                                properties:
-                                                  host:
-                                                    type: string
-                                                  port:
-                                                    anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                    x-kubernetes-int-or-string: true
-                                                required:
-                                                  - port
-                                                type: object
-                                            type: object
-                                          preStop:
-                                            properties:
-                                              exec:
-                                                properties:
-                                                  command:
-                                                    items:
-                                                      type: string
-                                                    type: array
-                                                type: object
-                                              httpGet:
-                                                properties:
-                                                  host:
-                                                    type: string
-                                                  httpHeaders:
-                                                    items:
-                                                      properties:
-                                                        name:
-                                                          type: string
-                                                        value:
-                                                          type: string
-                                                      required:
-                                                        - name
-                                                        - value
-                                                      type: object
-                                                    type: array
-                                                  path:
-                                                    type: string
-                                                  port:
-                                                    anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                    x-kubernetes-int-or-string: true
-                                                  scheme:
-                                                    type: string
-                                                required:
-                                                  - port
-                                                type: object
-                                              tcpSocket:
-                                                properties:
-                                                  host:
-                                                    type: string
-                                                  port:
-                                                    anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                    x-kubernetes-int-or-string: true
-                                                required:
-                                                  - port
-                                                type: object
-                                            type: object
-                                        type: object
-                                      livenessProbe:
-                                        properties:
-                                          exec:
-                                            properties:
-                                              command:
-                                                items:
-                                                  type: string
-                                                type: array
-                                            type: object
-                                          failureThreshold:
-                                            format: int32
-                                            type: integer
-                                          grpc:
-                                            properties:
-                                              port:
-                                                format: int32
-                                                type: integer
-                                              service:
-                                                type: string
-                                            required:
-                                              - port
-                                            type: object
-                                          httpGet:
-                                            properties:
-                                              host:
-                                                type: string
-                                              httpHeaders:
-                                                items:
-                                                  properties:
-                                                    name:
-                                                      type: string
-                                                    value:
-                                                      type: string
-                                                  required:
-                                                    - name
-                                                    - value
-                                                  type: object
-                                                type: array
-                                              path:
-                                                type: string
-                                              port:
-                                                anyOf:
-                                                  - type: integer
-                                                  - type: string
-                                                x-kubernetes-int-or-string: true
-                                              scheme:
-                                                type: string
-                                            required:
-                                              - port
-                                            type: object
-                                          initialDelaySeconds:
-                                            format: int32
-                                            type: integer
-                                          periodSeconds:
-                                            format: int32
-                                            type: integer
-                                          successThreshold:
-                                            format: int32
-                                            type: integer
-                                          tcpSocket:
-                                            properties:
-                                              host:
-                                                type: string
-                                              port:
-                                                anyOf:
-                                                  - type: integer
-                                                  - type: string
-                                                x-kubernetes-int-or-string: true
-                                            required:
-                                              - port
-                                            type: object
-                                          terminationGracePeriodSeconds:
-                                            format: int64
-                                            type: integer
-                                          timeoutSeconds:
-                                            format: int32
-                                            type: integer
-                                        type: object
-                                      name:
-                                        type: string
-                                      ports:
-                                        items:
-                                          properties:
-                                            containerPort:
-                                              format: int32
-                                              type: integer
-                                            hostIP:
-                                              type: string
-                                            hostPort:
-                                              format: int32
-                                              type: integer
-                                            name:
-                                              type: string
-                                            protocol:
-                                              default: TCP
-                                              type: string
-                                          required:
-                                            - containerPort
-                                          type: object
-                                        type: array
-                                        x-kubernetes-list-map-keys:
-                                          - containerPort
-                                          - protocol
-                                        x-kubernetes-list-type: map
-                                      readinessProbe:
-                                        properties:
-                                          exec:
-                                            properties:
-                                              command:
-                                                items:
-                                                  type: string
-                                                type: array
-                                            type: object
-                                          failureThreshold:
-                                            format: int32
-                                            type: integer
-                                          grpc:
-                                            properties:
-                                              port:
-                                                format: int32
-                                                type: integer
-                                              service:
-                                                type: string
-                                            required:
-                                              - port
-                                            type: object
-                                          httpGet:
-                                            properties:
-                                              host:
-                                                type: string
-                                              httpHeaders:
-                                                items:
-                                                  properties:
-                                                    name:
-                                                      type: string
-                                                    value:
-                                                      type: string
-                                                  required:
-                                                    - name
-                                                    - value
-                                                  type: object
-                                                type: array
-                                              path:
-                                                type: string
-                                              port:
-                                                anyOf:
-                                                  - type: integer
-                                                  - type: string
-                                                x-kubernetes-int-or-string: true
-                                              scheme:
-                                                type: string
-                                            required:
-                                              - port
-                                            type: object
-                                          initialDelaySeconds:
-                                            format: int32
-                                            type: integer
-                                          periodSeconds:
-                                            format: int32
-                                            type: integer
-                                          successThreshold:
-                                            format: int32
-                                            type: integer
-                                          tcpSocket:
-                                            properties:
-                                              host:
-                                                type: string
-                                              port:
-                                                anyOf:
-                                                  - type: integer
-                                                  - type: string
-                                                x-kubernetes-int-or-string: true
-                                            required:
-                                              - port
-                                            type: object
-                                          terminationGracePeriodSeconds:
-                                            format: int64
-                                            type: integer
-                                          timeoutSeconds:
-                                            format: int32
-                                            type: integer
-                                        type: object
-                                      resources:
-                                        properties:
-                                          limits:
-                                            additionalProperties:
-                                              anyOf:
-                                                - type: integer
-                                                - type: string
-                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                              x-kubernetes-int-or-string: true
-                                            type: object
-                                          requests:
-                                            additionalProperties:
-                                              anyOf:
-                                                - type: integer
-                                                - type: string
-                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                              x-kubernetes-int-or-string: true
-                                            type: object
-                                        type: object
-                                      securityContext:
-                                        properties:
-                                          allowPrivilegeEscalation:
-                                            type: boolean
-                                          capabilities:
-                                            properties:
-                                              add:
-                                                items:
-                                                  type: string
-                                                type: array
-                                              drop:
-                                                items:
-                                                  type: string
-                                                type: array
-                                            type: object
-                                          privileged:
-                                            type: boolean
-                                          procMount:
-                                            type: string
-                                          readOnlyRootFilesystem:
-                                            type: boolean
-                                          runAsGroup:
-                                            format: int64
-                                            type: integer
-                                          runAsNonRoot:
-                                            type: boolean
-                                          runAsUser:
-                                            format: int64
-                                            type: integer
-                                          seLinuxOptions:
-                                            properties:
-                                              level:
-                                                type: string
-                                              role:
-                                                type: string
-                                              type:
-                                                type: string
-                                              user:
-                                                type: string
-                                            type: object
-                                          seccompProfile:
-                                            properties:
-                                              localhostProfile:
-                                                type: string
-                                              type:
-                                                type: string
-                                            required:
-                                              - type
-                                            type: object
-                                          windowsOptions:
-                                            properties:
-                                              gmsaCredentialSpec:
-                                                type: string
-                                              gmsaCredentialSpecName:
-                                                type: string
-                                              hostProcess:
-                                                type: boolean
-                                              runAsUserName:
-                                                type: string
-                                            type: object
-                                        type: object
-                                      startupProbe:
-                                        properties:
-                                          exec:
-                                            properties:
-                                              command:
-                                                items:
-                                                  type: string
-                                                type: array
-                                            type: object
-                                          failureThreshold:
-                                            format: int32
-                                            type: integer
-                                          grpc:
-                                            properties:
-                                              port:
-                                                format: int32
-                                                type: integer
-                                              service:
-                                                type: string
-                                            required:
-                                              - port
-                                            type: object
-                                          httpGet:
-                                            properties:
-                                              host:
-                                                type: string
-                                              httpHeaders:
-                                                items:
-                                                  properties:
-                                                    name:
-                                                      type: string
-                                                    value:
-                                                      type: string
-                                                  required:
-                                                    - name
-                                                    - value
-                                                  type: object
-                                                type: array
-                                              path:
-                                                type: string
-                                              port:
-                                                anyOf:
-                                                  - type: integer
-                                                  - type: string
-                                                x-kubernetes-int-or-string: true
-                                              scheme:
-                                                type: string
-                                            required:
-                                              - port
-                                            type: object
-                                          initialDelaySeconds:
-                                            format: int32
-                                            type: integer
-                                          periodSeconds:
-                                            format: int32
-                                            type: integer
-                                          successThreshold:
-                                            format: int32
-                                            type: integer
-                                          tcpSocket:
-                                            properties:
-                                              host:
-                                                type: string
-                                              port:
-                                                anyOf:
-                                                  - type: integer
-                                                  - type: string
-                                                x-kubernetes-int-or-string: true
-                                            required:
-                                              - port
-                                            type: object
-                                          terminationGracePeriodSeconds:
-                                            format: int64
-                                            type: integer
-                                          timeoutSeconds:
-                                            format: int32
-                                            type: integer
-                                        type: object
-                                      stdin:
-                                        type: boolean
-                                      stdinOnce:
-                                        type: boolean
-                                      terminationMessagePath:
-                                        type: string
-                                      terminationMessagePolicy:
-                                        type: string
-                                      tty:
-                                        type: boolean
-                                      volumeDevices:
-                                        items:
-                                          properties:
-                                            devicePath:
-                                              type: string
-                                            name:
-                                              type: string
-                                          required:
-                                            - devicePath
-                                            - name
-                                          type: object
-                                        type: array
-                                      volumeMounts:
-                                        items:
-                                          properties:
-                                            mountPath:
-                                              type: string
-                                            mountPropagation:
-                                              type: string
-                                            name:
-                                              type: string
-                                            readOnly:
-                                              type: boolean
-                                            subPath:
-                                              type: string
-                                            subPathExpr:
-                                              type: string
-                                          required:
-                                            - mountPath
-                                            - name
-                                          type: object
-                                        type: array
-                                      workingDir:
-                                        type: string
-                                    required:
-                                      - name
-                                    type: object
-                                  type: array
-                                nodeName:
-                                  type: string
-                                nodeSelector:
-                                  additionalProperties:
-                                    type: string
-                                  type: object
-                                  x-kubernetes-map-type: atomic
-                                os:
-                                  properties:
-                                    name:
-                                      type: string
-                                  required:
-                                    - name
-                                  type: object
-                                overhead:
-                                  additionalProperties:
-                                    anyOf:
-                                      - type: integer
-                                      - type: string
-                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                    x-kubernetes-int-or-string: true
-                                  type: object
-                                preemptionPolicy:
-                                  type: string
-                                priority:
-                                  format: int32
-                                  type: integer
-                                priorityClassName:
-                                  type: string
-                                readinessGates:
-                                  items:
-                                    properties:
-                                      conditionType:
-                                        type: string
-                                    required:
-                                      - conditionType
-                                    type: object
-                                  type: array
-                                restartPolicy:
-                                  type: string
-                                runtimeClassName:
-                                  type: string
-                                schedulerName:
-                                  type: string
-                                securityContext:
-                                  properties:
-                                    fsGroup:
-                                      format: int64
-                                      type: integer
-                                    fsGroupChangePolicy:
-                                      type: string
-                                    runAsGroup:
-                                      format: int64
-                                      type: integer
-                                    runAsNonRoot:
-                                      type: boolean
-                                    runAsUser:
-                                      format: int64
-                                      type: integer
-                                    seLinuxOptions:
-                                      properties:
-                                        level:
-                                          type: string
-                                        role:
-                                          type: string
-                                        type:
-                                          type: string
-                                        user:
-                                          type: string
-                                      type: object
-                                    seccompProfile:
-                                      properties:
-                                        localhostProfile:
-                                          type: string
-                                        type:
-                                          type: string
-                                      required:
-                                        - type
-                                      type: object
-                                    supplementalGroups:
-                                      items:
-                                        format: int64
-                                        type: integer
-                                      type: array
-                                    sysctls:
-                                      items:
-                                        properties:
-                                          name:
-                                            type: string
-                                          value:
-                                            type: string
-                                        required:
-                                          - name
-                                          - value
-                                        type: object
-                                      type: array
-                                    windowsOptions:
-                                      properties:
-                                        gmsaCredentialSpec:
-                                          type: string
-                                        gmsaCredentialSpecName:
-                                          type: string
-                                        hostProcess:
-                                          type: boolean
-                                        runAsUserName:
-                                          type: string
-                                      type: object
-                                  type: object
-                                serviceAccount:
-                                  type: string
-                                serviceAccountName:
-                                  type: string
-                                setHostnameAsFQDN:
-                                  type: boolean
-                                shareProcessNamespace:
-                                  type: boolean
-                                subdomain:
-                                  type: string
-                                terminationGracePeriodSeconds:
-                                  format: int64
-                                  type: integer
-                                tolerations:
-                                  items:
-                                    properties:
-                                      effect:
-                                        type: string
-                                      key:
-                                        type: string
-                                      operator:
-                                        type: string
-                                      tolerationSeconds:
-                                        format: int64
-                                        type: integer
-                                      value:
-                                        type: string
-                                    type: object
-                                  type: array
-                                topologySpreadConstraints:
-                                  items:
-                                    properties:
-                                      labelSelector:
-                                        properties:
-                                          matchExpressions:
+                                          nodeSelectorTerms:
                                             items:
                                               properties:
-                                                key:
-                                                  type: string
-                                                operator:
-                                                  type: string
-                                                values:
+                                                matchExpressions:
+                                                  items:
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      operator:
+                                                        type: string
+                                                      values:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                matchFields:
+                                                  items:
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      operator:
+                                                        type: string
+                                                      values:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            type: array
+                                        required:
+                                        - nodeSelectorTerms
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                  podAffinity:
+                                    properties:
+                                      preferredDuringSchedulingIgnoredDuringExecution:
+                                        items:
+                                          properties:
+                                            podAffinityTerm:
+                                              properties:
+                                                labelSelector:
+                                                  properties:
+                                                    matchExpressions:
+                                                      items:
+                                                        properties:
+                                                          key:
+                                                            type: string
+                                                          operator:
+                                                            type: string
+                                                          values:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      type: object
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                namespaceSelector:
+                                                  properties:
+                                                    matchExpressions:
+                                                      items:
+                                                        properties:
+                                                          key:
+                                                            type: string
+                                                          operator:
+                                                            type: string
+                                                          values:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      type: object
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                namespaces:
                                                   items:
                                                     type: string
                                                   type: array
+                                                topologyKey:
+                                                  type: string
                                               required:
-                                                - key
-                                                - operator
+                                              - topologyKey
                                               type: object
-                                            type: array
-                                          matchLabels:
-                                            additionalProperties:
-                                              type: string
-                                            type: object
-                                        type: object
-                                        x-kubernetes-map-type: atomic
-                                      matchLabelKeys:
-                                        items:
-                                          type: string
+                                            weight:
+                                              format: int32
+                                              type: integer
+                                          required:
+                                          - podAffinityTerm
+                                          - weight
+                                          type: object
                                         type: array
-                                        x-kubernetes-list-type: atomic
-                                      maxSkew:
-                                        format: int32
-                                        type: integer
-                                      minDomains:
-                                        format: int32
-                                        type: integer
-                                      nodeAffinityPolicy:
-                                        type: string
-                                      nodeTaintsPolicy:
-                                        type: string
-                                      topologyKey:
-                                        type: string
-                                      whenUnsatisfiable:
-                                        type: string
-                                    required:
-                                      - maxSkew
-                                      - topologyKey
-                                      - whenUnsatisfiable
-                                    type: object
-                                  type: array
-                                  x-kubernetes-list-map-keys:
-                                    - topologyKey
-                                    - whenUnsatisfiable
-                                  x-kubernetes-list-type: map
-                                volumes:
-                                  items:
-                                    properties:
-                                      awsElasticBlockStore:
-                                        properties:
-                                          fsType:
-                                            type: string
-                                          partition:
-                                            format: int32
-                                            type: integer
-                                          readOnly:
-                                            type: boolean
-                                          volumeID:
-                                            type: string
-                                        required:
-                                          - volumeID
-                                        type: object
-                                      azureDisk:
-                                        properties:
-                                          cachingMode:
-                                            type: string
-                                          diskName:
-                                            type: string
-                                          diskURI:
-                                            type: string
-                                          fsType:
-                                            type: string
-                                          kind:
-                                            type: string
-                                          readOnly:
-                                            type: boolean
-                                        required:
-                                          - diskName
-                                          - diskURI
-                                        type: object
-                                      azureFile:
-                                        properties:
-                                          readOnly:
-                                            type: boolean
-                                          secretName:
-                                            type: string
-                                          shareName:
-                                            type: string
-                                        required:
-                                          - secretName
-                                          - shareName
-                                        type: object
-                                      cephfs:
-                                        properties:
-                                          monitors:
-                                            items:
-                                              type: string
-                                            type: array
-                                          path:
-                                            type: string
-                                          readOnly:
-                                            type: boolean
-                                          secretFile:
-                                            type: string
-                                          secretRef:
-                                            properties:
-                                              name:
-                                                type: string
-                                            type: object
-                                            x-kubernetes-map-type: atomic
-                                          user:
-                                            type: string
-                                        required:
-                                          - monitors
-                                        type: object
-                                      cinder:
-                                        properties:
-                                          fsType:
-                                            type: string
-                                          readOnly:
-                                            type: boolean
-                                          secretRef:
-                                            properties:
-                                              name:
-                                                type: string
-                                            type: object
-                                            x-kubernetes-map-type: atomic
-                                          volumeID:
-                                            type: string
-                                        required:
-                                          - volumeID
-                                        type: object
-                                      configMap:
-                                        properties:
-                                          defaultMode:
-                                            format: int32
-                                            type: integer
-                                          items:
-                                            items:
+                                      requiredDuringSchedulingIgnoredDuringExecution:
+                                        items:
+                                          properties:
+                                            labelSelector:
                                               properties:
-                                                key:
-                                                  type: string
-                                                mode:
-                                                  format: int32
-                                                  type: integer
-                                                path:
+                                                matchExpressions:
+                                                  items:
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      operator:
+                                                        type: string
+                                                      values:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  type: object
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            namespaceSelector:
+                                              properties:
+                                                matchExpressions:
+                                                  items:
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      operator:
+                                                        type: string
+                                                      values:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  type: object
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            namespaces:
+                                              items:
+                                                type: string
+                                              type: array
+                                            topologyKey:
+                                              type: string
+                                          required:
+                                          - topologyKey
+                                          type: object
+                                        type: array
+                                    type: object
+                                  podAntiAffinity:
+                                    properties:
+                                      preferredDuringSchedulingIgnoredDuringExecution:
+                                        items:
+                                          properties:
+                                            podAffinityTerm:
+                                              properties:
+                                                labelSelector:
+                                                  properties:
+                                                    matchExpressions:
+                                                      items:
+                                                        properties:
+                                                          key:
+                                                            type: string
+                                                          operator:
+                                                            type: string
+                                                          values:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      type: object
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                namespaceSelector:
+                                                  properties:
+                                                    matchExpressions:
+                                                      items:
+                                                        properties:
+                                                          key:
+                                                            type: string
+                                                          operator:
+                                                            type: string
+                                                          values:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      type: object
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                namespaces:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                topologyKey:
                                                   type: string
                                               required:
-                                                - key
-                                                - path
+                                              - topologyKey
                                               type: object
-                                            type: array
+                                            weight:
+                                              format: int32
+                                              type: integer
+                                          required:
+                                          - podAffinityTerm
+                                          - weight
+                                          type: object
+                                        type: array
+                                      requiredDuringSchedulingIgnoredDuringExecution:
+                                        items:
+                                          properties:
+                                            labelSelector:
+                                              properties:
+                                                matchExpressions:
+                                                  items:
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      operator:
+                                                        type: string
+                                                      values:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  type: object
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            namespaceSelector:
+                                              properties:
+                                                matchExpressions:
+                                                  items:
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      operator:
+                                                        type: string
+                                                      values:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  type: object
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            namespaces:
+                                              items:
+                                                type: string
+                                              type: array
+                                            topologyKey:
+                                              type: string
+                                          required:
+                                          - topologyKey
+                                          type: object
+                                        type: array
+                                    type: object
+                                type: object
+                              automountServiceAccountToken:
+                                type: boolean
+                              containers:
+                                items:
+                                  properties:
+                                    args:
+                                      items:
+                                        type: string
+                                      type: array
+                                    command:
+                                      items:
+                                        type: string
+                                      type: array
+                                    env:
+                                      items:
+                                        properties:
                                           name:
                                             type: string
-                                          optional:
-                                            type: boolean
+                                          value:
+                                            type: string
+                                          valueFrom:
+                                            properties:
+                                              configMapKeyRef:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  name:
+                                                    type: string
+                                                  optional:
+                                                    type: boolean
+                                                required:
+                                                - key
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              fieldRef:
+                                                properties:
+                                                  apiVersion:
+                                                    type: string
+                                                  fieldPath:
+                                                    type: string
+                                                required:
+                                                - fieldPath
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              resourceFieldRef:
+                                                properties:
+                                                  containerName:
+                                                    type: string
+                                                  divisor:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                    x-kubernetes-int-or-string: true
+                                                  resource:
+                                                    type: string
+                                                required:
+                                                - resource
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              secretKeyRef:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  name:
+                                                    type: string
+                                                  optional:
+                                                    type: boolean
+                                                required:
+                                                - key
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                            type: object
+                                        required:
+                                        - name
                                         type: object
-                                        x-kubernetes-map-type: atomic
-                                      csi:
+                                      type: array
+                                    envFrom:
+                                      items:
                                         properties:
-                                          driver:
-                                            type: string
-                                          fsType:
-                                            type: string
-                                          nodePublishSecretRef:
+                                          configMapRef:
                                             properties:
                                               name:
                                                 type: string
+                                              optional:
+                                                type: boolean
                                             type: object
                                             x-kubernetes-map-type: atomic
-                                          readOnly:
-                                            type: boolean
-                                          volumeAttributes:
-                                            additionalProperties:
-                                              type: string
+                                          prefix:
+                                            type: string
+                                          secretRef:
+                                            properties:
+                                              name:
+                                                type: string
+                                              optional:
+                                                type: boolean
                                             type: object
-                                        required:
-                                          - driver
+                                            x-kubernetes-map-type: atomic
                                         type: object
-                                      downwardAPI:
-                                        properties:
-                                          defaultMode:
-                                            format: int32
-                                            type: integer
-                                          items:
-                                            items:
+                                      type: array
+                                    image:
+                                      type: string
+                                    imagePullPolicy:
+                                      type: string
+                                    lifecycle:
+                                      properties:
+                                        postStart:
+                                          properties:
+                                            exec:
                                               properties:
-                                                fieldRef:
-                                                  properties:
-                                                    apiVersion:
-                                                      type: string
-                                                    fieldPath:
-                                                      type: string
-                                                  required:
-                                                    - fieldPath
-                                                  type: object
-                                                  x-kubernetes-map-type: atomic
-                                                mode:
-                                                  format: int32
-                                                  type: integer
+                                                command:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              type: object
+                                            httpGet:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                httpHeaders:
+                                                  items:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
                                                 path:
                                                   type: string
-                                                resourceFieldRef:
-                                                  properties:
-                                                    containerName:
-                                                      type: string
-                                                    divisor:
-                                                      anyOf:
-                                                        - type: integer
-                                                        - type: string
-                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                      x-kubernetes-int-or-string: true
-                                                    resource:
-                                                      type: string
-                                                  required:
-                                                    - resource
-                                                  type: object
-                                                  x-kubernetes-map-type: atomic
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                                scheme:
+                                                  type: string
                                               required:
-                                                - path
+                                              - port
                                               type: object
-                                            type: array
-                                        type: object
-                                      emptyDir:
-                                        properties:
-                                          medium:
-                                            type: string
-                                          sizeLimit:
-                                            anyOf:
+                                            tcpSocket:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                              required:
+                                              - port
+                                              type: object
+                                          type: object
+                                        preStop:
+                                          properties:
+                                            exec:
+                                              properties:
+                                                command:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              type: object
+                                            httpGet:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                httpHeaders:
+                                                  items:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                path:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                                scheme:
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            tcpSocket:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                              required:
+                                              - port
+                                              type: object
+                                          type: object
+                                      type: object
+                                    livenessProbe:
+                                      properties:
+                                        exec:
+                                          properties:
+                                            command:
+                                              items:
+                                                type: string
+                                              type: array
+                                          type: object
+                                        failureThreshold:
+                                          format: int32
+                                          type: integer
+                                        grpc:
+                                          properties:
+                                            port:
+                                              format: int32
+                                              type: integer
+                                            service:
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        httpGet:
+                                          properties:
+                                            host:
+                                              type: string
+                                            httpHeaders:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                            path:
+                                              type: string
+                                            port:
+                                              anyOf:
                                               - type: integer
                                               - type: string
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        initialDelaySeconds:
+                                          format: int32
+                                          type: integer
+                                        periodSeconds:
+                                          format: int32
+                                          type: integer
+                                        successThreshold:
+                                          format: int32
+                                          type: integer
+                                        tcpSocket:
+                                          properties:
+                                            host:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                        terminationGracePeriodSeconds:
+                                          format: int64
+                                          type: integer
+                                        timeoutSeconds:
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                    name:
+                                      type: string
+                                    ports:
+                                      items:
+                                        properties:
+                                          containerPort:
+                                            format: int32
+                                            type: integer
+                                          hostIP:
+                                            type: string
+                                          hostPort:
+                                            format: int32
+                                            type: integer
+                                          name:
+                                            type: string
+                                          protocol:
+                                            default: TCP
+                                            type: string
+                                        required:
+                                        - containerPort
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - containerPort
+                                      - protocol
+                                      x-kubernetes-list-type: map
+                                    readinessProbe:
+                                      properties:
+                                        exec:
+                                          properties:
+                                            command:
+                                              items:
+                                                type: string
+                                              type: array
+                                          type: object
+                                        failureThreshold:
+                                          format: int32
+                                          type: integer
+                                        grpc:
+                                          properties:
+                                            port:
+                                              format: int32
+                                              type: integer
+                                            service:
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        httpGet:
+                                          properties:
+                                            host:
+                                              type: string
+                                            httpHeaders:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                            path:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        initialDelaySeconds:
+                                          format: int32
+                                          type: integer
+                                        periodSeconds:
+                                          format: int32
+                                          type: integer
+                                        successThreshold:
+                                          format: int32
+                                          type: integer
+                                        tcpSocket:
+                                          properties:
+                                            host:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                        terminationGracePeriodSeconds:
+                                          format: int64
+                                          type: integer
+                                        timeoutSeconds:
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                    resizePolicy:
+                                      items:
+                                        properties:
+                                          resourceName:
+                                            type: string
+                                          restartPolicy:
+                                            type: string
+                                        required:
+                                        - resourceName
+                                        - restartPolicy
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    resources:
+                                      properties:
+                                        claims:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                            required:
+                                            - name
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
+                                        limits:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
                                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                             x-kubernetes-int-or-string: true
-                                        type: object
-                                      ephemeral:
-                                        properties:
-                                          volumeClaimTemplate:
-                                            properties:
-                                              metadata:
-                                                type: object
-                                              spec:
+                                          type: object
+                                        requests:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          type: object
+                                      type: object
+                                    restartPolicy:
+                                      type: string
+                                    securityContext:
+                                      properties:
+                                        allowPrivilegeEscalation:
+                                          type: boolean
+                                        capabilities:
+                                          properties:
+                                            add:
+                                              items:
+                                                type: string
+                                              type: array
+                                            drop:
+                                              items:
+                                                type: string
+                                              type: array
+                                          type: object
+                                        privileged:
+                                          type: boolean
+                                        procMount:
+                                          type: string
+                                        readOnlyRootFilesystem:
+                                          type: boolean
+                                        runAsGroup:
+                                          format: int64
+                                          type: integer
+                                        runAsNonRoot:
+                                          type: boolean
+                                        runAsUser:
+                                          format: int64
+                                          type: integer
+                                        seLinuxOptions:
+                                          properties:
+                                            level:
+                                              type: string
+                                            role:
+                                              type: string
+                                            type:
+                                              type: string
+                                            user:
+                                              type: string
+                                          type: object
+                                        seccompProfile:
+                                          properties:
+                                            localhostProfile:
+                                              type: string
+                                            type:
+                                              type: string
+                                          required:
+                                          - type
+                                          type: object
+                                        windowsOptions:
+                                          properties:
+                                            gmsaCredentialSpec:
+                                              type: string
+                                            gmsaCredentialSpecName:
+                                              type: string
+                                            hostProcess:
+                                              type: boolean
+                                            runAsUserName:
+                                              type: string
+                                          type: object
+                                      type: object
+                                    startupProbe:
+                                      properties:
+                                        exec:
+                                          properties:
+                                            command:
+                                              items:
+                                                type: string
+                                              type: array
+                                          type: object
+                                        failureThreshold:
+                                          format: int32
+                                          type: integer
+                                        grpc:
+                                          properties:
+                                            port:
+                                              format: int32
+                                              type: integer
+                                            service:
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        httpGet:
+                                          properties:
+                                            host:
+                                              type: string
+                                            httpHeaders:
+                                              items:
                                                 properties:
-                                                  accessModes:
-                                                    items:
-                                                      type: string
-                                                    type: array
-                                                  dataSource:
-                                                    properties:
-                                                      apiGroup:
-                                                        type: string
-                                                      kind:
-                                                        type: string
-                                                      name:
-                                                        type: string
-                                                    required:
-                                                      - kind
-                                                      - name
-                                                    type: object
-                                                    x-kubernetes-map-type: atomic
-                                                  dataSourceRef:
-                                                    properties:
-                                                      apiGroup:
-                                                        type: string
-                                                      kind:
-                                                        type: string
-                                                      name:
-                                                        type: string
-                                                    required:
-                                                      - kind
-                                                      - name
-                                                    type: object
-                                                    x-kubernetes-map-type: atomic
-                                                  resources:
-                                                    properties:
-                                                      limits:
-                                                        additionalProperties:
-                                                          anyOf:
-                                                            - type: integer
-                                                            - type: string
-                                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                          x-kubernetes-int-or-string: true
-                                                        type: object
-                                                      requests:
-                                                        additionalProperties:
-                                                          anyOf:
-                                                            - type: integer
-                                                            - type: string
-                                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                          x-kubernetes-int-or-string: true
-                                                        type: object
-                                                    type: object
-                                                  selector:
-                                                    properties:
-                                                      matchExpressions:
-                                                        items:
-                                                          properties:
-                                                            key:
-                                                              type: string
-                                                            operator:
-                                                              type: string
-                                                            values:
-                                                              items:
-                                                                type: string
-                                                              type: array
-                                                          required:
-                                                            - key
-                                                            - operator
-                                                          type: object
-                                                        type: array
-                                                      matchLabels:
-                                                        additionalProperties:
-                                                          type: string
-                                                        type: object
-                                                    type: object
-                                                    x-kubernetes-map-type: atomic
-                                                  storageClassName:
+                                                  name:
                                                     type: string
-                                                  volumeMode:
+                                                  value:
                                                     type: string
-                                                  volumeName:
-                                                    type: string
+                                                required:
+                                                - name
+                                                - value
                                                 type: object
-                                            required:
-                                              - spec
-                                            type: object
-                                        type: object
-                                      fc:
-                                        properties:
-                                          fsType:
-                                            type: string
-                                          lun:
-                                            format: int32
-                                            type: integer
-                                          readOnly:
-                                            type: boolean
-                                          targetWWNs:
-                                            items:
+                                              type: array
+                                            path:
                                               type: string
-                                            type: array
-                                          wwids:
-                                            items:
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
                                               type: string
-                                            type: array
-                                        type: object
-                                      flexVolume:
-                                        properties:
-                                          driver:
-                                            type: string
-                                          fsType:
-                                            type: string
-                                          options:
-                                            additionalProperties:
+                                          required:
+                                          - port
+                                          type: object
+                                        initialDelaySeconds:
+                                          format: int32
+                                          type: integer
+                                        periodSeconds:
+                                          format: int32
+                                          type: integer
+                                        successThreshold:
+                                          format: int32
+                                          type: integer
+                                        tcpSocket:
+                                          properties:
+                                            host:
                                               type: string
-                                            type: object
-                                          readOnly:
-                                            type: boolean
-                                          secretRef:
-                                            properties:
-                                              name:
-                                                type: string
-                                            type: object
-                                            x-kubernetes-map-type: atomic
-                                        required:
-                                          - driver
-                                        type: object
-                                      flocker:
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                        terminationGracePeriodSeconds:
+                                          format: int64
+                                          type: integer
+                                        timeoutSeconds:
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                    stdin:
+                                      type: boolean
+                                    stdinOnce:
+                                      type: boolean
+                                    terminationMessagePath:
+                                      type: string
+                                    terminationMessagePolicy:
+                                      type: string
+                                    tty:
+                                      type: boolean
+                                    volumeDevices:
+                                      items:
                                         properties:
-                                          datasetName:
+                                          devicePath:
                                             type: string
-                                          datasetUUID:
-                                            type: string
-                                        type: object
-                                      gcePersistentDisk:
-                                        properties:
-                                          fsType:
-                                            type: string
-                                          partition:
-                                            format: int32
-                                            type: integer
-                                          pdName:
-                                            type: string
-                                          readOnly:
-                                            type: boolean
-                                        required:
-                                          - pdName
-                                        type: object
-                                      gitRepo:
-                                        properties:
-                                          directory:
-                                            type: string
-                                          repository:
-                                            type: string
-                                          revision:
+                                          name:
                                             type: string
                                         required:
-                                          - repository
+                                        - devicePath
+                                        - name
                                         type: object
-                                      glusterfs:
+                                      type: array
+                                    volumeMounts:
+                                      items:
                                         properties:
-                                          endpoints:
+                                          mountPath:
                                             type: string
-                                          path:
+                                          mountPropagation:
+                                            type: string
+                                          name:
                                             type: string
                                           readOnly:
                                             type: boolean
-                                        required:
-                                          - endpoints
-                                          - path
-                                        type: object
-                                      hostPath:
-                                        properties:
-                                          path:
+                                          subPath:
                                             type: string
-                                          type:
+                                          subPathExpr:
                                             type: string
                                         required:
-                                          - path
+                                        - mountPath
+                                        - name
                                         type: object
-                                      iscsi:
-                                        properties:
-                                          chapAuthDiscovery:
-                                            type: boolean
-                                          chapAuthSession:
-                                            type: boolean
-                                          fsType:
-                                            type: string
-                                          initiatorName:
-                                            type: string
-                                          iqn:
-                                            type: string
-                                          iscsiInterface:
-                                            type: string
-                                          lun:
-                                            format: int32
-                                            type: integer
-                                          portals:
-                                            items:
-                                              type: string
-                                            type: array
-                                          readOnly:
-                                            type: boolean
-                                          secretRef:
-                                            properties:
-                                              name:
-                                                type: string
-                                            type: object
-                                            x-kubernetes-map-type: atomic
-                                          targetPortal:
-                                            type: string
-                                        required:
-                                          - iqn
-                                          - lun
-                                          - targetPortal
-                                        type: object
-                                      name:
+                                      type: array
+                                    workingDir:
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                              dnsConfig:
+                                properties:
+                                  nameservers:
+                                    items:
+                                      type: string
+                                    type: array
+                                  options:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                      type: object
+                                    type: array
+                                  searches:
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              dnsPolicy:
+                                type: string
+                              enableServiceLinks:
+                                type: boolean
+                              ephemeralContainers:
+                                items:
+                                  properties:
+                                    args:
+                                      items:
                                         type: string
-                                      nfs:
+                                      type: array
+                                    command:
+                                      items:
+                                        type: string
+                                      type: array
+                                    env:
+                                      items:
                                         properties:
-                                          path:
+                                          name:
                                             type: string
-                                          readOnly:
-                                            type: boolean
-                                          server:
+                                          value:
                                             type: string
+                                          valueFrom:
+                                            properties:
+                                              configMapKeyRef:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  name:
+                                                    type: string
+                                                  optional:
+                                                    type: boolean
+                                                required:
+                                                - key
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              fieldRef:
+                                                properties:
+                                                  apiVersion:
+                                                    type: string
+                                                  fieldPath:
+                                                    type: string
+                                                required:
+                                                - fieldPath
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              resourceFieldRef:
+                                                properties:
+                                                  containerName:
+                                                    type: string
+                                                  divisor:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                    x-kubernetes-int-or-string: true
+                                                  resource:
+                                                    type: string
+                                                required:
+                                                - resource
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              secretKeyRef:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  name:
+                                                    type: string
+                                                  optional:
+                                                    type: boolean
+                                                required:
+                                                - key
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                            type: object
                                         required:
-                                          - path
-                                          - server
+                                        - name
                                         type: object
-                                      persistentVolumeClaim:
+                                      type: array
+                                    envFrom:
+                                      items:
                                         properties:
-                                          claimName:
+                                          configMapRef:
+                                            properties:
+                                              name:
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          prefix:
                                             type: string
-                                          readOnly:
-                                            type: boolean
-                                        required:
-                                          - claimName
+                                          secretRef:
+                                            properties:
+                                              name:
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                            type: object
+                                            x-kubernetes-map-type: atomic
                                         type: object
-                                      photonPersistentDisk:
-                                        properties:
-                                          fsType:
-                                            type: string
-                                          pdID:
-                                            type: string
-                                        required:
-                                          - pdID
-                                        type: object
-                                      portworxVolume:
-                                        properties:
-                                          fsType:
-                                            type: string
-                                          readOnly:
-                                            type: boolean
-                                          volumeID:
-                                            type: string
-                                        required:
-                                          - volumeID
-                                        type: object
-                                      projected:
-                                        properties:
-                                          defaultMode:
-                                            format: int32
-                                            type: integer
-                                          sources:
-                                            items:
+                                      type: array
+                                    image:
+                                      type: string
+                                    imagePullPolicy:
+                                      type: string
+                                    lifecycle:
+                                      properties:
+                                        postStart:
+                                          properties:
+                                            exec:
                                               properties:
-                                                configMap:
-                                                  properties:
-                                                    items:
-                                                      items:
-                                                        properties:
-                                                          key:
-                                                            type: string
-                                                          mode:
-                                                            format: int32
-                                                            type: integer
-                                                          path:
-                                                            type: string
-                                                        required:
-                                                          - key
-                                                          - path
-                                                        type: object
-                                                      type: array
-                                                    name:
-                                                      type: string
-                                                    optional:
-                                                      type: boolean
-                                                  type: object
-                                                  x-kubernetes-map-type: atomic
-                                                downwardAPI:
-                                                  properties:
-                                                    items:
-                                                      items:
-                                                        properties:
-                                                          fieldRef:
-                                                            properties:
-                                                              apiVersion:
-                                                                type: string
-                                                              fieldPath:
-                                                                type: string
-                                                            required:
-                                                              - fieldPath
-                                                            type: object
-                                                            x-kubernetes-map-type: atomic
-                                                          mode:
-                                                            format: int32
-                                                            type: integer
-                                                          path:
-                                                            type: string
-                                                          resourceFieldRef:
-                                                            properties:
-                                                              containerName:
-                                                                type: string
-                                                              divisor:
-                                                                anyOf:
-                                                                  - type: integer
-                                                                  - type: string
-                                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                                x-kubernetes-int-or-string: true
-                                                              resource:
-                                                                type: string
-                                                            required:
-                                                              - resource
-                                                            type: object
-                                                            x-kubernetes-map-type: atomic
-                                                        required:
-                                                          - path
-                                                        type: object
-                                                      type: array
-                                                  type: object
-                                                secret:
-                                                  properties:
-                                                    items:
-                                                      items:
-                                                        properties:
-                                                          key:
-                                                            type: string
-                                                          mode:
-                                                            format: int32
-                                                            type: integer
-                                                          path:
-                                                            type: string
-                                                        required:
-                                                          - key
-                                                          - path
-                                                        type: object
-                                                      type: array
-                                                    name:
-                                                      type: string
-                                                    optional:
-                                                      type: boolean
-                                                  type: object
-                                                  x-kubernetes-map-type: atomic
-                                                serviceAccountToken:
-                                                  properties:
-                                                    audience:
-                                                      type: string
-                                                    expirationSeconds:
-                                                      format: int64
-                                                      type: integer
-                                                    path:
-                                                      type: string
-                                                  required:
-                                                    - path
-                                                  type: object
+                                                command:
+                                                  items:
+                                                    type: string
+                                                  type: array
                                               type: object
-                                            type: array
-                                        type: object
-                                      quobyte:
-                                        properties:
-                                          group:
-                                            type: string
-                                          readOnly:
-                                            type: boolean
-                                          registry:
-                                            type: string
-                                          tenant:
-                                            type: string
-                                          user:
-                                            type: string
-                                          volume:
-                                            type: string
-                                        required:
-                                          - registry
-                                          - volume
-                                        type: object
-                                      rbd:
-                                        properties:
-                                          fsType:
-                                            type: string
-                                          image:
-                                            type: string
-                                          keyring:
-                                            type: string
-                                          monitors:
-                                            items:
-                                              type: string
-                                            type: array
-                                          pool:
-                                            type: string
-                                          readOnly:
-                                            type: boolean
-                                          secretRef:
-                                            properties:
-                                              name:
-                                                type: string
-                                            type: object
-                                            x-kubernetes-map-type: atomic
-                                          user:
-                                            type: string
-                                        required:
-                                          - image
-                                          - monitors
-                                        type: object
-                                      scaleIO:
-                                        properties:
-                                          fsType:
-                                            type: string
-                                          gateway:
-                                            type: string
-                                          protectionDomain:
-                                            type: string
-                                          readOnly:
-                                            type: boolean
-                                          secretRef:
-                                            properties:
-                                              name:
-                                                type: string
-                                            type: object
-                                            x-kubernetes-map-type: atomic
-                                          sslEnabled:
-                                            type: boolean
-                                          storageMode:
-                                            type: string
-                                          storagePool:
-                                            type: string
-                                          system:
-                                            type: string
-                                          volumeName:
-                                            type: string
-                                        required:
-                                          - gateway
-                                          - secretRef
-                                          - system
-                                        type: object
-                                      secret:
-                                        properties:
-                                          defaultMode:
-                                            format: int32
-                                            type: integer
-                                          items:
-                                            items:
+                                            httpGet:
                                               properties:
-                                                key:
+                                                host:
                                                   type: string
-                                                mode:
-                                                  format: int32
-                                                  type: integer
+                                                httpHeaders:
+                                                  items:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
                                                 path:
                                                   type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                                scheme:
+                                                  type: string
                                               required:
-                                                - key
-                                                - path
+                                              - port
                                               type: object
-                                            type: array
-                                          optional:
-                                            type: boolean
-                                          secretName:
-                                            type: string
-                                        type: object
-                                      storageos:
+                                            tcpSocket:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                              required:
+                                              - port
+                                              type: object
+                                          type: object
+                                        preStop:
+                                          properties:
+                                            exec:
+                                              properties:
+                                                command:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              type: object
+                                            httpGet:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                httpHeaders:
+                                                  items:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                path:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                                scheme:
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            tcpSocket:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                              required:
+                                              - port
+                                              type: object
+                                          type: object
+                                      type: object
+                                    livenessProbe:
+                                      properties:
+                                        exec:
+                                          properties:
+                                            command:
+                                              items:
+                                                type: string
+                                              type: array
+                                          type: object
+                                        failureThreshold:
+                                          format: int32
+                                          type: integer
+                                        grpc:
+                                          properties:
+                                            port:
+                                              format: int32
+                                              type: integer
+                                            service:
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        httpGet:
+                                          properties:
+                                            host:
+                                              type: string
+                                            httpHeaders:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                            path:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        initialDelaySeconds:
+                                          format: int32
+                                          type: integer
+                                        periodSeconds:
+                                          format: int32
+                                          type: integer
+                                        successThreshold:
+                                          format: int32
+                                          type: integer
+                                        tcpSocket:
+                                          properties:
+                                            host:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                        terminationGracePeriodSeconds:
+                                          format: int64
+                                          type: integer
+                                        timeoutSeconds:
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                    name:
+                                      type: string
+                                    ports:
+                                      items:
                                         properties:
-                                          fsType:
+                                          containerPort:
+                                            format: int32
+                                            type: integer
+                                          hostIP:
                                             type: string
-                                          readOnly:
-                                            type: boolean
-                                          secretRef:
+                                          hostPort:
+                                            format: int32
+                                            type: integer
+                                          name:
+                                            type: string
+                                          protocol:
+                                            default: TCP
+                                            type: string
+                                        required:
+                                        - containerPort
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - containerPort
+                                      - protocol
+                                      x-kubernetes-list-type: map
+                                    readinessProbe:
+                                      properties:
+                                        exec:
+                                          properties:
+                                            command:
+                                              items:
+                                                type: string
+                                              type: array
+                                          type: object
+                                        failureThreshold:
+                                          format: int32
+                                          type: integer
+                                        grpc:
+                                          properties:
+                                            port:
+                                              format: int32
+                                              type: integer
+                                            service:
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        httpGet:
+                                          properties:
+                                            host:
+                                              type: string
+                                            httpHeaders:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                            path:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        initialDelaySeconds:
+                                          format: int32
+                                          type: integer
+                                        periodSeconds:
+                                          format: int32
+                                          type: integer
+                                        successThreshold:
+                                          format: int32
+                                          type: integer
+                                        tcpSocket:
+                                          properties:
+                                            host:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                        terminationGracePeriodSeconds:
+                                          format: int64
+                                          type: integer
+                                        timeoutSeconds:
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                    resizePolicy:
+                                      items:
+                                        properties:
+                                          resourceName:
+                                            type: string
+                                          restartPolicy:
+                                            type: string
+                                        required:
+                                        - resourceName
+                                        - restartPolicy
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    resources:
+                                      properties:
+                                        claims:
+                                          items:
                                             properties:
                                               name:
                                                 type: string
+                                            required:
+                                            - name
                                             type: object
-                                            x-kubernetes-map-type: atomic
-                                          volumeName:
-                                            type: string
-                                          volumeNamespace:
-                                            type: string
-                                        type: object
-                                      vsphereVolume:
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
+                                        limits:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          type: object
+                                        requests:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          type: object
+                                      type: object
+                                    restartPolicy:
+                                      type: string
+                                    securityContext:
+                                      properties:
+                                        allowPrivilegeEscalation:
+                                          type: boolean
+                                        capabilities:
+                                          properties:
+                                            add:
+                                              items:
+                                                type: string
+                                              type: array
+                                            drop:
+                                              items:
+                                                type: string
+                                              type: array
+                                          type: object
+                                        privileged:
+                                          type: boolean
+                                        procMount:
+                                          type: string
+                                        readOnlyRootFilesystem:
+                                          type: boolean
+                                        runAsGroup:
+                                          format: int64
+                                          type: integer
+                                        runAsNonRoot:
+                                          type: boolean
+                                        runAsUser:
+                                          format: int64
+                                          type: integer
+                                        seLinuxOptions:
+                                          properties:
+                                            level:
+                                              type: string
+                                            role:
+                                              type: string
+                                            type:
+                                              type: string
+                                            user:
+                                              type: string
+                                          type: object
+                                        seccompProfile:
+                                          properties:
+                                            localhostProfile:
+                                              type: string
+                                            type:
+                                              type: string
+                                          required:
+                                          - type
+                                          type: object
+                                        windowsOptions:
+                                          properties:
+                                            gmsaCredentialSpec:
+                                              type: string
+                                            gmsaCredentialSpecName:
+                                              type: string
+                                            hostProcess:
+                                              type: boolean
+                                            runAsUserName:
+                                              type: string
+                                          type: object
+                                      type: object
+                                    startupProbe:
+                                      properties:
+                                        exec:
+                                          properties:
+                                            command:
+                                              items:
+                                                type: string
+                                              type: array
+                                          type: object
+                                        failureThreshold:
+                                          format: int32
+                                          type: integer
+                                        grpc:
+                                          properties:
+                                            port:
+                                              format: int32
+                                              type: integer
+                                            service:
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        httpGet:
+                                          properties:
+                                            host:
+                                              type: string
+                                            httpHeaders:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                            path:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        initialDelaySeconds:
+                                          format: int32
+                                          type: integer
+                                        periodSeconds:
+                                          format: int32
+                                          type: integer
+                                        successThreshold:
+                                          format: int32
+                                          type: integer
+                                        tcpSocket:
+                                          properties:
+                                            host:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                        terminationGracePeriodSeconds:
+                                          format: int64
+                                          type: integer
+                                        timeoutSeconds:
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                    stdin:
+                                      type: boolean
+                                    stdinOnce:
+                                      type: boolean
+                                    targetContainerName:
+                                      type: string
+                                    terminationMessagePath:
+                                      type: string
+                                    terminationMessagePolicy:
+                                      type: string
+                                    tty:
+                                      type: boolean
+                                    volumeDevices:
+                                      items:
                                         properties:
-                                          fsType:
+                                          devicePath:
                                             type: string
-                                          storagePolicyID:
-                                            type: string
-                                          storagePolicyName:
-                                            type: string
-                                          volumePath:
+                                          name:
                                             type: string
                                         required:
-                                          - volumePath
+                                        - devicePath
+                                        - name
                                         type: object
-                                    required:
-                                      - name
-                                    type: object
-                                  type: array
-                              type: object
-                          type: object
-                      type: object
-                  type: object
-                external:
-                  properties:
-                    adminPassword:
-                      properties:
-                        key:
-                          type: string
-                        name:
-                          type: string
-                        optional:
-                          type: boolean
-                      required:
-                        - key
-                      type: object
-                      x-kubernetes-map-type: atomic
-                    adminUser:
-                      properties:
-                        key:
-                          type: string
-                        name:
-                          type: string
-                        optional:
-                          type: boolean
-                      required:
-                        - key
-                      type: object
-                      x-kubernetes-map-type: atomic
-                    apiKey:
-                      properties:
-                        key:
-                          type: string
-                        name:
-                          type: string
-                        optional:
-                          type: boolean
-                      required:
-                        - key
-                      type: object
-                      x-kubernetes-map-type: atomic
-                    url:
-                      type: string
-                  required:
-                    - url
-                  type: object
-                ingress:
-                  properties:
-                    metadata:
-                      properties:
-                        annotations:
-                          additionalProperties:
-                            type: string
-                          type: object
-                        labels:
-                          additionalProperties:
-                            type: string
-                          type: object
-                      type: object
-                    spec:
-                      properties:
-                        defaultBackend:
-                          properties:
-                            resource:
-                              properties:
-                                apiGroup:
-                                  type: string
-                                kind:
-                                  type: string
-                                name:
-                                  type: string
-                              required:
-                                - kind
-                                - name
-                              type: object
-                              x-kubernetes-map-type: atomic
-                            service:
-                              properties:
-                                name:
-                                  type: string
-                                port:
+                                      type: array
+                                    volumeMounts:
+                                      items:
+                                        properties:
+                                          mountPath:
+                                            type: string
+                                          mountPropagation:
+                                            type: string
+                                          name:
+                                            type: string
+                                          readOnly:
+                                            type: boolean
+                                          subPath:
+                                            type: string
+                                          subPathExpr:
+                                            type: string
+                                        required:
+                                        - mountPath
+                                        - name
+                                        type: object
+                                      type: array
+                                    workingDir:
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                              hostAliases:
+                                items:
+                                  properties:
+                                    hostnames:
+                                      items:
+                                        type: string
+                                      type: array
+                                    ip:
+                                      type: string
+                                  type: object
+                                type: array
+                              hostIPC:
+                                type: boolean
+                              hostNetwork:
+                                type: boolean
+                              hostPID:
+                                type: boolean
+                              hostUsers:
+                                type: boolean
+                              hostname:
+                                type: string
+                              imagePullSecrets:
+                                items:
                                   properties:
                                     name:
                                       type: string
-                                    number:
-                                      format: int32
-                                      type: integer
                                   type: object
-                              required:
-                                - name
-                              type: object
-                          type: object
-                        ingressClassName:
-                          type: string
-                        rules:
-                          items:
-                            properties:
-                              host:
-                                type: string
-                              http:
-                                properties:
-                                  paths:
-                                    items:
+                                  x-kubernetes-map-type: atomic
+                                type: array
+                              initContainers:
+                                items:
+                                  properties:
+                                    args:
+                                      items:
+                                        type: string
+                                      type: array
+                                    command:
+                                      items:
+                                        type: string
+                                      type: array
+                                    env:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                          valueFrom:
+                                            properties:
+                                              configMapKeyRef:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  name:
+                                                    type: string
+                                                  optional:
+                                                    type: boolean
+                                                required:
+                                                - key
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              fieldRef:
+                                                properties:
+                                                  apiVersion:
+                                                    type: string
+                                                  fieldPath:
+                                                    type: string
+                                                required:
+                                                - fieldPath
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              resourceFieldRef:
+                                                properties:
+                                                  containerName:
+                                                    type: string
+                                                  divisor:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                    x-kubernetes-int-or-string: true
+                                                  resource:
+                                                    type: string
+                                                required:
+                                                - resource
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              secretKeyRef:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  name:
+                                                    type: string
+                                                  optional:
+                                                    type: boolean
+                                                required:
+                                                - key
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                            type: object
+                                        required:
+                                        - name
+                                        type: object
+                                      type: array
+                                    envFrom:
+                                      items:
+                                        properties:
+                                          configMapRef:
+                                            properties:
+                                              name:
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          prefix:
+                                            type: string
+                                          secretRef:
+                                            properties:
+                                              name:
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                        type: object
+                                      type: array
+                                    image:
+                                      type: string
+                                    imagePullPolicy:
+                                      type: string
+                                    lifecycle:
                                       properties:
-                                        backend:
+                                        postStart:
                                           properties:
-                                            resource:
+                                            exec:
                                               properties:
-                                                apiGroup:
-                                                  type: string
-                                                kind:
-                                                  type: string
-                                                name:
-                                                  type: string
-                                              required:
-                                                - kind
-                                                - name
+                                                command:
+                                                  items:
+                                                    type: string
+                                                  type: array
                                               type: object
-                                              x-kubernetes-map-type: atomic
-                                            service:
+                                            httpGet:
                                               properties:
-                                                name:
+                                                host:
+                                                  type: string
+                                                httpHeaders:
+                                                  items:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                path:
                                                   type: string
                                                 port:
-                                                  properties:
-                                                    name:
-                                                      type: string
-                                                    number:
-                                                      format: int32
-                                                      type: integer
-                                                  type: object
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                                scheme:
+                                                  type: string
                                               required:
-                                                - name
+                                              - port
+                                              type: object
+                                            tcpSocket:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                              required:
+                                              - port
                                               type: object
                                           type: object
-                                        path:
+                                        preStop:
+                                          properties:
+                                            exec:
+                                              properties:
+                                                command:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              type: object
+                                            httpGet:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                httpHeaders:
+                                                  items:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                path:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                                scheme:
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            tcpSocket:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                              required:
+                                              - port
+                                              type: object
+                                          type: object
+                                      type: object
+                                    livenessProbe:
+                                      properties:
+                                        exec:
+                                          properties:
+                                            command:
+                                              items:
+                                                type: string
+                                              type: array
+                                          type: object
+                                        failureThreshold:
+                                          format: int32
+                                          type: integer
+                                        grpc:
+                                          properties:
+                                            port:
+                                              format: int32
+                                              type: integer
+                                            service:
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        httpGet:
+                                          properties:
+                                            host:
+                                              type: string
+                                            httpHeaders:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                            path:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        initialDelaySeconds:
+                                          format: int32
+                                          type: integer
+                                        periodSeconds:
+                                          format: int32
+                                          type: integer
+                                        successThreshold:
+                                          format: int32
+                                          type: integer
+                                        tcpSocket:
+                                          properties:
+                                            host:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                        terminationGracePeriodSeconds:
+                                          format: int64
+                                          type: integer
+                                        timeoutSeconds:
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                    name:
+                                      type: string
+                                    ports:
+                                      items:
+                                        properties:
+                                          containerPort:
+                                            format: int32
+                                            type: integer
+                                          hostIP:
+                                            type: string
+                                          hostPort:
+                                            format: int32
+                                            type: integer
+                                          name:
+                                            type: string
+                                          protocol:
+                                            default: TCP
+                                            type: string
+                                        required:
+                                        - containerPort
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - containerPort
+                                      - protocol
+                                      x-kubernetes-list-type: map
+                                    readinessProbe:
+                                      properties:
+                                        exec:
+                                          properties:
+                                            command:
+                                              items:
+                                                type: string
+                                              type: array
+                                          type: object
+                                        failureThreshold:
+                                          format: int32
+                                          type: integer
+                                        grpc:
+                                          properties:
+                                            port:
+                                              format: int32
+                                              type: integer
+                                            service:
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        httpGet:
+                                          properties:
+                                            host:
+                                              type: string
+                                            httpHeaders:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                            path:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        initialDelaySeconds:
+                                          format: int32
+                                          type: integer
+                                        periodSeconds:
+                                          format: int32
+                                          type: integer
+                                        successThreshold:
+                                          format: int32
+                                          type: integer
+                                        tcpSocket:
+                                          properties:
+                                            host:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                        terminationGracePeriodSeconds:
+                                          format: int64
+                                          type: integer
+                                        timeoutSeconds:
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                    resizePolicy:
+                                      items:
+                                        properties:
+                                          resourceName:
+                                            type: string
+                                          restartPolicy:
+                                            type: string
+                                        required:
+                                        - resourceName
+                                        - restartPolicy
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    resources:
+                                      properties:
+                                        claims:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                            required:
+                                            - name
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
+                                        limits:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          type: object
+                                        requests:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          type: object
+                                      type: object
+                                    restartPolicy:
+                                      type: string
+                                    securityContext:
+                                      properties:
+                                        allowPrivilegeEscalation:
+                                          type: boolean
+                                        capabilities:
+                                          properties:
+                                            add:
+                                              items:
+                                                type: string
+                                              type: array
+                                            drop:
+                                              items:
+                                                type: string
+                                              type: array
+                                          type: object
+                                        privileged:
+                                          type: boolean
+                                        procMount:
                                           type: string
-                                        pathType:
+                                        readOnlyRootFilesystem:
+                                          type: boolean
+                                        runAsGroup:
+                                          format: int64
+                                          type: integer
+                                        runAsNonRoot:
+                                          type: boolean
+                                        runAsUser:
+                                          format: int64
+                                          type: integer
+                                        seLinuxOptions:
+                                          properties:
+                                            level:
+                                              type: string
+                                            role:
+                                              type: string
+                                            type:
+                                              type: string
+                                            user:
+                                              type: string
+                                          type: object
+                                        seccompProfile:
+                                          properties:
+                                            localhostProfile:
+                                              type: string
+                                            type:
+                                              type: string
+                                          required:
+                                          - type
+                                          type: object
+                                        windowsOptions:
+                                          properties:
+                                            gmsaCredentialSpec:
+                                              type: string
+                                            gmsaCredentialSpecName:
+                                              type: string
+                                            hostProcess:
+                                              type: boolean
+                                            runAsUserName:
+                                              type: string
+                                          type: object
+                                      type: object
+                                    startupProbe:
+                                      properties:
+                                        exec:
+                                          properties:
+                                            command:
+                                              items:
+                                                type: string
+                                              type: array
+                                          type: object
+                                        failureThreshold:
+                                          format: int32
+                                          type: integer
+                                        grpc:
+                                          properties:
+                                            port:
+                                              format: int32
+                                              type: integer
+                                            service:
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        httpGet:
+                                          properties:
+                                            host:
+                                              type: string
+                                            httpHeaders:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                            path:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        initialDelaySeconds:
+                                          format: int32
+                                          type: integer
+                                        periodSeconds:
+                                          format: int32
+                                          type: integer
+                                        successThreshold:
+                                          format: int32
+                                          type: integer
+                                        tcpSocket:
+                                          properties:
+                                            host:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                        terminationGracePeriodSeconds:
+                                          format: int64
+                                          type: integer
+                                        timeoutSeconds:
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                    stdin:
+                                      type: boolean
+                                    stdinOnce:
+                                      type: boolean
+                                    terminationMessagePath:
+                                      type: string
+                                    terminationMessagePolicy:
+                                      type: string
+                                    tty:
+                                      type: boolean
+                                    volumeDevices:
+                                      items:
+                                        properties:
+                                          devicePath:
+                                            type: string
+                                          name:
+                                            type: string
+                                        required:
+                                        - devicePath
+                                        - name
+                                        type: object
+                                      type: array
+                                    volumeMounts:
+                                      items:
+                                        properties:
+                                          mountPath:
+                                            type: string
+                                          mountPropagation:
+                                            type: string
+                                          name:
+                                            type: string
+                                          readOnly:
+                                            type: boolean
+                                          subPath:
+                                            type: string
+                                          subPathExpr:
+                                            type: string
+                                        required:
+                                        - mountPath
+                                        - name
+                                        type: object
+                                      type: array
+                                    workingDir:
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                              nodeName:
+                                type: string
+                              nodeSelector:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              os:
+                                properties:
+                                  name:
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              overhead:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                type: object
+                              preemptionPolicy:
+                                type: string
+                              priority:
+                                format: int32
+                                type: integer
+                              priorityClassName:
+                                type: string
+                              readinessGates:
+                                items:
+                                  properties:
+                                    conditionType:
+                                      type: string
+                                  required:
+                                  - conditionType
+                                  type: object
+                                type: array
+                              restartPolicy:
+                                type: string
+                              runtimeClassName:
+                                type: string
+                              schedulerName:
+                                type: string
+                              securityContext:
+                                properties:
+                                  fsGroup:
+                                    format: int64
+                                    type: integer
+                                  fsGroupChangePolicy:
+                                    type: string
+                                  runAsGroup:
+                                    format: int64
+                                    type: integer
+                                  runAsNonRoot:
+                                    type: boolean
+                                  runAsUser:
+                                    format: int64
+                                    type: integer
+                                  seLinuxOptions:
+                                    properties:
+                                      level:
+                                        type: string
+                                      role:
+                                        type: string
+                                      type:
+                                        type: string
+                                      user:
+                                        type: string
+                                    type: object
+                                  seccompProfile:
+                                    properties:
+                                      localhostProfile:
+                                        type: string
+                                      type:
+                                        type: string
+                                    required:
+                                    - type
+                                    type: object
+                                  supplementalGroups:
+                                    items:
+                                      format: int64
+                                      type: integer
+                                    type: array
+                                  sysctls:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                        value:
                                           type: string
                                       required:
-                                        - backend
-                                        - pathType
+                                      - name
+                                      - value
                                       type: object
                                     type: array
-                                    x-kubernetes-list-type: atomic
-                                required:
-                                  - paths
+                                  windowsOptions:
+                                    properties:
+                                      gmsaCredentialSpec:
+                                        type: string
+                                      gmsaCredentialSpecName:
+                                        type: string
+                                      hostProcess:
+                                        type: boolean
+                                      runAsUserName:
+                                        type: string
+                                    type: object
                                 type: object
-                            type: object
-                          type: array
-                          x-kubernetes-list-type: atomic
-                        tls:
-                          items:
-                            properties:
-                              hosts:
+                              serviceAccount:
+                                type: string
+                              serviceAccountName:
+                                type: string
+                              setHostnameAsFQDN:
+                                type: boolean
+                              shareProcessNamespace:
+                                type: boolean
+                              subdomain:
+                                type: string
+                              terminationGracePeriodSeconds:
+                                format: int64
+                                type: integer
+                              tolerations:
                                 items:
-                                  type: string
-                                type: array
-                                x-kubernetes-list-type: atomic
-                              secretName:
-                                type: string
-                            type: object
-                          type: array
-                          x-kubernetes-list-type: atomic
-                      type: object
-                  type: object
-                jsonnet:
-                  properties:
-                    libraryLabelSelector:
-                      properties:
-                        matchExpressions:
-                          items:
-                            properties:
-                              key:
-                                type: string
-                              operator:
-                                type: string
-                              values:
-                                items:
-                                  type: string
-                                type: array
-                            required:
-                              - key
-                              - operator
-                            type: object
-                          type: array
-                        matchLabels:
-                          additionalProperties:
-                            type: string
-                          type: object
-                      type: object
-                      x-kubernetes-map-type: atomic
-                  type: object
-                persistentVolumeClaim:
-                  properties:
-                    metadata:
-                      properties:
-                        annotations:
-                          additionalProperties:
-                            type: string
-                          type: object
-                        labels:
-                          additionalProperties:
-                            type: string
-                          type: object
-                      type: object
-                    spec:
-                      properties:
-                        accessModes:
-                          items:
-                            type: string
-                          type: array
-                        dataSource:
-                          properties:
-                            apiGroup:
-                              type: string
-                            kind:
-                              type: string
-                            name:
-                              type: string
-                          required:
-                            - kind
-                            - name
-                          type: object
-                          x-kubernetes-map-type: atomic
-                        dataSourceRef:
-                          properties:
-                            apiGroup:
-                              type: string
-                            kind:
-                              type: string
-                            name:
-                              type: string
-                          required:
-                            - kind
-                            - name
-                          type: object
-                          x-kubernetes-map-type: atomic
-                        resources:
-                          properties:
-                            limits:
-                              additionalProperties:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                x-kubernetes-int-or-string: true
-                              type: object
-                            requests:
-                              additionalProperties:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                x-kubernetes-int-or-string: true
-                              type: object
-                          type: object
-                        selector:
-                          properties:
-                            matchExpressions:
-                              items:
-                                properties:
-                                  key:
-                                    type: string
-                                  operator:
-                                    type: string
-                                  values:
-                                    items:
+                                  properties:
+                                    effect:
                                       type: string
-                                    type: array
-                                required:
-                                  - key
-                                  - operator
-                                type: object
-                              type: array
-                            matchLabels:
-                              additionalProperties:
-                                type: string
-                              type: object
-                          type: object
-                          x-kubernetes-map-type: atomic
-                        storageClassName:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    tolerationSeconds:
+                                      format: int64
+                                      type: integer
+                                    value:
+                                      type: string
+                                  type: object
+                                type: array
+                              topologySpreadConstraints:
+                                items:
+                                  properties:
+                                    labelSelector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    maxSkew:
+                                      format: int32
+                                      type: integer
+                                    minDomains:
+                                      format: int32
+                                      type: integer
+                                    nodeAffinityPolicy:
+                                      type: string
+                                    nodeTaintsPolicy:
+                                      type: string
+                                    topologyKey:
+                                      type: string
+                                    whenUnsatisfiable:
+                                      type: string
+                                  required:
+                                  - maxSkew
+                                  - topologyKey
+                                  - whenUnsatisfiable
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - topologyKey
+                                - whenUnsatisfiable
+                                x-kubernetes-list-type: map
+                              volumes:
+                                items:
+                                  properties:
+                                    awsElasticBlockStore:
+                                      properties:
+                                        fsType:
+                                          type: string
+                                        partition:
+                                          format: int32
+                                          type: integer
+                                        readOnly:
+                                          type: boolean
+                                        volumeID:
+                                          type: string
+                                      required:
+                                      - volumeID
+                                      type: object
+                                    azureDisk:
+                                      properties:
+                                        cachingMode:
+                                          type: string
+                                        diskName:
+                                          type: string
+                                        diskURI:
+                                          type: string
+                                        fsType:
+                                          type: string
+                                        kind:
+                                          type: string
+                                        readOnly:
+                                          type: boolean
+                                      required:
+                                      - diskName
+                                      - diskURI
+                                      type: object
+                                    azureFile:
+                                      properties:
+                                        readOnly:
+                                          type: boolean
+                                        secretName:
+                                          type: string
+                                        shareName:
+                                          type: string
+                                      required:
+                                      - secretName
+                                      - shareName
+                                      type: object
+                                    cephfs:
+                                      properties:
+                                        monitors:
+                                          items:
+                                            type: string
+                                          type: array
+                                        path:
+                                          type: string
+                                        readOnly:
+                                          type: boolean
+                                        secretFile:
+                                          type: string
+                                        secretRef:
+                                          properties:
+                                            name:
+                                              type: string
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        user:
+                                          type: string
+                                      required:
+                                      - monitors
+                                      type: object
+                                    cinder:
+                                      properties:
+                                        fsType:
+                                          type: string
+                                        readOnly:
+                                          type: boolean
+                                        secretRef:
+                                          properties:
+                                            name:
+                                              type: string
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        volumeID:
+                                          type: string
+                                      required:
+                                      - volumeID
+                                      type: object
+                                    configMap:
+                                      properties:
+                                        defaultMode:
+                                          format: int32
+                                          type: integer
+                                        items:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              mode:
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                type: string
+                                            required:
+                                            - key
+                                            - path
+                                            type: object
+                                          type: array
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    csi:
+                                      properties:
+                                        driver:
+                                          type: string
+                                        fsType:
+                                          type: string
+                                        nodePublishSecretRef:
+                                          properties:
+                                            name:
+                                              type: string
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        readOnly:
+                                          type: boolean
+                                        volumeAttributes:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      required:
+                                      - driver
+                                      type: object
+                                    downwardAPI:
+                                      properties:
+                                        defaultMode:
+                                          format: int32
+                                          type: integer
+                                        items:
+                                          items:
+                                            properties:
+                                              fieldRef:
+                                                properties:
+                                                  apiVersion:
+                                                    type: string
+                                                  fieldPath:
+                                                    type: string
+                                                required:
+                                                - fieldPath
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              mode:
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                type: string
+                                              resourceFieldRef:
+                                                properties:
+                                                  containerName:
+                                                    type: string
+                                                  divisor:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                    x-kubernetes-int-or-string: true
+                                                  resource:
+                                                    type: string
+                                                required:
+                                                - resource
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                            required:
+                                            - path
+                                            type: object
+                                          type: array
+                                      type: object
+                                    emptyDir:
+                                      properties:
+                                        medium:
+                                          type: string
+                                        sizeLimit:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                      type: object
+                                    ephemeral:
+                                      properties:
+                                        volumeClaimTemplate:
+                                          properties:
+                                            metadata:
+                                              type: object
+                                            spec:
+                                              properties:
+                                                accessModes:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                dataSource:
+                                                  properties:
+                                                    apiGroup:
+                                                      type: string
+                                                    kind:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                  required:
+                                                  - kind
+                                                  - name
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                dataSourceRef:
+                                                  properties:
+                                                    apiGroup:
+                                                      type: string
+                                                    kind:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                    namespace:
+                                                      type: string
+                                                  required:
+                                                  - kind
+                                                  - name
+                                                  type: object
+                                                resources:
+                                                  properties:
+                                                    claims:
+                                                      items:
+                                                        properties:
+                                                          name:
+                                                            type: string
+                                                        required:
+                                                        - name
+                                                        type: object
+                                                      type: array
+                                                      x-kubernetes-list-map-keys:
+                                                      - name
+                                                      x-kubernetes-list-type: map
+                                                    limits:
+                                                      additionalProperties:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                        x-kubernetes-int-or-string: true
+                                                      type: object
+                                                    requests:
+                                                      additionalProperties:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                        x-kubernetes-int-or-string: true
+                                                      type: object
+                                                  type: object
+                                                selector:
+                                                  properties:
+                                                    matchExpressions:
+                                                      items:
+                                                        properties:
+                                                          key:
+                                                            type: string
+                                                          operator:
+                                                            type: string
+                                                          values:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      type: object
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                storageClassName:
+                                                  type: string
+                                                volumeMode:
+                                                  type: string
+                                                volumeName:
+                                                  type: string
+                                              type: object
+                                          required:
+                                          - spec
+                                          type: object
+                                      type: object
+                                    fc:
+                                      properties:
+                                        fsType:
+                                          type: string
+                                        lun:
+                                          format: int32
+                                          type: integer
+                                        readOnly:
+                                          type: boolean
+                                        targetWWNs:
+                                          items:
+                                            type: string
+                                          type: array
+                                        wwids:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    flexVolume:
+                                      properties:
+                                        driver:
+                                          type: string
+                                        fsType:
+                                          type: string
+                                        options:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                        readOnly:
+                                          type: boolean
+                                        secretRef:
+                                          properties:
+                                            name:
+                                              type: string
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                      required:
+                                      - driver
+                                      type: object
+                                    flocker:
+                                      properties:
+                                        datasetName:
+                                          type: string
+                                        datasetUUID:
+                                          type: string
+                                      type: object
+                                    gcePersistentDisk:
+                                      properties:
+                                        fsType:
+                                          type: string
+                                        partition:
+                                          format: int32
+                                          type: integer
+                                        pdName:
+                                          type: string
+                                        readOnly:
+                                          type: boolean
+                                      required:
+                                      - pdName
+                                      type: object
+                                    gitRepo:
+                                      properties:
+                                        directory:
+                                          type: string
+                                        repository:
+                                          type: string
+                                        revision:
+                                          type: string
+                                      required:
+                                      - repository
+                                      type: object
+                                    glusterfs:
+                                      properties:
+                                        endpoints:
+                                          type: string
+                                        path:
+                                          type: string
+                                        readOnly:
+                                          type: boolean
+                                      required:
+                                      - endpoints
+                                      - path
+                                      type: object
+                                    hostPath:
+                                      properties:
+                                        path:
+                                          type: string
+                                        type:
+                                          type: string
+                                      required:
+                                      - path
+                                      type: object
+                                    iscsi:
+                                      properties:
+                                        chapAuthDiscovery:
+                                          type: boolean
+                                        chapAuthSession:
+                                          type: boolean
+                                        fsType:
+                                          type: string
+                                        initiatorName:
+                                          type: string
+                                        iqn:
+                                          type: string
+                                        iscsiInterface:
+                                          type: string
+                                        lun:
+                                          format: int32
+                                          type: integer
+                                        portals:
+                                          items:
+                                            type: string
+                                          type: array
+                                        readOnly:
+                                          type: boolean
+                                        secretRef:
+                                          properties:
+                                            name:
+                                              type: string
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        targetPortal:
+                                          type: string
+                                      required:
+                                      - iqn
+                                      - lun
+                                      - targetPortal
+                                      type: object
+                                    name:
+                                      type: string
+                                    nfs:
+                                      properties:
+                                        path:
+                                          type: string
+                                        readOnly:
+                                          type: boolean
+                                        server:
+                                          type: string
+                                      required:
+                                      - path
+                                      - server
+                                      type: object
+                                    persistentVolumeClaim:
+                                      properties:
+                                        claimName:
+                                          type: string
+                                        readOnly:
+                                          type: boolean
+                                      required:
+                                      - claimName
+                                      type: object
+                                    photonPersistentDisk:
+                                      properties:
+                                        fsType:
+                                          type: string
+                                        pdID:
+                                          type: string
+                                      required:
+                                      - pdID
+                                      type: object
+                                    portworxVolume:
+                                      properties:
+                                        fsType:
+                                          type: string
+                                        readOnly:
+                                          type: boolean
+                                        volumeID:
+                                          type: string
+                                      required:
+                                      - volumeID
+                                      type: object
+                                    projected:
+                                      properties:
+                                        defaultMode:
+                                          format: int32
+                                          type: integer
+                                        sources:
+                                          items:
+                                            properties:
+                                              configMap:
+                                                properties:
+                                                  items:
+                                                    items:
+                                                      properties:
+                                                        key:
+                                                          type: string
+                                                        mode:
+                                                          format: int32
+                                                          type: integer
+                                                        path:
+                                                          type: string
+                                                      required:
+                                                      - key
+                                                      - path
+                                                      type: object
+                                                    type: array
+                                                  name:
+                                                    type: string
+                                                  optional:
+                                                    type: boolean
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              downwardAPI:
+                                                properties:
+                                                  items:
+                                                    items:
+                                                      properties:
+                                                        fieldRef:
+                                                          properties:
+                                                            apiVersion:
+                                                              type: string
+                                                            fieldPath:
+                                                              type: string
+                                                          required:
+                                                          - fieldPath
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        mode:
+                                                          format: int32
+                                                          type: integer
+                                                        path:
+                                                          type: string
+                                                        resourceFieldRef:
+                                                          properties:
+                                                            containerName:
+                                                              type: string
+                                                            divisor:
+                                                              anyOf:
+                                                              - type: integer
+                                                              - type: string
+                                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                              x-kubernetes-int-or-string: true
+                                                            resource:
+                                                              type: string
+                                                          required:
+                                                          - resource
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                      required:
+                                                      - path
+                                                      type: object
+                                                    type: array
+                                                type: object
+                                              secret:
+                                                properties:
+                                                  items:
+                                                    items:
+                                                      properties:
+                                                        key:
+                                                          type: string
+                                                        mode:
+                                                          format: int32
+                                                          type: integer
+                                                        path:
+                                                          type: string
+                                                      required:
+                                                      - key
+                                                      - path
+                                                      type: object
+                                                    type: array
+                                                  name:
+                                                    type: string
+                                                  optional:
+                                                    type: boolean
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              serviceAccountToken:
+                                                properties:
+                                                  audience:
+                                                    type: string
+                                                  expirationSeconds:
+                                                    format: int64
+                                                    type: integer
+                                                  path:
+                                                    type: string
+                                                required:
+                                                - path
+                                                type: object
+                                            type: object
+                                          type: array
+                                      type: object
+                                    quobyte:
+                                      properties:
+                                        group:
+                                          type: string
+                                        readOnly:
+                                          type: boolean
+                                        registry:
+                                          type: string
+                                        tenant:
+                                          type: string
+                                        user:
+                                          type: string
+                                        volume:
+                                          type: string
+                                      required:
+                                      - registry
+                                      - volume
+                                      type: object
+                                    rbd:
+                                      properties:
+                                        fsType:
+                                          type: string
+                                        image:
+                                          type: string
+                                        keyring:
+                                          type: string
+                                        monitors:
+                                          items:
+                                            type: string
+                                          type: array
+                                        pool:
+                                          type: string
+                                        readOnly:
+                                          type: boolean
+                                        secretRef:
+                                          properties:
+                                            name:
+                                              type: string
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        user:
+                                          type: string
+                                      required:
+                                      - image
+                                      - monitors
+                                      type: object
+                                    scaleIO:
+                                      properties:
+                                        fsType:
+                                          type: string
+                                        gateway:
+                                          type: string
+                                        protectionDomain:
+                                          type: string
+                                        readOnly:
+                                          type: boolean
+                                        secretRef:
+                                          properties:
+                                            name:
+                                              type: string
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        sslEnabled:
+                                          type: boolean
+                                        storageMode:
+                                          type: string
+                                        storagePool:
+                                          type: string
+                                        system:
+                                          type: string
+                                        volumeName:
+                                          type: string
+                                      required:
+                                      - gateway
+                                      - secretRef
+                                      - system
+                                      type: object
+                                    secret:
+                                      properties:
+                                        defaultMode:
+                                          format: int32
+                                          type: integer
+                                        items:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              mode:
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                type: string
+                                            required:
+                                            - key
+                                            - path
+                                            type: object
+                                          type: array
+                                        optional:
+                                          type: boolean
+                                        secretName:
+                                          type: string
+                                      type: object
+                                    storageos:
+                                      properties:
+                                        fsType:
+                                          type: string
+                                        readOnly:
+                                          type: boolean
+                                        secretRef:
+                                          properties:
+                                            name:
+                                              type: string
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        volumeName:
+                                          type: string
+                                        volumeNamespace:
+                                          type: string
+                                      type: object
+                                    vsphereVolume:
+                                      properties:
+                                        fsType:
+                                          type: string
+                                        storagePolicyID:
+                                          type: string
+                                        storagePolicyName:
+                                          type: string
+                                        volumePath:
+                                          type: string
+                                      required:
+                                      - volumePath
+                                      type: object
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                            type: object
+                        type: object
+                    type: object
+                type: object
+              external:
+                properties:
+                  adminPassword:
+                    properties:
+                      key:
+                        type: string
+                      name:
+                        type: string
+                      optional:
+                        type: boolean
+                    required:
+                    - key
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  adminUser:
+                    properties:
+                      key:
+                        type: string
+                      name:
+                        type: string
+                      optional:
+                        type: boolean
+                    required:
+                    - key
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  apiKey:
+                    properties:
+                      key:
+                        type: string
+                      name:
+                        type: string
+                      optional:
+                        type: boolean
+                    required:
+                    - key
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  url:
+                    type: string
+                required:
+                - url
+                type: object
+              ingress:
+                properties:
+                  metadata:
+                    properties:
+                      annotations:
+                        additionalProperties:
                           type: string
-                        volumeMode:
+                        type: object
+                      labels:
+                        additionalProperties:
                           type: string
-                        volumeName:
-                          type: string
-                      type: object
-                  type: object
-                route:
-                  properties:
-                    metadata:
-                      properties:
-                        annotations:
-                          additionalProperties:
-                            type: string
-                          type: object
-                        labels:
-                          additionalProperties:
-                            type: string
-                          type: object
-                      type: object
-                    spec:
-                      properties:
-                        alternateBackends:
-                          items:
+                        type: object
+                    type: object
+                  spec:
+                    properties:
+                      defaultBackend:
+                        properties:
+                          resource:
                             properties:
+                              apiGroup:
+                                type: string
                               kind:
                                 type: string
                               name:
                                 type: string
-                              weight:
-                                format: int32
-                                type: integer
                             required:
-                              - kind
-                              - name
-                              - weight
+                            - kind
+                            - name
                             type: object
-                          type: array
-                        host:
-                          type: string
-                        path:
-                          type: string
-                        port:
+                            x-kubernetes-map-type: atomic
+                          service:
+                            properties:
+                              name:
+                                type: string
+                              port:
+                                properties:
+                                  name:
+                                    type: string
+                                  number:
+                                    format: int32
+                                    type: integer
+                                type: object
+                            required:
+                            - name
+                            type: object
+                        type: object
+                      ingressClassName:
+                        type: string
+                      rules:
+                        items:
                           properties:
-                            targetPort:
-                              anyOf:
-                                - type: integer
-                                - type: string
-                              x-kubernetes-int-or-string: true
-                          required:
-                            - targetPort
+                            host:
+                              type: string
+                            http:
+                              properties:
+                                paths:
+                                  items:
+                                    properties:
+                                      backend:
+                                        properties:
+                                          resource:
+                                            properties:
+                                              apiGroup:
+                                                type: string
+                                              kind:
+                                                type: string
+                                              name:
+                                                type: string
+                                            required:
+                                            - kind
+                                            - name
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          service:
+                                            properties:
+                                              name:
+                                                type: string
+                                              port:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  number:
+                                                    format: int32
+                                                    type: integer
+                                                type: object
+                                            required:
+                                            - name
+                                            type: object
+                                        type: object
+                                      path:
+                                        type: string
+                                      pathType:
+                                        type: string
+                                    required:
+                                    - backend
+                                    - pathType
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                              - paths
+                              type: object
                           type: object
-                        tls:
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      tls:
+                        items:
                           properties:
-                            caCertificate:
+                            hosts:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            secretName:
                               type: string
-                            certificate:
-                              type: string
-                            destinationCACertificate:
-                              type: string
-                            insecureEdgeTerminationPolicy:
-                              type: string
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                    type: object
+                type: object
+              jsonnet:
+                properties:
+                  libraryLabelSelector:
+                    properties:
+                      matchExpressions:
+                        items:
+                          properties:
                             key:
                               type: string
-                            termination:
+                            operator:
                               type: string
+                            values:
+                              items:
+                                type: string
+                              type: array
                           required:
-                            - termination
+                          - key
+                          - operator
                           type: object
-                        to:
+                        type: array
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                    type: object
+                    x-kubernetes-map-type: atomic
+                type: object
+              persistentVolumeClaim:
+                properties:
+                  metadata:
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                    type: object
+                  spec:
+                    properties:
+                      accessModes:
+                        items:
+                          type: string
+                        type: array
+                      dataSource:
+                        properties:
+                          apiGroup:
+                            type: string
+                          kind:
+                            type: string
+                          name:
+                            type: string
+                        required:
+                        - kind
+                        - name
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      dataSourceRef:
+                        properties:
+                          apiGroup:
+                            type: string
+                          kind:
+                            type: string
+                          name:
+                            type: string
+                        required:
+                        - kind
+                        - name
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      resources:
+                        properties:
+                          claims:
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            type: object
+                        type: object
+                      selector:
+                        properties:
+                          matchExpressions:
+                            items:
+                              properties:
+                                key:
+                                  type: string
+                                operator:
+                                  type: string
+                                values:
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            type: object
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      storageClassName:
+                        type: string
+                      volumeMode:
+                        type: string
+                      volumeName:
+                        type: string
+                    type: object
+                type: object
+              preferences:
+                properties:
+                  homeDashboardUid:
+                    type: string
+                type: object
+              route:
+                properties:
+                  metadata:
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                    type: object
+                  spec:
+                    properties:
+                      alternateBackends:
+                        items:
                           properties:
                             kind:
                               type: string
@@ -3595,187 +3660,233 @@ spec:
                               format: int32
                               type: integer
                           required:
-                            - kind
-                            - name
-                            - weight
+                          - kind
+                          - name
+                          - weight
                           type: object
-                        wildcardPolicy:
-                          type: string
-                      type: object
-                  type: object
-                service:
-                  properties:
-                    metadata:
-                      properties:
-                        annotations:
-                          additionalProperties:
-                            type: string
-                          type: object
-                        labels:
-                          additionalProperties:
-                            type: string
-                          type: object
-                      type: object
-                    spec:
-                      properties:
-                        allocateLoadBalancerNodePorts:
-                          type: boolean
-                        clusterIP:
-                          type: string
-                        clusterIPs:
-                          items:
-                            type: string
-                          type: array
-                          x-kubernetes-list-type: atomic
-                        externalIPs:
-                          items:
-                            type: string
-                          type: array
-                        externalName:
-                          type: string
-                        externalTrafficPolicy:
-                          type: string
-                        healthCheckNodePort:
-                          format: int32
-                          type: integer
-                        internalTrafficPolicy:
-                          type: string
-                        ipFamilies:
-                          items:
-                            type: string
-                          type: array
-                          x-kubernetes-list-type: atomic
-                        ipFamilyPolicy:
-                          type: string
-                        loadBalancerClass:
-                          type: string
-                        loadBalancerIP:
-                          type: string
-                        loadBalancerSourceRanges:
-                          items:
-                            type: string
-                          type: array
-                        ports:
-                          items:
-                            properties:
-                              appProtocol:
-                                type: string
-                              name:
-                                type: string
-                              nodePort:
-                                format: int32
-                                type: integer
-                              port:
-                                format: int32
-                                type: integer
-                              protocol:
-                                default: TCP
-                                type: string
-                              targetPort:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                x-kubernetes-int-or-string: true
-                            required:
-                              - port
-                            type: object
-                          type: array
-                          x-kubernetes-list-map-keys:
-                            - port
-                            - protocol
-                          x-kubernetes-list-type: map
-                        publishNotReadyAddresses:
-                          type: boolean
-                        selector:
-                          additionalProperties:
-                            type: string
-                          type: object
-                          x-kubernetes-map-type: atomic
-                        sessionAffinity:
-                          type: string
-                        sessionAffinityConfig:
-                          properties:
-                            clientIP:
-                              properties:
-                                timeoutSeconds:
-                                  format: int32
-                                  type: integer
-                              type: object
-                          type: object
-                        type:
-                          type: string
-                      type: object
-                  type: object
-                serviceAccount:
-                  properties:
-                    automountServiceAccountToken:
-                      type: boolean
-                    imagePullSecrets:
-                      items:
+                        type: array
+                      host:
+                        type: string
+                      path:
+                        type: string
+                      port:
                         properties:
-                          name:
-                            type: string
+                          targetPort:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            x-kubernetes-int-or-string: true
+                        required:
+                        - targetPort
                         type: object
-                        x-kubernetes-map-type: atomic
-                      type: array
-                    metadata:
-                      properties:
-                        annotations:
-                          additionalProperties:
-                            type: string
-                          type: object
-                        labels:
-                          additionalProperties:
-                            type: string
-                          type: object
-                      type: object
-                    secrets:
-                      items:
+                      tls:
                         properties:
-                          apiVersion:
+                          caCertificate:
                             type: string
-                          fieldPath:
+                          certificate:
                             type: string
+                          destinationCACertificate:
+                            type: string
+                          insecureEdgeTerminationPolicy:
+                            type: string
+                          key:
+                            type: string
+                          termination:
+                            type: string
+                        required:
+                        - termination
+                        type: object
+                      to:
+                        properties:
                           kind:
                             type: string
                           name:
                             type: string
-                          namespace:
-                            type: string
-                          resourceVersion:
-                            type: string
-                          uid:
-                            type: string
+                          weight:
+                            format: int32
+                            type: integer
+                        required:
+                        - kind
+                        - name
+                        - weight
+                        type: object
+                      wildcardPolicy:
+                        type: string
+                    type: object
+                type: object
+              service:
+                properties:
+                  metadata:
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                    type: object
+                  spec:
+                    properties:
+                      allocateLoadBalancerNodePorts:
+                        type: boolean
+                      clusterIP:
+                        type: string
+                      clusterIPs:
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      externalIPs:
+                        items:
+                          type: string
+                        type: array
+                      externalName:
+                        type: string
+                      externalTrafficPolicy:
+                        type: string
+                      healthCheckNodePort:
+                        format: int32
+                        type: integer
+                      internalTrafficPolicy:
+                        type: string
+                      ipFamilies:
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      ipFamilyPolicy:
+                        type: string
+                      loadBalancerClass:
+                        type: string
+                      loadBalancerIP:
+                        type: string
+                      loadBalancerSourceRanges:
+                        items:
+                          type: string
+                        type: array
+                      ports:
+                        items:
+                          properties:
+                            appProtocol:
+                              type: string
+                            name:
+                              type: string
+                            nodePort:
+                              format: int32
+                              type: integer
+                            port:
+                              format: int32
+                              type: integer
+                            protocol:
+                              default: TCP
+                              type: string
+                            targetPort:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              x-kubernetes-int-or-string: true
+                          required:
+                          - port
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - port
+                        - protocol
+                        x-kubernetes-list-type: map
+                      publishNotReadyAddresses:
+                        type: boolean
+                      selector:
+                        additionalProperties:
+                          type: string
                         type: object
                         x-kubernetes-map-type: atomic
-                      type: array
-                  type: object
-              type: object
-            status:
-              properties:
-                adminUrl:
+                      sessionAffinity:
+                        type: string
+                      sessionAffinityConfig:
+                        properties:
+                          clientIP:
+                            properties:
+                              timeoutSeconds:
+                                format: int32
+                                type: integer
+                            type: object
+                        type: object
+                      type:
+                        type: string
+                    type: object
+                type: object
+              serviceAccount:
+                properties:
+                  automountServiceAccountToken:
+                    type: boolean
+                  imagePullSecrets:
+                    items:
+                      properties:
+                        name:
+                          type: string
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    type: array
+                  metadata:
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                    type: object
+                  secrets:
+                    items:
+                      properties:
+                        apiVersion:
+                          type: string
+                        fieldPath:
+                          type: string
+                        kind:
+                          type: string
+                        name:
+                          type: string
+                        namespace:
+                          type: string
+                        resourceVersion:
+                          type: string
+                        uid:
+                          type: string
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    type: array
+                type: object
+            type: object
+          status:
+            properties:
+              adminUrl:
+                type: string
+              dashboards:
+                items:
                   type: string
-                dashboards:
-                  items:
-                    type: string
-                  type: array
-                datasources:
-                  items:
-                    type: string
-                  type: array
-                folders:
-                  items:
-                    type: string
-                  type: array
-                lastMessage:
+                type: array
+              datasources:
+                items:
                   type: string
-                stage:
+                type: array
+              folders:
+                items:
                   type: string
-                stageStatus:
-                  type: string
-              type: object
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
+                type: array
+              lastMessage:
+                type: string
+              stage:
+                type: string
+              stageStatus:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}


### PR DESCRIPTION
### Description of the change

updates grafana-operator CRDs to match the appVersion

### Benefits

makes [organization home dashboard](https://github.com/grafana/grafana-operator/pull/1301) available ([spec.preferences](https://grafana.github.io/grafana-operator/docs/api/#grafanaspecpreferences))

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
