### PR TITLE
[bitnami/spark] fix: :bug: Add allowExternalEgress to avoid breaking istio

### DIFF
--- a/bitnami/spark/Chart.yaml
+++ b/bitnami/spark/Chart.yaml
@@ -27,4 +27,4 @@ maintainers:
 name: spark
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/spark
-version: 8.4.0
+version: 8.5.0

--- a/bitnami/spark/README.md
+++ b/bitnami/spark/README.md
@@ -173,6 +173,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `master.customStartupProbe`                                | Custom startupProbe that overrides the default one                                                                       | `{}`             |
 | `master.networkPolicy.enabled`                             | Specifies whether a NetworkPolicy should be created                                                                      | `true`           |
 | `master.networkPolicy.allowExternal`                       | Don't require client label for connections                                                                               | `true`           |
+| `master.networkPolicy.allowExternalEgress`                 | Allow the pod to access any range of port and all destinations.                                                          | `true`           |
 | `master.networkPolicy.extraIngress`                        | Add extra ingress rules to the NetworkPolice                                                                             | `[]`             |
 | `master.networkPolicy.extraEgress`                         | Add extra ingress rules to the NetworkPolicy                                                                             | `[]`             |
 | `master.networkPolicy.ingressNSMatchLabels`                | Labels to match to allow traffic from other namespaces                                                                   | `{}`             |
@@ -263,6 +264,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `worker.customStartupProbe`                                | Custom startupProbe that overrides the default one                                                                       | `{}`             |
 | `worker.networkPolicy.enabled`                             | Specifies whether a NetworkPolicy should be created                                                                      | `true`           |
 | `worker.networkPolicy.allowExternal`                       | Don't require client label for connections                                                                               | `true`           |
+| `worker.networkPolicy.allowExternalEgress`                 | Allow the pod to access any range of port and all destinations.                                                          | `true`           |
 | `worker.networkPolicy.extraIngress`                        | Add extra ingress rules to the NetworkPolice                                                                             | `[]`             |
 | `worker.networkPolicy.extraEgress`                         | Add extra ingress rules to the NetworkPolicy                                                                             | `[]`             |
 | `worker.networkPolicy.ingressNSMatchLabels`                | Labels to match to allow traffic from other namespaces                                                                   | `{}`             |

--- a/bitnami/spark/templates/networkpolicy-master.yaml
+++ b/bitnami/spark/templates/networkpolicy-master.yaml
@@ -22,6 +22,10 @@ spec:
   policyTypes:
     - Ingress
     - Egress
+  {{- if .Values.master.networkPolicy.allowExternalEgress }}
+  egress:
+    - {}
+  {{- else }}
   egress:
     # Allow dns resolution
     - ports:
@@ -52,6 +56,7 @@ spec:
     {{- if .Values.master.networkPolicy.extraEgress }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.master.networkPolicy.extraEgress "context" $ ) | nindent 4 }}
     {{- end }}
+  {{- end }}
   ingress:
     - ports:
         - port: {{ .Values.service.ports.cluster }}

--- a/bitnami/spark/templates/networkpolicy-worker.yaml
+++ b/bitnami/spark/templates/networkpolicy-worker.yaml
@@ -22,6 +22,10 @@ spec:
   policyTypes:
     - Ingress
     - Egress
+  {{- if .Values.worker.networkPolicy.allowExternalEgress }}
+  egress:
+    - {}
+  {{- else }}
   egress:
     # Allow dns resolution
     - ports:
@@ -52,6 +56,7 @@ spec:
     {{- if .Values.master.networkPolicy.extraEgress }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.master.networkPolicy.extraEgress "context" $ ) | nindent 4 }}
     {{- end }}
+  {{- end }}
   ingress:
     - ports:
         - port: {{ .Values.worker.containerPorts.cluster }}

--- a/bitnami/spark/values.yaml
+++ b/bitnami/spark/values.yaml
@@ -396,6 +396,9 @@ master:
     ## (with the correct destination port).
     ##
     allowExternal: true
+    ## @param master.networkPolicy.allowExternalEgress Allow the pod to access any range of port and all destinations.
+    ##
+    allowExternalEgress: true
     ## @param master.networkPolicy.extraIngress [array] Add extra ingress rules to the NetworkPolice
     ## e.g:
     ## extraIngress:
@@ -749,6 +752,9 @@ worker:
     ## (with the correct destination port).
     ##
     allowExternal: true
+    ## @param worker.networkPolicy.allowExternalEgress Allow the pod to access any range of port and all destinations.
+    ##
+    allowExternalEgress: true
     ## @param worker.networkPolicy.extraIngress [array] Add extra ingress rules to the NetworkPolice
     ## e.g:
     ## extraIngress:


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

This PR adds the value allowExternalEgress to the created NetworkPolicy. In order to avoid bumping a major change, we set this value to true by default. This should avoid issues with Istio.

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes https://github.com/bitnami/charts/issues/22934

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [ ] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [ ] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
