### PR TITLE
[bitnami/fluent-bit] feat: :lock: Enable networkPolicy

### DIFF
--- a/bitnami/fluent-bit/Chart.yaml
+++ b/bitnami/fluent-bit/Chart.yaml
@@ -28,4 +28,4 @@ maintainers:
 name: fluent-bit
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/fluent-bit
-version: 0.8.4
+version: 0.9.0

--- a/bitnami/fluent-bit/README.md
+++ b/bitnami/fluent-bit/README.md
@@ -89,103 +89,111 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Fluent Bit daemonset configuration
 
-| Name                                                | Description                                                                               | Value                        |
-| --------------------------------------------------- | ----------------------------------------------------------------------------------------- | ---------------------------- |
-| `daemonset.enabled`                                 | Use a daemonset instead of a deployment. `replicaCount` will not take effect.             | `false`                      |
-| `daemonset.podSecurityContext.enabled`              | Enable security context for daemonset pods                                                | `true`                       |
-| `daemonset.podSecurityContext.seLinuxOptions`       | Set SELinux options in container                                                          | `nil`                        |
-| `daemonset.podSecurityContext.runAsUser`            | User ID for daemonset containers                                                          | `0`                          |
-| `daemonset.podSecurityContext.runAsGroup`           | Group ID for daemonset containers                                                         | `0`                          |
-| `daemonset.podSecurityContext.fsGroupChangePolicy`  | Set filesystem group change policy                                                        | `Always`                     |
-| `daemonset.podSecurityContext.sysctls`              | Set kernel settings using the sysctl interface                                            | `[]`                         |
-| `daemonset.podSecurityContext.supplementalGroups`   | Set filesystem extra groups                                                               | `[]`                         |
-| `daemonset.podSecurityContext.fsGroup`              | Group ID for daemonset containers filesystem                                              | `0`                          |
-| `daemonset.hostPaths.logs`                          | Path to the node logs dir                                                                 | `/var/log`                   |
-| `daemonset.hostPaths.containerLogs`                 | Path to the container logs dir                                                            | `/var/lib/docker/containers` |
-| `daemonset.hostPaths.machineId`                     | Path to the machine-id file                                                               | `/etc/machine-id`            |
-| `hostNetwork`                                       | Enable HOST Network                                                                       | `false`                      |
-| `command`                                           | Command for running the container (set to default if not set). Use array form             | `[]`                         |
-| `args`                                              | Args for running the container (set to default if not set). Use array form                | `[]`                         |
-| `lifecycleHooks`                                    | Override default etcd container hooks                                                     | `{}`                         |
-| `extraEnvVars`                                      | Extra environment variables to be set on fluent-bit container                             | `[]`                         |
-| `extraEnvVarsCM`                                    | Name of existing ConfigMap containing extra env vars                                      | `""`                         |
-| `extraEnvVarsSecret`                                | Name of existing Secret containing extra env vars                                         | `""`                         |
-| `existingConfigMap`                                 | Name of an existing ConfigMap with the Fluent Bit config file                             | `""`                         |
-| `automountServiceAccountToken`                      | Mount Service Account token in pod                                                        | `true`                       |
-| `hostAliases`                                       | Deployment pod host aliases                                                               | `[]`                         |
-| `replicaCount`                                      | Number of Fluent Bit replicas                                                             | `1`                          |
-| `livenessProbe.enabled`                             | Enable livenessProbe on nodes                                                             | `true`                       |
-| `livenessProbe.initialDelaySeconds`                 | Initial delay seconds for livenessProbe                                                   | `10`                         |
-| `livenessProbe.periodSeconds`                       | Period seconds for livenessProbe                                                          | `10`                         |
-| `livenessProbe.timeoutSeconds`                      | Timeout seconds for livenessProbe                                                         | `1`                          |
-| `livenessProbe.failureThreshold`                    | Failure threshold for livenessProbe                                                       | `3`                          |
-| `livenessProbe.successThreshold`                    | Success threshold for livenessProbe                                                       | `1`                          |
-| `startupProbe.enabled`                              | Enable startupProbe on containers                                                         | `true`                       |
-| `startupProbe.initialDelaySeconds`                  | Initial delay seconds for startupProbe                                                    | `10`                         |
-| `startupProbe.periodSeconds`                        | Period seconds for startupProbe                                                           | `10`                         |
-| `startupProbe.timeoutSeconds`                       | Timeout seconds for startupProbe                                                          | `1`                          |
-| `startupProbe.failureThreshold`                     | Failure threshold for startupProbe                                                        | `15`                         |
-| `startupProbe.successThreshold`                     | Success threshold for startupProbe                                                        | `1`                          |
-| `readinessProbe.enabled`                            | Enable readinessProbe                                                                     | `true`                       |
-| `readinessProbe.initialDelaySeconds`                | Initial delay seconds for readinessProbe                                                  | `10`                         |
-| `readinessProbe.periodSeconds`                      | Period seconds for readinessProbe                                                         | `10`                         |
-| `readinessProbe.timeoutSeconds`                     | Timeout seconds for readinessProbe                                                        | `1`                          |
-| `readinessProbe.failureThreshold`                   | Failure threshold for readinessProbe                                                      | `15`                         |
-| `readinessProbe.successThreshold`                   | Success threshold for readinessProbe                                                      | `1`                          |
-| `customLivenessProbe`                               | Custom livenessProbe that overrides the default one                                       | `{}`                         |
-| `customStartupProbe`                                | Override default startup probe                                                            | `{}`                         |
-| `customReadinessProbe`                              | Override default readiness probe                                                          | `{}`                         |
-| `resources.limits`                                  | The resources limits for Fluent Bit containers                                            | `{}`                         |
-| `resources.requests`                                | The requested resources for Fluent Bit containers                                         | `{}`                         |
-| `extraVolumeMounts`                                 | Optionally specify extra list of additional volumeMounts for fluent-bit container         | `[]`                         |
-| `containerPorts.http`                               | Port for HTTP port                                                                        | `2020`                       |
-| `service.type`                                      | Fluent Bit service type                                                                   | `ClusterIP`                  |
-| `service.ports.http`                                | Port for HTTP port                                                                        | `2020`                       |
-| `service.nodePorts.http`                            | Node port for HTTP port                                                                   | `""`                         |
-| `service.extraPorts`                                | Extra ports to expose in the service (normally used with the `sidecar` value)             | `[]`                         |
-| `service.loadBalancerIP`                            | LoadBalancerIP if service type is `LoadBalancer`                                          | `""`                         |
-| `service.loadBalancerSourceRanges`                  | Service Load Balancer sources                                                             | `[]`                         |
-| `service.clusterIP`                                 | Service Cluster IP                                                                        | `""`                         |
-| `service.externalTrafficPolicy`                     | Service external traffic policy                                                           | `Cluster`                    |
-| `service.annotations`                               | Provide any additional annotations which may be required.                                 | `{}`                         |
-| `service.sessionAffinity`                           | Session Affinity for Kubernetes service, can be "None" or "ClientIP"                      | `None`                       |
-| `service.sessionAffinityConfig`                     | Additional settings for the sessionAffinity                                               | `{}`                         |
-| `serviceAccount.create`                             | Enables ServiceAccount                                                                    | `true`                       |
-| `serviceAccount.name`                               | ServiceAccount name                                                                       | `""`                         |
-| `serviceAccount.annotations`                        | Annotations to add to all deployed objects                                                | `{}`                         |
-| `serviceAccount.automountServiceAccountToken`       | Automount API credentials for a service account.                                          | `false`                      |
-| `podSecurityContext.enabled`                        | Enabled Fluent Bit pods' Security Context                                                 | `true`                       |
-| `podSecurityContext.fsGroupChangePolicy`            | Set filesystem group change policy                                                        | `Always`                     |
-| `podSecurityContext.sysctls`                        | Set kernel settings using the sysctl interface                                            | `[]`                         |
-| `podSecurityContext.supplementalGroups`             | Set filesystem extra groups                                                               | `[]`                         |
-| `podSecurityContext.fsGroup`                        | Set Fluent Bit pod's Security Context fsGroup                                             | `1001`                       |
-| `containerSecurityContext.enabled`                  | Enabled Fluent Bit containers' Security Context                                           | `true`                       |
-| `containerSecurityContext.seLinuxOptions`           | Set SELinux options in container                                                          | `nil`                        |
-| `containerSecurityContext.runAsUser`                | Set Fluent Bit containers' Security Context runAsUser                                     | `1001`                       |
-| `containerSecurityContext.runAsNonRoot`             | Set Fluent Bit container's Security Context runAsNonRoot                                  | `true`                       |
-| `containerSecurityContext.readOnlyRootFilesystem`   | Set Fluent Bit container's Security Context runAsNonRoot                                  | `false`                      |
-| `containerSecurityContext.privileged`               | Set primary container's Security Context privileged                                       | `false`                      |
-| `containerSecurityContext.allowPrivilegeEscalation` | Set primary container's Security Context allowPrivilegeEscalation                         | `false`                      |
-| `containerSecurityContext.capabilities.drop`        | List of capabilities to be dropped                                                        | `["ALL"]`                    |
-| `containerSecurityContext.seccompProfile.type`      | Set container's Security Context seccomp profile                                          | `RuntimeDefault`             |
-| `podAnnotations`                                    | Additional pod annotations                                                                | `{}`                         |
-| `podLabels`                                         | Additional pod labels                                                                     | `{}`                         |
-| `podAffinityPreset`                                 | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`       | `""`                         |
-| `podAntiAffinityPreset`                             | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`  | `soft`                       |
-| `nodeAffinityPreset.type`                           | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard` | `""`                         |
-| `nodeAffinityPreset.key`                            | Node label key to match. Ignored if `affinity` is set                                     | `""`                         |
-| `nodeAffinityPreset.values`                         | Node label values to match. Ignored if `affinity` is set                                  | `[]`                         |
-| `priorityClassName`                                 | Server priorityClassName                                                                  | `""`                         |
-| `affinity`                                          | Affinity for pod assignment                                                               | `{}`                         |
-| `nodeSelector`                                      | Node labels for pod assignment                                                            | `{}`                         |
-| `tolerations`                                       | Tolerations for pod assignment                                                            | `[]`                         |
-| `topologySpreadConstraints`                         | Topology Spread Constraints for pod assignment                                            | `[]`                         |
-| `schedulerName`                                     | Alternative scheduler                                                                     | `""`                         |
-| `updateStrategy.type`                               | Fluent Bit deployment strategy type                                                       | `RollingUpdate`              |
-| `updateStrategy.rollingUpdate`                      | Fluent Bit deployment rolling update configuration parameters                             | `{}`                         |
-| `extraVolumes`                                      | Optionally specify extra list of additional volumes for fluent-bit container              | `[]`                         |
-| `initContainers`                                    | Add additional init containers to the fluent-bit pods                                     | `[]`                         |
-| `sidecars`                                          | Add additional sidecar containers to the fluent-bit pods                                  | `[]`                         |
+| Name                                                | Description                                                                                        | Value                        |
+| --------------------------------------------------- | -------------------------------------------------------------------------------------------------- | ---------------------------- |
+| `daemonset.enabled`                                 | Use a daemonset instead of a deployment. `replicaCount` will not take effect.                      | `false`                      |
+| `daemonset.podSecurityContext.enabled`              | Enable security context for daemonset pods                                                         | `true`                       |
+| `daemonset.podSecurityContext.seLinuxOptions`       | Set SELinux options in container                                                                   | `nil`                        |
+| `daemonset.podSecurityContext.runAsUser`            | User ID for daemonset containers                                                                   | `0`                          |
+| `daemonset.podSecurityContext.runAsGroup`           | Group ID for daemonset containers                                                                  | `0`                          |
+| `daemonset.podSecurityContext.fsGroupChangePolicy`  | Set filesystem group change policy                                                                 | `Always`                     |
+| `daemonset.podSecurityContext.sysctls`              | Set kernel settings using the sysctl interface                                                     | `[]`                         |
+| `daemonset.podSecurityContext.supplementalGroups`   | Set filesystem extra groups                                                                        | `[]`                         |
+| `daemonset.podSecurityContext.fsGroup`              | Group ID for daemonset containers filesystem                                                       | `0`                          |
+| `daemonset.hostPaths.logs`                          | Path to the node logs dir                                                                          | `/var/log`                   |
+| `daemonset.hostPaths.containerLogs`                 | Path to the container logs dir                                                                     | `/var/lib/docker/containers` |
+| `daemonset.hostPaths.machineId`                     | Path to the machine-id file                                                                        | `/etc/machine-id`            |
+| `hostNetwork`                                       | Enable HOST Network                                                                                | `false`                      |
+| `command`                                           | Command for running the container (set to default if not set). Use array form                      | `[]`                         |
+| `args`                                              | Args for running the container (set to default if not set). Use array form                         | `[]`                         |
+| `lifecycleHooks`                                    | Override default etcd container hooks                                                              | `{}`                         |
+| `extraEnvVars`                                      | Extra environment variables to be set on fluent-bit container                                      | `[]`                         |
+| `extraEnvVarsCM`                                    | Name of existing ConfigMap containing extra env vars                                               | `""`                         |
+| `extraEnvVarsSecret`                                | Name of existing Secret containing extra env vars                                                  | `""`                         |
+| `existingConfigMap`                                 | Name of an existing ConfigMap with the Fluent Bit config file                                      | `""`                         |
+| `automountServiceAccountToken`                      | Mount Service Account token in pod                                                                 | `true`                       |
+| `hostAliases`                                       | Deployment pod host aliases                                                                        | `[]`                         |
+| `replicaCount`                                      | Number of Fluent Bit replicas                                                                      | `1`                          |
+| `livenessProbe.enabled`                             | Enable livenessProbe on nodes                                                                      | `true`                       |
+| `livenessProbe.initialDelaySeconds`                 | Initial delay seconds for livenessProbe                                                            | `10`                         |
+| `livenessProbe.periodSeconds`                       | Period seconds for livenessProbe                                                                   | `10`                         |
+| `livenessProbe.timeoutSeconds`                      | Timeout seconds for livenessProbe                                                                  | `1`                          |
+| `livenessProbe.failureThreshold`                    | Failure threshold for livenessProbe                                                                | `3`                          |
+| `livenessProbe.successThreshold`                    | Success threshold for livenessProbe                                                                | `1`                          |
+| `startupProbe.enabled`                              | Enable startupProbe on containers                                                                  | `true`                       |
+| `startupProbe.initialDelaySeconds`                  | Initial delay seconds for startupProbe                                                             | `10`                         |
+| `startupProbe.periodSeconds`                        | Period seconds for startupProbe                                                                    | `10`                         |
+| `startupProbe.timeoutSeconds`                       | Timeout seconds for startupProbe                                                                   | `1`                          |
+| `startupProbe.failureThreshold`                     | Failure threshold for startupProbe                                                                 | `15`                         |
+| `startupProbe.successThreshold`                     | Success threshold for startupProbe                                                                 | `1`                          |
+| `readinessProbe.enabled`                            | Enable readinessProbe                                                                              | `true`                       |
+| `readinessProbe.initialDelaySeconds`                | Initial delay seconds for readinessProbe                                                           | `10`                         |
+| `readinessProbe.periodSeconds`                      | Period seconds for readinessProbe                                                                  | `10`                         |
+| `readinessProbe.timeoutSeconds`                     | Timeout seconds for readinessProbe                                                                 | `1`                          |
+| `readinessProbe.failureThreshold`                   | Failure threshold for readinessProbe                                                               | `15`                         |
+| `readinessProbe.successThreshold`                   | Success threshold for readinessProbe                                                               | `1`                          |
+| `customLivenessProbe`                               | Custom livenessProbe that overrides the default one                                                | `{}`                         |
+| `customStartupProbe`                                | Override default startup probe                                                                     | `{}`                         |
+| `customReadinessProbe`                              | Override default readiness probe                                                                   | `{}`                         |
+| `resources.limits`                                  | The resources limits for Fluent Bit containers                                                     | `{}`                         |
+| `resources.requests`                                | The requested resources for Fluent Bit containers                                                  | `{}`                         |
+| `extraVolumeMounts`                                 | Optionally specify extra list of additional volumeMounts for fluent-bit container                  | `[]`                         |
+| `containerPorts.http`                               | Port for HTTP port                                                                                 | `2020`                       |
+| `service.type`                                      | Fluent Bit service type                                                                            | `ClusterIP`                  |
+| `service.ports.http`                                | Port for HTTP port                                                                                 | `2020`                       |
+| `service.nodePorts.http`                            | Node port for HTTP port                                                                            | `""`                         |
+| `service.extraPorts`                                | Extra ports to expose in the service (normally used with the `sidecar` value)                      | `[]`                         |
+| `service.loadBalancerIP`                            | LoadBalancerIP if service type is `LoadBalancer`                                                   | `""`                         |
+| `service.loadBalancerSourceRanges`                  | Service Load Balancer sources                                                                      | `[]`                         |
+| `service.clusterIP`                                 | Service Cluster IP                                                                                 | `""`                         |
+| `service.externalTrafficPolicy`                     | Service external traffic policy                                                                    | `Cluster`                    |
+| `service.annotations`                               | Provide any additional annotations which may be required.                                          | `{}`                         |
+| `service.sessionAffinity`                           | Session Affinity for Kubernetes service, can be "None" or "ClientIP"                               | `None`                       |
+| `service.sessionAffinityConfig`                     | Additional settings for the sessionAffinity                                                        | `{}`                         |
+| `networkPolicy.enabled`                             | Specifies whether a NetworkPolicy should be created                                                | `true`                       |
+| `networkPolicy.allowExternal`                       | Don't require server label for connections                                                         | `true`                       |
+| `networkPolicy.allowExternalEgress`                 | Allow the pod to access any range of port and all destinations.                                    | `true`                       |
+| `networkPolicy.kubeAPIServerPorts`                  | List of possible endpoints to kube-apiserver (limit to your cluster settings to increase security) | `[]`                         |
+| `networkPolicy.extraIngress`                        | Add extra ingress rules to the NetworkPolice                                                       | `[]`                         |
+| `networkPolicy.extraEgress`                         | Add extra ingress rules to the NetworkPolicy                                                       | `[]`                         |
+| `networkPolicy.ingressNSMatchLabels`                | Labels to match to allow traffic from other namespaces                                             | `{}`                         |
+| `networkPolicy.ingressNSPodMatchLabels`             | Pod labels to match to allow traffic from other namespaces                                         | `{}`                         |
+| `serviceAccount.create`                             | Enables ServiceAccount                                                                             | `true`                       |
+| `serviceAccount.name`                               | ServiceAccount name                                                                                | `""`                         |
+| `serviceAccount.annotations`                        | Annotations to add to all deployed objects                                                         | `{}`                         |
+| `serviceAccount.automountServiceAccountToken`       | Automount API credentials for a service account.                                                   | `false`                      |
+| `podSecurityContext.enabled`                        | Enabled Fluent Bit pods' Security Context                                                          | `true`                       |
+| `podSecurityContext.fsGroupChangePolicy`            | Set filesystem group change policy                                                                 | `Always`                     |
+| `podSecurityContext.sysctls`                        | Set kernel settings using the sysctl interface                                                     | `[]`                         |
+| `podSecurityContext.supplementalGroups`             | Set filesystem extra groups                                                                        | `[]`                         |
+| `podSecurityContext.fsGroup`                        | Set Fluent Bit pod's Security Context fsGroup                                                      | `1001`                       |
+| `containerSecurityContext.enabled`                  | Enabled Fluent Bit containers' Security Context                                                    | `true`                       |
+| `containerSecurityContext.seLinuxOptions`           | Set SELinux options in container                                                                   | `nil`                        |
+| `containerSecurityContext.runAsUser`                | Set Fluent Bit containers' Security Context runAsUser                                              | `1001`                       |
+| `containerSecurityContext.runAsNonRoot`             | Set Fluent Bit container's Security Context runAsNonRoot                                           | `true`                       |
+| `containerSecurityContext.readOnlyRootFilesystem`   | Set Fluent Bit container's Security Context runAsNonRoot                                           | `false`                      |
+| `containerSecurityContext.privileged`               | Set primary container's Security Context privileged                                                | `false`                      |
+| `containerSecurityContext.allowPrivilegeEscalation` | Set primary container's Security Context allowPrivilegeEscalation                                  | `false`                      |
+| `containerSecurityContext.capabilities.drop`        | List of capabilities to be dropped                                                                 | `["ALL"]`                    |
+| `containerSecurityContext.seccompProfile.type`      | Set container's Security Context seccomp profile                                                   | `RuntimeDefault`             |
+| `podAnnotations`                                    | Additional pod annotations                                                                         | `{}`                         |
+| `podLabels`                                         | Additional pod labels                                                                              | `{}`                         |
+| `podAffinityPreset`                                 | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                | `""`                         |
+| `podAntiAffinityPreset`                             | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`           | `soft`                       |
+| `nodeAffinityPreset.type`                           | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`          | `""`                         |
+| `nodeAffinityPreset.key`                            | Node label key to match. Ignored if `affinity` is set                                              | `""`                         |
+| `nodeAffinityPreset.values`                         | Node label values to match. Ignored if `affinity` is set                                           | `[]`                         |
+| `priorityClassName`                                 | Server priorityClassName                                                                           | `""`                         |
+| `affinity`                                          | Affinity for pod assignment                                                                        | `{}`                         |
+| `nodeSelector`                                      | Node labels for pod assignment                                                                     | `{}`                         |
+| `tolerations`                                       | Tolerations for pod assignment                                                                     | `[]`                         |
+| `topologySpreadConstraints`                         | Topology Spread Constraints for pod assignment                                                     | `[]`                         |
+| `schedulerName`                                     | Alternative scheduler                                                                              | `""`                         |
+| `updateStrategy.type`                               | Fluent Bit deployment strategy type                                                                | `RollingUpdate`              |
+| `updateStrategy.rollingUpdate`                      | Fluent Bit deployment rolling update configuration parameters                                      | `{}`                         |
+| `extraVolumes`                                      | Optionally specify extra list of additional volumes for fluent-bit container                       | `[]`                         |
+| `initContainers`                                    | Add additional init containers to the fluent-bit pods                                              | `[]`                         |
+| `sidecars`                                          | Add additional sidecar containers to the fluent-bit pods                                           | `[]`                         |
 
 ### Fluent Bit configuration
 

--- a/bitnami/fluent-bit/templates/networkpolicy.yaml
+++ b/bitnami/fluent-bit/templates/networkpolicy.yaml
@@ -1,0 +1,75 @@
+{{- /*
+Copyright VMware, Inc.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+{{- if .Values.networkPolicy.enabled }}
+kind: NetworkPolicy
+apiVersion: {{ include "common.capabilities.networkPolicy.apiVersion" . }}
+metadata:
+  name: {{ template "common.names.fullname" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.podLabels .Values.commonLabels ) "context" . ) }}
+  podSelector:
+    matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  {{- if .Values.networkPolicy.allowExternalEgress }}
+  egress:
+    - {}
+  {{- else }}
+  egress:
+    # Allow dns resolution
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+        {{- range $port := .Values.networkPolicy.kubeAPIServerPorts }}
+        - port: {{ $port }}
+        {{- end }}
+    # Allow connection to other aggregator pods
+    - ports:
+        - port: {{ .Values.containerPorts.http }}
+      to:
+        - podSelector:
+            matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 14 }}
+    {{- if .Values.networkPolicy.extraEgress }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.networkPolicy.extraEgress "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- end }}
+  ingress:
+    - ports:
+        - port: {{ .Values.containerPorts.http }}
+      {{- if not .Values.networkPolicy.allowExternal }}
+      from:
+        - podSelector:
+            matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 14 }}
+        - podSelector:
+            matchLabels:
+              {{ template "common.names.fullname" . }}-client: "true"
+        {{- if .Values.networkPolicy.ingressNSMatchLabels }}
+        - namespaceSelector:
+            matchLabels:
+              {{- range $key, $value := .Values.networkPolicy.ingressNSMatchLabels }}
+              {{ $key | quote }}: {{ $value | quote }}
+              {{- end }}
+          {{- if .Values.networkPolicy.ingressNSPodMatchLabels }}
+          podSelector:
+            matchLabels:
+              {{- range $key, $value := .Values.networkPolicy.ingressNSPodMatchLabels }}
+              {{ $key | quote }}: {{ $value | quote }}
+              {{- end }}
+          {{- end }}
+        {{- end }}
+      {{- end }}
+    {{- if .Values.networkPolicy.extraIngress }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.networkPolicy.extraIngress "context" $ ) | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/bitnami/fluent-bit/values.yaml
+++ b/bitnami/fluent-bit/values.yaml
@@ -309,6 +309,64 @@ service:
   ##     timeoutSeconds: 300
   ##
   sessionAffinityConfig: {}
+## Network Policies
+## Ref: https://kubernetes.io/docs/concepts/services-networking/network-policies/
+##
+networkPolicy:
+  ## @param networkPolicy.enabled Specifies whether a NetworkPolicy should be created
+  ##
+  enabled: true
+  ## @param networkPolicy.allowExternal Don't require server label for connections
+  ## The Policy model to apply. When set to false, only pods with the correct
+  ## server label will have network access to the ports server is listening
+  ## on. When true, server will accept connections from any source
+  ## (with the correct destination port).
+  ##
+  allowExternal: true
+  ## @param networkPolicy.allowExternalEgress Allow the pod to access any range of port and all destinations.
+  ##
+  allowExternalEgress: true
+  ## @param networkPolicy.kubeAPIServerPorts [array] List of possible endpoints to kube-apiserver (limit to your cluster settings to increase security)
+  ##
+  kubeAPIServerPorts: [443, 6443, 8443]
+  ## @param networkPolicy.extraIngress [array] Add extra ingress rules to the NetworkPolice
+  ## e.g:
+  ## extraIngress:
+  ##   - ports:
+  ##       - port: 1234
+  ##     from:
+  ##       - podSelector:
+  ##           - matchLabels:
+  ##               - role: frontend
+  ##       - podSelector:
+  ##           - matchExpressions:
+  ##               - key: role
+  ##                 operator: In
+  ##                 values:
+  ##                   - frontend
+  extraIngress: []
+  ## @param networkPolicy.extraEgress [array] Add extra ingress rules to the NetworkPolicy
+  ## e.g:
+  ## extraEgress:
+  ##   - ports:
+  ##       - port: 1234
+  ##     to:
+  ##       - podSelector:
+  ##           - matchLabels:
+  ##               - role: frontend
+  ##       - podSelector:
+  ##           - matchExpressions:
+  ##               - key: role
+  ##                 operator: In
+  ##                 values:
+  ##                   - frontend
+  ##
+  extraEgress: []
+  ## @param networkPolicy.ingressNSMatchLabels [object] Labels to match to allow traffic from other namespaces
+  ## @param networkPolicy.ingressNSPodMatchLabels [object] Pod labels to match to allow traffic from other namespaces
+  ##
+  ingressNSMatchLabels: {}
+  ingressNSPodMatchLabels: {}
 ## Fluent Bit serviceAccount parameters
 ##
 serviceAccount:


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

This PR normalizes the use of NetworkPolicy in the chart. Adds all Bitnami standards for NetworkPolicies as well as enabling it by default, in order to comply with security checklists.

<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

More security in the chart
<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
