### PR TITLE
change FLINK taskmanager host env

### DIFF
--- a/bitnami/flink/Chart.yaml
+++ b/bitnami/flink/Chart.yaml
@@ -28,4 +28,4 @@ maintainers:
 name: flink
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/flink
-version: 0.8.0
+version: 0.8.1

--- a/bitnami/flink/templates/taskmanager/deployment.yaml
+++ b/bitnami/flink/templates/taskmanager/deployment.yaml
@@ -105,7 +105,9 @@ spec:
             - name: FLINK_CFG_TASKMANAGER_RPC_PORT
               value: {{ .Values.taskmanager.containerPorts.rpc | quote }}
             - name: FLINK_CFG_TASKMANAGER_HOST
-              value: {{ include "flink.taskmanager.fullname" . | quote}}
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
             - name: FLINK_CFG_TASKMANAGER_BIND__HOST
               value: 0.0.0.0
             - name: BITNAMI_DEBUG

--- a/bitnami/moodle/Chart.lock
+++ b/bitnami/moodle/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: mariadb
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 15.2.0
+  version: 15.2.2
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 2.14.1
-digest: sha256:c834480bdc027d274b65cecbca6da36bbbb4a658846cb4692e08c1df9c8bcf8a
-generated: "2024-01-30T01:10:24.24719595Z"
+digest: sha256:31a498a752380481a7781ade5830a668d525c28ce46ca48641c5b7dff402734e
+generated: "2024-02-12T07:20:04.726493441Z"

--- a/bitnami/moodle/Chart.yaml
+++ b/bitnami/moodle/Chart.yaml
@@ -6,13 +6,13 @@ annotations:
   licenses: Apache-2.0
   images: |
     - name: apache-exporter
-      image: docker.io/bitnami/apache-exporter:1.0.6-debian-11-r1
+      image: docker.io/bitnami/apache-exporter:1.0.6-debian-11-r6
     - name: moodle
-      image: docker.io/bitnami/moodle:4.3.2-debian-11-r4
+      image: docker.io/bitnami/moodle:4.3.3-debian-11-r0
     - name: os-shell
-      image: docker.io/bitnami/os-shell:11-debian-11-r96
+      image: docker.io/bitnami/os-shell:11-debian-11-r100
 apiVersion: v2
-appVersion: 4.3.2
+appVersion: 4.3.3
 dependencies:
 - condition: mariadb.enabled
   name: mariadb
@@ -36,4 +36,4 @@ maintainers:
 name: moodle
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/moodle
-version: 20.2.4
+version: 20.2.5

--- a/bitnami/moodle/values.yaml
+++ b/bitnami/moodle/values.yaml
@@ -55,7 +55,7 @@ extraDeploy: []
 image:
   registry: docker.io
   repository: bitnami/moodle
-  tag: 4.3.2-debian-11-r4
+  tag: 4.3.3-debian-11-r0
   digest: ""
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
@@ -691,7 +691,7 @@ volumePermissions:
   image:
     registry: docker.io
     repository: bitnami/os-shell
-    tag: 11-debian-11-r96
+    tag: 11-debian-11-r100
     digest: ""
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
@@ -737,7 +737,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/apache-exporter
-    tag: 1.0.6-debian-11-r1
+    tag: 1.0.6-debian-11-r6
     digest: ""
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
@@ -854,7 +854,7 @@ certificates:
   image:
     registry: docker.io
     repository: bitnami/os-shell
-    tag: 11-debian-11-r96
+    tag: 11-debian-11-r100
     digest: ""
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Closes https://github.com/bitnami/charts/issues/22225


As per Flink docs taskmanager host name must be unique:
![image](https://github.com/bitnami/charts/assets/20227477/84c6808c-444d-470e-b84f-dd8035d35f88)


currently it is assigned to any taskmanager pod same name what is causing issues with registration to pekko framework. So in result chart doesnt work when you setup more replicas than one for taskmanager deployment. This PR is taking a unique name for `taskmanager.host` name which is equal to pod name (using downward API)

### Benefits

This chart will start working with more than one task manager host

### Possible drawbacks

none

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #22225

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
