### PR TITLE
[bitnami/odoo] Fix secret name for external database password

### DIFF
--- a/bitnami/odoo/Chart.yaml
+++ b/bitnami/odoo/Chart.yaml
@@ -34,4 +34,4 @@ maintainers:
 name: odoo
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/odoo
-version: 25.3.0
+version: 25.3.1

--- a/bitnami/odoo/templates/_helpers.tpl
+++ b/bitnami/odoo/templates/_helpers.tpl
@@ -98,7 +98,7 @@ Return the PostgreSQL Secret Name
         {{- default (include "odoo.postgresql.fullname" .) (tpl .Values.postgresql.auth.existingSecret $) -}}
     {{- end -}}
 {{- else -}}
-    {{- default (printf "%s-externaldb" .Release.Name | trunc 63 | trimSuffix "-") (tpl .Values.externalDatabase.existingSecret $) -}}
+    {{- default (printf "%s-externaldb" (include "common.names.fullname" .) | trunc 63 | trimSuffix "-") (tpl .Values.externalDatabase.existingSecret $) -}}
 {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
### Description of the change

The deployment cannot find the secret with external database password and fails to start.
This change makes consistent definition between the secret for the external database password with the deployment secret definition.

### Benefits

The pod will start without errors

### Possible drawbacks

Unknown

### Applicable issues

- fixes #14741

### Additional information

I tried to run the CI action on my side, but It didn't work, and I don't know if it's because of some specifications for the project itself.


### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)