### PR TITLE
[bitnami/milvus] fix: :lock: Move service-account token auto-mount to pod declaration

### DIFF
--- a/.vib/milvus/goss/goss.yaml
+++ b/.vib/milvus/goss/goss.yaml
@@ -95,7 +95,7 @@ command:
     - "CapBnd:	0000000000000000"
     - "CapAmb:	0000000000000000"
   {{- end }}
-  {{ if .Vars.proxy.serviceAccount.automountServiceAccountToken }}
+  {{ if .Vars.proxy.automountServiceAccountToken }}
   check-sa:
     exec: cat /var/run/secrets/kubernetes.io/serviceaccount/token | cut -d '.' -f 2 | xargs -I '{}' echo '{}====' | fold -w 4 | sed '$ d' | tr -d '\n' | base64 -d
     exit-status: 0

--- a/.vib/milvus/runtime-parameters.yaml
+++ b/.vib/milvus/runtime-parameters.yaml
@@ -30,7 +30,7 @@ proxy:
       metrics: 8003
   serviceAccount:
     create: true
-    automountServiceAccountToken: true
+  automountServiceAccountToken: true
 
 dataCoord:
   enabled: true

--- a/bitnami/milvus/Chart.yaml
+++ b/bitnami/milvus/Chart.yaml
@@ -48,4 +48,4 @@ maintainers:
 name: milvus
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/milvus
-version: 5.2.0
+version: 5.3.0

--- a/bitnami/milvus/README.md
+++ b/bitnami/milvus/README.md
@@ -142,6 +142,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `initJob.extraVolumeMounts`                                 | Array of extra volume mounts to be added to the jwt Container (evaluated as template). Normally used with `extraVolumes`. | `[]`             |
 | `initJob.resources.limits`                                  | The resources limits for the container                                                                                    | `{}`             |
 | `initJob.resources.requests`                                | The requested resources for the container                                                                                 | `{}`             |
+| `initJob.automountServiceAccountToken`                      | Mount Service Account token in pod                                                                                        | `false`          |
 | `initJob.hostAliases`                                       | Add deployment host aliases                                                                                               | `[]`             |
 | `initJob.annotations`                                       | Add annotations to the job                                                                                                | `{}`             |
 | `initJob.podLabels`                                         | Additional pod labels                                                                                                     | `{}`             |
@@ -203,6 +204,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `dataCoord.containerSecurityContext.seccompProfile.type`      | Set container's Security Context seccomp profile                                                           | `RuntimeDefault` |
 | `dataCoord.lifecycleHooks`                                    | for the data coordinator container(s) to automate configuration before or after startup                    | `{}`             |
 | `dataCoord.runtimeClassName`                                  | Name of the runtime class to be used by pod(s)                                                             | `""`             |
+| `dataCoord.automountServiceAccountToken`                      | Mount Service Account token in pod                                                                         | `false`          |
 | `dataCoord.hostAliases`                                       | data coordinator pods host aliases                                                                         | `[]`             |
 | `dataCoord.podLabels`                                         | Extra labels for data coordinator pods                                                                     | `{}`             |
 | `dataCoord.podAnnotations`                                    | Annotations for data coordinator pods                                                                      | `{}`             |
@@ -347,6 +349,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `rootCoord.containerSecurityContext.seccompProfile.type`      | Set container's Security Context seccomp profile                                                           | `RuntimeDefault` |
 | `rootCoord.lifecycleHooks`                                    | for the data coordinator container(s) to automate configuration before or after startup                    | `{}`             |
 | `rootCoord.runtimeClassName`                                  | Name of the runtime class to be used by pod(s)                                                             | `""`             |
+| `rootCoord.automountServiceAccountToken`                      | Mount Service Account token in pod                                                                         | `false`          |
 | `rootCoord.hostAliases`                                       | data coordinator pods host aliases                                                                         | `[]`             |
 | `rootCoord.podLabels`                                         | Extra labels for data coordinator pods                                                                     | `{}`             |
 | `rootCoord.podAnnotations`                                    | Annotations for data coordinator pods                                                                      | `{}`             |
