### PR TITLE
[bitnami/consul] fix: :lock: Move service-account token auto-mount to pod declaration

### DIFF
--- a/bitnami/consul/Chart.yaml
+++ b/bitnami/consul/Chart.yaml
@@ -32,4 +32,4 @@ maintainers:
 name: consul
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/consul
-version: 10.15.1
+version: 10.16.0

--- a/bitnami/consul/README.md
+++ b/bitnami/consul/README.md
@@ -96,6 +96,7 @@ helm delete --purge my-release
 | `raftMultiplier`                | Multiplier used to scale key Raft timing parameters                                                              | `1`                      |
 | `gossipKey`                     | Gossip key for all members. The key must be base64-encoded, can be generated with $(consul keygen)               | `""`                     |
 | `tlsEncryptionSecretName`       | Name of existing secret with TLS encryption data                                                                 | `""`                     |
+| `automountServiceAccountToken`  | Mount Service Account token in pod                                                                               | `false`                  |
 | `hostAliases`                   | Deployment pod host aliases                                                                                      | `[]`                     |
 | `configuration`                 | HashiCorp Consul configuration to be injected as ConfigMap                                                       | `""`                     |
 | `existingConfigmap`             | ConfigMap with HashiCorp Consul configuration                                                                    | `""`                     |
@@ -178,6 +179,10 @@ helm delete --purge my-release
 | `pdb.create`                                        | Enable/disable a Pod Disruption Budget creation                                           | `false`          |
 | `pdb.minAvailable`                                  | Minimum number of pods that must still be available after the eviction                    | `1`              |
 | `pdb.maxUnavailable`                                | Max number of pods that can be unavailable after the eviction                             | `""`             |
+| `serviceAccount.create`                             | Enable creation of ServiceAccount for WordPress pod                                       | `true`           |
+| `serviceAccount.name`                               | The name of the ServiceAccount to use.                                                    | `""`             |
+| `serviceAccount.automountServiceAccountToken`       | Allows auto mount of ServiceAccountToken on the serviceAccount created                    | `false`          |
+| `serviceAccount.annotations`                        | Additional custom annotations for the ServiceAccount                                      | `{}`             |
 
 ### Exposure parameters
 

--- a/bitnami/consul/templates/_helpers.tpl
+++ b/bitnami/consul/templates/_helpers.tpl
@@ -20,6 +20,17 @@ Return the proper metrics image name
 {{- end -}}
 
 {{/*
+ Create the name of the service account to use
+ */}}
+{{- define "consul.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "common.names.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Return the proper image name (for the init container volume-permissions image)
 */}}
 {{- define "consul.volumePermissions.image" -}}

--- a/bitnami/consul/templates/serviceaccount.yaml
+++ b/bitnami/consul/templates/serviceaccount.yaml
@@ -1,0 +1,18 @@
+{{- /*
+Copyright VMware, Inc.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "consul.serviceAccountName" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- if or .Values.serviceAccount.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.serviceAccount.annotations .Values.commonAnnotations ) "context" . ) }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end -}}

--- a/bitnami/consul/templates/statefulset.yaml
+++ b/bitnami/consul/templates/statefulset.yaml
@@ -37,6 +37,8 @@ spec:
       {{- end }}
     spec:
       {{- include "consul.imagePullSecrets" . | nindent 6 }}
+      serviceAccountName: {{ include "consul.serviceAccountName" .}}
+      automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
       {{- if .Values.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.hostAliases "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/consul/values.yaml
+++ b/bitnami/consul/values.yaml
@@ -115,6 +115,9 @@ gossipKey: ""
 ## tlsEncryptionSecretName: your-already-created-secret
 ##
 tlsEncryptionSecretName: ""
+## @param automountServiceAccountToken Mount Service Account token in pod
+##
+automountServiceAccountToken: false
 ## @param hostAliases Deployment pod host aliases
 ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
 ##
@@ -412,6 +415,25 @@ pdb:
   ## @param pdb.maxUnavailable Max number of pods that can be unavailable after the eviction
   ##
   maxUnavailable: ""
+
+## Service Account
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+##
+serviceAccount:
+  ## @param serviceAccount.create Enable creation of ServiceAccount for WordPress pod
+  ##
+  create: true
+  ## @param serviceAccount.name The name of the ServiceAccount to use.
+  ## If not set and create is true, a name is generated using the common.names.fullname template
+  ##
+  name: ""
+  ## @param serviceAccount.automountServiceAccountToken Allows auto mount of ServiceAccountToken on the serviceAccount created
+  ## Can be set to false if pods using this serviceAccount do not need to use K8s API
+  ##
+  automountServiceAccountToken: false
+  ## @param serviceAccount.annotations Additional custom annotations for the ServiceAccount
+  ##
+  annotations: {}
 
 ## @section Exposure parameters
 ##


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

### Description of the change

This PR sets all ServiceAccount automountServiceAccountToken=false by default, as the token mounting should be set in the pod declaration instead (if a new pod uses this service account and the token gets automatically mounted, it could be problematic in terms of security). This PR also adds automountServiceAccountToken in the pod declaration as a new value, which can be configured by users in case they want to use an external token.

### Benefits

Charts become more security-compliant

### Possible drawbacks

n/a

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)

