### PR TITLE
[bitnami/jaeger] feat: :lock: Enable networkPolicy

### DIFF
--- a/bitnami/jaeger/Chart.yaml
+++ b/bitnami/jaeger/Chart.yaml
@@ -34,4 +34,4 @@ maintainers:
 name: jaeger
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/jaeger
-version: 1.7.5
+version: 1.8.0

--- a/bitnami/jaeger/README.md
+++ b/bitnami/jaeger/README.md
@@ -140,6 +140,13 @@ The command removes all the Kubernetes components associated with the chart and 
 | `query.service.sessionAffinity`                           | Session Affinity for Kubernetes service, can be "None" or "ClientIP"                      | `None`           |
 | `query.service.sessionAffinityConfig`                     | Additional settings for the sessionAffinity                                               | `{}`             |
 | `query.service.metrics.annotations`                       | Annotations for Prometheus metrics                                                        | `{}`             |
+| `query.networkPolicy.enabled`                             | Specifies whether a NetworkPolicy should be created                                       | `true`           |
+| `query.networkPolicy.allowExternal`                       | Don't require server label for connections                                                | `true`           |
+| `query.networkPolicy.allowExternalEgress`                 | Allow the pod to access any range of port and all destinations.                           | `true`           |
+| `query.networkPolicy.extraIngress`                        | Add extra ingress rules to the NetworkPolice                                              | `[]`             |
+| `query.networkPolicy.extraEgress`                         | Add extra ingress rules to the NetworkPolicy                                              | `[]`             |
+| `query.networkPolicy.ingressNSMatchLabels`                | Labels to match to allow traffic from other namespaces                                    | `{}`             |
+| `query.networkPolicy.ingressNSPodMatchLabels`             | Pod labels to match to allow traffic from other namespaces                                | `{}`             |
 | `query.serviceAccount.create`                             | Enables ServiceAccount                                                                    | `true`           |
 | `query.serviceAccount.name`                               | ServiceAccount name                                                                       | `""`             |
 | `query.serviceAccount.annotations`                        | Annotations to add to all deployed objects                                                | `{}`             |
@@ -242,6 +249,13 @@ The command removes all the Kubernetes components associated with the chart and 
 | `collector.service.sessionAffinity`                           | Session Affinity for Kubernetes service, can be "None" or "ClientIP"                       | `None`           |
 | `collector.service.sessionAffinityConfig`                     | Additional settings for the sessionAffinity                                                | `{}`             |
 | `collector.service.metrics.annotations`                       | Annotations for Prometheus metrics                                                         | `{}`             |
+| `collector.networkPolicy.enabled`                             | Specifies whether a NetworkPolicy should be created                                        | `true`           |
+| `collector.networkPolicy.allowExternal`                       | Don't require server label for connections                                                 | `true`           |
+| `collector.networkPolicy.allowExternalEgress`                 | Allow the pod to access any range of port and all destinations.                            | `true`           |
+| `collector.networkPolicy.extraIngress`                        | Add extra ingress rules to the NetworkPolice                                               | `[]`             |
+| `collector.networkPolicy.extraEgress`                         | Add extra ingress rules to the NetworkPolicy                                               | `[]`             |
+| `collector.networkPolicy.ingressNSMatchLabels`                | Labels to match to allow traffic from other namespaces                                     | `{}`             |
+| `collector.networkPolicy.ingressNSPodMatchLabels`             | Pod labels to match to allow traffic from other namespaces                                 | `{}`             |
 | `collector.serviceAccount.create`                             | Enables ServiceAccount                                                                     | `true`           |
 | `collector.serviceAccount.name`                               | ServiceAccount name                                                                        | `""`             |
 | `collector.serviceAccount.annotations`                        | Annotations to add to all deployed objects                                                 | `{}`             |
@@ -341,6 +355,13 @@ The command removes all the Kubernetes components associated with the chart and 
 | `agent.service.sessionAffinity`                               | Session Affinity for Kubernetes service, can be "None" or "ClientIP"                                           | `None`           |
 | `agent.service.sessionAffinityConfig`                         | Additional settings for the sessionAffinity                                                                    | `{}`             |
 | `agent.service.metrics.annotations`                           | Annotations for Prometheus metrics                                                                             | `{}`             |
