### PR TITLE
[bitnami/grafana-loki] fix: :lock: Move service-account token auto-mount to pod declaration

### DIFF
--- a/bitnami/grafana-loki/Chart.yaml
+++ b/bitnami/grafana-loki/Chart.yaml
@@ -57,4 +57,4 @@ maintainers:
 name: grafana-loki
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/grafana-loki
-version: 2.13.1
+version: 2.14.0

--- a/bitnami/grafana-loki/README.md
+++ b/bitnami/grafana-loki/README.md
@@ -1077,7 +1077,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `promtail.containerSecurityContext.runAsUser`           | Set Promtail containers' Security Context runAsUser                                                              | `0`                        |
 | `promtail.containerSecurityContext.runAsNonRoot`        | Set Promtail containers' Security Context runAsNonRoot                                                           | `false`                    |
 | `promtail.containerSecurityContext.seccompProfile.type` | Set container's Security Context seccomp profile                                                                 | `RuntimeDefault`           |
-| `promtail.automountServiceAccountToken`                 | Mount Service Account token in pod                                                                               | `false`                    |
+| `promtail.automountServiceAccountToken`                 | Mount Service Account token in pod                                                                               | `true`                     |
 | `promtail.hostAliases`                                  | promtail pods host aliases                                                                                       | `[]`                       |
 | `promtail.podLabels`                                    | Extra labels for promtail pods                                                                                   | `{}`                       |
 | `promtail.podAnnotations`                               | Annotations for promtail pods                                                                                    | `{}`                       |

--- a/bitnami/grafana-loki/README.md
+++ b/bitnami/grafana-loki/README.md
@@ -146,6 +146,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `compactor.containerSecurityContext.runAsNonRoot`        | Set Compactor containers' Security Context runAsNonRoot                                             | `true`              |
 | `compactor.containerSecurityContext.seccompProfile.type` | Set container's Security Context seccomp profile                                                    | `RuntimeDefault`    |
 | `compactor.lifecycleHooks`                               | for the compactor container(s) to automate configuration before or after startup                    | `{}`                |
+| `compactor.automountServiceAccountToken`                 | Mount Service Account token in pod                                                                  | `false`             |
 | `compactor.hostAliases`                                  | compactor pods host aliases                                                                         | `[]`                |
 | `compactor.podLabels`                                    | Extra labels for compactor pods                                                                     | `{}`                |
 | `compactor.podAnnotations`                               | Annotations for compactor pods                                                                      | `{}`                |
@@ -249,6 +250,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `gateway.containerSecurityContext.runAsNonRoot`        | Set Gateway containers' Security Context runAsNonRoot                                                 | `true`                  |
 | `gateway.containerSecurityContext.seccompProfile.type` | Set container's Security Context seccomp profile                                                      | `RuntimeDefault`        |
 | `gateway.lifecycleHooks`                               | for the gateway container(s) to automate configuration before or after startup                        | `{}`                    |
+| `gateway.automountServiceAccountToken`                 | Mount Service Account token in pod                                                                    | `false`                 |
 | `gateway.hostAliases`                                  | gateway pods host aliases                                                                             | `[]`                    |
 | `gateway.podLabels`                                    | Extra labels for gateway pods                                                                         | `{}`                    |
 | `gateway.podAnnotations`                               | Annotations for gateway pods                                                                          | `{}`                    |
@@ -346,6 +348,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `indexGateway.containerSecurityContext.runAsNonRoot`        | Set index-gateway containers' Security Context runAsNonRoot                                            | `true`           |
 | `indexGateway.containerSecurityContext.seccompProfile.type` | Set container's Security Context seccomp profile                                                       | `RuntimeDefault` |
 | `indexGateway.lifecycleHooks`                               | for the indexGateway container(s) to automate configuration before or after startup                    | `{}`             |
