### PR TITLE
github-actions: Enhancements for automatic CRDs update feature

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -158,25 +158,71 @@ jobs:
         env:
           CHART: ${{ needs.get-chart.outputs.chart }}
         run: |
-          APP_VERSION="$(yq e '.appVersion' bitnami/${CHART}/Chart.yaml)"
           # Updating CRDs stored at 'bitnami/$CHART/crds' (not 'bitnami/$CHART/templates/crds')
-          mapfile -t crd_files < <(find "bitnami/${CHART}/crds" -name "*.yaml" -o -name "*.yml" 2>/dev/null || true)
+          mapfile -t crd_files < <(find "bitnami/${CHART}/crds" "bitnami/${CHART}/templates/crds" -name "*.yaml" -o -name "*.yml" 2>/dev/null || true)
           for file in "${crd_files[@]}"; do
             # Automatically update CRDs that use the '# Source' header
             source_url_tpl="$(head -n 1 $file | grep -E "^# ?Source: ?" | sed -E 's|^# ?Source: ?||' || true)"
             if [[ -n "$source_url_tpl" ]]; then
-              # Replace version placeholder, if present
-              source_url=$(echo "$source_url_tpl" | sed "s/{version}/${APP_VERSION}/")
               # Validate the second line of the CRD file includes the version of the CRD
               crd_version="$(head -n 2 $file | tail -n 1 | grep -E "^# ?Version: ?" | sed -E 's|^# ?Version: ?||' || true)"
               if [[ -z "$crd_version" ]]; then
                 echo "error=CRD file '${file}' does not include the '#Version: <version> header'"
                 exit 1
               fi
