### PR TITLE
[bitnami/kafka] Add useHelmHooks value to allow install with --wait

### DIFF
--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -42,4 +42,4 @@ maintainers:
 name: kafka
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/kafka
-version: 26.8.5
+version: 26.9.0

--- a/bitnami/kafka/README.md
+++ b/bitnami/kafka/README.md
@@ -685,6 +685,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `provisioning.sidecars`                                          | Add additional sidecar containers to the Kafka provisioning pod(s)                                                            | `[]`                  |
 | `provisioning.initContainers`                                    | Add additional Add init containers to the Kafka provisioning pod(s)                                                           | `[]`                  |
 | `provisioning.waitForKafka`                                      | If true use an init container to wait until kafka is ready before starting provisioning                                       | `true`                |
+| `provisioning.useHelmHooks`                                      | Flag to indicate usage of helm hooks                                                                                          | `true`                |
 
 ### KRaft chart parameters
 

--- a/bitnami/kafka/templates/provisioning/job.yaml
+++ b/bitnami/kafka/templates/provisioning/job.yaml
@@ -12,8 +12,10 @@ metadata:
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: kafka-provisioning
   annotations:
+    {{- if .Values.provisioning.useHelmHooks }}
     helm.sh/hook: post-install,post-upgrade
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    {{- end }}
     {{- if .Values.commonAnnotations }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
     {{- end }}

--- a/bitnami/kafka/values.yaml
+++ b/bitnami/kafka/values.yaml
@@ -2485,6 +2485,8 @@ provisioning:
   ## @param provisioning.waitForKafka If true use an init container to wait until kafka is ready before starting provisioning
   ##
   waitForKafka: true
+  ## @param provisioning.useHelmHooks Flag to indicate usage of helm hooks
+  useHelmHooks: true
 
 ## @section KRaft chart parameters
 


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->
This PR adds the option `provisioning.useHelmHooks` to allow disabling the helm hooks for the provisioning job. By default they will be enabled as before.
Disabling the hooks in combination with setting `provisioning.waitForKafka` to `true` (default value) there still won't be any failure with backoff happening.

### Benefits

<!-- What benefits will be realized by the code change? -->
* Allows to use `--wait` or even `--atomic` when trying to install the chart with provisioning.
* Allows to use helm's chart tester tool for `ct install` tests (the tool depends on the `--wait` flag).

### Possible drawbacks

<!-- Describe any known limitations with your change -->
* The job (and pod) will not be automatically removed (when disabling helm hooks)

### Additional information

Not having this option blocks us completely from using chart tester running on an umbrella chart with kafka as a dependency. In that umbrella chart there are init containers which wait until provisioned topics are present.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
