### PR TITLE
[bitnami/joomla] fix: :lock: Move service-account token auto-mount to pod declaration

### DIFF
--- a/bitnami/joomla/Chart.yaml
+++ b/bitnami/joomla/Chart.yaml
@@ -36,4 +36,4 @@ maintainers:
 name: joomla
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/joomla
-version: 18.1.1
+version: 18.2.0

--- a/bitnami/joomla/README.md
+++ b/bitnami/joomla/README.md
@@ -1,5 +1,6 @@
 <!--- app-name: Joomla! -->
 
+<!-- markdownlint-disable-next-line MD026 -->
 # Bitnami package for Joomla!
 
 Joomla! is an award winning open source CMS platform for building websites and applications. It includes page caching, page compression and Let's Encrypt auto-configuration support.

--- a/bitnami/joomla/README.md
+++ b/bitnami/joomla/README.md
@@ -171,7 +171,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `lifecycleHooks`                                    | LifecycleHook to set additional configuration at startup Evaluated as a template                                     | `{}`                     |
 | `podAnnotations`                                    | Pod annotations                                                                                                      | `{}`                     |
 | `podLabels`                                         | Add additional labels to the pod (evaluated as a template)                                                           | `{}`                     |
-| `serviceAccount.create`                             | Enable creation of ServiceAccount for WordPress pod                                                                  | `true`                   |
+| `serviceAccount.create`                             | Enable creation of ServiceAccount for pod                                                                            | `true`                   |
 | `serviceAccount.name`                               | The name of the ServiceAccount to use.                                                                               | `""`                     |
 | `serviceAccount.automountServiceAccountToken`       | Allows auto mount of ServiceAccountToken on the serviceAccount created                                               | `false`                  |
 | `serviceAccount.annotations`                        | Additional custom annotations for the ServiceAccount                                                                 | `{}`                     |

--- a/bitnami/joomla/README.md
+++ b/bitnami/joomla/README.md
@@ -95,6 +95,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `command`                                           | Override default container command (useful when using custom images)                                                 | `[]`                     |
 | `args`                                              | Override default container args (useful when using custom images)                                                    | `[]`                     |
 | `replicaCount`                                      | Number of replicas (requires ReadWriteMany PVC support)                                                              | `1`                      |
+| `automountServiceAccountToken`                      | Mount Service Account token in pod                                                                                   | `false`                  |
 | `hostAliases`                                       | Deployment pod host aliases                                                                                          | `[]`                     |
 | `updateStrategy.type`                               | Update strategy - only really applicable for deployments with RWO PVs attached                                       | `RollingUpdate`          |
 | `extraEnvVars`                                      | Extra environment variables                                                                                          | `[]`                     |
@@ -169,6 +170,10 @@ The command removes all the Kubernetes components associated with the chart and 
 | `lifecycleHooks`                                    | LifecycleHook to set additional configuration at startup Evaluated as a template                                     | `{}`                     |
 | `podAnnotations`                                    | Pod annotations                                                                                                      | `{}`                     |
 | `podLabels`                                         | Add additional labels to the pod (evaluated as a template)                                                           | `{}`                     |
+| `serviceAccount.create`                             | Enable creation of ServiceAccount for WordPress pod                                                                  | `true`                   |
+| `serviceAccount.name`                               | The name of the ServiceAccount to use.                                                                               | `""`                     |
+| `serviceAccount.automountServiceAccountToken`       | Allows auto mount of ServiceAccountToken on the serviceAccount created                                               | `false`                  |
+| `serviceAccount.annotations`                        | Additional custom annotations for the ServiceAccount                                                                 | `{}`                     |
 
 ### Traffic Exposure Parameters
 

--- a/bitnami/joomla/templates/_helpers.tpl
+++ b/bitnami/joomla/templates/_helpers.tpl
@@ -35,7 +35,7 @@ Return the proper Docker Image Registry Secret Names
 {{/*
  Create the name of the service account to use
  */}}
-{{- define "jasperreports.serviceAccountName" -}}
+{{- define "joomla.serviceAccountName" -}}
 {{- if .Values.serviceAccount.create -}}
     {{ default (include "common.names.fullname" .) .Values.serviceAccount.name }}
 {{- else -}}

--- a/bitnami/joomla/templates/_helpers.tpl
+++ b/bitnami/joomla/templates/_helpers.tpl
@@ -33,6 +33,17 @@ Return the proper Docker Image Registry Secret Names
 {{- end -}}
 
 {{/*
+ Create the name of the service account to use
+ */}}
+{{- define "jasperreports.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "common.names.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Return  the proper Storage Class
 */}}
 {{- define "joomla.storageClass" -}}

