### PR TITLE
[bitnami/pytorch] feat: :lock: Enable networkPolicy

### DIFF
--- a/bitnami/pytorch/Chart.yaml
+++ b/bitnami/pytorch/Chart.yaml
@@ -33,4 +33,4 @@ maintainers:
 name: pytorch
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/pytorch
-version: 3.6.1
+version: 3.7.0

--- a/bitnami/pytorch/README.md
+++ b/bitnami/pytorch/README.md
@@ -170,20 +170,26 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Traffic Exposure Parameters
 
-| Name                               | Description                                                                        | Value       |
-| ---------------------------------- | ---------------------------------------------------------------------------------- | ----------- |
-| `service.type`                     | Kubernetes service type                                                            | `ClusterIP` |
-| `service.ports.pytorch`            | Scheduler Service port                                                             | `49875`     |
-| `service.nodePorts.pytorch`        | Node port for Pytorch                                                              | `""`        |
-| `service.clusterIP`                | Pytorch service Cluster IP                                                         | `""`        |
-| `service.loadBalancerIP`           | Pytorch service Load Balancer IP                                                   | `""`        |
-| `service.loadBalancerSourceRanges` | Pytorch service Load Balancer sources                                              | `[]`        |
-| `service.externalTrafficPolicy`    | Pytorch service external traffic policy                                            | `Cluster`   |
-| `service.annotations`              | Additional custom annotations for Pytorch service                                  | `{}`        |
-| `service.extraPorts`               | Extra ports to expose in Pytorch service (normally used with the `sidecars` value) | `[]`        |
-| `service.sessionAffinity`          | Control where client requests go, to the same pod or round-robin                   | `None`      |
-| `service.sessionAffinityConfig`    | Additional settings for the sessionAffinity                                        | `{}`        |
-| `service.headless.annotations`     | Annotations for the headless service.                                              | `{}`        |
+| Name                                    | Description                                                                        | Value       |
+| --------------------------------------- | ---------------------------------------------------------------------------------- | ----------- |
+| `service.type`                          | Kubernetes service type                                                            | `ClusterIP` |
+| `service.ports.pytorch`                 | Scheduler Service port                                                             | `49875`     |
+| `service.nodePorts.pytorch`             | Node port for Pytorch                                                              | `""`        |
+| `service.clusterIP`                     | Pytorch service Cluster IP                                                         | `""`        |
+| `service.loadBalancerIP`                | Pytorch service Load Balancer IP                                                   | `""`        |
+| `service.loadBalancerSourceRanges`      | Pytorch service Load Balancer sources                                              | `[]`        |
+| `service.externalTrafficPolicy`         | Pytorch service external traffic policy                                            | `Cluster`   |
+| `service.annotations`                   | Additional custom annotations for Pytorch service                                  | `{}`        |
+| `service.extraPorts`                    | Extra ports to expose in Pytorch service (normally used with the `sidecars` value) | `[]`        |
+| `service.sessionAffinity`               | Control where client requests go, to the same pod or round-robin                   | `None`      |
+| `service.sessionAffinityConfig`         | Additional settings for the sessionAffinity                                        | `{}`        |
+| `service.headless.annotations`          | Annotations for the headless service.                                              | `{}`        |
+| `networkPolicy.enabled`                 | Specifies whether a NetworkPolicy should be created                                | `true`      |
+| `networkPolicy.allowExternal`           | Don't require server label for connections                                         | `true`      |
+| `networkPolicy.extraIngress`            | Add extra ingress rules to the NetworkPolice                                       | `[]`        |
+| `networkPolicy.extraEgress`             | Add extra ingress rules to the NetworkPolicy                                       | `[]`        |
+| `networkPolicy.ingressNSMatchLabels`    | Labels to match to allow traffic from other namespaces                             | `{}`        |
+| `networkPolicy.ingressNSPodMatchLabels` | Pod labels to match to allow traffic from other namespaces                         | `{}`        |
 
 ### Init Container Parameters
 

