### PR TITLE
[bitnami/spring-cloud-dataflow] feat: :recycle: :lock: Refactor and enable NetworkPolicy by default

### DIFF
--- a/.vib/spring-cloud-dataflow/goss/goss.yaml
+++ b/.vib/spring-cloud-dataflow/goss/goss.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: APACHE-2.0
 
 http:
-  http://spring-cloud-dataflow-skipper:{{ .Vars.skipper.service.port }}:
+  http://spring-cloud-dataflow-skipper:{{ .Vars.skipper.service.ports.http }}:
     status: 200
 file:
   /opt/bitnami/spring-cloud-dataflow/conf/application.yml:

--- a/.vib/spring-cloud-dataflow/runtime-parameters.yaml
+++ b/.vib/spring-cloud-dataflow/runtime-parameters.yaml
@@ -3,7 +3,8 @@ waitForBackends:
     enabled: true
     runAsUser: 1002
 server:
-  containerPort: 8081
+  containerPorts: 
+    http: 8081
   configuration:
     batchEnabled: true
     accountName: test_default
@@ -15,7 +16,8 @@ server:
     runAsUser: 1002
   service:
     type: LoadBalancer
-    port: 80
+    ports:
+      http: 80
 skipper:
   enabled: true
   podSecurityContext:
@@ -26,7 +28,8 @@ skipper:
     runAsUser: 1002
   service:
     type: ClusterIP
-    port: 80
+    ports: 
+      http: 80
 deployer:
   podSecurityContext:
     enabled: true

--- a/bitnami/spring-cloud-dataflow/Chart.yaml
+++ b/bitnami/spring-cloud-dataflow/Chart.yaml
@@ -53,4 +53,4 @@ maintainers:
 name: spring-cloud-dataflow
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/spring-cloud-dataflow
-version: 26.4.1
+version: 26.5.0

--- a/bitnami/spring-cloud-dataflow/README.md
+++ b/bitnami/spring-cloud-dataflow/README.md
@@ -60,15 +60,15 @@ helm uninstall my-release
 
 ### Common parameters
 
-| Name                | Description                                                                           | Value           |
-| ------------------- | ------------------------------------------------------------------------------------- | --------------- |
-| `nameOverride`      | String to partially override scdf.fullname template (will maintain the release name). | `""`            |
-| `fullnameOverride`  | String to fully override scdf.fullname template.                                      | `""`            |
-| `commonAnnotations` | Annotations to add to all deployed objects                                            | `{}`            |
-| `commonLabels`      | Labels to add to all deployed objects                                                 | `{}`            |
-| `kubeVersion`       | Force target Kubernetes version (using Helm capabilities if not set)                  | `""`            |
-| `clusterDomain`     | Default Kubernetes cluster domain                                                     | `cluster.local` |
-| `extraDeploy`       | Array of extra objects to deploy with the release                                     | `[]`            |
+| Name                | Description                                                                                   | Value           |
+| ------------------- | --------------------------------------------------------------------------------------------- | --------------- |
+| `nameOverride`      | String to partially override common.names.fullname template (will maintain the release name). | `""`            |
+| `fullnameOverride`  | String to fully override common.names.fullname template.                                      | `""`            |
+| `commonAnnotations` | Annotations to add to all deployed objects                                                    | `{}`            |
+| `commonLabels`      | Labels to add to all deployed objects                                                         | `{}`            |
+| `kubeVersion`       | Force target Kubernetes version (using Helm capabilities if not set)                          | `""`            |
+| `clusterDomain`     | Default Kubernetes cluster domain                                                             | `cluster.local` |
+| `extraDeploy`       | Array of extra objects to deploy with the release                                             | `[]`            |
 
 ### Dataflow Server parameters
 
@@ -94,6 +94,8 @@ helm uninstall my-release
 | `server.configuration.metricsDashboard`                    | Endpoint to the metricsDashboard instance                                                                                                  | `""`                                                         |
 | `server.configuration.defaultSpringApplicationJSON`        | Injects default values for environment variable SPRING_APPLICATION_JSON                                                                    | `true`                                                       |
 | `server.existingConfigmap`                                 | ConfigMap with Spring Cloud Dataflow Server Configuration                                                                                  | `""`                                                         |
+| `server.containerPorts.http`                               | Container HTTP port                                                                                                                        | `8080`                                                       |
+| `server.containerPorts.jdwp`                               | Container JDWP port                                                                                                                        | `5005`                                                       |
 | `server.command`                                           | Override default container command (useful when using custom images)                                                                       | `[]`                                                         |
 | `server.args`                                              | Override default container args (useful when using custom images)                                                                          | `[]`                                                         |
 | `server.lifecycleHooks`                                    | for the Dataflow server container(s) to automate configuration before or after startup                                                     | `{}`                                                         |
@@ -103,7 +105,6 @@ helm uninstall my-release
 | `server.replicaCount`                                      | Number of Dataflow server replicas to deploy                                                                                               | `1`                                                          |
 | `server.podAffinityPreset`                                 | Dataflow server pod affinity preset. Ignored if `server.affinity` is set. Allowed values: `soft` or `hard`                                 | `""`                                                         |
 | `server.podAntiAffinityPreset`                             | Dataflow server pod anti-affinity preset. Ignored if `server.affinity` is set. Allowed values: `soft` or `hard`                            | `soft`                                                       |
-| `server.containerPort`                                     | Dataflow server port                                                                                                                       | `8080`                                                       |
 | `server.nodeAffinityPreset.type`                           | Dataflow server node affinity preset type. Ignored if `server.affinity` is set. Allowed values: `soft` or `hard`                           | `""`                                                         |
 | `server.nodeAffinityPreset.key`                            | Dataflow server node label key to match Ignored if `server.affinity` is set.                                                               | `""`                                                         |
 | `server.nodeAffinityPreset.values`                         | Dataflow server node label values to match. Ignored if `server.affinity` is set.                                                           | `[]`                                                         |
@@ -153,8 +154,15 @@ helm uninstall my-release
 | `server.customStartupProbe`                                | Override default startup probe                                                                                                             | `{}`                                                         |
 | `server.customLivenessProbe`                               | Override default liveness probe                                                                                                            | `{}`                                                         |
 | `server.customReadinessProbe`                              | Override default readiness probe                                                                                                           | `{}`                                                         |
+| `server.networkPolicy.enabled`                             | Specifies whether a NetworkPolicy should be created                                                                                        | `true`                                                       |
+| `server.networkPolicy.allowExternal`                       | Don't require client label for connections                                                                                                 | `true`                                                       |
+| `server.networkPolicy.kubeAPIServerPorts`                  | List of possible endpoints to kube-apiserver (limit to your cluster settings to increase security)                                         | `[]`                                                         |
+| `server.networkPolicy.extraIngress`                        | Add extra ingress rules to the NetworkPolice                                                                                               | `[]`                                                         |
+| `server.networkPolicy.extraEgress`                         | Add extra ingress rules to the NetworkPolicy                                                                                               | `[]`                                                         |
+| `server.networkPolicy.ingressNSMatchLabels`                | Labels to match to allow traffic from other namespaces                                                                                     | `{}`                                                         |
+| `server.networkPolicy.ingressNSPodMatchLabels`             | Pod labels to match to allow traffic from other namespaces                                                                                 | `{}`                                                         |
 | `server.service.type`                                      | Kubernetes service type                                                                                                                    | `ClusterIP`                                                  |
-| `server.service.port`                                      | Service HTTP port                                                                                                                          | `8080`                                                       |
+| `server.service.ports.http`                                | Server HTTP port                                                                                                                           | `8080`                                                       |
 | `server.service.nodePort`                                  | Specify the nodePort value for the LoadBalancer and NodePort service types                                                                 | `""`                                                         |
 | `server.service.clusterIP`                                 | Dataflow server service cluster IP                                                                                                         | `""`                                                         |
 | `server.service.externalTrafficPolicy`                     | Enable client source IP preservation                                                                                                       | `Cluster`                                                    |
