### PR TITLE
[bitnami/haproxy] Fix securityContext for testing env

### DIFF
--- a/.vib/haproxy/runtime-parameters.yaml
+++ b/.vib/haproxy/runtime-parameters.yaml
@@ -38,3 +38,11 @@ sidecars:
     ports:
       - name: web
         containerPort: 8080
+    securityContext:
+      runAsUser: 1001
+      runAsNonRoot: true
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: ["ALL"]
+      seccompProfile:
+        type: "RuntimeDefault"

--- a/.vib/haproxy/runtime-parameters.yaml
+++ b/.vib/haproxy/runtime-parameters.yaml
@@ -41,6 +41,8 @@ sidecars:
     securityContext:
       runAsUser: 1001
       runAsNonRoot: true
+      privileged: false
+      readOnlyRootFilesystem: false
       allowPrivilegeEscalation: false
       capabilities:
         drop: ["ALL"]


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

This PR adapts the `securityContext` of the testing NGINX pod with the same config introduced in https://github.com/bitnami/charts/commit/b17d6aeceb48ce6686b60ced1861753d9ea4596e

### Benefits

<!-- What benefits will be realized by the code change? -->
The chart tests work in a TKG cluster

### Possible drawbacks

<!-- Describe any known limitations with your change -->
None

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
