### PR TITLE
[bitnami/grafana-mimir] fix: :lock: Move service-account token auto-mount to pod declaration

### DIFF
--- a/bitnami/grafana-mimir/Chart.yaml
+++ b/bitnami/grafana-mimir/Chart.yaml
@@ -59,4 +59,4 @@ maintainers:
 name: grafana-mimir
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/grafana-mimir
-version: 0.8.1
+version: 0.9.0

--- a/bitnami/grafana-mimir/README.md
+++ b/bitnami/grafana-mimir/README.md
@@ -156,6 +156,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `alertmanager.containerSecurityContext.capabilities.drop`        | List of capabilities to be dropped                                                                     | `["ALL"]`           |
 | `alertmanager.containerSecurityContext.seccompProfile.type`      | Set container's Security Context seccomp profile                                                       | `RuntimeDefault`    |
 | `alertmanager.lifecycleHooks`                                    | for the ingester container(s) to automate configuration before or after startup                        | `{}`                |
+| `alertmanager.automountServiceAccountToken`                      | Mount Service Account token in pod                                                                     | `false`             |
 | `alertmanager.hostAliases`                                       | ingester pods host aliases                                                                             | `[]`                |
 | `alertmanager.podLabels`                                         | Extra labels for ingester pods                                                                         | `{}`                |
 | `alertmanager.podAnnotations`                                    | Annotations for ingester pods                                                                          | `{}`                |
@@ -259,6 +260,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `compactor.containerSecurityContext.capabilities.drop`        | List of capabilities to be dropped                                                                  | `["ALL"]`           |
 | `compactor.containerSecurityContext.seccompProfile.type`      | Set container's Security Context seccomp profile                                                    | `RuntimeDefault`    |
 | `compactor.lifecycleHooks`                                    | for the compactor container(s) to automate configuration before or after startup                    | `{}`                |
+| `compactor.automountServiceAccountToken`                      | Mount Service Account token in pod                                                                  | `false`             |
 | `compactor.hostAliases`                                       | compactor pods host aliases                                                                         | `[]`                |
 | `compactor.podLabels`                                         | Extra labels for compactor pods                                                                     | `{}`                |
 | `compactor.podAnnotations`                                    | Annotations for compactor pods                                                                      | `{}`                |
@@ -358,6 +360,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `distributor.containerSecurityContext.capabilities.drop`        | List of capabilities to be dropped                                                                    | `["ALL"]`        |
 | `distributor.containerSecurityContext.seccompProfile.type`      | Set container's Security Context seccomp profile                                                      | `RuntimeDefault` |
 | `distributor.lifecycleHooks`                                    | for the distributor container(s) to automate configuration before or after startup                    | `{}`             |
+| `distributor.automountServiceAccountToken`                      | Mount Service Account token in pod                                                                    | `false`          |
 | `distributor.hostAliases`                                       | distributor pods host aliases                                                                         | `[]`             |
 | `distributor.podLabels`                                         | Extra labels for distributor pods                                                                     | `{}`             |
 | `distributor.podAnnotations`                                    | Annotations for distributor pods                                                                      | `{}`             |
@@ -463,6 +466,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `gateway.containerSecurityContext.capabilities.drop`        | List of capabilities to be dropped                                                                    | `["ALL"]`               |
 | `gateway.containerSecurityContext.seccompProfile.type`      | Set container's Security Context seccomp profile                                                      | `RuntimeDefault`        |
 | `gateway.lifecycleHooks`                                    | for the gateway container(s) to automate configuration before or after startup                        | `{}`                    |
+| `gateway.automountServiceAccountToken`                      | Mount Service Account token in pod                                                                    | `false`                 |
 | `gateway.hostAliases`                                       | gateway pods host aliases                                                                             | `[]`                    |
 | `gateway.podLabels`                                         | Extra labels for gateway pods                                                                         | `{}`                    |
 | `gateway.podAnnotations`                                    | Annotations for gateway pods                                                                          | `{}`                    |
@@ -566,6 +570,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `ingester.containerSecurityContext.capabilities.drop`        | List of capabilities to be dropped                                                                 | `["ALL"]`           |
 | `ingester.containerSecurityContext.seccompProfile.type`      | Set container's Security Context seccomp profile                                                   | `RuntimeDefault`    |
 | `ingester.lifecycleHooks`                                    | for the ingester container(s) to automate configuration before or after startup                    | `{}`                |
