### PR TITLE
[bitnami/opensearch] fix network policy ingress

### DIFF
--- a/bitnami/opensearch/Chart.yaml
+++ b/bitnami/opensearch/Chart.yaml
@@ -30,4 +30,4 @@ maintainers:
 name: opensearch
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/opensearch
-version: 0.7.0
+version: 0.7.1

--- a/bitnami/opensearch/templates/coordinating/networkpolicy.yaml
+++ b/bitnami/opensearch/templates/coordinating/networkpolicy.yaml
@@ -19,7 +19,6 @@ spec:
   {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.coordinating.podLabels .Values.commonLabels ) "context" . ) }}
   podSelector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
-      app.kubernetes.io/part-of: opensearch
       app.kubernetes.io/component: coordinating-only
   policyTypes:
     - Ingress

--- a/bitnami/opensearch/templates/coordinating/networkpolicy.yaml
+++ b/bitnami/opensearch/templates/coordinating/networkpolicy.yaml
@@ -50,7 +50,8 @@ spec:
         - podSelector:
             matchLabels:
               {{ template "common.names.fullname" . }}-client: "true"
-      {{- end }}
+        - podSelector:
+            matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 14 }}
         {{- if .Values.coordinating.networkPolicy.ingressNSMatchLabels }}
         - namespaceSelector:
             matchLabels:
@@ -65,6 +66,7 @@ spec:
               {{- end }}
           {{- end }}
         {{- end }}
+      {{- end }}
     {{- if .Values.coordinating.networkPolicy.extraIngress }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.coordinating.networkPolicy.extraIngress "context" $ ) | nindent 4 }}
     {{- end }}

--- a/bitnami/opensearch/templates/dashboards/networkpolicy.yaml
+++ b/bitnami/opensearch/templates/dashboards/networkpolicy.yaml
@@ -19,7 +19,6 @@ spec:
   {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.dashboards.podLabels .Values.commonLabels ) "context" . ) }}
   podSelector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
-      app.kubernetes.io/part-of: opensearch
       app.kubernetes.io/component: dashboards
   policyTypes:
     - Ingress

--- a/bitnami/opensearch/templates/dashboards/networkpolicy.yaml
+++ b/bitnami/opensearch/templates/dashboards/networkpolicy.yaml
@@ -50,7 +50,8 @@ spec:
         - podSelector:
             matchLabels:
               {{ template "common.names.fullname" . }}-client: "true"
-      {{- end }}
+        - podSelector:
+            matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 14 }}
         {{- if .Values.dashboards.networkPolicy.ingressNSMatchLabels }}
         - namespaceSelector:
             matchLabels:
@@ -65,7 +66,7 @@ spec:
               {{- end }}
           {{- end }}
         {{- end }}
-
+      {{- end }}
     {{- if .Values.dashboards.networkPolicy.extraIngress }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.dashboards.networkPolicy.extraIngress "context" $ ) | nindent 4 }}
     {{- end }}

--- a/bitnami/opensearch/templates/data/networkpolicy.yaml
+++ b/bitnami/opensearch/templates/data/networkpolicy.yaml
@@ -50,7 +50,8 @@ spec:
         - podSelector:
             matchLabels:
               {{ template "common.names.fullname" . }}-client: "true"
-      {{- end }}
+        - podSelector:
+            matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 14 }}
         {{- if .Values.data.networkPolicy.ingressNSMatchLabels }}
         - namespaceSelector:
             matchLabels:
@@ -65,6 +66,7 @@ spec:
               {{- end }}
           {{- end }}
         {{- end }}
+      {{- end }}
     {{- if .Values.data.networkPolicy.extraIngress }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.data.networkPolicy.extraIngress "context" $ ) | nindent 4 }}
     {{- end }}

--- a/bitnami/opensearch/templates/data/networkpolicy.yaml
+++ b/bitnami/opensearch/templates/data/networkpolicy.yaml
@@ -19,7 +19,6 @@ spec:
   {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.data.podLabels .Values.commonLabels ) "context" . ) }}
   podSelector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
-      app.kubernetes.io/part-of: opensearch
       app.kubernetes.io/component: data
   policyTypes:
     - Ingress

--- a/bitnami/opensearch/templates/ingest/networkpolicy.yaml
+++ b/bitnami/opensearch/templates/ingest/networkpolicy.yaml
@@ -19,7 +19,6 @@ spec:
   {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.ingest.podLabels .Values.commonLabels ) "context" . ) }}
   podSelector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
-      app.kubernetes.io/part-of: opensearch
       app.kubernetes.io/component: ingest
   policyTypes:
     - Ingress

--- a/bitnami/opensearch/templates/ingest/networkpolicy.yaml
+++ b/bitnami/opensearch/templates/ingest/networkpolicy.yaml
@@ -50,7 +50,8 @@ spec:
         - podSelector:
             matchLabels:
               {{ template "common.names.fullname" . }}-client: "true"
-      {{- end }}
+        - podSelector:
+            matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 14 }}
         {{- if .Values.ingest.networkPolicy.ingressNSMatchLabels }}
         - namespaceSelector:
             matchLabels:
@@ -65,6 +66,7 @@ spec:
               {{- end }}
           {{- end }}
         {{- end }}
+      {{- end }}
     {{- if .Values.ingest.networkPolicy.extraIngress }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.ingest.networkPolicy.extraIngress "context" $ ) | nindent 4 }}
     {{- end }}

--- a/bitnami/opensearch/templates/master/networkpolicy.yaml
+++ b/bitnami/opensearch/templates/master/networkpolicy.yaml
@@ -50,7 +50,8 @@ spec:
         - podSelector:
             matchLabels:
               {{ template "common.names.fullname" . }}-client: "true"
-      {{- end }}
+        - podSelector:
+            matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 14 }}
         {{- if .Values.master.networkPolicy.ingressNSMatchLabels }}
         - namespaceSelector:
             matchLabels:
@@ -65,6 +66,7 @@ spec:
               {{- end }}
           {{- end }}
         {{- end }}
+      {{- end }}
     {{- if .Values.master.networkPolicy.extraIngress }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.master.networkPolicy.extraIngress "context" $ ) | nindent 4 }}
     {{- end }}

--- a/bitnami/opensearch/templates/master/networkpolicy.yaml
+++ b/bitnami/opensearch/templates/master/networkpolicy.yaml
@@ -19,7 +19,6 @@ spec:
   {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.master.podLabels .Values.commonLabels ) "context" . ) }}
   podSelector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
-      app.kubernetes.io/part-of: opensearch
       app.kubernetes.io/component: master
   policyTypes:
     - Ingress


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->
- The label `app.kubernetes.io/part-of: opensearch` is not added to the pods, so network policy fails to apply.
- Allow access to other opensearch pods when network policy is enabled and default ingress is blocked. This is now the same behavior as on `redis` and `redis-cluster`.

### Benefits

<!-- What benefits will be realized by the code change? -->
Buildin network policies work as expected.

### Possible drawbacks

<!-- Describe any known limitations with your change -->
none

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
none

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
