### PR TITLE
[bitnami/grafana] Enable templating of all volumes and volumeMounts

### DIFF
--- a/bitnami/grafana/Chart.yaml
+++ b/bitnami/grafana/Chart.yaml
@@ -31,4 +31,4 @@ maintainers:
 name: grafana
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/grafana
-version: 9.8.1
+version: 9.8.2

--- a/bitnami/grafana/templates/deployment.yaml
+++ b/bitnami/grafana/templates/deployment.yaml
@@ -182,11 +182,11 @@ spec:
             {{- range .Values.dashboardsConfigMaps }}
             - name: {{ include "common.tplvalues.render" ( dict "value" .configMapName "context" $ ) }}
             {{- if .folderName }}
-              mountPath: /opt/bitnami/grafana/dashboards/{{ .folderName }}/{{ .fileName }}
+              mountPath: /opt/bitnami/grafana/dashboards/{{ include "common.tplvalues.render" ( dict "value" .folderName "context" $ ) }}/{{ include "common.tplvalues.render" ( dict "value" .fileName "context" $ ) }}
             {{- else }}
-              mountPath: /opt/bitnami/grafana/dashboards/{{ .fileName }}
+              mountPath: /opt/bitnami/grafana/dashboards/{{ include "common.tplvalues.render" ( dict "value" .fileName "context" $ ) }}
             {{- end }}
-              subPath: {{ .fileName }}
+              subPath: {{ include "common.tplvalues.render" ( dict "value" .fileName "context" $ ) }}
             {{- end }}
             {{- if or (.Values.datasources.secretName) (.Values.datasources.secretDefinition) }}
             - name: datasources
@@ -207,13 +207,13 @@ spec:
             {{- end }}
             {{- if and .Values.ldap.tls.enabled .Values.ldap.tls.certificatesSecret }}
             - name: ldap-tls
-              mountPath: {{ .Values.ldap.tls.certificatesMountPath }}
+              mountPath: {{ include "common.tplvalues.render" (dict "value" .Values.ldap.tls.certificatesMountPath "context" $) }}
             {{- end }}
             {{- range .Values.grafana.extraConfigmaps }}
-            - name: {{ .name }}
-              mountPath: {{ .mountPath }}
-              subPath: {{ .subPath | default "" }}
-              readOnly: {{ .readOnly }}
+            - name: {{ include "common.tplvalues.render" (dict "value" .name "context" $) }}
+              mountPath: {{ include "common.tplvalues.render" (dict "value" .mountPath "context" $) }}
+              subPath: {{ include "common.tplvalues.render" (dict "value" .subPath "context" $) | default "" }}
+              readOnly: {{ include "common.tplvalues.render" (dict "value" .readOnly "context" $) }}
             {{- end }}
             {{- if .Values.grafana.extraVolumeMounts }}
             {{- include "common.tplvalues.render" (dict "value" .Values.grafana.extraVolumeMounts "context" $) | nindent 12 }}
@@ -280,7 +280,7 @@ spec:
         - name: data
         {{- if .Values.persistence.enabled }}
           persistentVolumeClaim:
-            claimName: {{ .Values.persistence.existingClaim | default (include "common.names.fullname" .) }}
+            claimName: {{ include "common.tplvalues.render" ( dict "value" .Values.persistence.existingClaim "context" $) | default (include "common.names.fullname" .) }}
         {{- else }}
           emptyDir: {}
         {{- end }}
@@ -288,10 +288,10 @@ spec:
         - name: ldap
           {{- if not (empty .Values.ldap.configMapName) }}
           configMap:
-            name: {{ .Values.ldap.configMapName }}
+            name: {{ include "common.tplvalues.render" ( dict "value" .Values.ldap.configMapName "context" $) }}
           {{- else if not (empty .Values.ldap.secretName) }}
           secret:
-            secretName: {{ .Values.ldap.secretName }}
+            secretName: {{ include "common.tplvalues.render" ( dict "value" .Values.ldap.secretName "context" $) }}
           {{- else }}
           secret:
             secretName: {{ printf "%s-ldap-conf" (include "common.names.fullname" .) }}
@@ -323,32 +323,32 @@ spec:
         {{- if .Values.notifiers.configMapName }}
         - name: notifiers
           configMap:
-            name: {{ .Values.notifiers.configMapName }}
+            name: {{ include "common.tplvalues.render" (dict "value" .Values.notifiers.configMapName "context" $) }}
         {{- end }}
         {{- if .Values.alerting.configMapName }}
         - name: alerting
           configMap:
-            name: {{ .Values.alerting.configMapName }}
+            name: {{ include "common.tplvalues.render" (dict "value" .Values.alerting.configMapName "context" $) }}
         {{- end }}
         {{- if .Values.config.useGrafanaIniFile }}
         - name: grafana-ini
           {{- if .Values.config.grafanaIniConfigMap }}
           configMap:
-            name: {{ .Values.config.grafanaIniConfigMap }}
+            name: {{ include "common.tplvalues.render" (dict "value" .Values.config.grafanaIniConfigMap "context" $) }}
           {{- else if .Values.config.grafanaIniSecret }}
           secret:
-            secretName: {{ .Values.config.grafanaIniSecret }}
+            secretName: {{ include "common.tplvalues.render" (dict "value" .Values.config.grafanaIniSecret "context" $) }}
           {{- end }}
         {{- end }}
         {{- if and .Values.ldap.tls.enabled .Values.ldap.tls.certificatesSecret }}
         - name: ldap-tls
           secret:
-            secretName: {{ .Values.ldap.tls.certificatesSecret }}
+            secretName: {{ include "common.tplvalues.render" (dict "value" .Values.ldap.tls.certificatesSecret "context" $) }}
         {{- end }}
         {{- range .Values.grafana.extraConfigmaps }}
-        - name: {{ .name }}
+        - name: {{ include "common.tplvalues.render" (dict "value" .name "context" $) }}
           configMap:
-            name: {{ .name }}
+            name: {{ include "common.tplvalues.render" (dict "value" .name "context" $) }}
         {{- end }}
         {{- if .Values.grafana.extraVolumes }}
         {{- include "common.tplvalues.render" (dict "value" .Values.grafana.extraVolumes  "context" $) | nindent 8 }}


### PR DESCRIPTION
### Description of the change

In the Grafana chart some re sources, that are mounted to the container, allow for templated names. Others don't.

This change enables templating for all resources.

### Benefits

Streamlining. All resources  work the same.

### Possible drawbacks

None

### Applicable issues

None

### Additional information

None

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
