### PR TITLE
[bitnami/grafana-loki] fix: :bug: Set seLinuxOptions to null for Openshift compatibility

### DIFF
--- a/bitnami/grafana-loki/Chart.yaml
+++ b/bitnami/grafana-loki/Chart.yaml
@@ -57,4 +57,4 @@ maintainers:
 name: grafana-loki
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/grafana-loki
-version: 2.14.0
+version: 2.14.1

--- a/bitnami/grafana-loki/README.md
+++ b/bitnami/grafana-loki/README.md
@@ -141,7 +141,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `compactor.podSecurityContext.supplementalGroups`        | Set filesystem extra groups                                                                         | `[]`                |
 | `compactor.podSecurityContext.fsGroup`                   | Set Compactor pod's Security Context fsGroup                                                        | `1001`              |
 | `compactor.containerSecurityContext.enabled`             | Enabled Compactor containers' Security Context                                                      | `true`              |
-| `compactor.containerSecurityContext.seLinuxOptions`      | Set SELinux options in container                                                                    | `{}`                |
+| `compactor.containerSecurityContext.seLinuxOptions`      | Set SELinux options in container                                                                    | `nil`               |
 | `compactor.containerSecurityContext.runAsUser`           | Set Compactor containers' Security Context runAsUser                                                | `1001`              |
 | `compactor.containerSecurityContext.runAsNonRoot`        | Set Compactor containers' Security Context runAsNonRoot                                             | `true`              |
 | `compactor.containerSecurityContext.seccompProfile.type` | Set container's Security Context seccomp profile                                                    | `RuntimeDefault`    |
@@ -245,7 +245,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `gateway.podSecurityContext.supplementalGroups`        | Set filesystem extra groups                                                                           | `[]`                    |
 | `gateway.podSecurityContext.fsGroup`                   | Set Gateway pod's Security Context fsGroup                                                            | `1001`                  |
 | `gateway.containerSecurityContext.enabled`             | Enabled Gateway containers' Security Context                                                          | `true`                  |
-| `gateway.containerSecurityContext.seLinuxOptions`      | Set SELinux options in container                                                                      | `{}`                    |
+| `gateway.containerSecurityContext.seLinuxOptions`      | Set SELinux options in container                                                                      | `nil`                   |
 | `gateway.containerSecurityContext.runAsUser`           | Set Gateway containers' Security Context runAsUser                                                    | `1001`                  |
 | `gateway.containerSecurityContext.runAsNonRoot`        | Set Gateway containers' Security Context runAsNonRoot                                                 | `true`                  |
 | `gateway.containerSecurityContext.seccompProfile.type` | Set container's Security Context seccomp profile                                                      | `RuntimeDefault`        |
@@ -343,7 +343,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `indexGateway.podSecurityContext.supplementalGroups`        | Set filesystem extra groups                                                                            | `[]`             |
 | `indexGateway.podSecurityContext.fsGroup`                   | Set index-gateway pod's Security Context fsGroup                                                       | `1001`           |
 | `indexGateway.containerSecurityContext.enabled`             | Enabled index-gateway containers' Security Context                                                     | `true`           |
-| `indexGateway.containerSecurityContext.seLinuxOptions`      | Set SELinux options in container                                                                       | `{}`             |
+| `indexGateway.containerSecurityContext.seLinuxOptions`      | Set SELinux options in container                                                                       | `nil`            |
 | `indexGateway.containerSecurityContext.runAsUser`           | Set index-gateway containers' Security Context runAsUser                                               | `1001`           |
 | `indexGateway.containerSecurityContext.runAsNonRoot`        | Set index-gateway containers' Security Context runAsNonRoot                                            | `true`           |
 | `indexGateway.containerSecurityContext.seccompProfile.type` | Set container's Security Context seccomp profile                                                       | `RuntimeDefault` |
@@ -428,7 +428,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `distributor.podSecurityContext.supplementalGroups`        | Set filesystem extra groups                                                                           | `[]`             |
 | `distributor.podSecurityContext.fsGroup`                   | Set Distributor pod's Security Context fsGroup                                                        | `1001`           |
 | `distributor.containerSecurityContext.enabled`             | Enabled Distributor containers' Security Context                                                      | `true`           |