+| `ingester.automountServiceAccountToken`                      | Mount Service Account token in pod                                                                 | `false`             |
 | `ingester.hostAliases`                                       | ingester pods host aliases                                                                         | `[]`                |
 | `ingester.podLabels`                                         | Extra labels for ingester pods                                                                     | `{}`                |
 | `ingester.podAnnotations`                                    | Annotations for ingester pods                                                                      | `{}`                |
@@ -662,6 +667,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `overridesExporter.containerSecurityContext.capabilities.drop`        | List of capabilities to be dropped                                                                          | `["ALL"]`        |
 | `overridesExporter.containerSecurityContext.seccompProfile.type`      | Set container's Security Context seccomp profile                                                            | `RuntimeDefault` |
 | `overridesExporter.lifecycleHooks`                                    | for the ingester container(s) to automate configuration before or after startup                             | `{}`             |
+| `overridesExporter.automountServiceAccountToken`                      | Mount Service Account token in pod                                                                          | `false`          |
 | `overridesExporter.hostAliases`                                       | ingester pods host aliases                                                                                  | `[]`             |
 | `overridesExporter.podLabels`                                         | Extra labels for ingester pods                                                                              | `{}`             |
 | `overridesExporter.podAnnotations`                                    | Annotations for ingester pods                                                                               | `{}`             |
@@ -755,6 +761,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `querier.containerSecurityContext.capabilities.drop`        | List of capabilities to be dropped                                                                | `["ALL"]`        |
 | `querier.containerSecurityContext.seccompProfile.type`      | Set container's Security Context seccomp profile                                                  | `RuntimeDefault` |
 | `querier.lifecycleHooks`                                    | for the ingester container(s) to automate configuration before or after startup                   | `{}`             |
+| `querier.automountServiceAccountToken`                      | Mount Service Account token in pod                                                                | `false`          |
 | `querier.hostAliases`                                       | ingester pods host aliases                                                                        | `[]`             |
 | `querier.podLabels`                                         | Extra labels for ingester pods                                                                    | `{}`             |
 | `querier.podAnnotations`                                    | Annotations for ingester pods                                                                     | `{}`             |
@@ -848,6 +855,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `queryFrontend.containerSecurityContext.capabilities.drop`        | List of capabilities to be dropped                                                                      | `["ALL"]`        |
 | `queryFrontend.containerSecurityContext.seccompProfile.type`      | Set container's Security Context seccomp profile                                                        | `RuntimeDefault` |
 | `queryFrontend.lifecycleHooks`                                    | for the ingester container(s) to automate configuration before or after startup                         | `{}`             |
+| `queryFrontend.automountServiceAccountToken`                      | Mount Service Account token in pod                                                                      | `false`          |
 | `queryFrontend.hostAliases`                                       | ingester pods host aliases                                                                              | `[]`             |
 | `queryFrontend.podLabels`                                         | Extra labels for ingester pods                                                                          | `{}`             |
 | `queryFrontend.podAnnotations`                                    | Annotations for ingester pods                                                                           | `{}`             |
@@ -937,6 +945,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `queryScheduler.containerSecurityContext.capabilities.drop`        | List of capabilities to be dropped                                                                       | `["ALL"]`        |
 | `queryScheduler.containerSecurityContext.seccompProfile.type`      | Set container's Security Context seccomp profile                                                         | `RuntimeDefault` |
 | `queryScheduler.lifecycleHooks`                                    | for the ingester container(s) to automate configuration before or after startup                          | `{}`             |
+| `queryScheduler.automountServiceAccountToken`                      | Mount Service Account token in pod                                                                       | `false`          |
 | `queryScheduler.hostAliases`                                       | ingester pods host aliases                                                                               | `[]`             |
 | `queryScheduler.podLabels`                                         | Extra labels for ingester pods                                                                           | `{}`             |
 | `queryScheduler.podAnnotations`                                    | Annotations for ingester pods                                                                            | `{}`             |
