### PR TITLE
[bitnami/spark] fix: :lock: Move service-account token auto-mount to pod declaration

### DIFF
--- a/bitnami/spark/Chart.yaml
+++ b/bitnami/spark/Chart.yaml
@@ -27,4 +27,4 @@ maintainers:
 name: spark
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/spark
-version: 8.2.1
+version: 8.3.0

--- a/bitnami/spark/README.md
+++ b/bitnami/spark/README.md
@@ -102,6 +102,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `master.containerPorts.http`                               | Specify the port where the web interface will listen on the master over HTTP                                             | `8080`           |
 | `master.containerPorts.https`                              | Specify the port where the web interface will listen on the master over HTTPS                                            | `8480`           |
 | `master.containerPorts.cluster`                            | Specify the port where the master listens to communicate with workers                                                    | `7077`           |
+| `master.automountServiceAccountToken`                      | Mount Service Account token in pod                                                                                       | `false`          |
 | `master.hostAliases`                                       | Deployment pod host aliases                                                                                              | `[]`             |
 | `master.extraContainerPorts`                               | Specify the port where the running jobs inside the masters listens                                                       | `[]`             |
 | `master.daemonMemoryLimit`                                 | Set the memory limit for the master daemon                                                                               | `""`             |
@@ -181,6 +182,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `worker.containerPorts.http`                               | Specify the port where the web interface will listen on the worker over HTTP                                             | `8080`           |
 | `worker.containerPorts.https`                              | Specify the port where the web interface will listen on the worker over HTTPS                                            | `8480`           |
 | `worker.containerPorts.cluster`                            | Specify the port where the worker listens to communicate with workers                                                    | `""`             |
+| `worker.automountServiceAccountToken`                      | Mount Service Account token in pod                                                                                       | `false`          |
 | `worker.hostAliases`                                       | Add deployment host aliases                                                                                              | `[]`             |
 | `worker.extraContainerPorts`                               | Specify the port where the running jobs inside the workers listens                                                       | `[]`             |
 | `worker.daemonMemoryLimit`                                 | Set the memory limit for the worker daemon                                                                               | `""`             |

--- a/bitnami/spark/templates/statefulset-master.yaml
+++ b/bitnami/spark/templates/statefulset-master.yaml
@@ -47,6 +47,7 @@ spec:
         podAntiAffinity: {{- include "common.affinities.pods" (dict "type" .Values.master.podAntiAffinityPreset "component" "master" "customLabels" $podLabels "context" $) | nindent 10 }}
         nodeAffinity: {{- include "common.affinities.nodes" (dict "type" .Values.master.nodeAffinityPreset.type "key" .Values.master.nodeAffinityPreset.key "values" .Values.master.nodeAffinityPreset.values) | nindent 10 }}
       {{- end }}
+      automountServiceAccountToken: {{ .Values.master.automountServiceAccountToken }}
       {{- if .Values.master.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.master.hostAliases "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/spark/templates/statefulset-worker.yaml
+++ b/bitnami/spark/templates/statefulset-worker.yaml
@@ -48,6 +48,7 @@ spec:
         podAntiAffinity: {{- include "common.affinities.pods" (dict "type" .Values.worker.podAntiAffinityPreset "component" "worker" "customLabels" $podLabels "context" $) | nindent 10 }}
         nodeAffinity: {{- include "common.affinities.nodes" (dict "type" .Values.worker.nodeAffinityPreset.type "key" .Values.worker.nodeAffinityPreset.key "values" .Values.worker.nodeAffinityPreset.values) | nindent 10 }}
       {{- end }}
+      automountServiceAccountToken: {{ .Values.worker.automountServiceAccountToken }}
       {{- if .Values.worker.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.worker.hostAliases "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/spark/values.yaml
+++ b/bitnami/spark/values.yaml
@@ -136,6 +136,9 @@ master:
     http: 8080
     https: 8480
     cluster: 7077
+  ## @param master.automountServiceAccountToken Mount Service Account token in pod
+  ##
+  automountServiceAccountToken: false
   ## @param master.hostAliases Deployment pod host aliases
   ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
   ##
@@ -419,6 +422,9 @@ worker:
     http: 8080
     https: 8480
     cluster: ""
+  ## @param worker.automountServiceAccountToken Mount Service Account token in pod
+  ##
+  automountServiceAccountToken: false
   ## @param worker.hostAliases Add deployment host aliases
   ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
   ##


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

### Description of the change

This PR sets all ServiceAccount automountServiceAccountToken=false by default, as the token mounting should be set in the pod declaration instead (if a new pod uses this service account and the token gets automatically mounted, it could be problematic in terms of security). This PR also adds automountServiceAccountToken in the pod declaration as a new value, which can be configured by users in case they want to use an external token.

### Benefits

Charts become more security-compliant

### Possible drawbacks

n/a

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)

