### PR TITLE
[bitnami/grafana-mimir] fix: :bug: Set seLinuxOptions to null for Openshift compatibility

### DIFF
--- a/bitnami/grafana-mimir/Chart.yaml
+++ b/bitnami/grafana-mimir/Chart.yaml
@@ -59,4 +59,4 @@ maintainers:
 name: grafana-mimir
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/grafana-mimir
-version: 0.9.0
+version: 0.9.1

--- a/bitnami/grafana-mimir/README.md
+++ b/bitnami/grafana-mimir/README.md
@@ -147,7 +147,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `alertmanager.podSecurityContext.supplementalGroups`             | Set filesystem extra groups                                                                            | `[]`                |
 | `alertmanager.podSecurityContext.fsGroup`                        | Set Alertmanager pod's Security Context fsGroup                                                        | `1001`              |
 | `alertmanager.containerSecurityContext.enabled`                  | Enabled containers' Security Context                                                                   | `true`              |
-| `alertmanager.containerSecurityContext.seLinuxOptions`           | Set SELinux options in container                                                                       | `{}`                |
+| `alertmanager.containerSecurityContext.seLinuxOptions`           | Set SELinux options in container                                                                       | `nil`               |
 | `alertmanager.containerSecurityContext.runAsUser`                | Set containers' Security Context runAsUser                                                             | `1001`              |
 | `alertmanager.containerSecurityContext.runAsNonRoot`             | Set container's Security Context runAsNonRoot                                                          | `true`              |
 | `alertmanager.containerSecurityContext.privileged`               | Set container's Security Context privileged                                                            | `false`             |
@@ -251,7 +251,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `compactor.podSecurityContext.supplementalGroups`             | Set filesystem extra groups                                                                         | `[]`                |
 | `compactor.podSecurityContext.fsGroup`                        | Set Compactor pod's Security Context fsGroup                                                        | `1001`              |
 | `compactor.containerSecurityContext.enabled`                  | Enabled containers' Security Context                                                                | `true`              |
-| `compactor.containerSecurityContext.seLinuxOptions`           | Set SELinux options in container                                                                    | `{}`                |
+| `compactor.containerSecurityContext.seLinuxOptions`           | Set SELinux options in container                                                                    | `nil`               |
 | `compactor.containerSecurityContext.runAsUser`                | Set containers' Security Context runAsUser                                                          | `1001`              |
 | `compactor.containerSecurityContext.runAsNonRoot`             | Set container's Security Context runAsNonRoot                                                       | `true`              |
 | `compactor.containerSecurityContext.privileged`               | Set container's Security Context privileged                                                         | `false`             |
@@ -351,7 +351,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `distributor.podSecurityContext.supplementalGroups`             | Set filesystem extra groups                                                                           | `[]`             |
 | `distributor.podSecurityContext.fsGroup`                        | Set Distributor pod's Security Context fsGroup                                                        | `1001`           |
 | `distributor.containerSecurityContext.enabled`                  | Enabled containers' Security Context                                                                  | `true`           |
-| `distributor.containerSecurityContext.seLinuxOptions`           | Set SELinux options in container                                                                      | `{}`             |
+| `distributor.containerSecurityContext.seLinuxOptions`           | Set SELinux options in container                                                                      | `nil`            |
 | `distributor.containerSecurityContext.runAsUser`                | Set containers' Security Context runAsUser                                                            | `1001`           |
 | `distributor.containerSecurityContext.runAsNonRoot`             | Set container's Security Context runAsNonRoot                                                         | `true`           |
 | `distributor.containerSecurityContext.privileged`               | Set container's Security Context privileged                                                           | `false`          |
@@ -457,7 +457,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `gateway.podSecurityContext.supplementalGroups`             | Set filesystem extra groups                                                                           | `[]`                    |
 | `gateway.podSecurityContext.fsGroup`                        | Set Gateway pod's Security Context fsGroup                                                            | `1001`                  |
 | `gateway.containerSecurityContext.enabled`                  | Enabled containers' Security Context                                                                  | `true`                  |
