### PR TITLE
[bitnami/cert-manager] fix: :bug: Set seLinuxOptions to null for Openshift compatibility

### DIFF
--- a/bitnami/cert-manager/Chart.yaml
+++ b/bitnami/cert-manager/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: cert-manager
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/cert-manager
-version: 0.18.0
+version: 0.18.1

--- a/bitnami/cert-manager/README.md
+++ b/bitnami/cert-manager/README.md
@@ -102,7 +102,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `controller.podSecurityContext.supplementalGroups`             | Set filesystem extra groups                                                                                | `[]`                           |
 | `controller.podSecurityContext.fsGroup`                        | Set Controller pod's Security Context fsGroup                                                              | `1001`                         |
 | `controller.containerSecurityContext.enabled`                  | Enabled controller containers' Security Context                                                            | `true`                         |
-| `controller.containerSecurityContext.seLinuxOptions`           | Set SELinux options in container                                                                           | `{}`                           |
+| `controller.containerSecurityContext.seLinuxOptions`           | Set SELinux options in container                                                                           | `nil`                          |
 | `controller.containerSecurityContext.runAsUser`                | Set controller containers' Security Context runAsUser                                                      | `1001`                         |
 | `controller.containerSecurityContext.runAsNonRoot`             | Set controller containers' Security Context runAsNonRoot                                                   | `true`                         |
 | `controller.containerSecurityContext.readOnlyRootFilesystem`   | Set read only root file system pod's Security Conte                                                        | `false`                        |
@@ -193,7 +193,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `webhook.podSecurityContext.supplementalGroups`             | Set filesystem extra groups                                                                             | `[]`                                   |
 | `webhook.podSecurityContext.fsGroup`                        | Set Webhook pod's Security Context fsGroup                                                              | `1001`                                 |
 | `webhook.containerSecurityContext.enabled`                  | Enabled webhook containers' Security Context                                                            | `true`                                 |
-| `webhook.containerSecurityContext.seLinuxOptions`           | Set SELinux options in container                                                                        | `{}`                                   |
+| `webhook.containerSecurityContext.seLinuxOptions`           | Set SELinux options in container                                                                        | `nil`                                  |
 | `webhook.containerSecurityContext.runAsUser`                | Set webhook containers' Security Context runAsUser                                                      | `1001`                                 |
 | `webhook.containerSecurityContext.runAsNonRoot`             | Set webhook containers' Security Context runAsNonRoot                                                   | `true`                                 |
 | `webhook.containerSecurityContext.readOnlyRootFilesystem`   | Set read only root file system pod's Security Conte                                                     | `false`                                |
@@ -280,7 +280,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `cainjector.podSecurityContext.supplementalGroups`             | Set filesystem extra groups                                                                                | `[]`                         |
 | `cainjector.podSecurityContext.fsGroup`                        | Set CAInjector pod's Security Context fsGroup                                                              | `1001`                       |
 | `cainjector.containerSecurityContext.enabled`                  | Enabled cainjector containers' Security Context                                                            | `true`                       |
-| `cainjector.containerSecurityContext.seLinuxOptions`           | Set SELinux options in container                                                                           | `{}`                         |
+| `cainjector.containerSecurityContext.seLinuxOptions`           | Set SELinux options in container                                                                           | `nil`                        |
 | `cainjector.containerSecurityContext.runAsUser`                | Set cainjector containers' Security Context runAsUser                                                      | `1001`                       |
 | `cainjector.containerSecurityContext.runAsNonRoot`             | Set cainjector containers' Security Context runAsNonRoot                                                   | `true`                       |
 | `cainjector.containerSecurityContext.readOnlyRootFilesystem`   | Set read only root file system pod's Security Conte                                                        | `false`                      |

--- a/bitnami/cert-manager/values.yaml
+++ b/bitnami/cert-manager/values.yaml
@@ -146,7 +146,7 @@ controller:
   ## controller containers' Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
   ## @param controller.containerSecurityContext.enabled Enabled controller containers' Security Context
-  ## @param controller.containerSecurityContext.seLinuxOptions Set SELinux options in container
+  ## @param controller.containerSecurityContext.seLinuxOptions [object,nullable] Set SELinux options in container
   ## @param controller.containerSecurityContext.runAsUser Set controller containers' Security Context runAsUser
   ## @param controller.containerSecurityContext.runAsNonRoot Set controller containers' Security Context runAsNonRoot
   ## @param controller.containerSecurityContext.readOnlyRootFilesystem Set read only root file system pod's Security Conte
@@ -157,7 +157,7 @@ controller:
   ##
   containerSecurityContext:
     enabled: true
-    seLinuxOptions: {}
+    seLinuxOptions: null
     runAsUser: 1001
     runAsNonRoot: true
     privileged: false
@@ -504,7 +504,7 @@ webhook:
   ## webhook containers' Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
   ## @param webhook.containerSecurityContext.enabled Enabled webhook containers' Security Context
-  ## @param webhook.containerSecurityContext.seLinuxOptions Set SELinux options in container
+  ## @param webhook.containerSecurityContext.seLinuxOptions [object,nullable] Set SELinux options in container
   ## @param webhook.containerSecurityContext.runAsUser Set webhook containers' Security Context runAsUser
   ## @param webhook.containerSecurityContext.runAsNonRoot Set webhook containers' Security Context runAsNonRoot
   ## @param webhook.containerSecurityContext.readOnlyRootFilesystem Set read only root file system pod's Security Conte
@@ -515,7 +515,7 @@ webhook:
   ##
   containerSecurityContext:
     enabled: true
-    seLinuxOptions: {}
+    seLinuxOptions: null
     runAsUser: 1001
     runAsNonRoot: true
     privileged: false
@@ -847,7 +847,7 @@ cainjector:
   ## cainjector containers' Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
   ## @param cainjector.containerSecurityContext.enabled Enabled cainjector containers' Security Context
-  ## @param cainjector.containerSecurityContext.seLinuxOptions Set SELinux options in container
+  ## @param cainjector.containerSecurityContext.seLinuxOptions [object,nullable] Set SELinux options in container
   ## @param cainjector.containerSecurityContext.runAsUser Set cainjector containers' Security Context runAsUser
   ## @param cainjector.containerSecurityContext.runAsNonRoot Set cainjector containers' Security Context runAsNonRoot
   ## @param cainjector.containerSecurityContext.readOnlyRootFilesystem Set read only root file system pod's Security Conte
@@ -858,7 +858,7 @@ cainjector:
   ##
   containerSecurityContext:
     enabled: true
-    seLinuxOptions: {}
+    seLinuxOptions: null
     runAsUser: 1001
     runAsNonRoot: true
     privileged: false


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

### Description of the change

Setting seLinuxOptions to `{}` causes the following issue in Openshift

```
Forbidden: not usable by user or serviceaccount, provider restricted: .containers[0].seLinuxOptions.level: Invalid value: ""
```

This PR sets the value to `null` to allow compatibility with this platform.

### Benefits

Fix compatibility with Openshift

### Possible drawbacks

n/a

### Issues

Fixes https://github.com/bitnami/charts/issues/22511

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)

