### PR TITLE
[bitnami/discourse] fix: :bug: Set seLinuxOptions to null for Openshift compatibility

### DIFF
--- a/bitnami/discourse/Chart.yaml
+++ b/bitnami/discourse/Chart.yaml
@@ -41,4 +41,4 @@ maintainers:
 name: discourse
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/discourse
-version: 12.4.0
+version: 12.4.1

--- a/bitnami/discourse/README.md
+++ b/bitnami/discourse/README.md
@@ -170,7 +170,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `discourse.resources.limits`                             | The resources limits for the Discourse containers                                            | `{}`             |
 | `discourse.resources.requests`                           | The requested resources for the Discourse containers                                         | `{}`             |
 | `discourse.containerSecurityContext.enabled`             | Enabled Discourse containers' Security Context                                               | `true`           |
-| `discourse.containerSecurityContext.seLinuxOptions`      | Set SELinux options in container                                                             | `{}`             |
+| `discourse.containerSecurityContext.seLinuxOptions`      | Set SELinux options in container                                                             | `nil`            |
 | `discourse.containerSecurityContext.runAsUser`           | Set Discourse containers' Security Context runAsUser                                         | `0`              |
 | `discourse.containerSecurityContext.runAsNonRoot`        | Set Discourse containers' Security Context runAsNonRoot                                      | `false`          |
 | `discourse.containerSecurityContext.seccompProfile.type` | Set container's Security Context seccomp profile                                             | `RuntimeDefault` |
@@ -218,7 +218,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `sidekiq.resources.limits`                             | The resources limits for the Sidekiq containers                                            | `{}`                                                |
 | `sidekiq.resources.requests`                           | The requested resources for the Sidekiq containers                                         | `{}`                                                |
 | `sidekiq.containerSecurityContext.enabled`             | Enabled Sidekiq containers' Security Context                                               | `true`                                              |
-| `sidekiq.containerSecurityContext.seLinuxOptions`      | Set SELinux options in container                                                           | `{}`                                                |
+| `sidekiq.containerSecurityContext.seLinuxOptions`      | Set SELinux options in container                                                           | `nil`                                               |
 | `sidekiq.containerSecurityContext.runAsUser`           | Set Sidekiq containers' Security Context runAsUser                                         | `0`                                                 |
 | `sidekiq.containerSecurityContext.runAsNonRoot`        | Set Sidekiq containers' Security Context runAsNonRoot                                      | `false`                                             |
 | `sidekiq.containerSecurityContext.seccompProfile.type` | Set container's Security Context seccomp profile                                           | `RuntimeDefault`                                    |
@@ -267,7 +267,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `volumePermissions.image.pullSecrets`                            | Init container volume-permissions image pull secrets                                                                              | `[]`                       |
 | `volumePermissions.resources.limits`                             | Init container volume-permissions resource limits                                                                                 | `{}`                       |
 | `volumePermissions.resources.requests`                           | Init container volume-permissions resource requests                                                                               | `{}`                       |
-| `volumePermissions.containerSecurityContext.seLinuxOptions`      | Set SELinux options in container                                                                                                  | `{}`                       |
+| `volumePermissions.containerSecurityContext.seLinuxOptions`      | Set SELinux options in container                                                                                                  | `nil`                      |
 | `volumePermissions.containerSecurityContext.runAsUser`           | User ID for the init container                                                                                                    | `0`                        |
 | `volumePermissions.containerSecurityContext.seccompProfile.type` | Set container's Security Context seccomp profile                                                                                  | `RuntimeDefault`           |
 

--- a/bitnami/discourse/values.yaml
+++ b/bitnami/discourse/values.yaml
@@ -360,14 +360,14 @@ discourse:
   ## Configure Discourse containers (only main one) Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
   ## @param discourse.containerSecurityContext.enabled Enabled Discourse containers' Security Context
-  ## @param discourse.containerSecurityContext.seLinuxOptions Set SELinux options in container
+  ## @param discourse.containerSecurityContext.seLinuxOptions [object,nullable] Set SELinux options in container
   ## @param discourse.containerSecurityContext.runAsUser Set Discourse containers' Security Context runAsUser
   ## @param discourse.containerSecurityContext.runAsNonRoot Set Discourse containers' Security Context runAsNonRoot
   ## @param discourse.containerSecurityContext.seccompProfile.type Set container's Security Context seccomp profile
   ##
   containerSecurityContext:
     enabled: true
-    seLinuxOptions: {}
+    seLinuxOptions: null
     runAsUser: 0
     runAsNonRoot: false
     seccompProfile:
@@ -500,14 +500,14 @@ sidekiq:
   ## Configure Sidekiq containers (only main one) Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
   ## @param sidekiq.containerSecurityContext.enabled Enabled Sidekiq containers' Security Context
-  ## @param sidekiq.containerSecurityContext.seLinuxOptions Set SELinux options in container
+  ## @param sidekiq.containerSecurityContext.seLinuxOptions [object,nullable] Set SELinux options in container
   ## @param sidekiq.containerSecurityContext.runAsUser Set Sidekiq containers' Security Context runAsUser
   ## @param sidekiq.containerSecurityContext.runAsNonRoot Set Sidekiq containers' Security Context runAsNonRoot
   ## @param sidekiq.containerSecurityContext.seccompProfile.type Set container's Security Context seccomp profile
   ##
   containerSecurityContext:
     enabled: true
-    seLinuxOptions: {}
+    seLinuxOptions: null
     runAsUser: 0
     runAsNonRoot: false
     seccompProfile:
@@ -721,12 +721,12 @@ volumePermissions:
   ## Init container' Security Context
   ## Note: the chown of the data folder is done to containerSecurityContext.runAsUser
   ## and not the below volumePermissions.containerSecurityContext.runAsUser
-  ## @param volumePermissions.containerSecurityContext.seLinuxOptions Set SELinux options in container
+  ## @param volumePermissions.containerSecurityContext.seLinuxOptions [object,nullable] Set SELinux options in container
   ## @param volumePermissions.containerSecurityContext.runAsUser User ID for the init container
   ## @param volumePermissions.containerSecurityContext.seccompProfile.type Set container's Security Context seccomp profile
   ##
   containerSecurityContext:
-    seLinuxOptions: {}
+    seLinuxOptions: null
     runAsUser: 0
     seccompProfile:
       type: "RuntimeDefault"


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

### Description of the change

Setting seLinuxOptions to `{}` causes the following issue in Openshift

```
Forbidden: not usable by user or serviceaccount, provider restricted: .containers[0].seLinuxOptions.level: Invalid value: ""
```

This PR sets the value to `null` to allow compatibility with this platform.

### Benefits

Fix compatibility with Openshift

### Possible drawbacks

n/a

### Issues

Fixes https://github.com/bitnami/charts/issues/22511

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)

