### PR TITLE
[bitnami/oauth2-proxy] fix: :lock: Move service-account token auto-mount to pod declaration

### DIFF
--- a/.vib/oauth2-proxy/goss/goss.yaml
+++ b/.vib/oauth2-proxy/goss/goss.yaml
@@ -15,7 +15,7 @@ command:
     # or the one randomly defined by openshift (larger values). Otherwise, the chart is still using the default value.
     exec: if [ $(id -u) -lt {{ $uid }} ] || [ $(id -G | awk '{print $2}') -lt {{ $gid }} ]; then exit 1; fi
     exit-status: 0
-  {{ if .Vars.serviceAccount.automountServiceAccountToken }}
+  {{ if .Vars.automountServiceAccountToken }}
   check-sa:
     exec: cat /var/run/secrets/kubernetes.io/serviceaccount/token | cut -d '.' -f 2 | xargs -I '{}' echo '{}====' | fold -w 4 | sed '$ d' | tr -d '\n' | base64 -d
     exit-status: 0

--- a/.vib/oauth2-proxy/runtime-parameters.yaml
+++ b/.vib/oauth2-proxy/runtime-parameters.yaml
@@ -26,7 +26,7 @@ containerSecurityContext:
   runAsUser: 1002
 serviceAccount:
   create: true
-  automountServiceAccountToken: true
+automountServiceAccountToken: true
 redis:
   enabled: true
   auth:

--- a/bitnami/oauth2-proxy/Chart.yaml
+++ b/bitnami/oauth2-proxy/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: oauth2-proxy
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/oauth2-proxy
-version: 4.4.1
+version: 4.5.0

--- a/bitnami/oauth2-proxy/README.md
+++ b/bitnami/oauth2-proxy/README.md
@@ -197,6 +197,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `containerSecurityContext.seccompProfile.type`      | Set container's Security Context seccomp profile                                                 | `RuntimeDefault` |
 | `command`                                           | Override default container command (useful when using custom images)                             | `[]`             |
 | `args`                                              | Override default container args (useful when using custom images)                                | `[]`             |
+| `automountServiceAccountToken`                      | Mount Service Account token in pod                                                               | `false`          |
 | `hostAliases`                                       | OAuth2 Proxy pods host aliases                                                                   | `[]`             |
 | `podLabels`                                         | Extra labels for OAuth2 Proxy pods                                                               | `{}`             |
 | `podAnnotations`                                    | Annotations for OAuth2 Proxy pods                                                                | `{}`             |

--- a/bitnami/oauth2-proxy/templates/deployment.yaml
+++ b/bitnami/oauth2-proxy/templates/deployment.yaml
@@ -34,6 +34,7 @@ spec:
     spec:
       serviceAccountName: {{ template "oauth2-proxy.serviceAccountName" . }}
       {{- include "oauth2-proxy.imagePullSecrets" . | nindent 6 }}
+      automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
       {{- if .Values.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.hostAliases "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/oauth2-proxy/values.yaml
+++ b/bitnami/oauth2-proxy/values.yaml
@@ -505,6 +505,9 @@ command: []
 ## @param args Override default container args (useful when using custom images)
 ##
 args: []
+## @param automountServiceAccountToken Mount Service Account token in pod
+##
+automountServiceAccountToken: false
 ## @param hostAliases OAuth2 Proxy pods host aliases
 ## ref: https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
 ##


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

### Description of the change

This PR sets all ServiceAccount automountServiceAccountToken=false by default, as the token mounting should be set in the pod declaration instead (if a new pod uses this service account and the token gets automatically mounted, it could be problematic in terms of security). This PR also adds automountServiceAccountToken in the pod declaration as a new value, which can be configured by users in case they want to use an external token.

### Benefits

Charts become more security-compliant

### Possible drawbacks

n/a

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)