+| `agent.networkPolicy.enabled`                                 | Specifies whether a NetworkPolicy should be created                                                            | `true`           |
+| `agent.networkPolicy.allowExternal`                           | Don't require server label for connections                                                                     | `true`           |
+| `agent.networkPolicy.allowExternalEgress`                     | Allow the pod to access any range of port and all destinations.                                                | `true`           |
+| `agent.networkPolicy.extraIngress`                            | Add extra ingress rules to the NetworkPolice                                                                   | `[]`             |
+| `agent.networkPolicy.extraEgress`                             | Add extra ingress rules to the NetworkPolicy                                                                   | `[]`             |
+| `agent.networkPolicy.ingressNSMatchLabels`                    | Labels to match to allow traffic from other namespaces                                                         | `{}`             |
+| `agent.networkPolicy.ingressNSPodMatchLabels`                 | Pod labels to match to allow traffic from other namespaces                                                     | `{}`             |
 | `agent.serviceAccount.create`                                 | Enables ServiceAccount                                                                                         | `true`           |
 | `agent.serviceAccount.name`                                   | ServiceAccount name                                                                                            | `""`             |
 | `agent.serviceAccount.annotations`                            | Annotations to add to all deployed objects                                                                     | `{}`             |
@@ -400,6 +421,13 @@ The command removes all the Kubernetes components associated with the chart and 
 | `migration.extraVolumeMounts`                                 | Optionally specify extra list of additional volumeMounts for jaeger container                                  | `[]`             |
 | `migration.resources.limits`                                  | The resources limits for Jaeger containers                                                                     | `{}`             |
 | `migration.resources.requests`                                | The requested resources for Jaeger containers                                                                  | `{}`             |
+| `migration.networkPolicy.enabled`                             | Specifies whether a NetworkPolicy should be created                                                            | `true`           |
+| `migration.networkPolicy.allowExternal`                       | Don't require server label for connections                                                                     | `true`           |
+| `migration.networkPolicy.allowExternalEgress`                 | Allow the pod to access any range of port and all destinations.                                                | `true`           |
+| `migration.networkPolicy.extraIngress`                        | Add extra ingress rules to the NetworkPolice                                                                   | `[]`             |
+| `migration.networkPolicy.extraEgress`                         | Add extra ingress rules to the NetworkPolicy                                                                   | `[]`             |
+| `migration.networkPolicy.ingressNSMatchLabels`                | Labels to match to allow traffic from other namespaces                                                         | `{}`             |
+| `migration.networkPolicy.ingressNSPodMatchLabels`             | Pod labels to match to allow traffic from other namespaces                                                     | `{}`             |
 | `migration.extraVolumes`                                      | Optionally specify extra list of additional volumes for jaeger container                                       | `[]`             |
 
 ### Set the image to use for the migration job

