### PR TITLE
[bitnami/kuberay] fix: :lock: Move service-account token auto-mount to pod declaration

### DIFF
--- a/bitnami/kuberay/Chart.yaml
+++ b/bitnami/kuberay/Chart.yaml
@@ -32,4 +32,4 @@ maintainers:
 name: kuberay
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/kuberay
-version: 0.2.1
+version: 0.3.0

--- a/bitnami/kuberay/README.md
+++ b/bitnami/kuberay/README.md
@@ -139,6 +139,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `operator.containerSecurityContext.seccompProfile.type`      | Set container's Security Context seccomp profile                                                                                                                       | `RuntimeDefault`                   |
 | `operator.command`                                           | Override default container command (useful when using custom images)                                                                                                   | `[]`                               |
 | `operator.args`                                              | Override default container args (useful when using custom images)                                                                                                      | `[]`                               |
+| `operator.automountServiceAccountToken`                      | Mount Service Account token in pod                                                                                                                                     | `false`                            |
 | `operator.hostAliases`                                       | Kuberay Operator pods host aliases                                                                                                                                     | `[]`                               |
 | `operator.podLabels`                                         | Extra labels for Kuberay Operator pods                                                                                                                                 | `{}`                               |
 | `operator.podAnnotations`                                    | Annotations for Kuberay Operator pods                                                                                                                                  | `{}`                               |
@@ -210,14 +211,14 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Kuberay Operator RBAC Parameters
 
-| Name                                                   | Description                                                      | Value  |
-| ------------------------------------------------------ | ---------------------------------------------------------------- | ------ |
-| `operator.rbac.create`                                 | Specifies whether RBAC resources should be created               | `true` |
-| `operator.rbac.rules`                                  | Custom RBAC rules to set                                         | `[]`   |
-| `operator.serviceAccount.create`                       | Specifies whether a ServiceAccount should be created             | `true` |
-| `operator.serviceAccount.name`                         | The name of the ServiceAccount to use.                           | `""`   |
-| `operator.serviceAccount.annotations`                  | Additional Service Account annotations (evaluated as a template) | `{}`   |
-| `operator.serviceAccount.automountServiceAccountToken` | Automount service account token for the server service account   | `true` |
+| Name                                                   | Description                                                      | Value   |
+| ------------------------------------------------------ | ---------------------------------------------------------------- | ------- |
+| `operator.rbac.create`                                 | Specifies whether RBAC resources should be created               | `true`  |
+| `operator.rbac.rules`                                  | Custom RBAC rules to set                                         | `[]`    |
+| `operator.serviceAccount.create`                       | Specifies whether a ServiceAccount should be created             | `true`  |
+| `operator.serviceAccount.name`                         | The name of the ServiceAccount to use.                           | `""`    |
+| `operator.serviceAccount.annotations`                  | Additional Service Account annotations (evaluated as a template) | `{}`    |
+| `operator.serviceAccount.automountServiceAccountToken` | Automount service account token for the server service account   | `false` |
 
 ### Kuberay Operator Metrics Parameters
 
@@ -292,6 +293,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `apiserver.containerSecurityContext.seccompProfile.type`      | Set container's Security Context seccomp profile                                                                                                                       | `RuntimeDefault`                    |
 | `apiserver.command`                                           | Override default container command (useful when using custom images)                                                                                                   | `[]`                                |
 | `apiserver.args`                                              | Override default container args (useful when using custom images)                                                                                                      | `[]`                                |
+| `apiserver.automountServiceAccountToken`                      | Mount Service Account token in pod                                                                                                                                     | `false`                             |
 | `apiserver.hostAliases`                                       | Kuberay API Server pods host aliases                                                                                                                                   | `[]`                                |
 | `apiserver.podLabels`                                         | Extra labels for Kuberay API Server pods                                                                                                                               | `{}`                                |
 | `apiserver.podAnnotations`                                    | Annotations for Kuberay API Server pods                                                                                                                                | `{}`                                |
