### PR TITLE
[bitnami/osclass] Mark Osclass chart as deprecated

### DIFF
--- a/bitnami/osclass/Chart.yaml
+++ b/bitnami/osclass/Chart.yaml
@@ -25,7 +25,9 @@ dependencies:
   tags:
   - bitnami-common
   version: 2.x.x
-description: Osclass allows you to easily create a classifieds site without any technical knowledge. It provides support for presenting general ads or specialized ads, is customizable, extensible and multilingual.
+# The Osclass chart is deprecated and no longer maintained.
+deprecated: true
+description: DEPRECATED Osclass allows you to easily create a classifieds site without any technical knowledge. It provides support for presenting general ads or specialized ads, is customizable, extensible and multilingual.
 home: https://bitnami.com
 icon: https://bitnami.com/assets/stacks/osclass/img/osclass-stack-220x234.png
 keywords:
@@ -34,10 +36,8 @@ keywords:
 - http
 - web
 - php
-maintainers:
-- name: VMware, Inc.
-  url: https://github.com/bitnami/charts
+maintainers: []
 name: osclass
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/osclass
-version: 18.2.3
+version: 18.2.4

--- a/bitnami/osclass/README.md
+++ b/bitnami/osclass/README.md
@@ -8,6 +8,10 @@ Osclass allows you to easily create a classifieds site without any technical kno
 
 Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
 
+## This Helm chart is deprecated
+
+The Osclass chart will no longer be released in our catalog.
+
 ## TL;DR
 
 ```console

--- a/bitnami/osclass/templates/NOTES.txt
+++ b/bitnami/osclass/templates/NOTES.txt
@@ -1,3 +1,5 @@
+This Helm chart is deprecated
+
 CHART NAME: {{ .Chart.Name }}
 CHART VERSION: {{ .Chart.Version }}
 APP VERSION: {{ .Chart.AppVersion }}


### PR DESCRIPTION
### Description of the change

Osclass helm chart will be deprecated.

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
