### PR TITLE
[bitnami/vault] feat: :lock: Enable networkPolicy

### DIFF
--- a/bitnami/vault/Chart.yaml
+++ b/bitnami/vault/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: vault
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/vault
-version: 0.6.0
+version: 0.7.0

--- a/bitnami/vault/README.md
+++ b/bitnami/vault/README.md
@@ -190,6 +190,13 @@ The command removes all the Kubernetes components associated with the chart and 
 | `server.service.active.extraPorts`                | Extra ports to expose in Vault Server service (normally used with the `sidecars` value)                                          | `[]`                     |
 | `server.service.active.sessionAffinity`           | Control where web requests go, to the same pod or round-robin                                                                    | `None`                   |
 | `server.service.active.sessionAffinityConfig`     | Additional settings for the sessionAffinity                                                                                      | `{}`                     |
+| `server.networkPolicy.enabled`                    | Specifies whether a NetworkPolicy should be created                                                                              | `true`                   |
+| `server.networkPolicy.kubeAPIServerPorts`         | List of possible endpoints to kube-apiserver (limit to your cluster settings to increase security)                               | `[]`                     |
+| `server.networkPolicy.allowExternal`              | Don't require server label for connections                                                                                       | `true`                   |
+| `server.networkPolicy.extraIngress`               | Add extra ingress rules to the NetworkPolice                                                                                     | `[]`                     |
+| `server.networkPolicy.extraEgress`                | Add extra ingress rules to the NetworkPolicy                                                                                     | `[]`                     |
+| `server.networkPolicy.ingressNSMatchLabels`       | Labels to match to allow traffic from other namespaces                                                                           | `{}`                     |
+| `server.networkPolicy.ingressNSPodMatchLabels`    | Pod labels to match to allow traffic from other namespaces                                                                       | `{}`                     |
 | `server.ingress.enabled`                          | Enable ingress record generation for Vault                                                                                       | `false`                  |
 | `server.ingress.pathType`                         | Ingress path type                                                                                                                | `ImplementationSpecific` |
 | `server.ingress.apiVersion`                       | Force Ingress API version (automatically detected if not set)                                                                    | `""`                     |
@@ -286,6 +293,10 @@ The command removes all the Kubernetes components associated with the chart and 
 | `csiProvider.podSecurityContext.sysctls`                                 | Set kernel settings using the sysctl interface                                                                                                                | `[]`                                          |
 | `csiProvider.podSecurityContext.supplementalGroups`                      | Set filesystem extra groups                                                                                                                                   | `[]`                                          |
 | `csiProvider.podSecurityContext.fsGroup`                                 | Set CSI Provider pod's Security Context fsGroup                                                                                                               | `1001`                                        |
+| `csiProvider.networkPolicy.enabled`                                      | Specifies whether a NetworkPolicy should be created                                                                                                           | `true`                                        |
+| `csiProvider.networkPolicy.kubeAPIServerPorts`                           | List of possible endpoints to kube-apiserver (limit to your cluster settings to increase security)                                                            | `[]`                                          |
+| `csiProvider.networkPolicy.extraIngress`                                 | Add extra ingress rules to the NetworkPolice                                                                                                                  | `[]`                                          |
+| `csiProvider.networkPolicy.extraEgress`                                  | Add extra ingress rules to the NetworkPolicy                                                                                                                  | `[]`                                          |
 | `csiProvider.provider.containerPorts.health`                             | CSI Provider health container port                                                                                                                            | `8080`                                        |
 | `csiProvider.provider.livenessProbe.enabled`                             | Enable livenessProbe on CSI Provider container                                                                                                                | `true`                                        |
 | `csiProvider.provider.livenessProbe.initialDelaySeconds`                 | Initial delay seconds for livenessProbe                                                                                                                       | `5`                                           |
@@ -466,19 +477,26 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Vault Kubernetes Injector Traffic Exposure Parameters
 