@@ -365,14 +367,14 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Kuberay API Server RBAC Parameters
 
-| Name                                                    | Description                                                      | Value  |
-| ------------------------------------------------------- | ---------------------------------------------------------------- | ------ |
-| `apiserver.rbac.create`                                 | Specifies whether RBAC resources should be created               | `true` |
-| `apiserver.rbac.rules`                                  | Custom RBAC rules to set                                         | `[]`   |
-| `apiserver.serviceAccount.create`                       | Specifies whether a ServiceAccount should be created             | `true` |
-| `apiserver.serviceAccount.name`                         | The name of the ServiceAccount to use.                           | `""`   |
-| `apiserver.serviceAccount.annotations`                  | Additional Service Account annotations (evaluated as a template) | `{}`   |
-| `apiserver.serviceAccount.automountServiceAccountToken` | Automount service account token for the server service account   | `true` |
+| Name                                                    | Description                                                      | Value   |
+| ------------------------------------------------------- | ---------------------------------------------------------------- | ------- |
+| `apiserver.rbac.create`                                 | Specifies whether RBAC resources should be created               | `true`  |
+| `apiserver.rbac.rules`                                  | Custom RBAC rules to set                                         | `[]`    |
+| `apiserver.serviceAccount.create`                       | Specifies whether a ServiceAccount should be created             | `true`  |
+| `apiserver.serviceAccount.name`                         | The name of the ServiceAccount to use.                           | `""`    |
+| `apiserver.serviceAccount.annotations`                  | Additional Service Account annotations (evaluated as a template) | `{}`    |
+| `apiserver.serviceAccount.automountServiceAccountToken` | Automount service account token for the server service account   | `false` |
 
 ### Kuberay API Server Metrics Parameters
 
@@ -422,6 +424,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `cluster.head.containerSecurityContext.seccompProfile.type`      | Set container's Security Context seccomp profile                                                                         | `RuntimeDefault` |
 | `cluster.head.command`                                           | Override default container command (useful when using custom images)                                                     | `[]`             |
 | `cluster.head.args`                                              | Override default container args (useful when using custom images)                                                        | `[]`             |
+| `cluster.head.automountServiceAccountToken`                      | Mount Service Account token in pod                                                                                       | `false`          |
 | `cluster.head.hostAliases`                                       | Ray Cluster Worker (common) pods host aliases                                                                            | `[]`             |
 | `cluster.head.podLabels`                                         | Extra labels for Ray Cluster Worker (common) pods                                                                        | `{}`             |
 | `cluster.head.podAnnotations`                                    | Annotations for Ray Cluster Worker (common) pods                                                                         | `{}`             |
@@ -476,6 +479,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `cluster.worker.common.containerSecurityContext.seccompProfile.type`      | Set container's Security Context seccomp profile                                                                         | `RuntimeDefault` |
 | `cluster.worker.common.command`                                           | Override default container command (useful when using custom images)                                                     | `[]`             |
 | `cluster.worker.common.args`                                              | Override default container args (useful when using custom images)                                                        | `[]`             |
+| `cluster.worker.common.automountServiceAccountToken`                      | Mount Service Account token in pod                                                                                       | `false`          |
 | `cluster.worker.common.hostAliases`                                       | Ray Cluster Worker (common) pods host aliases                                                                            | `[]`             |
 | `cluster.worker.common.podLabels`                                         | Extra labels for Ray Cluster Worker (common) pods                                                                        | `{}`             |
 | `cluster.worker.common.podAnnotations`                                    | Annotations for Ray Cluster Worker (common) pods                                                                         | `{}`             |

--- a/bitnami/kuberay/templates/apiserver/deployment.yaml
+++ b/bitnami/kuberay/templates/apiserver/deployment.yaml
@@ -40,6 +40,7 @@ spec:
     spec:
       serviceAccountName: {{ template "kuberay.apiserver.serviceAccountName" . }}
       {{- include "kuberay.imagePullSecrets" . | nindent 6 }}
