### PR TITLE
[bitnami/whereabouts] Enable readinessProbe by default

### DIFF
--- a/bitnami/whereabouts/Chart.yaml
+++ b/bitnami/whereabouts/Chart.yaml
@@ -29,4 +29,4 @@ maintainers:
 name: whereabouts
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/whereabouts
-version: 0.7.1
+version: 0.7.2

--- a/bitnami/whereabouts/README.md
+++ b/bitnami/whereabouts/README.md
@@ -138,7 +138,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `livenessProbe.timeoutSeconds`                 | Timeout seconds for livenessProbe                                                                                     | `5`                           |
 | `livenessProbe.failureThreshold`               | Failure threshold for livenessProbe                                                                                   | `5`                           |
 | `livenessProbe.successThreshold`               | Success threshold for livenessProbe                                                                                   | `1`                           |
-| `readinessProbe.enabled`                       | Enable readinessProbe                                                                                                 | `false`                       |
+| `readinessProbe.enabled`                       | Enable readinessProbe                                                                                                 | `true`                        |
 | `readinessProbe.initialDelaySeconds`           | Initial delay seconds for readinessProbe                                                                              | `10`                          |
 | `readinessProbe.periodSeconds`                 | Period seconds for readinessProbe                                                                                     | `5`                           |
 | `readinessProbe.timeoutSeconds`                | Timeout seconds for readinessProbe                                                                                    | `1`                           |

--- a/bitnami/whereabouts/values.yaml
+++ b/bitnami/whereabouts/values.yaml
@@ -281,7 +281,7 @@ livenessProbe:
 ## @param readinessProbe.successThreshold Success threshold for readinessProbe
 ##
 readinessProbe:
-  enabled: false
+  enabled: true
   initialDelaySeconds: 10
   periodSeconds: 5
   timeoutSeconds: 1


### PR DESCRIPTION
### Description of the change

This PR enables the readiness probe, which was disabled for no reason.

### Benefits

The chart will use the already implemented probe.

### Possible drawbacks

None.

### Applicable issues

NA.

### Additional information

NA.

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