@@ -1031,6 +1040,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `storeGateway.containerSecurityContext.capabilities.drop`        | List of capabilities to be dropped                                                                     | `["ALL"]`           |
 | `storeGateway.containerSecurityContext.seccompProfile.type`      | Set container's Security Context seccomp profile                                                       | `RuntimeDefault`    |
 | `storeGateway.lifecycleHooks`                                    | for the ingester container(s) to automate configuration before or after startup                        | `{}`                |
+| `storeGateway.automountServiceAccountToken`                      | Mount Service Account token in pod                                                                     | `false`             |
 | `storeGateway.hostAliases`                                       | ingester pods host aliases                                                                             | `[]`                |
 | `storeGateway.podLabels`                                         | Extra labels for ingester pods                                                                         | `{}`                |
 | `storeGateway.podAnnotations`                                    | Annotations for ingester pods                                                                          | `{}`                |
@@ -1134,6 +1144,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `ruler.containerSecurityContext.allowPrivilegeEscalation` | Set container's Security Context allowPrivilegeEscalation                                       | `false`          |
 | `ruler.containerSecurityContext.capabilities.drop`        | List of capabilities to be dropped                                                              | `["ALL"]`        |
 | `ruler.containerSecurityContext.seccompProfile.type`      | Set container's Security Context seccomp profile                                                | `RuntimeDefault` |
+| `ruler.automountServiceAccountToken`                      | Mount Service Account token in pod                                                              | `false`          |
 | `ruler.hostAliases`                                       | ruler pods host aliases                                                                         | `[]`             |
 | `ruler.podLabels`                                         | Extra labels for ruler pods                                                                     | `{}`             |
 | `ruler.podAnnotations`                                    | Annotations for ruler pods                                                                      | `{}`             |

--- a/bitnami/grafana-mimir/templates/alertmanager/statefulset.yaml
+++ b/bitnami/grafana-mimir/templates/alertmanager/statefulset.yaml
@@ -39,6 +39,7 @@ spec:
     spec:
       serviceAccountName: {{ template "grafana-mimir.serviceAccountName" . }}
       {{- include "grafana-mimir.imagePullSecrets" . | nindent 6 }}
