### PR TITLE
[bitnami/flink] feat: :lock: Enable networkPolicy

### DIFF
--- a/bitnami/flink/Chart.yaml
+++ b/bitnami/flink/Chart.yaml
@@ -28,4 +28,4 @@ maintainers:
 name: flink
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/flink
-version: 0.7.4
+version: 0.8.0

--- a/bitnami/flink/README.md
+++ b/bitnami/flink/README.md
@@ -143,6 +143,13 @@ The command removes all the Kubernetes components associated with the chart and 
 | `jobmanager.service.annotations`                               | Provide any additional annotations which may be required.                                 | `{}`             |
 | `jobmanager.service.sessionAffinity`                           | Session Affinity for Kubernetes service, can be "None" or "ClientIP"                      | `None`           |
 | `jobmanager.service.sessionAffinityConfig`                     | Additional settings for the sessionAffinity                                               | `{}`             |
+| `jobmanager.networkPolicy.enabled`                             | Specifies whether a NetworkPolicy should be created                                       | `true`           |
+| `jobmanager.networkPolicy.allowExternal`                       | Don't require server label for connections                                                | `true`           |
+| `jobmanager.networkPolicy.allowExternalEgress`                 | Allow the pod to access any range of port and all destinations.                           | `true`           |
+| `jobmanager.networkPolicy.extraIngress`                        | Add extra ingress rules to the NetworkPolice                                              | `[]`             |
+| `jobmanager.networkPolicy.extraEgress`                         | Add extra ingress rules to the NetworkPolicy                                              | `[]`             |
+| `jobmanager.networkPolicy.ingressNSMatchLabels`                | Labels to match to allow traffic from other namespaces                                    | `{}`             |
+| `jobmanager.networkPolicy.ingressNSPodMatchLabels`             | Pod labels to match to allow traffic from other namespaces                                | `{}`             |
 | `jobmanager.serviceAccount.create`                             | Enables ServiceAccount                                                                    | `true`           |
 | `jobmanager.serviceAccount.name`                               | ServiceAccount name                                                                       | `""`             |
 | `jobmanager.serviceAccount.annotations`                        | Annotations to add to all deployed objects                                                | `{}`             |
@@ -231,6 +238,13 @@ The command removes all the Kubernetes components associated with the chart and 
 | `taskmanager.service.annotations`                               | Provide any additional annotations which may be required.                                 | `{}`             |
 | `taskmanager.service.sessionAffinity`                           | Session Affinity for Kubernetes service, can be "None" or "ClientIP"                      | `None`           |
 | `taskmanager.service.sessionAffinityConfig`                     | Additional settings for the sessionAffinity                                               | `{}`             |
+| `taskmanager.networkPolicy.enabled`                             | Specifies whether a NetworkPolicy should be created                                       | `true`           |
+| `taskmanager.networkPolicy.allowExternal`                       | Don't require server label for connections                                                | `true`           |
+| `taskmanager.networkPolicy.allowExternalEgress`                 | Allow the pod to access any range of port and all destinations.                           | `true`           |
+| `taskmanager.networkPolicy.extraIngress`                        | Add extra ingress rules to the NetworkPolice                                              | `[]`             |
+| `taskmanager.networkPolicy.extraEgress`                         | Add extra ingress rules to the NetworkPolicy                                              | `[]`             |
+| `taskmanager.networkPolicy.ingressNSMatchLabels`                | Labels to match to allow traffic from other namespaces                                    | `{}`             |
+| `taskmanager.networkPolicy.ingressNSPodMatchLabels`             | Pod labels to match to allow traffic from other namespaces                                | `{}`             |
 | `taskmanager.serviceAccount.create`                             | Enables ServiceAccount                                                                    | `true`           |
 | `taskmanager.serviceAccount.name`                               | ServiceAccount name                                                                       | `""`             |
 | `taskmanager.serviceAccount.annotations`                        | Annotations to add to all deployed objects                                                | `{}`             |

