### PR TITLE
[bitnami/cassandra] fix: :lock: Move service-account token auto-mount to pod declaration

### DIFF
--- a/bitnami/cassandra/Chart.yaml
+++ b/bitnami/cassandra/Chart.yaml
@@ -32,4 +32,4 @@ maintainers:
 name: cassandra
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/cassandra
-version: 10.7.0
+version: 10.8.0

--- a/bitnami/cassandra/README.md
+++ b/bitnami/cassandra/README.md
@@ -119,6 +119,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | --------------------------------------------------- | ----------------------------------------------------------------------------------------- | ---------------- |
 | `replicaCount`                                      | Number of Cassandra replicas                                                              | `1`              |
 | `updateStrategy.type`                               | updateStrategy for Cassandra statefulset                                                  | `RollingUpdate`  |
+| `automountServiceAccountToken`                      | Mount Service Account token in pod                                                        | `false`          |
 | `hostAliases`                                       | Add deployment host aliases                                                               | `[]`             |
 | `podManagementPolicy`                               | StatefulSet pod management policy                                                         | `OrderedReady`   |
 | `priorityClassName`                                 | Cassandra pods' priority.                                                                 | `""`             |

--- a/bitnami/cassandra/templates/statefulset.yaml
+++ b/bitnami/cassandra/templates/statefulset.yaml
@@ -34,6 +34,7 @@ spec:
       {{- end }}
     spec:
       {{- include "cassandra.imagePullSecrets" . | nindent 6 }}
+      automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
       {{- if .Values.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.hostAliases "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/cassandra/values.yaml
+++ b/bitnami/cassandra/values.yaml
@@ -214,6 +214,9 @@ replicaCount: 1
 ##
 updateStrategy:
   type: RollingUpdate
+## @param automountServiceAccountToken Mount Service Account token in pod
+##
+automountServiceAccountToken: false
 ## @param hostAliases Add deployment host aliases
 ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
 ##


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

### Description of the change

This PR sets all ServiceAccount automountServiceAccountToken=false by default, as the token mounting should be set in the pod declaration instead (if a new pod uses this service account and the token gets automatically mounted, it could be problematic in terms of security). This PR also adds automountServiceAccountToken in the pod declaration as a new value, which can be configured by users in case they want to use an external token.

### Benefits

Charts become more security-compliant

### Possible drawbacks

n/a

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)

