### PR TITLE
[github-actions] update-pr: Use BITNAMI_BOT_TOKEN instead of GITHUB_TOKEN when pushing changes

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -104,7 +104,7 @@ jobs:
         with:
           ref: ${{github.event.pull_request.head.ref}}
           repository: ${{github.event.pull_request.head.repo.full_name}}
-          token: ${{ github.actor == 'bitnami-bot' && secrets.GITHUB_TOKEN || secrets.BITNAMI_BOT_TOKEN }}
+          token: ${{ secrets.BITNAMI_BOT_TOKEN }}
       - name: Setup git configuration
         run: |
           git config user.name "Bitnami Containers"


### PR DESCRIPTION
### Description of the change

Remove exception to use GITHUB_TOKEN when action actor is 'bitnami-bot'.

