### PR TITLE
[bitnami/kube-prometheus] Omit empty metadata blocks in volume claim templates of Prometheus and Alertmanager

### DIFF
--- a/bitnami/kube-prometheus/Chart.yaml
+++ b/bitnami/kube-prometheus/Chart.yaml
@@ -46,4 +46,4 @@ maintainers:
 name: kube-prometheus
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/kube-prometheus
-version: 8.25.3
+version: 8.25.4

--- a/bitnami/kube-prometheus/templates/alertmanager/alertmanager.yaml
+++ b/bitnami/kube-prometheus/templates/alertmanager/alertmanager.yaml
@@ -49,6 +49,7 @@ spec:
   {{- if .Values.alertmanager.persistence.enabled }}
   storage:
     volumeClaimTemplate:
+      {{- if or .Values.alertmanager.persistence.annotations .Values.commonAnnotations .Values.commonLabels }}
       metadata:
         {{- if or .Values.alertmanager.persistence.annotations .Values.commonAnnotations }}
         {{- $claimAnnotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.alertmanager.persistence.annotations .Values.commonAnnotations ) "context" . ) }}
@@ -57,6 +58,7 @@ spec:
         {{- if .Values.commonLabels }}
         labels: {{- include "common.tplvalues.render" (dict "value" .Values.commonLabels "context" $) | nindent 10 }}
         {{- end }}
+      {{- end }}
       spec:
         accessModes:
           {{- range .Values.alertmanager.persistence.accessModes }}

--- a/bitnami/kube-prometheus/templates/prometheus/prometheus.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus/prometheus.yaml
@@ -167,6 +167,7 @@ spec:
   {{- else if .Values.prometheus.persistence.enabled }}
   storage:
     volumeClaimTemplate:
+      {{- if or .Values.prometheus.persistence.annotations .Values.commonAnnotations .Values.commonLabels }}
       metadata:
         {{- if or .Values.prometheus.persistence.annotations .Values.commonAnnotations }}
         {{- $claimAnnotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.prometheus.persistence.annotations .Values.commonAnnotations ) "context" . ) }}
@@ -175,6 +176,7 @@ spec:
         {{- if .Values.commonLabels }}
         labels: {{- include "common.tplvalues.render" (dict "value" .Values.commonLabels "context" $) | nindent 10 }}
         {{- end }}
+      {{- end }}
       spec:
         accessModes:
           {{- range .Values.prometheus.persistence.accessModes }}


### PR DESCRIPTION
### Description of the change

When neither annotations nor labels are given for the `volumeClaimTemplate`s xof the Prometheus or Alertmanager custom resource, the metadata block of that resource renders to `null`, which is not valid and fails a deployment.

So in case there is neither an annotation nor a label given, just don't render the metadata block at all.

### Benefits

Bugfix

### Possible drawbacks

None

### Applicable issues

None

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