@@ -211,6 +219,8 @@ helm uninstall my-release
 | `skipper.configuration.accountName`                         | The name of the account to configure for the Kubernetes platform                                                     | `default`                              |
 | `skipper.configuration.trustK8sCerts`                       | Trust K8s certificates when querying the Kubernetes API                                                              | `false`                                |
 | `skipper.existingConfigmap`                                 | Name of existing ConfigMap with Skipper server configuration                                                         | `""`                                   |
+| `skipper.containerPorts.http`                               | Container HTTP port                                                                                                  | `7577`                                 |
+| `skipper.containerPorts.jdwp`                               | Container JDWP port                                                                                                  | `5005`                                 |
 | `skipper.command`                                           | Override default container command (useful when using custom images)                                                 | `[]`                                   |
 | `skipper.args`                                              | Override default container args (useful when using custom images)                                                    | `[]`                                   |
 | `skipper.lifecycleHooks`                                    | for the Skipper container(s) to automate configuration before or after startup                                       | `{}`                                   |
@@ -269,8 +279,15 @@ helm uninstall my-release
 | `skipper.customStartupProbe`                                | Override default startup probe                                                                                       | `{}`                                   |
 | `skipper.customLivenessProbe`                               | Override default liveness probe                                                                                      | `{}`                                   |
 | `skipper.customReadinessProbe`                              | Override default readiness probe                                                                                     | `{}`                                   |
+| `skipper.networkPolicy.enabled`                             | Specifies whether a NetworkPolicy should be created                                                                  | `true`                                 |
+| `skipper.networkPolicy.allowExternal`                       | Don't require client label for connections                                                                           | `true`                                 |
+| `skipper.networkPolicy.kubeAPIServerPorts`                  | List of possible endpoints to kube-apiserver (limit to your cluster settings to increase security)                   | `[]`                                   |
+| `skipper.networkPolicy.extraIngress`                        | Add extra ingress rules to the NetworkPolice                                                                         | `[]`                                   |
+| `skipper.networkPolicy.extraEgress`                         | Add extra ingress rules to the NetworkPolicy                                                                         | `[]`                                   |
+| `skipper.networkPolicy.ingressNSMatchLabels`                | Labels to match to allow traffic from other namespaces                                                               | `{}`                                   |
+| `skipper.networkPolicy.ingressNSPodMatchLabels`             | Pod labels to match to allow traffic from other namespaces                                                           | `{}`                                   |
 | `skipper.service.type`                                      | Kubernetes service type                                                                                              | `ClusterIP`                            |
-| `skipper.service.port`                                      | Service HTTP port                                                                                                    | `80`                                   |
+| `skipper.service.ports.http`                                | Skipper HTTP port                                                                                                    | `80`                                   |
 | `skipper.service.nodePort`                                  | Service HTTP node port                                                                                               | `""`                                   |
 | `skipper.service.clusterIP`                                 | Skipper server service cluster IP                                                                                    | `""`                                   |
 | `skipper.service.externalTrafficPolicy`                     | Enable client source IP preservation                                                                                 | `Cluster`                              |
@@ -319,13 +336,13 @@ helm uninstall my-release
 
 ### RBAC parameters
 
-| Name                                          | Description                                                                                                             | Value   |
-| --------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- | ------- |
-| `serviceAccount.create`                       | Enable the creation of a ServiceAccount for Dataflow server and Skipper server pods                                     | `true`  |
-| `serviceAccount.name`                         | Name of the created serviceAccount. If not set and create is true, a name is generated using the scdf.fullname template | `""`    |
-| `serviceAccount.automountServiceAccountToken` | Automount service account token for the server service account                                                          | `false` |
-| `serviceAccount.annotations`                  | Annotations for service account. Evaluated as a template. Only used if `create` is `true`.                              | `{}`    |
-| `rbac.create`                                 | Whether to create and use RBAC resources or not                                                                         | `true`  |
+| Name                                          | Description                                                                                                                     | Value   |
+| --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `serviceAccount.create`                       | Enable the creation of a ServiceAccount for Dataflow server and Skipper server pods                                             | `true`  |
+| `serviceAccount.name`                         | Name of the created serviceAccount. If not set and create is true, a name is generated using the common.names.fullname template | `""`    |
+| `serviceAccount.automountServiceAccountToken` | Automount service account token for the server service account                                                                  | `false` |
+| `serviceAccount.annotations`                  | Annotations for service account. Evaluated as a template. Only used if `create` is `true`.                                      | `{}`    |
+| `rbac.create`                                 | Whether to create and use RBAC resources or not                                                                                 | `true`  |
 
 ### Metrics parameters
 
@@ -403,6 +420,12 @@ helm uninstall my-release
 | `metrics.priorityClassName`                                 | Prometheus Rsocket Proxy pods' priority.                                                                                   | `""`                                       |
 | `metrics.schedulerName`                                     | Name of the k8s scheduler (other than default)                                                                             | `""`                                       |
 | `metrics.topologySpreadConstraints`                         | Topology Spread Constraints for pod assignment                                                                             | `[]`                                       |
+| `metrics.networkPolicy.enabled`                             | Specifies whether a NetworkPolicy should be created                                                                        | `true`                                     |
+| `metrics.networkPolicy.allowExternal`                       | Don't require client label for connections                                                                                 | `true`                                     |
+| `metrics.networkPolicy.extraIngress`                        | Add extra ingress rules to the NetworkPolice                                                                               | `[]`                                       |
+| `metrics.networkPolicy.extraEgress`                         | Add extra ingress rules to the NetworkPolicy                                                                               | `[]`                                       |
+| `metrics.networkPolicy.ingressNSMatchLabels`                | Labels to match to allow traffic from other namespaces                                                                     | `{}`                                       |
+| `metrics.networkPolicy.ingressNSPodMatchLabels`             | Pod labels to match to allow traffic from other namespaces                                                                 | `{}`                                       |
 | `metrics.service.type`                                      | Prometheus Proxy service type                                                                                              | `ClusterIP`                                |
 | `metrics.service.ports.http`                                | Prometheus Rsocket Proxy HTTP port                                                                                         | `8080`                                     |
 | `metrics.service.ports.rsocket`                             | Prometheus Rsocket Proxy Rsocket port                                                                                      | `7001`                                     |

--- a/bitnami/spring-cloud-dataflow/templates/NOTES.txt
+++ b/bitnami/spring-cloud-dataflow/templates/NOTES.txt
@@ -24,7 +24,7 @@ Spring Cloud Data Flow chart was deployed enabling the following components:
 
 Spring Cloud Data Flow can be accessed through the following DNS name from within your cluster:
 
-    {{ include "scdf.fullname" . }}-server.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }} (port {{ .Values.server.service.port }})
+    {{ include "scdf.server.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }} (port {{ coalesce .Values.server.service.ports.http .Values.server.service.port }})
 
 To access Spring Cloud Data Flow dashboard from outside the cluster execute the following commands:
 
@@ -42,23 +42,23 @@ To access Spring Cloud Data Flow dashboard from outside the cluster execute the 
 
 {{- if contains "NodePort" .Values.server.service.type }}
 
-    export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "scdf.fullname" . }}-server)
+    export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "scdf.server.fullname" . }})
     export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
     echo "http://${NODE_IP}:${NODE_PORT}/dashboard"
 
 {{- else if contains "LoadBalancer" .Values.server.service.type }}
 
   NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-        You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "scdf.fullname" . }}-server'
+        You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "scdf.server.fullname" . }}'
 
-    export SERVICE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].port}" services {{ include "scdf.fullname" . }}-server)
-    export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "scdf.fullname" . }}-server -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+    export SERVICE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].port}" services {{ include "scdf.server.fullname" . }})
+    export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "scdf.server.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
     echo "http://${SERVICE_IP}:${SERVICE_PORT}/dashboard"
 
 {{- else if contains "ClusterIP" .Values.server.service.type }}
 
