### PR TITLE
[bitnami/moodle] fix: :lock: Move service-account token auto-mount to pod declaration

### DIFF
--- a/bitnami/moodle/Chart.yaml
+++ b/bitnami/moodle/Chart.yaml
@@ -36,4 +36,4 @@ maintainers:
 name: moodle
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/moodle
-version: 20.1.1
+version: 20.2.0

--- a/bitnami/moodle/README.md
+++ b/bitnami/moodle/README.md
@@ -104,6 +104,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `extraVolumeMounts`                                 | Array of extra volume mounts to be added to the container (evaluated as template). Normally used with `extraVolumes`. | `[]`                     |
 | `initContainers`                                    | Extra init containers to add to the deployment                                                                        | `[]`                     |
 | `sidecars`                                          | Extra sidecar containers to add to the deployment                                                                     | `[]`                     |
+| `automountServiceAccountToken`                      | Mount Service Account token in pod                                                                                    | `false`                  |
 | `hostAliases`                                       | Moodle&trade; pods host aliases                                                                                       | `[]`                     |
 | `tolerations`                                       | Tolerations for pod assignment                                                                                        | `[]`                     |
 | `priorityClassName`                                 | Moodle&trade; pods' priorityClassName                                                                                 | `""`                     |
@@ -175,6 +176,10 @@ The command removes all the Kubernetes components associated with the chart and 
 | `lifecycleHooks`                                    | LifecycleHook to set additional configuration at startup Evaluated as a template                                      | `""`                     |
 | `podAnnotations`                                    | Pod annotations                                                                                                       | `{}`                     |
 | `podLabels`                                         | Add additional labels to the pod (evaluated as a template)                                                            | `{}`                     |
+| `serviceAccount.create`                             | Enable creation of ServiceAccount for WordPress pod                                                                   | `true`                   |
+| `serviceAccount.name`                               | The name of the ServiceAccount to use.                                                                                | `""`                     |
+| `serviceAccount.automountServiceAccountToken`       | Allows auto mount of ServiceAccountToken on the serviceAccount created                                                | `false`                  |
+| `serviceAccount.annotations`                        | Additional custom annotations for the ServiceAccount                                                                  | `{}`                     |
 
 ### Traffic Exposure Parameters
 

--- a/bitnami/moodle/README.md
+++ b/bitnami/moodle/README.md
@@ -176,7 +176,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `lifecycleHooks`                                    | LifecycleHook to set additional configuration at startup Evaluated as a template                                      | `""`                     |
 | `podAnnotations`                                    | Pod annotations                                                                                                       | `{}`                     |
 | `podLabels`                                         | Add additional labels to the pod (evaluated as a template)                                                            | `{}`                     |
-| `serviceAccount.create`                             | Enable creation of ServiceAccount for WordPress pod                                                                   | `true`                   |
+| `serviceAccount.create`                             | Enable creation of ServiceAccount for Moodle pod                                                                      | `true`                   |
 | `serviceAccount.name`                               | The name of the ServiceAccount to use.                                                                                | `""`                     |
 | `serviceAccount.automountServiceAccountToken`       | Allows auto mount of ServiceAccountToken on the serviceAccount created                                                | `false`                  |
 | `serviceAccount.annotations`                        | Additional custom annotations for the ServiceAccount                                                                  | `{}`                     |

--- a/bitnami/moodle/templates/_helpers.tpl
+++ b/bitnami/moodle/templates/_helpers.tpl
@@ -54,6 +54,17 @@ Return  the proper Storage Class
 {{- end -}}
 
 {{/*
+ Create the name of the service account to use
+ */}}
+{{- define "moodle.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "common.names.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Moodle&trade; credential secret name
 */}}
 {{- define "moodle.secretName" -}}

--- a/bitnami/moodle/templates/deployment.yaml
+++ b/bitnami/moodle/templates/deployment.yaml
@@ -35,6 +35,8 @@ spec:
       {{- if .Values.podSecurityContext.enabled }}
       securityContext: {{- omit .Values.podSecurityContext "enabled" | toYaml | nindent 8 }}
       {{- end }}
+      serviceAccountName: {{ include "moodle.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
       {{- if .Values.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.hostAliases "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/moodle/templates/serviceaccount.yaml
+++ b/bitnami/moodle/templates/serviceaccount.yaml
@@ -1,0 +1,18 @@
+{{- /*
+Copyright VMware, Inc.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "moodle.serviceAccountName" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- if or .Values.serviceAccount.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.serviceAccount.annotations .Values.commonAnnotations ) "context" . ) }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end -}}

--- a/bitnami/moodle/values.yaml
+++ b/bitnami/moodle/values.yaml
@@ -142,6 +142,9 @@ initContainers: []
 ## @param sidecars Extra sidecar containers to add to the deployment
 ##
 sidecars: []
+## @param automountServiceAccountToken Mount Service Account token in pod
+##
+automountServiceAccountToken: false
 ## @param hostAliases Moodle&trade; pods host aliases
 ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
 ##
@@ -405,6 +408,25 @@ podAnnotations: {}
 ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
 ##
 podLabels: {}
+
+## Service Account
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+##
+serviceAccount:
+  ## @param serviceAccount.create Enable creation of ServiceAccount for WordPress pod
+  ##
+  create: true
+  ## @param serviceAccount.name The name of the ServiceAccount to use.
+  ## If not set and create is true, a name is generated using the common.names.fullname template
+  ##
+  name: ""
+  ## @param serviceAccount.automountServiceAccountToken Allows auto mount of ServiceAccountToken on the serviceAccount created
+  ## Can be set to false if pods using this serviceAccount do not need to use K8s API
+  ##
+  automountServiceAccountToken: false
+  ## @param serviceAccount.annotations Additional custom annotations for the ServiceAccount
+  ##
+  annotations: {}
 
 ## @section Traffic Exposure Parameters
 

--- a/bitnami/moodle/values.yaml
+++ b/bitnami/moodle/values.yaml
@@ -413,7 +413,7 @@ podLabels: {}
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
 ##
 serviceAccount:
-  ## @param serviceAccount.create Enable creation of ServiceAccount for WordPress pod
+  ## @param serviceAccount.create Enable creation of ServiceAccount for Moodle pod
   ##
   create: true
   ## @param serviceAccount.name The name of the ServiceAccount to use.


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

### Description of the change

This PR sets all ServiceAccount automountServiceAccountToken=false by default, as the token mounting should be set in the pod declaration instead (if a new pod uses this service account and the token gets automatically mounted, it could be problematic in terms of security). This PR also adds automountServiceAccountToken in the pod declaration as a new value, which can be configured by users in case they want to use an external token.

### Benefits

Charts become more security-compliant

### Possible drawbacks

n/a

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)

