### PR TITLE
[bitnami/mysql] feat: :lock: Enable networkPolicy

### DIFF
--- a/bitnami/mysql/Chart.yaml
+++ b/bitnami/mysql/Chart.yaml
@@ -34,4 +34,4 @@ maintainers:
 name: mysql
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/mysql
-version: 9.18.2
+version: 9.19.0

--- a/bitnami/mysql/README.md
+++ b/bitnami/mysql/README.md
@@ -118,6 +118,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `primary.hostAliases`                                       | Deployment pod host aliases                                                                                     | `[]`                |
 | `primary.configuration`                                     | Configure MySQL Primary with a custom my.cnf file                                                               | `""`                |
 | `primary.existingConfigmap`                                 | Name of existing ConfigMap with MySQL Primary configuration.                                                    | `""`                |
+| `primary.containerPorts.mysql`                              | Container port for mysql                                                                                        | `3306`              |
 | `primary.updateStrategy.type`                               | Update strategy type for the MySQL primary statefulset                                                          | `RollingUpdate`     |
 | `primary.podAnnotations`                                    | Additional pod annotations for MySQL primary pods                                                               | `{}`                |
 | `primary.podAffinityPreset`                                 | MySQL primary pod affinity preset. Ignored if `primary.affinity` is set. Allowed values: `soft` or `hard`       | `""`                |
@@ -220,6 +221,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `secondary.lifecycleHooks`                                    | for the MySQL Secondary container(s) to automate configuration before or after startup                              | `{}`                |
 | `secondary.configuration`                                     | Configure MySQL Secondary with a custom my.cnf file                                                                 | `""`                |
 | `secondary.existingConfigmap`                                 | Name of existing ConfigMap with MySQL Secondary configuration.                                                      | `""`                |
+| `secondary.containerPorts.mysql`                              | Container port for mysql                                                                                            | `3306`              |
 | `secondary.updateStrategy.type`                               | Update strategy type for the MySQL secondary statefulset                                                            | `RollingUpdate`     |
 | `secondary.podAnnotations`                                    | Additional pod annotations for MySQL secondary pods                                                                 | `{}`                |
 | `secondary.podAffinityPreset`                                 | MySQL secondary pod affinity preset. Ignored if `secondary.affinity` is set. Allowed values: `soft` or `hard`       | `""`                |
@@ -322,11 +324,15 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Network Policy
 
-| Name                                       | Description                                                                                                     | Value   |
-| ------------------------------------------ | --------------------------------------------------------------------------------------------------------------- | ------- |
-| `networkPolicy.enabled`                    | Enable creation of NetworkPolicy resources                                                                      | `false` |
-| `networkPolicy.allowExternal`              | The Policy model to apply.                                                                                      | `true`  |
-| `networkPolicy.explicitNamespacesSelector` | A Kubernetes LabelSelector to explicitly select namespaces from which ingress traffic could be allowed to MySQL | `{}`    |
+| Name                                    | Description                                                     | Value  |
+| --------------------------------------- | --------------------------------------------------------------- | ------ |
+| `networkPolicy.enabled`                 | Enable creation of NetworkPolicy resources                      | `true` |
+| `networkPolicy.allowExternal`           | The Policy model to apply                                       | `true` |
+| `networkPolicy.allowExternalEgress`     | Allow the pod to access any range of port and all destinations. | `true` |
+| `networkPolicy.extraIngress`            | Add extra ingress rules to the NetworkPolicy                    | `[]`   |
+| `networkPolicy.extraEgress`             | Add extra ingress rules to the NetworkPolicy                    | `[]`   |
+| `networkPolicy.ingressNSMatchLabels`    | Labels to match to allow traffic from other namespaces          | `{}`   |
+| `networkPolicy.ingressNSPodMatchLabels` | Pod labels to match to allow traffic from other namespaces      | `{}`   |
 
 ### Volume Permissions parameters
 
