### PR TITLE
[bitnami/argo-cd] Fix typo in runtime-parameters.yaml

### DIFF
--- a/.vib/argo-cd/runtime-parameters.yaml
+++ b/.vib/argo-cd/runtime-parameters.yaml
@@ -18,7 +18,7 @@ server:
     readOnlyRootFilesystem: false
     capabilities:
       drop:
-      - all
+      - ALL
   insecure: false
   configEnabled: true
   containerPorts:


### PR DESCRIPTION
### Description of the change

Fixes typo `all` -> `ALL` in Argo CD runtime parameters, affecting TKG deployment.
