### PR TITLE
[bitnami/gitea] fix: :lock: Move service-account token auto-mount to pod declaration

### DIFF
--- a/bitnami/gitea/Chart.yaml
+++ b/bitnami/gitea/Chart.yaml
@@ -37,4 +37,4 @@ maintainers:
 name: gitea
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/gitea
-version: 1.3.2
+version: 1.4.0

--- a/bitnami/gitea/README.md
+++ b/bitnami/gitea/README.md
@@ -99,6 +99,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `priorityClassName`                                 | Gitea pods' priorityClassName                                                                                         | `""`                    |
 | `schedulerName`                                     | Name of the k8s scheduler (other than default)                                                                        | `""`                    |
 | `topologySpreadConstraints`                         | Topology Spread Constraints for pod assignment                                                                        | `[]`                    |
+| `automountServiceAccountToken`                      | Mount Service Account token in pod                                                                                    | `false`                 |
 | `hostAliases`                                       | Add deployment host aliases                                                                                           | `[]`                    |
 | `extraEnvVars`                                      | Extra environment variables                                                                                           | `[]`                    |
 | `extraEnvVarsCM`                                    | ConfigMap containing extra env vars                                                                                   | `""`                    |

--- a/bitnami/gitea/templates/deployment.yaml
+++ b/bitnami/gitea/templates/deployment.yaml
@@ -53,6 +53,7 @@ spec:
       {{- if .Values.tolerations }}
       tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.tolerations "context" $) | nindent 8 }}
       {{- end }}
+      automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
       {{- if .Values.hostAliases }}
       # yamllint disable rule:indentation
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.hostAliases "context" $) | nindent 8 }}

--- a/bitnami/gitea/values.yaml
+++ b/bitnami/gitea/values.yaml
@@ -132,6 +132,9 @@ schedulerName: ""
 ## The value is evaluated as a template
 ##
 topologySpreadConstraints: []
+## @param automountServiceAccountToken Mount Service Account token in pod
+##
+automountServiceAccountToken: false
 ## @param hostAliases [array] Add deployment host aliases
 ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
 ##


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

### Description of the change

This PR sets all ServiceAccount automountServiceAccountToken=false by default, as the token mounting should be set in the pod declaration instead (if a new pod uses this service account and the token gets automatically mounted, it could be problematic in terms of security). This PR also adds automountServiceAccountToken in the pod declaration as a new value, which can be configured by users in case they want to use an external token.

### Benefits

Charts become more security-compliant

### Possible drawbacks

n/a

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)

