### PR TITLE
[bitnami/clickhouse] fix: :lock: Move service-account token auto-mount to pod declaration

### DIFF
--- a/bitnami/cert-manager/Chart.yaml
+++ b/bitnami/cert-manager/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: cert-manager
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/cert-manager
-version: 0.16.2
+version: 0.17.0

--- a/bitnami/cert-manager/README.md
+++ b/bitnami/cert-manager/README.md
@@ -124,6 +124,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `controller.runtimeClassName`                                  | Name of the runtime class to be used by pod(s)                                                             | `""`                           |
 | `controller.schedulerName`                                     | Name of the k8s scheduler (other than default)                                                             | `""`                           |
 | `controller.topologySpreadConstraints`                         | Topology Spread Constraints for pod assignment                                                             | `[]`                           |
+| `controller.automountServiceAccountToken`                      | Mount Service Account token in pod                                                                         | `true`                         |
 | `controller.hostAliases`                                       | Custom host aliases for Controller pods                                                                    | `[]`                           |
 | `controller.tolerations`                                       | Tolerations for pod assignment                                                                             | `[]`                           |
 | `controller.podLabels`                                         | Extra labels for Controller pods                                                                           | `{}`                           |
@@ -165,7 +166,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `controller.serviceAccount.create`                             | Specifies whether a ServiceAccount should be created                                                       | `true`                         |
 | `controller.serviceAccount.name`                               | The name of the ServiceAccount to use.                                                                     | `""`                           |
 | `controller.serviceAccount.annotations`                        | Additional custom annotations for the ServiceAccount                                                       | `{}`                           |
-| `controller.serviceAccount.automountServiceAccountToken`       | Automount service account token for the server service account                                             | `true`                         |
+| `controller.serviceAccount.automountServiceAccountToken`       | Automount service account token for the server service account                                             | `false`                        |
 
 ### Webhook deployment parameters
 
@@ -226,6 +227,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `webhook.runtimeClassName`                                  | Name of the runtime class to be used by pod(s)                                                          | `""`                                   |
 | `webhook.schedulerName`                                     | Name of the k8s scheduler (other than default)                                                          | `""`                                   |
 | `webhook.topologySpreadConstraints`                         | Topology Spread Constraints for pod assignment                                                          | `[]`                                   |
+| `webhook.automountServiceAccountToken`                      | Mount Service Account token in pod                                                                      | `true`                                 |
 | `webhook.hostAliases`                                       | Custom host aliases for Webhook pods                                                                    | `[]`                                   |
 | `webhook.tolerations`                                       | Tolerations for pod assignment                                                                          | `[]`                                   |
 | `webhook.podLabels`                                         | Extra labels for Webhook pods                                                                           | `{}`                                   |
@@ -244,7 +246,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `webhook.serviceAccount.create`                             | Specifies whether a ServiceAccount should be created                                                    | `true`                                 |
 | `webhook.serviceAccount.name`                               | The name of the ServiceAccount to use.                                                                  | `""`                                   |
 | `webhook.serviceAccount.annotations`                        | Additional custom annotations for the ServiceAccount                                                    | `{}`                                   |
-| `webhook.serviceAccount.automountServiceAccountToken`       | Automount service account token for the server service account                                          | `true`                                 |
+| `webhook.serviceAccount.automountServiceAccountToken`       | Automount service account token for the server service account                                          | `false`                                |
 | `webhook.hostNetwork`                                       | Specifies hostNetwork value                                                                             | `false`                                |
 
 ### CAInjector deployment parameters
@@ -287,6 +289,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `cainjector.runtimeClassName`                                  | Name of the runtime class to be used by pod(s)                                                             | `""`                         |
 | `cainjector.schedulerName`                                     | Name of the k8s scheduler (other than default)                                                             | `""`                         |
 | `cainjector.topologySpreadConstraints`                         | Topology Spread Constraints for pod assignment                                                             | `[]`                         |
+| `cainjector.automountServiceAccountToken`                      | Mount Service Account token in pod                                                                         | `true`                       |
 | `cainjector.hostAliases`                                       | Custom host aliases for CAInjector pods                                                                    | `[]`                         |
 | `cainjector.tolerations`                                       | Tolerations for pod assignment                                                                             | `[]`                         |
 | `cainjector.podLabels`                                         | Extra labels for CAInjector pods                                                                           | `{}`                         |
@@ -326,7 +329,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `cainjector.serviceAccount.create`                             | Specifies whether a ServiceAccount should be created                                                       | `true`                       |
 | `cainjector.serviceAccount.name`                               | The name of the ServiceAccount to use.                                                                     | `""`                         |
 | `cainjector.serviceAccount.annotations`                        | Additional custom annotations for the ServiceAccount                                                       | `{}`                         |
-| `cainjector.serviceAccount.automountServiceAccountToken`       | Automount service account token for the server service account                                             | `true`                       |
+| `cainjector.serviceAccount.automountServiceAccountToken`       | Automount service account token for the server service account                                             | `false`                      |
 
 ### Metrics Parameters
 

--- a/bitnami/cert-manager/templates/cainjector/deployment.yaml
+++ b/bitnami/cert-manager/templates/cainjector/deployment.yaml
@@ -62,6 +62,7 @@ spec:
       {{- if .Values.cainjector.tolerations }}
       tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.cainjector.tolerations "context" $) | nindent 8 }}
       {{- end }}
