### PR TITLE
[bitnami/apisix] feat: :lock: Enable networkPolicy

### DIFF
--- a/bitnami/apisix/Chart.yaml
+++ b/bitnami/apisix/Chart.yaml
@@ -45,4 +45,4 @@ sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/apisix
 - https://github.com/bitnami/charts/tree/main/bitnami/apisix-dashboard
 - https://github.com/bitnami/charts/tree/main/bitnami/apisix-ingress-controller
-version: 2.5.6
+version: 2.6.0

--- a/bitnami/apisix/README.md
+++ b/bitnami/apisix/README.md
@@ -175,37 +175,45 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### APISIX Data Plane Traffic Exposure Parameters
 
-| Name                                         | Description                                                                                                                      | Value                     |
-| -------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- | ------------------------- |
-| `dataPlane.service.type`                     | APISIX service type                                                                                                              | `LoadBalancer`            |
-| `dataPlane.service.ports.http`               | APISIX service HTTP port                                                                                                         | `80`                      |
-| `dataPlane.service.ports.https`              | APISIX service HTTPS port                                                                                                        | `443`                     |
-| `dataPlane.service.ports.metrics`            | APISIX service HTTPS port                                                                                                        | `8080`                    |
-| `dataPlane.service.nodePorts.http`           | Node port for HTTP                                                                                                               | `""`                      |
-| `dataPlane.service.nodePorts.https`          | Node port for HTTPS                                                                                                              | `""`                      |
-| `dataPlane.service.nodePorts.metrics`        | Node port for metrics                                                                                                            | `""`                      |
-| `dataPlane.service.clusterIP`                | APISIX service Cluster IP                                                                                                        | `""`                      |
-| `dataPlane.service.loadBalancerIP`           | APISIX service Load Balancer IP                                                                                                  | `""`                      |
-| `dataPlane.service.loadBalancerSourceRanges` | APISIX service Load Balancer sources                                                                                             | `[]`                      |
-| `dataPlane.service.externalTrafficPolicy`    | APISIX service external traffic policy                                                                                           | `Cluster`                 |
-| `dataPlane.service.annotations`              | Additional custom annotations for APISIX service                                                                                 | `{}`                      |
-| `dataPlane.service.extraPorts`               | Extra ports to expose in APISIX service (normally used with the `sidecars` value)                                                | `[]`                      |
-| `dataPlane.service.sessionAffinity`          | Control where web requests go, to the same pod or round-robin                                                                    | `None`                    |
-| `dataPlane.service.sessionAffinityConfig`    | Additional settings for the sessionAffinity                                                                                      | `{}`                      |
-| `dataPlane.ingress.enabled`                  | Enable ingress record generation for Apisix                                                                                      | `false`                   |
-| `dataPlane.ingress.pathType`                 | Ingress path type                                                                                                                | `ImplementationSpecific`  |
-| `dataPlane.ingress.apiVersion`               | Force Ingress API version (automatically detected if not set)                                                                    | `""`                      |
-| `dataPlane.ingress.hostname`                 | Default host for the ingress record                                                                                              | `apisix-data-plane.local` |
-| `dataPlane.ingress.ingressClassName`         | IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)                                                    | `""`                      |
-| `dataPlane.ingress.path`                     | Default path for the ingress record                                                                                              | `/`                       |
-| `dataPlane.ingress.annotations`              | Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations. | `{}`                      |
-| `dataPlane.ingress.tls`                      | Enable TLS configuration for the host defined at `dataPlane.ingress.hostname` parameter                                          | `false`                   |
-| `dataPlane.ingress.selfSigned`               | Create a TLS secret for this ingress record using self-signed certificates generated by Helm                                     | `false`                   |
-| `dataPlane.ingress.extraHosts`               | An array with additional hostname(s) to be covered with the ingress record                                                       | `[]`                      |
-| `dataPlane.ingress.extraPaths`               | An array with additional arbitrary paths that may need to be added to the ingress under the main host                            | `[]`                      |
-| `dataPlane.ingress.extraTls`                 | TLS configuration for additional hostname(s) to be covered with this ingress record                                              | `[]`                      |
-| `dataPlane.ingress.secrets`                  | Custom TLS certificates as secrets                                                                                               | `[]`                      |
-| `dataPlane.ingress.extraRules`               | Additional rules to be covered with this ingress record                                                                          | `[]`                      |
+| Name                                              | Description                                                                                                                      | Value                     |
+| ------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- | ------------------------- |
+| `dataPlane.service.type`                          | APISIX service type                                                                                                              | `LoadBalancer`            |
+| `dataPlane.service.ports.http`                    | APISIX service HTTP port                                                                                                         | `80`                      |
+| `dataPlane.service.ports.https`                   | APISIX service HTTPS port                                                                                                        | `443`                     |
+| `dataPlane.service.ports.metrics`                 | APISIX service HTTPS port                                                                                                        | `8080`                    |
+| `dataPlane.service.nodePorts.http`                | Node port for HTTP                                                                                                               | `""`                      |
+| `dataPlane.service.nodePorts.https`               | Node port for HTTPS                                                                                                              | `""`                      |
+| `dataPlane.service.nodePorts.metrics`             | Node port for metrics                                                                                                            | `""`                      |
+| `dataPlane.service.clusterIP`                     | APISIX service Cluster IP                                                                                                        | `""`                      |
+| `dataPlane.service.loadBalancerIP`                | APISIX service Load Balancer IP                                                                                                  | `""`                      |
+| `dataPlane.service.loadBalancerSourceRanges`      | APISIX service Load Balancer sources                                                                                             | `[]`                      |
+| `dataPlane.service.externalTrafficPolicy`         | APISIX service external traffic policy                                                                                           | `Cluster`                 |
+| `dataPlane.service.annotations`                   | Additional custom annotations for APISIX service                                                                                 | `{}`                      |
+| `dataPlane.service.extraPorts`                    | Extra ports to expose in APISIX service (normally used with the `sidecars` value)                                                | `[]`                      |
+| `dataPlane.service.sessionAffinity`               | Control where web requests go, to the same pod or round-robin                                                                    | `None`                    |
+| `dataPlane.service.sessionAffinityConfig`         | Additional settings for the sessionAffinity                                                                                      | `{}`                      |
+| `dataPlane.networkPolicy.enabled`                 | Specifies whether a NetworkPolicy should be created                                                                              | `true`                    |
+| `dataPlane.networkPolicy.allowExternal`           | Don't require server label for connections                                                                                       | `true`                    |
+| `dataPlane.networkPolicy.allowExternalEgress`     | Allow the pod to access any range of port and all destinations.                                                                  | `true`                    |
+| `dataPlane.networkPolicy.kubeAPIServerPorts`      | List of possible endpoints to kube-apiserver (limit to your cluster settings to increase security)                               | `[]`                      |
+| `dataPlane.networkPolicy.extraIngress`            | Add extra ingress rules to the NetworkPolice                                                                                     | `[]`                      |
+| `dataPlane.networkPolicy.extraEgress`             | Add extra ingress rules to the NetworkPolicy (ignored if allowExternalEgress=true)                                               | `[]`                      |
+| `dataPlane.networkPolicy.ingressNSMatchLabels`    | Labels to match to allow traffic from other namespaces                                                                           | `{}`                      |
+| `dataPlane.networkPolicy.ingressNSPodMatchLabels` | Pod labels to match to allow traffic from other namespaces                                                                       | `{}`                      |
+| `dataPlane.ingress.enabled`                       | Enable ingress record generation for Apisix                                                                                      | `false`                   |
+| `dataPlane.ingress.pathType`                      | Ingress path type                                                                                                                | `ImplementationSpecific`  |
+| `dataPlane.ingress.apiVersion`                    | Force Ingress API version (automatically detected if not set)                                                                    | `""`                      |
+| `dataPlane.ingress.hostname`                      | Default host for the ingress record                                                                                              | `apisix-data-plane.local` |
+| `dataPlane.ingress.ingressClassName`              | IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)                                                    | `""`                      |
+| `dataPlane.ingress.path`                          | Default path for the ingress record                                                                                              | `/`                       |
+| `dataPlane.ingress.annotations`                   | Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations. | `{}`                      |
+| `dataPlane.ingress.tls`                           | Enable TLS configuration for the host defined at `dataPlane.ingress.hostname` parameter                                          | `false`                   |
+| `dataPlane.ingress.selfSigned`                    | Create a TLS secret for this ingress record using self-signed certificates generated by Helm                                     | `false`                   |
+| `dataPlane.ingress.extraHosts`                    | An array with additional hostname(s) to be covered with the ingress record                                                       | `[]`                      |
+| `dataPlane.ingress.extraPaths`                    | An array with additional arbitrary paths that may need to be added to the ingress under the main host                            | `[]`                      |
+| `dataPlane.ingress.extraTls`                      | TLS configuration for additional hostname(s) to be covered with this ingress record                                              | `[]`                      |
+| `dataPlane.ingress.secrets`                       | Custom TLS certificates as secrets                                                                                               | `[]`                      |
+| `dataPlane.ingress.extraRules`                    | Additional rules to be covered with this ingress record                                                                          | `[]`                      |
 
 ### APISIX Data Plane Autoscaling configuration
 