+              # Additional headers may be used for extra features
+              # Conditional - Adds a conditional {{if}}/{{end}} to the downloaded upstream CRD
+              # VersionOf - Name of a subcomponent, its version will be used for CRD tracking instead of the main component version
+              # UseKustomize - If set to true, uses Kustomize to render the CRDs
+              continue=true
+              line_n=2
+              extra_headers=""
+              CONDITIONAL=""
+              SUBCOMPONENT=""
+              USE_KUSTOMIZE=""
+              SPLIT_FILE=""
+              while [ "$continue" = true ]; do
+                line_n=$((line_n+1))
+                line="$(head -n $line_n $file | tail -n 1)"
+                if [[ $line =~ ^#\ ?[a-zA-Z]+:\ ? ]]; then
+                  if [[ $line =~ ^#\ ?Conditional:\ ? ]]; then
+                    CONDITIONAL="$(echo $line | sed -E 's|^# ?Conditional: ?||')"
+                    CONDITIONAL="{{- if ${CONDITIONAL} }}\n"
+                  elif [[ $line =~ ^#\ ?VersionOf:\ ? ]]; then
+                    SUBCOMPONENT="$(echo $line | sed -E 's|^# ?VersionOf: ?||')"
+                  elif [[ $line =~ ^#\ ?UseKustomize:\ ? ]]; then
+                    USE_KUSTOMIZE="$(echo $line | sed -E 's|^# ?UseKustomize: ?||' || true)"
+                  else
+                    echo "error=Header ${line} not recognized'"
+                    exit 1
+                  fi
+                  extra_headers="${extra_headers}${line}\n"
+                else
+                  continue=false
+                fi
+              done
+              # Obtain the version of the subcomponent if provided, otherwise use the main component version
+              if [[ -n "$SUBCOMPONENT" ]]; then
+                APP_VERSION="$(cat bitnami/${CHART}/Chart.yaml | grep -E "image: \S+${SUBCOMPONENT}:" | sed -E "s|.*${SUBCOMPONENT}:([0-9\.]+)-.*|\1|")"
+              else
+                APP_VERSION="$(yq e '.appVersion' bitnami/${CHART}/Chart.yaml)"
+              fi
+              # Replace version placeholder, if present
+              source_url=$(echo "$source_url_tpl" | sed "s/{version}/${APP_VERSION}/")
               # If the application version is newer, automatically update the CRD file
-              if [[ "$APP_VERSION" != "$crd_version" ]]; then
-                curl -Lks --fail -o $file "$source_url"
-                sed -i "1s|^|# Source: ${source_url_tpl}\n# Version: ${APP_VERSION}\n|" $file
+              if [[ "$APP_VERSION" != "$crd_version" || "$skip_version" = true ]]; then
+                if [[ "$USE_KUSTOMIZE" = "true" ]]; then
+                  kubectl kustomize "$source_url" > $file
+                else
+                  curl -Lks --fail -o $file "$source_url"
+                fi
+                if [[ "$SPLIT_FILE" = "true" ]]; then
+                  yq -i e '. | select(.kind == "CustomResourceDefinition") | ... head_comment=""' $file
+                fi
+                sed -i "1s|^|# Source: ${source_url_tpl}\n# Version: ${APP_VERSION}\n${extra_headers}${CONDITIONAL}|" $file
+                if [[ -n "$CONDITIONAL" ]]; then
+                  echo -E "{{- end }}" >> $file
+                fi
                 echo "info=CRD file '${file}' automatically updated using source '$source_url'"
               fi
             else

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -158,7 +158,7 @@ jobs:
         env:
           CHART: ${{ needs.get-chart.outputs.chart }}
         run: |
-          # Updating CRDs stored at 'bitnami/$CHART/crds' (not 'bitnami/$CHART/templates/crds')
+          # Updating CRDs stored at 'bitnami/$CHART/crds' and 'bitnami/$CHART/templates/crds'
           mapfile -t crd_files < <(find "bitnami/${CHART}/crds" "bitnami/${CHART}/templates/crds" -name "*.yaml" -o -name "*.yml" 2>/dev/null || true)
           for file in "${crd_files[@]}"; do
             # Automatically update CRDs that use the '# Source' header
@@ -174,14 +174,14 @@ jobs:
               # Conditional - Adds a conditional {{if}}/{{end}} to the downloaded upstream CRD
               # VersionOf - Name of a subcomponent, its version will be used for CRD tracking instead of the main component version
               # UseKustomize - If set to true, uses Kustomize to render the CRDs
-              # SplitFile - If set to true, uses yq to filter resources having 'kind: CustomResourceDefinition', useful when using 'install.yaml' file as upstream source
+              # RequiresFilter - If set to true, uses yq to filter resources having 'kind: CustomResourceDefinition', useful when using 'install.yaml' file as upstream source
               continue=true
               line_n=2
               extra_headers=""
               CONDITIONAL=""
               SUBCOMPONENT=""
               USE_KUSTOMIZE=""
-              SPLIT_FILE=""
+              REQUIRES_FILTER=""
               while [ "$continue" = true ]; do
                 line_n=$((line_n+1))
                 line="$(head -n $line_n $file | tail -n 1)"
@@ -193,8 +193,8 @@ jobs:
                     SUBCOMPONENT="$(echo $line | sed -E 's|^# ?VersionOf: ?||')"
                   elif [[ $line =~ ^#\ ?UseKustomize:\ ? ]]; then
                     USE_KUSTOMIZE="$(echo $line | sed -E 's|^# ?UseKustomize: ?||' || true)"
-                  elif [[ $line =~ ^#\ ?SplitFile:\ ? ]]; then
-                    SPLIT_FILE="$(echo $line | sed -E 's|^# ?SplitFile: ?||' || true)"
+                  elif [[ $line =~ ^#\ ?RequiresFilter:\ ? ]]; then
+                    REQUIRES_FILTER="$(echo $line | sed -E 's|^# ?RequiresFilter: ?||' || true)"
                   else
                     echo "error=Header ${line} not recognized'"
                     exit 1
@@ -219,7 +219,7 @@ jobs:
                 else
                   curl -Lks --fail -o $file "$source_url"
                 fi
-                if [[ "$SPLIT_FILE" = "true" ]]; then
+                if [[ "$REQUIRES_FILTER" = "true" ]]; then
                   yq -i e '. | select(.kind == "CustomResourceDefinition") | ... head_comment=""' $file
                 fi
                 sed -i "1s|^|# Source: ${source_url_tpl}\n# Version: ${APP_VERSION}\n${extra_headers}${CONDITIONAL}|" $file

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -174,6 +174,7 @@ jobs:
               # Conditional - Adds a conditional {{if}}/{{end}} to the downloaded upstream CRD
               # VersionOf - Name of a subcomponent, its version will be used for CRD tracking instead of the main component version
               # UseKustomize - If set to true, uses Kustomize to render the CRDs
+              # SplitFile - If set to true, uses yq to filter resources having 'kind: CustomResourceDefinition', useful when using 'install.yaml' file as upstream source
               continue=true
               line_n=2
               extra_headers=""
@@ -192,6 +193,8 @@ jobs:
                     SUBCOMPONENT="$(echo $line | sed -E 's|^# ?VersionOf: ?||')"
                   elif [[ $line =~ ^#\ ?UseKustomize:\ ? ]]; then
                     USE_KUSTOMIZE="$(echo $line | sed -E 's|^# ?UseKustomize: ?||' || true)"
+                  elif [[ $line =~ ^#\ ?SplitFile:\ ? ]]; then
+                    SPLIT_FILE="$(echo $line | sed -E 's|^# ?SplitFile: ?||' || true)"
                   else
                     echo "error=Header ${line} not recognized'"
                     exit 1


### PR DESCRIPTION
### Description of the change

Adds several enhancements to the automatic CRDs update workflow to increase its coverage.

The new features are:
   - `# Conditional` - Adds a conditional {{if}}/{{end}} to the downloaded upstream CRD
   - `# VersionOf` - Name of a subcomponent, its version will be used for CRD tracking instead of the main component version
   - `# UseKustomize` - If set to true, uses Kustomize to render the CRDs
   - `# RequiresFilter` - If set to true, uses yq to filter resources having 'kind: CustomResourceDefinition', useful when using 'install.yaml' file as upstream source 

### Benefits

Increase automatic CRD coverage from 7 out of 16, to 15 out of 16. 
The only exception is `cert-manager`, since upstream uses templating that needs to be manually modified.

### Summary of the method used by each chart

- Base feature (Source + Version)
  - bitnami/argo-cd
  - bitnami/argo-workflows
  - bitnami/grafana-operator
  - bitnami/kube-prometheus
  - bitnami/kuberay
  - bitnami/pinniped
  - bitnami/whereabouts

- Base feature + Conditional
  - bitnami/contour
  - bitnami/external-dns
  - bitnami/metallb

- Base feature + Split file
    - bitnami/multus-cni

- Base feature + Subcomponent version
    - bitnami/rabbitmq-cluster-operator

- Base feature + Conditional + Subcomponent version
    - bitnami/flux

- Base feature + Kustomize + Subcomponent version
    - bitnami/apisix
    - bitnami/kong

- Excluded
    - bitnami/cert-manager