### PR TITLE
github-actions: Fix issue when {version} placeholder not present

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -165,10 +165,8 @@ jobs:
             # Automatically update CRDs that use the '# Source' header
             source_url_tpl="$(head -n 1 $file | grep -E "^# ?Source: ?" | sed -E 's|^# ?Source: ?||' || true)"
             if [[ -n "$source_url_tpl" ]]; then
-              # Replace version placeholder
-              if [[ "$source_url_tpl" =~ "{version}" ]]; then
-                source_url=$(echo "$source_url_tpl" | sed "s/{version}/${APP_VERSION}/")
-              fi
+              # Replace version placeholder, if present
+              source_url=$(echo "$source_url_tpl" | sed "s/{version}/${APP_VERSION}/")
               # Validate the second line of the CRD file includes the version of the CRD
               crd_version="$(head -n 2 $file | tail -n 1 | grep -E "^# ?Version: ?" | sed -E 's|^# ?Version: ?||' || true)"
               if [[ -z "$crd_version" ]]; then


### PR DESCRIPTION
### Description of the change

Fixes issue where $source_url is not set if {version} placeholder is not in the URL.

URLs not including {version} placeholder may be intentional in case of upstream not being versioned, and we would like to pull the latest version in case of release event.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
