### PR TITLE
[bitnami/rabbitmq-cluster-operator] fix: 🐛 Add RabbitMQ port to NetworkPolicy for Topology Operator

### DIFF
--- a/bitnami/rabbitmq-cluster-operator/Chart.yaml
+++ b/bitnami/rabbitmq-cluster-operator/Chart.yaml
@@ -37,4 +37,4 @@ maintainers:
 name: rabbitmq-cluster-operator
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/rabbitmq-cluster-operator
-version: 3.16.0
+version: 3.16.1

--- a/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/networkpolicy.yaml
+++ b/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/networkpolicy.yaml
@@ -35,6 +35,9 @@ spec:
           protocol: UDP
         - port: 53
           protocol: TCP
+        # Allow rabbitmq api
+        - port: 15672
+          protocol: TCP
         # Allow access to kube-apiserver
         {{- range $port := .Values.msgTopologyOperator.networkPolicy.kubeAPIServerPorts }}
         - port: {{ $port }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

This adds the rabbitmq port 15672 to the network policy for the topology operator allowing it to access the rabbitmq api for performing changes.

### Benefits

This will allow the topology operator to create resources within the rabbitmq cluster again, otherwise connections would time out when creating users, permissions, etc. 

```json
{
  "level": "error",
  "ts": "2024-02-14T10:09:18Z",
  "msg": "Reconciler error",
  "controller": "user",
  "controllerGroup": "rabbitmq.com",
  "controllerKind": "User",
  "User": {
    "name": "hello-world-example",
    "namespace": "default"
  },
  "namespace": "default",
  "name": "hello-world-example",
  "reconcileID": "d8a36e0e-88c9-4240-8054-7fa358e00cbc",
  "error": "Put \"http://hello-world.default.svc:15672/api/users/AFu_qP-3iogUYqq1QpjI0ck9-IOqUpgv\": dial tcp 10.43.168.83:15672: i/o timeout",
  "stacktrace": "sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/bitnami/blacksmith-sandox/rmq-messaging-topology-operator-1.13.0/pkg/mod/sigs.k8s.io/controller-runtime@v0.16.3/pkg/internal/controller/controller.go:329\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/bitnami/blacksmith-sandox/rmq-messaging-topology-operator-1.13.0/pkg/mod/sigs.k8s.io/controller-runtime@v0.16.3/pkg/internal/controller/controller.go:266\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2\n\t/bitnami/blacksmith-sandox/rmq-messaging-topology-operator-1.13.0/pkg/mod/sigs.k8s.io/controller-runtime@v0.16.3/pkg/internal/controller/controller.go:227"
}
```

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [ ] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