@@ -351,37 +359,45 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### APISIX Control Plane Traffic Exposure Parameters
 
-| Name                                            | Description                                                                                                                      | Value                        |
-| ----------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- | ---------------------------- |
-| `controlPlane.service.type`                     | APISIX service type                                                                                                              | `ClusterIP`                  |
-| `controlPlane.service.ports.adminAPI`           | APISIX service Admin API port                                                                                                    | `9180`                       |
-| `controlPlane.service.ports.configServer`       | APISIX service Config Server port                                                                                                | `9280`                       |
-| `controlPlane.service.ports.metrics`            | APISIX service metrics port                                                                                                      | `8080`                       |
-| `controlPlane.service.nodePorts.adminAPI`       | Node port for Admin API                                                                                                          | `""`                         |
-| `controlPlane.service.nodePorts.configServer`   | Node port for Config Server                                                                                                      | `""`                         |
-| `controlPlane.service.nodePorts.metrics`        | Node port for Metrics                                                                                                            | `""`                         |
-| `controlPlane.service.clusterIP`                | APISIX service Cluster IP                                                                                                        | `""`                         |
-| `controlPlane.service.loadBalancerIP`           | APISIX service Load Balancer IP                                                                                                  | `""`                         |
-| `controlPlane.service.loadBalancerSourceRanges` | APISIX service Load Balancer sources                                                                                             | `[]`                         |
-| `controlPlane.service.externalTrafficPolicy`    | APISIX service external traffic policy                                                                                           | `Cluster`                    |
-| `controlPlane.service.annotations`              | Additional custom annotations for APISIX service                                                                                 | `{}`                         |
-| `controlPlane.service.extraPorts`               | Extra ports to expose in APISIX service (normally used with the `sidecars` value)                                                | `[]`                         |
-| `controlPlane.service.sessionAffinity`          | Control where web requests go, to the same pod or round-robin                                                                    | `None`                       |
-| `controlPlane.service.sessionAffinityConfig`    | Additional settings for the sessionAffinity                                                                                      | `{}`                         |
-| `controlPlane.ingress.enabled`                  | Enable ingress record generation for Apisix                                                                                      | `false`                      |
-| `controlPlane.ingress.pathType`                 | Ingress path type                                                                                                                | `ImplementationSpecific`     |
-| `controlPlane.ingress.apiVersion`               | Force Ingress API version (automatically detected if not set)                                                                    | `""`                         |
-| `controlPlane.ingress.hostname`                 | Default host for the ingress record                                                                                              | `apisix-control-plane.local` |
-| `controlPlane.ingress.ingressClassName`         | IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)                                                    | `""`                         |
-| `controlPlane.ingress.path`                     | Default path for the ingress record                                                                                              | `/`                          |
-| `controlPlane.ingress.annotations`              | Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations. | `{}`                         |
-| `controlPlane.ingress.tls`                      | Enable TLS configuration for the host defined at `controlPlane.ingress.hostname` parameter                                       | `false`                      |
-| `controlPlane.ingress.selfSigned`               | Create a TLS secret for this ingress record using self-signed certificates generated by Helm                                     | `false`                      |
-| `controlPlane.ingress.extraHosts`               | An array with additional hostname(s) to be covered with the ingress record                                                       | `[]`                         |
-| `controlPlane.ingress.extraPaths`               | An array with additional arbitrary paths that may need to be added to the ingress under the main host                            | `[]`                         |
-| `controlPlane.ingress.extraTls`                 | TLS configuration for additional hostname(s) to be covered with this ingress record                                              | `[]`                         |
-| `controlPlane.ingress.secrets`                  | Custom TLS certificates as secrets                                                                                               | `[]`                         |
-| `controlPlane.ingress.extraRules`               | Additional rules to be covered with this ingress record                                                                          | `[]`                         |
+| Name                                                 | Description                                                                                                                      | Value                        |
+| ---------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- | ---------------------------- |
+| `controlPlane.service.type`                          | APISIX service type                                                                                                              | `ClusterIP`                  |
+| `controlPlane.service.ports.adminAPI`                | APISIX service Admin API port                                                                                                    | `9180`                       |
+| `controlPlane.service.ports.configServer`            | APISIX service Config Server port                                                                                                | `9280`                       |
+| `controlPlane.service.ports.metrics`                 | APISIX service metrics port                                                                                                      | `8080`                       |
+| `controlPlane.service.nodePorts.adminAPI`            | Node port for Admin API                                                                                                          | `""`                         |
+| `controlPlane.service.nodePorts.configServer`        | Node port for Config Server                                                                                                      | `""`                         |
+| `controlPlane.service.nodePorts.metrics`             | Node port for Metrics                                                                                                            | `""`                         |
+| `controlPlane.service.clusterIP`                     | APISIX service Cluster IP                                                                                                        | `""`                         |
+| `controlPlane.service.loadBalancerIP`                | APISIX service Load Balancer IP                                                                                                  | `""`                         |
+| `controlPlane.service.loadBalancerSourceRanges`      | APISIX service Load Balancer sources                                                                                             | `[]`                         |
+| `controlPlane.service.externalTrafficPolicy`         | APISIX service external traffic policy                                                                                           | `Cluster`                    |
+| `controlPlane.service.annotations`                   | Additional custom annotations for APISIX service                                                                                 | `{}`                         |
+| `controlPlane.service.extraPorts`                    | Extra ports to expose in APISIX service (normally used with the `sidecars` value)                                                | `[]`                         |
+| `controlPlane.service.sessionAffinity`               | Control where web requests go, to the same pod or round-robin                                                                    | `None`                       |
+| `controlPlane.service.sessionAffinityConfig`         | Additional settings for the sessionAffinity                                                                                      | `{}`                         |
+| `controlPlane.networkPolicy.enabled`                 | Specifies whether a NetworkPolicy should be created                                                                              | `true`                       |
+| `controlPlane.networkPolicy.allowExternal`           | Don't require server label for connections                                                                                       | `true`                       |
+| `controlPlane.networkPolicy.allowExternalEgress`     | Allow the pod to access any range of port and all destinations.                                                                  | `true`                       |
+| `controlPlane.networkPolicy.kubeAPIServerPorts`      | List of possible endpoints to kube-apiserver (limit to your cluster settings to increase security)                               | `[]`                         |
+| `controlPlane.networkPolicy.extraIngress`            | Add extra ingress rules to the NetworkPolice                                                                                     | `[]`                         |
+| `controlPlane.networkPolicy.extraEgress`             | Add extra ingress rules to the NetworkPolicy (ignored if allowExternalEgress=true)                                               | `[]`                         |
+| `controlPlane.networkPolicy.ingressNSMatchLabels`    | Labels to match to allow traffic from other namespaces                                                                           | `{}`                         |
+| `controlPlane.networkPolicy.ingressNSPodMatchLabels` | Pod labels to match to allow traffic from other namespaces                                                                       | `{}`                         |
+| `controlPlane.ingress.enabled`                       | Enable ingress record generation for Apisix                                                                                      | `false`                      |
+| `controlPlane.ingress.pathType`                      | Ingress path type                                                                                                                | `ImplementationSpecific`     |
+| `controlPlane.ingress.apiVersion`                    | Force Ingress API version (automatically detected if not set)                                                                    | `""`                         |
+| `controlPlane.ingress.hostname`                      | Default host for the ingress record                                                                                              | `apisix-control-plane.local` |
+| `controlPlane.ingress.ingressClassName`              | IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)                                                    | `""`                         |
+| `controlPlane.ingress.path`                          | Default path for the ingress record                                                                                              | `/`                          |
+| `controlPlane.ingress.annotations`                   | Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations. | `{}`                         |
+| `controlPlane.ingress.tls`                           | Enable TLS configuration for the host defined at `controlPlane.ingress.hostname` parameter                                       | `false`                      |
+| `controlPlane.ingress.selfSigned`                    | Create a TLS secret for this ingress record using self-signed certificates generated by Helm                                     | `false`                      |
+| `controlPlane.ingress.extraHosts`                    | An array with additional hostname(s) to be covered with the ingress record                                                       | `[]`                         |
+| `controlPlane.ingress.extraPaths`                    | An array with additional arbitrary paths that may need to be added to the ingress under the main host                            | `[]`                         |
+| `controlPlane.ingress.extraTls`                      | TLS configuration for additional hostname(s) to be covered with this ingress record                                              | `[]`                         |
+| `controlPlane.ingress.secrets`                       | Custom TLS certificates as secrets                                                                                               | `[]`                         |
+| `controlPlane.ingress.extraRules`                    | Additional rules to be covered with this ingress record                                                                          | `[]`                         |
 
 ### APISIX Control Plane Autoscaling configuration
 
