### PR TITLE
[bitnami/kiam] fix: :lock: Move service-account token auto-mount to pod declaration

### DIFF
--- a/bitnami/kiam/Chart.yaml
+++ b/bitnami/kiam/Chart.yaml
@@ -28,4 +28,4 @@ maintainers:
 name: kiam
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/kiam
-version: 1.6.1
+version: 1.7.0

--- a/bitnami/kiam/README.md
+++ b/bitnami/kiam/README.md
@@ -97,6 +97,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `server.enabled`                                      | Deploy the kiam server                                                                                                                      | `true`           |
 | `server.containerPort`                                | HTTPS port to expose at container level                                                                                                     | `8443`           |
 | `server.resourceType`                                 | Specify how to deploy the server (allowed values: `daemonset` and `deployment`)                                                             | `daemonset`      |
+| `server.automountServiceAccountToken`                 | Mount Service Account token in pod                                                                                                          | `true`           |
 | `server.hostAliases`                                  | Add deployment host aliases                                                                                                                 | `[]`             |
 | `server.useHostNetwork`                               | Use host networking (ports will be directly exposed in the host)                                                                            | `false`          |
 | `server.replicaCount`                                 | Number of replicas to deploy (when `server.resourceType` is `daemonset`)                                                                    | `1`              |
@@ -191,12 +192,12 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### kiam server Service Account parameters
 
-| Name                                                 | Description                                                                                                         | Value  |
-| ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- | ------ |
-| `server.serviceAccount.create`                       | Specifies whether a ServiceAccount should be created                                                                | `true` |
-| `server.serviceAccount.name`                         | Name of the service account to use. If not set and create is true, a name is generated using the fullname template. | `""`   |
-| `server.serviceAccount.automountServiceAccountToken` | Automount service account token for the server service account                                                      | `true` |
-| `server.serviceAccount.annotations`                  | Annotations for service account. Evaluated as a template. Only used if `create` is `true`.                          | `{}`   |
+| Name                                                 | Description                                                                                                         | Value   |
+| ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- | ------- |
+| `server.serviceAccount.create`                       | Specifies whether a ServiceAccount should be created                                                                | `true`  |
+| `server.serviceAccount.name`                         | Name of the service account to use. If not set and create is true, a name is generated using the fullname template. | `""`    |
+| `server.serviceAccount.automountServiceAccountToken` | Automount service account token for the server service account                                                      | `false` |
+| `server.serviceAccount.annotations`                  | Annotations for service account. Evaluated as a template. Only used if `create` is `true`.                          | `{}`    |
 
 ### kiam server metrics parameters
 
@@ -228,6 +229,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `agent.schedulerName`                                | Name of the k8s scheduler (other than default)                                                                                              | `""`                      |
 | `agent.topologySpreadConstraints`                    | Topology Spread Constraints for pod assignment                                                                                              | `[]`                      |
 | `agent.allowRouteRegExp`                             | Regexp with the allowed paths for agents to redirect                                                                                        | `""`                      |
+| `agent.automountServiceAccountToken`                 | Mount Service Account token in pod                                                                                                          | `false`                   |
 | `agent.hostAliases`                                  | Add deployment host aliases                                                                                                                 | `[]`                      |
 | `agent.containerPort`                                | HTTPS port to expose at container level                                                                                                     | `8183`                    |
 | `agent.iptables`                                     | Have the agent modify the host iptables rules                                                                                               | `false`                   |

--- a/bitnami/kiam/templates/agent/agent-daemonset.yaml
+++ b/bitnami/kiam/templates/agent/agent-daemonset.yaml
@@ -31,6 +31,7 @@ spec:
         app.kubernetes.io/component: agent
     spec:
       {{- include "kiam.imagePullSecrets" . | nindent 6 }}
+      automountServiceAccountToken: {{ .Values.agent.automountServiceAccountToken }}
       {{- if .Values.agent.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.agent.hostAliases "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/kiam/templates/server/server-daemonset.yaml
+++ b/bitnami/kiam/templates/server/server-daemonset.yaml
@@ -31,6 +31,7 @@ spec:
         app.kubernetes.io/component: server
     spec:
       {{- include "kiam.imagePullSecrets" . | nindent 6 }}
+      automountServiceAccountToken: {{ .Values.server.automountServiceAccountToken }}
       {{- if .Values.server.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.server.hostAliases "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/kiam/templates/server/server-deployment.yaml
+++ b/bitnami/kiam/templates/server/server-deployment.yaml
@@ -32,6 +32,7 @@ spec:
         app.kubernetes.io/component: server
     spec:
       {{- include "kiam.imagePullSecrets" . | nindent 6 }}
+      automountServiceAccountToken: {{ .Values.server.automountServiceAccountToken }}
       {{- if .Values.server.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.server.hostAliases "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/kiam/values.yaml
+++ b/bitnami/kiam/values.yaml
@@ -97,6 +97,9 @@ server:
   ## @param server.resourceType Specify how to deploy the server (allowed values: `daemonset` and `deployment`)
   ##
   resourceType: daemonset
+  ## @param server.automountServiceAccountToken Mount Service Account token in pod
+  ##
+  automountServiceAccountToken: true
   ## @param server.hostAliases Add deployment host aliases
   ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
   ##
@@ -445,7 +448,7 @@ server:
   serviceAccount:
     create: true
     name: ""
-    automountServiceAccountToken: true
+    automountServiceAccountToken: false
     annotations: {}
 
   ## @section kiam server metrics parameters
@@ -534,6 +537,9 @@ agent:
   ## @param agent.allowRouteRegExp Regexp with the allowed paths for agents to redirect
   ##
   allowRouteRegExp: ""
+  ## @param agent.automountServiceAccountToken Mount Service Account token in pod
+  ##
+  automountServiceAccountToken: false
   ## @param agent.hostAliases Add deployment host aliases
   ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
   ##


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

### Description of the change

This PR sets all ServiceAccount automountServiceAccountToken=false by default, as the token mounting should be set in the pod declaration instead (if a new pod uses this service account and the token gets automatically mounted, it could be problematic in terms of security). This PR also adds automountServiceAccountToken in the pod declaration as a new value, which can be configured by users in case they want to use an external token.

### Benefits

Charts become more security-compliant

### Possible drawbacks

n/a

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)