+      automountServiceAccountToken: {{ .Values.cainjector.automountServiceAccountToken }}
       {{- if .Values.cainjector.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.cainjector.hostAliases "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/cert-manager/templates/controller/deployment.yaml
+++ b/bitnami/cert-manager/templates/controller/deployment.yaml
@@ -66,6 +66,7 @@ spec:
       {{- if .Values.controller.tolerations }}
       tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.controller.tolerations "context" $) | nindent 8 }}
       {{- end }}
+      automountServiceAccountToken: {{ .Values.controller.automountServiceAccountToken }}
       {{- if .Values.controller.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.controller.hostAliases "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/cert-manager/templates/webhook/deployment.yaml
+++ b/bitnami/cert-manager/templates/webhook/deployment.yaml
@@ -64,6 +64,7 @@ spec:
       {{- if .Values.webhook.tolerations }}
       tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.webhook.tolerations "context" $) | nindent 8 }}
       {{- end }}
+      automountServiceAccountToken: {{ .Values.webhook.automountServiceAccountToken }}
       {{- if .Values.webhook.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.webhook.hostAliases "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/cert-manager/values.yaml
+++ b/bitnami/cert-manager/values.yaml
@@ -225,6 +225,9 @@ controller:
   ## The value is evaluated as a template
   ##
   topologySpreadConstraints: []
+  ## @param controller.automountServiceAccountToken Mount Service Account token in pod
+  ##
+  automountServiceAccountToken: true
   ## @param controller.hostAliases Custom host aliases for Controller pods
   ## ref: https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
   ##
@@ -380,7 +383,7 @@ controller:
     annotations: {}
     ## @param controller.serviceAccount.automountServiceAccountToken Automount service account token for the server service account
     ##
-    automountServiceAccountToken: true
+    automountServiceAccountToken: false
 
 ## @section Webhook deployment parameters
 
@@ -575,6 +578,9 @@ webhook:
   ## The value is evaluated as a template
   ##
   topologySpreadConstraints: []
+  ## @param webhook.automountServiceAccountToken Mount Service Account token in pod
+  ##
+  automountServiceAccountToken: true
   ## @param webhook.hostAliases Custom host aliases for Webhook pods
   ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
   ##
@@ -663,7 +669,7 @@ webhook:
     annotations: {}
     ## @param webhook.serviceAccount.automountServiceAccountToken Automount service account token for the server service account
     ##
-    automountServiceAccountToken: true
+    automountServiceAccountToken: false
   ##  @param webhook.hostNetwork Specifies hostNetwork value
   ##
   hostNetwork: false
@@ -809,6 +815,9 @@ cainjector:
   ## The value is evaluated as a template
   ##
   topologySpreadConstraints: []
+  ## @param cainjector.automountServiceAccountToken Mount Service Account token in pod
+  ##
+  automountServiceAccountToken: true
   ## @param cainjector.hostAliases Custom host aliases for CAInjector pods
   ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
   ##
@@ -950,7 +959,7 @@ cainjector:
     annotations: {}
     ## @param cainjector.serviceAccount.automountServiceAccountToken Automount service account token for the server service account
     ##
-    automountServiceAccountToken: true
+    automountServiceAccountToken: false
 
 ## @section Metrics Parameters
 

--- a/bitnami/clickhouse/Chart.yaml
+++ b/bitnami/clickhouse/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: clickhouse
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/clickhouse
-version: 4.3.0
+version: 4.4.0

--- a/bitnami/clickhouse/README.md
+++ b/bitnami/clickhouse/README.md
@@ -173,6 +173,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `startdbScriptsSecret`          | ConfigMap with the startdb scripts (Note: Overrides `startdbScripts`)                                                    | `""`                    |
 | `command`                       | Override default container command (useful when using custom images)                                                     | `["/scripts/setup.sh"]` |
 | `args`                          | Override default container args (useful when using custom images)                                                        | `[]`                    |
+| `automountServiceAccountToken`  | Mount Service Account token in pod                                                                                       | `false`                 |
 | `hostAliases`                   | ClickHouse pods host aliases                                                                                             | `[]`                    |
 | `podLabels`                     | Extra labels for ClickHouse pods                                                                                         | `{}`                    |
 | `podAnnotations`                | Annotations for ClickHouse pods                                                                                          | `{}`                    |

--- a/bitnami/clickhouse/templates/statefulset.yaml
+++ b/bitnami/clickhouse/templates/statefulset.yaml
@@ -44,6 +44,7 @@ spec:
     spec:
       serviceAccountName: {{ template "clickhouse.serviceAccountName" $ }}
       {{- include "clickhouse.imagePullSecrets" $ | nindent 6 }}
+      automountServiceAccountToken: {{ $.Values.automountServiceAccountToken }}
       {{- if $.Values.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" $.Values.hostAliases "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/clickhouse/values.yaml
+++ b/bitnami/clickhouse/values.yaml
@@ -458,6 +458,9 @@ command:
 ## @param args Override default container args (useful when using custom images)
 ##
 args: []
+## @param automountServiceAccountToken Mount Service Account token in pod
+##
+automountServiceAccountToken: false
 ## @param hostAliases ClickHouse pods host aliases
 ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
 ##


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

### Description of the change

This PR sets all ServiceAccount automountServiceAccountToken=false by default, as the token mounting should be set in the pod declaration instead (if a new pod uses this service account and the token gets automatically mounted, it could be problematic in terms of security). This PR also adds automountServiceAccountToken in the pod declaration as a new value, which can be configured by users in case they want to use an external token.

### Benefits

Charts become more security-compliant

### Possible drawbacks

n/a

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)