@@ -529,35 +545,42 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### APISIX Dashboard Traffic Exposure Parameters
 
-| Name                                         | Description                                                                                                                      | Value                    |
-| -------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- | ------------------------ |
-| `dashboard.service.type`                     | APISIX Dashboard service type                                                                                                    | `LoadBalancer`           |
-| `dashboard.service.ports.http`               | APISIX Dashboard service HTTP                                                                                                    | `80`                     |
-| `dashboard.service.ports.https`              | APISIX Dashboard service HTTPS                                                                                                   | `443`                    |
-| `dashboard.service.nodePorts.http`           | Node port for HTTP                                                                                                               | `""`                     |
-| `dashboard.service.nodePorts.https`          | Node port for HTTPS                                                                                                              | `""`                     |
-| `dashboard.service.clusterIP`                | APISIX Dashboard service Cluster IP                                                                                              | `""`                     |
-| `dashboard.service.loadBalancerIP`           | APISIX Dashboard service Load Balancer IP                                                                                        | `""`                     |
-| `dashboard.service.loadBalancerSourceRanges` | APISIX Dashboard service Load Balancer sources                                                                                   | `[]`                     |
-| `dashboard.service.externalTrafficPolicy`    | APISIX Dashboard service external traffic policy                                                                                 | `Cluster`                |
-| `dashboard.service.annotations`              | Additional custom annotations for APISIX Dashboard service                                                                       | `{}`                     |
-| `dashboard.service.extraPorts`               | Extra ports to expose in APISIX Dashboard service (normally used with the `sidecars` value)                                      | `[]`                     |
-| `dashboard.service.sessionAffinity`          | Control where web requests go, to the same pod or round-robin                                                                    | `None`                   |
-| `dashboard.service.sessionAffinityConfig`    | Additional settings for the sessionAffinity                                                                                      | `{}`                     |
-| `dashboard.ingress.enabled`                  | Enable ingress record generation for Apisix                                                                                      | `false`                  |
-| `dashboard.ingress.pathType`                 | Ingress path type                                                                                                                | `ImplementationSpecific` |
-| `dashboard.ingress.apiVersion`               | Force Ingress API version (automatically detected if not set)                                                                    | `""`                     |
-| `dashboard.ingress.hostname`                 | Default host for the ingress record                                                                                              | `apisix-dashboard.local` |
-| `dashboard.ingress.ingressClassName`         | IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)                                                    | `""`                     |
-| `dashboard.ingress.path`                     | Default path for the ingress record                                                                                              | `/`                      |
-| `dashboard.ingress.annotations`              | Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations. | `{}`                     |
-| `dashboard.ingress.tls`                      | Enable TLS configuration for the host defined at `dashboard.ingress.hostname` parameter                                          | `false`                  |
-| `dashboard.ingress.selfSigned`               | Create a TLS secret for this ingress record using self-signed certificates generated by Helm                                     | `false`                  |
-| `dashboard.ingress.extraHosts`               | An array with additional hostname(s) to be covered with the ingress record                                                       | `[]`                     |
-| `dashboard.ingress.extraPaths`               | An array with additional arbitrary paths that may need to be added to the ingress under the main host                            | `[]`                     |
-| `dashboard.ingress.extraTls`                 | TLS configuration for additional hostname(s) to be covered with this ingress record                                              | `[]`                     |
-| `dashboard.ingress.secrets`                  | Custom TLS certificates as secrets                                                                                               | `[]`                     |
-| `dashboard.ingress.extraRules`               | Additional rules to be covered with this ingress record                                                                          | `[]`                     |
+| Name                                              | Description                                                                                                                      | Value                    |
+| ------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- | ------------------------ |
+| `dashboard.service.type`                          | APISIX Dashboard service type                                                                                                    | `LoadBalancer`           |
+| `dashboard.service.ports.http`                    | APISIX Dashboard service HTTP                                                                                                    | `80`                     |
+| `dashboard.service.ports.https`                   | APISIX Dashboard service HTTPS                                                                                                   | `443`                    |
+| `dashboard.service.nodePorts.http`                | Node port for HTTP                                                                                                               | `""`                     |
+| `dashboard.service.nodePorts.https`               | Node port for HTTPS                                                                                                              | `""`                     |
+| `dashboard.service.clusterIP`                     | APISIX Dashboard service Cluster IP                                                                                              | `""`                     |
+| `dashboard.service.loadBalancerIP`                | APISIX Dashboard service Load Balancer IP                                                                                        | `""`                     |
+| `dashboard.service.loadBalancerSourceRanges`      | APISIX Dashboard service Load Balancer sources                                                                                   | `[]`                     |
+| `dashboard.service.externalTrafficPolicy`         | APISIX Dashboard service external traffic policy                                                                                 | `Cluster`                |
+| `dashboard.service.annotations`                   | Additional custom annotations for APISIX Dashboard service                                                                       | `{}`                     |
+| `dashboard.service.extraPorts`                    | Extra ports to expose in APISIX Dashboard service (normally used with the `sidecars` value)                                      | `[]`                     |
+| `dashboard.service.sessionAffinity`               | Control where web requests go, to the same pod or round-robin                                                                    | `None`                   |
+| `dashboard.service.sessionAffinityConfig`         | Additional settings for the sessionAffinity                                                                                      | `{}`                     |
+| `dashboard.networkPolicy.enabled`                 | Specifies whether a NetworkPolicy should be created                                                                              | `true`                   |
+| `dashboard.networkPolicy.allowExternal`           | Don't require server label for connections                                                                                       | `true`                   |
+| `dashboard.networkPolicy.allowExternalEgress`     | Allow the pod to access any range of port and all destinations.                                                                  | `true`                   |
+| `dashboard.networkPolicy.extraIngress`            | Add extra ingress rules to the NetworkPolice                                                                                     | `[]`                     |
+| `dashboard.networkPolicy.extraEgress`             | Add extra ingress rules to the NetworkPolicy (ignored if allowExternalEgress=true)                                               | `[]`                     |
+| `dashboard.networkPolicy.ingressNSMatchLabels`    | Labels to match to allow traffic from other namespaces                                                                           | `{}`                     |
+| `dashboard.networkPolicy.ingressNSPodMatchLabels` | Pod labels to match to allow traffic from other namespaces                                                                       | `{}`                     |
+| `dashboard.ingress.enabled`                       | Enable ingress record generation for Apisix                                                                                      | `false`                  |
+| `dashboard.ingress.pathType`                      | Ingress path type                                                                                                                | `ImplementationSpecific` |
+| `dashboard.ingress.apiVersion`                    | Force Ingress API version (automatically detected if not set)                                                                    | `""`                     |
+| `dashboard.ingress.hostname`                      | Default host for the ingress record                                                                                              | `apisix-dashboard.local` |
+| `dashboard.ingress.ingressClassName`              | IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)                                                    | `""`                     |
+| `dashboard.ingress.path`                          | Default path for the ingress record                                                                                              | `/`                      |
+| `dashboard.ingress.annotations`                   | Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations. | `{}`                     |
+| `dashboard.ingress.tls`                           | Enable TLS configuration for the host defined at `dashboard.ingress.hostname` parameter                                          | `false`                  |
+| `dashboard.ingress.selfSigned`                    | Create a TLS secret for this ingress record using self-signed certificates generated by Helm                                     | `false`                  |
+| `dashboard.ingress.extraHosts`                    | An array with additional hostname(s) to be covered with the ingress record                                                       | `[]`                     |
+| `dashboard.ingress.extraPaths`                    | An array with additional arbitrary paths that may need to be added to the ingress under the main host                            | `[]`                     |
+| `dashboard.ingress.extraTls`                      | TLS configuration for additional hostname(s) to be covered with this ingress record                                              | `[]`                     |
+| `dashboard.ingress.secrets`                       | Custom TLS certificates as secrets                                                                                               | `[]`                     |
+| `dashboard.ingress.extraRules`                    | Additional rules to be covered with this ingress record                                                                          | `[]`                     |
 
 ### APISIX Dashboard Autoscaling configuration
 
