### PR TITLE
[bitnami/grafana-tempo] fix: :lock: Move service-account token auto-mount to pod declaration

### DIFF
--- a/bitnami/grafana-tempo/Chart.yaml
+++ b/bitnami/grafana-tempo/Chart.yaml
@@ -39,4 +39,4 @@ maintainers:
 name: grafana-tempo
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/grafana-tempo
-version: 2.6.1
+version: 2.7.0

--- a/bitnami/grafana-tempo/README.md
+++ b/bitnami/grafana-tempo/README.md
@@ -159,6 +159,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `compactor.containerSecurityContext.capabilities.drop`        | List of capabilities to be dropped                                                                  | `["ALL"]`        |
 | `compactor.containerSecurityContext.seccompProfile.type`      | Set container's Security Context seccomp profile                                                    | `RuntimeDefault` |
 | `compactor.lifecycleHooks`                                    | for the compactor container(s) to automate configuration before or after startup                    | `{}`             |
+| `compactor.automountServiceAccountToken`                      | Mount Service Account token in pod                                                                  | `false`          |
 | `compactor.hostAliases`                                       | compactor pods host aliases                                                                         | `[]`             |
 | `compactor.podLabels`                                         | Extra labels for compactor pods                                                                     | `{}`             |
 | `compactor.podAnnotations`                                    | Annotations for compactor pods                                                                      | `{}`             |
@@ -244,6 +245,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `distributor.containerSecurityContext.capabilities.drop`        | List of capabilities to be dropped                                                                    | `["ALL"]`        |
 | `distributor.containerSecurityContext.seccompProfile.type`      | Set container's Security Context seccomp profile                                                      | `RuntimeDefault` |
 | `distributor.lifecycleHooks`                                    | for the distributor container(s) to automate configuration before or after startup                    | `{}`             |
+| `distributor.automountServiceAccountToken`                      | Mount Service Account token in pod                                                                    | `false`          |
 | `distributor.hostAliases`                                       | distributor pods host aliases                                                                         | `[]`             |
 | `distributor.podLabels`                                         | Extra labels for distributor pods                                                                     | `{}`             |
 | `distributor.podAnnotations`                                    | Annotations for distributor pods                                                                      | `{}`             |
@@ -332,6 +334,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `metricsGenerator.containerSecurityContext.capabilities.drop`        | List of capabilities to be dropped                                                                         | `["ALL"]`        |
 | `metricsGenerator.containerSecurityContext.seccompProfile.type`      | Set container's Security Context seccomp profile                                                           | `RuntimeDefault` |
 | `metricsGenerator.lifecycleHooks`                                    | for the metricsGenerator container(s) to automate configuration before or after startup                    | `{}`             |
+| `metricsGenerator.automountServiceAccountToken`                      | Mount Service Account token in pod                                                                         | `false`          |
 | `metricsGenerator.hostAliases`                                       | metricsGenerator pods host aliases                                                                         | `[]`             |
 | `metricsGenerator.podLabels`                                         | Extra labels for metricsGenerator pods                                                                     | `{}`             |
 | `metricsGenerator.podAnnotations`                                    | Annotations for metricsGenerator pods                                                                      | `{}`             |
@@ -418,6 +421,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `ingester.containerSecurityContext.allowPrivilegeEscalation` | Set container's Security Context allowPrivilegeEscalation                                          | `false`          |
 | `ingester.containerSecurityContext.capabilities.drop`        | List of capabilities to be dropped                                                                 | `["ALL"]`        |
 | `ingester.containerSecurityContext.seccompProfile.type`      | Set container's Security Context seccomp profile                                                   | `RuntimeDefault` |
+| `ingester.automountServiceAccountToken`                      | Mount Service Account token in pod                                                                 | `false`          |
 | `ingester.hostAliases`                                       | ingester pods host aliases                                                                         | `[]`             |
 | `ingester.podLabels`                                         | Extra labels for ingester pods                                                                     | `{}`             |
 | `ingester.podAnnotations`                                    | Annotations for ingester pods                                                                      | `{}`             |
@@ -518,6 +522,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `querier.containerSecurityContext.capabilities.drop`        | List of capabilities to be dropped                                                                | `["ALL"]`        |
 | `querier.containerSecurityContext.seccompProfile.type`      | Set container's Security Context seccomp profile                                                  | `RuntimeDefault` |
 | `querier.lifecycleHooks`                                    | for the Querier container(s) to automate configuration before or after startup                    | `{}`             |