+| `indexGateway.automountServiceAccountToken`                 | Mount Service Account token in pod                                                                     | `false`          |
 | `indexGateway.hostAliases`                                  | indexGateway pods host aliases                                                                         | `[]`             |
 | `indexGateway.podLabels`                                    | Extra labels for indexGateway pods                                                                     | `{}`             |
 | `indexGateway.podAnnotations`                               | Annotations for indexGateway pods                                                                      | `{}`             |
@@ -430,6 +433,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `distributor.containerSecurityContext.runAsNonRoot`        | Set Distributor containers' Security Context runAsNonRoot                                             | `true`           |
 | `distributor.containerSecurityContext.seccompProfile.type` | Set container's Security Context seccomp profile                                                      | `RuntimeDefault` |
 | `distributor.lifecycleHooks`                               | for the distributor container(s) to automate configuration before or after startup                    | `{}`             |
+| `distributor.automountServiceAccountToken`                 | Mount Service Account token in pod                                                                    | `false`          |
 | `distributor.hostAliases`                                  | distributor pods host aliases                                                                         | `[]`             |
 | `distributor.podLabels`                                    | Extra labels for distributor pods                                                                     | `{}`             |
 | `distributor.podAnnotations`                               | Annotations for distributor pods                                                                      | `{}`             |
@@ -514,6 +518,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `ingester.containerSecurityContext.runAsUser`           | Set Ingester containers' Security Context runAsUser                                                | `1001`           |
 | `ingester.containerSecurityContext.runAsNonRoot`        | Set Ingester containers' Security Context runAsNonRoot                                             | `true`           |
 | `ingester.containerSecurityContext.seccompProfile.type` | Set container's Security Context seccomp profile                                                   | `RuntimeDefault` |
+| `ingester.automountServiceAccountToken`                 | Mount Service Account token in pod                                                                 | `false`          |
 | `ingester.hostAliases`                                  | ingester pods host aliases                                                                         | `[]`             |
 | `ingester.podLabels`                                    | Extra labels for ingester pods                                                                     | `{}`             |
 | `ingester.podAnnotations`                               | Annotations for ingester pods                                                                      | `{}`             |
@@ -612,6 +617,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `querier.containerSecurityContext.runAsNonRoot`        | Set Querier containers' Security Context runAsNonRoot                                             | `true`           |
 | `querier.containerSecurityContext.seccompProfile.type` | Set container's Security Context seccomp profile                                                  | `RuntimeDefault` |
 | `querier.lifecycleHooks`                               | for the Querier container(s) to automate configuration before or after startup                    | `{}`             |
+| `querier.automountServiceAccountToken`                 | Mount Service Account token in pod                                                                | `false`          |
 | `querier.hostAliases`                                  | querier pods host aliases                                                                         | `[]`             |
 | `querier.podLabels`                                    | Extra labels for querier pods                                                                     | `{}`             |
 | `querier.podAnnotations`                               | Annotations for querier pods                                                                      | `{}`             |
@@ -708,6 +714,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `queryFrontend.containerSecurityContext.runAsNonRoot`        | Set queryFrontend containers' Security Context runAsNonRoot                                             | `true`           |
 | `queryFrontend.containerSecurityContext.seccompProfile.type` | Set container's Security Context seccomp profile                                                        | `RuntimeDefault` |
 | `queryFrontend.lifecycleHooks`                               | for the queryFrontend container(s) to automate configuration before or after startup                    | `{}`             |
+| `queryFrontend.automountServiceAccountToken`                 | Mount Service Account token in pod                                                                      | `false`          |
 | `queryFrontend.hostAliases`                                  | queryFrontend pods host aliases                                                                         | `[]`             |
 | `queryFrontend.podLabels`                                    | Extra labels for queryFrontend pods                                                                     | `{}`             |
 | `queryFrontend.podAnnotations`                               | Annotations for queryFrontend pods                                                                      | `{}`             |
@@ -794,6 +801,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `queryScheduler.containerSecurityContext.runAsNonRoot`        | Set queryScheduler containers' Security Context runAsNonRoot                                             | `true`           |
 | `queryScheduler.containerSecurityContext.seccompProfile.type` | Set container's Security Context seccomp profile                                                         | `RuntimeDefault` |
 | `queryScheduler.lifecycleHooks`                               | for the queryScheduler container(s) to automate configuration before or after startup                    | `{}`             |