@@ -491,6 +494,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `queryCoord.containerSecurityContext.seccompProfile.type`      | Set container's Security Context seccomp profile                                                           | `RuntimeDefault` |
 | `queryCoord.lifecycleHooks`                                    | for the data coordinator container(s) to automate configuration before or after startup                    | `{}`             |
 | `queryCoord.runtimeClassName`                                  | Name of the runtime class to be used by pod(s)                                                             | `""`             |
+| `queryCoord.automountServiceAccountToken`                      | Mount Service Account token in pod                                                                         | `false`          |
 | `queryCoord.hostAliases`                                       | data coordinator pods host aliases                                                                         | `[]`             |
 | `queryCoord.podLabels`                                         | Extra labels for data coordinator pods                                                                     | `{}`             |
 | `queryCoord.podAnnotations`                                    | Annotations for data coordinator pods                                                                      | `{}`             |
@@ -635,6 +639,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `indexCoord.containerSecurityContext.seccompProfile.type`      | Set container's Security Context seccomp profile                                                           | `RuntimeDefault` |
 | `indexCoord.lifecycleHooks`                                    | for the data coordinator container(s) to automate configuration before or after startup                    | `{}`             |
 | `indexCoord.runtimeClassName`                                  | Name of the runtime class to be used by pod(s)                                                             | `""`             |
+| `indexCoord.automountServiceAccountToken`                      | Mount Service Account token in pod                                                                         | `false`          |
 | `indexCoord.hostAliases`                                       | data coordinator pods host aliases                                                                         | `[]`             |
 | `indexCoord.podLabels`                                         | Extra labels for data coordinator pods                                                                     | `{}`             |
 | `indexCoord.podAnnotations`                                    | Annotations for data coordinator pods                                                                      | `{}`             |
@@ -779,6 +784,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `dataNode.containerSecurityContext.seccompProfile.type`      | Set container's Security Context seccomp profile                                                    | `RuntimeDefault` |
 | `dataNode.lifecycleHooks`                                    | for the data node container(s) to automate configuration before or after startup                    | `{}`             |
 | `dataNode.runtimeClassName`                                  | Name of the runtime class to be used by pod(s)                                                      | `""`             |
+| `dataNode.automountServiceAccountToken`                      | Mount Service Account token in pod                                                                  | `false`          |
 | `dataNode.hostAliases`                                       | data node pods host aliases                                                                         | `[]`             |
 | `dataNode.podLabels`                                         | Extra labels for data node pods                                                                     | `{}`             |
 | `dataNode.podAnnotations`                                    | Annotations for data node pods                                                                      | `{}`             |
@@ -923,6 +929,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `queryNode.containerSecurityContext.seccompProfile.type`      | Set container's Security Context seccomp profile                                                    | `RuntimeDefault` |
 | `queryNode.lifecycleHooks`                                    | for the data node container(s) to automate configuration before or after startup                    | `{}`             |
 | `queryNode.runtimeClassName`                                  | Name of the runtime class to be used by pod(s)                                                      | `""`             |
+| `queryNode.automountServiceAccountToken`                      | Mount Service Account token in pod                                                                  | `false`          |
 | `queryNode.hostAliases`                                       | data node pods host aliases                                                                         | `[]`             |
 | `queryNode.podLabels`                                         | Extra labels for data node pods                                                                     | `{}`             |
 | `queryNode.podAnnotations`                                    | Annotations for data node pods                                                                      | `{}`             |
@@ -1067,6 +1074,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `indexNode.containerSecurityContext.seccompProfile.type`      | Set container's Security Context seccomp profile                                                    | `RuntimeDefault` |
 | `indexNode.lifecycleHooks`                                    | for the data node container(s) to automate configuration before or after startup                    | `{}`             |
 | `indexNode.runtimeClassName`                                  | Name of the runtime class to be used by pod(s)                                                      | `""`             |