+| `querier.automountServiceAccountToken`                      | Mount Service Account token in pod                                                                | `false`          |
 | `querier.hostAliases`                                       | querier pods host aliases                                                                         | `[]`             |
 | `querier.podLabels`                                         | Extra labels for querier pods                                                                     | `{}`             |
 | `querier.podAnnotations`                                    | Annotations for querier pods                                                                      | `{}`             |
@@ -605,6 +610,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `queryFrontend.containerSecurityContext.capabilities.drop`              | List of capabilities to be dropped                                                                                  | `["ALL"]`                             |
 | `queryFrontend.containerSecurityContext.seccompProfile.type`            | Set container's Security Context seccomp profile                                                                    | `RuntimeDefault`                      |
 | `queryFrontend.lifecycleHooks`                                          | for the queryFrontend container(s) to automate configuration before or after startup                                | `{}`                                  |
+| `queryFrontend.automountServiceAccountToken`                            | Mount Service Account token in pod                                                                                  | `false`                               |
 | `queryFrontend.hostAliases`                                             | queryFrontend pods host aliases                                                                                     | `[]`                                  |
 | `queryFrontend.podLabels`                                               | Extra labels for queryFrontend pods                                                                                 | `{}`                                  |
 | `queryFrontend.podAnnotations`                                          | Annotations for queryFrontend pods                                                                                  | `{}`                                  |
@@ -747,6 +753,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `vulture.containerSecurityContext.capabilities.drop`        | List of capabilities to be dropped                                                                              | `["ALL"]`                               |
 | `vulture.containerSecurityContext.seccompProfile.type`      | Set container's Security Context seccomp profile                                                                | `RuntimeDefault`                        |
 | `vulture.lifecycleHooks`                                    | for the vulture container(s) to automate configuration before or after startup                                  | `{}`                                    |
+| `vulture.automountServiceAccountToken`                      | Mount Service Account token in pod                                                                              | `false`                                 |
 | `vulture.hostAliases`                                       | vulture pods host aliases                                                                                       | `[]`                                    |
 | `vulture.podLabels`                                         | Extra labels for vulture pods                                                                                   | `{}`                                    |
 | `vulture.podAnnotations`                                    | Annotations for vulture pods                                                                                    | `{}`                                    |

--- a/bitnami/grafana-tempo/templates/compactor/deployment.yaml
+++ b/bitnami/grafana-tempo/templates/compactor/deployment.yaml
@@ -36,6 +36,7 @@ spec:
     spec:
       serviceAccountName: {{ template "grafana-tempo.serviceAccountName" . }}
       {{- include "grafana-tempo.imagePullSecrets" . | nindent 6 }}
