### PR TITLE
[bitnami/mediawiki] fix: :lock: Move service-account token auto-mount to pod declaration

### DIFF
--- a/bitnami/magento/templates/serviceaccount.yaml
+++ b/bitnami/magento/templates/serviceaccount.yaml
@@ -1,0 +1,18 @@
+{{- /*
+Copyright VMware, Inc.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "magento.serviceAccountName" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- if or .Values.serviceAccount.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.serviceAccount.annotations .Values.commonAnnotations ) "context" . ) }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end -}}

--- a/bitnami/mediawiki/Chart.yaml
+++ b/bitnami/mediawiki/Chart.yaml
@@ -39,4 +39,4 @@ maintainers:
 name: mediawiki
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/mediawiki
-version: 18.1.1
+version: 18.2.0

--- a/bitnami/mediawiki/README.md
+++ b/bitnami/mediawiki/README.md
@@ -183,7 +183,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `persistence.accessModes`                           | Persistent Volume access modes                                                            | `[]`                                              |
 | `persistence.size`                                  | PVC Storage Request for MediaWiki volume                                                  | `8Gi`                                             |
 | `persistence.annotations`                           | Persistent Volume Claim annotations                                                       | `{}`                                              |
-| `serviceAccount.create`                             | Enable creation of ServiceAccount for WordPress pod                                       | `true`                                            |
+| `serviceAccount.create`                             | Enable creation of ServiceAccount for Dokuwiki pod                                        | `true`                                            |
 | `serviceAccount.name`                               | The name of the ServiceAccount to use.                                                    | `""`                                              |
 | `serviceAccount.automountServiceAccountToken`       | Allows auto mount of ServiceAccountToken on the serviceAccount created                    | `false`                                           |
 | `serviceAccount.annotations`                        | Additional custom annotations for the ServiceAccount                                      | `{}`                                              |

--- a/bitnami/mediawiki/README.md
+++ b/bitnami/mediawiki/README.md
@@ -79,33 +79,34 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Mediawiki parameters
 
-| Name                 | Description                                                                                                                                        | Value                       |
-| -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------- |
-| `image.registry`     | MediaWiki image registry                                                                                                                           | `REGISTRY_NAME`             |
-| `image.repository`   | MediaWiki image repository                                                                                                                         | `REPOSITORY_NAME/mediawiki` |
-| `image.digest`       | MediaWiki image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag                                          | `""`                        |
-| `image.pullPolicy`   | Image pull policy                                                                                                                                  | `IfNotPresent`              |
-| `image.pullSecrets`  | Specify docker-registry secret names as an array                                                                                                   | `[]`                        |
-| `image.debug`        | Enable MediaWiki image debug mode                                                                                                                  | `false`                     |
-| `hostAliases`        | Deployment pod host aliases                                                                                                                        | `[]`                        |
-| `mediawikiUser`      | User of the application                                                                                                                            | `user`                      |
-| `mediawikiPassword`  | Application password                                                                                                                               | `""`                        |
-| `mediawikiSecret`    | Existing `Secret` containing the password for the `mediawikiUser` user; must contain the key `mediawiki-password` and optional key `smtp-password` | `""`                        |
-| `mediawikiEmail`     | Admin email                                                                                                                                        | `user@example.com`          |
-| `mediawikiName`      | Name for the wiki                                                                                                                                  | `My Wiki`                   |
-| `mediawikiHost`      | Mediawiki host to create application URLs                                                                                                          | `""`                        |
-| `allowEmptyPassword` | Allow DB blank passwords                                                                                                                           | `yes`                       |
-| `smtpHost`           | SMTP host                                                                                                                                          | `""`                        |
-| `smtpPort`           | SMTP port                                                                                                                                          | `""`                        |
-| `smtpHostID`         | SMTP host ID                                                                                                                                       | `""`                        |
-| `smtpUser`           | SMTP user                                                                                                                                          | `""`                        |
-| `smtpPassword`       | SMTP password                                                                                                                                      | `""`                        |
-| `command`            | Override default container command (useful when using custom images)                                                                               | `[]`                        |
-| `args`               | Override default container args (useful when using custom images)                                                                                  | `[]`                        |
-| `lifecycleHooks`     | for the Mediawiki container(s) to automate configuration before or after startup                                                                   | `{}`                        |
-| `extraEnvVars`       | Extra environment variables to be set on Mediawki container                                                                                        | `[]`                        |
-| `extraEnvVarsCM`     | Name of existing ConfigMap containing extra env vars                                                                                               | `""`                        |
-| `extraEnvVarsSecret` | Name of existing Secret containing extra env vars                                                                                                  | `""`                        |
+| Name                           | Description                                                                                                                                        | Value                       |
+| ------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------- |
+| `image.registry`               | MediaWiki image registry                                                                                                                           | `REGISTRY_NAME`             |
+| `image.repository`             | MediaWiki image repository                                                                                                                         | `REPOSITORY_NAME/mediawiki` |
+| `image.digest`                 | MediaWiki image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag                                          | `""`                        |
+| `image.pullPolicy`             | Image pull policy                                                                                                                                  | `IfNotPresent`              |
+| `image.pullSecrets`            | Specify docker-registry secret names as an array                                                                                                   | `[]`                        |
+| `image.debug`                  | Enable MediaWiki image debug mode                                                                                                                  | `false`                     |
+| `automountServiceAccountToken` | Mount Service Account token in pod                                                                                                                 | `false`                     |
+| `hostAliases`                  | Deployment pod host aliases                                                                                                                        | `[]`                        |
+| `mediawikiUser`                | User of the application                                                                                                                            | `user`                      |
+| `mediawikiPassword`            | Application password                                                                                                                               | `""`                        |
+| `mediawikiSecret`              | Existing `Secret` containing the password for the `mediawikiUser` user; must contain the key `mediawiki-password` and optional key `smtp-password` | `""`                        |
+| `mediawikiEmail`               | Admin email                                                                                                                                        | `user@example.com`          |
+| `mediawikiName`                | Name for the wiki                                                                                                                                  | `My Wiki`                   |
+| `mediawikiHost`                | Mediawiki host to create application URLs                                                                                                          | `""`                        |
+| `allowEmptyPassword`           | Allow DB blank passwords                                                                                                                           | `yes`                       |
+| `smtpHost`                     | SMTP host                                                                                                                                          | `""`                        |
+| `smtpPort`                     | SMTP port                                                                                                                                          | `""`                        |
+| `smtpHostID`                   | SMTP host ID                                                                                                                                       | `""`                        |
+| `smtpUser`                     | SMTP user                                                                                                                                          | `""`                        |
+| `smtpPassword`                 | SMTP password                                                                                                                                      | `""`                        |
+| `command`                      | Override default container command (useful when using custom images)                                                                               | `[]`                        |
+| `args`                         | Override default container args (useful when using custom images)                                                                                  | `[]`                        |
+| `lifecycleHooks`               | for the Mediawiki container(s) to automate configuration before or after startup                                                                   | `{}`                        |
+| `extraEnvVars`                 | Extra environment variables to be set on Mediawki container                                                                                        | `[]`                        |
+| `extraEnvVarsCM`               | Name of existing ConfigMap containing extra env vars                                                                                               | `""`                        |
+| `extraEnvVarsSecret`           | Name of existing Secret containing extra env vars                                                                                                  | `""`                        |
 
 ### Mediawiki deployment parameters
 
@@ -182,6 +183,10 @@ The command removes all the Kubernetes components associated with the chart and 
 | `persistence.accessModes`                           | Persistent Volume access modes                                                            | `[]`                                              |
 | `persistence.size`                                  | PVC Storage Request for MediaWiki volume                                                  | `8Gi`                                             |
 | `persistence.annotations`                           | Persistent Volume Claim annotations                                                       | `{}`                                              |
+| `serviceAccount.create`                             | Enable creation of ServiceAccount for WordPress pod                                       | `true`                                            |
+| `serviceAccount.name`                               | The name of the ServiceAccount to use.                                                    | `""`                                              |
+| `serviceAccount.automountServiceAccountToken`       | Allows auto mount of ServiceAccountToken on the serviceAccount created                    | `false`                                           |
+| `serviceAccount.annotations`                        | Additional custom annotations for the ServiceAccount                                      | `{}`                                              |
 
 ### Traffic Exposure parameters
 

--- a/bitnami/mediawiki/templates/_helpers.tpl
+++ b/bitnami/mediawiki/templates/_helpers.tpl
@@ -60,6 +60,17 @@ Return the proper Docker Image Registry Secret Names
 {{- end -}}
 
 {{/*
+ Create the name of the service account to use
+ */}}
+{{- define "mediawiki.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "common.names.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Return the MariaDB Hostname
 */}}
 {{- define "mediawiki.databaseHost" -}}

