### PR TITLE
[bitnami/kafka] Add missing version, kind to volumeClaimTemplates

### DIFF
--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -42,4 +42,4 @@ maintainers:
 name: kafka
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/kafka
-version: 26.8.1
+version: 26.8.2

--- a/bitnami/kafka/templates/broker/statefulset.yaml
+++ b/bitnami/kafka/templates/broker/statefulset.yaml
@@ -437,7 +437,9 @@ spec:
   {{- if or (and .Values.broker.persistence.enabled (not .Values.broker.persistence.existingClaim)) (and .Values.broker.logPersistence.enabled (not .Values.broker.logPersistence.existingClaim)) }}
   volumeClaimTemplates:
     {{- if and .Values.broker.persistence.enabled (not .Values.broker.persistence.existingClaim) }}
-    - metadata:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
         name: data
         {{- if .Values.broker.persistence.annotations }}
         annotations: {{- include "common.tplvalues.render" (dict "value" .Values.broker.persistence.annotations "context" $) | nindent 10 }}
@@ -459,7 +461,9 @@ spec:
         {{- end -}}
     {{- end }}
     {{- if and .Values.broker.logPersistence.enabled (not .Values.broker.logPersistence.existingClaim) }}
-    - metadata:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
         name: logs
         {{- if .Values.broker.logPersistence.annotations }}
         annotations: {{- include "common.tplvalues.render" (dict "value" .Values.broker.logPersistence.annotations "context" $) | nindent 10 }}

--- a/bitnami/kafka/templates/controller-eligible/statefulset.yaml
+++ b/bitnami/kafka/templates/controller-eligible/statefulset.yaml
@@ -436,7 +436,9 @@ spec:
   {{- if or (and .Values.controller.persistence.enabled (not .Values.controller.persistence.existingClaim)) (and .Values.controller.logPersistence.enabled (not .Values.controller.logPersistence.existingClaim)) }}
   volumeClaimTemplates:
     {{- if and .Values.controller.persistence.enabled (not .Values.controller.persistence.existingClaim) }}
-    - metadata:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
         name: data
         {{- if .Values.controller.persistence.annotations }}
         annotations: {{- include "common.tplvalues.render" (dict "value" .Values.controller.persistence.annotations "context" $) | nindent 10 }}
@@ -458,7 +460,9 @@ spec:
         {{- end -}}
     {{- end }}
     {{- if and .Values.controller.logPersistence.enabled (not .Values.controller.logPersistence.existingClaim) }}
-    - metadata:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
         name: logs
         {{- if .Values.controller.logPersistence.annotations }}
         annotations: {{- include "common.tplvalues.render" (dict "value" .Values.controller.logPersistence.annotations "context" $) | nindent 10 }}


### PR DESCRIPTION
### Description of the change

Applies same fix from https://github.com/bitnami/charts/pull/15816 to kafka chart.

### Benefits

Prevents deployments via ArgoCD from showing as constantly OutOfSync.

### Possible drawbacks

### Applicable issues

- fixes same issue as described in https://github.com/bitnami/charts/issues/15526 for kafka

### Additional information

Only impact is a rolling restart of the deployment due to the helm chart version change.

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
