### PR TITLE
[bitnami/magento] fix: :lock: Move service-account token auto-mount to pod declaration

### DIFF
--- a/bitnami/magento/Chart.yaml
+++ b/bitnami/magento/Chart.yaml
@@ -48,4 +48,4 @@ maintainers:
 name: magento
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/magento
-version: 25.1.0
+version: 25.2.0

--- a/bitnami/magento/README.md
+++ b/bitnami/magento/README.md
@@ -90,6 +90,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `image.pullPolicy`                                  | Magento image pull policy                                                                                            | `IfNotPresent`            |
 | `image.pullSecrets`                                 | Specify docker-registry secret names as an array                                                                     | `[]`                      |
 | `image.debug`                                       | Specify if debug logs should be enabled                                                                              | `false`                   |
+| `automountServiceAccountToken`                      | Mount Service Account token in pod                                                                                   | `false`                   |
 | `hostAliases`                                       | Add deployment host aliases                                                                                          | `[]`                      |
 | `replicaCount`                                      | Number of Magento Pods to run                                                                                        | `1`                       |
 | `magentoSkipInstall`                                | Skip Magento installation wizard. Useful for migrations and restoring from SQL dump                                  | `false`                   |
@@ -252,16 +253,20 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Volume Permissions parameters
 
-| Name                                   | Description                                                                                                                                               | Value                      |
-| -------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------- |
-| `volumePermissions.enabled`            | Enable init container that changes volume permissions in the data directory (for cases where the default k8s `runAsUser` and `fsUser` values do not work) | `false`                    |
-| `volumePermissions.image.registry`     | Init container volume-permissions image registry                                                                                                          | `REGISTRY_NAME`            |
-| `volumePermissions.image.repository`   | Init container volume-permissions image repository                                                                                                        | `REPOSITORY_NAME/os-shell` |
-| `volumePermissions.image.digest`       | Init container volume-permissions image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag                         | `""`                       |
-| `volumePermissions.image.pullPolicy`   | Init container volume-permissions image pull policy                                                                                                       | `IfNotPresent`             |
-| `volumePermissions.image.pullSecrets`  | Specify docker-registry secret names as an array                                                                                                          | `[]`                       |
-| `volumePermissions.resources.limits`   | The resources limits for the init container                                                                                                               | `{}`                       |
-| `volumePermissions.resources.requests` | The requested resourcesc for the init container                                                                                                           | `{}`                       |
+| Name                                          | Description                                                                                                                                               | Value                      |
+| --------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------- |
+| `volumePermissions.enabled`                   | Enable init container that changes volume permissions in the data directory (for cases where the default k8s `runAsUser` and `fsUser` values do not work) | `false`                    |
+| `volumePermissions.image.registry`            | Init container volume-permissions image registry                                                                                                          | `REGISTRY_NAME`            |
+| `volumePermissions.image.repository`          | Init container volume-permissions image repository                                                                                                        | `REPOSITORY_NAME/os-shell` |
+| `volumePermissions.image.digest`              | Init container volume-permissions image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag                         | `""`                       |
+| `volumePermissions.image.pullPolicy`          | Init container volume-permissions image pull policy                                                                                                       | `IfNotPresent`             |
+| `volumePermissions.image.pullSecrets`         | Specify docker-registry secret names as an array                                                                                                          | `[]`                       |
+| `volumePermissions.resources.limits`          | The resources limits for the init container                                                                                                               | `{}`                       |
+| `volumePermissions.resources.requests`        | The requested resourcesc for the init container                                                                                                           | `{}`                       |
+| `serviceAccount.create`                       | Enable creation of ServiceAccount for WordPress pod                                                                                                       | `true`                     |
+| `serviceAccount.name`                         | The name of the ServiceAccount to use.                                                                                                                    | `""`                       |
+| `serviceAccount.automountServiceAccountToken` | Allows auto mount of ServiceAccountToken on the serviceAccount created                                                                                    | `false`                    |
+| `serviceAccount.annotations`                  | Additional custom annotations for the ServiceAccount                                                                                                      | `{}`                       |
 
 ### Traffic Exposure Parameters
 

--- a/bitnami/magento/templates/_helpers.tpl
+++ b/bitnami/magento/templates/_helpers.tpl
@@ -68,6 +68,17 @@ When using Ingress, it will be set to the Ingress hostname.
 {{- end -}}
 
 {{/*
+ Create the name of the service account to use
+ */}}
+{{- define "magento.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "common.names.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Return the proper certificate image name
 */}}
 {{- define "certificates.image" -}}

--- a/bitnami/magento/templates/deployment.yaml
+++ b/bitnami/magento/templates/deployment.yaml
@@ -32,6 +32,8 @@ spec:
         {{- end }}
     spec:
       {{- include "magento.imagePullSecrets" . | nindent 6 }}
+      serviceAccountName: {{ include "magento.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
       {{- if .Values.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.hostAliases "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/magento/templates/serviceaccount.yaml
+++ b/bitnami/magento/templates/serviceaccount.yaml
@@ -1,0 +1,18 @@
+{{- /*
+Copyright VMware, Inc.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "magento.serviceAccountName" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- if or .Values.serviceAccount.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.serviceAccount.annotations .Values.commonAnnotations ) "context" . ) }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end -}}

--- a/bitnami/magento/values.yaml
+++ b/bitnami/magento/values.yaml
@@ -89,6 +89,9 @@ image:
   ## Set to true if you would like to see extra information on logs
   ##
   debug: false
+## @param automountServiceAccountToken Mount Service Account token in pod
+##
+automountServiceAccountToken: false
 ## @param hostAliases [array] Add deployment host aliases
 ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
 ##
@@ -748,6 +751,25 @@ volumePermissions:
     ##    cpu: 100m
     ##    memory: 128Mi
     requests: {}
+
+## Service Account
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+##
+serviceAccount:
+  ## @param serviceAccount.create Enable creation of ServiceAccount for WordPress pod
+  ##
+  create: true
+  ## @param serviceAccount.name The name of the ServiceAccount to use.
+  ## If not set and create is true, a name is generated using the common.names.fullname template
+  ##
+  name: ""
+  ## @param serviceAccount.automountServiceAccountToken Allows auto mount of ServiceAccountToken on the serviceAccount created
+  ## Can be set to false if pods using this serviceAccount do not need to use K8s API
+  ##
+  automountServiceAccountToken: false
+  ## @param serviceAccount.annotations Additional custom annotations for the ServiceAccount
+  ##
+  annotations: {}
 
 ## @section Traffic Exposure Parameters
 


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

### Description of the change

This PR sets all ServiceAccount automountServiceAccountToken=false by default, as the token mounting should be set in the pod declaration instead (if a new pod uses this service account and the token gets automatically mounted, it could be problematic in terms of security). This PR also adds automountServiceAccountToken in the pod declaration as a new value, which can be configured by users in case they want to use an external token.

### Benefits

Charts become more security-compliant

### Possible drawbacks

n/a

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)