-| `distributor.containerSecurityContext.seLinuxOptions`      | Set SELinux options in container                                                                      | `{}`             |
+| `distributor.containerSecurityContext.seLinuxOptions`      | Set SELinux options in container                                                                      | `nil`            |
 | `distributor.containerSecurityContext.runAsUser`           | Set Distributor containers' Security Context runAsUser                                                | `1001`           |
 | `distributor.containerSecurityContext.runAsNonRoot`        | Set Distributor containers' Security Context runAsNonRoot                                             | `true`           |
 | `distributor.containerSecurityContext.seccompProfile.type` | Set container's Security Context seccomp profile                                                      | `RuntimeDefault` |
@@ -514,7 +514,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `ingester.podSecurityContext.supplementalGroups`        | Set filesystem extra groups                                                                        | `[]`             |
 | `ingester.podSecurityContext.fsGroup`                   | Set Ingester pod's Security Context fsGroup                                                        | `1001`           |
 | `ingester.containerSecurityContext.enabled`             | Enabled Ingester containers' Security Context                                                      | `true`           |
-| `ingester.containerSecurityContext.seLinuxOptions`      | Set SELinux options in container                                                                   | `{}`             |
+| `ingester.containerSecurityContext.seLinuxOptions`      | Set SELinux options in container                                                                   | `nil`            |
 | `ingester.containerSecurityContext.runAsUser`           | Set Ingester containers' Security Context runAsUser                                                | `1001`           |
 | `ingester.containerSecurityContext.runAsNonRoot`        | Set Ingester containers' Security Context runAsNonRoot                                             | `true`           |
 | `ingester.containerSecurityContext.seccompProfile.type` | Set container's Security Context seccomp profile                                                   | `RuntimeDefault` |
@@ -612,7 +612,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `querier.podSecurityContext.supplementalGroups`        | Set filesystem extra groups                                                                       | `[]`             |
 | `querier.podSecurityContext.fsGroup`                   | Set Querier pod's Security Context fsGroup                                                        | `1001`           |
 | `querier.containerSecurityContext.enabled`             | Enabled Querier containers' Security Context                                                      | `true`           |
-| `querier.containerSecurityContext.seLinuxOptions`      | Set SELinux options in container                                                                  | `{}`             |
+| `querier.containerSecurityContext.seLinuxOptions`      | Set SELinux options in container                                                                  | `nil`            |
 | `querier.containerSecurityContext.runAsUser`           | Set Querier containers' Security Context runAsUser                                                | `1001`           |
 | `querier.containerSecurityContext.runAsNonRoot`        | Set Querier containers' Security Context runAsNonRoot                                             | `true`           |
 | `querier.containerSecurityContext.seccompProfile.type` | Set container's Security Context seccomp profile                                                  | `RuntimeDefault` |
@@ -709,7 +709,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `queryFrontend.podSecurityContext.supplementalGroups`        | Set filesystem extra groups                                                                             | `[]`             |
 | `queryFrontend.podSecurityContext.fsGroup`                   | Set queryFrontend pod's Security Context fsGroup                                                        | `1001`           |
 | `queryFrontend.containerSecurityContext.enabled`             | Enabled queryFrontend containers' Security Context                                                      | `true`           |
-| `queryFrontend.containerSecurityContext.seLinuxOptions`      | Set SELinux options in container                                                                        | `{}`             |
+| `queryFrontend.containerSecurityContext.seLinuxOptions`      | Set SELinux options in container                                                                        | `nil`            |
 | `queryFrontend.containerSecurityContext.runAsUser`           | Set queryFrontend containers' Security Context runAsUser                                                | `1001`           |
 | `queryFrontend.containerSecurityContext.runAsNonRoot`        | Set queryFrontend containers' Security Context runAsNonRoot                                             | `true`           |
 | `queryFrontend.containerSecurityContext.seccompProfile.type` | Set container's Security Context seccomp profile                                                        | `RuntimeDefault` |
@@ -796,7 +796,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `queryScheduler.podSecurityContext.supplementalGroups`        | Set filesystem extra groups                                                                              | `[]`             |
 | `queryScheduler.podSecurityContext.fsGroup`                   | Set queryScheduler pod's Security Context fsGroup                                                        | `1001`           |
 | `queryScheduler.containerSecurityContext.enabled`             | Enabled queryScheduler containers' Security Context                                                      | `true`           |