@@ -354,6 +360,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `metrics.containerSecurityContext.seLinuxOptions` | Set SELinux options in container                                                                                               | `nil`                             |
 | `metrics.containerSecurityContext.runAsUser`      | User ID for the MySQL metrics container                                                                                        | `1001`                            |
 | `metrics.containerSecurityContext.runAsNonRoot`   | Set MySQL metrics container's Security Context runAsNonRoot                                                                    | `true`                            |
+| `metrics.containerPorts.http`                     | Container port for http                                                                                                        | `9104`                            |
 | `metrics.service.type`                            | Kubernetes service type for MySQL Prometheus Exporter                                                                          | `ClusterIP`                       |
 | `metrics.service.clusterIP`                       | Kubernetes service clusterIP for MySQL Prometheus Exporter                                                                     | `""`                              |
 | `metrics.service.port`                            | MySQL Prometheus Exporter service port                                                                                         | `9104`                            |

--- a/bitnami/mysql/templates/networkpolicy.yaml
+++ b/bitnami/mysql/templates/networkpolicy.yaml
@@ -15,26 +15,64 @@ metadata:
   {{- end }}
 spec:
   podSelector:
-    matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 6 }}
-  ingress:
-    # Allow inbound connections
+    matchLabels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  {{- if .Values.networkPolicy.allowExternalEgress }}
+  egress:
+    - {}
+  {{- else }}
+  egress:
+    # Allow dns resolution
     - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+    # Allow connection to other cluster pods
+    - ports:
+        - port: {{ .Values.primary.containerPorts.mysql }}
+        - port: {{ .Values.secondary.containerPorts.mysql }}
         - port: {{ .Values.primary.service.ports.mysql }}
+        - port: {{ .Values.secondary.service.ports.mysql }}
+      to:
+        - podSelector:
+            matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 14 }}
+    {{- if .Values.networkPolicy.extraEgress }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.rts.networkPolicy.extraEgress "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- end }}
+  ingress:
+    - ports:
+        - port: {{ .Values.primary.containerPorts.mysql }}
+        - port: {{ .Values.secondary.containerPorts.mysql }}
+      {{- if .Values.metrics.enabled }}
+        - port: {{ .Values.metrics.containerPorts.http }}
+      {{- end }}
       {{- if not .Values.networkPolicy.allowExternal }}
       from:
         - podSelector:
             matchLabels:
               {{ template "common.names.fullname" . }}-client: "true"
-          {{- if .Values.networkPolicy.explicitNamespacesSelector }}
-          namespaceSelector:
-{{ toYaml .Values.networkPolicy.explicitNamespacesSelector | indent 12 }}
-          {{- end }}
         - podSelector:
             matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 14 }}
+        {{- if .Values.networkPolicy.ingressNSMatchLabels }}
+        - namespaceSelector:
+            matchLabels:
+              {{- range $key, $value := .Values.networkPolicy.ingressNSMatchLabels }}
+              {{ $key | quote }}: {{ $value | quote }}
+              {{- end }}
+          {{- if .Values.networkPolicy.ingressNSPodMatchLabels }}
+          podSelector:
+            matchLabels:
+              {{- range $key, $value := .Values.networkPolicy.ingressNSPodMatchLabels }}
+              {{ $key | quote }}: {{ $value | quote }}
+              {{- end }}
+          {{- end }}
+        {{- end }}
       {{- end }}
-    {{- if .Values.metrics.enabled }}
-    # Allow prometheus scrapes
-    - ports:
-        - port: 9104
+    {{- if .Values.networkPolicy.extraIngress }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.networkPolicy.extraIngress "context" $ ) | nindent 4 }}
     {{- end }}
 {{- end }}

--- a/bitnami/mysql/templates/primary/statefulset.yaml
+++ b/bitnami/mysql/templates/primary/statefulset.yaml
@@ -151,6 +151,8 @@ spec:
                   key: mysql-password
             {{- end }}
             {{- end }}
+            - name: MYSQL_PORT
+              value: {{ .Values.primary.containerPorts.mysql | quote}}
             {{- if and .Values.auth.createDatabase .Values.auth.database }}
             - name: MYSQL_DATABASE
               value: {{ .Values.auth.database | quote }}