--- a/bitnami/joomla/templates/deployment.yaml
+++ b/bitnami/joomla/templates/deployment.yaml
@@ -36,7 +36,7 @@ spec:
       {{- include "joomla.imagePullSecrets" . | nindent 6 }}
       serviceAccountName: {{ include "joomla.serviceAccountName" .}}
       {{- if .Values.podSecurityContext.enabled }}
-      securityContext: {{- include "common.tplvalues.render" (dict "value" .Values.podSecurityContext "context" $) | nindent 8 }}
+      securityContext: {{- omit .Values.podSecurityContext "enabled" | toYaml | nindent 8 }}
       {{- end }}
       {{- if .Values.affinity }}
       affinity: {{- include "common.tplvalues.render" (dict "value" .Values.affinity "context" $) | nindent 8 }}

--- a/bitnami/joomla/templates/deployment.yaml
+++ b/bitnami/joomla/templates/deployment.yaml
@@ -34,9 +34,9 @@ spec:
         {{- end }}
     spec:
       {{- include "joomla.imagePullSecrets" . | nindent 6 }}
+      serviceAccountName: {{ include "joomla.serviceAccountName" .}}
       {{- if .Values.podSecurityContext.enabled }}
-      securityContext:
-        fsGroup: {{ .Values.podSecurityContext.fsGroup }}
+      securityContext: {{- include "common.tplvalues.render" (dict "value" .Values.podSecurityContext "context" $) | nindent 8 }}
       {{- end }}
       {{- if .Values.affinity }}
       affinity: {{- include "common.tplvalues.render" (dict "value" .Values.affinity "context" $) | nindent 8 }}
@@ -64,6 +64,7 @@ spec:
       {{- if .Values.initContainers }}
       initContainers: {{- include "common.tplvalues.render" (dict "value" .Values.initContainers "context" $) | nindent 8 }}
       {{- end }}
+      automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
       {{- if .Values.hostAliases }}
       # yamllint disable rule:indentation
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.hostAliases "context" $) | nindent 8 }}

--- a/bitnami/joomla/templates/serviceaccount.yaml
+++ b/bitnami/joomla/templates/serviceaccount.yaml
@@ -1,0 +1,18 @@
+{{- /*
+Copyright VMware, Inc.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "joomla.serviceAccountName" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- if or .Values.serviceAccount.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.serviceAccount.annotations .Values.commonAnnotations ) "context" . ) }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end -}}

--- a/bitnami/joomla/values.yaml
+++ b/bitnami/joomla/values.yaml
@@ -109,6 +109,9 @@ args: []
 ## @param replicaCount Number of replicas (requires ReadWriteMany PVC support)
 ##
 replicaCount: 1
+## @param automountServiceAccountToken Mount Service Account token in pod
+##
+automountServiceAccountToken: false
 ## @param hostAliases [array] Deployment pod host aliases
 ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
 ##
@@ -377,6 +380,25 @@ podAnnotations: {}
 ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
 ##
 podLabels: {}
+
+## Service Account
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+##
+serviceAccount:
+  ## @param serviceAccount.create Enable creation of ServiceAccount for WordPress pod
+  ##
+  create: true
+  ## @param serviceAccount.name The name of the ServiceAccount to use.
+  ## If not set and create is true, a name is generated using the common.names.fullname template
+  ##
+  name: ""
+  ## @param serviceAccount.automountServiceAccountToken Allows auto mount of ServiceAccountToken on the serviceAccount created
+  ## Can be set to false if pods using this serviceAccount do not need to use K8s API
+  ##
+  automountServiceAccountToken: false
+  ## @param serviceAccount.annotations Additional custom annotations for the ServiceAccount
+  ##
+  annotations: {}
 
 ## @section Traffic Exposure Parameters
 ##

--- a/bitnami/joomla/values.yaml
+++ b/bitnami/joomla/values.yaml
@@ -385,7 +385,7 @@ podLabels: {}
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
 ##
 serviceAccount:
-  ## @param serviceAccount.create Enable creation of ServiceAccount for WordPress pod
+  ## @param serviceAccount.create Enable creation of ServiceAccount for pod
   ##
   create: true
   ## @param serviceAccount.name The name of the ServiceAccount to use.


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

### Description of the change

This PR sets all ServiceAccount automountServiceAccountToken=false by default, as the token mounting should be set in the pod declaration instead (if a new pod uses this service account and the token gets automatically mounted, it could be problematic in terms of security). This PR also adds automountServiceAccountToken in the pod declaration as a new value, which can be configured by users in case they want to use an external token.

### Benefits

Charts become more security-compliant

### Possible drawbacks

n/a

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)