-| `queryScheduler.containerSecurityContext.seLinuxOptions`      | Set SELinux options in container                                                                         | `{}`             |
+| `queryScheduler.containerSecurityContext.seLinuxOptions`      | Set SELinux options in container                                                                         | `nil`            |
 | `queryScheduler.containerSecurityContext.runAsUser`           | Set queryScheduler containers' Security Context runAsUser                                                | `1001`           |
 | `queryScheduler.containerSecurityContext.runAsNonRoot`        | Set queryScheduler containers' Security Context runAsNonRoot                                             | `true`           |
 | `queryScheduler.containerSecurityContext.seccompProfile.type` | Set container's Security Context seccomp profile                                                         | `RuntimeDefault` |
@@ -884,7 +884,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `ruler.podSecurityContext.supplementalGroups`        | Set filesystem extra groups                                                                     | `[]`             |
 | `ruler.podSecurityContext.fsGroup`                   | Set Ruler pod's Security Context fsGroup                                                        | `1001`           |
 | `ruler.containerSecurityContext.enabled`             | Enabled Ruler containers' Security Context                                                      | `true`           |
-| `ruler.containerSecurityContext.seLinuxOptions`      | Set SELinux options in container                                                                | `{}`             |
+| `ruler.containerSecurityContext.seLinuxOptions`      | Set SELinux options in container                                                                | `nil`            |
 | `ruler.containerSecurityContext.runAsUser`           | Set Ruler containers' Security Context runAsUser                                                | `1001`           |
 | `ruler.containerSecurityContext.runAsNonRoot`        | Set Ruler containers' Security Context runAsNonRoot                                             | `true`           |
 | `ruler.containerSecurityContext.seccompProfile.type` | Set container's Security Context seccomp profile                                                | `RuntimeDefault` |
@@ -981,7 +981,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `tableManager.podSecurityContext.supplementalGroups`        | Set filesystem extra groups                                                                            | `[]`             |
 | `tableManager.podSecurityContext.fsGroup`                   | Set table-manager pod's Security Context fsGroup                                                       | `1001`           |
 | `tableManager.containerSecurityContext.enabled`             | Enabled table-manager containers' Security Context                                                     | `true`           |
-| `tableManager.containerSecurityContext.seLinuxOptions`      | Set SELinux options in container                                                                       | `{}`             |
+| `tableManager.containerSecurityContext.seLinuxOptions`      | Set SELinux options in container                                                                       | `nil`            |
 | `tableManager.containerSecurityContext.runAsUser`           | Set table-manager containers' Security Context runAsUser                                               | `1001`           |
 | `tableManager.containerSecurityContext.runAsNonRoot`        | Set table-manager containers' Security Context runAsNonRoot                                            | `true`           |
 | `tableManager.containerSecurityContext.seccompProfile.type` | Set container's Security Context seccomp profile                                                       | `RuntimeDefault` |
@@ -1073,7 +1073,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `promtail.podSecurityContext.supplementalGroups`        | Set filesystem extra groups                                                                                      | `[]`                       |
 | `promtail.podSecurityContext.fsGroup`                   | Set Promtail pod's Security Context fsGroup                                                                      | `0`                        |
 | `promtail.containerSecurityContext.enabled`             | Enabled Promtail containers' Security Context                                                                    | `true`                     |
-| `promtail.containerSecurityContext.seLinuxOptions`      | Set SELinux options in container                                                                                 | `{}`                       |
+| `promtail.containerSecurityContext.seLinuxOptions`      | Set SELinux options in container                                                                                 | `nil`                      |
 | `promtail.containerSecurityContext.runAsUser`           | Set Promtail containers' Security Context runAsUser                                                              | `0`                        |
 | `promtail.containerSecurityContext.runAsNonRoot`        | Set Promtail containers' Security Context runAsNonRoot                                                           | `false`                    |
 | `promtail.containerSecurityContext.seccompProfile.type` | Set container's Security Context seccomp profile                                                                 | `RuntimeDefault`           |
