### PR TITLE
[bitnami/fluent-bit] fix: :bug: Set seLinuxOptions to null for Openshift compatibility

### DIFF
--- a/bitnami/fluent-bit/Chart.yaml
+++ b/bitnami/fluent-bit/Chart.yaml
@@ -28,4 +28,4 @@ maintainers:
 name: fluent-bit
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/fluent-bit
-version: 0.8.0
+version: 0.8.1

--- a/bitnami/fluent-bit/README.md
+++ b/bitnami/fluent-bit/README.md
@@ -93,7 +93,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | --------------------------------------------------- | ----------------------------------------------------------------------------------------- | ---------------------------- |
 | `daemonset.enabled`                                 | Use a daemonset instead of a deployment. `replicaCount` will not take effect.             | `false`                      |
 | `daemonset.podSecurityContext.enabled`              | Enable security context for daemonset pods                                                | `true`                       |
-| `daemonset.podSecurityContext.seLinuxOptions`       | Set SELinux options in container                                                          | `{}`                         |
+| `daemonset.podSecurityContext.seLinuxOptions`       | Set SELinux options in container                                                          | `nil`                        |
 | `daemonset.podSecurityContext.runAsUser`            | User ID for daemonset containers                                                          | `0`                          |
 | `daemonset.podSecurityContext.runAsGroup`           | Group ID for daemonset containers                                                         | `0`                          |
 | `daemonset.podSecurityContext.fsGroupChangePolicy`  | Set filesystem group change policy                                                        | `Always`                     |
@@ -160,7 +160,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `podSecurityContext.supplementalGroups`             | Set filesystem extra groups                                                               | `[]`                         |
 | `podSecurityContext.fsGroup`                        | Set Fluent Bit pod's Security Context fsGroup                                             | `1001`                       |
 | `containerSecurityContext.enabled`                  | Enabled Fluent Bit containers' Security Context                                           | `true`                       |
-| `containerSecurityContext.seLinuxOptions`           | Set SELinux options in container                                                          | `{}`                         |
+| `containerSecurityContext.seLinuxOptions`           | Set SELinux options in container                                                          | `nil`                        |
 | `containerSecurityContext.runAsUser`                | Set Fluent Bit containers' Security Context runAsUser                                     | `1001`                       |
 | `containerSecurityContext.runAsNonRoot`             | Set Fluent Bit container's Security Context runAsNonRoot                                  | `true`                       |
 | `containerSecurityContext.readOnlyRootFilesystem`   | Set Fluent Bit container's Security Context runAsNonRoot                                  | `false`                      |

--- a/bitnami/fluent-bit/values.yaml
+++ b/bitnami/fluent-bit/values.yaml
@@ -99,7 +99,7 @@ daemonset:
   ## Pod security context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param daemonset.podSecurityContext.enabled Enable security context for daemonset pods
-  ## @param daemonset.podSecurityContext.seLinuxOptions Set SELinux options in container
+  ## @param daemonset.podSecurityContext.seLinuxOptions [object,nullable] Set SELinux options in container
   ## @param daemonset.podSecurityContext.runAsUser User ID for daemonset containers
   ## @param daemonset.podSecurityContext.runAsGroup Group ID for daemonset containers
   ## @param daemonset.podSecurityContext.fsGroupChangePolicy Set filesystem group change policy
@@ -109,7 +109,7 @@ daemonset:
   ##
   podSecurityContext:
     enabled: true
-    seLinuxOptions: {}
+    seLinuxOptions: null
     runAsUser: 0
     runAsGroup: 0
     fsGroupChangePolicy: Always
@@ -341,7 +341,7 @@ podSecurityContext:
 ## Configure Container Security Context (only main container)
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
 ## @param containerSecurityContext.enabled Enabled Fluent Bit containers' Security Context
-## @param containerSecurityContext.seLinuxOptions Set SELinux options in container
+## @param containerSecurityContext.seLinuxOptions [object,nullable] Set SELinux options in container
 ## @param containerSecurityContext.runAsUser Set Fluent Bit containers' Security Context runAsUser
 ## @param containerSecurityContext.runAsNonRoot Set Fluent Bit container's Security Context runAsNonRoot
 ## @param containerSecurityContext.readOnlyRootFilesystem Set Fluent Bit container's Security Context runAsNonRoot
@@ -352,7 +352,7 @@ podSecurityContext:
 ##
 containerSecurityContext:
   enabled: true
-  seLinuxOptions: {}
+  seLinuxOptions: null
   runAsUser: 1001
   runAsNonRoot: true
   privileged: false


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

### Description of the change

Setting seLinuxOptions to `{}` causes the following issue in Openshift

```
Forbidden: not usable by user or serviceaccount, provider restricted: .containers[0].seLinuxOptions.level: Invalid value: ""
```

This PR sets the value to `null` to allow compatibility with this platform.

### Benefits

Fix compatibility with Openshift

### Possible drawbacks

n/a

### Issues

Fixes https://github.com/bitnami/charts/issues/22511

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)

