### PR TITLE
[bitnami/zookeeper] fix: :bug: Add allowExternalEgress to avoid breaking istio

### DIFF
--- a/bitnami/zookeeper/Chart.yaml
+++ b/bitnami/zookeeper/Chart.yaml
@@ -28,4 +28,4 @@ maintainers:
 name: zookeeper
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/zookeeper
-version: 12.7.0
+version: 12.8.0

--- a/bitnami/zookeeper/README.md
+++ b/bitnami/zookeeper/README.md
@@ -228,6 +228,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `service.headless.servicenameOverride`      | String to partially override headless service name                                      | `""`        |
 | `networkPolicy.enabled`                     | Specifies whether a NetworkPolicy should be created                                     | `true`      |
 | `networkPolicy.allowExternal`               | Don't require client label for connections                                              | `true`      |
+| `networkPolicy.allowExternalEgress`         | Allow the pod to access any range of port and all destinations.                         | `true`      |
 | `networkPolicy.extraIngress`                | Add extra ingress rules to the NetworkPolice                                            | `[]`        |
 | `networkPolicy.extraEgress`                 | Add extra ingress rules to the NetworkPolicy                                            | `[]`        |
 | `networkPolicy.ingressNSMatchLabels`        | Labels to match to allow traffic from other namespaces                                  | `{}`        |

--- a/bitnami/zookeeper/templates/networkpolicy.yaml
+++ b/bitnami/zookeeper/templates/networkpolicy.yaml
@@ -20,6 +20,10 @@ spec:
   policyTypes:
     - Ingress
     - Egress
+  {{- if .Values.networkPolicy.allowExternalEgress }}
+  egress:
+    - {}
+  {{- else }}
   egress:
     # Allow dns resolution
     - ports:
@@ -37,6 +41,7 @@ spec:
     {{- if .Values.networkPolicy.extraEgress }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.rts.networkPolicy.extraEgress "context" $ ) | nindent 4 }}
     {{- end }}
+  {{- end }}
   ingress:
     # Allow inbound connections to ZooKeeper
     - ports:

--- a/bitnami/zookeeper/values.yaml
+++ b/bitnami/zookeeper/values.yaml
@@ -608,6 +608,9 @@ networkPolicy:
   ## listening on. When true, zookeeper accept connections from any source (with the correct destination port).
   ##
   allowExternal: true
+  ## @param networkPolicy.allowExternalEgress Allow the pod to access any range of port and all destinations.
+  ##
+  allowExternalEgress: true
   ## @param networkPolicy.extraIngress [array] Add extra ingress rules to the NetworkPolice
   ## e.g:
   ## extraIngress:


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

This PR adds the value allowExternalEgress to the created NetworkPolicy. In order to avoid bumping a major change, we set this value to true by default. This should avoid issues with Istio.

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes https://github.com/bitnami/charts/issues/22934

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [ ] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [ ] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
