### PR TITLE
[bitnami/fluentd] bug/fluentd fix loadBalancerSourceRanges as list of IP Ranges

### DIFF
--- a/bitnami/fluentd/Chart.yaml
+++ b/bitnami/fluentd/Chart.yaml
@@ -30,4 +30,4 @@ maintainers:
 name: fluentd
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/fluentd
-version: 5.14.0
+version: 5.14.1

--- a/bitnami/fluentd/templates/aggregator-svc.yaml
+++ b/bitnami/fluentd/templates/aggregator-svc.yaml
@@ -25,7 +25,7 @@ spec:
   loadBalancerIP: {{ .Values.aggregator.service.loadBalancerIP }}
   {{- end }}
   {{- if and .Values.aggregator.service.loadBalancerSourceRanges (eq .Values.aggregator.service.type "LoadBalancer") }}
-  loadBalancerSourceRanges: {{ .Values.aggregator.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges: {{- toYaml .Values.aggregator.service.loadBalancerSourceRanges | nindent 4  }}
   {{- end }}
   {{- if (or (eq .Values.aggregator.service.type "LoadBalancer") (eq .Values.aggregator.service.type "NodePort")) }}
   externalTrafficPolicy: {{ .Values.aggregator.service.externalTrafficPolicy | quote }}


### PR DESCRIPTION
### Description of the change

Change is made to Fluentd template of aggregator-svc.yaml where if service type is LoadBalancer then we can specify list of loadBalancerSourceRanges. Current the helm release fails if values provided are in list.
Changes will accommodate those list of IP ranges.

### Benefits

We can pass multiple IP ranges to get whitelisted on loadbalancer end.

### Possible drawbacks

### Applicable issues

### Additional information

There are many more templates where this fix is needed, this has been fixed in a couple other charts already aswell, see:
https://github.com/bitnami/charts/pull/19175
https://github.com/bitnami/charts/pull/21490
https://github.com/bitnami/charts/issues/18395
https://github.com/bitnami/charts/issues/17450
...
Someone might want to look at this and fix all charts :)

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