@@ -1135,7 +1135,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `volumePermissions.image.pullSecrets`                            | OS Shell + Utility image pull secrets                                                                              | `[]`                       |
 | `volumePermissions.resources.limits`                             | The resources limits for the init container                                                                        | `{}`                       |
 | `volumePermissions.resources.requests`                           | The requested resources for the init container                                                                     | `{}`                       |
-| `volumePermissions.containerSecurityContext.seLinuxOptions`      | Set SELinux options in container                                                                                   | `{}`                       |
+| `volumePermissions.containerSecurityContext.seLinuxOptions`      | Set SELinux options in container                                                                                   | `nil`                      |
 | `volumePermissions.containerSecurityContext.runAsUser`           | Set init container's Security Context runAsUser                                                                    | `0`                        |
 | `volumePermissions.containerSecurityContext.seccompProfile.type` | Set container's Security Context seccomp profile                                                                   | `RuntimeDefault`           |
 

--- a/bitnami/grafana-loki/values.yaml
+++ b/bitnami/grafana-loki/values.yaml
@@ -378,14 +378,14 @@ compactor:
   ## Configure Container Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param compactor.containerSecurityContext.enabled Enabled Compactor containers' Security Context
-  ## @param compactor.containerSecurityContext.seLinuxOptions Set SELinux options in container
+  ## @param compactor.containerSecurityContext.seLinuxOptions [object,nullable] Set SELinux options in container
   ## @param compactor.containerSecurityContext.runAsUser Set Compactor containers' Security Context runAsUser
   ## @param compactor.containerSecurityContext.runAsNonRoot Set Compactor containers' Security Context runAsNonRoot
   ## @param compactor.containerSecurityContext.seccompProfile.type Set container's Security Context seccomp profile
   ##
   containerSecurityContext:
     enabled: true
-    seLinuxOptions: {}
+    seLinuxOptions: null
     runAsUser: 1001
     runAsNonRoot: true
     seccompProfile:
@@ -746,14 +746,14 @@ gateway:
   ## Configure Container Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param gateway.containerSecurityContext.enabled Enabled Gateway containers' Security Context
-  ## @param gateway.containerSecurityContext.seLinuxOptions Set SELinux options in container
+  ## @param gateway.containerSecurityContext.seLinuxOptions [object,nullable] Set SELinux options in container
   ## @param gateway.containerSecurityContext.runAsUser Set Gateway containers' Security Context runAsUser
   ## @param gateway.containerSecurityContext.runAsNonRoot Set Gateway containers' Security Context runAsNonRoot
   ## @param gateway.containerSecurityContext.seccompProfile.type Set container's Security Context seccomp profile
   ##
   containerSecurityContext:
     enabled: true
-    seLinuxOptions: {}
+    seLinuxOptions: null
     runAsUser: 1001
     runAsNonRoot: true
     seccompProfile:
@@ -1124,14 +1124,14 @@ indexGateway:
   ## Configure Container Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param indexGateway.containerSecurityContext.enabled Enabled index-gateway containers' Security Context
-  ## @param indexGateway.containerSecurityContext.seLinuxOptions Set SELinux options in container
+  ## @param indexGateway.containerSecurityContext.seLinuxOptions [object,nullable] Set SELinux options in container
   ## @param indexGateway.containerSecurityContext.runAsUser Set index-gateway containers' Security Context runAsUser
   ## @param indexGateway.containerSecurityContext.runAsNonRoot Set index-gateway containers' Security Context runAsNonRoot
   ## @param indexGateway.containerSecurityContext.seccompProfile.type Set container's Security Context seccomp profile
   ##
   containerSecurityContext:
     enabled: true
-    seLinuxOptions: {}
+    seLinuxOptions: null
     runAsUser: 1001
     runAsNonRoot: true
     seccompProfile:
@@ -1405,14 +1405,14 @@ distributor:
   ## Configure Container Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param distributor.containerSecurityContext.enabled Enabled Distributor containers' Security Context