@@ -681,35 +704,43 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### APISIX Ingress Controller Traffic Exposure Parameters
 
-| Name                                                 | Description                                                                                                                      | Value                             |
-| ---------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- | --------------------------------- |
-| `ingressController.service.type`                     | APISIX Ingress Controller service type                                                                                           | `ClusterIP`                       |
-| `ingressController.service.ports.http`               | APISIX Ingress Controller service HTTP port                                                                                      | `80`                              |
-| `ingressController.service.ports.https`              | APISIX Ingress Controller service HTTPS port                                                                                     | `443`                             |
-| `ingressController.service.nodePorts.http`           | Node port for HTTP                                                                                                               | `""`                              |
-| `ingressController.service.nodePorts.https`          | Node port for HTTPS                                                                                                              | `""`                              |
-| `ingressController.service.clusterIP`                | APISIX Ingress Controller service Cluster IP                                                                                     | `""`                              |
-| `ingressController.service.loadBalancerIP`           | APISIX Ingress Controller service Load Balancer IP                                                                               | `""`                              |
-| `ingressController.service.loadBalancerSourceRanges` | APISIX Ingress Controller service Load Balancer sources                                                                          | `[]`                              |
-| `ingressController.service.externalTrafficPolicy`    | APISIX Ingress Controller service external traffic policy                                                                        | `Cluster`                         |
-| `ingressController.service.annotations`              | Additional custom annotations for APISIX Ingress Controller service                                                              | `{}`                              |
-| `ingressController.service.extraPorts`               | Extra ports to expose in APISIX Ingress Controller service (normally used with the `sidecars` value)                             | `[]`                              |
-| `ingressController.service.sessionAffinity`          | Control where web requests go, to the same pod or round-robin                                                                    | `None`                            |
-| `ingressController.service.sessionAffinityConfig`    | Additional settings for the sessionAffinity                                                                                      | `{}`                              |
-| `ingressController.ingress.enabled`                  | Enable ingress record generation for Apisix                                                                                      | `false`                           |
-| `ingressController.ingress.pathType`                 | Ingress path type                                                                                                                | `ImplementationSpecific`          |
-| `ingressController.ingress.apiVersion`               | Force Ingress API version (automatically detected if not set)                                                                    | `""`                              |
-| `ingressController.ingress.hostname`                 | Default host for the ingress record                                                                                              | `apisix-ingress-controller.local` |
-| `ingressController.ingress.ingressClassName`         | IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)                                                    | `""`                              |
-| `ingressController.ingress.path`                     | Default path for the ingress record                                                                                              | `/`                               |
-| `ingressController.ingress.annotations`              | Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations. | `{}`                              |
-| `ingressController.ingress.tls`                      | Enable TLS configuration for the host defined at `ingressController.ingress.hostname` parameter                                  | `false`                           |
-| `ingressController.ingress.selfSigned`               | Create a TLS secret for this ingress record using self-signed certificates generated by Helm                                     | `false`                           |
-| `ingressController.ingress.extraHosts`               | An array with additional hostname(s) to be covered with the ingress record                                                       | `[]`                              |
-| `ingressController.ingress.extraPaths`               | An array with additional arbitrary paths that may need to be added to the ingress under the main host                            | `[]`                              |
-| `ingressController.ingress.extraTls`                 | TLS configuration for additional hostname(s) to be covered with this ingress record                                              | `[]`                              |
-| `ingressController.ingress.secrets`                  | Custom TLS certificates as secrets                                                                                               | `[]`                              |
-| `ingressController.ingress.extraRules`               | Additional rules to be covered with this ingress record                                                                          | `[]`                              |
+| Name                                                      | Description                                                                                                                      | Value                             |
+| --------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- | --------------------------------- |
+| `ingressController.service.type`                          | APISIX Ingress Controller service type                                                                                           | `ClusterIP`                       |
+| `ingressController.service.ports.http`                    | APISIX Ingress Controller service HTTP port                                                                                      | `80`                              |
+| `ingressController.service.ports.https`                   | APISIX Ingress Controller service HTTPS port                                                                                     | `443`                             |
+| `ingressController.service.nodePorts.http`                | Node port for HTTP                                                                                                               | `""`                              |
+| `ingressController.service.nodePorts.https`               | Node port for HTTPS                                                                                                              | `""`                              |
+| `ingressController.service.clusterIP`                     | APISIX Ingress Controller service Cluster IP                                                                                     | `""`                              |
+| `ingressController.service.loadBalancerIP`                | APISIX Ingress Controller service Load Balancer IP                                                                               | `""`                              |
+| `ingressController.service.loadBalancerSourceRanges`      | APISIX Ingress Controller service Load Balancer sources                                                                          | `[]`                              |
+| `ingressController.service.externalTrafficPolicy`         | APISIX Ingress Controller service external traffic policy                                                                        | `Cluster`                         |
+| `ingressController.service.annotations`                   | Additional custom annotations for APISIX Ingress Controller service                                                              | `{}`                              |
+| `ingressController.service.extraPorts`                    | Extra ports to expose in APISIX Ingress Controller service (normally used with the `sidecars` value)                             | `[]`                              |
+| `ingressController.service.sessionAffinity`               | Control where web requests go, to the same pod or round-robin                                                                    | `None`                            |
+| `ingressController.service.sessionAffinityConfig`         | Additional settings for the sessionAffinity                                                                                      | `{}`                              |
+| `ingressController.networkPolicy.enabled`                 | Specifies whether a NetworkPolicy should be created                                                                              | `true`                            |
+| `ingressController.networkPolicy.allowExternal`           | Don't require server label for connections                                                                                       | `true`                            |
+| `ingressController.networkPolicy.allowExternalEgress`     | Allow the pod to access any range of port and all destinations.                                                                  | `true`                            |
+| `ingressController.networkPolicy.kubeAPIServerPorts`      | List of possible endpoints to kube-apiserver (limit to your cluster settings to increase security)                               | `[]`                              |
+| `ingressController.networkPolicy.extraIngress`            | Add extra ingress rules to the NetworkPolice                                                                                     | `[]`                              |
+| `ingressController.networkPolicy.extraEgress`             | Add extra ingress rules to the NetworkPolicy (ignored if allowExternalEgress=true)                                               | `[]`                              |
+| `ingressController.networkPolicy.ingressNSMatchLabels`    | Labels to match to allow traffic from other namespaces                                                                           | `{}`                              |
+| `ingressController.networkPolicy.ingressNSPodMatchLabels` | Pod labels to match to allow traffic from other namespaces                                                                       | `{}`                              |
+| `ingressController.ingress.enabled`                       | Enable ingress record generation for Apisix                                                                                      | `false`                           |
+| `ingressController.ingress.pathType`                      | Ingress path type                                                                                                                | `ImplementationSpecific`          |
+| `ingressController.ingress.apiVersion`                    | Force Ingress API version (automatically detected if not set)                                                                    | `""`                              |
+| `ingressController.ingress.hostname`                      | Default host for the ingress record                                                                                              | `apisix-ingress-controller.local` |
+| `ingressController.ingress.ingressClassName`              | IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)                                                    | `""`                              |
+| `ingressController.ingress.path`                          | Default path for the ingress record                                                                                              | `/`                               |
+| `ingressController.ingress.annotations`                   | Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations. | `{}`                              |
+| `ingressController.ingress.tls`                           | Enable TLS configuration for the host defined at `ingressController.ingress.hostname` parameter                                  | `false`                           |
+| `ingressController.ingress.selfSigned`                    | Create a TLS secret for this ingress record using self-signed certificates generated by Helm                                     | `false`                           |
+| `ingressController.ingress.extraHosts`                    | An array with additional hostname(s) to be covered with the ingress record                                                       | `[]`                              |
+| `ingressController.ingress.extraPaths`                    | An array with additional arbitrary paths that may need to be added to the ingress under the main host                            | `[]`                              |
+| `ingressController.ingress.extraTls`                      | TLS configuration for additional hostname(s) to be covered with this ingress record                                              | `[]`                              |
+| `ingressController.ingress.secrets`                       | Custom TLS certificates as secrets                                                                                               | `[]`                              |
+| `ingressController.ingress.extraRules`                    | Additional rules to be covered with this ingress record                                                                          | `[]`                              |
 
 ### APISIX Ingress Controller Autoscaling configuration
 

