### PR TITLE
[bitnami/nginx] Fix NetworkPolicy

### DIFF
--- a/bitnami/nginx/Chart.yaml
+++ b/bitnami/nginx/Chart.yaml
@@ -34,4 +34,4 @@ maintainers:
 name: nginx
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/nginx
-version: 15.10.2
+version: 15.10.3

--- a/bitnami/nginx/templates/networkpolicy.yaml
+++ b/bitnami/nginx/templates/networkpolicy.yaml
@@ -19,12 +19,9 @@ spec:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
   policyTypes:
     - Ingress
+  {{- if not .Values.networkPolicy.allowExternalEgress }}
     - Egress
   egress:
-    {{- if .Values.networkPolicy.allowExternalEgress }}
-    - ports:
-        - {}
-    {{- else }}
     - ports:
         # Allow dns resolution
         - port: 53
@@ -34,7 +31,7 @@ spec:
     {{- if .Values.networkPolicy.extraEgress }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.networkPolicy.extraEgress "context" $ ) | nindent 4 }}
     {{- end }}
-    {{- end }}
+  {{- end }}
   ingress:
     - ports:
         - port: {{ .Values.containerPorts.http }}


### PR DESCRIPTION
### Description of the change
#22875 introduced the use of `NetworkPolicy`. Unfortunately this denies all outgoing traffic when `networkPolicy.allowExternalEgress` is set to `true` (default).

This PR fixes this behavior.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