-  ## @param distributor.containerSecurityContext.seLinuxOptions Set SELinux options in container
+  ## @param distributor.containerSecurityContext.seLinuxOptions [object,nullable] Set SELinux options in container
   ## @param distributor.containerSecurityContext.runAsUser Set Distributor containers' Security Context runAsUser
   ## @param distributor.containerSecurityContext.runAsNonRoot Set Distributor containers' Security Context runAsNonRoot
   ## @param distributor.containerSecurityContext.seccompProfile.type Set container's Security Context seccomp profile
   ##
   containerSecurityContext:
     enabled: true
-    seLinuxOptions: {}
+    seLinuxOptions: null
     runAsUser: 1001
     runAsNonRoot: true
     seccompProfile:
@@ -1689,14 +1689,14 @@ ingester:
   ## Configure Container Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param ingester.containerSecurityContext.enabled Enabled Ingester containers' Security Context
-  ## @param ingester.containerSecurityContext.seLinuxOptions Set SELinux options in container
+  ## @param ingester.containerSecurityContext.seLinuxOptions [object,nullable] Set SELinux options in container
   ## @param ingester.containerSecurityContext.runAsUser Set Ingester containers' Security Context runAsUser
   ## @param ingester.containerSecurityContext.runAsNonRoot Set Ingester containers' Security Context runAsNonRoot
   ## @param ingester.containerSecurityContext.seccompProfile.type Set container's Security Context seccomp profile
   ##
   containerSecurityContext:
     enabled: true
-    seLinuxOptions: {}
+    seLinuxOptions: null
     runAsUser: 1001
     runAsNonRoot: true
     seccompProfile:
@@ -2015,14 +2015,14 @@ querier:
   ## Configure Container Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param querier.containerSecurityContext.enabled Enabled Querier containers' Security Context
-  ## @param querier.containerSecurityContext.seLinuxOptions Set SELinux options in container
+  ## @param querier.containerSecurityContext.seLinuxOptions [object,nullable] Set SELinux options in container
   ## @param querier.containerSecurityContext.runAsUser Set Querier containers' Security Context runAsUser
   ## @param querier.containerSecurityContext.runAsNonRoot Set Querier containers' Security Context runAsNonRoot
   ## @param querier.containerSecurityContext.seccompProfile.type Set container's Security Context seccomp profile
   ##
   containerSecurityContext:
     enabled: true
-    seLinuxOptions: {}
+    seLinuxOptions: null
     runAsUser: 1001
     runAsNonRoot: true
     seccompProfile:
@@ -2336,14 +2336,14 @@ queryFrontend:
   ## Configure Container Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param queryFrontend.containerSecurityContext.enabled Enabled queryFrontend containers' Security Context
-  ## @param queryFrontend.containerSecurityContext.seLinuxOptions Set SELinux options in container
+  ## @param queryFrontend.containerSecurityContext.seLinuxOptions [object,nullable] Set SELinux options in container
   ## @param queryFrontend.containerSecurityContext.runAsUser Set queryFrontend containers' Security Context runAsUser
   ## @param queryFrontend.containerSecurityContext.runAsNonRoot Set queryFrontend containers' Security Context runAsNonRoot
   ## @param queryFrontend.containerSecurityContext.seccompProfile.type Set container's Security Context seccomp profile
   ##
   containerSecurityContext:
     enabled: true
-    seLinuxOptions: {}
+    seLinuxOptions: null
     runAsUser: 1001
     runAsNonRoot: true
     seccompProfile:
@@ -2627,14 +2627,14 @@ queryScheduler:
   ## Configure Container Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param queryScheduler.containerSecurityContext.enabled Enabled queryScheduler containers' Security Context
-  ## @param queryScheduler.containerSecurityContext.seLinuxOptions Set SELinux options in container
+  ## @param queryScheduler.containerSecurityContext.seLinuxOptions [object,nullable] Set SELinux options in container
   ## @param queryScheduler.containerSecurityContext.runAsUser Set queryScheduler containers' Security Context runAsUser
   ## @param queryScheduler.containerSecurityContext.runAsNonRoot Set queryScheduler containers' Security Context runAsNonRoot
   ## @param queryScheduler.containerSecurityContext.seccompProfile.type Set container's Security Context seccomp profile
   ##
   containerSecurityContext:
     enabled: true
-    seLinuxOptions: {}
+    seLinuxOptions: null
     runAsUser: 1001
     runAsNonRoot: true
     seccompProfile:
