### PR TITLE
[bitnami/gitea] fix: :bug: Set seLinuxOptions to null for Openshift compatibility

### DIFF
--- a/bitnami/gitea/Chart.yaml
+++ b/bitnami/gitea/Chart.yaml
@@ -37,4 +37,4 @@ maintainers:
 name: gitea
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/gitea
-version: 1.4.0
+version: 1.4.1

--- a/bitnami/gitea/README.md
+++ b/bitnami/gitea/README.md
@@ -141,7 +141,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `podSecurityContext.supplementalGroups`             | Set filesystem extra groups                                                                                           | `[]`                    |
 | `podSecurityContext.fsGroup`                        | Gitea pods' group ID                                                                                                  | `1001`                  |
 | `containerSecurityContext.enabled`                  | Enabled containers' Security Context                                                                                  | `true`                  |
-| `containerSecurityContext.seLinuxOptions`           | Set SELinux options in container                                                                                      | `{}`                    |
+| `containerSecurityContext.seLinuxOptions`           | Set SELinux options in container                                                                                      | `nil`                   |
 | `containerSecurityContext.runAsUser`                | Set containers' Security Context runAsUser                                                                            | `1001`                  |
 | `containerSecurityContext.runAsNonRoot`             | Set container's Security Context runAsNonRoot                                                                         | `true`                  |
 | `containerSecurityContext.privileged`               | Set container's Security Context privileged                                                                           | `false`                 |

--- a/bitnami/gitea/values.yaml
+++ b/bitnami/gitea/values.yaml
@@ -304,7 +304,7 @@ podSecurityContext:
 ## Configure Container Security Context (only main container)
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
 ## @param containerSecurityContext.enabled Enabled containers' Security Context
-## @param containerSecurityContext.seLinuxOptions Set SELinux options in container
+## @param containerSecurityContext.seLinuxOptions [object,nullable] Set SELinux options in container
 ## @param containerSecurityContext.runAsUser Set containers' Security Context runAsUser
 ## @param containerSecurityContext.runAsNonRoot Set container's Security Context runAsNonRoot
 ## @param containerSecurityContext.privileged Set container's Security Context privileged
@@ -315,7 +315,7 @@ podSecurityContext:
 ##
 containerSecurityContext:
   enabled: true
-  seLinuxOptions: {}
+  seLinuxOptions: null
   runAsUser: 1001
   runAsNonRoot: true
   privileged: false


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

### Description of the change

Setting seLinuxOptions to `{}` causes the following issue in Openshift

```
Forbidden: not usable by user or serviceaccount, provider restricted: .containers[0].seLinuxOptions.level: Invalid value: ""
```

This PR sets the value to `null` to allow compatibility with this platform.

### Benefits

Fix compatibility with Openshift

### Possible drawbacks

n/a

### Issues

Fixes https://github.com/bitnami/charts/issues/22511

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)