+      automountServiceAccountToken: {{ .Values.alertmanager.automountServiceAccountToken }}
       {{- if .Values.alertmanager.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.alertmanager.hostAliases "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/grafana-mimir/templates/compactor/statefulset.yaml
+++ b/bitnami/grafana-mimir/templates/compactor/statefulset.yaml
@@ -38,6 +38,7 @@ spec:
     spec:
       serviceAccountName: {{ template "grafana-mimir.serviceAccountName" . }}
       {{- include "grafana-mimir.imagePullSecrets" . | nindent 6 }}
+      automountServiceAccountToken: {{ .Values.compactor.automountServiceAccountToken }}
       {{- if .Values.compactor.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.compactor.hostAliases "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/grafana-mimir/templates/distributor/deployment.yaml
+++ b/bitnami/grafana-mimir/templates/distributor/deployment.yaml
@@ -36,6 +36,7 @@ spec:
     spec:
       serviceAccountName: {{ template "grafana-mimir.serviceAccountName" . }}
       {{- include "grafana-mimir.imagePullSecrets" . | nindent 6 }}
+      automountServiceAccountToken: {{ .Values.distributor.automountServiceAccountToken }}
       {{- if .Values.distributor.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.distributor.hostAliases "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/grafana-mimir/templates/gateway/deployment.yaml
+++ b/bitnami/grafana-mimir/templates/gateway/deployment.yaml
@@ -39,6 +39,7 @@ spec:
         {{- end }}
     spec:
       {{- include "grafana-mimir.imagePullSecrets" . | nindent 6 }}
+      automountServiceAccountToken: {{ .Values.gateway.automountServiceAccountToken }}
       {{- if .Values.gateway.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.gateway.hostAliases "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/grafana-mimir/templates/ingester/statefulset.yaml
+++ b/bitnami/grafana-mimir/templates/ingester/statefulset.yaml
@@ -38,6 +38,7 @@ spec:
     spec:
       serviceAccountName: {{ template "grafana-mimir.serviceAccountName" . }}
       {{- include "grafana-mimir.imagePullSecrets" . | nindent 6 }}
+      automountServiceAccountToken: {{ .Values.ingester.automountServiceAccountToken }}
       {{- if .Values.ingester.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.ingester.hostAliases "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/grafana-mimir/templates/overrides-exporter/deployment.yaml
+++ b/bitnami/grafana-mimir/templates/overrides-exporter/deployment.yaml
@@ -36,6 +36,7 @@ spec:
     spec:
       serviceAccountName: {{ template "grafana-mimir.serviceAccountName" . }}
       {{- include "grafana-mimir.imagePullSecrets" . | nindent 6 }}
+      automountServiceAccountToken: {{ .Values.overridesExporter.automountServiceAccountToken }}
       {{- if .Values.overridesExporter.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.overridesExporter.hostAliases "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/grafana-mimir/templates/querier/deployment.yaml
+++ b/bitnami/grafana-mimir/templates/querier/deployment.yaml
@@ -36,6 +36,7 @@ spec:
     spec:
       serviceAccountName: {{ template "grafana-mimir.serviceAccountName" . }}
       {{- include "grafana-mimir.imagePullSecrets" . | nindent 6 }}
+      automountServiceAccountToken: {{ .Values.querier.automountServiceAccountToken }}
       {{- if .Values.querier.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.querier.hostAliases "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/grafana-mimir/templates/query-frontend/deployment.yaml
+++ b/bitnami/grafana-mimir/templates/query-frontend/deployment.yaml
@@ -35,6 +35,7 @@ spec:
     spec:
       serviceAccountName: {{ template "grafana-mimir.serviceAccountName" . }}
       {{- include "grafana-mimir.imagePullSecrets" . | nindent 6 }}
+      automountServiceAccountToken: {{ .Values.queryFrontend.automountServiceAccountToken }}
       {{- if .Values.queryFrontend.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.queryFrontend.hostAliases "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/grafana-mimir/templates/query-scheduler/deployment.yaml
+++ b/bitnami/grafana-mimir/templates/query-scheduler/deployment.yaml
@@ -36,6 +36,7 @@ spec:
     spec:
       serviceAccountName: {{ template "grafana-mimir.serviceAccountName" . }}
       {{- include "grafana-mimir.imagePullSecrets" . | nindent 6 }}
+      automountServiceAccountToken: {{ .Values.queryScheduler.automountServiceAccountToken }}
       {{- if .Values.queryScheduler.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.queryScheduler.hostAliases "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/grafana-mimir/templates/ruler/deployment.yaml
+++ b/bitnami/grafana-mimir/templates/ruler/deployment.yaml
@@ -36,6 +36,7 @@ spec:
     spec:
       serviceAccountName: {{ template "grafana-mimir.serviceAccountName" . }}
       {{- include "grafana-mimir.imagePullSecrets" . | nindent 6 }}
+      automountServiceAccountToken: {{ .Values.ruler.automountServiceAccountToken }}
       {{- if .Values.ruler.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.ruler.hostAliases "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/grafana-mimir/templates/store-gateway/statefulset.yaml
+++ b/bitnami/grafana-mimir/templates/store-gateway/statefulset.yaml
@@ -38,6 +38,7 @@ spec:
     spec:
       serviceAccountName: {{ template "grafana-mimir.serviceAccountName" . }}
       {{- include "grafana-mimir.imagePullSecrets" . | nindent 6 }}
+      automountServiceAccountToken: {{ .Values.storeGateway.automountServiceAccountToken }}
       {{- if .Values.storeGateway.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.storeGateway.hostAliases "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/grafana-mimir/values.yaml
+++ b/bitnami/grafana-mimir/values.yaml
@@ -469,6 +469,9 @@ alertmanager:
   ## @param alertmanager.lifecycleHooks for the ingester container(s) to automate configuration before or after startup
   ##
   lifecycleHooks: {}
+  ## @param alertmanager.automountServiceAccountToken Mount Service Account token in pod
+  ##
+  automountServiceAccountToken: false
   ## @param alertmanager.hostAliases ingester pods host aliases
   ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
   ##
@@ -836,6 +839,9 @@ compactor:
   ## @param compactor.lifecycleHooks for the compactor container(s) to automate configuration before or after startup
   ##
   lifecycleHooks: {}
+  ## @param compactor.automountServiceAccountToken Mount Service Account token in pod
+  ##
+  automountServiceAccountToken: false
   ## @param compactor.hostAliases compactor pods host aliases
   ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
   ##
@@ -1177,6 +1183,9 @@ distributor:
   ## @param distributor.lifecycleHooks for the distributor container(s) to automate configuration before or after startup
   ##
   lifecycleHooks: {}
+  ## @param distributor.automountServiceAccountToken Mount Service Account token in pod
+  ##
+  automountServiceAccountToken: false
   ## @param distributor.hostAliases distributor pods host aliases
   ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
   ##
@@ -1533,6 +1542,9 @@ gateway:
   ## @param gateway.lifecycleHooks for the gateway container(s) to automate configuration before or after startup
   ##
   lifecycleHooks: {}
+  ## @param gateway.automountServiceAccountToken Mount Service Account token in pod
+  ##
+  automountServiceAccountToken: false
   ## @param gateway.hostAliases gateway pods host aliases
   ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
   ##
@@ -1926,6 +1938,9 @@ ingester:
   ## @param ingester.lifecycleHooks for the ingester container(s) to automate configuration before or after startup
   ##
   lifecycleHooks: {}
+  ## @param ingester.automountServiceAccountToken Mount Service Account token in pod
+  ##
+  automountServiceAccountToken: false
   ## @param ingester.hostAliases ingester pods host aliases
   ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
   ##
@@ -2276,6 +2291,9 @@ overridesExporter:
   ## @param overridesExporter.lifecycleHooks for the ingester container(s) to automate configuration before or after startup
   ##
   lifecycleHooks: {}
+  ## @param overridesExporter.automountServiceAccountToken Mount Service Account token in pod
+  ##
+  automountServiceAccountToken: false
   ## @param overridesExporter.hostAliases ingester pods host aliases
   ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
   ##
@@ -2586,6 +2604,9 @@ querier:
   ## @param querier.lifecycleHooks for the ingester container(s) to automate configuration before or after startup
   ##
   lifecycleHooks: {}
+  ## @param querier.automountServiceAccountToken Mount Service Account token in pod
+  ##
+  automountServiceAccountToken: false
   ## @param querier.hostAliases ingester pods host aliases
   ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
   ##
@@ -2896,6 +2917,9 @@ queryFrontend:
   ## @param queryFrontend.lifecycleHooks for the ingester container(s) to automate configuration before or after startup
   ##
   lifecycleHooks: {}
+  ## @param queryFrontend.automountServiceAccountToken Mount Service Account token in pod
+  ##
+  automountServiceAccountToken: false
   ## @param queryFrontend.hostAliases ingester pods host aliases
   ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
   ##
@@ -3209,6 +3233,9 @@ queryScheduler:
   ## @param queryScheduler.lifecycleHooks for the ingester container(s) to automate configuration before or after startup
   ##
   lifecycleHooks: {}
+  ## @param queryScheduler.automountServiceAccountToken Mount Service Account token in pod
+  ##
+  automountServiceAccountToken: false
   ## @param queryScheduler.hostAliases ingester pods host aliases
   ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
   ##
@@ -3523,6 +3550,9 @@ storeGateway:
   ## @param storeGateway.lifecycleHooks for the ingester container(s) to automate configuration before or after startup
   ##
   lifecycleHooks: {}
+  ## @param storeGateway.automountServiceAccountToken Mount Service Account token in pod
+  ##
+  automountServiceAccountToken: false
   ## @param storeGateway.hostAliases ingester pods host aliases
   ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
   ##
@@ -3880,6 +3910,9 @@ ruler:
       drop: ["ALL"]
     seccompProfile:
       type: "RuntimeDefault"
+  ## @param ruler.automountServiceAccountToken Mount Service Account token in pod
+  ##
+  automountServiceAccountToken: false
   ## @param ruler.hostAliases ruler pods host aliases
   ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
   ##


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

### Description of the change

This PR sets all ServiceAccount automountServiceAccountToken=false by default, as the token mounting should be set in the pod declaration instead (if a new pod uses this service account and the token gets automatically mounted, it could be problematic in terms of security). This PR also adds automountServiceAccountToken in the pod declaration as a new value, which can be configured by users in case they want to use an external token.

### Benefits

Charts become more security-compliant

### Possible drawbacks

n/a

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)