-| `gateway.containerSecurityContext.seLinuxOptions`           | Set SELinux options in container                                                                      | `{}`                    |
+| `gateway.containerSecurityContext.seLinuxOptions`           | Set SELinux options in container                                                                      | `nil`                   |
 | `gateway.containerSecurityContext.runAsUser`                | Set containers' Security Context runAsUser                                                            | `1001`                  |
 | `gateway.containerSecurityContext.runAsNonRoot`             | Set container's Security Context runAsNonRoot                                                         | `true`                  |
 | `gateway.containerSecurityContext.privileged`               | Set container's Security Context privileged                                                           | `false`                 |
@@ -561,7 +561,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `ingester.podSecurityContext.supplementalGroups`             | Set filesystem extra groups                                                                        | `[]`                |
 | `ingester.podSecurityContext.fsGroup`                        | Set Ingester pod's Security Context fsGroup                                                        | `1001`              |
 | `ingester.containerSecurityContext.enabled`                  | Enabled containers' Security Context                                                               | `true`              |
-| `ingester.containerSecurityContext.seLinuxOptions`           | Set SELinux options in container                                                                   | `{}`                |
+| `ingester.containerSecurityContext.seLinuxOptions`           | Set SELinux options in container                                                                   | `nil`               |
 | `ingester.containerSecurityContext.runAsUser`                | Set containers' Security Context runAsUser                                                         | `1001`              |
 | `ingester.containerSecurityContext.runAsNonRoot`             | Set container's Security Context runAsNonRoot                                                      | `true`              |
 | `ingester.containerSecurityContext.privileged`               | Set container's Security Context privileged                                                        | `false`             |
@@ -658,7 +658,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `overridesExporter.podSecurityContext.supplementalGroups`             | Set filesystem extra groups                                                                                 | `[]`             |
 | `overridesExporter.podSecurityContext.fsGroup`                        | Set Overrides Exporter pod's Security Context fsGroup                                                       | `1001`           |
 | `overridesExporter.containerSecurityContext.enabled`                  | Enabled containers' Security Context                                                                        | `true`           |
-| `overridesExporter.containerSecurityContext.seLinuxOptions`           | Set SELinux options in container                                                                            | `{}`             |
+| `overridesExporter.containerSecurityContext.seLinuxOptions`           | Set SELinux options in container                                                                            | `nil`            |
 | `overridesExporter.containerSecurityContext.runAsUser`                | Set containers' Security Context runAsUser                                                                  | `1001`           |
 | `overridesExporter.containerSecurityContext.runAsNonRoot`             | Set container's Security Context runAsNonRoot                                                               | `true`           |
 | `overridesExporter.containerSecurityContext.privileged`               | Set container's Security Context privileged                                                                 | `false`          |
@@ -752,7 +752,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `querier.podSecurityContext.supplementalGroups`             | Set filesystem extra groups                                                                       | `[]`             |
 | `querier.podSecurityContext.fsGroup`                        | Set Querier pod's Security Context fsGroup                                                        | `1001`           |
 | `querier.containerSecurityContext.enabled`                  | Enabled containers' Security Context                                                              | `true`           |
-| `querier.containerSecurityContext.seLinuxOptions`           | Set SELinux options in container                                                                  | `{}`             |
+| `querier.containerSecurityContext.seLinuxOptions`           | Set SELinux options in container                                                                  | `nil`            |
 | `querier.containerSecurityContext.runAsUser`                | Set containers' Security Context runAsUser                                                        | `1001`           |
 | `querier.containerSecurityContext.runAsNonRoot`             | Set container's Security Context runAsNonRoot                                                     | `true`           |
 | `querier.containerSecurityContext.privileged`               | Set container's Security Context privileged                                                       | `false`          |
@@ -846,7 +846,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `queryFrontend.podSecurityContext.supplementalGroups`             | Set filesystem extra groups                                                                             | `[]`             |
 | `queryFrontend.podSecurityContext.fsGroup`                        | Set Query Frontend pod's Security Context fsGroup                                                       | `1001`           |
 | `queryFrontend.containerSecurityContext.enabled`                  | Enabled containers' Security Context                                                                    | `true`           |