@@ -2918,14 +2918,14 @@ ruler:
   ## Configure Container Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param ruler.containerSecurityContext.enabled Enabled Ruler containers' Security Context
-  ## @param ruler.containerSecurityContext.seLinuxOptions Set SELinux options in container
+  ## @param ruler.containerSecurityContext.seLinuxOptions [object,nullable] Set SELinux options in container
   ## @param ruler.containerSecurityContext.runAsUser Set Ruler containers' Security Context runAsUser
   ## @param ruler.containerSecurityContext.runAsNonRoot Set Ruler containers' Security Context runAsNonRoot
   ## @param ruler.containerSecurityContext.seccompProfile.type Set container's Security Context seccomp profile
   ##
   containerSecurityContext:
     enabled: true
-    seLinuxOptions: {}
+    seLinuxOptions: null
     runAsUser: 1001
     runAsNonRoot: true
     seccompProfile:
@@ -3239,14 +3239,14 @@ tableManager:
   ## Configure Container Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param tableManager.containerSecurityContext.enabled Enabled table-manager containers' Security Context
-  ## @param tableManager.containerSecurityContext.seLinuxOptions Set SELinux options in container
+  ## @param tableManager.containerSecurityContext.seLinuxOptions [object,nullable] Set SELinux options in container
   ## @param tableManager.containerSecurityContext.runAsUser Set table-manager containers' Security Context runAsUser
   ## @param tableManager.containerSecurityContext.runAsNonRoot Set table-manager containers' Security Context runAsNonRoot
   ## @param tableManager.containerSecurityContext.seccompProfile.type Set container's Security Context seccomp profile
   ##
   containerSecurityContext:
     enabled: true
-    seLinuxOptions: {}
+    seLinuxOptions: null
     runAsUser: 1001
     runAsNonRoot: true
     seccompProfile:
@@ -3557,14 +3557,14 @@ promtail:
   ## Configure Container Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param promtail.containerSecurityContext.enabled Enabled Promtail containers' Security Context
-  ## @param promtail.containerSecurityContext.seLinuxOptions Set SELinux options in container
+  ## @param promtail.containerSecurityContext.seLinuxOptions [object,nullable] Set SELinux options in container
   ## @param promtail.containerSecurityContext.runAsUser Set Promtail containers' Security Context runAsUser
   ## @param promtail.containerSecurityContext.runAsNonRoot Set Promtail containers' Security Context runAsNonRoot
   ## @param promtail.containerSecurityContext.seccompProfile.type Set container's Security Context seccomp profile
   ##
   containerSecurityContext:
     enabled: true
-    seLinuxOptions: {}
+    seLinuxOptions: null
     runAsUser: 0
     runAsNonRoot: false
     seccompProfile:
@@ -3885,7 +3885,7 @@ volumePermissions:
     requests: {}
   ## Init container Container Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
-  ## @param volumePermissions.containerSecurityContext.seLinuxOptions Set SELinux options in container
+  ## @param volumePermissions.containerSecurityContext.seLinuxOptions [object,nullable] Set SELinux options in container
   ## @param volumePermissions.containerSecurityContext.runAsUser Set init container's Security Context runAsUser
   ## @param volumePermissions.containerSecurityContext.seccompProfile.type Set container's Security Context seccomp profile
   ## NOTE: when runAsUser is set to special value "auto", init container will try to chown the
@@ -3893,7 +3893,7 @@ volumePermissions:
   ##   "auto" is especially useful for OpenShift which has scc with dynamic user ids (and 0 is not allowed)
   ##
   containerSecurityContext:
-    seLinuxOptions: {}
+    seLinuxOptions: null
     runAsUser: 0
     seccompProfile:
       type: "RuntimeDefault"


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

### Description of the change

Setting seLinuxOptions to `{}` causes the following issue in Openshift

```
Forbidden: not usable by user or serviceaccount, provider restricted: .containers[0].seLinuxOptions.level: Invalid value: ""
```

This PR sets the value to `null` to allow compatibility with this platform.

### Benefits

Fix compatibility with Openshift

### Possible drawbacks

n/a

### Issues

Fixes https://github.com/bitnami/charts/issues/22511

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)