--- a/bitnami/flink/templates/jobmanager/networkpolicy.yaml
+++ b/bitnami/flink/templates/jobmanager/networkpolicy.yaml
@@ -1,0 +1,94 @@
+{{- /*
+Copyright VMware, Inc.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+{{- if .Values.jobmanager.networkPolicy.enabled }}
+kind: NetworkPolicy
+apiVersion: {{ include "common.capabilities.networkPolicy.apiVersion" . }}
+metadata:
+  name: {{ template "flink.jobmanager.fullname" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+    app.kubernetes.io/part-of: flink
+    app.kubernetes.io/component: jobmanager
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.jobmanager.podLabels .Values.commonLabels ) "context" . ) }}
+  podSelector:
+    matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
+      app.kubernetes.io/part-of: flink
+      app.kubernetes.io/component: jobmanager
+  policyTypes:
+    - Ingress
+    - Egress
+  {{- if .Values.jobmanager.networkPolicy.allowExternalEgress }}
+  egress:
+    - {}
+  {{- else }}
+  egress:
+    - ports:
+        # Allow dns resolution
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+    # Allow outbound connections to other jobmanager pods
+    - ports:
+        - port: {{ .Values.jobmanager.containerPorts.blob }}
+        - port: {{ .Values.jobmanager.containerPorts.rpc }}
+        - port: {{ .Values.jobmanager.containerPorts.http }}
+      to:
+        - podSelector:
+            matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 14 }}
+              app.kubernetes.io/part-of: flink
+              app.kubernetes.io/component: jobmanager
+    # Allow outbound connections to other taskmanager pods
+    - ports:
+        - port: {{ .Values.taskmanager.containerPorts.data }}
+        - port: {{ .Values.taskmanager.containerPorts.rpc }}
+      to:
+        - podSelector:
+            matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 14 }}
+              app.kubernetes.io/part-of: flink
+              app.kubernetes.io/component: taskmanager
+    {{- if .Values.jobmanager.networkPolicy.extraEgress }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.jobmanager.networkPolicy.extraEgress "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- end }}
+  ingress:
+    - ports:
+        - port: {{ .Values.jobmanager.containerPorts.blob }}
+        - port: {{ .Values.jobmanager.containerPorts.rpc }}
+        - port: {{ .Values.jobmanager.containerPorts.http }}
+      {{- if not .Values.jobmanager.networkPolicy.allowExternal }}
+      from:
+        - podSelector:
+            matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 14 }}
+        - podSelector:
+            matchLabels:
+              {{ template "flink.jobmanager.fullname" . }}-client: "true"
+        {{- if .Values.jobmanager.networkPolicy.ingressNSMatchLabels }}
+        - namespaceSelector:
+            matchLabels:
+              {{- range $key, $value := .Values.jobmanager.networkPolicy.ingressNSMatchLabels }}
+              {{ $key | quote }}: {{ $value | quote }}
+              {{- end }}
+          {{- if .Values.jobmanager.networkPolicy.ingressNSPodMatchLabels }}
+          podSelector:
+            matchLabels:
+              {{- range $key, $value := .Values.jobmanager.networkPolicy.ingressNSPodMatchLabels }}
+              {{ $key | quote }}: {{ $value | quote }}
+              {{- end }}
+          {{- end }}
+        {{- end }}
+        - podSelector:
+            matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 14 }}
+              app.kubernetes.io/part-of: flink        
+      {{- end }}
+    {{- if .Values.jobmanager.networkPolicy.extraIngress }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.jobmanager.networkPolicy.extraIngress "context" $ ) | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/bitnami/flink/templates/taskmanager/networkpolicy.yaml
+++ b/bitnami/flink/templates/taskmanager/networkpolicy.yaml
@@ -1,0 +1,93 @@
+{{- /*
+Copyright VMware, Inc.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+{{- if .Values.taskmanager.networkPolicy.enabled }}
+kind: NetworkPolicy
+apiVersion: {{ include "common.capabilities.networkPolicy.apiVersion" . }}
+metadata:
+  name: {{ template "flink.taskmanager.fullname" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+    app.kubernetes.io/part-of: flink
+    app.kubernetes.io/component: taskmanager
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.taskmanager.podLabels .Values.commonLabels ) "context" . ) }}
+  podSelector:
+    matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
+      app.kubernetes.io/part-of: flink
+      app.kubernetes.io/component: taskmanager
+  policyTypes:
+    - Ingress
+    - Egress
+  {{- if .Values.taskmanager.networkPolicy.allowExternalEgress }}
+  egress:
+    - {}
+  {{- else }}
+  egress:
+    - ports:
+        # Allow dns resolution
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+    # Allow outbound connections to other jobmanager pods
+    - ports:
+        - port: {{ .Values.jobmanager.containerPorts.blob }}
+        - port: {{ .Values.jobmanager.containerPorts.rpc }}
+        - port: {{ .Values.jobmanager.containerPorts.http }}
+      to:
+        - podSelector:
+            matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 14 }}
+              app.kubernetes.io/part-of: flink
+              app.kubernetes.io/component: jobmanager
+    # Allow outbound connections to other taskmanager pods
+    - ports:
+        - port: {{ .Values.taskmanager.containerPorts.data }}
+        - port: {{ .Values.taskmanager.containerPorts.rpc }}
+      to:
+        - podSelector:
+            matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 14 }}
+              app.kubernetes.io/part-of: flink
+              app.kubernetes.io/component: taskmanager
+    {{- if .Values.taskmanager.networkPolicy.extraEgress }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.taskmanager.networkPolicy.extraEgress "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- end }}
+  ingress:
+    - ports:
+        - port: {{ .Values.taskmanager.containerPorts.data }}
+        - port: {{ .Values.taskmanager.containerPorts.rpc }}
+      {{- if not .Values.taskmanager.networkPolicy.allowExternal }}
+      from:
+        - podSelector:
+            matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 14 }}
+        - podSelector:
+            matchLabels:
+              {{ template "flink.taskmanager.fullname" . }}-client: "true"
+        {{- if .Values.taskmanager.networkPolicy.ingressNSMatchLabels }}
+        - namespaceSelector:
+            matchLabels:
+              {{- range $key, $value := .Values.taskmanager.networkPolicy.ingressNSMatchLabels }}
+              {{ $key | quote }}: {{ $value | quote }}
+              {{- end }}
+          {{- if .Values.taskmanager.networkPolicy.ingressNSPodMatchLabels }}
+          podSelector:
+            matchLabels:
+              {{- range $key, $value := .Values.taskmanager.networkPolicy.ingressNSPodMatchLabels }}
+              {{ $key | quote }}: {{ $value | quote }}
+              {{- end }}
+          {{- end }}
+        {{- end }}
+        - podSelector:
+            matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 14 }}
+              app.kubernetes.io/part-of: flink        
+      {{- end }}
+    {{- if .Values.taskmanager.networkPolicy.extraIngress }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.taskmanager.networkPolicy.extraIngress "context" $ ) | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/bitnami/flink/values.yaml
+++ b/bitnami/flink/values.yaml
@@ -290,6 +290,61 @@ jobmanager:
     ##     timeoutSeconds: 300
     ##
     sessionAffinityConfig: {}
+  ## Network Policies
+  ## Ref: https://kubernetes.io/docs/concepts/services-networking/network-policies/
+  ##
+  networkPolicy:
+    ## @param jobmanager.networkPolicy.enabled Specifies whether a NetworkPolicy should be created
+    ##
+    enabled: true
+    ## @param jobmanager.networkPolicy.allowExternal Don't require server label for connections
+    ## The Policy model to apply. When set to false, only pods with the correct
+    ## server label will have network access to the ports server is listening
+    ## on. When true, server will accept connections from any source
+    ## (with the correct destination port).
+    ##
+    allowExternal: true
+    ## @param jobmanager.networkPolicy.allowExternalEgress Allow the pod to access any range of port and all destinations.
+    ##
+    allowExternalEgress: true
+    ## @param jobmanager.networkPolicy.extraIngress [array] Add extra ingress rules to the NetworkPolice
+    ## e.g:
+    ## extraIngress:
+    ##   - ports:
+    ##       - port: 1234
+    ##     from:
+    ##       - podSelector:
+    ##           - matchLabels:
+    ##               - role: frontend
+    ##       - podSelector:
+    ##           - matchExpressions:
+    ##               - key: role
+    ##                 operator: In
+    ##                 values:
+    ##                   - frontend
+    extraIngress: []
+    ## @param jobmanager.networkPolicy.extraEgress [array] Add extra ingress rules to the NetworkPolicy
+    ## e.g:
+    ## extraEgress:
+    ##   - ports:
+    ##       - port: 1234
+    ##     to:
+    ##       - podSelector:
+    ##           - matchLabels:
+    ##               - role: frontend
+    ##       - podSelector:
+    ##           - matchExpressions:
+    ##               - key: role
+    ##                 operator: In
+    ##                 values:
+    ##                   - frontend
+    ##
+    extraEgress: []
+    ## @param jobmanager.networkPolicy.ingressNSMatchLabels [object] Labels to match to allow traffic from other namespaces
+    ## @param jobmanager.networkPolicy.ingressNSPodMatchLabels [object] Pod labels to match to allow traffic from other namespaces
+    ##
+    ingressNSMatchLabels: {}
+    ingressNSPodMatchLabels: {}
   ## Apache Flink Jobmanager serviceAccount parameters
   ##
   serviceAccount:
@@ -606,6 +661,61 @@ taskmanager:
     ##     timeoutSeconds: 300
     ##
     sessionAffinityConfig: {}
+  ## Network Policies
+  ## Ref: https://kubernetes.io/docs/concepts/services-networking/network-policies/
+  ##
+  networkPolicy:
+    ## @param taskmanager.networkPolicy.enabled Specifies whether a NetworkPolicy should be created
+    ##
+    enabled: true
+    ## @param taskmanager.networkPolicy.allowExternal Don't require server label for connections
+    ## The Policy model to apply. When set to false, only pods with the correct
+    ## server label will have network access to the ports server is listening
+    ## on. When true, server will accept connections from any source
+    ## (with the correct destination port).
+    ##
+    allowExternal: true
+    ## @param taskmanager.networkPolicy.allowExternalEgress Allow the pod to access any range of port and all destinations.
+    ##
+    allowExternalEgress: true
+    ## @param taskmanager.networkPolicy.extraIngress [array] Add extra ingress rules to the NetworkPolice
+    ## e.g:
+    ## extraIngress:
+    ##   - ports:
+    ##       - port: 1234
+    ##     from:
+    ##       - podSelector:
+    ##           - matchLabels:
+    ##               - role: frontend
+    ##       - podSelector:
+    ##           - matchExpressions:
+    ##               - key: role
+    ##                 operator: In
+    ##                 values:
+    ##                   - frontend
+    extraIngress: []
+    ## @param taskmanager.networkPolicy.extraEgress [array] Add extra ingress rules to the NetworkPolicy
+    ## e.g:
+    ## extraEgress:
+    ##   - ports:
+    ##       - port: 1234
+    ##     to:
+    ##       - podSelector:
+    ##           - matchLabels:
+    ##               - role: frontend
+    ##       - podSelector:
+    ##           - matchExpressions:
+    ##               - key: role
+    ##                 operator: In
+    ##                 values:
+    ##                   - frontend
+    ##
+    extraEgress: []
+    ## @param taskmanager.networkPolicy.ingressNSMatchLabels [object] Labels to match to allow traffic from other namespaces
+    ## @param taskmanager.networkPolicy.ingressNSPodMatchLabels [object] Pod labels to match to allow traffic from other namespaces
+    ##
+    ingressNSMatchLabels: {}
+    ingressNSPodMatchLabels: {}
   ## Apache Flink taskmanager serviceAccount parameters
   ##
   serviceAccount:


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

This PR normalizes the use of NetworkPolicy in the chart. Adds all Bitnami standards for NetworkPolicies as well as enabling it by default, in order to comply with security checklists.

<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

More security in the chart
<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