--- a/bitnami/jaeger/templates/agent/networkpolicy.yaml
+++ b/bitnami/jaeger/templates/agent/networkpolicy.yaml
@@ -1,0 +1,112 @@
+{{- /*
+Copyright VMware, Inc.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+{{- if .Values.agent.networkPolicy.enabled }}
+kind: NetworkPolicy
+apiVersion: {{ include "common.capabilities.networkPolicy.apiVersion" . }}
+metadata:
+  name: {{ template "jaeger.agent.fullname" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+    app.kubernetes.io/component: agent
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.agent.podLabels .Values.commonLabels ) "context" . ) }}
+  podSelector:
+    matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
+      app.kubernetes.io/component: agent
+  policyTypes:
+    - Ingress
+    - Egress
+  {{- if .Values.agent.networkPolicy.allowExternalEgress }}
+  egress:
+    - {}
+  {{- else }}
+  egress:
+    # Allow dns resolution
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+    # Allow outbound connections to other agent pods
+    - ports:
+        - port: {{ .Values.agent.containerPorts.binary }}
+        - port: {{ .Values.agent.containerPorts.zipkin }}
+        - port: {{ .Values.agent.containerPorts.admin }}
+        - port: {{ .Values.agent.containerPorts.compact }}
+        - port: {{ .Values.agent.containerPorts.config }}
+      to:
+        - podSelector:
+            matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 14 }}
+              app.kubernetes.io/component: agent
+    # Allow outbound connections to other collector pods
+    - ports:
+        - port: {{ .Values.collector.containerPorts.binary }}
+        - port: {{ .Values.collector.containerPorts.zipkin }}
+        - port: {{ .Values.collector.containerPorts.grpc }}
+        - port: {{ .Values.collector.containerPorts.admin }}
+        - port: {{ .Values.collector.containerPorts.otlp.grpc }}
+        - port: {{ .Values.collector.containerPorts.otlp.http }}
+      to:
+        - podSelector:
+            matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 14 }}
+              app.kubernetes.io/component: collector
+    # Allow outbound connections to other query pods
+    - ports:
+        - port: {{ .Values.query.containerPorts.admin }}
+      to:
+        - podSelector:
+            matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 14 }}
+              app.kubernetes.io/component: query
+    # Allow outbound connections to Cassandra
+    - ports:
+        - port: {{ include "jaeger.cassandra.port" . | trimAll "\"" | int }}
+      {{- if .Values.cassandra.enabled }}
+      to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: cassandra
+              app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- end }}
+    {{- if .Values.agent.networkPolicy.extraEgress }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.agent.networkPolicy.extraEgress "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- end }}
+  ingress:
+    - ports:
+        - port: {{ .Values.agent.containerPorts.binary }}
+        - port: {{ .Values.agent.containerPorts.zipkin }}
+        - port: {{ .Values.agent.containerPorts.admin }}
+        - port: {{ .Values.agent.containerPorts.compact }}
+        - port: {{ .Values.agent.containerPorts.config }}
+      {{- if not .Values.agent.networkPolicy.allowExternal }}
+      from:
+        - podSelector:
+            matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 14 }}
+        - podSelector:
+            matchLabels:
+              {{ template "jaeger.agent.fullname" . }}-client: "true"
+        {{- if .Values.agent.networkPolicy.ingressNSMatchLabels }}
+        - namespaceSelector:
+            matchLabels:
+              {{- range $key, $value := .Values.agent.networkPolicy.ingressNSMatchLabels }}
+              {{ $key | quote }}: {{ $value | quote }}
+              {{- end }}
+          {{- if .Values.agent.networkPolicy.ingressNSPodMatchLabels }}
+          podSelector:
+            matchLabels:
+              {{- range $key, $value := .Values.agent.networkPolicy.ingressNSPodMatchLabels }}
+              {{ $key | quote }}: {{ $value | quote }}
+              {{- end }}
+          {{- end }}
+        {{- end }}
+      {{- end }}
+    {{- if .Values.agent.networkPolicy.extraIngress }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.agent.networkPolicy.extraIngress "context" $ ) | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/bitnami/jaeger/templates/collector/networkpolicy.yaml
+++ b/bitnami/jaeger/templates/collector/networkpolicy.yaml
@@ -1,0 +1,111 @@
+{{- /*
+Copyright VMware, Inc.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+{{- if .Values.collector.networkPolicy.enabled }}
+kind: NetworkPolicy
+apiVersion: {{ include "common.capabilities.networkPolicy.apiVersion" . }}
+metadata:
+  name: {{ template "jaeger.collector.fullname" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+    app.kubernetes.io/component: collector
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.collector.podLabels .Values.commonLabels ) "context" . ) }}
+  podSelector:
+    matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
+      app.kubernetes.io/component: collector
+  policyTypes:
+    - Ingress
+    - Egress
+  {{- if .Values.collector.networkPolicy.allowExternalEgress }}
+  egress:
+    - {}
+  {{- else }}
+  egress:
+    # Allow dns resolution
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+    # Allow outbound connections to other agent pods
+    - ports:
+        - port: {{ .Values.agent.containerPorts.binary }}
+        - port: {{ .Values.agent.containerPorts.zipkin }}
+        - port: {{ .Values.agent.containerPorts.admin }}
+        - port: {{ .Values.agent.containerPorts.compact }}
+        - port: {{ .Values.agent.containerPorts.config }}
+      to:
+        - podSelector:
+            matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 14 }}
+              app.kubernetes.io/component: agent
+    # Allow outbound connections to other collector pods
+    - ports:
+        - port: {{ .Values.collector.containerPorts.binary }}
+        - port: {{ .Values.collector.containerPorts.zipkin }}
+        - port: {{ .Values.collector.containerPorts.grpc }}
+        - port: {{ .Values.collector.containerPorts.admin }}
+      to:
+        - podSelector:
+            matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 14 }}
+              app.kubernetes.io/component: collector
+    # Allow outbound connections to other query pods
+    - ports:
+        - port: {{ .Values.query.containerPorts.admin }}
+      to:
+        - podSelector:
+            matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 14 }}
+              app.kubernetes.io/component: query
+    # Allow outbound connections to Cassandra
+    - ports:
+        - port: {{ include "jaeger.cassandra.port" . | trimAll "\"" | int }}
+      {{- if .Values.cassandra.enabled }}
+      to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: cassandra
+              app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- end }}
+    {{- if .Values.collector.networkPolicy.extraEgress }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.collector.networkPolicy.extraEgress "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- end }}
+  ingress:
+    - ports:
+        - port: {{ .Values.collector.containerPorts.binary }}
+        - port: {{ .Values.collector.containerPorts.zipkin }}
+        - port: {{ .Values.collector.containerPorts.grpc }}
+        - port: {{ .Values.collector.containerPorts.admin }}
+        - port: {{ .Values.collector.containerPorts.otlp.grpc }}
+        - port: {{ .Values.collector.containerPorts.otlp.http }}
+      {{- if not .Values.collector.networkPolicy.allowExternal }}
+      from:
+        - podSelector:
+            matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 14 }}
+        - podSelector:
+            matchLabels:
+              {{ template "jaeger.collector.fullname" . }}-client: "true"
+        {{- if .Values.collector.networkPolicy.ingressNSMatchLabels }}
+        - namespaceSelector:
+            matchLabels:
+              {{- range $key, $value := .Values.collector.networkPolicy.ingressNSMatchLabels }}
+              {{ $key | quote }}: {{ $value | quote }}
+              {{- end }}
+          {{- if .Values.collector.networkPolicy.ingressNSPodMatchLabels }}
+          podSelector:
+            matchLabels:
+              {{- range $key, $value := .Values.collector.networkPolicy.ingressNSPodMatchLabels }}
+              {{ $key | quote }}: {{ $value | quote }}
+              {{- end }}
+          {{- end }}
+        {{- end }}
+      {{- end }}
+    {{- if .Values.collector.networkPolicy.extraIngress }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.collector.networkPolicy.extraIngress "context" $ ) | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/bitnami/jaeger/templates/migrate-networkpolicy.yaml
+++ b/bitnami/jaeger/templates/migrate-networkpolicy.yaml
@@ -1,0 +1,54 @@
+{{- /*
+Copyright VMware, Inc.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+{{- if .Values.migration.networkPolicy.enabled }}
+kind: NetworkPolicy
+apiVersion: {{ include "common.capabilities.networkPolicy.apiVersion" . }}
+metadata:
+  name: {{ include "common.names.fullname" . }}-migrate
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+    app.kubernetes.io/component: migration
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.migration.podLabels .Values.commonLabels ) "context" . ) }}
+  podSelector:
+    matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
+      app.kubernetes.io/component: migration
+  policyTypes:
+    - Ingress
+    - Egress
+  {{- if .Values.migration.networkPolicy.allowExternalEgress }}
+  egress:
+    - {}
+  {{- else }}
+  egress:
+    # Allow dns resolution
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+    # Allow outbound connections to Cassandra
+    - ports:
+        - port: {{ include "jaeger.cassandra.port" . | trimAll "\"" | int }}
+      {{- if .Values.cassandra.enabled }}
+      to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: cassandra
+              app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- end }}
+    {{- if .Values.migration.networkPolicy.extraEgress }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.migration.networkPolicy.extraEgress "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- end }}
+  ingress:
+    {{- if .Values.migration.networkPolicy.extraIngress }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.migration.networkPolicy.extraIngress "context" $ ) | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/bitnami/jaeger/templates/query/networkpolicy.yaml
+++ b/bitnami/jaeger/templates/query/networkpolicy.yaml
@@ -1,0 +1,108 @@
+{{- /*
+Copyright VMware, Inc.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+{{- if .Values.query.networkPolicy.enabled }}
+kind: NetworkPolicy
+apiVersion: {{ include "common.capabilities.networkPolicy.apiVersion" . }}
+metadata:
+  name: {{ template "jaeger.query.fullname" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+    app.kubernetes.io/component: query
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.query.podLabels .Values.commonLabels ) "context" . ) }}
+  podSelector:
+    matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
+      app.kubernetes.io/component: query
+  policyTypes:
+    - Ingress
+    - Egress
+  {{- if .Values.query.networkPolicy.allowExternalEgress }}
+  egress:
+    - {}
+  {{- else }}
+  egress:
+    # Allow dns resolution
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+    # Allow outbound connections to other agent pods
+    - ports:
+        - port: {{ .Values.agent.containerPorts.binary }}
+        - port: {{ .Values.agent.containerPorts.zipkin }}
+        - port: {{ .Values.agent.containerPorts.admin }}
+        - port: {{ .Values.agent.containerPorts.compact }}
+        - port: {{ .Values.agent.containerPorts.config }}
+      to:
+        - podSelector:
+            matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 14 }}
+              app.kubernetes.io/component: agent
+    # Allow outbound connections to other collector pods
+    - ports:
+        - port: {{ .Values.collector.containerPorts.binary }}
+        - port: {{ .Values.collector.containerPorts.zipkin }}
+        - port: {{ .Values.collector.containerPorts.grpc }}
+        - port: {{ .Values.collector.containerPorts.admin }}
+      to:
+        - podSelector:
+            matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 14 }}
+              app.kubernetes.io/component: collector
+    # Allow outbound connections to other query pods
+    - ports:
+        - port: {{ .Values.query.containerPorts.admin }}
+        - port: {{ .Values.query.containerPorts.ui }}
+      to:
+        - podSelector:
+            matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 14 }}
+              app.kubernetes.io/component: query
+    # Allow outbound connections to Cassandra
+    - ports:
+        - port: {{ include "jaeger.cassandra.port" . | trimAll "\"" | int }}
+      {{- if .Values.cassandra.enabled }}
+      to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: cassandra
+              app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- end }}
+    {{- if .Values.query.networkPolicy.extraEgress }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.query.networkPolicy.extraEgress "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- end }}
+  ingress:
+    - ports:
+        - port: {{ .Values.query.containerPorts.admin }}
+        - port: {{ .Values.query.containerPorts.ui }}
+      {{- if not .Values.collector.networkPolicy.allowExternal }}
+      from:
+        - podSelector:
+            matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 14 }}
+        - podSelector:
+            matchLabels:
+              {{ template "jaeger.query.fullname" . }}-client: "true"
+        {{- if .Values.query.networkPolicy.ingressNSMatchLabels }}
+        - namespaceSelector:
+            matchLabels:
+              {{- range $key, $value := .Values.query.networkPolicy.ingressNSMatchLabels }}
+              {{ $key | quote }}: {{ $value | quote }}
+              {{- end }}
+          {{- if .Values.query.networkPolicy.ingressNSPodMatchLabels }}
+          podSelector:
+            matchLabels:
+              {{- range $key, $value := .Values.query.networkPolicy.ingressNSPodMatchLabels }}
+              {{ $key | quote }}: {{ $value | quote }}
+              {{- end }}
+          {{- end }}
+        {{- end }}
+      {{- end }}
+    {{- if .Values.query.networkPolicy.extraIngress }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.query.networkPolicy.extraIngress "context" $ ) | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/bitnami/jaeger/values.yaml
+++ b/bitnami/jaeger/values.yaml
@@ -283,6 +283,61 @@ query:
         prometheus.io/scrape: "true"
         prometheus.io/port: "{{ .Values.query.service.ports.admin }}"
         prometheus.io/path: "/metrics"
+  ## Network Policies
+  ## Ref: https://kubernetes.io/docs/concepts/services-networking/network-policies/
+  ##
+  networkPolicy:
+    ## @param query.networkPolicy.enabled Specifies whether a NetworkPolicy should be created
+    ##
+    enabled: true
+    ## @param query.networkPolicy.allowExternal Don't require server label for connections
+    ## The Policy model to apply. When set to false, only pods with the correct
+    ## server label will have network access to the ports server is listening
+    ## on. When true, server will accept connections from any source
+    ## (with the correct destination port).
+    ##
+    allowExternal: true
+    ## @param query.networkPolicy.allowExternalEgress Allow the pod to access any range of port and all destinations.
+    ##
+    allowExternalEgress: true
+    ## @param query.networkPolicy.extraIngress [array] Add extra ingress rules to the NetworkPolice
+    ## e.g:
+    ## extraIngress:
+    ##   - ports:
+    ##       - port: 1234
+    ##     from:
+    ##       - podSelector:
+    ##           - matchLabels:
+    ##               - role: frontend
+    ##       - podSelector:
+    ##           - matchExpressions:
+    ##               - key: role
+    ##                 operator: In
+    ##                 values:
+    ##                   - frontend
+    extraIngress: []
+    ## @param query.networkPolicy.extraEgress [array] Add extra ingress rules to the NetworkPolicy
+    ## e.g:
+    ## extraEgress:
+    ##   - ports:
+    ##       - port: 1234
+    ##     to:
+    ##       - podSelector:
+    ##           - matchLabels:
+    ##               - role: frontend
+    ##       - podSelector:
+    ##           - matchExpressions:
+    ##               - key: role
+    ##                 operator: In
+    ##                 values:
+    ##                   - frontend
+    ##
+    extraEgress: []
+    ## @param query.networkPolicy.ingressNSMatchLabels [object] Labels to match to allow traffic from other namespaces
+    ## @param query.networkPolicy.ingressNSPodMatchLabels [object] Pod labels to match to allow traffic from other namespaces
+    ##
+    ingressNSMatchLabels: {}
+    ingressNSPodMatchLabels: {}
   ## Jaeger Query serviceAccount parameters
   ##
   serviceAccount:
@@ -652,6 +707,61 @@ collector:
         prometheus.io/scrape: "true"
         prometheus.io/port: "{{ .Values.collector.service.ports.admin }}"
         prometheus.io/path: "/metrics"
+  ## Network Policies
+  ## Ref: https://kubernetes.io/docs/concepts/services-networking/network-policies/
+  ##
+  networkPolicy:
+    ## @param collector.networkPolicy.enabled Specifies whether a NetworkPolicy should be created
+    ##
+    enabled: true
+    ## @param collector.networkPolicy.allowExternal Don't require server label for connections
+    ## The Policy model to apply. When set to false, only pods with the correct
+    ## server label will have network access to the ports server is listening
+    ## on. When true, server will accept connections from any source
+    ## (with the correct destination port).
+    ##
+    allowExternal: true
+    ## @param collector.networkPolicy.allowExternalEgress Allow the pod to access any range of port and all destinations.
+    ##
+    allowExternalEgress: true
+    ## @param collector.networkPolicy.extraIngress [array] Add extra ingress rules to the NetworkPolice
+    ## e.g:
+    ## extraIngress:
+    ##   - ports:
+    ##       - port: 1234
+    ##     from:
+    ##       - podSelector:
+    ##           - matchLabels:
+    ##               - role: frontend
+    ##       - podSelector:
+    ##           - matchExpressions:
+    ##               - key: role
+    ##                 operator: In
+    ##                 values:
+    ##                   - frontend
+    extraIngress: []
+    ## @param collector.networkPolicy.extraEgress [array] Add extra ingress rules to the NetworkPolicy
+    ## e.g:
+    ## extraEgress:
+    ##   - ports:
+    ##       - port: 1234
+    ##     to:
+    ##       - podSelector:
+    ##           - matchLabels:
+    ##               - role: frontend
+    ##       - podSelector:
+    ##           - matchExpressions:
+    ##               - key: role
+    ##                 operator: In
+    ##                 values:
+    ##                   - frontend
+    ##
+    extraEgress: []
+    ## @param collector.networkPolicy.ingressNSMatchLabels [object] Labels to match to allow traffic from other namespaces
+    ## @param collector.networkPolicy.ingressNSPodMatchLabels [object] Pod labels to match to allow traffic from other namespaces
+    ##
+    ingressNSMatchLabels: {}
+    ingressNSPodMatchLabels: {}
   ## Jaeger collector serviceAccount parameters
   ##
   serviceAccount:
@@ -1003,6 +1113,61 @@ agent:
         prometheus.io/scrape: "true"
         prometheus.io/port: "{{ .Values.agent.service.ports.admin }}"
         prometheus.io/path: "/metrics"
+  ## Network Policies
+  ## Ref: https://kubernetes.io/docs/concepts/services-networking/network-policies/
+  ##
+  networkPolicy:
+    ## @param agent.networkPolicy.enabled Specifies whether a NetworkPolicy should be created
+    ##
+    enabled: true
+    ## @param agent.networkPolicy.allowExternal Don't require server label for connections
+    ## The Policy model to apply. When set to false, only pods with the correct
+    ## server label will have network access to the ports server is listening
+    ## on. When true, server will accept connections from any source
+    ## (with the correct destination port).
+    ##
+    allowExternal: true
+    ## @param agent.networkPolicy.allowExternalEgress Allow the pod to access any range of port and all destinations.
+    ##
+    allowExternalEgress: true
+    ## @param agent.networkPolicy.extraIngress [array] Add extra ingress rules to the NetworkPolice
+    ## e.g:
+    ## extraIngress:
+    ##   - ports:
+    ##       - port: 1234
+    ##     from:
+    ##       - podSelector:
+    ##           - matchLabels:
+    ##               - role: frontend
+    ##       - podSelector:
+    ##           - matchExpressions:
+    ##               - key: role
+    ##                 operator: In
+    ##                 values:
+    ##                   - frontend
+    extraIngress: []
+    ## @param agent.networkPolicy.extraEgress [array] Add extra ingress rules to the NetworkPolicy
+    ## e.g:
+    ## extraEgress:
+    ##   - ports:
+    ##       - port: 1234
+    ##     to:
+    ##       - podSelector:
+    ##           - matchLabels:
+    ##               - role: frontend
+    ##       - podSelector:
+    ##           - matchExpressions:
+    ##               - key: role
+    ##                 operator: In
+    ##                 values:
+    ##                   - frontend
+    ##
+    extraEgress: []
+    ## @param agent.networkPolicy.ingressNSMatchLabels [object] Labels to match to allow traffic from other namespaces
+    ## @param agent.networkPolicy.ingressNSPodMatchLabels [object] Pod labels to match to allow traffic from other namespaces
+    ##
+    ingressNSMatchLabels: {}
+    ingressNSPodMatchLabels: {}
   ## Jaeger agent serviceAccount parameters
   ##
   serviceAccount:
@@ -1224,6 +1389,61 @@ migration:
     ##    memory: 4Gi
     ##
     requests: {}
+  ## Network Policies
+  ## Ref: https://kubernetes.io/docs/concepts/services-networking/network-policies/
+  ##
+  networkPolicy:
+    ## @param migration.networkPolicy.enabled Specifies whether a NetworkPolicy should be created
+    ##
+    enabled: true
+    ## @param migration.networkPolicy.allowExternal Don't require server label for connections
+    ## The Policy model to apply. When set to false, only pods with the correct
+    ## server label will have network access to the ports server is listening
+    ## on. When true, server will accept connections from any source
+    ## (with the correct destination port).
+    ##
+    allowExternal: true
+    ## @param migration.networkPolicy.allowExternalEgress Allow the pod to access any range of port and all destinations.
+    ##
+    allowExternalEgress: true
+    ## @param migration.networkPolicy.extraIngress [array] Add extra ingress rules to the NetworkPolice
+    ## e.g:
+    ## extraIngress:
+    ##   - ports:
+    ##       - port: 1234
+    ##     from:
+    ##       - podSelector:
+    ##           - matchLabels:
+    ##               - role: frontend
+    ##       - podSelector:
+    ##           - matchExpressions:
+    ##               - key: role
+    ##                 operator: In
+    ##                 values:
+    ##                   - frontend
+    extraIngress: []
+    ## @param migration.networkPolicy.extraEgress [array] Add extra ingress rules to the NetworkPolicy
+    ## e.g:
+    ## extraEgress:
+    ##   - ports:
+    ##       - port: 1234
+    ##     to:
+    ##       - podSelector:
+    ##           - matchLabels:
+    ##               - role: frontend
+    ##       - podSelector:
+    ##           - matchExpressions:
+    ##               - key: role
+    ##                 operator: In
+    ##                 values:
+    ##                   - frontend
+    ##
+    extraEgress: []
+    ## @param migration.networkPolicy.ingressNSMatchLabels [object] Labels to match to allow traffic from other namespaces
+    ## @param migration.networkPolicy.ingressNSPodMatchLabels [object] Pod labels to match to allow traffic from other namespaces
+    ##
+    ingressNSMatchLabels: {}
+    ingressNSPodMatchLabels: {}
   ## @param migration.extraVolumes Optionally specify extra list of additional volumes for jaeger container
   ##
   extraVolumes: []


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

This PR normalizes the use of NetworkPolicy in the chart. Adds all Bitnami standards for NetworkPolicies as well as enabling it by default, in order to comply with security checklists.

<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

More security in the chart
<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
