### PR TITLE
[bitnami/pytorch] fix: :lock: Move service-account token auto-mount to pod declaration

### DIFF
--- a/bitnami/pytorch/Chart.yaml
+++ b/bitnami/pytorch/Chart.yaml
@@ -33,4 +33,4 @@ maintainers:
 name: pytorch
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/pytorch
-version: 3.5.1
+version: 3.6.0

--- a/bitnami/pytorch/README.md
+++ b/bitnami/pytorch/README.md
@@ -163,7 +163,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `extraVolumeMounts`                                 | Optionally specify extra list of additional volumeMounts for the Pytorch container(s)                                    | `[]`                      |
 | `sidecars`                                          | Add additional sidecar containers to the Pytorch pod(s)                                                                  | `[]`                      |
 | `initContainers`                                    | Add additional init containers to the %%MAIN_CONTAINER_NAME%% pod(s)                                                     | `[]`                      |
-| `serviceAccount.create`                             | Enable creation of ServiceAccount for WordPress pod                                                                      | `true`                    |
+| `serviceAccount.create`                             | Enable creation of ServiceAccount for Pytorch pod                                                                        | `true`                    |
 | `serviceAccount.name`                               | The name of the ServiceAccount to use.                                                                                   | `""`                      |
 | `serviceAccount.automountServiceAccountToken`       | Allows auto mount of ServiceAccountToken on the serviceAccount created                                                   | `false`                   |
 | `serviceAccount.annotations`                        | Additional custom annotations for the ServiceAccount                                                                     | `{}`                      |

--- a/bitnami/pytorch/README.md
+++ b/bitnami/pytorch/README.md
@@ -130,6 +130,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `entrypoint.file`                                   | Main entrypoint to your application                                                                                      | `""`                      |
 | `entrypoint.args`                                   | Args required by your entrypoint                                                                                         | `[]`                      |
 | `architecture`                                      | Run PyTorch in standalone or distributed mode. Possible values: `standalone`, `distributed`                              | `standalone`              |
+| `automountServiceAccountToken`                      | Mount Service Account token in pod                                                                                       | `false`                   |
 | `hostAliases`                                       | Deployment pod host aliases                                                                                              | `[]`                      |
 | `command`                                           | Override default container command (useful when using custom images)                                                     | `[]`                      |
 | `args`                                              | Override default container args (useful when using custom images)                                                        | `[]`                      |
@@ -162,6 +163,10 @@ The command removes all the Kubernetes components associated with the chart and 
 | `extraVolumeMounts`                                 | Optionally specify extra list of additional volumeMounts for the Pytorch container(s)                                    | `[]`                      |
 | `sidecars`                                          | Add additional sidecar containers to the Pytorch pod(s)                                                                  | `[]`                      |
 | `initContainers`                                    | Add additional init containers to the %%MAIN_CONTAINER_NAME%% pod(s)                                                     | `[]`                      |
+| `serviceAccount.create`                             | Enable creation of ServiceAccount for WordPress pod                                                                      | `true`                    |
+| `serviceAccount.name`                               | The name of the ServiceAccount to use.                                                                                   | `""`                      |
+| `serviceAccount.automountServiceAccountToken`       | Allows auto mount of ServiceAccountToken on the serviceAccount created                                                   | `false`                   |
+| `serviceAccount.annotations`                        | Additional custom annotations for the ServiceAccount                                                                     | `{}`                      |
 
 ### Traffic Exposure Parameters
 

--- a/bitnami/pytorch/templates/_helpers.tpl
+++ b/bitnami/pytorch/templates/_helpers.tpl
@@ -61,6 +61,17 @@ Return the proper securityContext when enabled by the deprecated or new params
 {{- end -}}
 
 {{/*
+ Create the name of the service account to use
+ */}}
+{{- define "pytorch.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "common.names.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Compile all warnings into a single message, and call fail.
 */}}
 {{- define "pytorch.validateValues" -}}

--- a/bitnami/pytorch/templates/deployment.yaml
+++ b/bitnami/pytorch/templates/deployment.yaml
@@ -31,6 +31,8 @@ spec:
         app.kubernetes.io/component: master
     spec:
       {{- include "pytorch.imagePullSecrets" . | nindent 6 }}
+      serviceAccountName: {{ include "pytorch.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
       {{- if .Values.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.hostAliases "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/pytorch/templates/serviceaccount.yaml
+++ b/bitnami/pytorch/templates/serviceaccount.yaml
@@ -1,0 +1,18 @@
+{{- /*
+Copyright VMware, Inc.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "pytorch.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- if or .Values.serviceAccount.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.serviceAccount.annotations .Values.commonAnnotations ) "context" . ) }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end -}}

--- a/bitnami/pytorch/templates/statefulset.yaml
+++ b/bitnami/pytorch/templates/statefulset.yaml
@@ -32,6 +32,8 @@ spec:
         app.kubernetes.io/component: worker
     spec:
       {{- include "pytorch.imagePullSecrets" . | nindent 6 }}
+      serviceAccountName: {{ include "pytorch.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
       {{- if .Values.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.hostAliases "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/pytorch/values.yaml
+++ b/bitnami/pytorch/values.yaml
@@ -379,7 +379,7 @@ initContainers: []
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
 ##
 serviceAccount:
-  ## @param serviceAccount.create Enable creation of ServiceAccount for WordPress pod
+  ## @param serviceAccount.create Enable creation of ServiceAccount for Pytorch pod
   ##
   create: true
   ## @param serviceAccount.name The name of the ServiceAccount to use.

--- a/bitnami/pytorch/values.yaml
+++ b/bitnami/pytorch/values.yaml
@@ -220,6 +220,9 @@ entrypoint:
 ## @param architecture Run PyTorch in standalone or distributed mode. Possible values: `standalone`, `distributed`
 ##
 architecture: standalone
+## @param automountServiceAccountToken Mount Service Account token in pod
+##
+automountServiceAccountToken: false
 ## @param hostAliases Deployment pod host aliases
 ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
 ##
@@ -371,6 +374,25 @@ sidecars: []
 ##    command: ['sh', '-c', 'echo "hello world"']
 ##
 initContainers: []
+
+## Service Account
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+##
+serviceAccount:
+  ## @param serviceAccount.create Enable creation of ServiceAccount for WordPress pod
+  ##
+  create: true
+  ## @param serviceAccount.name The name of the ServiceAccount to use.
+  ## If not set and create is true, a name is generated using the common.names.fullname template
+  ##
+  name: ""
+  ## @param serviceAccount.automountServiceAccountToken Allows auto mount of ServiceAccountToken on the serviceAccount created
+  ## Can be set to false if pods using this serviceAccount do not need to use K8s API
+  ##
+  automountServiceAccountToken: false
+  ## @param serviceAccount.annotations Additional custom annotations for the ServiceAccount
+  ##
+  annotations: {}
 
 ## @section Traffic Exposure Parameters
 ##


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

### Description of the change

This PR sets all ServiceAccount automountServiceAccountToken=false by default, as the token mounting should be set in the pod declaration instead (if a new pod uses this service account and the token gets automatically mounted, it could be problematic in terms of security). This PR also adds automountServiceAccountToken in the pod declaration as a new value, which can be configured by users in case they want to use an external token.

### Benefits

Charts become more security-compliant

### Possible drawbacks

n/a

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)

