### PR TITLE
[bitnami/thanos] fix: :lock: Move service-account token auto-mount to pod declaration

### DIFF
--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: thanos
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/thanos
-version: 12.21.0
+version: 12.22.0

--- a/bitnami/thanos/templates/bucketweb/deployment.yaml
+++ b/bitnami/thanos/templates/bucketweb/deployment.yaml
@@ -38,6 +38,7 @@ spec:
       {{- include "thanos.imagePullSecrets" . | nindent 6 }}
       serviceAccountName: {{ include "thanos.serviceAccountName" (dict "component" "bucketweb" "context" $) }}
       automountServiceAccountToken: {{ .Values.bucketweb.automountServiceAccountToken }}
+      automountServiceAccountToken: {{ .Values.bucketweb.automountServiceAccountToken }}
       {{- if .Values.bucketweb.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.bucketweb.hostAliases "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/thanos/templates/compactor/_pod-template.tpl
+++ b/bitnami/thanos/templates/compactor/_pod-template.tpl
@@ -22,6 +22,7 @@ spec:
   {{- include "thanos.imagePullSecrets" . | nindent 2 }}
   serviceAccountName: {{ include "thanos.serviceAccountName" (dict "component" "compactor" "context" $) }}
   automountServiceAccountToken: {{ .Values.compactor.automountServiceAccountToken }}
+  automountServiceAccountToken: {{ .Values.compactor.automountServiceAccountToken }}
   {{- if .Values.compactor.hostAliases }}
   hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.compactor.hostAliases "context" $) | nindent 4 }}
   {{- end }}

--- a/bitnami/thanos/templates/query-frontend/deployment.yaml
+++ b/bitnami/thanos/templates/query-frontend/deployment.yaml
@@ -43,6 +43,7 @@ spec:
       {{- include "thanos.imagePullSecrets" . | nindent 6 }}
       serviceAccountName: {{ include "thanos.serviceAccountName" (dict "component" "query-frontend" "context" $) }}
       automountServiceAccountToken: {{ .Values.queryFrontend.automountServiceAccountToken }}