+| `indexNode.automountServiceAccountToken`                      | Mount Service Account token in pod                                                                  | `false`          |
 | `indexNode.hostAliases`                                       | data node pods host aliases                                                                         | `[]`             |
 | `indexNode.podLabels`                                         | Extra labels for data node pods                                                                     | `{}`             |
 | `indexNode.podAnnotations`                                    | Annotations for data node pods                                                                      | `{}`             |
@@ -1223,6 +1231,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `proxy.containerSecurityContext.seccompProfile.type`      | Set container's Security Context seccomp profile                                                | `RuntimeDefault` |
 | `proxy.lifecycleHooks`                                    | for the proxy container(s) to automate configuration before or after startup                    | `{}`             |
 | `proxy.runtimeClassName`                                  | Name of the runtime class to be used by pod(s)                                                  | `""`             |
+| `proxy.automountServiceAccountToken`                      | Mount Service Account token in pod                                                              | `false`          |
 | `proxy.hostAliases`                                       | proxy pods host aliases                                                                         | `[]`             |
 | `proxy.podLabels`                                         | Extra labels for proxy pods                                                                     | `{}`             |
 | `proxy.podAnnotations`                                    | Annotations for proxy pods                                                                      | `{}`             |
@@ -1368,6 +1377,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `attu.containerSecurityContext.seccompProfile.type`      | Set container's Security Context seccomp profile                                                     | `RuntimeDefault`       |
 | `attu.lifecycleHooks`                                    | for the attu container(s) to automate configuration before or after startup                          | `{}`                   |
 | `attu.runtimeClassName`                                  | Name of the runtime class to be used by pod(s)                                                       | `""`                   |
+| `attu.automountServiceAccountToken`                      | Mount Service Account token in pod                                                                   | `false`                |
 | `attu.hostAliases`                                       | attu pods host aliases                                                                               | `[]`                   |
 | `attu.podLabels`                                         | Extra labels for attu pods                                                                           | `{}`                   |
 | `attu.podAnnotations`                                    | Annotations for attu pods                                                                            | `{}`                   |

--- a/bitnami/milvus/templates/attu/deployment.yaml
+++ b/bitnami/milvus/templates/attu/deployment.yaml
@@ -43,6 +43,7 @@ spec:
       {{- end }}
       serviceAccountName: {{ template "milvus.attu.serviceAccountName" . }}
       {{- include "milvus.imagePullSecrets" . | nindent 6 }}
