### PR TITLE
[bitnami/flux] Fix flux tests, do not disable dokuwiki securityContexts

### DIFF
--- a/.vib/flux/runtime-parameters.yaml
+++ b/.vib/flux/runtime-parameters.yaml
@@ -143,10 +143,6 @@ extraDeploy:
         fullnameOverride: vib-dokuwiki
         persistence:
           enabled: false
-        podSecurityContext:
-          enabled: false
-        containerSecurityContext:
-          enabled: false
   # This is for image-notification-controller. We will use the metrics to ensure that it is consumed
   # and therefore RBAC is correct. The values do not need to be correct
   # Source: https://fluxcd.io/flux/components/notification/receiver/


### PR DESCRIPTION
### Description of the change

This PR, in addition to https://github.com/mdhont/podinfo/pull/1, should fix Flux testing deployment in TKG.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