-| `queryFrontend.containerSecurityContext.seLinuxOptions`           | Set SELinux options in container                                                                        | `{}`             |
+| `queryFrontend.containerSecurityContext.seLinuxOptions`           | Set SELinux options in container                                                                        | `nil`            |
 | `queryFrontend.containerSecurityContext.runAsUser`                | Set containers' Security Context runAsUser                                                              | `1001`           |
 | `queryFrontend.containerSecurityContext.runAsNonRoot`             | Set container's Security Context runAsNonRoot                                                           | `true`           |
 | `queryFrontend.containerSecurityContext.privileged`               | Set container's Security Context privileged                                                             | `false`          |
@@ -936,7 +936,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `queryScheduler.podSecurityContext.supplementalGroups`             | Set filesystem extra groups                                                                              | `[]`             |
 | `queryScheduler.podSecurityContext.fsGroup`                        | Set Query Scheduler pod's Security Context fsGroup                                                       | `1001`           |
 | `queryScheduler.containerSecurityContext.enabled`                  | Enabled containers' Security Context                                                                     | `true`           |
-| `queryScheduler.containerSecurityContext.seLinuxOptions`           | Set SELinux options in container                                                                         | `{}`             |
+| `queryScheduler.containerSecurityContext.seLinuxOptions`           | Set SELinux options in container                                                                         | `nil`            |
 | `queryScheduler.containerSecurityContext.runAsUser`                | Set containers' Security Context runAsUser                                                               | `1001`           |
 | `queryScheduler.containerSecurityContext.runAsNonRoot`             | Set container's Security Context runAsNonRoot                                                            | `true`           |
 | `queryScheduler.containerSecurityContext.privileged`               | Set container's Security Context privileged                                                              | `false`          |
@@ -1031,7 +1031,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `storeGateway.podSecurityContext.supplementalGroups`             | Set filesystem extra groups                                                                            | `[]`                |
 | `storeGateway.podSecurityContext.fsGroup`                        | Set Store Gateway pod's Security Context fsGroup                                                       | `1001`              |
 | `storeGateway.containerSecurityContext.enabled`                  | Enabled containers' Security Context                                                                   | `true`              |
-| `storeGateway.containerSecurityContext.seLinuxOptions`           | Set SELinux options in container                                                                       | `{}`                |
+| `storeGateway.containerSecurityContext.seLinuxOptions`           | Set SELinux options in container                                                                       | `nil`               |
 | `storeGateway.containerSecurityContext.runAsUser`                | Set containers' Security Context runAsUser                                                             | `1001`              |
 | `storeGateway.containerSecurityContext.runAsNonRoot`             | Set container's Security Context runAsNonRoot                                                          | `true`              |
 | `storeGateway.containerSecurityContext.privileged`               | Set container's Security Context privileged                                                            | `false`             |
@@ -1136,7 +1136,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `ruler.podSecurityContext.supplementalGroups`             | Set filesystem extra groups                                                                     | `[]`             |
 | `ruler.podSecurityContext.fsGroup`                        | Set Ruler pod's Security Context fsGroup                                                        | `1001`           |
 | `ruler.containerSecurityContext.enabled`                  | Enabled containers' Security Context                                                            | `true`           |
-| `ruler.containerSecurityContext.seLinuxOptions`           | Set SELinux options in container                                                                | `{}`             |
+| `ruler.containerSecurityContext.seLinuxOptions`           | Set SELinux options in container                                                                | `nil`            |
 | `ruler.containerSecurityContext.runAsUser`                | Set containers' Security Context runAsUser                                                      | `1001`           |
 | `ruler.containerSecurityContext.runAsNonRoot`             | Set container's Security Context runAsNonRoot                                                   | `true`           |
 | `ruler.containerSecurityContext.privileged`               | Set container's Security Context privileged                                                     | `false`          |
@@ -1212,7 +1212,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `volumePermissions.image.pullSecrets`                       | OS Shell + Utility image pull secrets                                                           | `[]`                       |
 | `volumePermissions.resources.limits`                        | The resources limits for the init container                                                     | `{}`                       |
 | `volumePermissions.resources.requests`                      | The requested resources for the init container                                                  | `{}`                       |
