### PR TITLE
[bitnami/consul] fix: :bug: Set seLinuxOptions to null for Openshift compatibility

### DIFF
--- a/bitnami/consul/Chart.yaml
+++ b/bitnami/consul/Chart.yaml
@@ -32,4 +32,4 @@ maintainers:
 name: consul
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/consul
-version: 10.16.0
+version: 10.16.1

--- a/bitnami/consul/README.md
+++ b/bitnami/consul/README.md
@@ -141,7 +141,7 @@ helm delete --purge my-release
 | `podSecurityContext.supplementalGroups`             | Set filesystem extra groups                                                               | `[]`             |
 | `podSecurityContext.fsGroup`                        | Group ID for the volumes of the pod                                                       | `1001`           |
 | `containerSecurityContext.enabled`                  | Enabled Consul containers' Security Context                                               | `true`           |
-| `containerSecurityContext.seLinuxOptions`           | Set SELinux options in container                                                          | `{}`             |
+| `containerSecurityContext.seLinuxOptions`           | Set SELinux options in container                                                          | `nil`            |
 | `containerSecurityContext.runAsUser`                | Set Consul containers' Security Context runAsUser                                         | `1001`           |
 | `containerSecurityContext.allowPrivilegeEscalation` | Set Consul containers' Security Context allowPrivilegeEscalation                          | `false`          |
 | `containerSecurityContext.capabilities.drop`        | Set Argo CD containers' repo server Security Context capabilities to be dropped           | `["ALL"]`        |
@@ -251,7 +251,7 @@ helm delete --purge my-release
 | `metrics.image.pullPolicy`                        | HashiCorp Consul Prometheus Exporter image pull policy                                                                               | `IfNotPresent`                    |
 | `metrics.image.pullSecrets`                       | HashiCorp Consul Prometheus Exporter image pull secrets                                                                              | `[]`                              |
 | `metrics.containerSecurityContext.enabled`        | HashiCorp Consul Prometheus Exporter securityContext                                                                                 | `true`                            |
-| `metrics.containerSecurityContext.seLinuxOptions` | Set SELinux options in container                                                                                                     | `{}`                              |
+| `metrics.containerSecurityContext.seLinuxOptions` | Set SELinux options in container                                                                                                     | `nil`                             |
 | `metrics.containerSecurityContext.runAsUser`      | User ID for the HashiCorp Consul Prometheus Exporter                                                                                 | `1001`                            |
 | `metrics.containerSecurityContext.runAsNonRoot`   | Force the container to be run as non root                                                                                            | `true`                            |
 | `metrics.service.type`                            | Kubernetes Service type                                                                                                              | `ClusterIP`                       |

--- a/bitnami/consul/values.yaml
+++ b/bitnami/consul/values.yaml
@@ -292,7 +292,7 @@ podSecurityContext:
 ## Container security context
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
 ## @param containerSecurityContext.enabled Enabled Consul containers' Security Context
-## @param containerSecurityContext.seLinuxOptions Set SELinux options in container
+## @param containerSecurityContext.seLinuxOptions [object,nullable] Set SELinux options in container
 ## @param containerSecurityContext.runAsUser Set Consul containers' Security Context runAsUser
 ## @param containerSecurityContext.allowPrivilegeEscalation Set Consul containers' Security Context allowPrivilegeEscalation
 ## @param containerSecurityContext.capabilities.drop Set Argo CD containers' repo server Security Context capabilities to be dropped
@@ -303,7 +303,7 @@ podSecurityContext:
 ##
 containerSecurityContext:
   enabled: true
-  seLinuxOptions: {}
+  seLinuxOptions: null
   runAsUser: 1001
   runAsNonRoot: true
   privileged: false
@@ -727,13 +727,13 @@ metrics:
   ## Container security context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
   ## @param metrics.containerSecurityContext.enabled HashiCorp Consul Prometheus Exporter securityContext
-  ## @param metrics.containerSecurityContext.seLinuxOptions Set SELinux options in container
+  ## @param metrics.containerSecurityContext.seLinuxOptions [object,nullable] Set SELinux options in container
   ## @param metrics.containerSecurityContext.runAsUser User ID for the HashiCorp Consul Prometheus Exporter
   ## @param metrics.containerSecurityContext.runAsNonRoot Force the container to be run as non root
   ##
   containerSecurityContext:
     enabled: true
-    seLinuxOptions: {}
+    seLinuxOptions: null
     runAsUser: 1001
     runAsNonRoot: true
   ## Consul Prometheus exporter service type


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

### Description of the change

Setting seLinuxOptions to `{}` causes the following issue in Openshift

```
Forbidden: not usable by user or serviceaccount, provider restricted: .containers[0].seLinuxOptions.level: Invalid value: ""
```

This PR sets the value to `null` to allow compatibility with this platform.

### Benefits

Fix compatibility with Openshift

### Possible drawbacks

n/a

### Issues

Fixes https://github.com/bitnami/charts/issues/22511

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)

