### PR TITLE
[bitnami/tomcat] fix: :lock: Move service-account token auto-mount to pod declaration

### DIFF
--- a/bitnami/tomcat/Chart.yaml
+++ b/bitnami/tomcat/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: tomcat
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/tomcat
-version: 10.12.1
+version: 10.13.0

--- a/bitnami/tomcat/README.md
+++ b/bitnami/tomcat/README.md
@@ -79,24 +79,25 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Tomcat parameters
 
-| Name                          | Description                                                                                            | Value                    |
-| ----------------------------- | ------------------------------------------------------------------------------------------------------ | ------------------------ |
-| `image.registry`              | Tomcat image registry                                                                                  | `REGISTRY_NAME`          |
-| `image.repository`            | Tomcat image repository                                                                                | `REPOSITORY_NAME/tomcat` |
-| `image.digest`                | Tomcat image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                     |
-| `image.pullPolicy`            | Tomcat image pull policy                                                                               | `IfNotPresent`           |
-| `image.pullSecrets`           | Specify docker-registry secret names as an array                                                       | `[]`                     |
-| `image.debug`                 | Specify if debug logs should be enabled                                                                | `false`                  |
-| `hostAliases`                 | Deployment pod host aliases                                                                            | `[]`                     |
-| `tomcatUsername`              | Tomcat admin user                                                                                      | `user`                   |
-| `tomcatPassword`              | Tomcat admin password                                                                                  | `""`                     |
-| `tomcatAllowRemoteManagement` | Enable remote access to management interface                                                           | `0`                      |
-| `catalinaOpts`                | Java runtime option used by tomcat JVM                                                                 | `""`                     |
-| `command`                     | Override default container command (useful when using custom images)                                   | `[]`                     |
-| `args`                        | Override default container args (useful when using custom images)                                      | `[]`                     |
-| `extraEnvVars`                | Extra environment variables to be set on Tomcat container                                              | `[]`                     |
-| `extraEnvVarsCM`              | Name of existing ConfigMap containing extra environment variables                                      | `""`                     |
-| `extraEnvVarsSecret`          | Name of existing Secret containing extra environment variables                                         | `""`                     |
+| Name                           | Description                                                                                            | Value                    |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------ | ------------------------ |
+| `image.registry`               | Tomcat image registry                                                                                  | `REGISTRY_NAME`          |
+| `image.repository`             | Tomcat image repository                                                                                | `REPOSITORY_NAME/tomcat` |
+| `image.digest`                 | Tomcat image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                     |
+| `image.pullPolicy`             | Tomcat image pull policy                                                                               | `IfNotPresent`           |
+| `image.pullSecrets`            | Specify docker-registry secret names as an array                                                       | `[]`                     |
+| `image.debug`                  | Specify if debug logs should be enabled                                                                | `false`                  |
+| `automountServiceAccountToken` | Mount Service Account token in pod                                                                     | `false`                  |
+| `hostAliases`                  | Deployment pod host aliases                                                                            | `[]`                     |
+| `tomcatUsername`               | Tomcat admin user                                                                                      | `user`                   |
+| `tomcatPassword`               | Tomcat admin password                                                                                  | `""`                     |
+| `tomcatAllowRemoteManagement`  | Enable remote access to management interface                                                           | `0`                      |
+| `catalinaOpts`                 | Java runtime option used by tomcat JVM                                                                 | `""`                     |
+| `command`                      | Override default container command (useful when using custom images)                                   | `[]`                     |
+| `args`                         | Override default container args (useful when using custom images)                                      | `[]`                     |
+| `extraEnvVars`                 | Extra environment variables to be set on Tomcat container                                              | `[]`                     |
+| `extraEnvVarsCM`               | Name of existing ConfigMap containing extra environment variables                                      | `""`                     |
+| `extraEnvVarsSecret`           | Name of existing Secret containing extra environment variables                                         | `""`                     |
 
 ### Tomcat deployment parameters
 
@@ -174,6 +175,10 @@ The command removes all the Kubernetes components associated with the chart and 
 | `networkPolicy.enabled`                             | Enable creation of NetworkPolicy resources. Only Ingress traffic is filtered for now.                                    | `false`             |
 | `networkPolicy.allowExternal`                       | Don't require client label for connections                                                                               | `true`              |
 | `networkPolicy.explicitNamespacesSelector`          | A Kubernetes LabelSelector to explicitly select namespaces from which traffic could be allowed                           | `{}`                |
+| `serviceAccount.create`                             | Enable creation of ServiceAccount for WordPress pod                                                                      | `true`              |
+| `serviceAccount.name`                               | The name of the ServiceAccount to use.                                                                                   | `""`                |
+| `serviceAccount.automountServiceAccountToken`       | Allows auto mount of ServiceAccountToken on the serviceAccount created                                                   | `false`             |
+| `serviceAccount.annotations`                        | Additional custom annotations for the ServiceAccount                                                                     | `{}`                |
 
 ### Traffic Exposure parameters
 