+      automountServiceAccountToken: {{ .Values.queryFrontend.automountServiceAccountToken }}
       {{- if .Values.queryFrontend.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.queryFrontend.hostAliases "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/thanos/templates/query/deployment.yaml
+++ b/bitnami/thanos/templates/query/deployment.yaml
@@ -42,6 +42,7 @@ spec:
       {{- include "thanos.imagePullSecrets" . | nindent 6 }}
       serviceAccountName: {{ include "thanos.serviceAccountName" (dict "component" "query" "context" $) }}
       automountServiceAccountToken: {{ .Values.query.automountServiceAccountToken }}
+      automountServiceAccountToken: {{ .Values.query.automountServiceAccountToken }}
       {{- if .Values.query.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.query.hostAliases "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/thanos/templates/receive-distributor/deployment.yaml
+++ b/bitnami/thanos/templates/receive-distributor/deployment.yaml
@@ -41,6 +41,7 @@ spec:
       {{- include "thanos.imagePullSecrets" . | nindent 6 }}
       serviceAccountName: {{ include "thanos.serviceAccountName" (dict "component" "receive" "context" $) }}
       automountServiceAccountToken: {{ .Values.receiveDistributor.automountServiceAccountToken }}
+      automountServiceAccountToken: {{ .Values.receiveDistributor.automountServiceAccountToken }}
       {{- if .Values.receiveDistributor.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.receiveDistributor.hostAliases "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/thanos/templates/receive/statefulset.yaml
+++ b/bitnami/thanos/templates/receive/statefulset.yaml
@@ -47,6 +47,7 @@ spec:
       {{- include "thanos.imagePullSecrets" . | nindent 6 }}
       serviceAccountName: {{ include "thanos.serviceAccountName" (dict "component" "receive" "context" $) }}
       automountServiceAccountToken: {{ .Values.receive.automountServiceAccountToken }}
+      automountServiceAccountToken: {{ .Values.receive.automountServiceAccountToken }}
       {{- if .Values.receive.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.receive.hostAliases "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/thanos/templates/ruler/statefulset.yaml
+++ b/bitnami/thanos/templates/ruler/statefulset.yaml
@@ -42,6 +42,7 @@ spec:
       {{- include "thanos.imagePullSecrets" . | nindent 6 }}
       serviceAccountName: {{ include "thanos.serviceAccountName" (dict "component" "ruler" "context" $) }}
       automountServiceAccountToken: {{ .Values.ruler.automountServiceAccountToken }}
+      automountServiceAccountToken: {{ .Values.ruler.automountServiceAccountToken }}
       {{- if .Values.ruler.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.ruler.hostAliases "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/thanos/templates/storegateway/statefulset-sharded.yaml
+++ b/bitnami/thanos/templates/storegateway/statefulset-sharded.yaml
@@ -60,6 +60,7 @@ spec:
       {{- include "thanos.imagePullSecrets" $ | nindent 6 }}
       serviceAccountName: {{ include "thanos.serviceAccountName" (dict "component" "storegateway" "context" $) }}
       automountServiceAccountToken: {{ $.Values.storegateway.automountServiceAccountToken }}
+      automountServiceAccountToken: {{ $.Values.storegateway.automountServiceAccountToken }}
       {{- if $.Values.storegateway.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" $.Values.storegateway.hostAliases "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/thanos/templates/storegateway/statefulset.yaml
+++ b/bitnami/thanos/templates/storegateway/statefulset.yaml
@@ -43,6 +43,7 @@ spec:
       {{- include "thanos.imagePullSecrets" . | nindent 6 }}
       serviceAccountName: {{ include "thanos.serviceAccountName" (dict "component" "storegateway" "context" $) }}
       automountServiceAccountToken: {{ .Values.storegateway.automountServiceAccountToken }}
+      automountServiceAccountToken: {{ .Values.storegateway.automountServiceAccountToken }}
       {{- if .Values.storegateway.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.storegateway.hostAliases "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/thanos/values.yaml
+++ b/bitnami/thanos/values.yaml
@@ -411,6 +411,9 @@ query:
   ## dnsPolicy: ClusterFirstWithHostNet
   ##
   dnsPolicy: ""
+  ## @param query.automountServiceAccountToken Mount Service Account token in pod
+  ##
+  automountServiceAccountToken: false
   ## @param query.hostAliases Deployment pod host aliases
   ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
   ##
@@ -603,7 +606,7 @@ query:
   ## Autoscaling parameters
   ## @param query.automountServiceAccountToken Enable/disable auto mounting of the service account token only for the deployment
   ##
-  automountServiceAccountToken: true
+  automountServiceAccountToken: false
   ## ServiceAccount configuration
   ## @param query.serviceAccount.create Specifies whether a ServiceAccount should be created
   ## @param query.serviceAccount.name Name of the service account to use. If not set and create is true, a name is generated using the fullname template.
@@ -1098,6 +1101,9 @@ queryFrontend:
   ## dnsPolicy: ClusterFirstWithHostNet
   ##
   dnsPolicy: ""
+  ## @param queryFrontend.automountServiceAccountToken Mount Service Account token in pod
+  ##
+  automountServiceAccountToken: false
   ## @param queryFrontend.hostAliases Deployment pod host aliases
   ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
   ##
@@ -1167,7 +1173,7 @@ queryFrontend:
     labelSelectorsOverride: {}
   ## @param queryFrontend.automountServiceAccountToken Enable/disable auto mounting of the service account token only for the deployment
   ##
-  automountServiceAccountToken: true
+  automountServiceAccountToken: false
   ## ServiceAccount configuration
   ## @param queryFrontend.serviceAccount.create Specifies whether a ServiceAccount should be created
   ## @param queryFrontend.serviceAccount.name Name of the service account to use. If not set and create is true, a name is generated using the fullname template.
@@ -1561,6 +1567,9 @@ bucketweb:
   ## dnsPolicy: ClusterFirstWithHostNet
   ##
   dnsPolicy: ""
+  ## @param bucketweb.automountServiceAccountToken Mount Service Account token in pod
+  ##
+  automountServiceAccountToken: false
   ## @param bucketweb.hostAliases Deployment pod host aliases
   ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
   ##
@@ -1628,7 +1637,7 @@ bucketweb:
     labelSelectorsOverride: {}
   ## @param bucketweb.automountServiceAccountToken Enable/disable auto mounting of the service account token only for the deployment
   ##
-  automountServiceAccountToken: true
+  automountServiceAccountToken: false
   ## ServiceAccount configuration
   ## @param bucketweb.serviceAccount.create Specifies whether a ServiceAccount should be created
   ## @param bucketweb.serviceAccount.name Name of the service account to use. If not set and create is true, a name is generated using the fullname template.
@@ -2026,6 +2035,9 @@ compactor:
   ## dnsPolicy: ClusterFirstWithHostNet
   ##
   dnsPolicy: ""
+  ## @param compactor.automountServiceAccountToken Mount Service Account token in pod
+  ##
+  automountServiceAccountToken: false
   ## @param compactor.hostAliases Deployment pod host aliases
   ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
   ##
@@ -2095,7 +2107,7 @@ compactor:
     labelSelectorsOverride: {}
   ## @param compactor.automountServiceAccountToken Enable/disable auto mounting of the service account token only for the deployment
   ##
-  automountServiceAccountToken: true
+  automountServiceAccountToken: false
   ## ServiceAccount configuration
   ## @param compactor.serviceAccount.create Specifies whether a ServiceAccount should be created
   ## @param compactor.serviceAccount.name Name of the service account to use. If not set and create is true, a name is generated using the fullname template.
@@ -2507,6 +2519,9 @@ storegateway:
   ## dnsPolicy: ClusterFirstWithHostNet
   ##
   dnsPolicy: ""
+  ## @param storegateway.automountServiceAccountToken Mount Service Account token in pod
+  ##
+  automountServiceAccountToken: false
   ## @param storegateway.hostAliases Deployment pod host aliases
   ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
   ##
@@ -2619,7 +2634,7 @@ storegateway:
     existingClaim: ""
   ## @param storegateway.automountServiceAccountToken Enable/disable auto mounting of the service account token only for the sts
   ##
-  automountServiceAccountToken: true
+  automountServiceAccountToken: false
   ## ServiceAccount configuration
   ## @param storegateway.serviceAccount.create Specifies whether a ServiceAccount should be created
   ## @param storegateway.serviceAccount.name Name of the service account to use. If not set and create is true, a name is generated using the fullname template.
@@ -3166,6 +3181,9 @@ ruler:
   ## dnsPolicy: ClusterFirstWithHostNet
   ##
   dnsPolicy: ""
+  ## @param ruler.automountServiceAccountToken Mount Service Account token in pod
+  ##
+  automountServiceAccountToken: false
   ## @param ruler.hostAliases Deployment pod host aliases
   ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
   ##
@@ -3275,7 +3293,7 @@ ruler:
     existingClaim: ""
   ## @param ruler.automountServiceAccountToken Enable/disable auto mounting of the service account token only for the sts
   ##
-  automountServiceAccountToken: true
+  automountServiceAccountToken: false
   ## ServiceAccount configuration
   ## @param ruler.serviceAccount.create Specifies whether a ServiceAccount should be created
   ## @param ruler.serviceAccount.name Name of the service account to use. If not set and create is true, a name is generated using the fullname template.
@@ -3694,6 +3712,9 @@ receive:
   ## dnsPolicy: ClusterFirstWithHostNet
   ##
   dnsPolicy: ""
+  ## @param receive.automountServiceAccountToken Mount Service Account token in pod
+  ##
+  automountServiceAccountToken: false
   ## @param receive.hostAliases Deployment pod host aliases
   ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
   ##
@@ -3779,7 +3800,7 @@ receive:
       annotations: {}
   ## @param receive.automountServiceAccountToken Enable/disable auto mounting of the service account token only for the sts
   ##
-  automountServiceAccountToken: true
+  automountServiceAccountToken: false
   ## ServiceAccount configuration
   ## @param receive.serviceAccount.create Specifies whether a ServiceAccount should be created
   ## @param receive.serviceAccount.name Name of the service account to use. If not set and create is true, a name is generated using the fullname template.
@@ -4176,6 +4197,9 @@ receiveDistributor:
   ## dnsPolicy: ClusterFirstWithHostNet
   ##
   dnsPolicy: ""
+  ## @param receiveDistributor.automountServiceAccountToken Mount Service Account token in pod
+  ##
+  automountServiceAccountToken: false
   ## @param receiveDistributor.hostAliases Deployment pod host aliases
   ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
   ##
@@ -4197,7 +4221,7 @@ receiveDistributor:
   topologySpreadConstraints: []
   ## @param receiveDistributor.automountServiceAccountToken Enable/disable auto mounting of the service account token only for the deployment
   ##
-  automountServiceAccountToken: true
+  automountServiceAccountToken: false
   ## ServiceAccount configuration
   ## @param receiveDistributor.serviceAccount.create Specifies whether a ServiceAccount should be created
   ## @param receiveDistributor.serviceAccount.name Name of the service account to use. If not set and create is true, a name is generated using the fullname template.


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

### Description of the change

This PR sets all ServiceAccount automountServiceAccountToken=false by default, as the token mounting should be set in the pod declaration instead (if a new pod uses this service account and the token gets automatically mounted, it could be problematic in terms of security). This PR also adds automountServiceAccountToken in the pod declaration as a new value, which can be configured by users in case they want to use an external token.

### Benefits

Charts become more security-compliant

### Possible drawbacks

n/a

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)