+| `queryScheduler.automountServiceAccountToken`                 | Mount Service Account token in pod                                                                       | `false`          |
 | `queryScheduler.hostAliases`                                  | queryScheduler pods host aliases                                                                         | `[]`             |
 | `queryScheduler.podLabels`                                    | Extra labels for queryScheduler pods                                                                     | `{}`             |
 | `queryScheduler.podAnnotations`                               | Annotations for queryScheduler pods                                                                      | `{}`             |
@@ -880,6 +888,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `ruler.containerSecurityContext.runAsUser`           | Set Ruler containers' Security Context runAsUser                                                | `1001`           |
 | `ruler.containerSecurityContext.runAsNonRoot`        | Set Ruler containers' Security Context runAsNonRoot                                             | `true`           |
 | `ruler.containerSecurityContext.seccompProfile.type` | Set container's Security Context seccomp profile                                                | `RuntimeDefault` |
+| `ruler.automountServiceAccountToken`                 | Mount Service Account token in pod                                                              | `false`          |
 | `ruler.hostAliases`                                  | ruler pods host aliases                                                                         | `[]`             |
 | `ruler.podLabels`                                    | Extra labels for ruler pods                                                                     | `{}`             |
 | `ruler.podAnnotations`                               | Annotations for ruler pods                                                                      | `{}`             |
@@ -977,6 +986,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `tableManager.containerSecurityContext.runAsNonRoot`        | Set table-manager containers' Security Context runAsNonRoot                                            | `true`           |
 | `tableManager.containerSecurityContext.seccompProfile.type` | Set container's Security Context seccomp profile                                                       | `RuntimeDefault` |
 | `tableManager.lifecycleHooks`                               | for the tableManager container(s) to automate configuration before or after startup                    | `{}`             |
+| `tableManager.automountServiceAccountToken`                 | Mount Service Account token in pod                                                                     | `false`          |
 | `tableManager.hostAliases`                                  | tableManager pods host aliases                                                                         | `[]`             |
 | `tableManager.podLabels`                                    | Extra labels for tableManager pods                                                                     | `{}`             |
 | `tableManager.podAnnotations`                               | Annotations for tableManager pods                                                                      | `{}`             |
@@ -1067,6 +1077,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `promtail.containerSecurityContext.runAsUser`           | Set Promtail containers' Security Context runAsUser                                                              | `0`                        |
 | `promtail.containerSecurityContext.runAsNonRoot`        | Set Promtail containers' Security Context runAsNonRoot                                                           | `false`                    |
 | `promtail.containerSecurityContext.seccompProfile.type` | Set container's Security Context seccomp profile                                                                 | `RuntimeDefault`           |
+| `promtail.automountServiceAccountToken`                 | Mount Service Account token in pod                                                                               | `false`                    |
 | `promtail.hostAliases`                                  | promtail pods host aliases                                                                                       | `[]`                       |
 | `promtail.podLabels`                                    | Extra labels for promtail pods                                                                                   | `{}`                       |
 | `promtail.podAnnotations`                               | Annotations for promtail pods                                                                                    | `{}`                       |
@@ -1109,7 +1120,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `promtail.rbac.create`                                 | Create RBAC rules                                                               | `true`      |
 | `promtail.serviceAccount.create`                       | Enable creation of ServiceAccount for Promtail pods                             | `true`      |
 | `promtail.serviceAccount.name`                         | The name of the ServiceAccount to use                                           | `""`        |
-| `promtail.serviceAccount.automountServiceAccountToken` | Allows auto mount of ServiceAccountToken on the promtail.serviceAccount.created | `true`      |
+| `promtail.serviceAccount.automountServiceAccountToken` | Allows auto mount of ServiceAccountToken on the promtail.serviceAccount.created | `false`     |
 | `promtail.serviceAccount.annotations`                  | Additional custom annotations for the ServiceAccount                            | `{}`        |
 
 ### Init Container Parameters