-| Name                                        | Description                                                                                          | Value       |
-| ------------------------------------------- | ---------------------------------------------------------------------------------------------------- | ----------- |
-| `injector.service.type`                     | Vault Kubernetes Injector service type                                                               | `ClusterIP` |
-| `injector.service.ports.https`              | Vault Kubernetes Injector service HTTPS port                                                         | `443`       |
-| `injector.service.nodePorts.https`          | Node port for HTTPS                                                                                  | `""`        |
-| `injector.service.clusterIP`                | Vault Kubernetes Injector service Cluster IP                                                         | `""`        |
-| `injector.service.loadBalancerIP`           | Vault Kubernetes Injector service Load Balancer IP                                                   | `""`        |
-| `injector.service.loadBalancerSourceRanges` | Vault Kubernetes Injector service Load Balancer sources                                              | `[]`        |
-| `injector.service.externalTrafficPolicy`    | Vault Kubernetes Injector service external traffic policy                                            | `Cluster`   |
-| `injector.service.annotations`              | Additional custom annotations for Vault Kubernetes Injector service                                  | `{}`        |
-| `injector.service.extraPorts`               | Extra ports to expose in Vault Kubernetes Injector service (normally used with the `sidecars` value) | `[]`        |
-| `injector.service.sessionAffinity`          | Control where web requests go, to the same pod or round-robin                                        | `None`      |
-| `injector.service.sessionAffinityConfig`    | Additional settings for the sessionAffinity                                                          | `{}`        |
+| Name                                             | Description                                                                                          | Value       |
+| ------------------------------------------------ | ---------------------------------------------------------------------------------------------------- | ----------- |
+| `injector.service.type`                          | Vault Kubernetes Injector service type                                                               | `ClusterIP` |
+| `injector.service.ports.https`                   | Vault Kubernetes Injector service HTTPS port                                                         | `443`       |
+| `injector.service.nodePorts.https`               | Node port for HTTPS                                                                                  | `""`        |
+| `injector.service.clusterIP`                     | Vault Kubernetes Injector service Cluster IP                                                         | `""`        |
+| `injector.service.loadBalancerIP`                | Vault Kubernetes Injector service Load Balancer IP                                                   | `""`        |
+| `injector.service.loadBalancerSourceRanges`      | Vault Kubernetes Injector service Load Balancer sources                                              | `[]`        |
+| `injector.service.externalTrafficPolicy`         | Vault Kubernetes Injector service external traffic policy                                            | `Cluster`   |
+| `injector.service.annotations`                   | Additional custom annotations for Vault Kubernetes Injector service                                  | `{}`        |
+| `injector.service.extraPorts`                    | Extra ports to expose in Vault Kubernetes Injector service (normally used with the `sidecars` value) | `[]`        |
+| `injector.service.sessionAffinity`               | Control where web requests go, to the same pod or round-robin                                        | `None`      |
+| `injector.service.sessionAffinityConfig`         | Additional settings for the sessionAffinity                                                          | `{}`        |
+| `injector.networkPolicy.enabled`                 | Specifies whether a NetworkPolicy should be created                                                  | `true`      |
+| `injector.networkPolicy.kubeAPIServerPorts`      | List of possible endpoints to kube-apiserver (limit to your cluster settings to increase security)   | `[]`        |
+| `injector.networkPolicy.allowExternal`           | Don't require injector label for connections                                                         | `true`      |
+| `injector.networkPolicy.extraIngress`            | Add extra ingress rules to the NetworkPolice                                                         | `[]`        |
+| `injector.networkPolicy.extraEgress`             | Add extra ingress rules to the NetworkPolicy                                                         | `[]`        |
+| `injector.networkPolicy.ingressNSMatchLabels`    | Labels to match to allow traffic from other namespaces                                               | `{}`        |
+| `injector.networkPolicy.ingressNSPodMatchLabels` | Pod labels to match to allow traffic from other namespaces                                           | `{}`        |
 
 ### Vault Kubernetes Injector RBAC Parameters
 

