### PR TITLE
 [bitnami/clickhouse] feat: 🔒 Enable networkPolicy 

### DIFF
--- a/bitnami/clickhouse/Chart.yaml
+++ b/bitnami/clickhouse/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: clickhouse
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/clickhouse
-version: 4.4.0
+version: 4.5.0

--- a/bitnami/clickhouse/README.md
+++ b/bitnami/clickhouse/README.md
@@ -360,6 +360,17 @@ The command removes all the Kubernetes components associated with the chart and 
 | `zookeeper.image.repository`     | Zookeeper image repository    | `REPOSITORY_NAME/zookeeper` |
 | `zookeeper.image.pullPolicy`     | Zookeeper image pull policy   | `IfNotPresent`              |
 
+### Network Policies
+
+| Name                                    | Description                                                | Value  |
+| --------------------------------------- | ---------------------------------------------------------- | ------ |
+| `networkPolicy.enabled`                 | Specifies whether a NetworkPolicy should be created        | `true` |
+| `networkPolicy.allowExternal`           | Don't require client label for connections                 | `true` |
+| `networkPolicy.extraIngress`            | Add extra ingress rules to the NetworkPolice               | `[]`   |
+| `networkPolicy.extraEgress`             | Add extra ingress rules to the NetworkPolicy               | `[]`   |
+| `networkPolicy.ingressNSMatchLabels`    | Labels to match to allow traffic from other namespaces     | `{}`   |
+| `networkPolicy.ingressNSPodMatchLabels` | Pod labels to match to allow traffic from other namespaces | `{}`   |
+
 See <https://github.com/bitnami/readme-generator-for-helm> to create the table.
 
 The above parameters map to the env variables defined in [bitnami/clickhouse](https://github.com/bitnami/containers/tree/main/bitnami/clickhouse). For more information please refer to the [bitnami/clickhouse](https://github.com/bitnami/containers/tree/main/bitnami/clickhouse) image documentation.

--- a/bitnami/clickhouse/templates/networkpolicy.yaml
+++ b/bitnami/clickhouse/templates/networkpolicy.yaml
@@ -1,0 +1,128 @@
+{{- /*
+Copyright VMware, Inc.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+{{- if .Values.networkPolicy.enabled }}
+kind: NetworkPolicy
+apiVersion: {{ include "common.capabilities.networkPolicy.apiVersion" . }}
+metadata:
+  name: {{ include "common.names.fullname" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+    app.kubernetes.io/component: clickhouse
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.podLabels .Values.commonLabels ) "context" . ) }}
+  podSelector:
+    matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
+      app.kubernetes.io/component: clickhouse
+  policyTypes:
+    - Ingress
+    - Egress
+  egress:
+    # Allow dns resolution
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+    # Allow outbound connections to other cluster pods
+    - ports:
+        - port: {{ .Values.service.ports.http }}
+        {{- if .Values.tls.enabled }}
+        - port: {{ .Values.service.ports.https }}
+        {{- end }}
+        - port: {{ .Values.service.ports.tcp }}
+        {{- if .Values.tls.enabled }}
+        - port: {{ .Values.service.ports.tcpSecure }}
+        {{- end }}
+        {{- if .Values.keeper.enabled }}
+        - port: {{ .Values.service.ports.keeper }}
+        - port: {{ .Values.service.ports.keeperInter }}
+        {{- if .Values.tls.enabled }}
+        - port: {{ .Values.service.ports.keeperSecure }}
+        {{- end }}
+        {{- end }}
+        - port: {{ .Values.service.ports.mysql }}
+        - port: {{ .Values.service.ports.postgresql }}
+        - port: {{ .Values.service.ports.interserver }}
+        {{- if .Values.metrics.enabled }}
+        - port: {{ .Values.service.ports.metrics }}
+        {{- end }}
+      {{- if $.Values.externalAccess.enabled }}
+        - port: {{ $.Values.externalAccess.service.ports.http }}
+        {{- if $.Values.tls.enabled }}
+        - port: {{ $.Values.externalAccess.service.ports.https }}
+        {{- end }}
+        {{- if $.Values.metrics.enabled }}
+        - port: {{ $.Values.externalAccess.service.ports.metrics }}
+        {{- end }}
+        - port: {{ $.Values.externalAccess.service.ports.tcp }}
+        {{- if $.Values.tls.enabled }}
+        - port: {{ $.Values.externalAccess.service.ports.tcpSecure }}
+        {{- end }}
+        {{- if $.Values.keeper.enabled }}
+        - port: {{ $.Values.externalAccess.service.ports.keeper }}
+        - port: {{ $.Values.externalAccess.service.ports.keeperInter }}
+        {{- if $.Values.tls.enabled }}
+        - port: {{ $.Values.externalAccess.service.ports.keeperSecure }}
+        {{- end }}
+        {{- end }}
+        - port: {{ $.Values.externalAccess.service.ports.mysql }}
+        - port: {{ $.Values.externalAccess.service.ports.postgresql }}
+        - port: {{ $.Values.externalAccess.service.ports.interserver }}
+      {{- end }}
+      to:
+        - podSelector:
+            matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 14 }}
+    {{- if .Values.networkPolicy.extraEgress }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.networkPolicy.extraEgress "context" $ ) | nindent 4 }}
+    {{- end }}
+  ingress:
+    - ports:
+        - port: {{ $.Values.containerPorts.http }}
+        - port: {{ $.Values.containerPorts.tcp }}
+        - port: {{ $.Values.containerPorts.mysql }}
+        - port: {{ $.Values.containerPorts.postgresql }}
+        - port: {{ $.Values.containerPorts.interserver }}
+        {{- if $.Values.tls.enabled }}
+        - port: {{ $.Values.containerPorts.tcpSecure }}
+        - port: {{ $.Values.containerPorts.https }}
+        {{- end }}
+        {{- if $.Values.keeper.enabled }}
+        - port: {{ $.Values.containerPorts.keeper }}
+        - port: {{ $.Values.containerPorts.keeperInter }}
+        {{- if $.Values.tls.enabled }}
+        - port : {{ $.Values.containerPorts.keeperSecure }}
+        {{- end }}
+        {{- end }}
+        {{- if $.Values.metrics.enabled }}
+        - port: {{ $.Values.containerPorts.metrics }}
+        {{- end }}
+      {{- if not .Values.networkPolicy.allowExternal }}
+      from:
+        - podSelector:
+            matchLabels:
+              {{ include "common.names.fullname" . }}-client: "true"
+        {{- if .Values.networkPolicy.ingressNSMatchLabels }}
+        - namespaceSelector:
+            matchLabels:
+              {{- range $key, $value := .Values.networkPolicy.ingressNSMatchLabels }}
+              {{ $key | quote }}: {{ $value | quote }}
+              {{- end }}
+          {{- if .Values.networkPolicy.ingressNSPodMatchLabels }}
+          podSelector:
+            matchLabels:
+              {{- range $key, $value := .Values.networkPolicy.ingressNSPodMatchLabels }}
+              {{ $key | quote }}: {{ $value | quote }}
+              {{- end }}
+          {{- end }}
+        {{- end }}
+      {{- end }}
+    {{- if .Values.networkPolicy.extraIngress }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.networkPolicy.extraIngress "context" $ ) | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/bitnami/clickhouse/values.yaml
+++ b/bitnami/clickhouse/values.yaml
@@ -1145,3 +1145,57 @@ zookeeper:
   service:
     ports:
       client: 2181
+
+## @section Network Policies
+## Ref: https://kubernetes.io/docs/concepts/services-networking/network-policies/
+##
+networkPolicy:
+  ## @param networkPolicy.enabled Specifies whether a NetworkPolicy should be created
+  ##
+  enabled: true
+  ## @param networkPolicy.allowExternal Don't require client label for connections
+  ## The Policy model to apply. When set to false, only pods with the correct
+  ## client label will have network access to the ports Clickhouse is listening
+  ## on. When true, Clickhouse will accept connections from any source
+  ## (with the correct destination port).
+  ##
+  allowExternal: true
+  ## @param networkPolicy.extraIngress [array] Add extra ingress rules to the NetworkPolice
+  ## e.g:
+  ## extraIngress:
+  ##   - ports:
+  ##       - port: 1234
+  ##     from:
+  ##       - podSelector:
+  ##           - matchLabels:
+  ##               - role: frontend
+  ##       - podSelector:
+  ##           - matchExpressions:
+  ##               - key: role
+  ##                 operator: In
+  ##                 values:
+  ##                   - frontend
+  extraIngress: []
+  ## @param networkPolicy.extraEgress [array] Add extra ingress rules to the NetworkPolicy
+  ## e.g:
+  ## extraEgress:
+  ##   - ports:
+  ##       - port: 1234
+  ##     to:
+  ##       - podSelector:
+  ##           - matchLabels:
+  ##               - role: frontend
+  ##       - podSelector:
+  ##           - matchExpressions:
+  ##               - key: role
+  ##                 operator: In
+  ##                 values:
+  ##                   - frontend
+  ##
+  extraEgress: []
+  ## @param networkPolicy.ingressNSMatchLabels [object] Labels to match to allow traffic from other namespaces
+  ## @param networkPolicy.ingressNSPodMatchLabels [object] Pod labels to match to allow traffic from other namespaces
+  ##
+  ingressNSMatchLabels: {}
+  ingressNSPodMatchLabels: {}
+


### PR DESCRIPTION
### Description of the change

This PR normalizes the use of NetworkPolicy in the chart. Adds all Bitnami standards for NetworkPolicies as well as enabling it by default, in order to comply with security checklists.

### Benefits

More security in the chart

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
