### PR TITLE
[bitnami/multus-cni] fix: :bug: Set seLinuxOptions to null for Openshift compatibility

### DIFF
--- a/bitnami/multus-cni/Chart.yaml
+++ b/bitnami/multus-cni/Chart.yaml
@@ -29,4 +29,4 @@ maintainers:
 name: multus-cni
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/multus-cni
-version: 1.4.1
+version: 1.4.2

--- a/bitnami/multus-cni/README.md
+++ b/bitnami/multus-cni/README.md
@@ -123,7 +123,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `podSecurityContext.supplementalGroups`        | Set filesystem extra groups                                                                                           | `[]`                         |
 | `podSecurityContext.fsGroup`                   | Multus CNI pods' group ID                                                                                             | `0`                          |
 | `containerSecurityContext.enabled`             | Enable Multus CNI containers' Security Context                                                                        | `true`                       |
-| `containerSecurityContext.seLinuxOptions`      | Set SELinux options in container                                                                                      | `{}`                         |
+| `containerSecurityContext.seLinuxOptions`      | Set SELinux options in container                                                                                      | `nil`                        |
 | `containerSecurityContext.runAsUser`           | Multus CNI containers' Security Context                                                                               | `0`                          |
 | `containerSecurityContext.runAsNonRoot`        | Set Multus CNI container's Security Context runAsNonRoot                                                              | `false`                      |
 | `containerSecurityContext.privileged`          | Set Multus CNI container's Security Context privileged                                                                | `true`                       |

--- a/bitnami/multus-cni/values.yaml
+++ b/bitnami/multus-cni/values.yaml
@@ -231,7 +231,7 @@ podSecurityContext:
 ## Configure Container Security Context (only main container)
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
 ## @param containerSecurityContext.enabled Enable Multus CNI containers' Security Context
-## @param containerSecurityContext.seLinuxOptions Set SELinux options in container
+## @param containerSecurityContext.seLinuxOptions [object,nullable] Set SELinux options in container
 ## @param containerSecurityContext.runAsUser Multus CNI containers' Security Context
 ## @param containerSecurityContext.runAsNonRoot Set Multus CNI container's Security Context runAsNonRoot
 ## @param containerSecurityContext.privileged Set Multus CNI container's Security Context privileged
@@ -239,7 +239,7 @@ podSecurityContext:
 ##
 containerSecurityContext:
   enabled: true
-  seLinuxOptions: {}
+  seLinuxOptions: null
   runAsUser: 0
   runAsNonRoot: false
   privileged: true


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

### Description of the change

Setting seLinuxOptions to `{}` causes the following issue in Openshift

```
Forbidden: not usable by user or serviceaccount, provider restricted: .containers[0].seLinuxOptions.level: Invalid value: ""
```

This PR sets the value to `null` to allow compatibility with this platform.

### Benefits

Fix compatibility with Openshift

### Possible drawbacks

n/a

### Issues

Fixes https://github.com/bitnami/charts/issues/22511

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)

