### PR TITLE
[bitnami/kubernetes-event-exporter] Set security context in ginkgo tests

### DIFF
--- a/.vib/kubernetes-event-exporter/ginkgo/integration_suite_test.go
+++ b/.vib/kubernetes-event-exporter/ginkgo/integration_suite_test.go
@@ -48,6 +48,17 @@ func clusterConfigOrDie() *rest.Config {
 }
 
 func createPodOrDie(ctx context.Context, c cv1.PodsGetter, name string, image string) *v1.Pod {
+	securityContext := &v1.SecurityContext{
+		Privileged:               &[]bool{false}[0],
+		AllowPrivilegeEscalation: &[]bool{false}[0],
+		RunAsNonRoot:             &[]bool{true}[0],
+		Capabilities: &v1.Capabilities{
+			Drop: []v1.Capability{"ALL"},
+		},
+		SeccompProfile: &v1.SeccompProfile{
+			Type: "RuntimeDefault",
+		},
+	}
 	podData := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: *namespace,
@@ -58,6 +69,7 @@ func createPodOrDie(ctx context.Context, c cv1.PodsGetter, name string, image st
 				{
 					Name:  name,
 					Image: image,
+					SecurityContext: securityContext,
 				},
 			},
 		},


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Include `securityContext` config in test pods created by ginkgo.

### Benefits

These changes allow running ginkgo tests on clusters with PSA enabled.

### Possible drawbacks

None

### Additional information

[vib execution](https://github.com/bitnami/charts/actions/runs/7696596394/job/20971772449?pr=22828)
### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
