### PR TITLE
[bitnami/redis-cluster] Small typo fix on redis-cluster templates

### DIFF
--- a/bitnami/redis-cluster/Chart.yaml
+++ b/bitnami/redis-cluster/Chart.yaml
@@ -32,4 +32,4 @@ maintainers:
 name: redis-cluster
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/redis-cluster
-version: 9.4.0
+version: 9.4.1

--- a/bitnami/redis-cluster/templates/networkpolicy.yaml
+++ b/bitnami/redis-cluster/templates/networkpolicy.yaml
@@ -41,7 +41,7 @@ spec:
         - port: {{ .Values.redis.containerPorts.bus }}
         {{- if .Values.metrics.enabled }}
         # Allow prometheus scrapes for metrics
-        - port: {{ .Values.metrics.contanierPorts.http }}
+        - port: {{ .Values.metrics.containerPorts.http }}
         {{- end }}
       {{- if not .Values.networkPolicy.allowExternal }}
       from:

--- a/bitnami/redis-cluster/templates/redis-statefulset.yaml
+++ b/bitnami/redis-cluster/templates/redis-statefulset.yaml
@@ -342,7 +342,7 @@ spec:
               value: {{ template "redis-cluster.tlsCACert" . }}
             {{- end }}
             - name: REDIS_EXPORTER_WEB_LISTEN_ADDRESS
-              value: {{ printf ":%d" .Values.metrics.contanierPorts.http }}
+              value: {{ printf ":%d" .Values.metrics.containerPorts.http }}
             {{- if .Values.metrics.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.metrics.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}
@@ -360,7 +360,7 @@ spec:
           {{- end }}
           ports:
             - name: http-metrics
-              containerPort: {{ .Values.metrics.contanierPorts.http }}
+              containerPort: {{ .Values.metrics.containerPorts.http }}
           resources:
         {{- toYaml .Values.metrics.resources | nindent 12 }}
         {{- end }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->

- Changes "contanierPorts" to "containerPorts" on `redis-cluster` templates.

### Benefits

- `serviceMonitors` resources fixed

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- fixes typo on `redis-cluster` helm chart templates

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
