### PR TITLE
[bitnami/nginx-ingress-controller] fix: :lock: Move service-account token auto-mount to pod declaration

### DIFF
--- a/.vib/nginx-ingress-controller/goss/goss.yaml
+++ b/.vib/nginx-ingress-controller/goss/goss.yaml
@@ -18,7 +18,7 @@ command:
     exit-status: 0
     stdout:
       - "Bounding set =cap_{{ index .Vars.containerSecurityContext.capabilities.add 0 | toLower }}"
-  {{ if .Vars.serviceAccount.automountServiceAccountToken }}
+  {{ if .Vars.automountServiceAccountToken }}
   check-sa:
     exec: cat /var/run/secrets/kubernetes.io/serviceaccount/token | cut -d '.' -f 2 | xargs -I '{}' echo '{}====' | fold -w 4 | sed '$ d' | tr -d '\n' | base64 -d
     exit-status: 0

--- a/.vib/nginx-ingress-controller/runtime-parameters.yaml
+++ b/.vib/nginx-ingress-controller/runtime-parameters.yaml
@@ -33,7 +33,7 @@ service:
   type: LoadBalancer
 serviceAccount:
   create: true
-  automountServiceAccountToken: true
+automountServiceAccountToken: true
 rbac:
   create: true
 extraDeploy:

--- a/bitnami/nginx-ingress-controller/Chart.yaml
+++ b/bitnami/nginx-ingress-controller/Chart.yaml
@@ -34,4 +34,4 @@ maintainers:
 name: nginx-ingress-controller
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/nginx-ingress-controller
-version: 10.0.1
+version: 10.1.0

--- a/bitnami/nginx-ingress-controller/README.md
+++ b/bitnami/nginx-ingress-controller/README.md
@@ -85,6 +85,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `image.pullPolicy`                     | Nginx Ingress Controller image pull policy                                                                                                         | `IfNotPresent`                             |
 | `image.pullSecrets`                    | Specify docker-registry secret names as an array                                                                                                   | `[]`                                       |
 | `containerPorts`                       | Controller container ports to open                                                                                                                 | `{}`                                       |
+| `automountServiceAccountToken`         | Mount Service Account token in pod                                                                                                                 | `true`                                     |
 | `hostAliases`                          | Deployment pod host aliases                                                                                                                        | `[]`                                       |
 | `config`                               | Custom configuration options for NGINX                                                                                                             | `{}`                                       |
 | `proxySetHeaders`                      | Custom headers before sending traffic to backends                                                                                                  | `{}`                                       |
@@ -195,6 +196,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | Name                                                               | Description                                                                                                     | Value                   |
 | ------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------- | ----------------------- |
 | `defaultBackend.enabled`                                           | Enable a default backend based on NGINX                                                                         | `true`                  |
+| `defaultBackend.automountServiceAccountToken`                      | Mount Service Account token in pod                                                                              | `true`                  |
 | `defaultBackend.hostAliases`                                       | Add deployment host aliases                                                                                     | `[]`                    |
 | `defaultBackend.image.registry`                                    | Default backend image registry                                                                                  | `REGISTRY_NAME`         |
 | `defaultBackend.image.repository`                                  | Default backend image repository                                                                                | `REPOSITORY_NAME/nginx` |
@@ -295,14 +297,14 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### RBAC parameters
 
-| Name                                          | Description                                                    | Value  |
-| --------------------------------------------- | -------------------------------------------------------------- | ------ |
-| `serviceAccount.create`                       | Enable the creation of a ServiceAccount for Controller pods    | `true` |
-| `serviceAccount.name`                         | Name of the created ServiceAccount                             | `""`   |
-| `serviceAccount.annotations`                  | Annotations for service account.                               | `{}`   |
-| `serviceAccount.automountServiceAccountToken` | Automount service account token for the server service account | `true` |
-| `rbac.create`                                 | Specifies whether RBAC rules should be created                 | `true` |
-| `rbac.rules`                                  | Custom RBAC rules                                              | `[]`   |
+| Name                                          | Description                                                    | Value   |
+| --------------------------------------------- | -------------------------------------------------------------- | ------- |
+| `serviceAccount.create`                       | Enable the creation of a ServiceAccount for Controller pods    | `true`  |
+| `serviceAccount.name`                         | Name of the created ServiceAccount                             | `""`    |
+| `serviceAccount.annotations`                  | Annotations for service account.                               | `{}`    |
+| `serviceAccount.automountServiceAccountToken` | Automount service account token for the server service account | `false` |
+| `rbac.create`                                 | Specifies whether RBAC rules should be created                 | `true`  |
+| `rbac.rules`                                  | Custom RBAC rules                                              | `[]`    |
 
 ### Other parameters
 

