### PR TITLE
[bitnami/appsmith] fix: :lock: Move service-account token auto-mount to pod declaration

### DIFF
--- a/bitnami/appsmith/Chart.yaml
+++ b/bitnami/appsmith/Chart.yaml
@@ -37,4 +37,4 @@ maintainers:
 name: appsmith
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/appsmith
-version: 2.2.0
+version: 2.3.0

--- a/bitnami/appsmith/README.md
+++ b/bitnami/appsmith/README.md
@@ -134,6 +134,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `client.containerSecurityContext.seccompProfile.type`      | Set container's Security Context seccomp profile                                                                         | `RuntimeDefault` |
 | `client.command`                                           | Override default container command (useful when using custom images)                                                     | `[]`             |
 | `client.args`                                              | Override default container args (useful when using custom images)                                                        | `[]`             |
+| `client.automountServiceAccountToken`                      | Mount Service Account token in pod                                                                                       | `false`          |
 | `client.hostAliases`                                       | Appsmith client pods host aliases                                                                                        | `[]`             |
 | `client.podLabels`                                         | Extra labels for Appsmith client pods                                                                                    | `{}`             |
 | `client.podAnnotations`                                    | Annotations for Appsmith client pods                                                                                     | `{}`             |
@@ -243,6 +244,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `backend.containerSecurityContext.seccompProfile.type`      | Set container's Security Context seccomp profile                                                                         | `RuntimeDefault`      |
 | `backend.command`                                           | Override default container command (useful when using custom images)                                                     | `[]`                  |
 | `backend.args`                                              | Override default container args (useful when using custom images)                                                        | `[]`                  |
+| `backend.automountServiceAccountToken`                      | Mount Service Account token in pod                                                                                       | `false`               |
 | `backend.hostAliases`                                       | Appsmith backend pods host aliases                                                                                       | `[]`                  |
 | `backend.podLabels`                                         | Extra labels for Appsmith backend pods                                                                                   | `{}`                  |
 | `backend.podAnnotations`                                    | Annotations for Appsmith backend pods                                                                                    | `{}`                  |
@@ -345,6 +347,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `rts.containerSecurityContext.seccompProfile.type`      | Set container's Security Context seccomp profile                                                                         | `RuntimeDefault` |
 | `rts.command`                                           | Override default container command (useful when using custom images)                                                     | `[]`             |
 | `rts.args`                                              | Override default container args (useful when using custom images)                                                        | `[]`             |
+| `rts.automountServiceAccountToken`                      | Mount Service Account token in pod                                                                                       | `false`          |
 | `rts.hostAliases`                                       | Appsmith rts pods host aliases                                                                                           | `[]`             |
 | `rts.podLabels`                                         | Extra labels for Appsmith rts pods                                                                                       | `{}`             |
 | `rts.podAnnotations`                                    | Annotations for Appsmith rts pods                                                                                        | `{}`             |

--- a/bitnami/appsmith/templates/backend/deployment.yaml
+++ b/bitnami/appsmith/templates/backend/deployment.yaml
@@ -32,6 +32,7 @@ spec:
     spec:
       serviceAccountName: {{ template "appsmith.serviceAccountName" . }}
       {{- include "appsmith.imagePullSecrets" . | nindent 6 }}
+      automountServiceAccountToken: {{ .Values.backend.automountServiceAccountToken }}
       {{- if .Values.backend.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.backend.hostAliases "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/appsmith/templates/client/deployment.yaml
+++ b/bitnami/appsmith/templates/client/deployment.yaml
@@ -32,6 +32,7 @@ spec:
     spec:
       serviceAccountName: {{ template "appsmith.serviceAccountName" . }}
       {{- include "appsmith.imagePullSecrets" . | nindent 6 }}
+      automountServiceAccountToken: {{ .Values.client.automountServiceAccountToken }}
       {{- if .Values.client.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.client.hostAliases "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/appsmith/templates/rts/deployment.yaml
+++ b/bitnami/appsmith/templates/rts/deployment.yaml
@@ -32,6 +32,7 @@ spec:
     spec:
       serviceAccountName: {{ template "appsmith.serviceAccountName" . }}
       {{- include "appsmith.imagePullSecrets" . | nindent 6 }}
+      automountServiceAccountToken: {{ .Values.rts.automountServiceAccountToken }}
       {{- if .Values.rts.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.rts.hostAliases "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/appsmith/values.yaml
+++ b/bitnami/appsmith/values.yaml
@@ -212,6 +212,9 @@ client:
   ## @param client.args Override default container args (useful when using custom images)
   ##
   args: []
+  ## @param client.automountServiceAccountToken Mount Service Account token in pod
+  ##
+  automountServiceAccountToken: false
   ## @param client.hostAliases Appsmith client pods host aliases
   ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
   ##
@@ -635,6 +638,9 @@ backend:
   ## @param backend.args Override default container args (useful when using custom images)
   ##
   args: []
+  ## @param backend.automountServiceAccountToken Mount Service Account token in pod
+  ##
+  automountServiceAccountToken: false
   ## @param backend.hostAliases Appsmith backend pods host aliases
   ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
   ##
@@ -977,6 +983,9 @@ rts:
   ## @param rts.args Override default container args (useful when using custom images)
   ##
   args: []
+  ## @param rts.automountServiceAccountToken Mount Service Account token in pod
+  ##
+  automountServiceAccountToken: false
   ## @param rts.hostAliases Appsmith rts pods host aliases
   ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
   ##


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

### Description of the change

This PR sets all ServiceAccount automountServiceAccountToken=false by default, as the token mounting should be set in the pod declaration instead (if a new pod uses this service account and the token gets automatically mounted, it could be problematic in terms of security). This PR also adds automountServiceAccountToken in the pod declaration as a new value, which can be configured by users in case they want to use an external token.

### Benefits

Charts become more security-compliant

### Possible drawbacks

n/a

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)

