### PR TITLE
[bitnami/kubernetes-event-exporter]: fix PrometheusRule alert provided as example (#23368)

### DIFF
--- a/bitnami/kubernetes-event-exporter/Chart.yaml
+++ b/bitnami/kubernetes-event-exporter/Chart.yaml
@@ -31,4 +31,4 @@ maintainers:
 name: kubernetes-event-exporter
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/kubernetes-event-exporter
-version: 2.13.2
+version: 2.13.3

--- a/bitnami/kubernetes-event-exporter/values.yaml
+++ b/bitnami/kubernetes-event-exporter/values.yaml
@@ -530,7 +530,7 @@ metrics:
     ##           annotations:
     ##             message: "Kubernetes Event Exporter instance in namespace {{ `{{` }} $labels.namespace {{ `}}` }} has reported too many watch errors in 5 minutes."
     ##           expr: |
-    ##             sum(watch_errors{namespace="{{ include "common.names.namespace" . }}"})
+    ##             sum(watch_errors{namespace="{{ include "common.names.namespace" . }}"}) >= 1
     ##           for: 5m
     ##           labels:
     ##             severity: critical


### PR DESCRIPTION
### Description of the change

Fix for issue [kubernetes-event-exporter PrometheusRule KubernetesEventExporterTooManyWatchErrors example always triggered](https://github.com/bitnami/charts/issues/23368)

https://github.com/bitnami/charts/issues/23368

I simply updated the PrometheusRule provided as an example

### Benefits

Do not trigger an immediate Prometheus alert despite the fact that there is no error

### Additional information

- Fixes https://github.com/bitnami/charts/issues/23368

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