--- a/bitnami/pytorch/templates/networkpolicy.yaml
+++ b/bitnami/pytorch/templates/networkpolicy.yaml
@@ -1,0 +1,77 @@
+{{- /*
+Copyright VMware, Inc.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+{{- if .Values.networkPolicy.enabled }}
+kind: NetworkPolicy
+apiVersion: {{ include "common.capabilities.networkPolicy.apiVersion" . }}
+metadata:
+  name: {{ include "common.names.fullname" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.podLabels .Values.commonLabels ) "context" . ) }}
+  podSelector:
+    matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  egress:
+    # Allow dns resolution
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+        {{- if .Values.cloneFilesFromGit.enabled }}
+        # Use general ports for cloning from git (http,https and ssh)
+        - port: 443
+        - port: 80
+        - port: 22
+        {{- end }}
+    # Allow internal communications between nodes
+    - ports:
+        - port: {{ .Values.containerPorts.pytorch }}
+        - port: {{ .Values.service.ports.pytorch }}
+      to:
+        - podSelector:
+            matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 14 }}
+    {{- if .Values.networkPolicy.extraEgress }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.rts.networkPolicy.extraEgress "context" $ ) | nindent 4 }}
+    {{- end }}
+  ingress:
+    # Allow inbound connections
+    - ports:
+        - port: {{ .Values.containerPorts.pytorch }}
+      {{- if not .Values.networkPolicy.allowExternal }}
+      from:
+        - podSelector:
+            matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 14 }}
+        - podSelector:
+            matchLabels:
+              {{ include "common.names.fullname" . }}-client: "true"
+        - podSelector:
+            matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 14 }}
+        {{- if .Values.networkPolicy.ingressNSMatchLabels }}
+        - namespaceSelector:
+            matchLabels:
+              {{- range $key, $value := .Values.networkPolicy.ingressNSMatchLabels }}
+              {{ $key | quote }}: {{ $value | quote }}
+              {{- end }}
+          {{- if .Values.networkPolicy.ingressNSPodMatchLabels }}
+          podSelector:
+            matchLabels:
+              {{- range $key, $value := .Values.networkPolicy.ingressNSPodMatchLabels }}
+              {{ $key | quote }}: {{ $value | quote }}
+              {{- end }}
+          {{- end }}
+        {{- end }}
+      {{- end }}
+    {{- if .Values.networkPolicy.extraIngress }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.networkPolicy.extraIngress "context" $ ) | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/bitnami/pytorch/templates/networkpolicy.yaml
+++ b/bitnami/pytorch/templates/networkpolicy.yaml
@@ -27,12 +27,10 @@ spec:
           protocol: UDP
         - port: 53
           protocol: TCP
-        {{- if .Values.cloneFilesFromGit.enabled }}
-        # Use general ports for cloning from git (http,https and ssh)
+        # Allow these ports to download models
         - port: 443
         - port: 80
         - port: 22
-        {{- end }}
     # Allow internal communications between nodes
     - ports:
         - port: {{ .Values.containerPorts.pytorch }}

--- a/bitnami/pytorch/values.yaml
+++ b/bitnami/pytorch/values.yaml
@@ -463,6 +463,59 @@ service:
     ##
     annotations: {}
 
+## Network Policies
+## Ref: https://kubernetes.io/docs/concepts/services-networking/network-policies/
+##
+networkPolicy:
+  ## @param networkPolicy.enabled Specifies whether a NetworkPolicy should be created
+  ##
+  enabled: true
+  ## @param networkPolicy.allowExternal Don't require server label for connections
+  ## The Policy model to apply. When set to false, only pods with the correct
+  ## server label will have network access to the ports server is listening
+  ## on. When true, server will accept connections from any source
+  ## (with the correct destination port).
+  ##
+  allowExternal: true
+  ## @param networkPolicy.extraIngress [array] Add extra ingress rules to the NetworkPolice
+  ## e.g:
+  ## extraIngress:
+  ##   - ports:
+  ##       - port: 1234
+  ##     from:
+  ##       - podSelector:
+  ##           - matchLabels:
+  ##               - role: frontend
+  ##       - podSelector:
+  ##           - matchExpressions:
+  ##               - key: role
+  ##                 operator: In
+  ##                 values:
+  ##                   - frontend
+  extraIngress: []
+  ## @param networkPolicy.extraEgress [array] Add extra ingress rules to the NetworkPolicy
+  ## e.g:
+  ## extraEgress:
+  ##   - ports:
+  ##       - port: 1234
+  ##     to:
+  ##       - podSelector:
+  ##           - matchLabels:
+  ##               - role: frontend
+  ##       - podSelector:
+  ##           - matchExpressions:
+  ##               - key: role
+  ##                 operator: In
+  ##                 values:
+  ##                   - frontend
+  ##
+  extraEgress: []
+  ## @param networkPolicy.ingressNSMatchLabels [object] Labels to match to allow traffic from other namespaces
+  ## @param networkPolicy.ingressNSPodMatchLabels [object] Pod labels to match to allow traffic from other namespaces
+  ##
+  ingressNSMatchLabels: {}
+  ingressNSPodMatchLabels: {}
+
 ## @section Init Container Parameters
 ##
 


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

This PR normalizes the use of NetworkPolicy in the chart. Adds all Bitnami standards for NetworkPolicies as well as enabling it by default, in order to comply with security checklists.

<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

More security in the chart
<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