@@ -299,11 +301,11 @@ spec:
               if [[ -f "${MYSQL_ROOT_PASSWORD_FILE:-}" ]]; then
                   password_aux=$(cat "$MYSQL_ROOT_PASSWORD_FILE")
               fi
-              MYSQLD_EXPORTER_PASSWORD=${password_aux} /bin/mysqld_exporter --mysqld.address=localhost:3306 --mysqld.username=root {{- range .Values.metrics.extraArgs.primary }} {{ . }} {{- end }}
+              MYSQLD_EXPORTER_PASSWORD=${password_aux} /bin/mysqld_exporter --mysqld.address=localhost:3306 --mysqld.username=root --web.listen-address=:{{ .Values.metrics.containerPorts.http }} {{- range .Values.metrics.extraArgs.primary }} {{ . }} {{- end }}
           {{- end }}
           ports:
             - name: metrics
-              containerPort: 9104
+              containerPort: {{ .Values.metrics.containerPorts.http }}
           {{- if not .Values.diagnosticMode.enabled }}
           {{- if .Values.metrics.livenessProbe.enabled }}
           livenessProbe: {{- omit .Values.metrics.livenessProbe "enabled" | toYaml | nindent 12 }}

--- a/bitnami/mysql/templates/secondary/statefulset.yaml
+++ b/bitnami/mysql/templates/secondary/statefulset.yaml
@@ -136,6 +136,8 @@ spec:
               value: {{ .Values.primary.service.ports.mysql | quote }}
             - name: MYSQL_MASTER_ROOT_USER
               value: "root"
+            - name: MYSQL_PORT
+              value: {{ .Values.secondary.containerPorts.mysql | quote}}
             - name: MYSQL_REPLICATION_USER
               value: {{ .Values.auth.replicationUser | quote }}
             {{- if .Values.auth.usePasswordFiles }}
@@ -287,7 +289,7 @@ spec:
           {{- end }}
           ports:
             - name: metrics
-              containerPort: 9104
+              containerPort: {{ .Values.metrics.containerPorts.http }}
           {{- if not .Values.diagnosticMode.enabled }}
           {{- if .Values.metrics.livenessProbe.enabled }}
           livenessProbe: {{- omit .Values.metrics.livenessProbe "enabled" | toYaml | nindent 12 }}

--- a/bitnami/mysql/values.yaml
+++ b/bitnami/mysql/values.yaml
@@ -212,7 +212,7 @@ primary:
     explicit_defaults_for_timestamp
     basedir=/opt/bitnami/mysql
     plugin_dir=/opt/bitnami/mysql/lib/plugin
-    port=3306
+    port= {{ .Values.primary.containerPorts.mysql }}
     socket=/opt/bitnami/mysql/tmp/mysql.sock
     datadir=/bitnami/mysql/data
     tmpdir=/opt/bitnami/mysql/tmp
@@ -238,6 +238,10 @@ primary:
   ## NOTE: When it's set the 'configuration' parameter is ignored
   ##
   existingConfigmap: ""
+  ## @param primary.containerPorts.mysql Container port for mysql
+  ##
+  containerPorts:
+    mysql: 3306
   ## @param primary.updateStrategy.type Update strategy type for the MySQL primary statefulset
   ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies
   ##
@@ -624,7 +628,7 @@ secondary:
     explicit_defaults_for_timestamp
     basedir=/opt/bitnami/mysql
     plugin_dir=/opt/bitnami/mysql/lib/plugin
-    port=3306
+    port={{ .Values.secondary.containerPorts.mysql }}
     socket=/opt/bitnami/mysql/tmp/mysql.sock
     datadir=/bitnami/mysql/data
     tmpdir=/opt/bitnami/mysql/tmp
@@ -650,6 +654,10 @@ secondary:
   ## NOTE: When it's set the 'configuration' parameter is ignored
   ##
   existingConfigmap: ""
+  ## @param secondary.containerPorts.mysql Container port for mysql
+  ##
+  containerPorts:
+    mysql: 3306
   ## @param secondary.updateStrategy.type Update strategy type for the MySQL secondary statefulset
   ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies
   ##
