### PR TITLE
[bitnami/redis-cluster] add dnsPolicy

### DIFF
--- a/bitnami/redis-cluster/templates/redis-statefulset.yaml
+++ b/bitnami/redis-cluster/templates/redis-statefulset.yaml
@@ -43,6 +43,7 @@ spec:
         {{- end }}
     spec:
       hostNetwork: {{ .Values.redis.hostNetwork }}
+      dnsPolicy: {{ .Values.redis.dnsPolicy }}
       {{- if semverCompare ">= 1.13" (include "common.capabilities.kubeVersion" .) }}
       enableServiceLinks: false
       {{- end }}

--- a/bitnami/redis-cluster/values.yaml
+++ b/bitnami/redis-cluster/values.yaml
@@ -499,6 +499,10 @@ redis:
   ## https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#podspec-v1-core
   ##
   hostNetwork: false
+  ## @param redis.dnsPolicy, Pod's DNS Policy.
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
+  ##
+  dnsPolicy: ClusterFirst
   ## @param redis.useAOFPersistence Whether to use AOF Persistence mode or not
   ## It is strongly recommended to use this type when dealing with clusters
   ## ref: https://redis.io/topics/persistence#append-only-file


### PR DESCRIPTION
 Signed-off-by: xu zhao <zhaoxu@01.ai>

### Description of the change
When Redis cluster is configured with hostNetwork, it cannot resolve the Redis service addres and always sleep 5s. so we need modify dnsPolicy to ClusterFirstWithHostNet.

### Benefits

Redis clusters can work with host networks.

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #23198

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [ ] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [ ] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