-| `volumePermissions.containerSecurityContext.seLinuxOptions` | Set SELinux options in container                                                                | `{}`                       |
+| `volumePermissions.containerSecurityContext.seLinuxOptions` | Set SELinux options in container                                                                | `nil`                      |
 | `volumePermissions.containerSecurityContext.runAsUser`      | Set init container's Security Context runAsUser                                                 | `0`                        |
 
 ### Other Parameters

--- a/bitnami/grafana-mimir/values.yaml
+++ b/bitnami/grafana-mimir/values.yaml
@@ -445,7 +445,7 @@ alertmanager:
   ## Configure Container Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param alertmanager.containerSecurityContext.enabled Enabled containers' Security Context
-  ## @param alertmanager.containerSecurityContext.seLinuxOptions Set SELinux options in container
+  ## @param alertmanager.containerSecurityContext.seLinuxOptions [object,nullable] Set SELinux options in container
   ## @param alertmanager.containerSecurityContext.runAsUser Set containers' Security Context runAsUser
   ## @param alertmanager.containerSecurityContext.runAsNonRoot Set container's Security Context runAsNonRoot
   ## @param alertmanager.containerSecurityContext.privileged Set container's Security Context privileged
@@ -456,7 +456,7 @@ alertmanager:
   ##
   containerSecurityContext:
     enabled: true
-    seLinuxOptions: {}
+    seLinuxOptions: null
     runAsUser: 1001
     runAsNonRoot: true
     privileged: false
@@ -815,7 +815,7 @@ compactor:
   ## Configure Container Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param compactor.containerSecurityContext.enabled Enabled containers' Security Context
-  ## @param compactor.containerSecurityContext.seLinuxOptions Set SELinux options in container
+  ## @param compactor.containerSecurityContext.seLinuxOptions [object,nullable] Set SELinux options in container
   ## @param compactor.containerSecurityContext.runAsUser Set containers' Security Context runAsUser
   ## @param compactor.containerSecurityContext.runAsNonRoot Set container's Security Context runAsNonRoot
   ## @param compactor.containerSecurityContext.privileged Set container's Security Context privileged
@@ -826,7 +826,7 @@ compactor:
   ##
   containerSecurityContext:
     enabled: true
-    seLinuxOptions: {}
+    seLinuxOptions: null
     runAsUser: 1001
     runAsNonRoot: true
     privileged: false
@@ -1159,7 +1159,7 @@ distributor:
   ## Configure Container Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param distributor.containerSecurityContext.enabled Enabled containers' Security Context
-  ## @param distributor.containerSecurityContext.seLinuxOptions Set SELinux options in container
+  ## @param distributor.containerSecurityContext.seLinuxOptions [object,nullable] Set SELinux options in container
   ## @param distributor.containerSecurityContext.runAsUser Set containers' Security Context runAsUser
   ## @param distributor.containerSecurityContext.runAsNonRoot Set container's Security Context runAsNonRoot
   ## @param distributor.containerSecurityContext.privileged Set container's Security Context privileged
@@ -1170,7 +1170,7 @@ distributor:
   ##
   containerSecurityContext:
     enabled: true
-    seLinuxOptions: {}
+    seLinuxOptions: null
     runAsUser: 1001
     runAsNonRoot: true
     privileged: false
@@ -1518,7 +1518,7 @@ gateway:
   ## Configure Container Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param gateway.containerSecurityContext.enabled Enabled containers' Security Context
-  ## @param gateway.containerSecurityContext.seLinuxOptions Set SELinux options in container
+  ## @param gateway.containerSecurityContext.seLinuxOptions [object,nullable] Set SELinux options in container
   ## @param gateway.containerSecurityContext.runAsUser Set containers' Security Context runAsUser
   ## @param gateway.containerSecurityContext.runAsNonRoot Set container's Security Context runAsNonRoot
   ## @param gateway.containerSecurityContext.privileged Set container's Security Context privileged
