### PR TITLE
[bitnam/supabase] Fix supabase studio svc

### DIFF
--- a/bitnami/supabase/Chart.yaml
+++ b/bitnami/supabase/Chart.yaml
@@ -53,4 +53,4 @@ maintainers:
 name: supabase
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/supabase
-version: 2.4.0
+version: 2.5.0

--- a/bitnami/supabase/templates/studio/deployment.yaml
+++ b/bitnami/supabase/templates/studio/deployment.yaml
@@ -135,7 +135,7 @@ spec:
           resources: {{- toYaml .Values.studio.resources | nindent 12 }}
           {{- end }}
           ports:
-            - name: http
+            - name: http-studio
               containerPort: {{ .Values.studio.containerPorts.http }}
           {{- if not .Values.diagnosticMode.enabled }}
           {{- if .Values.studio.customLivenessProbe }}
@@ -144,7 +144,7 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.studio.livenessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: /
-              port: http
+              port: http-studio
           {{- end }}
           {{- if .Values.studio.customReadinessProbe }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.studio.customReadinessProbe "context" $) | nindent 12 }}
@@ -152,7 +152,7 @@ spec:
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.studio.readinessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: /
-              port: http
+              port: http-studio
           {{- end }}
           {{- if .Values.studio.customStartupProbe }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.studio.customStartupProbe "context" $) | nindent 12 }}
@@ -160,7 +160,7 @@ spec:
           startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.studio.startupProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: /
-              port: http
+              port: http-studio
           {{- end }}
           {{- end }}
           {{- if .Values.studio.lifecycleHooks }}

--- a/bitnami/supabase/templates/studio/service.yaml
+++ b/bitnami/supabase/templates/studio/service.yaml
@@ -36,12 +36,12 @@ spec:
   loadBalancerIP: {{ .Values.studio.service.loadBalancerIP }}
   {{- end }}
   ports:
-    - name: http
+    - name: http-studio
       port: {{ .Values.studio.service.ports.http }}
       protocol: TCP
       {{- if and (or (eq .Values.studio.service.type "NodePort") (eq .Values.studio.service.type "LoadBalancer")) (not (empty .Values.studio.service.nodePorts.http)) }}
       nodePort: {{ .Values.studio.service.nodePorts.http }}
-      targetPort: http
+      targetPort: http-studio
       {{- else if eq .Values.studio.service.type "ClusterIP" }}
       nodePort: null
       targetPort: {{ .Values.studio.containerPorts.http }}


### PR DESCRIPTION
The svc on supabase-studio was not able to reach the port in the containers.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
