### PR TITLE
[bitnami/minio] Skip the ServiceMonitor if Prometheus CRDs are not available

### DIFF
--- a/bitnami/minio/Chart.yaml
+++ b/bitnami/minio/Chart.yaml
@@ -34,4 +34,4 @@ maintainers:
 name: minio
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/minio
-version: 13.2.0
+version: 13.2.1

--- a/bitnami/minio/templates/servicemonitor.yaml
+++ b/bitnami/minio/templates/servicemonitor.yaml
@@ -3,9 +3,10 @@ Copyright VMware, Inc.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- if .Values.metrics.serviceMonitor.enabled }}
+{{- $prometheusApiVersion := default "monitoring.coreos.com/v1" .Values.metrics.serviceMonitor.apiVersion -}}
+{{- if and (.Capabilities.APIVersions.Has $prometheusApiVersion) .Values.metrics.serviceMonitor.enabled }}
 {{- $releaseNamespace := default (include "common.names.namespace" .) .Values.metrics.serviceMonitor.namespace }}
-apiVersion: {{ default "monitoring.coreos.com/v1" .Values.metrics.serviceMonitor.apiVersion }}
+apiVersion: {{ $prometheusApiVersion }}
 kind: ServiceMonitor
 metadata:
   name: {{ include "common.names.fullname" . }}


### PR DESCRIPTION
### Description of the change

Add a check so that MinIO ServiceMonitor resource is not created unless Prometheus CRDs are available.

### Benefits

Extra guardrail in case of installing the minio chart with metrics enabled without having Prometheus installed.

### Possible drawbacks

None

### Applicable issues

- fixes #22365

### Additional information

```sh
# Won't render the service monitor
helm template --set metrics.serviceMonitor.enabled=true bitnami/minio

# Will render the service monitor
helm template --api-versions "monitoring.coreos.com/v1" --set metrics.serviceMonitor.enabled=true bitnami/minio
```

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