@@ -1529,7 +1529,7 @@ gateway:
   ##
   containerSecurityContext:
     enabled: true
-    seLinuxOptions: {}
+    seLinuxOptions: null
     runAsUser: 1001
     runAsNonRoot: true
     privileged: false
@@ -1914,7 +1914,7 @@ ingester:
   ## Configure Container Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param ingester.containerSecurityContext.enabled Enabled containers' Security Context
-  ## @param ingester.containerSecurityContext.seLinuxOptions Set SELinux options in container
+  ## @param ingester.containerSecurityContext.seLinuxOptions [object,nullable] Set SELinux options in container
   ## @param ingester.containerSecurityContext.runAsUser Set containers' Security Context runAsUser
   ## @param ingester.containerSecurityContext.runAsNonRoot Set container's Security Context runAsNonRoot
   ## @param ingester.containerSecurityContext.privileged Set container's Security Context privileged
@@ -1925,7 +1925,7 @@ ingester:
   ##
   containerSecurityContext:
     enabled: true
-    seLinuxOptions: {}
+    seLinuxOptions: null
     runAsUser: 1001
     runAsNonRoot: true
     privileged: false
@@ -2267,7 +2267,7 @@ overridesExporter:
   ## Configure Container Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param overridesExporter.containerSecurityContext.enabled Enabled containers' Security Context
-  ## @param overridesExporter.containerSecurityContext.seLinuxOptions Set SELinux options in container
+  ## @param overridesExporter.containerSecurityContext.seLinuxOptions [object,nullable] Set SELinux options in container
   ## @param overridesExporter.containerSecurityContext.runAsUser Set containers' Security Context runAsUser
   ## @param overridesExporter.containerSecurityContext.runAsNonRoot Set container's Security Context runAsNonRoot
   ## @param overridesExporter.containerSecurityContext.privileged Set container's Security Context privileged
@@ -2278,7 +2278,7 @@ overridesExporter:
   ##
   containerSecurityContext:
     enabled: true
-    seLinuxOptions: {}
+    seLinuxOptions: null
     runAsUser: 1001
     runAsNonRoot: true
     privileged: false
@@ -2580,7 +2580,7 @@ querier:
   ## Configure Container Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param querier.containerSecurityContext.enabled Enabled containers' Security Context
-  ## @param querier.containerSecurityContext.seLinuxOptions Set SELinux options in container
+  ## @param querier.containerSecurityContext.seLinuxOptions [object,nullable] Set SELinux options in container
   ## @param querier.containerSecurityContext.runAsUser Set containers' Security Context runAsUser
   ## @param querier.containerSecurityContext.runAsNonRoot Set container's Security Context runAsNonRoot
   ## @param querier.containerSecurityContext.privileged Set container's Security Context privileged
@@ -2591,7 +2591,7 @@ querier:
   ##
   containerSecurityContext:
     enabled: true
-    seLinuxOptions: {}
+    seLinuxOptions: null
     runAsUser: 1001
     runAsNonRoot: true
     privileged: false
@@ -2893,7 +2893,7 @@ queryFrontend:
   ## Configure Container Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param queryFrontend.containerSecurityContext.enabled Enabled containers' Security Context
-  ## @param queryFrontend.containerSecurityContext.seLinuxOptions Set SELinux options in container
+  ## @param queryFrontend.containerSecurityContext.seLinuxOptions [object,nullable] Set SELinux options in container
   ## @param queryFrontend.containerSecurityContext.runAsUser Set containers' Security Context runAsUser
   ## @param queryFrontend.containerSecurityContext.runAsNonRoot Set container's Security Context runAsNonRoot
   ## @param queryFrontend.containerSecurityContext.privileged Set container's Security Context privileged
@@ -2904,7 +2904,7 @@ queryFrontend:
   ##
   containerSecurityContext:
     enabled: true
-    seLinuxOptions: {}
+    seLinuxOptions: null
     runAsUser: 1001
     runAsNonRoot: true
     privileged: false
@@ -3209,7 +3209,7 @@ queryScheduler:
   ## Configure Container Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param queryScheduler.containerSecurityContext.enabled Enabled containers' Security Context
