### PR TITLE
[bitnami/mastodon] fix: :lock: Move service-account token auto-mount to pod declaration

### DIFF
--- a/.vib/mastodon/goss/goss.yaml
+++ b/.vib/mastodon/goss/goss.yaml
@@ -32,7 +32,7 @@ command:
     - /REDIS_HOST.*mastodon-redis/
     - /REDIS_PORT.*{{ .Vars.redis.master.service.ports.redis }}/
     - /S3_ENDPOINT.*http://mastodon-minio:{{ .Vars.minio.service.ports.api }}/
-  {{ if .Vars.serviceAccount.automountServiceAccountToken }}
+  {{ if .Vars.web.automountServiceAccountToken }}
   check-sa:
     exec: cat /var/run/secrets/kubernetes.io/serviceaccount/token | cut -d '.' -f 2 | xargs -I '{}' echo '{}====' | fold -w 4 | sed '$ d' | tr -d '\n' | base64 -d
     exit-status: 0

--- a/.vib/mastodon/runtime-parameters.yaml
+++ b/.vib/mastodon/runtime-parameters.yaml
@@ -5,7 +5,6 @@ webDomain: bitnami-mastodon.my
 
 serviceAccount:
   create: true
-  automountServiceAccountToken: true
 
 web:
   containerPorts:
@@ -23,6 +22,7 @@ web:
   service:
     ports:
       http: 8500
+  automountServiceAccountToken: true
 
 streaming:
   service:

--- a/bitnami/mastodon/Chart.yaml
+++ b/bitnami/mastodon/Chart.yaml
@@ -49,4 +49,4 @@ maintainers:
 name: mastodon
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/mastodon
-version: 4.1.1
+version: 4.2.0

--- a/bitnami/mastodon/README.md
+++ b/bitnami/mastodon/README.md
@@ -178,6 +178,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `web.containerSecurityContext.seccompProfile.type`      | Set container's Security Context seccomp profile                                                                         | `RuntimeDefault` |
 | `web.command`                                           | Override default container command (useful when using custom images)                                                     | `[]`             |
 | `web.args`                                              | Override default container args (useful when using custom images)                                                        | `[]`             |
+| `web.automountServiceAccountToken`                      | Mount Service Account token in pod                                                                                       | `false`          |
 | `web.hostAliases`                                       | Mastodon web pods host aliases                                                                                           | `[]`             |
 | `web.podLabels`                                         | Extra labels for Mastodon web pods                                                                                       | `{}`             |
 | `web.podAnnotations`                                    | Annotations for Mastodon web pods                                                                                        | `{}`             |
@@ -263,6 +264,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `sidekiq.containerSecurityContext.seccompProfile.type`      | Set container's Security Context seccomp profile                                                                         | `RuntimeDefault` |
 | `sidekiq.command`                                           | Override default container command (useful when using custom images)                                                     | `[]`             |
 | `sidekiq.args`                                              | Override default container args (useful when using custom images)                                                        | `[]`             |
+| `sidekiq.automountServiceAccountToken`                      | Mount Service Account token in pod                                                                                       | `false`          |
 | `sidekiq.hostAliases`                                       | Mastodon sidekiq pods host aliases                                                                                       | `[]`             |
 | `sidekiq.podLabels`                                         | Extra labels for Mastodon sidekiq pods                                                                                   | `{}`             |
 | `sidekiq.podAnnotations`                                    | Annotations for Mastodon sidekiq pods                                                                                    | `{}`             |
@@ -333,6 +335,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `streaming.containerSecurityContext.seccompProfile.type`      | Set container's Security Context seccomp profile                                                                         | `RuntimeDefault` |
 | `streaming.command`                                           | Override default container command (useful when using custom images)                                                     | `[]`             |
 | `streaming.args`                                              | Override default container args (useful when using custom images)                                                        | `[]`             |
+| `streaming.automountServiceAccountToken`                      | Mount Service Account token in pod                                                                                       | `false`          |
 | `streaming.hostAliases`                                       | Mastodon streaming pods host aliases                                                                                     | `[]`             |
 | `streaming.podLabels`                                         | Extra labels for Mastodon streaming pods                                                                                 | `{}`             |
 | `streaming.podAnnotations`                                    | Annotations for Mastodon streaming pods                                                                                  | `{}`             |
@@ -425,6 +428,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `initJob.extraVolumeMounts`                                 | Array of extra volume mounts to be added to the Mastodon Container (evaluated as template). Normally used with `extraVolumes`. | `[]`             |
 | `initJob.resources.limits`                                  | The resources limits for the container                                                                                         | `{}`             |
 | `initJob.resources.requests`                                | The requested resources for the container                                                                                      | `{}`             |
