### PR TITLE
[bitnami/studio] Updates container image version + fix studio svc target port

### DIFF
--- a/bitnami/supabase/Chart.yaml
+++ b/bitnami/supabase/Chart.yaml
@@ -24,7 +24,7 @@ annotations:
     - name: supabase-storage
       image: docker.io/bitnami/supabase-storage:0.46.2-debian-11-r0
     - name: supabase-studio
-      image: docker.io/bitnami/supabase-studio:0.23.11-debian-11-r0
+      image: docker.io/bitnami/supabase-studio:0.23.11-debian-11-r2
 apiVersion: v2
 appVersion: 0.23.11
 dependencies:
@@ -53,4 +53,4 @@ maintainers:
 name: supabase
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/supabase
-version: 2.5.1
+version: 2.5.2

--- a/bitnami/supabase/templates/studio/service.yaml
+++ b/bitnami/supabase/templates/studio/service.yaml
@@ -39,12 +39,11 @@ spec:
     - name: http-studio
       port: {{ .Values.studio.service.ports.http }}
       protocol: TCP
+      targetPort: http-studio
       {{- if and (or (eq .Values.studio.service.type "NodePort") (eq .Values.studio.service.type "LoadBalancer")) (not (empty .Values.studio.service.nodePorts.http)) }}
       nodePort: {{ .Values.studio.service.nodePorts.http }}
-      targetPort: http-studio
       {{- else if eq .Values.studio.service.type "ClusterIP" }}
       nodePort: null
-      targetPort: {{ .Values.studio.containerPorts.http }}
       {{- end }}
     {{- if .Values.studio.service.extraPorts }}
     {{- include "common.tplvalues.render" (dict "value" .Values.studio.service.extraPorts "context" $) | nindent 4 }}

--- a/bitnami/supabase/values.yaml
+++ b/bitnami/supabase/values.yaml
@@ -2120,7 +2120,7 @@ studio:
   image:
     registry: docker.io
     repository: bitnami/supabase-studio
-    tag: 0.23.11-debian-11-r0
+    tag: 0.23.11-debian-11-r2
     digest: ""
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'


### PR DESCRIPTION

### Description of the change

- Updates the studio container image to the latest one that has the redirection fixed.
- Fix studio service target port


### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #20914



### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