+      automountServiceAccountToken: {{ .Values.attu.automountServiceAccountToken }}
       {{- if .Values.attu.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.attu.hostAliases "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/milvus/templates/data-coordinator/deployment.yaml
+++ b/bitnami/milvus/templates/data-coordinator/deployment.yaml
@@ -45,6 +45,7 @@ spec:
       {{- end }}
       serviceAccountName: {{ template "milvus.data-coordinator.serviceAccountName" . }}
       {{- include "milvus.imagePullSecrets" . | nindent 6 }}
+      automountServiceAccountToken: {{ .Values.dataCoord.automountServiceAccountToken }}
       {{- if .Values.dataCoord.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.dataCoord.hostAliases "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/milvus/templates/data-node/deployment.yaml
+++ b/bitnami/milvus/templates/data-node/deployment.yaml
@@ -45,6 +45,7 @@ spec:
       {{- end }}
       serviceAccountName: {{ template "milvus.data-node.serviceAccountName" . }}
       {{- include "milvus.imagePullSecrets" . | nindent 6 }}
+      automountServiceAccountToken: {{ .Values.dataNode.automountServiceAccountToken }}
       {{- if .Values.dataNode.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.dataNode.hostAliases "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/milvus/templates/index-coordinator/deployment.yaml
+++ b/bitnami/milvus/templates/index-coordinator/deployment.yaml
@@ -45,6 +45,7 @@ spec:
       {{- end }}
       serviceAccountName: {{ template "milvus.index-coordinator.serviceAccountName" . }}
       {{- include "milvus.imagePullSecrets" . | nindent 6 }}
+      automountServiceAccountToken: {{ .Values.indexCoord.automountServiceAccountToken }}
       {{- if .Values.indexCoord.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.indexCoord.hostAliases "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/milvus/templates/index-node/deployment.yaml
+++ b/bitnami/milvus/templates/index-node/deployment.yaml
@@ -45,6 +45,7 @@ spec:
       {{- end }}
       serviceAccountName: {{ template "milvus.index-node.serviceAccountName" . }}
       {{- include "milvus.imagePullSecrets" . | nindent 6 }}
+      automountServiceAccountToken: {{ .Values.indexNode.automountServiceAccountToken }}
       {{- if .Values.indexNode.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.indexNode.hostAliases "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/milvus/templates/init-job.yaml
+++ b/bitnami/milvus/templates/init-job.yaml
@@ -33,6 +33,7 @@ spec:
       {{- if .Values.initJob.podSecurityContext.enabled }}
       securityContext: {{- omit .Values.initJob.podSecurityContext "enabled" | toYaml | nindent 8 }}
       {{- end }}
+      automountServiceAccountToken: {{ .Values.initJob.automountServiceAccountToken }}
       {{- if .Values.initJob.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.initJob.hostAliases "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/milvus/templates/proxy/deployment.yaml
+++ b/bitnami/milvus/templates/proxy/deployment.yaml
@@ -45,6 +45,7 @@ spec:
       {{- end }}
       serviceAccountName: {{ template "milvus.proxy.serviceAccountName" . }}
       {{- include "milvus.imagePullSecrets" . | nindent 6 }}
+      automountServiceAccountToken: {{ .Values.proxy.automountServiceAccountToken }}
       {{- if .Values.proxy.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.proxy.hostAliases "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/milvus/templates/query-coordinator/deployment.yaml
+++ b/bitnami/milvus/templates/query-coordinator/deployment.yaml
@@ -45,6 +45,7 @@ spec:
       {{- end }}
       serviceAccountName: {{ template "milvus.query-coordinator.serviceAccountName" . }}
       {{- include "milvus.imagePullSecrets" . | nindent 6 }}
+      automountServiceAccountToken: {{ .Values.queryCoord.automountServiceAccountToken }}
       {{- if .Values.queryCoord.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.queryCoord.hostAliases "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/milvus/templates/query-node/deployment.yaml
+++ b/bitnami/milvus/templates/query-node/deployment.yaml
@@ -45,6 +45,7 @@ spec:
       {{- end }}
       serviceAccountName: {{ template "milvus.query-node.serviceAccountName" . }}
       {{- include "milvus.imagePullSecrets" . | nindent 6 }}
+      automountServiceAccountToken: {{ .Values.queryNode.automountServiceAccountToken }}
       {{- if .Values.queryNode.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.queryNode.hostAliases "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/milvus/templates/root-coordinator/deployment.yaml
+++ b/bitnami/milvus/templates/root-coordinator/deployment.yaml
@@ -45,6 +45,7 @@ spec:
       {{- end }}
       serviceAccountName: {{ template "milvus.root-coordinator.serviceAccountName" . }}
       {{- include "milvus.imagePullSecrets" . | nindent 6 }}
+      automountServiceAccountToken: {{ .Values.rootCoord.automountServiceAccountToken }}
       {{- if .Values.rootCoord.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.rootCoord.hostAliases "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/milvus/values.yaml
+++ b/bitnami/milvus/values.yaml
@@ -378,6 +378,9 @@ initJob:
   resources:
     limits: {}
     requests: {}
+  ## @param initJob.automountServiceAccountToken Mount Service Account token in pod
+  ##
+  automountServiceAccountToken: false
   ## @param initJob.hostAliases Add deployment host aliases
   ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
   ##
@@ -555,6 +558,9 @@ dataCoord:
   ## ref: https://kubernetes.io/docs/concepts/containers/runtime-class/
   ##
   runtimeClassName: ""
+  ## @param dataCoord.automountServiceAccountToken Mount Service Account token in pod
+  ##
+  automountServiceAccountToken: false
   ## @param dataCoord.hostAliases data coordinator pods host aliases
   ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
   ##
@@ -1051,6 +1057,9 @@ rootCoord:
   ## ref: https://kubernetes.io/docs/concepts/containers/runtime-class/
   ##
   runtimeClassName: ""
+  ## @param rootCoord.automountServiceAccountToken Mount Service Account token in pod
+  ##
+  automountServiceAccountToken: false
   ## @param rootCoord.hostAliases data coordinator pods host aliases
   ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
   ##
@@ -1546,6 +1555,9 @@ queryCoord:
   ## ref: https://kubernetes.io/docs/concepts/containers/runtime-class/
   ##
   runtimeClassName: ""
+  ## @param queryCoord.automountServiceAccountToken Mount Service Account token in pod
+  ##
+  automountServiceAccountToken: false
   ## @param queryCoord.hostAliases data coordinator pods host aliases
   ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
   ##
@@ -2042,6 +2054,9 @@ indexCoord:
   ## ref: https://kubernetes.io/docs/concepts/containers/runtime-class/
   ##
   runtimeClassName: ""
+  ## @param indexCoord.automountServiceAccountToken Mount Service Account token in pod
+  ##
+  automountServiceAccountToken: false
   ## @param indexCoord.hostAliases data coordinator pods host aliases
   ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
   ##
@@ -2538,6 +2553,9 @@ dataNode:
   ## ref: https://kubernetes.io/docs/concepts/containers/runtime-class/
   ##
   runtimeClassName: ""
+  ## @param dataNode.automountServiceAccountToken Mount Service Account token in pod
+  ##
+  automountServiceAccountToken: false
   ## @param dataNode.hostAliases data node pods host aliases
   ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
   ##
@@ -3034,6 +3052,9 @@ queryNode:
   ## ref: https://kubernetes.io/docs/concepts/containers/runtime-class/
   ##
   runtimeClassName: ""
+  ## @param queryNode.automountServiceAccountToken Mount Service Account token in pod
+  ##
+  automountServiceAccountToken: false
   ## @param queryNode.hostAliases data node pods host aliases
   ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
   ##
@@ -3530,6 +3551,9 @@ indexNode:
   ## ref: https://kubernetes.io/docs/concepts/containers/runtime-class/
   ##
   runtimeClassName: ""
+  ## @param indexNode.automountServiceAccountToken Mount Service Account token in pod
+  ##
+  automountServiceAccountToken: false
   ## @param indexNode.hostAliases data node pods host aliases
   ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
   ##
@@ -4055,6 +4079,9 @@ proxy:
   ## ref: https://kubernetes.io/docs/concepts/containers/runtime-class/
   ##
   runtimeClassName: ""
+  ## @param proxy.automountServiceAccountToken Mount Service Account token in pod
+  ##
+  automountServiceAccountToken: false
   ## @param proxy.hostAliases proxy pods host aliases
   ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
   ##
@@ -4563,6 +4590,9 @@ attu:
   ## ref: https://kubernetes.io/docs/concepts/containers/runtime-class/
   ##
   runtimeClassName: ""
+  ## @param attu.automountServiceAccountToken Mount Service Account token in pod
+  ##
+  automountServiceAccountToken: false
   ## @param attu.hostAliases attu pods host aliases
   ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
   ##


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

### Description of the change

This PR sets all ServiceAccount automountServiceAccountToken=false by default, as the token mounting should be set in the pod declaration instead (if a new pod uses this service account and the token gets automatically mounted, it could be problematic in terms of security). This PR also adds automountServiceAccountToken in the pod declaration as a new value, which can be configured by users in case they want to use an external token.

### Benefits

Charts become more security-compliant

### Possible drawbacks

n/a

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)