+      automountServiceAccountToken: {{ .Values.apiserver.automountServiceAccountToken }}
       {{- if .Values.apiserver.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.apiserver.hostAliases "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/kuberay/templates/cluster/raycluster.yaml
+++ b/bitnami/kuberay/templates/cluster/raycluster.yaml
@@ -37,6 +37,7 @@ spec:
       spec:
         {{- include "kuberay.imagePullSecrets" . | nindent 8 }}
         serviceAccountName: {{ template "kuberay.cluster.serviceAccountName" . }}
+        automountServiceAccountToken: {{ .Values.cluster.head.automountServiceAccountToken }}
         {{- if .Values.cluster.head.hostAliases }}
         hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.cluster.head.hostAliases "context" $) | nindent 10 }}
         {{- end }}

--- a/bitnami/kuberay/templates/operator/deployment.yaml
+++ b/bitnami/kuberay/templates/operator/deployment.yaml
@@ -40,6 +40,7 @@ spec:
     spec:
       serviceAccountName: {{ template "kuberay.operator.serviceAccountName" . }}
       {{- include "kuberay.imagePullSecrets" . | nindent 6 }}
+      automountServiceAccountToken: {{ .Values.operator.automountServiceAccountToken }}
       {{- if .Values.operator.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.operator.hostAliases "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/kuberay/values.yaml
+++ b/bitnami/kuberay/values.yaml
@@ -256,6 +256,9 @@ operator:
   ## @param operator.args Override default container args (useful when using custom images)
   ##
   args: []
+  ## @param operator.automountServiceAccountToken Mount Service Account token in pod
+  ##
+  automountServiceAccountToken: false
   ## @param operator.hostAliases Kuberay Operator pods host aliases
   ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
   ##
@@ -623,7 +626,7 @@ operator:
     annotations: {}
     ## @param operator.serviceAccount.automountServiceAccountToken Automount service account token for the server service account
     ##
-    automountServiceAccountToken: true
+    automountServiceAccountToken: false
 
   ## @section Kuberay Operator Metrics Parameters
   ##
@@ -842,6 +845,9 @@ apiserver:
   ## @param apiserver.args Override default container args (useful when using custom images)
   ##
   args: []
+  ## @param apiserver.automountServiceAccountToken Mount Service Account token in pod
+  ##
+  automountServiceAccountToken: false
   ## @param apiserver.hostAliases Kuberay API Server pods host aliases
   ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
   ##
@@ -1212,7 +1218,7 @@ apiserver:
     annotations: {}
     ## @param apiserver.serviceAccount.automountServiceAccountToken Automount service account token for the server service account
     ##
-    automountServiceAccountToken: true
+    automountServiceAccountToken: false
 
   ## @section Kuberay API Server Metrics Parameters
   ##
@@ -1341,6 +1347,9 @@ cluster:
     ## @param cluster.head.args Override default container args (useful when using custom images)
     ##
     args: []
+    ## @param cluster.head.automountServiceAccountToken Mount Service Account token in pod
+    ##
+    automountServiceAccountToken: false
     ## @param cluster.head.hostAliases Ray Cluster Worker (common) pods host aliases
     ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
     ##
@@ -1530,6 +1539,9 @@ cluster:
       ## @param cluster.worker.common.args Override default container args (useful when using custom images)
       ##
       args: []
+      ## @param cluster.worker.common.automountServiceAccountToken Mount Service Account token in pod
+      ##
+      automountServiceAccountToken: false
       ## @param cluster.worker.common.hostAliases Ray Cluster Worker (common) pods host aliases
       ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
       ##


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

### Description of the change

This PR sets all ServiceAccount automountServiceAccountToken=false by default, as the token mounting should be set in the pod declaration instead (if a new pod uses this service account and the token gets automatically mounted, it could be problematic in terms of security). This PR also adds automountServiceAccountToken in the pod declaration as a new value, which can be configured by users in case they want to use an external token.

### Benefits

Charts become more security-compliant

### Possible drawbacks

n/a

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)

