### PR TITLE
[bitnami/jasperreports] Mark JasperReports chart as deprecated

### DIFF
--- a/.vib/discourse/runtime-parameters.yaml
+++ b/.vib/discourse/runtime-parameters.yaml
@@ -5,7 +5,7 @@ auth:
 postgresql:
   auth:
     username: bn_discourse
-host: bitnami-discourse.my
+host: localhost
 service:
   type: LoadBalancer
   ports:

--- a/.vib/discourse/runtime-parameters.yaml
+++ b/.vib/discourse/runtime-parameters.yaml
@@ -5,7 +5,7 @@ auth:
 postgresql:
   auth:
     username: bn_discourse
-host: localhost
+host: bitnami-discourse.my
 service:
   type: LoadBalancer
   ports:

--- a/bitnami/jasperreports/Chart.yaml
+++ b/bitnami/jasperreports/Chart.yaml
@@ -30,7 +30,7 @@ keywords:
 - reporting
 - analytic
 - visualization
-maintainers:
+maintainers: []
 name: jasperreports
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/jasperreports

--- a/bitnami/jasperreports/Chart.yaml
+++ b/bitnami/jasperreports/Chart.yaml
@@ -19,7 +19,8 @@ dependencies:
   tags:
   - bitnami-common
   version: 2.x.x
-description: JasperReports Server is a stand-alone and embeddable reporting server. It is a central information hub, with reporting and analytics that can be embedded into web and mobile applications.
+deprecated: true  
+description: DEPRECATED JasperReports Server is a stand-alone and embeddable reporting server. It is a central information hub, with reporting and analytics that can be embedded into web and mobile applications.
 home: https://bitnami.com
 icon: https://bitnami.com/assets/stacks/jasperserver/img/jasperserver-stack-220x234.png
 keywords:
@@ -30,9 +31,7 @@ keywords:
 - analytic
 - visualization
 maintainers:
-- name: VMware, Inc.
-  url: https://github.com/bitnami/charts
 name: jasperreports
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/jasperreports
-version: 18.2.4
+version: 18.2.5


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Remove JasperReports chart


<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
