### PR TITLE
[bitnami/external-dns] Fix pihole secret name

### DIFF
--- a/bitnami/external-dns/Chart.yaml
+++ b/bitnami/external-dns/Chart.yaml
@@ -28,4 +28,4 @@ maintainers:
 name: external-dns
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/external-dns
-version: 6.30.1
+version: 6.30.2

--- a/bitnami/external-dns/templates/_helpers.tpl
+++ b/bitnami/external-dns/templates/_helpers.tpl
@@ -186,6 +186,8 @@ Return the name of the Secret used to store the passwords
 {{- .Values.ns1.secretName }}
 {{- else if and (eq .Values.provider "civo") .Values.civo.secretName }}
 {{- .Values.civo.secretName }}
+{{- else if and (eq .Values.provider "pihole") .Values.pihole.secretName }}
+{{- .Values.pihole.secretName }}
 {{- else -}}
 {{- template "external-dns.fullname" . }}
 {{- end -}}


### PR DESCRIPTION
### Description of the change

Adds missing mapping for a proper secretName for pihole provider.

### Benefits

Makes chart working as expected :)

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
