### PR TITLE
[bitnami/ejbca] fix: :bug: Set seLinuxOptions to null for Openshift compatibility

### DIFF
--- a/bitnami/ejbca/Chart.yaml
+++ b/bitnami/ejbca/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: ejbca
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/ejbca
-version: 11.2.0
+version: 11.2.1

--- a/bitnami/ejbca/README.md
+++ b/bitnami/ejbca/README.md
@@ -139,7 +139,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `resources.limits`                                  | The resources limits for Ejbca containers                                                                   | `{}`                    |
 | `resources.requests`                                | The requested resources for Ejbca containers                                                                | `{}`                    |
 | `containerSecurityContext.enabled`                  | Enabled EJBCA containers' Security Context                                                                  | `true`                  |
-| `containerSecurityContext.seLinuxOptions`           | Set SELinux options in container                                                                            | `{}`                    |
+| `containerSecurityContext.seLinuxOptions`           | Set SELinux options in container                                                                            | `nil`                   |
 | `containerSecurityContext.runAsUser`                | Set EJBCA containers' Security Context runAsUser                                                            | `1001`                  |
 | `containerSecurityContext.runAsNonRoot`             | Set Controller container's Security Context runAsNonRoot                                                    | `true`                  |
 | `containerSecurityContext.privileged`               | Set primary container's Security Context privileged                                                         | `false`                 |

--- a/bitnami/ejbca/values.yaml
+++ b/bitnami/ejbca/values.yaml
@@ -336,7 +336,7 @@ resources:
   requests: {}
 ## K8s Security Context for EJBCA container
 ## @param containerSecurityContext.enabled Enabled EJBCA containers' Security Context
-## @param containerSecurityContext.seLinuxOptions Set SELinux options in container
+## @param containerSecurityContext.seLinuxOptions [object,nullable] Set SELinux options in container
 ## @param containerSecurityContext.runAsUser Set EJBCA containers' Security Context runAsUser
 ## @param containerSecurityContext.runAsNonRoot Set Controller container's Security Context runAsNonRoot
 ## @param containerSecurityContext.privileged Set primary container's Security Context privileged
@@ -346,7 +346,7 @@ resources:
 ##
 containerSecurityContext:
   enabled: true
-  seLinuxOptions: {}
+  seLinuxOptions: null
   runAsUser: 1001
   runAsNonRoot: true
   privileged: false


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

### Description of the change

Setting seLinuxOptions to `{}` causes the following issue in Openshift

```
Forbidden: not usable by user or serviceaccount, provider restricted: .containers[0].seLinuxOptions.level: Invalid value: ""
```

This PR sets the value to `null` to allow compatibility with this platform.

### Benefits

Fix compatibility with Openshift

### Possible drawbacks

n/a

### Issues

Fixes https://github.com/bitnami/charts/issues/22511

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)

