### PR TITLE
[bitnami/deepspeed] fix: :lock: Move service-account token auto-mount to pod declaration

### DIFF
--- a/.vib/deepspeed/goss/goss.yaml
+++ b/.vib/deepspeed/goss/goss.yaml
@@ -35,7 +35,7 @@ command:
     # or the one randomly defined by openshift (larger values). Othenrwise, the chart is still using the default value.
     exec: if [ $(id -u) -lt {{ $uid }} ] || [ $(id -G | awk '{print $2}') -lt {{ $gid }} ]; then exit 1; fi
     exit-status: 0
-  {{ if .Vars.client.serviceAccount.automountServiceAccountToken }}
+  {{ if .Vars.client.automountServiceAccountToken }}
   check-sa:
     exec: cat /var/run/secrets/kubernetes.io/serviceaccount/token | cut -d '.' -f 2 | xargs -I '{}' echo '{}====' | fold -w 4 | sed '$ d' | tr -d '\n' | base64 -d
     exit-status: 0

--- a/.vib/deepspeed/runtime-parameters.yaml
+++ b/.vib/deepspeed/runtime-parameters.yaml
@@ -13,7 +13,7 @@ client:
     runAsGroup: 1002
   serviceAccount:
     create: true
-    automountServiceAccountToken: true
+  automountServiceAccountToken: true
   persistence:
     enabled: true
     mountPath: /bitnami/deepspeed/vib-test

--- a/bitnami/deepspeed/Chart.yaml
+++ b/bitnami/deepspeed/Chart.yaml
@@ -35,4 +35,4 @@ name: deepspeed
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/deepspeed
 - https://github.com/bitnami/charts/tree/main/bitnami/pytorch
-version: 1.4.0
+version: 1.5.0

--- a/bitnami/deepspeed/README.md
+++ b/bitnami/deepspeed/README.md
@@ -161,6 +161,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `client.containerSecurityContext.seccompProfile.type`      | Set Client container's Security Context seccomp profile                                          | `RuntimeDefault` |
 | `client.lifecycleHooks`                                    | for the client container(s) to automate configuration before or after startup                    | `{}`             |
 | `client.runtimeClassName`                                  | Name of the runtime class to be used by pod(s)                                                   | `""`             |
+| `client.automountServiceAccountToken`                      | Mount Service Account token in pod                                                               | `false`          |
 | `client.hostAliases`                                       | client pods host aliases                                                                         | `[]`             |
 | `client.labels`                                            | Extra labels for the client deployment                                                           | `{}`             |
 | `client.podLabels`                                         | Extra labels for client pods                                                                     | `{}`             |
@@ -260,6 +261,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `worker.containerSecurityContext.privileged`               | Set Worker container's Security Context privileged                                                 | `false`          |
 | `worker.lifecycleHooks`                                    | for the client container(s) to automate configuration before or after startup                      | `{}`             |
 | `worker.runtimeClassName`                                  | Name of the runtime class to be used by pod(s)                                                     | `""`             |
+| `worker.automountServiceAccountToken`                      | Mount Service Account token in pod                                                                 | `false`          |
 | `worker.hostAliases`                                       | client pods host aliases                                                                           | `[]`             |
 | `worker.labels`                                            | Labels for the worker deployment                                                                   | `{}`             |
 | `worker.annotations`                                       | Annotations for the worker deployment                                                              | `{}`             |

--- a/bitnami/deepspeed/templates/client/client-dep-job.yaml
+++ b/bitnami/deepspeed/templates/client/client-dep-job.yaml
@@ -49,6 +49,7 @@ spec:
     spec:
       {{- include "deepspeed.v0.imagePullSecrets" . | nindent 6 }}
       serviceAccountName: {{ template "deepspeed.v0.client.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.client.automountServiceAccountToken }}
       {{- if .Values.client.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.client.hostAliases "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/deepspeed/templates/worker/worker-statefulset.yaml
+++ b/bitnami/deepspeed/templates/worker/worker-statefulset.yaml
@@ -47,6 +47,7 @@ spec:
     spec:
       serviceAccountName: {{ template "deepspeed.v0.worker.serviceAccountName" . }}
       {{- include "deepspeed.v0.imagePullSecrets" . | nindent 6 }}
+      automountServiceAccountToken: {{ .Values.worker.automountServiceAccountToken }}
       {{- if .Values.worker.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.worker.hostAliases "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/deepspeed/values.yaml
+++ b/bitnami/deepspeed/values.yaml
@@ -326,6 +326,9 @@ client:
   ## ref: https://kubernetes.io/docs/concepts/containers/runtime-class/
   ##https://github.com/microsoft/DeepSpeedExamples
   runtimeClassName: ""
+  ## @param client.automountServiceAccountToken Mount Service Account token in pod
+  ##
+  automountServiceAccountToken: false
   ## @param client.hostAliases client pods host aliases
   ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
   ##
@@ -681,6 +684,9 @@ worker:
   ## ref: https://kubernetes.io/docs/concepts/containers/runtime-class/
   ##
   runtimeClassName: ""
+  ## @param worker.automountServiceAccountToken Mount Service Account token in pod
+  ##
+  automountServiceAccountToken: false
   ## @param worker.hostAliases client pods host aliases
   ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
   ##


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

### Description of the change

This PR sets all ServiceAccount automountServiceAccountToken=false by default, as the token mounting should be set in the pod declaration instead (if a new pod uses this service account and the token gets automatically mounted, it could be problematic in terms of security). This PR also adds automountServiceAccountToken in the pod declaration as a new value, which can be configured by users in case they want to use an external token.

### Benefits

Charts become more security-compliant

### Possible drawbacks

n/a

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)

