### PR TITLE
[bitnami/jupyterhub] Bump chart version

### DIFF
--- a/bitnami/jupyterhub/Chart.yaml
+++ b/bitnami/jupyterhub/Chart.yaml
@@ -37,4 +37,4 @@ maintainers:
 name: jupyterhub
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/jupyterhub
-version: 5.6.2
+version: 5.6.3


### PR DESCRIPTION
When https://github.com/bitnami/charts/pull/22735 was merged the version bump collided with another bump (https://github.com/bitnami/charts/pull/22799), so at this moment the CD job is failing. This PR bumps the chart version so the changes included in the previously mentioned PR will be released.