+      automountServiceAccountToken: {{ .Values.compactor.automountServiceAccountToken }}
       {{- if .Values.compactor.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.compactor.hostAliases "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/grafana-tempo/templates/distributor/deployment.yaml
+++ b/bitnami/grafana-tempo/templates/distributor/deployment.yaml
@@ -35,6 +35,7 @@ spec:
     spec:
       serviceAccountName: {{ template "grafana-tempo.serviceAccountName" . }}
       {{- include "grafana-tempo.imagePullSecrets" . | nindent 6 }}
+      automountServiceAccountToken: {{ .Values.distributor.automountServiceAccountToken }}
       {{- if .Values.distributor.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.distributor.hostAliases "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/grafana-tempo/templates/ingester/statefulset.yaml
+++ b/bitnami/grafana-tempo/templates/ingester/statefulset.yaml
@@ -36,6 +36,7 @@ spec:
     spec:
       serviceAccountName: {{ template "grafana-tempo.serviceAccountName" . }}
       {{- include "grafana-tempo.imagePullSecrets" . | nindent 6 }}
+      automountServiceAccountToken: {{ .Values.ingester.automountServiceAccountToken }}
       {{- if .Values.ingester.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.ingester.hostAliases "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/grafana-tempo/templates/metrics-generator/deployment.yaml
+++ b/bitnami/grafana-tempo/templates/metrics-generator/deployment.yaml
@@ -35,6 +35,7 @@ spec:
     spec:
       serviceAccountName: {{ template "grafana-tempo.serviceAccountName" . }}
       {{- include "grafana-tempo.imagePullSecrets" . | nindent 6 }}
+      automountServiceAccountToken: {{ .Values.metricsGenerator.automountServiceAccountToken }}
       {{- if .Values.metricsGenerator.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.metricsGenerator.hostAliases "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/grafana-tempo/templates/querier/deployment.yaml
+++ b/bitnami/grafana-tempo/templates/querier/deployment.yaml
@@ -35,6 +35,7 @@ spec:
     spec:
       serviceAccountName: {{ template "grafana-tempo.serviceAccountName" . }}
       {{- include "grafana-tempo.imagePullSecrets" . | nindent 6 }}
+      automountServiceAccountToken: {{ .Values.querier.automountServiceAccountToken }}
       {{- if .Values.querier.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.querier.hostAliases "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/grafana-tempo/templates/query-frontend/deployment.yaml
+++ b/bitnami/grafana-tempo/templates/query-frontend/deployment.yaml
@@ -37,6 +37,7 @@ spec:
     spec:
       serviceAccountName: {{ template "grafana-tempo.serviceAccountName" . }}
       {{- include "grafana-tempo.imagePullSecrets" . | nindent 6 }}
+      automountServiceAccountToken: {{ .Values.queryFrontend.automountServiceAccountToken }}
       {{- if .Values.queryFrontend.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.queryFrontend.hostAliases "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/grafana-tempo/templates/vulture/deployment.yaml
+++ b/bitnami/grafana-tempo/templates/vulture/deployment.yaml
@@ -37,6 +37,7 @@ spec:
     spec:
       serviceAccountName: {{ template "grafana-tempo.serviceAccountName" . }}
       {{- include "grafana-tempo.imagePullSecrets" . | nindent 6 }}
+      automountServiceAccountToken: {{ .Values.vulture.automountServiceAccountToken }}
       {{- if .Values.vulture.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.vulture.hostAliases "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/grafana-tempo/values.yaml
+++ b/bitnami/grafana-tempo/values.yaml
@@ -381,6 +381,9 @@ compactor:
   ## @param compactor.lifecycleHooks for the compactor container(s) to automate configuration before or after startup
   ##
   lifecycleHooks: {}
+  ## @param compactor.automountServiceAccountToken Mount Service Account token in pod
+  ##
+  automountServiceAccountToken: false
   ## @param compactor.hostAliases compactor pods host aliases
   ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
   ##
@@ -660,6 +663,9 @@ distributor:
   ## @param distributor.lifecycleHooks for the distributor container(s) to automate configuration before or after startup
   ##
   lifecycleHooks: {}
+  ## @param distributor.automountServiceAccountToken Mount Service Account token in pod
+  ##
+  automountServiceAccountToken: false
   ## @param distributor.hostAliases distributor pods host aliases
   ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
   ##
@@ -945,6 +951,9 @@ metricsGenerator:
   ## @param metricsGenerator.lifecycleHooks for the metricsGenerator container(s) to automate configuration before or after startup
   ##
   lifecycleHooks: {}
+  ## @param metricsGenerator.automountServiceAccountToken Mount Service Account token in pod
+  ##
+  automountServiceAccountToken: false
   ## @param metricsGenerator.hostAliases metricsGenerator pods host aliases
   ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
   ##
@@ -1222,6 +1231,9 @@ ingester:
       drop: ["ALL"]
     seccompProfile:
       type: "RuntimeDefault"
+  ## @param ingester.automountServiceAccountToken Mount Service Account token in pod
+  ##
+  automountServiceAccountToken: false
   ## @param ingester.hostAliases ingester pods host aliases
   ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
   ##
@@ -1548,6 +1560,9 @@ querier:
   ## @param querier.lifecycleHooks for the Querier container(s) to automate configuration before or after startup
   ##
   lifecycleHooks: {}
+  ## @param querier.automountServiceAccountToken Mount Service Account token in pod
+  ##
+  automountServiceAccountToken: false
   ## @param querier.hostAliases querier pods host aliases
   ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
   ##
@@ -1831,6 +1846,9 @@ queryFrontend:
   ## @param queryFrontend.lifecycleHooks for the queryFrontend container(s) to automate configuration before or after startup
   ##
   lifecycleHooks: {}
+  ## @param queryFrontend.automountServiceAccountToken Mount Service Account token in pod
+  ##
+  automountServiceAccountToken: false
   ## @param queryFrontend.hostAliases queryFrontend pods host aliases
   ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
   ##
@@ -2306,6 +2324,9 @@ vulture:
   ## @param vulture.lifecycleHooks for the vulture container(s) to automate configuration before or after startup
   ##
   lifecycleHooks: {}
+  ## @param vulture.automountServiceAccountToken Mount Service Account token in pod
+  ##
+  automountServiceAccountToken: false
   ## @param vulture.hostAliases vulture pods host aliases
   ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
   ##


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

### Description of the change

This PR sets all ServiceAccount automountServiceAccountToken=false by default, as the token mounting should be set in the pod declaration instead (if a new pod uses this service account and the token gets automatically mounted, it could be problematic in terms of security). This PR also adds automountServiceAccountToken in the pod declaration as a new value, which can be configured by users in case they want to use an external token.

### Benefits

Charts become more security-compliant

### Possible drawbacks

n/a

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)