+| `initJob.automountServiceAccountToken`                      | Mount Service Account token in pod                                                                                             | `false`          |
 | `initJob.hostAliases`                                       | Add deployment host aliases                                                                                                    | `[]`             |
 | `initJob.annotations`                                       | Add annotations to the job                                                                                                     | `{}`             |
 | `initJob.podLabels`                                         | Additional pod labels                                                                                                          | `{}`             |

--- a/bitnami/mastodon/templates/init-job/init-job.yaml
+++ b/bitnami/mastodon/templates/init-job/init-job.yaml
@@ -31,6 +31,7 @@ spec:
       {{- if .Values.initJob.podSecurityContext.enabled }}
       securityContext: {{- omit .Values.initJob.podSecurityContext "enabled" | toYaml | nindent 8 }}
       {{- end }}
+      automountServiceAccountToken: {{ .Values.initJob.automountServiceAccountToken }}
       {{- if .Values.initJob.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.initJob.hostAliases "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/mastodon/templates/sidekiq/deployment.yaml
+++ b/bitnami/mastodon/templates/sidekiq/deployment.yaml
@@ -34,6 +34,7 @@ spec:
     spec:
       serviceAccountName: {{ template "mastodon.serviceAccountName" . }}
       {{- include "mastodon.imagePullSecrets" . | nindent 6 }}
+      automountServiceAccountToken: {{ .Values.sidekiq.automountServiceAccountToken }}
       {{- if .Values.sidekiq.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.sidekiq.hostAliases "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/mastodon/templates/streaming/deployment.yaml
+++ b/bitnami/mastodon/templates/streaming/deployment.yaml
@@ -34,6 +34,7 @@ spec:
     spec:
       serviceAccountName: {{ template "mastodon.serviceAccountName" . }}
       {{- include "mastodon.imagePullSecrets" . | nindent 6 }}
+      automountServiceAccountToken: {{ .Values.streaming.automountServiceAccountToken }}
       {{- if .Values.streaming.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.streaming.hostAliases "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/mastodon/templates/web/deployment.yaml
+++ b/bitnami/mastodon/templates/web/deployment.yaml
@@ -34,6 +34,7 @@ spec:
     spec:
       serviceAccountName: {{ template "mastodon.serviceAccountName" . }}
       {{- include "mastodon.imagePullSecrets" . | nindent 6 }}
+      automountServiceAccountToken: {{ .Values.web.automountServiceAccountToken }}
       {{- if .Values.web.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.web.hostAliases "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/mastodon/values.yaml
+++ b/bitnami/mastodon/values.yaml
@@ -356,6 +356,9 @@ web:
   ## @param web.args Override default container args (useful when using custom images)
   ##
   args: []
+  ## @param web.automountServiceAccountToken Mount Service Account token in pod
+  ##
+  automountServiceAccountToken: false
   ## @param web.hostAliases Mastodon web pods host aliases
   ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
   ##
@@ -642,6 +645,9 @@ sidekiq:
   ## @param sidekiq.args Override default container args (useful when using custom images)
   ##
   args: []
+  ## @param sidekiq.automountServiceAccountToken Mount Service Account token in pod
+  ##
+  automountServiceAccountToken: false
   ## @param sidekiq.hostAliases Mastodon sidekiq pods host aliases
   ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
   ##
@@ -878,6 +884,9 @@ streaming:
   ## @param streaming.args Override default container args (useful when using custom images)
   ##
   args: []
+  ## @param streaming.automountServiceAccountToken Mount Service Account token in pod
+  ##
+  automountServiceAccountToken: false
   ## @param streaming.hostAliases Mastodon streaming pods host aliases
   ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
   ##
@@ -1173,6 +1182,9 @@ initJob:
   resources:
     limits: {}
     requests: {}
+  ## @param initJob.automountServiceAccountToken Mount Service Account token in pod
+  ##
+  automountServiceAccountToken: false
   ## @param initJob.hostAliases Add deployment host aliases
   ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
   ##


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

### Description of the change

This PR sets all ServiceAccount automountServiceAccountToken=false by default, as the token mounting should be set in the pod declaration instead (if a new pod uses this service account and the token gets automatically mounted, it could be problematic in terms of security). This PR also adds automountServiceAccountToken in the pod declaration as a new value, which can be configured by users in case they want to use an external token.

### Benefits

Charts become more security-compliant

### Possible drawbacks

n/a

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)

