### PR TITLE
[bitnami/opencart] fix: :lock: Move service-account token auto-mount to pod declaration

### DIFF
--- a/bitnami/opencart/Chart.yaml
+++ b/bitnami/opencart/Chart.yaml
@@ -38,4 +38,4 @@ maintainers:
 name: opencart
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/opencart
-version: 17.1.1
+version: 17.2.0

--- a/bitnami/opencart/README.md
+++ b/bitnami/opencart/README.md
@@ -175,7 +175,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `lifecycleHooks`                                    | lifecycleHooks for the container to automate configuration before or after startup                       | `{}`                       |
 | `podAnnotations`                                    | Pod annotations                                                                                          | `{}`                       |
 | `podLabels`                                         | Add additional labels to the pod (evaluated as a template)                                               | `{}`                       |
-| `serviceAccount.create`                             | Enable creation of ServiceAccount for WordPress pod                                                      | `true`                     |
+| `serviceAccount.create`                             | Enable creation of ServiceAccount for Opencart pod                                                       | `true`                     |
 | `serviceAccount.name`                               | The name of the ServiceAccount to use.                                                                   | `""`                       |
 | `serviceAccount.automountServiceAccountToken`       | Allows auto mount of ServiceAccountToken on the serviceAccount created                                   | `false`                    |
 | `serviceAccount.annotations`                        | Additional custom annotations for the ServiceAccount                                                     | `{}`                       |

--- a/bitnami/opencart/README.md
+++ b/bitnami/opencart/README.md
@@ -87,6 +87,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `image.pullPolicy`                                  | OpenCart image pull policy                                                                               | `IfNotPresent`             |
 | `image.pullSecrets`                                 | Specify docker-registry secret names as an array                                                         | `[]`                       |
 | `image.debug`                                       | Specify if debug logs should be enabled                                                                  | `false`                    |
+| `automountServiceAccountToken`                      | Mount Service Account token in pod                                                                       | `false`                    |
 | `hostAliases`                                       | Deployment pod host aliases                                                                              | `[]`                       |
 | `replicaCount`                                      | Number of replicas (requires ReadWriteMany PVC support)                                                  | `1`                        |
 | `opencartSkipInstall`                               | Skip OpenCart installation wizard. Useful for migrations and restoring from SQL dump                     | `false`                    |
@@ -174,6 +175,10 @@ The command removes all the Kubernetes components associated with the chart and 
 | `lifecycleHooks`                                    | lifecycleHooks for the container to automate configuration before or after startup                       | `{}`                       |
 | `podAnnotations`                                    | Pod annotations                                                                                          | `{}`                       |
 | `podLabels`                                         | Add additional labels to the pod (evaluated as a template)                                               | `{}`                       |
+| `serviceAccount.create`                             | Enable creation of ServiceAccount for WordPress pod                                                      | `true`                     |
+| `serviceAccount.name`                               | The name of the ServiceAccount to use.                                                                   | `""`                       |
+| `serviceAccount.automountServiceAccountToken`       | Allows auto mount of ServiceAccountToken on the serviceAccount created                                   | `false`                    |
+| `serviceAccount.annotations`                        | Additional custom annotations for the ServiceAccount                                                     | `{}`                       |
 
 ### Traffic Exposure Parameters
 

--- a/bitnami/opencart/templates/_helpers.tpl
+++ b/bitnami/opencart/templates/_helpers.tpl
@@ -74,6 +74,17 @@ Return the proper Docker Image Registry Secret Names
 {{- end -}}
 
 {{/*
+ Create the name of the service account to use
+ */}}
+{{- define "opencart.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "common.names.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Return  the proper Storage Class
 */}}
 {{- define "opencart.storageClass" -}}

--- a/bitnami/opencart/templates/deployment.yaml
+++ b/bitnami/opencart/templates/deployment.yaml
@@ -33,6 +33,7 @@ spec:
         {{- end }}
     spec:
       {{- include "opencart.imagePullSecrets" . | nindent 6 }}
+      serviceAccountName: {{ include "opencart.serviceAccountName" . }}
       {{- if .Values.podSecurityContext.enabled }}
       securityContext: {{- omit .Values.podSecurityContext "enabled" | toYaml | nindent 8 }}
       {{- end }}
@@ -57,6 +58,7 @@ spec:
       {{- if .Values.tolerations }}
       tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.tolerations "context" $) | nindent 8 }}
       {{- end }}
+      automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
       {{- if .Values.hostAliases }}
       # yamllint disable rule:indentation
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.hostAliases "context" $) | nindent 8 }}

--- a/bitnami/opencart/templates/serviceaccount.yaml
+++ b/bitnami/opencart/templates/serviceaccount.yaml
@@ -1,0 +1,18 @@
+{{- /*
+Copyright VMware, Inc.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "opencart.serviceAccountName" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- if or .Values.serviceAccount.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.serviceAccount.annotations .Values.commonAnnotations ) "context" . ) }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end -}}

--- a/bitnami/opencart/values.yaml
+++ b/bitnami/opencart/values.yaml
@@ -399,7 +399,7 @@ podLabels: {}
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
 ##
 serviceAccount:
-  ## @param serviceAccount.create Enable creation of ServiceAccount for WordPress pod
+  ## @param serviceAccount.create Enable creation of ServiceAccount for Opencart pod
   ##
   create: true
   ## @param serviceAccount.name The name of the ServiceAccount to use.

--- a/bitnami/opencart/values.yaml
+++ b/bitnami/opencart/values.yaml
@@ -76,6 +76,9 @@ image:
   ## Set to true if you would like to see extra information on logs
   ##
   debug: false
+## @param automountServiceAccountToken Mount Service Account token in pod
+##
+automountServiceAccountToken: false
 ## @param hostAliases [array] Deployment pod host aliases
 ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
 ##
@@ -391,6 +394,25 @@ podAnnotations: {}
 ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
 ##
 podLabels: {}
+
+## Service Account
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+##
+serviceAccount:
+  ## @param serviceAccount.create Enable creation of ServiceAccount for WordPress pod
+  ##
+  create: true
+  ## @param serviceAccount.name The name of the ServiceAccount to use.
+  ## If not set and create is true, a name is generated using the common.names.fullname template
+  ##
+  name: ""
+  ## @param serviceAccount.automountServiceAccountToken Allows auto mount of ServiceAccountToken on the serviceAccount created
+  ## Can be set to false if pods using this serviceAccount do not need to use K8s API
+  ##
+  automountServiceAccountToken: false
+  ## @param serviceAccount.annotations Additional custom annotations for the ServiceAccount
+  ##
+  annotations: {}
 
 ## @section Traffic Exposure Parameters
 


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

### Description of the change

This PR sets all ServiceAccount automountServiceAccountToken=false by default, as the token mounting should be set in the pod declaration instead (if a new pod uses this service account and the token gets automatically mounted, it could be problematic in terms of security). This PR also adds automountServiceAccountToken in the pod declaration as a new value, which can be configured by users in case they want to use an external token.

### Benefits

Charts become more security-compliant

### Possible drawbacks

n/a

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)

