### PR TITLE
[bitnami/kafka] fix: Migrate existing broker.id to node.id only when kraft mode enabled (bitnami#21940)

### DIFF
--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -42,4 +42,4 @@ maintainers:
 name: kafka
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/kafka
-version: 26.8.1
+version: 26.8.2

--- a/bitnami/kafka/templates/scripts-configmap.yaml
+++ b/bitnami/kafka/templates/scripts-configmap.yaml
@@ -333,7 +333,7 @@ data:
     if [[ -f "/bitnami/kafka/data/meta.properties" ]]; then
         if grep -q "broker.id" /bitnami/kafka/data/meta.properties; then
           ID="$(grep "broker.id" /bitnami/kafka/data/meta.properties | awk -F '=' '{print $2}')"
-          {{- if or (not .Values.broker.zookeeperMigrationMode) (and (not .Values.zookeeper.enabled) (not .Values.externalZookeeper.servers)) }}
+          {{- if or (and .Values.kraft.enabled (not .Values.broker.zookeeperMigrationMode)) (and (not .Values.zookeeper.enabled) (not .Values.externalZookeeper.servers)) }}
           kafka_conf_set "$KAFKA_CONFIG_FILE" "node.id" "$ID"
           {{- else }}
           kafka_conf_set "$KAFKA_CONFIG_FILE" "broker.id" "$ID"


### PR DESCRIPTION
### Description of the change

An existing broker.id in `/bitnami/kafka/data/meta.properties` needs only migration to node.id when kraftmode is enabled.

### Benefits

Existing broker installations with external zookeeper get proper broker.id entries in server.properties.

### Possible drawbacks

n/a

### Applicable issues

- fixes #21940 

### Additional information

n/a

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
