### PR TITLE
 [bitnami/nginx]: Remove duplicate automountServiceAccountToken [#22517] 

### DIFF
--- a/bitnami/nginx/Chart.yaml
+++ b/bitnami/nginx/Chart.yaml
@@ -34,4 +34,4 @@ maintainers:
 name: nginx
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/nginx
-version: 15.9.0
+version: 15.9.1

--- a/bitnami/nginx/README.md
+++ b/bitnami/nginx/README.md
@@ -80,20 +80,20 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### NGINX parameters
 
-| Name                           | Description                                                                                           | Value                   |
-| ------------------------------ | ----------------------------------------------------------------------------------------------------- | ----------------------- |
-| `image.registry`               | NGINX image registry                                                                                  | `REGISTRY_NAME`         |
-| `image.repository`             | NGINX image repository                                                                                | `REPOSITORY_NAME/nginx` |
-| `image.digest`                 | NGINX image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                    |
-| `image.pullPolicy`             | NGINX image pull policy                                                                               | `IfNotPresent`          |
-| `image.pullSecrets`            | Specify docker-registry secret names as an array                                                      | `[]`                    |
-| `image.debug`                  | Set to true if you would like to see extra information on logs                                        | `false`                 |
-| `hostAliases`                  | Deployment pod host aliases                                                                           | `[]`                    |
-| `command`                      | Override default container command (useful when using custom images)                                  | `[]`                    |
-| `args`                         | Override default container args (useful when using custom images)                                     | `[]`                    |
-| `extraEnvVars`                 | Extra environment variables to be set on NGINX containers                                             | `[]`                    |
-| `extraEnvVarsCM`               | ConfigMap with extra environment variables                                                            | `""`                    |
-| `extraEnvVarsSecret`           | Secret with extra environment variables                                                               | `""`                    |
+| Name                 | Description                                                                                           | Value                   |
+| -------------------- | ----------------------------------------------------------------------------------------------------- | ----------------------- |
+| `image.registry`     | NGINX image registry                                                                                  | `REGISTRY_NAME`         |
+| `image.repository`   | NGINX image repository                                                                                | `REPOSITORY_NAME/nginx` |
+| `image.digest`       | NGINX image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                    |
+| `image.pullPolicy`   | NGINX image pull policy                                                                               | `IfNotPresent`          |
+| `image.pullSecrets`  | Specify docker-registry secret names as an array                                                      | `[]`                    |
+| `image.debug`        | Set to true if you would like to see extra information on logs                                        | `false`                 |
+| `hostAliases`        | Deployment pod host aliases                                                                           | `[]`                    |
+| `command`            | Override default container command (useful when using custom images)                                  | `[]`                    |
+| `args`               | Override default container args (useful when using custom images)                                     | `[]`                    |
+| `extraEnvVars`       | Extra environment variables to be set on NGINX containers                                             | `[]`                    |
+| `extraEnvVarsCM`     | ConfigMap with extra environment variables                                                            | `""`                    |
+| `extraEnvVarsSecret` | Secret with extra environment variables                                                               | `""`                    |
 
 ### NGINX deployment parameters
 

--- a/bitnami/nginx/README.md
+++ b/bitnami/nginx/README.md
@@ -88,7 +88,6 @@ The command removes all the Kubernetes components associated with the chart and 
 | `image.pullPolicy`             | NGINX image pull policy                                                                               | `IfNotPresent`          |
 | `image.pullSecrets`            | Specify docker-registry secret names as an array                                                      | `[]`                    |
 | `image.debug`                  | Set to true if you would like to see extra information on logs                                        | `false`                 |
-| `automountServiceAccountToken` | Mount Service Account token in pod                                                                    | `false`                 |
 | `hostAliases`                  | Deployment pod host aliases                                                                           | `[]`                    |
 | `command`                      | Override default container command (useful when using custom images)                                  | `[]`                    |
 | `args`                         | Override default container args (useful when using custom images)                                     | `[]`                    |

--- a/bitnami/nginx/templates/deployment.yaml
+++ b/bitnami/nginx/templates/deployment.yaml
@@ -41,7 +41,6 @@ spec:
       automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
       shareProcessNamespace: {{ .Values.sidecarSingleProcessNamespace }}
       serviceAccountName: {{ template "nginx.serviceAccountName" . }}
-      automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
       {{- if .Values.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.hostAliases "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/nginx/values.yaml
+++ b/bitnami/nginx/values.yaml
@@ -92,9 +92,6 @@ image:
   ## Set to true if you would like to see extra information on logs
   ##
   debug: false
-## @param automountServiceAccountToken Mount Service Account token in pod
-##
-automountServiceAccountToken: false
 ## @param hostAliases Deployment pod host aliases
 ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
 ##


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Removes duplicate automountServiceAccountToken from Deployment and values.

Similar to https://github.com/bitnami/charts/pull/22518 but remove the superfluous automountServiceAccountToken from values and README.md

### Benefits

Can be parsed with strict linters again

### Possible drawbacks

None

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #22517

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
