### PR TITLE
[bitnami/jasperreports] fix: :lock: Move service-account token auto-mount to pod declaration

### DIFF
--- a/bitnami/jasperreports/Chart.yaml
+++ b/bitnami/jasperreports/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: jasperreports
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/jasperreports
-version: 18.1.1
+version: 18.2.0

--- a/bitnami/jasperreports/README.md
+++ b/bitnami/jasperreports/README.md
@@ -177,7 +177,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `persistence.size`                                  | PVC Storage Request for Jasperreports volume                                              | `8Gi`                      |
 | `persistence.existingClaim`                         | An Existing PVC name for Jasperreports volume                                             | `""`                       |
 | `persistence.annotations`                           | Persistent Volume Claim annotations                                                       | `{}`                       |
-| `serviceAccount.create`                             | Enable creation of ServiceAccount for WordPress pod                                       | `true`                     |
+| `serviceAccount.create`                             | Enable creation of ServiceAccount for JasperReports pod                                   | `true`                     |
 | `serviceAccount.name`                               | The name of the ServiceAccount to use.                                                    | `""`                       |
 | `serviceAccount.automountServiceAccountToken`       | Allows auto mount of ServiceAccountToken on the serviceAccount created                    | `false`                    |
 | `serviceAccount.annotations`                        | Additional custom annotations for the ServiceAccount                                      | `{}`                       |

--- a/bitnami/jasperreports/README.md
+++ b/bitnami/jasperreports/README.md
@@ -109,6 +109,7 @@ The command removes all the Kubernetes components associated with the chart and 
 
 | Name                                                | Description                                                                               | Value                      |
 | --------------------------------------------------- | ----------------------------------------------------------------------------------------- | -------------------------- |
+| `automountServiceAccountToken`                      | Mount Service Account token in pod                                                        | `false`                    |
 | `hostAliases`                                       | Add deployment host aliases                                                               | `[]`                       |
 | `containerPorts.http`                               | HTTP port to expose at container level                                                    | `8080`                     |
 | `dnsConfig`                                         | Pod DNS configuration.                                                                    | `{}`                       |
@@ -176,6 +177,10 @@ The command removes all the Kubernetes components associated with the chart and 
 | `persistence.size`                                  | PVC Storage Request for Jasperreports volume                                              | `8Gi`                      |
 | `persistence.existingClaim`                         | An Existing PVC name for Jasperreports volume                                             | `""`                       |
 | `persistence.annotations`                           | Persistent Volume Claim annotations                                                       | `{}`                       |
+| `serviceAccount.create`                             | Enable creation of ServiceAccount for WordPress pod                                       | `true`                     |
+| `serviceAccount.name`                               | The name of the ServiceAccount to use.                                                    | `""`                       |
+| `serviceAccount.automountServiceAccountToken`       | Allows auto mount of ServiceAccountToken on the serviceAccount created                    | `false`                    |
+| `serviceAccount.annotations`                        | Additional custom annotations for the ServiceAccount                                      | `{}`                       |
 
 ### Exposure parameters
 

--- a/bitnami/jasperreports/templates/_helpers.tpl
+++ b/bitnami/jasperreports/templates/_helpers.tpl
@@ -32,6 +32,17 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 
 {{/*
+ Create the name of the service account to use
+ */}}
+{{- define "jasperreports.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "common.names.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Return the database Type
 */}}
 {{- define "jasperreports.databaseType" -}}

--- a/bitnami/jasperreports/templates/deployment.yaml
+++ b/bitnami/jasperreports/templates/deployment.yaml
@@ -25,6 +25,8 @@ spec:
       {{- end }}
     spec:
       {{- include "jasperreports.imagePullSecrets" . | nindent 6 }}
+      serviceAccountName: {{ include "jasperreports.serviceAccountName" .}}
+      automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
       {{- if .Values.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.hostAliases "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/jasperreports/templates/serviceaccount.yaml
+++ b/bitnami/jasperreports/templates/serviceaccount.yaml
@@ -1,0 +1,18 @@
+{{- /*
+Copyright VMware, Inc.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "jasperreports.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- if or .Values.serviceAccount.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.serviceAccount.annotations .Values.commonAnnotations ) "context" . ) }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end -}}

--- a/bitnami/jasperreports/values.yaml
+++ b/bitnami/jasperreports/values.yaml
@@ -413,7 +413,7 @@ persistence:
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
 ##
 serviceAccount:
-  ## @param serviceAccount.create Enable creation of ServiceAccount for WordPress pod
+  ## @param serviceAccount.create Enable creation of ServiceAccount for JasperReports pod
   ##
   create: true
   ## @param serviceAccount.name The name of the ServiceAccount to use.

--- a/bitnami/jasperreports/values.yaml
+++ b/bitnami/jasperreports/values.yaml
@@ -142,6 +142,9 @@ updateStrategy:
 ## @section Jasperreports deployment parameters
 ##
 
+## @param automountServiceAccountToken Mount Service Account token in pod
+##
+automountServiceAccountToken: false
 ## @param hostAliases Add deployment host aliases
 ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
 ##
@@ -403,6 +406,25 @@ persistence:
   ##
   existingClaim: ""
   ## @param persistence.annotations Persistent Volume Claim annotations
+  ##
+  annotations: {}
+
+## Service Account
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+##
+serviceAccount:
+  ## @param serviceAccount.create Enable creation of ServiceAccount for WordPress pod
+  ##
+  create: true
+  ## @param serviceAccount.name The name of the ServiceAccount to use.
+  ## If not set and create is true, a name is generated using the common.names.fullname template
+  ##
+  name: ""
+  ## @param serviceAccount.automountServiceAccountToken Allows auto mount of ServiceAccountToken on the serviceAccount created
+  ## Can be set to false if pods using this serviceAccount do not need to use K8s API
+  ##
+  automountServiceAccountToken: false
+  ## @param serviceAccount.annotations Additional custom annotations for the ServiceAccount
   ##
   annotations: {}
 


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

### Description of the change

This PR sets all ServiceAccount automountServiceAccountToken=false by default, as the token mounting should be set in the pod declaration instead (if a new pod uses this service account and the token gets automatically mounted, it could be problematic in terms of security). This PR also adds automountServiceAccountToken in the pod declaration as a new value, which can be configured by users in case they want to use an external token.

### Benefits

Charts become more security-compliant

### Possible drawbacks

n/a

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)

