### PR TITLE
[bitnami/grafana] fix: :lock: Move service-account token auto-mount to pod declaration

### DIFF
--- a/bitnami/grafana/Chart.yaml
+++ b/bitnami/grafana/Chart.yaml
@@ -31,4 +31,4 @@ maintainers:
 name: grafana
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/grafana
-version: 9.7.1
+version: 9.8.0

--- a/bitnami/grafana/README.md
+++ b/bitnami/grafana/README.md
@@ -222,6 +222,7 @@ This solution allows to easily deploy multiple Grafana instances compared to the
 | ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- | ---------------- |
 | `grafana.replicaCount`                                      | Number of Grafana nodes                                                                                 | `1`              |
 | `grafana.updateStrategy.type`                               | Set up update strategy for Grafana installation.                                                        | `RollingUpdate`  |
+| `grafana.automountServiceAccountToken`                      | Mount Service Account token in pod                                                                      | `false`          |
 | `grafana.hostAliases`                                       | Add deployment host aliases                                                                             | `[]`             |
 | `grafana.schedulerName`                                     | Alternative scheduler                                                                                   | `""`             |
 | `grafana.terminationGracePeriodSeconds`                     | In seconds, time the given to the Grafana pod needs to terminate gracefully                             | `""`             |

--- a/bitnami/grafana/templates/deployment.yaml
+++ b/bitnami/grafana/templates/deployment.yaml
@@ -43,6 +43,7 @@ spec:
         {{- end }}
     spec:
       {{- include "grafana.imagePullSecrets" . | nindent 6 }}
+      automountServiceAccountToken: {{ .Values.grafana.automountServiceAccountToken }}
       {{- if .Values.grafana.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.grafana.hostAliases "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/grafana/values.yaml
+++ b/bitnami/grafana/values.yaml
@@ -302,6 +302,9 @@ grafana:
   ##
   updateStrategy:
     type: RollingUpdate
+  ## @param grafana.automountServiceAccountToken Mount Service Account token in pod
+  ##
+  automountServiceAccountToken: false
   ## @param grafana.hostAliases Add deployment host aliases
   ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
   ##


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

### Description of the change

This PR sets all ServiceAccount automountServiceAccountToken=false by default, as the token mounting should be set in the pod declaration instead (if a new pod uses this service account and the token gets automatically mounted, it could be problematic in terms of security). This PR also adds automountServiceAccountToken in the pod declaration as a new value, which can be configured by users in case they want to use an external token.

### Benefits

Charts become more security-compliant

### Possible drawbacks

n/a

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)