@@ -1045,33 +1053,61 @@ rbac:
 ## @section Network Policy
 ##
 
-## MySQL Nework Policy configuration
+## Network Policy configuration
+## ref: https://kubernetes.io/docs/concepts/services-networking/network-policies/
 ##
 networkPolicy:
   ## @param networkPolicy.enabled Enable creation of NetworkPolicy resources
   ##
-  enabled: false
-  ## @param networkPolicy.allowExternal The Policy model to apply.
-  ## When set to false, only pods with the correct
-  ## client label will have network access to the port MySQL is listening
-  ## on. When true, MySQL will accept connections from any source
-  ## (with the correct destination port).
+  enabled: true
+  ## @param networkPolicy.allowExternal The Policy model to apply
+  ## When set to false, only pods with the correct client label will have network access to the ports Keycloak is
+  ## listening on. When true, Keycloak will accept connections from any source (with the correct destination port).
   ##
   allowExternal: true
-  ## @param networkPolicy.explicitNamespacesSelector A Kubernetes LabelSelector to explicitly select namespaces from which ingress traffic could be allowed to MySQL
-  ## If explicitNamespacesSelector is missing or set to {}, only client Pods that are in the networkPolicy's namespace
-  ## and that match other criteria, the ones that have the good label, can reach the DB.
-  ## But sometimes, we want the DB to be accessible to clients from other namespaces, in this case, we can use this
-  ## LabelSelector to select these namespaces, note that the networkPolicy's namespace should also be explicitly added.
+  ## @param networkPolicy.allowExternalEgress Allow the pod to access any range of port and all destinations.
   ##
-  ## Example:
-  ## explicitNamespacesSelector:
-  ##   matchLabels:
-  ##     role: frontend
-  ##   matchExpressions:
-  ##    - {key: role, operator: In, values: [frontend]}
+  allowExternalEgress: true
+  ## @param networkPolicy.extraIngress [array] Add extra ingress rules to the NetworkPolicy
+  ## e.g:
+  ## extraIngress:
+  ##   - ports:
+  ##       - port: 1234
+  ##     from:
+  ##       - podSelector:
+  ##           - matchLabels:
+  ##               - role: frontend
+  ##       - podSelector:
+  ##           - matchExpressions:
+  ##               - key: role
+  ##                 operator: In
+  ##                 values:
+  ##                   - frontend
   ##
-  explicitNamespacesSelector: {}
+  extraIngress: []
+  ## @param networkPolicy.extraEgress [array] Add extra ingress rules to the NetworkPolicy
+  ## e.g:
+  ## extraEgress:
+  ##   - ports:
+  ##       - port: 1234
+  ##     to:
+  ##       - podSelector:
+  ##           - matchLabels:
+  ##               - role: frontend
+  ##       - podSelector:
+  ##           - matchExpressions:
+  ##               - key: role
+  ##                 operator: In
+  ##                 values:
+  ##                   - frontend
+  ##
+  extraEgress: []
+  ## @param networkPolicy.ingressNSMatchLabels [object] Labels to match to allow traffic from other namespaces
+  ## @param networkPolicy.ingressNSPodMatchLabels [object] Pod labels to match to allow traffic from other namespaces
+  ##
+  ingressNSMatchLabels: {}
+  ingressNSPodMatchLabels: {}
+
 
 ## @section Volume Permissions parameters
 ##
@@ -1150,6 +1186,10 @@ metrics:
     seLinuxOptions: null
     runAsUser: 1001
     runAsNonRoot: true
+  ## @param metrics.containerPorts.http Container port for http
+  ##
+  containerPorts:
+    http: 9104
   ## MySQL Prometheus exporter service parameters
   ## Mysqld Prometheus exporter liveness and readiness probes
   ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

This PR normalizes the use of NetworkPolicy in the chart. Adds all Bitnami standards for NetworkPolicies as well as enabling it by default, in order to comply with security checklists.

<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

More security in the chart
<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
