### PR TITLE
[bitnami/common] feat: :sparkles: Add support for resource presets

### DIFF
--- a/bitnami/common/Chart.yaml
+++ b/bitnami/common/Chart.yaml
@@ -23,4 +23,4 @@ name: common
 sources:
   - https://github.com/bitnami/charts
 type: library
-version: 2.14.1
+version: 2.15.0

--- a/bitnami/common/templates/_resources.tpl
+++ b/bitnami/common/templates/_resources.tpl
@@ -1,0 +1,50 @@
+{{/*
+Copyright VMware, Inc.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+{{/* vim: set filetype=mustache: */}}
+
+{{/*
+Return a resource request/limit object based on a given preset.
+These presets are for basic testing and not meant to be used in production
+{{ include "common.resources.preset" (dict "type" "nano") -}}
+*/}}
+{{- define "common.resources.preset" -}}
+{{/* The limits are the requests increased by 50% */}}
+{{- $presets := dict 
+  "nano" (dict 
+      "requests" (dict "cpu" "100m" "memory" "128Mi")
+      "limits" (dict "cpu" "150m" "memory" "192Mi")
+   )
+  "micro" (dict 
+      "requests" (dict "cpu" "250m" "memory" "256Mi")
+      "limits" (dict "cpu" "375m" "memory" "384Mi")
+   )
+  "small" (dict 
+      "requests" (dict "cpu" "500m" "memory" "512Mi")
+      "limits" (dict "cpu" "750m" "memory" "768Mi")
+   )
+  "medium" (dict 
+      "requests" (dict "cpu" "500m" "memory" "1024Mi")
+      "limits" (dict "cpu" "750m" "memory" "1536Mi")
+   )
+  "large" (dict 
+      "requests" (dict "cpu" "1.0" "memory" "2048Mi")
+      "limits" (dict "cpu" "1.5" "memory" "3072Mi")
+   )
+  "xlarge" (dict 
+      "requests" (dict "cpu" "2.0" "memory" "4096Mi")
+      "limits" (dict "cpu" "3.0" "memory" "6144Mi")
+   )
+  "2xlarge" (dict 
+      "requests" (dict "cpu" "4.0" "memory" "8192Mi")
+      "limits" (dict "cpu" "6.0" "memory" "12288Mi")
+   )
+ }}
+{{- if hasKey $presets .type -}}
+{{- index $presets .type | toYaml -}}
+{{- else -}}
+{{- printf "ERROR: Preset key '%s' invalid. Allowed values are %s" .type (join "," (keys $presets)) | fail -}}
+{{- end -}}
+{{- end -}}

--- a/bitnami/common/templates/_warnings.tpl
+++ b/bitnami/common/templates/_warnings.tpl
@@ -15,5 +15,43 @@ Usage:
 WARNING: Rolling tag detected ({{ .repository }}:{{ .tag }}), please note that it is strongly recommended to avoid using rolling tags in a production environment.
 +info https://docs.bitnami.com/tutorials/understand-rolling-tags-containers
 {{- end }}
+{{- end -}}
 
+{{/*
+Warning about not setting the resource object in all deployments.
+Usage:
+{{ include "common.warnings.resources" (dict "sections" (list "path1" "path2") context $) }}
+Example:
+{{- include "common.warnings.resources" (dict "sections" (list "csiProvider.provider" "server" "volumePermissions" "") "context" $) }}
+The list in the example assumes that the following values exist:
+  - csiProvider.provider.resources
+  - server.resources
+  - volumePermissions.resources
+  - resources
+*/}}
+{{- define "common.warnings.resources" -}}
+{{ $values := .context.Values -}}
+{{- range .sections -}}
+{{- if eq . "" -}}
+{{/* Case where the resources section is at the root (one main deployment in the chart) */}}
+{{- if not (index $values "resources") }}
+
+WARNING: Main deployment does not have the "resources" value set. Using "resourcesPreset" is not recommended for production. For production workloads, please set the "resources" value adapted to your workload needs. 
++info https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+{{- end -}}
+{{- else -}}
+{{/* Case where the are multiple resources sections (more than one main deployment in the chart) */}}
+{{- $keys := split "." .}}
+{{/* We iterate through the different levels until arriving to the resource section. Example: a.b.c.resources */}}
+{{- $section := $values }}
+{{- range $keys -}}
+{{- $section = index $section . -}}
+{{- end -}}
+{{- if not (index $section "resources") }}
+
+WARNING: Section {{ . }} does not have the "resources" value set. Using "{{ . }}.resourcesPreset" is not recommended for production. For production workloads, please set the "{{ . }}.resources" value adapted to your workload needs. 
++info https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+{{- end }}
+{{- end -}}
+{{- end -}}
 {{- end -}}


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

This PR adds support for a future improvement in our charts: resource presets. Currently, Bitnami charts do not set the `resources` object by default. While it is true that this is a task of the operator to adapt the resources to their use case, we do not explicitly mention in our documentation that a deployment without resources is not recommended for production. 

The PR adds a helper for defining the resources based on a set of presets (nano, micro, small...), which will be configured in our charts by default to the smallest size that works in our testing. This value will be called `resourcesPreset` , and will be superseded if the user sets the already existing `resources` value. Additionally, we will add warnings explaining users that the should set the `resources` object, regardless of whether they use the `resourcesPreset` value or not.

This is an example of this would look in the chart:

```
          {{- if .Values.metrics.resources }}
          resources: {{- toYaml .Values.metrics.resources | nindent 12 }}
          {{- else if ne .Values.metrics.resourcesPreset "none" }}
          resources: {{- include "common.resources.preset" (dict "type" .Values.metrics.resourcesPreset) | nindent 12 }}
          {{- end }}
```

Additionally, in the NOTES.txt section we would have something like this

```
{{- include "common.warnings.resources" (dict "sections" (list "" "metrics" "volumePermissions") "context" $) }}
```

Before bumping the major version, the value would look like this

```
## @param metrics.resourcesPreset Set the container resources based on a preset (ignored if metrics.resources is set). Possible values: none, nano, micro, small, medium, large, 2xlarge
resourcesPreset: "none"
```

After we perform a major bump, we will set the nalue to one of the presets so our charts set resources by default following the security best practices, but alerting the user that these should not be used in production.
<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

Charts more secure.

### Possible drawbacks

Users will need to get used to resource management

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