--- a/bitnami/vault/templates/csi-provider/networkpolicy.yaml
+++ b/bitnami/vault/templates/csi-provider/networkpolicy.yaml
@@ -1,0 +1,45 @@
+{{- /*
+Copyright VMware, Inc.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+{{- if .Values.csiProvider.networkPolicy.enabled }}
+kind: NetworkPolicy
+apiVersion: {{ include "common.capabilities.networkPolicy.apiVersion" . }}
+metadata:
+  name: {{ template "vault.csi-provider.fullname" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+    app.kubernetes.io/part-of: vault
+    app.kubernetes.io/component: csi-provider
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.csiProvider.podLabels .Values.commonLabels ) "context" . ) }}
+  podSelector:
+    matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
+      app.kubernetes.io/part-of: vault
+      app.kubernetes.io/component: csi-provider
+  policyTypes:
+    - Ingress
+    - Egress
+  egress:
+    - ports:
+        # Allow dns resolution
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+        # Allow access to kube-apiserver
+        {{- range $port := .Values.csiProvider.networkPolicy.kubeAPIServerPorts }}
+        - port: {{ $port }}
+        {{- end }}
+    {{- if .Values.csiProvider.networkPolicy.extraEgress }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.csiProvider.networkPolicy.extraEgress "context" $ ) | nindent 4 }}
+    {{- end }}
+  ingress:
+    {{- if .Values.csiProvider.networkPolicy.extraIngress }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.csiProvider.networkPolicy.extraIngress "context" $ ) | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/bitnami/vault/templates/injector/networkpolicy.yaml
+++ b/bitnami/vault/templates/injector/networkpolicy.yaml
@@ -63,6 +63,8 @@ spec:
       {{- if not .Values.injector.networkPolicy.allowExternal }}
       from:
         - podSelector:
+            matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 14 }}
+        - podSelector:
             matchLabels:
               {{ template "vault.injector.fullname" . }}-client: "true"
         {{- if .Values.injector.networkPolicy.ingressNSMatchLabels }}

--- a/bitnami/vault/templates/injector/networkpolicy.yaml
+++ b/bitnami/vault/templates/injector/networkpolicy.yaml
@@ -1,0 +1,89 @@
+{{- /*
+Copyright VMware, Inc.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+{{- if .Values.injector.networkPolicy.enabled }}
+kind: NetworkPolicy
+apiVersion: {{ include "common.capabilities.networkPolicy.apiVersion" . }}
+metadata:
+  name: {{ template "vault.injector.fullname" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+    app.kubernetes.io/part-of: vault
+    app.kubernetes.io/component: injector
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.injector.podLabels .Values.commonLabels ) "context" . ) }}
+  podSelector:
+    matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
+      app.kubernetes.io/part-of: vault
+      app.kubernetes.io/component: injector
+  policyTypes:
+    - Ingress
+    - Egress
+  egress:
+    # Allow dns resolution
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+        # Allow access to kube-apiserver
+        {{- range $port := .Values.injector.networkPolicy.kubeAPIServerPorts }}
+        - port: {{ $port }}
+        {{- end }}
+    # Allow outbound connections to other cluster pods
+    - ports:
+        - port: {{ .Values.injector.service.ports.https }}
+        - port: {{ .Values.injector.containerPorts.https }}
+      to:
+        - podSelector:
+            matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 14 }}
+              app.kubernetes.io/part-of: vault
+              app.kubernetes.io/component: injector
+    # Allow outbound connections to vault server
+    - ports:
+        - port: {{ .Values.server.service.general.ports.http }}
+        - port: {{ .Values.server.service.active.ports.http }}
+        - port: {{ .Values.server.containerPorts.http }}
+      to:
+        - podSelector:
+            matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 14 }}
+              app.kubernetes.io/part-of: vault
+              app.kubernetes.io/component: server
+    {{- if .Values.injector.networkPolicy.extraEgress }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.injector.networkPolicy.extraEgress "context" $ ) | nindent 4 }}
+    {{- end }}
+  ingress:
+    - ports:
+        - port: {{ .Values.injector.service.ports.https }}
+      {{- if not .Values.injector.networkPolicy.allowExternal }}
+      from:
+        - podSelector:
+            matchLabels:
+              {{ template "vault.injector.fullname" . }}-client: "true"
+        {{- if .Values.injector.networkPolicy.ingressNSMatchLabels }}
+        - namespaceSelector:
+            matchLabels:
+              {{- range $key, $value := .Values.injector.networkPolicy.ingressNSMatchLabels }}
+              {{ $key | quote }}: {{ $value | quote }}
+              {{- end }}
+          {{- if .Values.injector.networkPolicy.ingressNSPodMatchLabels }}
+          podSelector:
+            matchLabels:
+              {{- range $key, $value := .Values.injector.networkPolicy.ingressNSPodMatchLabels }}
+              {{ $key | quote }}: {{ $value | quote }}
+              {{- end }}
+          {{- end }}
+        {{- end }}
+        - podSelector:
+            matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 14 }}
+              app.kubernetes.io/part-of: vault        
+      {{- end }}
+    {{- if .Values.injector.networkPolicy.extraIngress }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.injector.networkPolicy.extraIngress "context" $ ) | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/bitnami/vault/templates/server/networkpolicy.yaml
+++ b/bitnami/vault/templates/server/networkpolicy.yaml
@@ -1,0 +1,88 @@
+{{- /*
+Copyright VMware, Inc.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+{{- if .Values.server.networkPolicy.enabled }}
+kind: NetworkPolicy
+apiVersion: {{ include "common.capabilities.networkPolicy.apiVersion" . }}
+metadata:
+  name: {{ template "vault.server.fullname" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+    app.kubernetes.io/part-of: vault
+    app.kubernetes.io/component: server
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.server.podLabels .Values.commonLabels ) "context" . ) }}
+  podSelector:
+    matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
+      app.kubernetes.io/part-of: vault
+      app.kubernetes.io/component: server
+  policyTypes:
+    - Ingress
+    - Egress
+  egress:
+    - ports:
+        # Allow dns resolution
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+        # Allow access to kube-apiserver
+        {{- range $port := .Values.server.networkPolicy.kubeAPIServerPorts }}
+        - port: {{ $port }}
+        {{- end }}
+    # Allow outbound connections to other cluster pods
+    - ports:
+        - port: {{ .Values.server.service.general.ports.http }}
+        - port: {{ .Values.server.service.general.ports.internal }}
+        - port: {{ .Values.server.service.active.ports.http }}
+        - port: {{ .Values.server.service.active.ports.internal }}
+        - port: {{ .Values.server.containerPorts.internal }}
+        - port: {{ .Values.server.containerPorts.http }}
+      to:
+        - podSelector:
+            matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 14 }}
+              app.kubernetes.io/part-of: vault
+              app.kubernetes.io/component: server
+    {{- if .Values.server.networkPolicy.extraEgress }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.server.networkPolicy.extraEgress "context" $ ) | nindent 4 }}
+    {{- end }}
+  ingress:
+    - ports:
+        - port: {{ .Values.server.service.general.ports.http }}
+        - port: {{ .Values.server.service.active.ports.http }}
+        - port: {{ .Values.server.containerPorts.http }}
+        - port: {{ .Values.server.service.general.ports.internal }}
+        - port: {{ .Values.server.service.active.ports.internal }}
+        - port: {{ .Values.server.containerPorts.internal }}
+      {{- if not .Values.server.networkPolicy.allowExternal }}
+      from:
+        - podSelector:
+            matchLabels:
+              {{ template "vault.server.fullname" . }}-client: "true"
+        {{- if .Values.server.networkPolicy.ingressNSMatchLabels }}
+        - namespaceSelector:
+            matchLabels:
+              {{- range $key, $value := .Values.server.networkPolicy.ingressNSMatchLabels }}
+              {{ $key | quote }}: {{ $value | quote }}
+              {{- end }}
+          {{- if .Values.server.networkPolicy.ingressNSPodMatchLabels }}
+          podSelector:
+            matchLabels:
+              {{- range $key, $value := .Values.server.networkPolicy.ingressNSPodMatchLabels }}
+              {{ $key | quote }}: {{ $value | quote }}
+              {{- end }}
+          {{- end }}
+        {{- end }}
+        - podSelector:
+            matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 14 }}
+              app.kubernetes.io/part-of: vault        
+      {{- end }}
+    {{- if .Values.server.networkPolicy.extraIngress }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.server.networkPolicy.extraIngress "context" $ ) | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/bitnami/vault/templates/server/networkpolicy.yaml
+++ b/bitnami/vault/templates/server/networkpolicy.yaml
@@ -62,6 +62,8 @@ spec:
       {{- if not .Values.server.networkPolicy.allowExternal }}
       from:
         - podSelector:
+            matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 14 }}
+        - podSelector:
             matchLabels:
               {{ template "vault.server.fullname" . }}-client: "true"
         {{- if .Values.server.networkPolicy.ingressNSMatchLabels }}

--- a/bitnami/vault/values.yaml
+++ b/bitnami/vault/values.yaml
@@ -492,6 +492,62 @@ server:
       ##
       sessionAffinityConfig: {}
 
+  ## Network Policies
+  ## Ref: https://kubernetes.io/docs/concepts/services-networking/network-policies/
+  ##
+  networkPolicy:
+    ## @param server.networkPolicy.enabled Specifies whether a NetworkPolicy should be created
+    ##
+    enabled: true
+    ## @param server.networkPolicy.kubeAPIServerPorts [array] List of possible endpoints to kube-apiserver (limit to your cluster settings to increase security)
+    ##
+    kubeAPIServerPorts: [443, 6443, 8443]
+    ## @param server.networkPolicy.allowExternal Don't require server label for connections
+    ## The Policy model to apply. When set to false, only pods with the correct
+    ## server label will have network access to the ports server is listening
+    ## on. When true, server will accept connections from any source
+    ## (with the correct destination port).
+    ##
+    allowExternal: true
+    ## @param server.networkPolicy.extraIngress [array] Add extra ingress rules to the NetworkPolice
+    ## e.g:
+    ## extraIngress:
+    ##   - ports:
+    ##       - port: 1234
+    ##     from:
+    ##       - podSelector:
+    ##           - matchLabels:
+    ##               - role: frontend
+    ##       - podSelector:
+    ##           - matchExpressions:
+    ##               - key: role
+    ##                 operator: In
+    ##                 values:
+    ##                   - frontend
+    extraIngress: []
+    ## @param server.networkPolicy.extraEgress [array] Add extra ingress rules to the NetworkPolicy
+    ## e.g:
+    ## extraEgress:
+    ##   - ports:
+    ##       - port: 1234
+    ##     to:
+    ##       - podSelector:
+    ##           - matchLabels:
+    ##               - role: frontend
+    ##       - podSelector:
+    ##           - matchExpressions:
+    ##               - key: role
+    ##                 operator: In
+    ##                 values:
+    ##                   - frontend
+    ##
+    extraEgress: []
+    ## @param server.networkPolicy.ingressNSMatchLabels [object] Labels to match to allow traffic from other namespaces
+    ## @param server.networkPolicy.ingressNSPodMatchLabels [object] Pod labels to match to allow traffic from other namespaces
+    ##
+    ingressNSMatchLabels: {}
+    ingressNSPodMatchLabels: {}
+
   ## ref: http://kubernetes.io/docs/concepts/services-networking/ingress/
   ##
   ingress:
@@ -902,6 +958,50 @@ csiProvider:
     sysctls: []
     supplementalGroups: []
     fsGroup: 1001
+
+  ## Network Policies
+  ## Ref: https://kubernetes.io/docs/concepts/services-networking/network-policies/
+  ##
+  networkPolicy:
+    ## @param csiProvider.networkPolicy.enabled Specifies whether a NetworkPolicy should be created
+    ##
+    enabled: true
+    ## @param csiProvider.networkPolicy.kubeAPIServerPorts [array] List of possible endpoints to kube-apiserver (limit to your cluster settings to increase security)
+    ##
+    kubeAPIServerPorts: [443, 6443, 8443]
+    ## @param csiProvider.networkPolicy.extraIngress [array] Add extra ingress rules to the NetworkPolice
+    ## e.g:
+    ## extraIngress:
+    ##   - ports:
+    ##       - port: 1234
+    ##     from:
+    ##       - podSelector:
+    ##           - matchLabels:
+    ##               - role: frontend
+    ##       - podSelector:
+    ##           - matchExpressions:
+    ##               - key: role
+    ##                 operator: In
+    ##                 values:
+    ##                   - frontend
+    extraIngress: []
+    ## @param csiProvider.networkPolicy.extraEgress [array] Add extra ingress rules to the NetworkPolicy
+    ## e.g:
+    ## extraEgress:
+    ##   - ports:
+    ##       - port: 1234
+    ##     to:
+    ##       - podSelector:
+    ##           - matchLabels:
+    ##               - role: frontend
+    ##       - podSelector:
+    ##           - matchExpressions:
+    ##               - key: role
+    ##                 operator: In
+    ##                 values:
+    ##                   - frontend
+    ##
+    extraEgress: []
 
   provider:
     ## @param csiProvider.provider.containerPorts.health CSI Provider health container port
@@ -1530,6 +1630,61 @@ injector:
     ##
     sessionAffinityConfig: {}
 
+  ## Network Policies
+  ## Ref: https://kubernetes.io/docs/concepts/services-networking/network-policies/
+  ##
+  networkPolicy:
+    ## @param injector.networkPolicy.enabled Specifies whether a NetworkPolicy should be created
+    ##
+    enabled: true
+    ## @param injector.networkPolicy.kubeAPIServerPorts [array] List of possible endpoints to kube-apiserver (limit to your cluster settings to increase security)
+    ##
+    kubeAPIServerPorts: [443, 6443, 8443]
+    ## @param injector.networkPolicy.allowExternal Don't require injector label for connections
+    ## The Policy model to apply. When set to false, only pods with the correct
+    ## injector label will have network access to the ports injector is listening
+    ## on. When true, injector will accept connections from any source
+    ## (with the correct destination port).
+    ##
+    allowExternal: true
+    ## @param injector.networkPolicy.extraIngress [array] Add extra ingress rules to the NetworkPolice
+    ## e.g:
+    ## extraIngress:
+    ##   - ports:
+    ##       - port: 1234
+    ##     from:
+    ##       - podSelector:
+    ##           - matchLabels:
+    ##               - role: frontend
+    ##       - podSelector:
+    ##           - matchExpressions:
+    ##               - key: role
+    ##                 operator: In
+    ##                 values:
+    ##                   - frontend
+    extraIngress: []
+    ## @param injector.networkPolicy.extraEgress [array] Add extra ingress rules to the NetworkPolicy
+    ## e.g:
+    ## extraEgress:
+    ##   - ports:
+    ##       - port: 1234
+    ##     to:
+    ##       - podSelector:
+    ##           - matchLabels:
+    ##               - role: frontend
+    ##       - podSelector:
+    ##           - matchExpressions:
+    ##               - key: role
+    ##                 operator: In
+    ##                 values:
+    ##                   - frontend
+    ##
+    extraEgress: []
+    ## @param injector.networkPolicy.ingressNSMatchLabels [object] Labels to match to allow traffic from other namespaces
+    ## @param injector.networkPolicy.ingressNSPodMatchLabels [object] Pod labels to match to allow traffic from other namespaces
+    ##
+    ingressNSMatchLabels: {}
+    ingressNSPodMatchLabels: {}
 
   ## @section Vault Kubernetes Injector RBAC Parameters
   ##


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

This PR normalizes the use of NetworkPolicy in the chart. Adds all Bitnami standards for NetworkPolicies as well as enabling it by default, in order to comply with security checklists.

<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

More security in the chart
<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