-  ## @param queryScheduler.containerSecurityContext.seLinuxOptions Set SELinux options in container
+  ## @param queryScheduler.containerSecurityContext.seLinuxOptions [object,nullable] Set SELinux options in container
   ## @param queryScheduler.containerSecurityContext.runAsUser Set containers' Security Context runAsUser
   ## @param queryScheduler.containerSecurityContext.runAsNonRoot Set container's Security Context runAsNonRoot
   ## @param queryScheduler.containerSecurityContext.privileged Set container's Security Context privileged
@@ -3220,7 +3220,7 @@ queryScheduler:
   ##
   containerSecurityContext:
     enabled: true
-    seLinuxOptions: {}
+    seLinuxOptions: null
     runAsUser: 1001
     runAsNonRoot: true
     privileged: false
@@ -3526,7 +3526,7 @@ storeGateway:
   ## Configure Container Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param storeGateway.containerSecurityContext.enabled Enabled containers' Security Context
-  ## @param storeGateway.containerSecurityContext.seLinuxOptions Set SELinux options in container
+  ## @param storeGateway.containerSecurityContext.seLinuxOptions [object,nullable] Set SELinux options in container
   ## @param storeGateway.containerSecurityContext.runAsUser Set containers' Security Context runAsUser
   ## @param storeGateway.containerSecurityContext.runAsNonRoot Set container's Security Context runAsNonRoot
   ## @param storeGateway.containerSecurityContext.privileged Set container's Security Context privileged
@@ -3537,7 +3537,7 @@ storeGateway:
   ##
   containerSecurityContext:
     enabled: true
-    seLinuxOptions: {}
+    seLinuxOptions: null
     runAsUser: 1001
     runAsNonRoot: true
     privileged: false
@@ -3889,7 +3889,7 @@ ruler:
   ## Configure Container Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param ruler.containerSecurityContext.enabled Enabled containers' Security Context
-  ## @param ruler.containerSecurityContext.seLinuxOptions Set SELinux options in container
+  ## @param ruler.containerSecurityContext.seLinuxOptions [object,nullable] Set SELinux options in container
   ## @param ruler.containerSecurityContext.runAsUser Set containers' Security Context runAsUser
   ## @param ruler.containerSecurityContext.runAsNonRoot Set container's Security Context runAsNonRoot
   ## @param ruler.containerSecurityContext.privileged Set container's Security Context privileged
@@ -3900,7 +3900,7 @@ ruler:
   ##
   containerSecurityContext:
     enabled: true
-    seLinuxOptions: {}
+    seLinuxOptions: null
     runAsUser: 1001
     runAsNonRoot: true
     privileged: false
@@ -4180,14 +4180,14 @@ volumePermissions:
     requests: {}
   ## Init container Container Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
-  ## @param volumePermissions.containerSecurityContext.seLinuxOptions Set SELinux options in container
+  ## @param volumePermissions.containerSecurityContext.seLinuxOptions [object,nullable] Set SELinux options in container
   ## @param volumePermissions.containerSecurityContext.runAsUser Set init container's Security Context runAsUser
   ## NOTE: when runAsUser is set to special value "auto", init container will try to chown the
   ##   data folder to auto-determined user&group, using commands: `id -u`:`id -G | cut -d" " -f2`
   ##   "auto" is especially useful for OpenShift which has scc with dynamic user ids (and 0 is not allowed)
   ##
   containerSecurityContext:
-    seLinuxOptions: {}
+    seLinuxOptions: null
     runAsUser: 0
 
 ## @section Other Parameters


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

### Description of the change

Setting seLinuxOptions to `{}` causes the following issue in Openshift

```
Forbidden: not usable by user or serviceaccount, provider restricted: .containers[0].seLinuxOptions.level: Invalid value: ""
```

This PR sets the value to `null` to allow compatibility with this platform.

### Benefits

Fix compatibility with Openshift

### Possible drawbacks

n/a

### Issues

Fixes https://github.com/bitnami/charts/issues/22511

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)