--- a/bitnami/mediawiki/templates/deployment.yaml
+++ b/bitnami/mediawiki/templates/deployment.yaml
@@ -33,6 +33,8 @@ spec:
       {{- end }}
     spec:
       {{- include "mediawiki.imagePullSecrets" . | nindent 6 }}
+      serviceAccountName: {{ include "mediawiki.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
       {{- if .Values.hostAliases }}
       # yamllint disable rule:indentation
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.hostAliases "context" $) | nindent 8 }}

--- a/bitnami/mediawiki/templates/serviceaccount.yaml
+++ b/bitnami/mediawiki/templates/serviceaccount.yaml
@@ -7,7 +7,7 @@ SPDX-License-Identifier: APACHE-2.0
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "magento.serviceAccountName" . }}
+  name: {{ include "mediawiki.serviceAccountName" . }}
   namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
   {{- if or .Values.serviceAccount.annotations .Values.commonAnnotations }}

--- a/bitnami/mediawiki/values.yaml
+++ b/bitnami/mediawiki/values.yaml
@@ -431,7 +431,7 @@ persistence:
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
 ##
 serviceAccount:
-  ## @param serviceAccount.create Enable creation of ServiceAccount for WordPress pod
+  ## @param serviceAccount.create Enable creation of ServiceAccount for Dokuwiki pod
   ##
   create: true
   ## @param serviceAccount.name The name of the ServiceAccount to use.