--- a/bitnami/apisix/templates/control-plane/networkpolicy.yaml
+++ b/bitnami/apisix/templates/control-plane/networkpolicy.yaml
@@ -1,0 +1,88 @@
+{{- /*
+Copyright VMware, Inc.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+{{- if and .Values.controlPlane.enabled .Values.controlPlane.networkPolicy.enabled }}
+kind: NetworkPolicy
+apiVersion: {{ include "common.capabilities.networkPolicy.apiVersion" . }}
+metadata:
+  name: {{ template "apisix.control-plane.fullname" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+    app.kubernetes.io/part-of: apisix
+    app.kubernetes.io/component: control-plane
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.controlPlane.podLabels .Values.commonLabels ) "context" . ) }}
+  podSelector:
+    matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
+      app.kubernetes.io/part-of: apisix
+      app.kubernetes.io/component: control-plane
+  policyTypes:
+    - Ingress
+    - Egress
+  {{- if .Values.controlPlane.networkPolicy.allowExternalEgress }}
+  egress:
+    - {}
+  {{- else }}
+  egress:
+    - ports:
+        # Allow dns resolution
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+        # Allow access to kube-apiserver
+        {{- range $port := .Values.controlPlane.networkPolicy.kubeAPIServerPorts }}
+        - port: {{ $port }}
+        {{- end }}
+    # Allow outbound connections to etcd
+    - ports:
+        - port: {{ include "apisix.etcd.port" . }}
+      to: 
+        {{- if .Values.etcd.enabled }}
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: etcd
+              app.kubernetes.io/instance: {{ .Release.Name }}
+        {{- end }}
+    {{- if .Values.controlPlane.networkPolicy.extraEgress }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.controlPlane.networkPolicy.extraEgress "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- end }}
+  ingress:
+    - ports:
+        - port: {{ .Values.controlPlane.containerPorts.adminAPI }}
+        - port: {{ .Values.controlPlane.containerPorts.configServer }}
+        - port: {{ .Values.controlPlane.containerPorts.control }}
+        - port: {{ .Values.controlPlane.containerPorts.metrics }}
+      {{- if not .Values.controlPlane.networkPolicy.allowExternal }}
+      from:
+        - podSelector:
+            matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 14 }}
+              app.kubernetes.io/part-of: apisix
+        - podSelector:
+            matchLabels:
+              {{ template "apisix.control-plane.fullname" . }}-client: "true"
+        {{- if .Values.controlPlane.networkPolicy.ingressNSMatchLabels }}
+        - namespaceSelector:
+            matchLabels:
+              {{- range $key, $value := .Values.controlPlane.networkPolicy.ingressNSMatchLabels }}
+              {{ $key | quote }}: {{ $value | quote }}
+              {{- end }}
+          {{- if .Values.controlPlane.networkPolicy.ingressNSPodMatchLabels }}
+          podSelector:
+            matchLabels:
+              {{- range $key, $value := .Values.controlPlane.networkPolicy.ingressNSPodMatchLabels }}
+              {{ $key | quote }}: {{ $value | quote }}
+              {{- end }}
+          {{- end }}
+        {{- end }}
+      {{- end }}
+    {{- if .Values.controlPlane.networkPolicy.extraIngress }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.controlPlane.networkPolicy.extraIngress "context" $ ) | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/bitnami/apisix/templates/dashboard/networkpolicy.yaml
+++ b/bitnami/apisix/templates/dashboard/networkpolicy.yaml
@@ -1,0 +1,82 @@
+{{- /*
+Copyright VMware, Inc.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+{{- if and .Values.dashboard.enabled .Values.dashboard.networkPolicy.enabled }}
+kind: NetworkPolicy
+apiVersion: {{ include "common.capabilities.networkPolicy.apiVersion" . }}
+metadata:
+  name: {{ template "apisix.dashboard.fullname" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+    app.kubernetes.io/part-of: apisix
+    app.kubernetes.io/component: dashboard
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.dashboard.podLabels .Values.commonLabels ) "context" . ) }}
+  podSelector:
+    matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
+      app.kubernetes.io/part-of: apisix
+      app.kubernetes.io/component: dashboard
+  policyTypes:
+    - Ingress
+    - Egress
+  {{- if .Values.dashboard.networkPolicy.allowExternalEgress }}
+  egress:
+    - {}
+  {{- else }}
+  egress:
+    - ports:
+        # Allow dns resolution
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+    # Allow outbound connections to etcd
+    - ports:
+        - port: {{ include "apisix.etcd.port" . }}
+      to: 
+        {{- if .Values.etcd.enabled }}
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: etcd
+              app.kubernetes.io/instance: {{ .Release.Name }}
+        {{- end }}
+    {{- if .Values.dashboard.networkPolicy.extraEgress }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.dashboard.networkPolicy.extraEgress "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- end }}
+  ingress:
+    - ports:
+        - port: {{ .Values.dashboard.containerPorts.http }}
+        - port: {{ .Values.dashboard.containerPorts.https }}
+      {{- if not .Values.dashboard.networkPolicy.allowExternal }}
+      from:
+        - podSelector:
+            matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 14 }}
+              app.kubernetes.io/part-of: apisix
+        - podSelector:
+            matchLabels:
+              {{ template "apisix.dashboard.fullname" . }}-client: "true"
+        {{- if .Values.dashboard.networkPolicy.ingressNSMatchLabels }}
+        - namespaceSelector:
+            matchLabels:
+              {{- range $key, $value := .Values.dashboard.networkPolicy.ingressNSMatchLabels }}
+              {{ $key | quote }}: {{ $value | quote }}
+              {{- end }}
+          {{- if .Values.dashboard.networkPolicy.ingressNSPodMatchLabels }}
+          podSelector:
+            matchLabels:
+              {{- range $key, $value := .Values.dashboard.networkPolicy.ingressNSPodMatchLabels }}
+              {{ $key | quote }}: {{ $value | quote }}
+              {{- end }}
+          {{- end }}
+        {{- end }}
+      {{- end }}
+    {{- if .Values.dashboard.networkPolicy.extraIngress }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.dashboard.networkPolicy.extraIngress "context" $ ) | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/bitnami/apisix/templates/data-plane/networkpolicy.yaml
+++ b/bitnami/apisix/templates/data-plane/networkpolicy.yaml
@@ -1,0 +1,99 @@
+{{- /*
+Copyright VMware, Inc.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+{{- if and .Values.dataPlane.enabled .Values.dataPlane.networkPolicy.enabled }}
+kind: NetworkPolicy
+apiVersion: {{ include "common.capabilities.networkPolicy.apiVersion" . }}
+metadata:
+  name: {{ template "apisix.data-plane.fullname" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+    app.kubernetes.io/part-of: apisix
+    app.kubernetes.io/component: data-plane
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.dataPlane.podLabels .Values.commonLabels ) "context" . ) }}
+  podSelector:
+    matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
+      app.kubernetes.io/part-of: apisix
+      app.kubernetes.io/component: data-plane
+  policyTypes:
+    - Ingress
+    - Egress
+  {{- if .Values.dataPlane.networkPolicy.allowExternalEgress }}
+  egress:
+    - {}
+  {{- else }}
+  egress:
+    - ports:
+        # Allow dns resolution
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+        # Allow access to kube-apiserver
+        {{- range $port := .Values.dataPlane.networkPolicy.kubeAPIServerPorts }}
+        - port: {{ $port }}
+        {{- end }}
+    # Allow outbound connections to etcd
+    - ports:
+        - port: {{ include "apisix.etcd.port" . }}
+      to: 
+        {{- if .Values.etcd.enabled }}
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: etcd
+              app.kubernetes.io/instance: {{ .Release.Name }}
+        {{- end }}
+    # Allow outbound connections to control plane
+    - ports:
+        - port: {{ .Values.controlPlane.containerPorts.adminAPI }}
+        - port: {{ .Values.controlPlane.containerPorts.configServer }}
+        - port: {{ .Values.controlPlane.containerPorts.control }}
+        - port: {{ .Values.controlPlane.containerPorts.metrics }}
+      to: 
+        - podSelector:
+            matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 14 }}
+              app.kubernetes.io/part-of: apisix
+              app.kubernetes.io/component: control-plane
+    {{- if .Values.dataPlane.networkPolicy.extraEgress }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.dataPlane.networkPolicy.extraEgress "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- end }}
+  ingress:
+    - ports:
+        - port: {{ .Values.dataPlane.containerPorts.http }}
+        - port: {{ .Values.dataPlane.containerPorts.https }}
+        - port: {{ .Values.dataPlane.containerPorts.control }}
+        - port: {{ .Values.dataPlane.containerPorts.metrics }}
+      {{- if not .Values.dataPlane.networkPolicy.allowExternal }}
+      from:
+        - podSelector:
+            matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 14 }}
+              app.kubernetes.io/part-of: apisix
+        - podSelector:
+            matchLabels:
+              {{ template "apisix.data-plane.fullname" . }}-client: "true"
+        {{- if .Values.dataPlane.networkPolicy.ingressNSMatchLabels }}
+        - namespaceSelector:
+            matchLabels:
+              {{- range $key, $value := .Values.dataPlane.networkPolicy.ingressNSMatchLabels }}
+              {{ $key | quote }}: {{ $value | quote }}
+              {{- end }}
+          {{- if .Values.dataPlane.networkPolicy.ingressNSPodMatchLabels }}
+          podSelector:
+            matchLabels:
+              {{- range $key, $value := .Values.dataPlane.networkPolicy.ingressNSPodMatchLabels }}
+              {{ $key | quote }}: {{ $value | quote }}
+              {{- end }}
+          {{- end }}
+        {{- end }}
+      {{- end }}
+    {{- if .Values.dataPlane.networkPolicy.extraIngress }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.dataPlane.networkPolicy.extraIngress "context" $ ) | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/bitnami/apisix/templates/ingress-controller/networkpolicy.yaml
+++ b/bitnami/apisix/templates/ingress-controller/networkpolicy.yaml
@@ -1,0 +1,98 @@
+{{- /*
+Copyright VMware, Inc.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+{{- if and .Values.ingressController.enabled .Values.ingressController.networkPolicy.enabled }}
+kind: NetworkPolicy
+apiVersion: {{ include "common.capabilities.networkPolicy.apiVersion" . }}
+metadata:
+  name: {{ template "apisix.ingress-controller.fullname" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+    app.kubernetes.io/part-of: apisix
+    app.kubernetes.io/component: ingress-controller
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.ingressController.podLabels .Values.commonLabels ) "context" . ) }}
+  podSelector:
+    matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
+      app.kubernetes.io/part-of: apisix
+      app.kubernetes.io/component: ingress-controller
+  policyTypes:
+    - Ingress
+    - Egress
+  {{- if .Values.ingressController.networkPolicy.allowExternalEgress }}
+  egress:
+    - {}
+  {{- else }}
+  egress:
+    - ports:
+        # Allow dns resolution
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+        # Allow access to kube-apiserver
+        {{- range $port := .Values.ingressController.networkPolicy.kubeAPIServerPorts }}
+        - port: {{ $port }}
+        {{- end }}
+    # Allow outbound connections to control plane
+    - ports:
+        - port: {{ .Values.controlPlane.containerPorts.adminAPI }}
+        - port: {{ .Values.controlPlane.containerPorts.configServer }}
+        - port: {{ .Values.controlPlane.containerPorts.control }}
+        - port: {{ .Values.controlPlane.containerPorts.metrics }}
+      to: 
+        - podSelector:
+            matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 14 }}
+              app.kubernetes.io/part-of: apisix
+              app.kubernetes.io/component: control-plane
+    # Allow outbound connections to data plane
+    - ports:
+        - port: {{ .Values.dataPlane.containerPorts.http }}
+        - port: {{ .Values.dataPlane.containerPorts.https }}
+        - port: {{ .Values.dataPlane.containerPorts.control }}
+        - port: {{ .Values.dataPlane.containerPorts.metrics }}
+      to: 
+        - podSelector:
+            matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 14 }}
+              app.kubernetes.io/part-of: apisix
+              app.kubernetes.io/component: data-plane
+    {{- if .Values.ingressController.networkPolicy.extraEgress }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.ingressController.networkPolicy.extraEgress "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- end }}
+  ingress:
+    - ports:
+        - port: {{ .Values.ingressController.containerPorts.http }}
+        - port: {{ .Values.ingressController.containerPorts.https }}
+      {{- if not .Values.ingressController.networkPolicy.allowExternal }}
+      from:
+        - podSelector:
+            matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 14 }}
+              app.kubernetes.io/part-of: apisix
+        - podSelector:
+            matchLabels:
+              {{ template "apisix.ingress-controller.fullname" . }}-client: "true"
+        {{- if .Values.ingressController.networkPolicy.ingressNSMatchLabels }}
+        - namespaceSelector:
+            matchLabels:
+              {{- range $key, $value := .Values.ingressController.networkPolicy.ingressNSMatchLabels }}
+              {{ $key | quote }}: {{ $value | quote }}
+              {{- end }}
+          {{- if .Values.ingressController.networkPolicy.ingressNSPodMatchLabels }}
+          podSelector:
+            matchLabels:
+              {{- range $key, $value := .Values.ingressController.networkPolicy.ingressNSPodMatchLabels }}
+              {{ $key | quote }}: {{ $value | quote }}
+              {{- end }}
+          {{- end }}
+        {{- end }}
+      {{- end }}
+    {{- if .Values.ingressController.networkPolicy.extraIngress }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.ingressController.networkPolicy.extraIngress "context" $ ) | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/bitnami/apisix/values.yaml
+++ b/bitnami/apisix/values.yaml
@@ -551,6 +551,64 @@ dataPlane:
     ##     timeoutSeconds: 300
     ##
     sessionAffinityConfig: {}
+  ## Network Policies
+  ## Ref: https://kubernetes.io/docs/concepts/services-networking/network-policies/
+  ##
+  networkPolicy:
+    ## @param dataPlane.networkPolicy.enabled Specifies whether a NetworkPolicy should be created
+    ##
+    enabled: true
+    ## @param dataPlane.networkPolicy.allowExternal Don't require server label for connections
+    ## The Policy model to apply. When set to false, only pods with the correct
+    ## server label will have network access to the ports server is listening
+    ## on. When true, server will accept connections from any source
+    ## (with the correct destination port).
+    ##
+    allowExternal: true
+    ## @param dataPlane.networkPolicy.allowExternalEgress Allow the pod to access any range of port and all destinations.
+    ##
+    allowExternalEgress: true
+    ## @param dataPlane.networkPolicy.kubeAPIServerPorts [array] List of possible endpoints to kube-apiserver (limit to your cluster settings to increase security)
+    ##
+    kubeAPIServerPorts: [443, 6443, 8443]
+    ## @param dataPlane.networkPolicy.extraIngress [array] Add extra ingress rules to the NetworkPolice
+    ## e.g:
+    ## extraIngress:
+    ##   - ports:
+    ##       - port: 1234
+    ##     from:
+    ##       - podSelector:
+    ##           - matchLabels:
+    ##               - role: frontend
+    ##       - podSelector:
+    ##           - matchExpressions:
+    ##               - key: role
+    ##                 operator: In
+    ##                 values:
+    ##                   - frontend
+    extraIngress: []
+    ## @param dataPlane.networkPolicy.extraEgress [array] Add extra ingress rules to the NetworkPolicy (ignored if allowExternalEgress=true)
+    ## e.g:
+    ## extraEgress:
+    ##   - ports:
+    ##       - port: 1234
+    ##     to:
+    ##       - podSelector:
+    ##           - matchLabels:
+    ##               - role: frontend
+    ##       - podSelector:
+    ##           - matchExpressions:
+    ##               - key: role
+    ##                 operator: In
+    ##                 values:
+    ##                   - frontend
+    ##
+    extraEgress: []
+    ## @param dataPlane.networkPolicy.ingressNSMatchLabels [object] Labels to match to allow traffic from other namespaces
+    ## @param dataPlane.networkPolicy.ingressNSPodMatchLabels [object] Pod labels to match to allow traffic from other namespaces
+    ##
+    ingressNSMatchLabels: {}
+    ingressNSPodMatchLabels: {}
 
   ## ref: http://kubernetes.io/docs/concepts/services-networking/ingress/
   ##
@@ -1282,6 +1340,64 @@ controlPlane:
     ##     timeoutSeconds: 300
     ##
     sessionAffinityConfig: {}
+  ## Network Policies
+  ## Ref: https://kubernetes.io/docs/concepts/services-networking/network-policies/
+  ##
+  networkPolicy:
+    ## @param controlPlane.networkPolicy.enabled Specifies whether a NetworkPolicy should be created
+    ##
+    enabled: true
+    ## @param controlPlane.networkPolicy.allowExternal Don't require server label for connections
+    ## The Policy model to apply. When set to false, only pods with the correct
+    ## server label will have network access to the ports server is listening
+    ## on. When true, server will accept connections from any source
+    ## (with the correct destination port).
+    ##
+    allowExternal: true
+    ## @param controlPlane.networkPolicy.allowExternalEgress Allow the pod to access any range of port and all destinations.
+    ##
+    allowExternalEgress: true
+    ## @param controlPlane.networkPolicy.kubeAPIServerPorts [array] List of possible endpoints to kube-apiserver (limit to your cluster settings to increase security)
+    ##
+    kubeAPIServerPorts: [443, 6443, 8443]
+    ## @param controlPlane.networkPolicy.extraIngress [array] Add extra ingress rules to the NetworkPolice
+    ## e.g:
+    ## extraIngress:
+    ##   - ports:
+    ##       - port: 1234
+    ##     from:
+    ##       - podSelector:
+    ##           - matchLabels:
+    ##               - role: frontend
+    ##       - podSelector:
+    ##           - matchExpressions:
+    ##               - key: role
+    ##                 operator: In
+    ##                 values:
+    ##                   - frontend
+    extraIngress: []
+    ## @param controlPlane.networkPolicy.extraEgress [array] Add extra ingress rules to the NetworkPolicy (ignored if allowExternalEgress=true)
+    ## e.g:
+    ## extraEgress:
+    ##   - ports:
+    ##       - port: 1234
+    ##     to:
+    ##       - podSelector:
+    ##           - matchLabels:
+    ##               - role: frontend
+    ##       - podSelector:
+    ##           - matchExpressions:
+    ##               - key: role
+    ##                 operator: In
+    ##                 values:
+    ##                   - frontend
+    ##
+    extraEgress: []
+    ## @param controlPlane.networkPolicy.ingressNSMatchLabels [object] Labels to match to allow traffic from other namespaces
+    ## @param controlPlane.networkPolicy.ingressNSPodMatchLabels [object] Pod labels to match to allow traffic from other namespaces
+    ##
+    ingressNSMatchLabels: {}
+    ingressNSPodMatchLabels: {}
 
   ## ref: http://kubernetes.io/docs/concepts/services-networking/ingress/
   ##
@@ -2055,6 +2171,61 @@ dashboard:
     ##     timeoutSeconds: 300
     ##
     sessionAffinityConfig: {}
+  ## Network Policies
+  ## Ref: https://kubernetes.io/docs/concepts/services-networking/network-policies/
+  ##
+  networkPolicy:
+    ## @param dashboard.networkPolicy.enabled Specifies whether a NetworkPolicy should be created
+    ##
+    enabled: true
+    ## @param dashboard.networkPolicy.allowExternal Don't require server label for connections
+    ## The Policy model to apply. When set to false, only pods with the correct
+    ## server label will have network access to the ports server is listening
+    ## on. When true, server will accept connections from any source
+    ## (with the correct destination port).
+    ##
+    allowExternal: true
+    ## @param dashboard.networkPolicy.allowExternalEgress Allow the pod to access any range of port and all destinations.
+    ##
+    allowExternalEgress: true
+    ## @param dashboard.networkPolicy.extraIngress [array] Add extra ingress rules to the NetworkPolice
+    ## e.g:
+    ## extraIngress:
+    ##   - ports:
+    ##       - port: 1234
+    ##     from:
+    ##       - podSelector:
+    ##           - matchLabels:
+    ##               - role: frontend
+    ##       - podSelector:
+    ##           - matchExpressions:
+    ##               - key: role
+    ##                 operator: In
+    ##                 values:
+    ##                   - frontend
+    extraIngress: []
+    ## @param dashboard.networkPolicy.extraEgress [array] Add extra ingress rules to the NetworkPolicy (ignored if allowExternalEgress=true)
+    ## e.g:
+    ## extraEgress:
+    ##   - ports:
+    ##       - port: 1234
+    ##     to:
+    ##       - podSelector:
+    ##           - matchLabels:
+    ##               - role: frontend
+    ##       - podSelector:
+    ##           - matchExpressions:
+    ##               - key: role
+    ##                 operator: In
+    ##                 values:
+    ##                   - frontend
+    ##
+    extraEgress: []
+    ## @param dashboard.networkPolicy.ingressNSMatchLabels [object] Labels to match to allow traffic from other namespaces
+    ## @param dashboard.networkPolicy.ingressNSPodMatchLabels [object] Pod labels to match to allow traffic from other namespaces
+    ##
+    ingressNSMatchLabels: {}
+    ingressNSPodMatchLabels: {}
 
   ## ref: http://kubernetes.io/docs/concepts/services-networking/ingress/
   ##
@@ -2638,6 +2809,64 @@ ingressController:
     ##     timeoutSeconds: 300
     ##
     sessionAffinityConfig: {}
+  ## Network Policies
+  ## Ref: https://kubernetes.io/docs/concepts/services-networking/network-policies/
+  ##
+  networkPolicy:
+    ## @param ingressController.networkPolicy.enabled Specifies whether a NetworkPolicy should be created
+    ##
+    enabled: true
+    ## @param ingressController.networkPolicy.allowExternal Don't require server label for connections
+    ## The Policy model to apply. When set to false, only pods with the correct
+    ## server label will have network access to the ports server is listening
+    ## on. When true, server will accept connections from any source
+    ## (with the correct destination port).
+    ##
+    allowExternal: true
+    ## @param ingressController.networkPolicy.allowExternalEgress Allow the pod to access any range of port and all destinations.
+    ##
+    allowExternalEgress: true
+    ## @param ingressController.networkPolicy.kubeAPIServerPorts [array] List of possible endpoints to kube-apiserver (limit to your cluster settings to increase security)
+    ##
+    kubeAPIServerPorts: [443, 6443, 8443]
+    ## @param ingressController.networkPolicy.extraIngress [array] Add extra ingress rules to the NetworkPolice
+    ## e.g:
+    ## extraIngress:
+    ##   - ports:
+    ##       - port: 1234
+    ##     from:
+    ##       - podSelector:
+    ##           - matchLabels:
+    ##               - role: frontend
+    ##       - podSelector:
+    ##           - matchExpressions:
+    ##               - key: role
+    ##                 operator: In
+    ##                 values:
+    ##                   - frontend
+    extraIngress: []
+    ## @param ingressController.networkPolicy.extraEgress [array] Add extra ingress rules to the NetworkPolicy (ignored if allowExternalEgress=true)
+    ## e.g:
+    ## extraEgress:
+    ##   - ports:
+    ##       - port: 1234
+    ##     to:
+    ##       - podSelector:
+    ##           - matchLabels:
+    ##               - role: frontend
+    ##       - podSelector:
+    ##           - matchExpressions:
+    ##               - key: role
+    ##                 operator: In
+    ##                 values:
+    ##                   - frontend
+    ##
+    extraEgress: []
+    ## @param ingressController.networkPolicy.ingressNSMatchLabels [object] Labels to match to allow traffic from other namespaces
+    ## @param ingressController.networkPolicy.ingressNSPodMatchLabels [object] Pod labels to match to allow traffic from other namespaces
+    ##
+    ingressNSMatchLabels: {}
+    ingressNSPodMatchLabels: {}
 
   ## ref: http://kubernetes.io/docs/concepts/services-networking/ingress/
   ##


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

This PR normalizes the use of NetworkPolicy in the chart. Adds all Bitnami standards for NetworkPolicies as well as enabling it by default, in order to comply with security checklists.

<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

More security in the chart
<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