-    export SERVICE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].port}" services {{ include "scdf.fullname" . }}-server)
-    kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ include "scdf.fullname" . }}-server ${SERVICE_PORT}:${SERVICE_PORT} &
+    export SERVICE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].port}" services {{ include "scdf.server.fullname" . }})
+    kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ include "scdf.server.fullname" . }} ${SERVICE_PORT}:${SERVICE_PORT} &
     echo "http://127.0.0.1:${SERVICE_PORT}/dashboard"
 
 {{- end }}
@@ -74,9 +74,9 @@ To access Spring Cloud Data Flow dashboard from outside the cluster execute the 
 
 {{- $passwordErrors := list -}}
 {{- $secretNameMariadb := include "scdf.mariadb.fullname" . -}}
-{{- $secretNameExternalDb := printf "%s-%s" (include "scdf.fullname" .) "externaldb" -}}
+{{- $secretNameExternalDb := printf "%s-%s" (include "common.names.fullname" .) "externaldb" -}}
 {{- $secretNameRabbitmq := include "scdf.rabbitmq.fullname" . -}}
-{{- $secretNameExternalRabbitmq := printf "%s-%s" (include "scdf.fullname" .) "externalrabbitmq" -}}
+{{- $secretNameExternalRabbitmq := printf "%s-%s" (include "common.names.fullname" .) "externalrabbitmq" -}}
 
 {{/* Mysql required password */}}
 {{- $passwordMysqlErrors := include "common.validations.values.mariadb.passwords" (dict "secret" $secretNameMariadb "subchart" true "context" $) -}}

--- a/bitnami/spring-cloud-dataflow/templates/_helpers.tpl
+++ b/bitnami/spring-cloud-dataflow/templates/_helpers.tpl
@@ -6,25 +6,32 @@ SPDX-License-Identifier: APACHE-2.0
 {{/* vim: set filetype=mustache: */}}
 
 {{/*
-Create a default fully qualified app name.
-We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
-If release name contains chart name it will be used as a full name.
+Return the proper server fullname
 */}}
-{{- define "scdf.fullname" -}}
-{{- include "common.names.fullname" . -}}
-{{- end }}
+{{- define "scdf.server.fullname" -}}
+{{- printf "%s-%s" (include "common.names.fullname" .) "server" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Return the proper skipper fullname
+*/}}
+{{- define "scdf.skipper.fullname" -}}
+{{- printf "%s-%s" (include "common.names.fullname" .) "skipper" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Return the proper prometheus-proxy fullname
+*/}}
+{{- define "scdf.prometheus-proxy.fullname" -}}
+{{- printf "%s-%s" (include "common.names.fullname" .) "prometheus-proxy" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
 
 {{/*
 Create a default fully qualified app name for MariaDB subchart
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "scdf.mariadb.fullname" -}}
-{{- if .Values.mariadb.fullnameOverride -}}
-{{- .Values.mariadb.fullnameOverride | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- $name := default "mariadb" .Values.mariadb.nameOverride -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
+{{- include "common.names.dependency.fullname" (dict "chartName" "mariadb" "chartValues" .Values.mariadb "context" $) -}}
 {{- end -}}
 
 {{/*
@@ -83,7 +90,7 @@ Create the name of the Service Account to use
 */}}
 {{- define "scdf.serviceAccountName" -}}
 {{- if .Values.serviceAccount.create }}
-    {{- default (include "scdf.fullname" .) .Values.serviceAccount.name }}
+    {{- default (include "common.names.fullname" .) .Values.serviceAccount.name }}
 {{- else }}
     {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
@@ -96,7 +103,7 @@ Return the Spring Cloud Dataflow Server configuration configmap.
 {{- if .Values.server.existingConfigmap -}}
     {{- printf "%s" (tpl .Values.server.existingConfigmap $) -}}
 {{- else -}}
-    {{- printf "%s-server" (include "scdf.fullname" .) -}}
+    {{- include "scdf.server.fullname" . -}}
 {{- end -}}
 {{- end -}}
 
@@ -117,7 +124,7 @@ Return the Spring Cloud Skipper configuration configmap.
 {{- if .Values.skipper.existingConfigmap -}}
     {{- printf "%s" (tpl .Values.skipper.existingConfigmap $) -}}
 {{- else -}}
-    {{- printf "%s-skipper" (include "scdf.fullname" .) -}}
+    {{- include "scdf.skipper.fullname" . -}}
 {{- end -}}
 {{- end -}}
 
@@ -261,7 +268,19 @@ Return the Database secret name
 {{- else if .Values.mariadb.enabled }}
     {{- printf "%s" (include "scdf.mariadb.fullname" .) -}}
 {{- else -}}
-    {{- printf "%s-%s" (include "scdf.fullname" .) "externaldb" -}}
+    {{- printf "%s-%s" (include "common.names.fullname" .) "externaldb" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the Kafka Port
+*/}}
+{{- define "scdf.kafka.port" -}}
+{{- if .Values.kafka.enabled }}
+    {{- printf "%d" (.Values.kafka.service.ports.client | int ) -}}
+{{- else -}}
+    {{- $port := regexFind ":[0-9]+" .Values.externalKafka.brokers | trimPrefix ":" | default "9092" | int -}}
+    {{- printf "%d" $port -}}
 {{- end -}}
 {{- end -}}
 
@@ -307,7 +326,7 @@ Return the RabbitMQ secret name
 {{- else if .Values.rabbitmq.enabled }}
     {{- printf "%s" (include "scdf.rabbitmq.fullname" .) -}}
 {{- else -}}
-    {{- printf "%s-%s" (include "scdf.fullname" .) "externalrabbitmq" -}}
+    {{- printf "%s-%s" (include "common.names.fullname" .) "externalrabbitmq" -}}
 {{- end -}}
 {{- end -}}
 

--- a/bitnami/spring-cloud-dataflow/templates/externaldb-secrets.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/externaldb-secrets.yaml
@@ -7,9 +7,9 @@ SPDX-License-Identifier: APACHE-2.0
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ printf "%s-%s" (include "scdf.fullname" .) "externaldb" }}
+  name: {{ printf "%s-%s" (include "common.names.fullname" .) "externaldb" }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}

--- a/bitnami/spring-cloud-dataflow/templates/externalrabbitmq-secrets.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/externalrabbitmq-secrets.yaml
@@ -7,9 +7,9 @@ SPDX-License-Identifier: APACHE-2.0
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ printf "%s-%s" (include "scdf.fullname" .) "externalrabbitmq" }}
+  name: {{ printf "%s-%s" (include "common.names.fullname" .) "externalrabbitmq" }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}

--- a/bitnami/spring-cloud-dataflow/templates/prometheus-proxy/deployment.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/prometheus-proxy/deployment.yaml
@@ -7,10 +7,10 @@ SPDX-License-Identifier: APACHE-2.0
 apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
 kind: Deployment
 metadata:
