### PR TITLE
[bitnami/matomo] Bugfix: missing volumeMounts for custom certificates in CronJob

### DIFF
--- a/bitnami/matomo/Chart.yaml
+++ b/bitnami/matomo/Chart.yaml
@@ -39,4 +39,4 @@ maintainers:
 name: matomo
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/matomo
-version: 5.1.4
+version: 5.1.5

--- a/bitnami/matomo/templates/cronjob.yaml
+++ b/bitnami/matomo/templates/cronjob.yaml
@@ -86,6 +86,22 @@ spec:
               volumeMounts:
                 - name: matomo-data
                   mountPath: /bitnami/matomo
+                {{- if .Values.certificates.customCertificate.certificateSecret }}
+                - name: custom-certificate
+                  mountPath: {{ .Values.certificates.customCertificate.certificateLocation }}
+                  subPath: tls.crt
+                  readOnly: true
+                - name: custom-certificate
+                  mountPath: {{ .Values.certificates.customCertificate.keyLocation }}
+                  subPath: tls.key
+                  readOnly: true
+                {{- if .Values.certificates.customCertificate.chainSecret }}
+                - name: custom-certificate-chain
+                  mountPath: {{ .Values.certificates.customCertificate.chainLocation }}
+                  subPath: {{ .Values.certificates.customCertificate.chainSecret.key }}
+                  readOnly: true
+                {{- end }}
+                {{- end }}
                 {{- if .Values.customPostInitScripts }}
                 - mountPath: /docker-entrypoint-init.d
                   name: custom-postinit
@@ -223,6 +239,26 @@ spec:
               volumeMounts:
                 - name: matomo-data
                   mountPath: /bitnami/matomo
+                {{- if .Values.certificates.customCertificate.certificateSecret }}
+                - name: custom-certificate
+                  mountPath: {{ .Values.certificates.customCertificate.certificateLocation }}
+                  subPath: tls.crt
+                  readOnly: true
+                - name: custom-certificate
+                  mountPath: {{ .Values.certificates.customCertificate.keyLocation }}
+                  subPath: tls.key
+                  readOnly: true
+                {{- if .Values.certificates.customCertificate.chainSecret }}
+                - name: custom-certificate-chain
+                  mountPath: {{ .Values.certificates.customCertificate.chainLocation }}
+                  subPath: {{ .Values.certificates.customCertificate.chainSecret.key }}
+                  readOnly: true
+                {{- end }}
+                {{- end }}
+                {{- if .Values.customPostInitScripts }}
+                - mountPath: /docker-entrypoint-init.d
+                  name: custom-postinit
+                {{- end }}
                 {{- if .Values.extraVolumeMounts }}
                 {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumeMounts "context" $) | nindent 16 }}
                 {{- end }}


### PR DESCRIPTION
### Description of the change

I tried to use custom certificates (using [`certificates`](https://github.com/bitnami/charts/tree/main/bitnami/matomo#certificate-injection-parameters) and I found a bug. Secret with certificate is correctly mounted on application container, but not on `CronJob` ones.

After reviewing chart code I found out that that in `CronJob` there is `volume` for custom certificates, but `volumeMounts` are missing.

I have deployed chart after changes and everything worked.

### Possible drawbacks

Code should be backwards compatible.

### Applicable issues

- fixes #23211.

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