--- a/bitnami/tomcat/README.md
+++ b/bitnami/tomcat/README.md
@@ -175,7 +175,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `networkPolicy.enabled`                             | Enable creation of NetworkPolicy resources. Only Ingress traffic is filtered for now.                                    | `false`             |
 | `networkPolicy.allowExternal`                       | Don't require client label for connections                                                                               | `true`              |
 | `networkPolicy.explicitNamespacesSelector`          | A Kubernetes LabelSelector to explicitly select namespaces from which traffic could be allowed                           | `{}`                |
-| `serviceAccount.create`                             | Enable creation of ServiceAccount for WordPress pod                                                                      | `true`              |
+| `serviceAccount.create`                             | Enable creation of ServiceAccount for Tomcat pod                                                                         | `true`              |
 | `serviceAccount.name`                               | The name of the ServiceAccount to use.                                                                                   | `""`                |
 | `serviceAccount.automountServiceAccountToken`       | Allows auto mount of ServiceAccountToken on the serviceAccount created                                                   | `false`             |
 | `serviceAccount.annotations`                        | Additional custom annotations for the ServiceAccount                                                                     | `{}`                |

--- a/bitnami/tomcat/templates/_helpers.tpl
+++ b/bitnami/tomcat/templates/_helpers.tpl
@@ -56,6 +56,17 @@ Check if there are rolling tags in the images
 {{- end -}}
 
 {{/*
+ Create the name of the service account to use
+ */}}
+{{- define "tomcat.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "common.names.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Expand the name of the chart.
 */}}
 {{- define "tomcat.pvc" -}}

--- a/bitnami/tomcat/templates/_pod.tpl
+++ b/bitnami/tomcat/templates/_pod.tpl
@@ -8,6 +8,7 @@ Pod Spec
 */}}
 {{- define "tomcat.pod" -}}
 {{- include "tomcat.imagePullSecrets" . }}
+automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
 {{- if .Values.hostAliases }}
 hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.hostAliases "context" $) | nindent 2 }}
 {{- end }}
@@ -20,6 +21,7 @@ affinity:
   podAntiAffinity: {{- include "common.affinities.pods" (dict "type" .Values.podAntiAffinityPreset "customLabels" $podLabels "context" $) | nindent 4 }}
   nodeAffinity: {{- include "common.affinities.nodes" (dict "type" .Values.nodeAffinityPreset.type "key" .Values.nodeAffinityPreset.key "values" .Values.nodeAffinityPreset.values) | nindent 4 }}
 {{- end }}
+serviceAccountName: {{ include "tomcat.serviceAccountName" . }}
 {{- if .Values.schedulerName }}
 schedulerName: {{ .Values.schedulerName | quote }}
 {{- end }}

--- a/bitnami/tomcat/templates/serviceaccount.yaml
+++ b/bitnami/tomcat/templates/serviceaccount.yaml
@@ -1,0 +1,18 @@
+{{- /*
+Copyright VMware, Inc.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "tomcat.serviceAccountName" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- if or .Values.serviceAccount.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.serviceAccount.annotations .Values.commonAnnotations ) "context" . ) }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end -}}

--- a/bitnami/tomcat/values.yaml
+++ b/bitnami/tomcat/values.yaml
@@ -79,6 +79,9 @@ image:
   ## Set to true if you would like to see extra information on logs
   ##
   debug: false
+## @param automountServiceAccountToken Mount Service Account token in pod
+##
+automountServiceAccountToken: false
 ## @param hostAliases Deployment pod host aliases
 ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
 ##
@@ -417,6 +420,26 @@ networkPolicy:
   ##    - {key: role, operator: In, values: [frontend]}
   ##
   explicitNamespacesSelector: {}
+
+## Service Account
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+##
+serviceAccount:
+  ## @param serviceAccount.create Enable creation of ServiceAccount for WordPress pod
+  ##
+  create: true
+  ## @param serviceAccount.name The name of the ServiceAccount to use.
+  ## If not set and create is true, a name is generated using the common.names.fullname template
+  ##
+  name: ""
+  ## @param serviceAccount.automountServiceAccountToken Allows auto mount of ServiceAccountToken on the serviceAccount created
+  ## Can be set to false if pods using this serviceAccount do not need to use K8s API
+  ##
+  automountServiceAccountToken: false
+  ## @param serviceAccount.annotations Additional custom annotations for the ServiceAccount
+  ##
+  annotations: {}
+
 ## @section Traffic Exposure parameters
 ##
 

--- a/bitnami/tomcat/values.yaml
+++ b/bitnami/tomcat/values.yaml
@@ -425,7 +425,7 @@ networkPolicy:
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
 ##
 serviceAccount:
-  ## @param serviceAccount.create Enable creation of ServiceAccount for WordPress pod
+  ## @param serviceAccount.create Enable creation of ServiceAccount for Tomcat pod
   ##
   create: true
   ## @param serviceAccount.name The name of the ServiceAccount to use.


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

### Description of the change

This PR sets all ServiceAccount automountServiceAccountToken=false by default, as the token mounting should be set in the pod declaration instead (if a new pod uses this service account and the token gets automatically mounted, it could be problematic in terms of security). This PR also adds automountServiceAccountToken in the pod declaration as a new value, which can be configured by users in case they want to use an external token.

### Benefits

Charts become more security-compliant

### Possible drawbacks

n/a

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)

