### PR TITLE
[bitnami/fluent-bit] fix: :lock: Move service-account token auto-mount to pod declaration

### DIFF
--- a/.vib/fluent-bit/goss/goss.yaml
+++ b/.vib/fluent-bit/goss/goss.yaml
@@ -26,7 +26,7 @@ command:
     # or the one randomly defined by openshift (larger values). Otherwise, the chart is still using the default value.
     exec: if [ $(id -u) -lt {{ $uid }} ] || [ $(id -G | awk '{print $2}') -lt {{ $gid }} ]; then exit 1; fi
     exit-status: 0
-  {{ if .Vars.serviceAccount.automountServiceAccountToken }}
+  {{ if .Vars.automountServiceAccountToken }}
   check-sa:
     exec: cat /var/run/secrets/kubernetes.io/serviceaccount/token | cut -d '.' -f 2 | xargs -I '{}' echo '{}====' | fold -w 4 | sed '$ d' | tr -d '\n' | base64 -d
     exit-status: 0

--- a/.vib/fluent-bit/runtime-parameters.yaml
+++ b/.vib/fluent-bit/runtime-parameters.yaml
@@ -8,7 +8,7 @@ containerSecurityContext:
   runAsUser: 1002
 serviceAccount:
   create: true
-  automountServiceAccountToken: true
+automountServiceAccountToken: true
 service:
   type: LoadBalancer
   ports:

--- a/bitnami/fluent-bit/Chart.yaml
+++ b/bitnami/fluent-bit/Chart.yaml
@@ -28,4 +28,4 @@ maintainers:
 name: fluent-bit
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/fluent-bit
-version: 0.7.1
+version: 0.8.0

--- a/bitnami/fluent-bit/README.md
+++ b/bitnami/fluent-bit/README.md
@@ -111,6 +111,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `extraEnvVarsCM`                                    | Name of existing ConfigMap containing extra env vars                                      | `""`                         |
 | `extraEnvVarsSecret`                                | Name of existing Secret containing extra env vars                                         | `""`                         |
 | `existingConfigMap`                                 | Name of an existing ConfigMap with the Fluent Bit config file                             | `""`                         |
+| `automountServiceAccountToken`                      | Mount Service Account token in pod                                                        | `true`                       |
 | `hostAliases`                                       | Deployment pod host aliases                                                               | `[]`                         |
 | `replicaCount`                                      | Number of Fluent Bit replicas                                                             | `1`                          |
 | `livenessProbe.enabled`                             | Enable livenessProbe on nodes                                                             | `true`                       |
@@ -152,7 +153,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `serviceAccount.create`                             | Enables ServiceAccount                                                                    | `true`                       |
 | `serviceAccount.name`                               | ServiceAccount name                                                                       | `""`                         |
 | `serviceAccount.annotations`                        | Annotations to add to all deployed objects                                                | `{}`                         |
-| `serviceAccount.automountServiceAccountToken`       | Automount API credentials for a service account.                                          | `true`                       |
+| `serviceAccount.automountServiceAccountToken`       | Automount API credentials for a service account.                                          | `false`                      |
 | `podSecurityContext.enabled`                        | Enabled Fluent Bit pods' Security Context                                                 | `true`                       |
 | `podSecurityContext.fsGroupChangePolicy`            | Set filesystem group change policy                                                        | `Always`                     |
 | `podSecurityContext.sysctls`                        | Set kernel settings using the sysctl interface                                            | `[]`                         |

--- a/bitnami/fluent-bit/templates/daemonset.yaml
+++ b/bitnami/fluent-bit/templates/daemonset.yaml
@@ -59,6 +59,7 @@ spec:
       {{- if .Values.tolerations }}
       tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.tolerations "context" $) | nindent 8 }}
       {{- end }}
+      automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
       {{- if .Values.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.hostAliases "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/fluent-bit/templates/deployment.yaml
+++ b/bitnami/fluent-bit/templates/deployment.yaml
@@ -58,6 +58,10 @@ spec:
       {{- if .Values.topologySpreadConstraints }}
       topologySpreadConstraints: {{- include "common.tplvalues.render" (dict "value" .Values.topologySpreadConstraints "context" $) | nindent 8 }}
       {{- end }}
+      automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
+      {{- if .Values.hostAliases }}
+      hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.hostAliases "context" $) | nindent 8 }}
+      {{- end }}
       initContainers:
       {{- if .Values.initContainers }}
       {{- include "common.tplvalues.render" (dict "value" .Values.initContainers "context" $) | nindent 8 }}

--- a/bitnami/fluent-bit/values.yaml
+++ b/bitnami/fluent-bit/values.yaml
@@ -154,6 +154,9 @@ extraEnvVarsSecret: ""
 ## @param existingConfigMap Name of an existing ConfigMap with the Fluent Bit config file
 ##
 existingConfigMap: ""
+## @param automountServiceAccountToken Mount Service Account token in pod
+##
+automountServiceAccountToken: true
 ## @param hostAliases Deployment pod host aliases
 ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
 ##
@@ -320,7 +323,7 @@ serviceAccount:
   annotations: {}
   ## @param serviceAccount.automountServiceAccountToken Automount API credentials for a service account.
   ##
-  automountServiceAccountToken: true
+  automountServiceAccountToken: false
 ## Pod security context
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
 ## @param podSecurityContext.enabled Enabled Fluent Bit pods' Security Context


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

### Description of the change

This PR sets all ServiceAccount automountServiceAccountToken=false by default, as the token mounting should be set in the pod declaration instead (if a new pod uses this service account and the token gets automatically mounted, it could be problematic in terms of security). This PR also adds automountServiceAccountToken in the pod declaration as a new value, which can be configured by users in case they want to use an external token.

### Benefits

Charts become more security-compliant

### Possible drawbacks

n/a

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)