--- a/bitnami/grafana-loki/templates/compactor/deployment.yaml
+++ b/bitnami/grafana-loki/templates/compactor/deployment.yaml
@@ -41,6 +41,7 @@ spec:
     spec:
       serviceAccountName: {{ template "grafana-loki.serviceAccountName" . }}
       {{- include "grafana-loki.imagePullSecrets" . | nindent 6 }}
+      automountServiceAccountToken: {{ .Values.compactor.automountServiceAccountToken }}
       {{- if .Values.compactor.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.compactor.hostAliases "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/grafana-loki/templates/distributor/deployment.yaml
+++ b/bitnami/grafana-loki/templates/distributor/deployment.yaml
@@ -42,6 +42,7 @@ spec:
     spec:
       serviceAccountName: {{ template "grafana-loki.serviceAccountName" . }}
       {{- include "grafana-loki.imagePullSecrets" . | nindent 6 }}
+      automountServiceAccountToken: {{ .Values.distributor.automountServiceAccountToken }}
       {{- if .Values.distributor.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.distributor.hostAliases "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/grafana-loki/templates/gateway/deployment.yaml
+++ b/bitnami/grafana-loki/templates/gateway/deployment.yaml
@@ -39,6 +39,7 @@ spec:
         {{- end }}
     spec:
       {{- include "grafana-loki.imagePullSecrets" . | nindent 6 }}
+      automountServiceAccountToken: {{ .Values.gateway.automountServiceAccountToken }}
       {{- if .Values.gateway.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.gateway.hostAliases "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/grafana-loki/templates/index-gateway/statefulset.yaml
+++ b/bitnami/grafana-loki/templates/index-gateway/statefulset.yaml
@@ -45,6 +45,7 @@ spec:
     spec:
       serviceAccountName: {{ template "grafana-loki.serviceAccountName" . }}
       {{- include "grafana-loki.imagePullSecrets" . | nindent 6 }}
+      automountServiceAccountToken: {{ .Values.indexGateway.automountServiceAccountToken }}
       {{- if .Values.indexGateway.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.indexGateway.hostAliases "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/grafana-loki/templates/ingester/statefulset.yaml
+++ b/bitnami/grafana-loki/templates/ingester/statefulset.yaml
@@ -42,6 +42,7 @@ spec:
     spec:
       serviceAccountName: {{ template "grafana-loki.serviceAccountName" . }}
       {{- include "grafana-loki.imagePullSecrets" . | nindent 6 }}
+      automountServiceAccountToken: {{ .Values.ingester.automountServiceAccountToken }}
       {{- if .Values.ingester.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.ingester.hostAliases "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/grafana-loki/templates/promtail/daemonset.yaml
+++ b/bitnami/grafana-loki/templates/promtail/daemonset.yaml
@@ -40,6 +40,7 @@ spec:
     spec:
       serviceAccountName: {{ template "grafana-loki.promtail.serviceAccountName" . }}
       {{- include "grafana-loki.imagePullSecrets" . | nindent 6 }}
+      automountServiceAccountToken: {{ .Values.promtail.automountServiceAccountToken }}
       {{- if .Values.promtail.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.promtail.hostAliases "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/grafana-loki/templates/querier/statefulset.yaml
+++ b/bitnami/grafana-loki/templates/querier/statefulset.yaml
@@ -44,6 +44,7 @@ spec:
     spec:
       serviceAccountName: {{ template "grafana-loki.serviceAccountName" . }}
       {{- include "grafana-loki.imagePullSecrets" . | nindent 6 }}
+      automountServiceAccountToken: {{ .Values.querier.automountServiceAccountToken }}
       {{- if .Values.querier.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.querier.hostAliases "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/grafana-loki/templates/query-frontend/deployment.yaml
+++ b/bitnami/grafana-loki/templates/query-frontend/deployment.yaml
@@ -40,6 +40,7 @@ spec:
     spec:
       serviceAccountName: {{ template "grafana-loki.serviceAccountName" . }}
       {{- include "grafana-loki.imagePullSecrets" . | nindent 6 }}
+      automountServiceAccountToken: {{ .Values.queryFrontend.automountServiceAccountToken }}
       {{- if .Values.queryFrontend.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.queryFrontend.hostAliases "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/grafana-loki/templates/query-scheduler/deployment.yaml
+++ b/bitnami/grafana-loki/templates/query-scheduler/deployment.yaml
@@ -43,6 +43,7 @@ spec:
     spec:
       serviceAccountName: {{ template "grafana-loki.serviceAccountName" . }}
       {{- include "grafana-loki.imagePullSecrets" . | nindent 6 }}
+      automountServiceAccountToken: {{ .Values.queryScheduler.automountServiceAccountToken }}
       {{- if .Values.queryScheduler.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.queryScheduler.hostAliases "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/grafana-loki/templates/ruler/statefulset.yaml
+++ b/bitnami/grafana-loki/templates/ruler/statefulset.yaml
@@ -45,6 +45,7 @@ spec:
     spec:
       serviceAccountName: {{ template "grafana-loki.serviceAccountName" . }}
       {{- include "grafana-loki.imagePullSecrets" . | nindent 6 }}
+      automountServiceAccountToken: {{ .Values.ruler.automountServiceAccountToken }}
       {{- if .Values.ruler.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.ruler.hostAliases "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/grafana-loki/templates/table-manager/deployment.yaml
+++ b/bitnami/grafana-loki/templates/table-manager/deployment.yaml
@@ -41,6 +41,7 @@ spec:
     spec:
       serviceAccountName: {{ template "grafana-loki.serviceAccountName" . }}
       {{- include "grafana-loki.imagePullSecrets" . | nindent 6 }}
+      automountServiceAccountToken: {{ .Values.tableManager.automountServiceAccountToken }}
       {{- if .Values.tableManager.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.tableManager.hostAliases "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/grafana-loki/values.yaml
+++ b/bitnami/grafana-loki/values.yaml
@@ -3571,7 +3571,7 @@ promtail:
       type: "RuntimeDefault"
   ## @param promtail.automountServiceAccountToken Mount Service Account token in pod
   ##
-  automountServiceAccountToken: false
+  automountServiceAccountToken: true
   ## @param promtail.hostAliases promtail pods host aliases
   ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
   ##

--- a/bitnami/grafana-loki/values.yaml
+++ b/bitnami/grafana-loki/values.yaml
@@ -393,6 +393,9 @@ compactor:
   ## @param compactor.lifecycleHooks for the compactor container(s) to automate configuration before or after startup
   ##
   lifecycleHooks: {}
+  ## @param compactor.automountServiceAccountToken Mount Service Account token in pod
+  ##
+  automountServiceAccountToken: false
   ## @param compactor.hostAliases compactor pods host aliases
   ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
   ##
@@ -758,6 +761,9 @@ gateway:
   ## @param gateway.lifecycleHooks for the gateway container(s) to automate configuration before or after startup
   ##
   lifecycleHooks: {}
+  ## @param gateway.automountServiceAccountToken Mount Service Account token in pod
+  ##
+  automountServiceAccountToken: false
   ## @param gateway.hostAliases gateway pods host aliases
   ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
   ##
@@ -1133,6 +1139,9 @@ indexGateway:
   ## @param indexGateway.lifecycleHooks for the indexGateway container(s) to automate configuration before or after startup
   ##
   lifecycleHooks: {}
+  ## @param indexGateway.automountServiceAccountToken Mount Service Account token in pod
+  ##
+  automountServiceAccountToken: false
   ## @param indexGateway.hostAliases indexGateway pods host aliases
   ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
   ##
@@ -1411,6 +1420,9 @@ distributor:
   ## @param distributor.lifecycleHooks for the distributor container(s) to automate configuration before or after startup
   ##
   lifecycleHooks: {}
+  ## @param distributor.automountServiceAccountToken Mount Service Account token in pod
+  ##
+  automountServiceAccountToken: false
   ## @param distributor.hostAliases distributor pods host aliases
   ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
   ##
@@ -1689,6 +1701,9 @@ ingester:
     runAsNonRoot: true
     seccompProfile:
       type: "RuntimeDefault"
+  ## @param ingester.automountServiceAccountToken Mount Service Account token in pod
+  ##
+  automountServiceAccountToken: false
   ## @param ingester.hostAliases ingester pods host aliases
   ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
   ##
@@ -2015,6 +2030,9 @@ querier:
   ## @param querier.lifecycleHooks for the Querier container(s) to automate configuration before or after startup
   ##
   lifecycleHooks: {}
+  ## @param querier.automountServiceAccountToken Mount Service Account token in pod
+  ##
+  automountServiceAccountToken: false
   ## @param querier.hostAliases querier pods host aliases
   ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
   ##
@@ -2333,6 +2351,9 @@ queryFrontend:
   ## @param queryFrontend.lifecycleHooks for the queryFrontend container(s) to automate configuration before or after startup
   ##
   lifecycleHooks: {}
+  ## @param queryFrontend.automountServiceAccountToken Mount Service Account token in pod
+  ##
+  automountServiceAccountToken: false
   ## @param queryFrontend.hostAliases queryFrontend pods host aliases
   ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
   ##
@@ -2621,6 +2642,9 @@ queryScheduler:
   ## @param queryScheduler.lifecycleHooks for the queryScheduler container(s) to automate configuration before or after startup
   ##
   lifecycleHooks: {}
+  ## @param queryScheduler.automountServiceAccountToken Mount Service Account token in pod
+  ##
+  automountServiceAccountToken: false
   ## @param queryScheduler.hostAliases queryScheduler pods host aliases
   ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
   ##
@@ -2906,6 +2930,9 @@ ruler:
     runAsNonRoot: true
     seccompProfile:
       type: "RuntimeDefault"
+  ## @param ruler.automountServiceAccountToken Mount Service Account token in pod
+  ##
+  automountServiceAccountToken: false
   ## @param ruler.hostAliases ruler pods host aliases
   ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
   ##
@@ -3227,6 +3254,9 @@ tableManager:
   ## @param tableManager.lifecycleHooks for the tableManager container(s) to automate configuration before or after startup
   ##
   lifecycleHooks: {}
+  ## @param tableManager.automountServiceAccountToken Mount Service Account token in pod
+  ##
+  automountServiceAccountToken: false
   ## @param tableManager.hostAliases tableManager pods host aliases
   ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
   ##
@@ -3539,6 +3569,9 @@ promtail:
     runAsNonRoot: false
     seccompProfile:
       type: "RuntimeDefault"
+  ## @param promtail.automountServiceAccountToken Mount Service Account token in pod
+  ##
+  automountServiceAccountToken: false
   ## @param promtail.hostAliases promtail pods host aliases
   ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
   ##
@@ -3803,7 +3836,7 @@ promtail:
     ## @param promtail.serviceAccount.automountServiceAccountToken Allows auto mount of ServiceAccountToken on the promtail.serviceAccount.created
     ## Can be set to false if pods using this promtail.serviceAccount.do not need to use K8s API
     ##
-    automountServiceAccountToken: true
+    automountServiceAccountToken: false
     ## @param promtail.serviceAccount.annotations Additional custom annotations for the ServiceAccount
     ##
     annotations: {}


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

### Description of the change

This PR sets all ServiceAccount automountServiceAccountToken=false by default, as the token mounting should be set in the pod declaration instead (if a new pod uses this service account and the token gets automatically mounted, it could be problematic in terms of security). This PR also adds automountServiceAccountToken in the pod declaration as a new value, which can be configured by users in case they want to use an external token.

### Benefits

Charts become more security-compliant

### Possible drawbacks

n/a

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)