-  name: {{ include "scdf.fullname" . }}-prometheus-proxy
+  name: {{ include "scdf.prometheus-proxy.fullname" . }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: prometheus-proxy
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
@@ -64,7 +64,7 @@ spec:
       priorityClassName: {{ .Values.metrics.priorityClassName | quote }}
       {{- end }}
       {{- if .Values.metrics.initContainers }}
-        initContainers: {{- include "common.tplvalues.render" (dict "value" .Values.metrics.initContainers "context" $) | trim | nindent 8 }}
+      initContainers: {{- include "common.tplvalues.render" (dict "value" .Values.metrics.initContainers "context" $) | trim | nindent 8 }}
       {{- end }}
       containers:
         - name: prometheus-proxy

--- a/bitnami/spring-cloud-dataflow/templates/prometheus-proxy/hpa.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/prometheus-proxy/hpa.yaml
@@ -7,10 +7,10 @@ SPDX-License-Identifier: APACHE-2.0
 apiVersion: {{ include "common.capabilities.hpa.apiVersion" ( dict "context" $ ) }}
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ include "scdf.fullname" . }}-prometheus-proxy
+  name: {{ include "scdf.prometheus-proxy.fullname" . }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: prometheus-proxy
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
@@ -18,7 +18,7 @@ spec:
   scaleTargetRef:
     apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
     kind: Deployment
-    name: {{ include "scdf.fullname" . }}-prometheus-proxy
+    name: {{ include "scdf.prometheus-proxy.fullname" . }}
   minReplicas: {{ .Values.metrics.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.metrics.autoscaling.maxReplicas }}
   metrics:

--- a/bitnami/spring-cloud-dataflow/templates/prometheus-proxy/networkpolicy.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/prometheus-proxy/networkpolicy.yaml
@@ -1,0 +1,67 @@
+{{- /*
+Copyright VMware, Inc.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+{{- if and .Values.metrics.enabled .Values.metrics.networkPolicy.enabled }}
+kind: NetworkPolicy
+apiVersion: {{ include "common.capabilities.networkPolicy.apiVersion" . }}
+metadata:
+  name: {{ include "scdf.prometheus-proxy.fullname" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.commonLabels ) "context" . ) }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
+    app.kubernetes.io/component: promotheus-proxy
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.metrics.podLabels .Values.commonLabels ) "context" . ) }}
+  podSelector:
+    matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
+      app.kubernetes.io/component: promotheus-proxy
+  policyTypes:
+    - Ingress
+    - Egress
+  egress:
+    - ports:
+        # Allow dns resolution
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+    {{- if .Values.metrics.networkPolicy.extraEgress }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.metrics.networkPolicy.extraEgress "context" $ ) | nindent 4 }}
+    {{- end }}
+  ingress:
+    - ports:
+        - port: {{ .Values.metrics.service.ports.http .Values.metrics.service.httpPort }}
+        - port: {{ .Values.metrics.service.ports.rsocket .Values.metrics.service.rsocketPort }}
+        - port: {{ .Values.metrics.containerPorts.http }}
+        - port: {{ .Values.metrics.containerPorts.rsocket }}
+      {{- if not .Values.metrics.networkPolicy.allowExternal }}
+      from:
+        - podSelector:
+            matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 14 }}
+        - podSelector:
+            matchLabels:
+              {{ template "scdf.prometheus-proxy.fullname" . }}-client: "true"
+        {{- if .Values.metrics.networkPolicy.ingressNSMatchLabels }}
+        - namespaceSelector:
+            matchLabels:
+              {{- range $key, $value := .Values.metrics.networkPolicy.ingressNSMatchLabels }}
+              {{ $key | quote }}: {{ $value | quote }}
+              {{- end }}
+          {{- if .Values.metrics.networkPolicy.ingressNSPodMatchLabels }}
+          podSelector:
+            matchLabels:
+              {{- range $key, $value := .Values.metrics.networkPolicy.ingressNSPodMatchLabels }}
+              {{ $key | quote }}: {{ $value | quote }}
+              {{- end }}
+          {{- end }}
+        {{- end }}
+      {{- end }}
+    {{- if .Values.metrics.networkPolicy.extraIngress }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.metrics.networkPolicy.extraIngress "context" $ ) | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/bitnami/spring-cloud-dataflow/templates/prometheus-proxy/pdb.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/prometheus-proxy/pdb.yaml
@@ -7,10 +7,10 @@ SPDX-License-Identifier: APACHE-2.0
 apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
-  name: {{ include "scdf.fullname" . }}-prometheus-proxy
+  name: {{ include "scdf.prometheus-proxy.fullname" . }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: prometheus-proxy
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}

--- a/bitnami/spring-cloud-dataflow/templates/prometheus-proxy/service.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/prometheus-proxy/service.yaml
@@ -7,10 +7,10 @@ SPDX-License-Identifier: APACHE-2.0
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "scdf.fullname" . }}-prometheus-proxy
+  name: {{ include "scdf.prometheus-proxy.fullname" . }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: prometheus-proxy
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   {{- if or .Values.metrics.service.annotations .Values.commonAnnotations }}
   {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.metrics.service.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}

--- a/bitnami/spring-cloud-dataflow/templates/prometheus-proxy/servicemonitor-metrics.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/prometheus-proxy/servicemonitor-metrics.yaml
@@ -7,7 +7,7 @@ SPDX-License-Identifier: APACHE-2.0
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ include "scdf.fullname" . }}-prometheus-proxy
+  name: {{ include "scdf.prometheus-proxy.fullname" . }}
   {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.metrics.serviceMonitor.labels .Values.commonLabels ) "context" . ) }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: prometheus-proxy

--- a/bitnami/spring-cloud-dataflow/templates/role.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/role.yaml
@@ -7,9 +7,9 @@ SPDX-License-Identifier: APACHE-2.0
 kind: Role
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 metadata:
-  name: {{ include "scdf.fullname" . }}
+  name: {{ include "common.names.fullname" . }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}

--- a/bitnami/spring-cloud-dataflow/templates/rolebinding.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/rolebinding.yaml
@@ -7,18 +7,18 @@ SPDX-License-Identifier: APACHE-2.0
 kind: RoleBinding
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 metadata:
-  name: {{ include "scdf.fullname" . }}
+  name: {{ include "common.names.fullname" . }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 roleRef:
   kind: Role
-  name: {{ include "scdf.fullname" . }}
+  name: {{ include "common.names.fullname" . }}
   apiGroup: rbac.authorization.k8s.io
 subjects:
   - kind: ServiceAccount
     name: {{ include "scdf.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ include "common.names.namespace" . | quote }}
 {{- end }}

--- a/bitnami/spring-cloud-dataflow/templates/scripts-configmap.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/scripts-configmap.yaml
@@ -7,9 +7,9 @@ SPDX-License-Identifier: APACHE-2.0
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "scdf.fullname" . }}-scripts
+  name: {{ include "common.names.fullname" . }}-scripts
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}

--- a/bitnami/spring-cloud-dataflow/templates/server/configmap.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/server/configmap.yaml
@@ -7,17 +7,17 @@ SPDX-License-Identifier: APACHE-2.0
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "scdf.fullname" . }}-server
+  name: {{ include "scdf.server.fullname" . }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: server
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 data:
   application.yaml: |-
     {{- if .Values.metrics.enabled }}
-    {{- $fullname := include "scdf.fullname" . }}
+    {{- $fullname := include "common.names.fullname" . }}
     {{- $rsocketPort := int (coalesce .Values.metrics.service.ports.rsocket .Values.metrics.service.rsocketPort) }}
     management:
       metrics:

--- a/bitnami/spring-cloud-dataflow/templates/server/deployment.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/server/deployment.yaml
@@ -3,18 +3,18 @@ Copyright VMware, Inc.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- $fullname := include "scdf.fullname" .  }}
-{{- $serverServicePort := int .Values.server.service.port }}
-{{- $skipperServicePort := int .Values.skipper.service.port }}
-{{- $releaseNamespace := .Release.Namespace }}
+{{- $fullname := include "common.names.fullname" .  }}
+{{- $serverServicePort := int (coalesce .Values.server.service.ports.http .Values.server.service.port) }}
+{{- $skipperServicePort := int (coalesce .Values.skipper.service.ports.http .Values.skipper.service.port) }}
+{{- $releaseNamespace := include "common.names.namespace" . }}
 {{- $clusterDomain := .Values.clusterDomain }}
 apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
 kind: Deployment
 metadata:
-  name: {{ include "scdf.fullname" . }}-server
+  name: {{ include "common.names.fullname" . }}-server
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: server
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
@@ -116,7 +116,7 @@ spec:
             - name: BITNAMI_DEBUG
               value: {{ ternary "true" "false" .Values.server.image.debug | quote }}
             - name: SERVER_PORT
-              value: "{{ .Values.server.containerPort }}"
+              value: {{ coalesce .Values.server.containerPorts.http .Values.server.containerPort | quote }}
             - name: SPRING_CLOUD_CONFIG_ENABLED
               value: "false"
             - name: SPRING_CLOUD_KUBERNETES_CONFIG_ENABLE_API
@@ -169,13 +169,12 @@ spec:
               value: {{ ternary "true" "false" .Values.server.configuration.trustK8sCerts | quote }}
             {{- if .Values.server.jdwp.enabled }}
             - name: JAVA_TOOL_OPTIONS
-              value: "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address={{ .Values.server.jdwp.port }}"
+              value: "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address={{ coalesce .Values.server.containerPorts.jdwp .Values.server.jdwp.port }}"
             {{- end }}
             - name: SPRING_CLOUD_DATAFLOW_TASK_COMPOSEDTASKRUNNER_URI
               value: 'docker://{{ include "common.images.image" (dict "imageRoot" .Values.server.composedTaskRunner.image) }}'
-            {{- range $key, $value := .Values.server.extraEnvVars }}
-            - name: {{ $value.name }}
-              value: "{{ $value.value }}"
+            {{- if .Values.server.extraEnvVars }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.server.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}
           {{- if or .Values.server.extraEnvVarsCM .Values.server.extraEnvVarsSecret }}
           envFrom:
@@ -190,11 +189,11 @@ spec:
           {{- end }}
           ports:
             - name: http
-              containerPort: {{ .Values.server.containerPort }}
+              containerPort: {{ coalesce .Values.server.containerPorts.http .Values.server.containerPort }}
               protocol: TCP
             {{- if .Values.server.jdwp.enabled }}
             - name: jdwp
-              containerPort: {{ .Values.server.jdwp.port }}
+              containerPort: {{ coalesce .Values.server.containerPorts.jdwp .Values.server.jdwp.port }}
               protocol: TCP
             {{- end }}
           {{- if .Values.server.customStartupProbe }}
@@ -265,7 +264,7 @@ spec:
         {{- if .Values.waitForBackends.enabled }}
         - name: scripts
           configMap:
-            name: {{ include "scdf.fullname" . }}-scripts
+            name: {{ include "common.names.fullname" . }}-scripts
             defaultMode: 0755
         {{- end }}
         {{- if .Values.server.extraVolumes }}

--- a/bitnami/spring-cloud-dataflow/templates/server/hpa.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/server/hpa.yaml
@@ -7,10 +7,10 @@ SPDX-License-Identifier: APACHE-2.0
 apiVersion: {{ include "common.capabilities.hpa.apiVersion" ( dict "context" $ ) }}
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ include "scdf.fullname" . }}-server
+  name: {{ include "scdf.server.fullname" . }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: server
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
@@ -18,7 +18,7 @@ spec:
   scaleTargetRef:
     apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
     kind: Deployment
-    name: {{ include "scdf.fullname" . }}-server
+    name: {{ include "scdf.server.fullname" . }}
   minReplicas: {{ .Values.server.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.server.autoscaling.maxReplicas }}
   metrics:

--- a/bitnami/spring-cloud-dataflow/templates/server/ingress.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/server/ingress.yaml
@@ -7,10 +7,10 @@ SPDX-License-Identifier: APACHE-2.0
 apiVersion: {{ template "common.capabilities.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
-  name: {{ include "scdf.fullname" . }}-server
+  name: {{ include "scdf.server.fullname" . }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: server
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   annotations:
     {{- if .Values.server.ingress.certManager }}
     kubernetes.io/tls-acme: "true"

--- a/bitnami/spring-cloud-dataflow/templates/server/networkpolicy.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/server/networkpolicy.yaml
@@ -1,0 +1,130 @@
+{{- /*
+Copyright VMware, Inc.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+{{- if .Values.server.networkPolicy.enabled }}
+kind: NetworkPolicy
+apiVersion: {{ include "common.capabilities.networkPolicy.apiVersion" . }}
+metadata:
+  name: {{ include "scdf.server.fullname" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.commonLabels ) "context" . ) }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
+    app.kubernetes.io/component: server
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.server.podLabels .Values.commonLabels ) "context" . ) }}
+  podSelector:
+    matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
+      app.kubernetes.io/component: server
+  policyTypes:
+    - Ingress
+    - Egress
+  egress:
+    - ports:
+        # Allow dns resolution
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+        {{- if .Values.waitForBackends.enabled }}
+        # Allow access to kube-apiserver
+        {{- range $port := .Values.server.networkPolicy.kubeAPIServerPorts }}
+        - port: {{ $port }}
+        {{- end }}
+        {{- end }}
+    {{- if or (.Values.rabbitmq.enabled) (.Values.externalRabbitmq.enabled) }}
+    # Allow connection to RabbitMQ
+    - ports:
+        - port: {{ include "scdf.rabbitmq.port" . }}
+      {{- if .Values.rabbitmq.enabled }}
+      to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: rabbitmq
+              app.kubernetes.io/instance: {{ .Release.Name }}              
+      {{- end }}
+    {{- end }}
+    {{- if or (.Values.kafka.enabled) (.Values.externalKafka.enabled) }}
+    # Allow connection to RabbitMQ
+    - ports:
+        - port: {{ include "scdf.kafka.port" . | int }}
+      {{- if .Values.kafka.enabled }}
+      to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: kafka
+              app.kubernetes.io/instance: {{ .Release.Name }}              
+      {{- end }}
+    {{- end }}
+    # Allow connection to MariaDB
+    - ports:
+        - port: {{ include "scdf.database.port" . | int }}
+      {{- if .Values.mariadb.enabled }}
+      to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: mariadb
+              app.kubernetes.io/instance: {{ .Release.Name }}              
+      {{- end }}
+    # Allow connection to skipper
+    - ports:
+        - port: {{ ternary (coalesce .Values.skipper.service.ports.http .Values.skipper.service.port) .Values.externalSkipper.port .Values.skipper.enabled }}
+      {{- if .Values.skipper.enabled }}
+      to:
+        - podSelector:
+            {{- $versionLabel := dict "app.kubernetes.io/version" ( include "common.images.version" ( dict "imageRoot" .Values.skipper.image "chart" .Chart ) ) }}
+            {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.skipper.podLabels .Values.commonLabels $versionLabel ) "context" . ) }}
+            matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 14 }}
+              app.kubernetes.io/component: skipper
+      {{- end }}
+    {{- if .Values.metrics.enabled }}
+    # Allow connection to prometheus-proxy
+    - ports:
+        - port: {{ .Values.metrics.service.ports.http .Values.metrics.service.httpPort }}
+        - port: {{ .Values.metrics.service.ports.rsocket .Values.metrics.service.rsocketPort }}
+      to:
+        - podSelector:
+            {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.metrics.podLabels .Values.commonLabels ) "context" . ) }}
+            matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 14 }}
+              app.kubernetes.io/component: prometheus-proxy
+    {{- end }}
+    {{- if .Values.server.networkPolicy.extraEgress }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.server.networkPolicy.extraEgress "context" $ ) | nindent 4 }}
+    {{- end }}
+  ingress:
+    - ports:
+        - port: {{ .Values.server.containerPorts.http }}
+        - port: {{ coalesce .Values.server.service.ports.http .Values.server.service.port }}
+        {{- if .Values.server.jdwp.enabled }}
+        - port: {{ coalesce .Values.server.containerPorts.jdwp .Values.server.jdwp.port }}
+        {{- end }}
+      {{- if not .Values.server.networkPolicy.allowExternal }}
+      from:
+        - podSelector:
+            matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 14 }}
+        - podSelector:
+            matchLabels:
+              {{ template "scdf.server.fullname" . }}-client: "true"
+        {{- if .Values.server.networkPolicy.ingressNSMatchLabels }}
+        - namespaceSelector:
+            matchLabels:
+              {{- range $key, $value := .Values.server.networkPolicy.ingressNSMatchLabels }}
+              {{ $key | quote }}: {{ $value | quote }}
+              {{- end }}
+          {{- if .Values.server.networkPolicy.ingressNSPodMatchLabels }}
+          podSelector:
+            matchLabels:
+              {{- range $key, $value := .Values.server.networkPolicy.ingressNSPodMatchLabels }}
+              {{ $key | quote }}: {{ $value | quote }}
+              {{- end }}
+          {{- end }}
+        {{- end }}
+      {{- end }}
+    {{- if .Values.server.networkPolicy.extraIngress }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.server.networkPolicy.extraIngress "context" $ ) | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/bitnami/spring-cloud-dataflow/templates/server/pdb.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/server/pdb.yaml
@@ -7,10 +7,10 @@ SPDX-License-Identifier: APACHE-2.0
 apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
-  name: {{ include "scdf.fullname" . }}-server
+  name: {{ include "scdf.server.fullname" . }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: server
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}

--- a/bitnami/spring-cloud-dataflow/templates/server/service.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/server/service.yaml
@@ -6,10 +6,10 @@ SPDX-License-Identifier: APACHE-2.0
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "scdf.fullname" . }}-server
+  name: {{ include "scdf.server.fullname" . }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: server
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   {{- if or .Values.server.service.annotations .Values.commonAnnotations }}
   {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.server.service.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
@@ -36,7 +36,7 @@ spec:
   {{- end }}
   ports:
     - name: http
-      port: {{ .Values.server.service.port }}
+      port: {{ coalesce .Values.server.service.ports.http .Values.server.service.port }}
       targetPort: http
       {{- if (and (or (eq .Values.server.service.type "NodePort") (eq .Values.server.service.type "LoadBalancer")) (not (empty .Values.server.service.nodePort))) }}
       nodePort: {{ .Values.server.service.nodePort }}

--- a/bitnami/spring-cloud-dataflow/templates/server/tls-secret.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/server/tls-secret.yaml
@@ -29,7 +29,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ $secretName }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}

--- a/bitnami/spring-cloud-dataflow/templates/serviceaccount.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/serviceaccount.yaml
@@ -9,7 +9,7 @@ kind: ServiceAccount
 metadata:
   name: {{ include "scdf.serviceAccountName" . }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   {{- if or .Values.serviceAccount.annotations .Values.commonAnnotations }}
   {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.serviceAccount.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}

--- a/bitnami/spring-cloud-dataflow/templates/skipper/configmap.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/skipper/configmap.yaml
@@ -7,19 +7,19 @@ SPDX-License-Identifier: APACHE-2.0
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "scdf.fullname" . }}-skipper
+  name: {{ include "scdf.skipper.fullname" . }}
   {{- $versionLabel := dict "app.kubernetes.io/version" ( include "common.images.version" ( dict "imageRoot" .Values.skipper.image "chart" .Chart ) ) }}
   {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.commonLabels $versionLabel ) "context" . ) }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: skipper
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 data:
   application.yaml: |-
     {{- if .Values.metrics.enabled }}
-    {{- $fullname := include "scdf.fullname" . }}
+    {{- $fullname := include "common.names.fullname" . }}
     {{- $rsocketPort := int (coalesce .Values.metrics.service.ports.rsocket .Values.metrics.service.rsocketPort) }}
     management:
       metrics:

--- a/bitnami/spring-cloud-dataflow/templates/skipper/deployment.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/skipper/deployment.yaml
@@ -7,12 +7,12 @@ SPDX-License-Identifier: APACHE-2.0
 apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
 kind: Deployment
 metadata:
-  name: {{ include "scdf.fullname" . }}-skipper
+  name: {{ include "scdf.skipper.fullname" . }}
   {{- $versionLabel := dict "app.kubernetes.io/version" ( include "common.images.version" ( dict "imageRoot" .Values.skipper.image "chart" .Chart ) ) }}
   {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.commonLabels $versionLabel ) "context" . ) }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: skipper
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
@@ -114,7 +114,7 @@ spec:
             - name: BITNAMI_DEBUG
               value: {{ ternary "true" "false" .Values.skipper.image.debug | quote }}
             - name: SERVER_PORT
-              value: "7577"
+              value: {{ .Values.skipper.containerPorts.http | quote }}
             - name: SPRING_CLOUD_CONFIG_ENABLED
               value: "false"
             - name: SPRING_CLOUD_KUBERNETES_CONFIG_ENABLE_API
@@ -131,7 +131,7 @@ spec:
               value: {{ ternary "true" "false" .Values.skipper.configuration.trustK8sCerts | quote }}
             {{- if .Values.skipper.jdwp.enabled }}
             - name: JAVA_TOOL_OPTIONS
-              value: "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address={{ .Values.skipper.jdwp.port }}"
+              value: "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address={{ coalesce .Values.skipper.containerPorts.jdwp .Values.skipper.jdwp.port }}"
             {{- end }}
             {{- range $key, $value := .Values.skipper.extraEnvVars }}
             - name: {{ $value.name }}
@@ -150,11 +150,11 @@ spec:
           {{- end }}
           ports:
             - name: http
-              containerPort: 7577
+              containerPort: {{ .Values.skipper.containerPorts.http }}
               protocol: TCP
             {{- if .Values.skipper.jdwp.enabled }}
             - name: jdwp
-              containerPort: {{ .Values.skipper.jdwp.port }}
+              containerPort: {{ coalesce .Values.skipper.containerPorts.jdwp .Values.skipper.jdwp.port }}
               protocol: TCP
             {{- end }}
           {{- if .Values.skipper.customStartupProbe }}
@@ -235,7 +235,7 @@ spec:
         {{- if .Values.waitForBackends.enabled }}
         - name: scripts
           configMap:
-            name: {{ include "scdf.fullname" . }}-scripts
+            name: {{ include "common.names.fullname" . }}-scripts
             defaultMode: 0755
         {{- end }}
         {{- if .Values.skipper.extraVolumes }}

--- a/bitnami/spring-cloud-dataflow/templates/skipper/hpa.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/skipper/hpa.yaml
@@ -7,12 +7,12 @@ SPDX-License-Identifier: APACHE-2.0
 apiVersion: {{ include "common.capabilities.hpa.apiVersion" ( dict "context" $ ) }}
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ include "scdf.fullname" . }}-skipper
+  name: {{ include "scdf.skipper.fullname" . }}
   {{- $versionLabel := dict "app.kubernetes.io/version" ( include "common.images.version" ( dict "imageRoot" .Values.skipper.image "chart" .Chart ) ) }}
   {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.commonLabels $versionLabel ) "context" . ) }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: skipper
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
@@ -20,7 +20,7 @@ spec:
   scaleTargetRef:
     apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
     kind: Deployment
-    name: {{ include "scdf.fullname" . }}-skipper
+    name: {{ include "scdf.skipper.fullname" . }}
   minReplicas: {{ .Values.skipper.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.skipper.autoscaling.maxReplicas }}
   metrics:

--- a/bitnami/spring-cloud-dataflow/templates/skipper/networkpolicy.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/skipper/networkpolicy.yaml
@@ -1,0 +1,109 @@
+{{- /*
+Copyright VMware, Inc.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+{{- if or .Values.skipper.enabled .Values.skipper.networkPolicy.enabled }}
+kind: NetworkPolicy
+apiVersion: {{ include "common.capabilities.networkPolicy.apiVersion" . }}
+metadata:
+  name: {{ include "scdf.skipper.fullname" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  {{- $versionLabel := dict "app.kubernetes.io/version" ( include "common.images.version" ( dict "imageRoot" .Values.skipper.image "chart" .Chart ) ) }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.commonLabels $versionLabel ) "context" . ) }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
+    app.kubernetes.io/component: skipper
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.skipper.podLabels .Values.commonLabels $versionLabel ) "context" . ) }}
+  podSelector:
+    matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
+      app.kubernetes.io/component: skipper
+  policyTypes:
+    - Ingress
+    - Egress
+  egress:
+    - ports:
+        # Allow dns resolution
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+        {{- if .Values.waitForBackends.enabled }}
+        # Allow access to kube-apiserver
+        {{- range $port := .Values.skipper.networkPolicy.kubeAPIServerPorts }}
+        - port: {{ $port }}
+        {{- end }}
+        {{- end }}
+    {{- if or (.Values.rabbitmq.enabled) (.Values.externalRabbitmq.enabled) }}
+    # Allow connection to RabbitMQ
+    - ports:
+        - port: {{ include "scdf.rabbitmq.port" . }}
+      {{- if .Values.rabbitmq.enabled }}
+      to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: rabbitmq
+              app.kubernetes.io/instance: {{ .Release.Name }}              
+      {{- end }}
+    {{- end }}
+    {{- if or (.Values.kafka.enabled) (.Values.externalKafka.enabled) }}
+    # Allow connection to RabbitMQ
+    - ports:
+        - port: {{ include "scdf.kafka.port" . | int }}
+      {{- if .Values.kafka.enabled }}
+      to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: kafka
+              app.kubernetes.io/instance: {{ .Release.Name }}              
+      {{- end }}
+    {{- end }}
+    # Allow connection to MariaDB
+    - ports:
+        - port: {{ include "scdf.database.port" . | int }}
+      {{- if .Values.mariadb.enabled }}
+      to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: mariadb
+              app.kubernetes.io/instance: {{ .Release.Name }}              
+      {{- end }}
+    {{- if .Values.skipper.networkPolicy.extraEgress }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.skipper.networkPolicy.extraEgress "context" $ ) | nindent 4 }}
+    {{- end }}
+  ingress:
+    - ports:
+        - port: {{ .Values.skipper.containerPorts.http }}
+        - port: {{ coalesce .Values.skipper.service.ports.http .Values.skipper.service.port }}
+        {{- if .Values.skipper.jdwp.enabled }}
+        - port: {{ coalesce .Values.skipper.containerPorts.jdwp .Values.skipper.jdwp.port }}
+        {{- end }}
+      {{- if not .Values.skipper.networkPolicy.allowExternal }}
+      from:
+        - podSelector:
+            matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 14 }}
+        - podSelector:
+            matchLabels:
+              {{ template "scdf.skipper.fullname" . }}-client: "true"
+        {{- if .Values.skipper.networkPolicy.ingressNSMatchLabels }}
+        - namespaceSelector:
+            matchLabels:
+              {{- range $key, $value := .Values.skipper.networkPolicy.ingressNSMatchLabels }}
+              {{ $key | quote }}: {{ $value | quote }}
+              {{- end }}
+          {{- if .Values.skipper.networkPolicy.ingressNSPodMatchLabels }}
+          podSelector:
+            matchLabels:
+              {{- range $key, $value := .Values.skipper.networkPolicy.ingressNSPodMatchLabels }}
+              {{ $key | quote }}: {{ $value | quote }}
+              {{- end }}
+          {{- end }}
+        {{- end }}
+      {{- end }}
+    {{- if .Values.skipper.networkPolicy.extraIngress }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.skipper.networkPolicy.extraIngress "context" $ ) | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/bitnami/spring-cloud-dataflow/templates/skipper/pdb.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/skipper/pdb.yaml
@@ -7,12 +7,12 @@ SPDX-License-Identifier: APACHE-2.0
 apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
-  name: {{ include "scdf.fullname" . }}-skipper
+  name: {{ include "scdf.skipper.fullname" . }}
   {{- $versionLabel := dict "app.kubernetes.io/version" ( include "common.images.version" ( dict "imageRoot" .Values.skipper.image "chart" .Chart ) ) }}
   {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.commonLabels $versionLabel ) "context" . ) }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: skipper
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}

--- a/bitnami/spring-cloud-dataflow/templates/skipper/service.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/skipper/service.yaml
@@ -7,12 +7,12 @@ SPDX-License-Identifier: APACHE-2.0
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "scdf.fullname" . }}-skipper
+  name: {{ include "scdf.skipper.fullname" . }}
   {{- $versionLabel := dict "app.kubernetes.io/version" ( include "common.images.version" ( dict "imageRoot" .Values.skipper.image "chart" .Chart ) ) }}
   {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.commonLabels $versionLabel ) "context" . ) }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: skipper
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   {{- if or .Values.skipper.service.annotations .Values.commonAnnotations }}
   {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.skipper.service.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
@@ -39,7 +39,7 @@ spec:
   {{- end }}
   ports:
     - name: http
-      port: {{ .Values.skipper.service.port }}
+      port: {{ coalesce .Values.skipper.service.ports.http .Values.skipper.service.port }}
       targetPort: http
       {{- if (and (or (eq .Values.skipper.service.type "NodePort") (eq .Values.skipper.service.type "LoadBalancer")) (not (empty .Values.skipper.service.nodePort))) }}
       nodePort: {{ .Values.skipper.service.nodePort }}

--- a/bitnami/spring-cloud-dataflow/values.yaml
+++ b/bitnami/spring-cloud-dataflow/values.yaml
@@ -21,10 +21,10 @@ global:
 
 ## @section Common parameters
 
-## @param nameOverride String to partially override scdf.fullname template (will maintain the release name).
+## @param nameOverride String to partially override common.names.fullname template (will maintain the release name).
 ##
 nameOverride: ""
-## @param fullnameOverride String to fully override scdf.fullname template.
+## @param fullnameOverride String to fully override common.names.fullname template.
 ##
 fullnameOverride: ""
 ## @param commonAnnotations Annotations to add to all deployed objects
@@ -145,6 +145,12 @@ server:
   ##  parameters are ignored,
   ##
   existingConfigmap: ""
+  ## @param server.containerPorts.http Container HTTP port
+  ## @param server.containerPorts.jdwp Container JDWP port
+  ##
+  containerPorts:
+    http: 8080
+    jdwp: 5005
   ## @param server.command Override default container command (useful when using custom images)
   ##
   command: []
@@ -178,9 +184,6 @@ server:
   ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
   ##
   podAntiAffinityPreset: soft
-  ## @param server.containerPort Dataflow server port
-  ##
-  containerPort: 8080
   ## Dataflow Server node affinity preset
   ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
   ##
@@ -360,15 +363,71 @@ server:
   ## @param server.customReadinessProbe Override default readiness probe
   ##
   customReadinessProbe: {}
+  ## Network Policies
+  ## Ref: https://kubernetes.io/docs/concepts/services-networking/network-policies/
+  ##
+  networkPolicy:
+    ## @param server.networkPolicy.enabled Specifies whether a NetworkPolicy should be created
+    ##
+    enabled: true
+    ## @param server.networkPolicy.allowExternal Don't require client label for connections
+    ## The Policy model to apply. When set to false, only pods with the correct
+    ## client label will have network access to the ports the application is listening
+    ## on. When true, the app will accept connections from any source
+    ## (with the correct destination port).
+    ##
+    allowExternal: true
+    ## @param server.networkPolicy.kubeAPIServerPorts [array] List of possible endpoints to kube-apiserver (limit to your cluster settings to increase security)
+    ##
+    kubeAPIServerPorts: [443, 6443, 8443]
+    ## @param server.networkPolicy.extraIngress [array] Add extra ingress rules to the NetworkPolice
+    ## e.g:
+    ## extraIngress:
+    ##   - ports:
+    ##       - port: 1234
+    ##     from:
+    ##       - podSelector:
+    ##           - matchLabels:
+    ##               - role: frontend
+    ##       - podSelector:
+    ##           - matchExpressions:
+    ##               - key: role
+    ##                 operator: In
+    ##                 values:
+    ##                   - frontend
+    extraIngress: []
+    ## @param server.networkPolicy.extraEgress [array] Add extra ingress rules to the NetworkPolicy
+    ## e.g:
+    ## extraEgress:
+    ##   - ports:
+    ##       - port: 1234
+    ##     to:
+    ##       - podSelector:
+    ##           - matchLabels:
+    ##               - role: frontend
+    ##       - podSelector:
+    ##           - matchExpressions:
+    ##               - key: role
+    ##                 operator: In
+    ##                 values:
+    ##                   - frontend
+    ##
+    extraEgress: []
+    ## @param server.networkPolicy.ingressNSMatchLabels [object] Labels to match to allow traffic from other namespaces
+    ## @param server.networkPolicy.ingressNSPodMatchLabels [object] Pod labels to match to allow traffic from other namespaces
+    ##
+    ingressNSMatchLabels: {}
+    ingressNSPodMatchLabels: {}
   ## Dataflow Server Service parameters.
   ##
   service:
     ## @param server.service.type Kubernetes service type
     ##
     type: ClusterIP
-    ## @param server.service.port Service HTTP port
+    ## @param server.service.ports.http Server HTTP port
     ##
-    port: 8080
+    ports:
+      http: 8080
     ## @param server.service.nodePort Specify the nodePort value for the LoadBalancer and NodePort service types
     ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
     ##
@@ -655,6 +714,12 @@ skipper:
   ##  parameters are ignored,
   ##
   existingConfigmap: ""
+  ## @param skipper.containerPorts.http Container HTTP port
+  ## @param skipper.containerPorts.jdwp Container JDWP port
+  ##
+  containerPorts:
+    http: 7577
+    jdwp: 5005
   ## @param skipper.command Override default container command (useful when using custom images)
   ##
   command: []
@@ -867,15 +932,71 @@ skipper:
   ## @param skipper.customReadinessProbe Override default readiness probe
   ##
   customReadinessProbe: {}
+  ## Network Policies
+  ## Ref: https://kubernetes.io/docs/concepts/services-networking/network-policies/
+  ##
+  networkPolicy:
+    ## @param skipper.networkPolicy.enabled Specifies whether a NetworkPolicy should be created
+    ##
+    enabled: true
+    ## @param skipper.networkPolicy.allowExternal Don't require client label for connections
+    ## The Policy model to apply. When set to false, only pods with the correct
+    ## client label will have network access to the ports the application is listening
+    ## on. When true, the app will accept connections from any source
+    ## (with the correct destination port).
+    ##
+    allowExternal: true
+    ## @param skipper.networkPolicy.kubeAPIServerPorts [array] List of possible endpoints to kube-apiserver (limit to your cluster settings to increase security)
+    ##
+    kubeAPIServerPorts: [443, 6443, 8443]
+    ## @param skipper.networkPolicy.extraIngress [array] Add extra ingress rules to the NetworkPolice
+    ## e.g:
+    ## extraIngress:
+    ##   - ports:
+    ##       - port: 1234
+    ##     from:
+    ##       - podSelector:
+    ##           - matchLabels:
+    ##               - role: frontend
+    ##       - podSelector:
+    ##           - matchExpressions:
+    ##               - key: role
+    ##                 operator: In
+    ##                 values:
+    ##                   - frontend
+    extraIngress: []
+    ## @param skipper.networkPolicy.extraEgress [array] Add extra ingress rules to the NetworkPolicy
+    ## e.g:
+    ## extraEgress:
+    ##   - ports:
+    ##       - port: 1234
+    ##     to:
+    ##       - podSelector:
+    ##           - matchLabels:
+    ##               - role: frontend
+    ##       - podSelector:
+    ##           - matchExpressions:
+    ##               - key: role
+    ##                 operator: In
+    ##                 values:
+    ##                   - frontend
+    ##
+    extraEgress: []
+    ## @param skipper.networkPolicy.ingressNSMatchLabels [object] Labels to match to allow traffic from other namespaces
+    ## @param skipper.networkPolicy.ingressNSPodMatchLabels [object] Pod labels to match to allow traffic from other namespaces
+    ##
+    ingressNSMatchLabels: {}
+    ingressNSPodMatchLabels: {}
   ## Skipper Service parameters.
   ##
   service:
     ## @param skipper.service.type Kubernetes service type
     ##
     type: ClusterIP
-    ## @param skipper.service.port Service HTTP port
+    ## @param skipper.service.ports.http Skipper HTTP port
     ##
-    port: 80
+    ports:
+      http: 80
     ## @param skipper.service.nodePort Service HTTP node port
     ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
     ##
@@ -1078,7 +1199,7 @@ deployer:
 ## K8s Service Account.
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
 ## @param serviceAccount.create Enable the creation of a ServiceAccount for Dataflow server and Skipper server pods
-## @param serviceAccount.name Name of the created serviceAccount. If not set and create is true, a name is generated using the scdf.fullname template
+## @param serviceAccount.name Name of the created serviceAccount. If not set and create is true, a name is generated using the common.names.fullname template
 ## @param serviceAccount.automountServiceAccountToken Automount service account token for the server service account
 ## @param serviceAccount.annotations Annotations for service account. Evaluated as a template. Only used if `create` is `true`.
 ##
@@ -1380,6 +1501,58 @@ metrics:
   ## The value is evaluated as a template
   ##
   topologySpreadConstraints: []
+  ## Network Policies
+  ## Ref: https://kubernetes.io/docs/concepts/services-networking/network-policies/
+  ##
+  networkPolicy:
+    ## @param metrics.networkPolicy.enabled Specifies whether a NetworkPolicy should be created
+    ##
+    enabled: true
+    ## @param metrics.networkPolicy.allowExternal Don't require client label for connections
+    ## The Policy model to apply. When set to false, only pods with the correct
+    ## client label will have network access to the ports the application is listening
+    ## on. When true, the app will accept connections from any source
+    ## (with the correct destination port).
+    ##
+    allowExternal: true
+    ## @param metrics.networkPolicy.extraIngress [array] Add extra ingress rules to the NetworkPolice
+    ## e.g:
+    ## extraIngress:
+    ##   - ports:
+    ##       - port: 1234
+    ##     from:
+    ##       - podSelector:
+    ##           - matchLabels:
+    ##               - role: frontend
+    ##       - podSelector:
+    ##           - matchExpressions:
+    ##               - key: role
+    ##                 operator: In
+    ##                 values:
+    ##                   - frontend
+    extraIngress: []
+    ## @param metrics.networkPolicy.extraEgress [array] Add extra ingress rules to the NetworkPolicy
+    ## e.g:
+    ## extraEgress:
+    ##   - ports:
+    ##       - port: 1234
+    ##     to:
+    ##       - podSelector:
+    ##           - matchLabels:
+    ##               - role: frontend
+    ##       - podSelector:
+    ##           - matchExpressions:
+    ##               - key: role
+    ##                 operator: In
+    ##                 values:
+    ##                   - frontend
+    ##
+    extraEgress: []
+    ## @param metrics.networkPolicy.ingressNSMatchLabels [object] Labels to match to allow traffic from other namespaces
+    ## @param metrics.networkPolicy.ingressNSPodMatchLabels [object] Pod labels to match to allow traffic from other namespaces
+    ##
+    ingressNSMatchLabels: {}
+    ingressNSPodMatchLabels: {}
   ## Prometheus Proxy service parameters
   ##
   service:


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

This PR normalizes the use of NetworkPolicy in the chart. Adds all Bitnami standards for NetworkPolicies as well as enabling it by default, in order to comply with security checklists.

<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

More security in the chart
<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