--- a/bitnami/mediawiki/values.yaml
+++ b/bitnami/mediawiki/values.yaml
@@ -76,6 +76,9 @@ image:
   ## Enable debug mode
   ##
   debug: false
+## @param automountServiceAccountToken Mount Service Account token in pod
+##
+automountServiceAccountToken: false
 ## @param hostAliases [array] Deployment pod host aliases
 ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
 ##
@@ -421,6 +424,25 @@ persistence:
   ##
   size: 8Gi
   ## @param persistence.annotations Persistent Volume Claim annotations
+  ##
+  annotations: {}
+
+## Service Account
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+##
+serviceAccount:
+  ## @param serviceAccount.create Enable creation of ServiceAccount for WordPress pod
+  ##
+  create: true
+  ## @param serviceAccount.name The name of the ServiceAccount to use.
+  ## If not set and create is true, a name is generated using the common.names.fullname template
+  ##
+  name: ""
+  ## @param serviceAccount.automountServiceAccountToken Allows auto mount of ServiceAccountToken on the serviceAccount created
+  ## Can be set to false if pods using this serviceAccount do not need to use K8s API
+  ##
+  automountServiceAccountToken: false
+  ## @param serviceAccount.annotations Additional custom annotations for the ServiceAccount
   ##
   annotations: {}
 


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

### Description of the change

This PR sets all ServiceAccount automountServiceAccountToken=false by default, as the token mounting should be set in the pod declaration instead (if a new pod uses this service account and the token gets automatically mounted, it could be problematic in terms of security). This PR also adds automountServiceAccountToken in the pod declaration as a new value, which can be configured by users in case they want to use an external token.

### Benefits

Charts become more security-compliant

### Possible drawbacks

n/a

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)

