### PR TITLE
[bitnami/thanos] Fix revisionHistoryLimit for thanos storegateway

### DIFF
--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: thanos
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/thanos
-version: 12.22.0
+version: 12.22.1

--- a/bitnami/thanos/templates/storegateway/statefulset-sharded.yaml
+++ b/bitnami/thanos/templates/storegateway/statefulset-sharded.yaml
@@ -32,7 +32,7 @@ spec:
   {{- if not $.Values.storegateway.autoscaling.enabled }}
   replicas: {{ $.Values.storegateway.replicaCount }}
   {{- end }}
-  revisionHistoryLimit: {{ .Values.storegateway.revisionHistoryLimit }}
+  revisionHistoryLimit: {{ $.Values.storegateway.revisionHistoryLimit }}
   podManagementPolicy: {{ $.Values.storegateway.podManagementPolicy }}
   {{- $svcNamePrefix := printf "%s-storegateway" (include "common.names.fullname" $) | trunc 61 | trimSuffix "-" }}
   serviceName: {{ printf "%s-%s" $svcNamePrefix (toString $index) }}


### PR DESCRIPTION

### Description of the change

Fixing the way we retreive the revisionHistoryLimit from the Values for thanos storegateway

### Benefits

Fixes the chart

### Possible drawbacks

None

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
