### PR TITLE
[bitnami/wildfly] fix: :lock: Move service-account token auto-mount to pod declaration

### DIFF
--- a/bitnami/wildfly/Chart.yaml
+++ b/bitnami/wildfly/Chart.yaml
@@ -33,4 +33,4 @@ maintainers:
 name: wildfly
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/wildfly
-version: 17.2.1
+version: 17.3.0

--- a/bitnami/wildfly/README.md
+++ b/bitnami/wildfly/README.md
@@ -111,6 +111,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | --------------------------------------------------- | ----------------------------------------------------------------------------------------- | ---------------- |
 | `replicaCount`                                      | Number of Wildfly replicas to deploy                                                      | `1`              |
 | `updateStrategy.type`                               | WildFly deployment strategy type                                                          | `RollingUpdate`  |
+| `automountServiceAccountToken`                      | Mount Service Account token in pod                                                        | `true`           |
 | `hostAliases`                                       | WildFly pod host aliases                                                                  | `[]`             |
 | `extraVolumes`                                      | Optionally specify extra list of additional volumes for WildFly pods                      | `[]`             |
 | `extraVolumeMounts`                                 | Optionally specify extra list of additional volumeMounts for WildFly container(s)         | `[]`             |

--- a/bitnami/wildfly/templates/deployment.yaml
+++ b/bitnami/wildfly/templates/deployment.yaml
@@ -28,6 +28,7 @@ spec:
         {{- end }}
     spec:
       {{- include "wildfly.imagePullSecrets" . | nindent 6 }}
+      automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
       {{- if .Values.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.hostAliases "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/wildfly/values.yaml
+++ b/bitnami/wildfly/values.yaml
@@ -145,6 +145,9 @@ replicaCount: 1
 ##
 updateStrategy:
   type: RollingUpdate
+## @param automountServiceAccountToken Mount Service Account token in pod
+##
+automountServiceAccountToken: true
 ## @param hostAliases [array] WildFly pod host aliases
 ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
 ##


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

### Description of the change

This PR sets all ServiceAccount automountServiceAccountToken=false by default, as the token mounting should be set in the pod declaration instead (if a new pod uses this service account and the token gets automatically mounted, it could be problematic in terms of security). This PR also adds automountServiceAccountToken in the pod declaration as a new value, which can be configured by users in case they want to use an external token.

### Benefits

Charts become more security-compliant

### Possible drawbacks

n/a

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)

