### PR TITLE
[bitnami/etcd] fix: :lock: Move service-account token auto-mount to pod declaration

### DIFF
--- a/bitnami/etcd/Chart.yaml
+++ b/bitnami/etcd/Chart.yaml
@@ -32,4 +32,4 @@ maintainers:
 name: etcd
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/etcd
-version: 9.9.1
+version: 9.10.0

--- a/bitnami/etcd/README.md
+++ b/bitnami/etcd/README.md
@@ -134,6 +134,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `replicaCount`                                      | Number of etcd replicas to deploy                                                         | `1`              |
 | `updateStrategy.type`                               | Update strategy type, can be set to RollingUpdate or OnDelete.                            | `RollingUpdate`  |
 | `podManagementPolicy`                               | Pod management policy for the etcd statefulset                                            | `Parallel`       |
+| `automountServiceAccountToken`                      | Mount Service Account token in pod                                                        | `false`          |
 | `hostAliases`                                       | etcd pod host aliases                                                                     | `[]`             |
 | `lifecycleHooks`                                    | Override default etcd container hooks                                                     | `{}`             |
 | `containerPorts.client`                             | Client port to expose at container level                                                  | `2379`           |

--- a/bitnami/etcd/templates/statefulset.yaml
+++ b/bitnami/etcd/templates/statefulset.yaml
@@ -41,6 +41,7 @@ spec:
         {{- end }}
     spec:
       {{- include "etcd.imagePullSecrets" . | nindent 6 }}
+      automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
       {{- if .Values.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.hostAliases "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/etcd/values.yaml
+++ b/bitnami/etcd/values.yaml
@@ -276,6 +276,9 @@ updateStrategy:
 ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#pod-management-policies
 ##
 podManagementPolicy: Parallel
+## @param automountServiceAccountToken Mount Service Account token in pod
+##
+automountServiceAccountToken: false
 ## @param hostAliases [array] etcd pod host aliases
 ## ref: https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
 ##


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

### Description of the change

This PR sets all ServiceAccount automountServiceAccountToken=false by default, as the token mounting should be set in the pod declaration instead (if a new pod uses this service account and the token gets automatically mounted, it could be problematic in terms of security). This PR also adds automountServiceAccountToken in the pod declaration as a new value, which can be configured by users in case they want to use an external token.

### Benefits

Charts become more security-compliant

### Possible drawbacks

n/a

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)