--- a/bitnami/nginx-ingress-controller/templates/controller-daemonset.yaml
+++ b/bitnami/nginx-ingress-controller/templates/controller-daemonset.yaml
@@ -41,6 +41,7 @@ spec:
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName | quote }}
       {{- end }}
+      automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
       {{- if .Values.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.hostAliases "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/nginx-ingress-controller/templates/controller-deployment.yaml
+++ b/bitnami/nginx-ingress-controller/templates/controller-deployment.yaml
@@ -43,6 +43,7 @@ spec:
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName | quote }}
       {{- end }}
+      automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
       {{- if .Values.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.hostAliases "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/nginx-ingress-controller/templates/default-backend-deployment.yaml
+++ b/bitnami/nginx-ingress-controller/templates/default-backend-deployment.yaml
@@ -34,6 +34,7 @@ spec:
       {{- if .Values.defaultBackend.priorityClassName }}
       priorityClassName: {{ .Values.defaultBackend.priorityClassName | quote }}
       {{- end }}
+      automountServiceAccountToken: {{ .Values.defaultBackend.automountServiceAccountToken }}
       {{- if .Values.defaultBackend.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.defaultBackend.hostAliases "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/nginx-ingress-controller/values.yaml
+++ b/bitnami/nginx-ingress-controller/values.yaml
@@ -79,6 +79,9 @@ containerPorts:
   http: 8080
   https: 8443
   metrics: 10254
+## @param automountServiceAccountToken Mount Service Account token in pod
+##
+automountServiceAccountToken: true
 ## @param hostAliases Deployment pod host aliases
 ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
 ##
@@ -487,6 +490,12 @@ defaultBackend:
   ## @param defaultBackend.enabled Enable a default backend based on NGINX
   ##
   enabled: true
+  ## @param defaultBackend.automountServiceAccountToken Mount Service Account token in pod
+  ##
+  automountServiceAccountToken: true
+  ## @param defaultBackend.automountServiceAccountToken Mount Service Account token in pod
+  ##
+  automountServiceAccountToken: true
   ## @param defaultBackend.hostAliases Add deployment host aliases
   ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
   ##
@@ -890,7 +899,7 @@ serviceAccount:
   annotations: {}
   ## @param serviceAccount.automountServiceAccountToken Automount service account token for the server service account
   ##
-  automountServiceAccountToken: true
+  automountServiceAccountToken: false
 ## Role Based Access
 ## Ref: https://kubernetes.io/docs/admin/authorization/rbac/
 ##

--- a/bitnami/nginx-ingress-controller/values.yaml
+++ b/bitnami/nginx-ingress-controller/values.yaml
@@ -493,9 +493,6 @@ defaultBackend:
   ## @param defaultBackend.automountServiceAccountToken Mount Service Account token in pod
   ##
   automountServiceAccountToken: true
-  ## @param defaultBackend.automountServiceAccountToken Mount Service Account token in pod
-  ##
-  automountServiceAccountToken: true
   ## @param defaultBackend.hostAliases Add deployment host aliases
   ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
   ##


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

### Description of the change

This PR sets all ServiceAccount automountServiceAccountToken=false by default, as the token mounting should be set in the pod declaration instead (if a new pod uses this service account and the token gets automatically mounted, it could be problematic in terms of security). This PR also adds automountServiceAccountToken in the pod declaration as a new value, which can be configured by users in case they want to use an external token.

### Benefits

Charts become more security-compliant

### Possible drawbacks

n/a

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)

