### PR TITLE
[bitnami/opensearch] Allow templating of secret names

### DIFF
--- a/bitnami/opensearch/Chart.yaml
+++ b/bitnami/opensearch/Chart.yaml
@@ -30,4 +30,4 @@ maintainers:
 name: opensearch
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/opensearch
-version: 0.8.1
+version: 0.8.2

--- a/bitnami/opensearch/templates/_helpers.tpl
+++ b/bitnami/opensearch/templates/_helpers.tpl
@@ -422,7 +422,11 @@ Return true if an authentication credentials secret object should be created
 Return the Opensearch authentication credentials secret name
 */}}
 {{- define "opensearch.secretName" -}}
-{{- default (include "common.names.fullname" .) .Values.security.existingSecret  -}}
+{{- if .Values.security.existingSecret -}}
+    {{- printf "%s" (tpl .Values.security.existingSecret $) -}}
+{{- else -}}
+    {{- printf "%s" (include "common.names.fullname" .) -}}
+{{- end -}}
 {{- end -}}
 
 {{/*
@@ -438,7 +442,11 @@ Return true if a TLS password secret object should be created
 Return the Opensearch TLS password secret name
 */}}
 {{- define "opensearch.tlsPasswordsSecret" -}}
-{{- default (printf "%s-tls-pass" (include "common.names.fullname" .)) .Values.security.tls.passwordsSecret -}}
+{{- if .Values.security.tls.passwordsSecret -}}
+    {{- printf "%s" (tpl .Values.security.tls.passwordsSecret $) -}}
+{{- else -}}
+    {{- printf "%s-tls-pass" (include "common.names.fullname" .) -}}
+{{- end -}}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
### Description of the change

Put secret names through `common.tplvalues.render` helper, before rendering to containers.

### Benefits

Templating of extra env vars possible.

### Possible drawbacks

None

### Applicable issues

None

### Additional information

None

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
