### PR TITLE
[bitnami/fluentd] Allow templating of extra env vars

### DIFF
--- a/bitnami/fluentd/Chart.yaml
+++ b/bitnami/fluentd/Chart.yaml
@@ -30,4 +30,4 @@ maintainers:
 name: fluentd
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/fluentd
-version: 5.14.1
+version: 5.14.2

--- a/bitnami/fluentd/templates/aggregator-statefulset.yaml
+++ b/bitnami/fluentd/templates/aggregator-statefulset.yaml
@@ -137,7 +137,7 @@ spec:
             - name: FLUENTD_OPT
               value: {{ .Values.aggregator.extraArgs | quote }}
             {{- if .Values.aggregator.extraEnvVars }}
-            {{- toYaml .Values.aggregator.extraEnvVars | nindent 12 }}
+            {{- include "common.tplvalues.render" ( dict "value" .Values.aggregator.extraEnvVars "context" $ ) | nindent 12 }}
             {{- end }}
           envFrom:
             {{- if .Values.aggregator.extraEnvVarsCM }}

--- a/bitnami/fluentd/templates/forwarder-daemonset.yaml
+++ b/bitnami/fluentd/templates/forwarder-daemonset.yaml
@@ -138,7 +138,7 @@ spec:
             - name: FLUENTD_DAEMON_GROUP
               value: {{ .Values.forwarder.daemonGroup | quote }}
             {{- if .Values.forwarder.extraEnvVars }}
-            {{- toYaml .Values.forwarder.extraEnvVars | nindent 12 }}
+            {{- include "common.tplvalues.render" ( dict "value" .Values.forwarder.extraEnvVars "context" $ ) | nindent 12 }}
             {{- end }}
           envFrom:
             {{- if .Values.forwarder.extraEnvVarsCM }}


### PR DESCRIPTION
### Description of the change

Put extra env vars through `common.tplvalues.render` helper, before rendering to containers.

### Benefits

Templating of extra env vars possible.

### Possible drawbacks

None

### Applicable issues

None

### Additional information

None

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
