### PR TITLE
[bitnami/spark] fix: :bug: Set seLinuxOptions to null for Openshift compatibility

### DIFF
--- a/bitnami/spark/Chart.yaml
+++ b/bitnami/spark/Chart.yaml
@@ -27,4 +27,4 @@ maintainers:
 name: spark
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/spark
-version: 8.3.0
+version: 8.3.1

--- a/bitnami/spark/README.md
+++ b/bitnami/spark/README.md
@@ -117,9 +117,9 @@ The command removes all the Kubernetes components associated with the chart and 
 | `master.podSecurityContext.fsGroup`                        | Set master pod's Security Context Group ID                                                                               | `1001`           |
 | `master.podSecurityContext.runAsUser`                      | Set master pod's Security Context User ID                                                                                | `1001`           |
 | `master.podSecurityContext.runAsGroup`                     | Set master pod's Security Context Group ID                                                                               | `0`              |
-| `master.podSecurityContext.seLinuxOptions`                 | Set master pod's Security Context SELinux options                                                                        | `{}`             |
+| `master.podSecurityContext.seLinuxOptions`                 | Set master pod's Security Context SELinux options                                                                        | `nil`            |
 | `master.containerSecurityContext.enabled`                  | Enabled containers' Security Context                                                                                     | `true`           |
-| `master.containerSecurityContext.seLinuxOptions`           | Set SELinux options in container                                                                                         | `{}`             |
+| `master.containerSecurityContext.seLinuxOptions`           | Set SELinux options in container                                                                                         | `nil`            |
 | `master.containerSecurityContext.runAsUser`                | Set containers' Security Context runAsUser                                                                               | `1001`           |
 | `master.containerSecurityContext.runAsNonRoot`             | Set container's Security Context runAsNonRoot                                                                            | `true`           |
 | `master.containerSecurityContext.privileged`               | Set container's Security Context privileged                                                                              | `false`          |
@@ -200,9 +200,9 @@ The command removes all the Kubernetes components associated with the chart and 
 | `worker.podSecurityContext.sysctls`                        | Set kernel settings using the sysctl interface                                                                           | `[]`             |
 | `worker.podSecurityContext.supplementalGroups`             | Set filesystem extra groups                                                                                              | `[]`             |
 | `worker.podSecurityContext.fsGroup`                        | Group ID for the container                                                                                               | `1001`           |
-| `worker.podSecurityContext.seLinuxOptions`                 | SELinux options for the container                                                                                        | `{}`             |
+| `worker.podSecurityContext.seLinuxOptions`                 | SELinux options for the container                                                                                        | `nil`            |
 | `worker.containerSecurityContext.enabled`                  | Enabled containers' Security Context                                                                                     | `true`           |
-| `worker.containerSecurityContext.seLinuxOptions`           | Set SELinux options in container                                                                                         | `{}`             |
+| `worker.containerSecurityContext.seLinuxOptions`           | Set SELinux options in container                                                                                         | `nil`            |
 | `worker.containerSecurityContext.runAsUser`                | Set containers' Security Context runAsUser                                                                               | `1001`           |
 | `worker.containerSecurityContext.runAsNonRoot`             | Set container's Security Context runAsNonRoot                                                                            | `true`           |
 | `worker.containerSecurityContext.privileged`               | Set container's Security Context privileged                                                                              | `false`          |

--- a/bitnami/spark/values.yaml
+++ b/bitnami/spark/values.yaml
@@ -179,7 +179,7 @@ master:
   ## @param master.podSecurityContext.fsGroup Set master pod's Security Context Group ID
   ## @param master.podSecurityContext.runAsUser Set master pod's Security Context User ID
   ## @param master.podSecurityContext.runAsGroup Set master pod's Security Context Group ID
-  ## @param master.podSecurityContext.seLinuxOptions Set master pod's Security Context SELinux options
+  ## @param master.podSecurityContext.seLinuxOptions [object,nullable] Set master pod's Security Context SELinux options
   ##
   podSecurityContext:
     enabled: true
@@ -189,11 +189,11 @@ master:
     fsGroup: 1001
     runAsUser: 1001
     runAsGroup: 0
-    seLinuxOptions: {}
+    seLinuxOptions: null
   ## Configure Container Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
   ## @param master.containerSecurityContext.enabled Enabled containers' Security Context
-  ## @param master.containerSecurityContext.seLinuxOptions Set SELinux options in container
+  ## @param master.containerSecurityContext.seLinuxOptions [object,nullable] Set SELinux options in container
   ## @param master.containerSecurityContext.runAsUser Set containers' Security Context runAsUser
   ## @param master.containerSecurityContext.runAsNonRoot Set container's Security Context runAsNonRoot
   ## @param master.containerSecurityContext.privileged Set container's Security Context privileged
@@ -204,7 +204,7 @@ master:
   ##
   containerSecurityContext:
     enabled: true
-    seLinuxOptions: {}
+    seLinuxOptions: null
     runAsUser: 1001
     runAsNonRoot: true
     privileged: false
@@ -478,7 +478,7 @@ worker:
   ## @param worker.podSecurityContext.sysctls Set kernel settings using the sysctl interface
   ## @param worker.podSecurityContext.supplementalGroups Set filesystem extra groups
   ## @param worker.podSecurityContext.fsGroup Group ID for the container
-  ## @param worker.podSecurityContext.seLinuxOptions SELinux options for the container
+  ## @param worker.podSecurityContext.seLinuxOptions [object,nullable] SELinux options for the container
   ##
   podSecurityContext:
     enabled: true
@@ -486,11 +486,11 @@ worker:
     sysctls: []
     supplementalGroups: []
     fsGroup: 1001
-    seLinuxOptions: {}
+    seLinuxOptions: null
   ## Configure Container Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
   ## @param worker.containerSecurityContext.enabled Enabled containers' Security Context
-  ## @param worker.containerSecurityContext.seLinuxOptions Set SELinux options in container
+  ## @param worker.containerSecurityContext.seLinuxOptions [object,nullable] Set SELinux options in container
   ## @param worker.containerSecurityContext.runAsUser Set containers' Security Context runAsUser
   ## @param worker.containerSecurityContext.runAsNonRoot Set container's Security Context runAsNonRoot
   ## @param worker.containerSecurityContext.privileged Set container's Security Context privileged
@@ -501,7 +501,7 @@ worker:
   ##
   containerSecurityContext:
     enabled: true
-    seLinuxOptions: {}
+    seLinuxOptions: null
     runAsUser: 1001
     runAsNonRoot: true
     privileged: false


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

### Description of the change

Setting seLinuxOptions to `{}` causes the following issue in Openshift

```
Forbidden: not usable by user or serviceaccount, provider restricted: .containers[0].seLinuxOptions.level: Invalid value: ""
```

This PR sets the value to `null` to allow compatibility with this platform.

### Benefits

Fix compatibility with Openshift

### Possible drawbacks

n/a

### Issues

Fixes https://github.com/bitnami/charts/issues/22511

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)

