### PR TITLE
[bitnami/tomcat] Add existing secret management

### DIFF
--- a/bitnami/tomcat/Chart.yaml
+++ b/bitnami/tomcat/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: tomcat
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/tomcat
-version: 10.14.0
+version: 10.15.0

--- a/bitnami/tomcat/README.md
+++ b/bitnami/tomcat/README.md
@@ -79,25 +79,26 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Tomcat parameters
 
-| Name                           | Description                                                                                            | Value                    |
-| ------------------------------ | ------------------------------------------------------------------------------------------------------ | ------------------------ |
-| `image.registry`               | Tomcat image registry                                                                                  | `REGISTRY_NAME`          |
-| `image.repository`             | Tomcat image repository                                                                                | `REPOSITORY_NAME/tomcat` |
-| `image.digest`                 | Tomcat image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                     |
-| `image.pullPolicy`             | Tomcat image pull policy                                                                               | `IfNotPresent`           |
-| `image.pullSecrets`            | Specify docker-registry secret names as an array                                                       | `[]`                     |
-| `image.debug`                  | Specify if debug logs should be enabled                                                                | `false`                  |
-| `automountServiceAccountToken` | Mount Service Account token in pod                                                                     | `false`                  |
-| `hostAliases`                  | Deployment pod host aliases                                                                            | `[]`                     |
-| `tomcatUsername`               | Tomcat admin user                                                                                      | `user`                   |
-| `tomcatPassword`               | Tomcat admin password                                                                                  | `""`                     |
-| `tomcatAllowRemoteManagement`  | Enable remote access to management interface                                                           | `0`                      |
-| `catalinaOpts`                 | Java runtime option used by tomcat JVM                                                                 | `""`                     |
-| `command`                      | Override default container command (useful when using custom images)                                   | `[]`                     |
-| `args`                         | Override default container args (useful when using custom images)                                      | `[]`                     |
-| `extraEnvVars`                 | Extra environment variables to be set on Tomcat container                                              | `[]`                     |
-| `extraEnvVarsCM`               | Name of existing ConfigMap containing extra environment variables                                      | `""`                     |
-| `extraEnvVarsSecret`           | Name of existing Secret containing extra environment variables                                         | `""`                     |
+| Name                           | Description                                                                                                                                                      | Value                    |
+| ------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------ |
+| `image.registry`               | Tomcat image registry                                                                                                                                            | `REGISTRY_NAME`          |
+| `image.repository`             | Tomcat image repository                                                                                                                                          | `REPOSITORY_NAME/tomcat` |
+| `image.digest`                 | Tomcat image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag                                                           | `""`                     |
+| `image.pullPolicy`             | Tomcat image pull policy                                                                                                                                         | `IfNotPresent`           |
+| `image.pullSecrets`            | Specify docker-registry secret names as an array                                                                                                                 | `[]`                     |
+| `image.debug`                  | Specify if debug logs should be enabled                                                                                                                          | `false`                  |
+| `automountServiceAccountToken` | Mount Service Account token in pod                                                                                                                               | `false`                  |
+| `hostAliases`                  | Deployment pod host aliases                                                                                                                                      | `[]`                     |
+| `tomcatUsername`               | Tomcat admin user                                                                                                                                                | `user`                   |
+| `tomcatPassword`               | Tomcat admin password                                                                                                                                            | `""`                     |
+| `existingSecret`               | Use existing secret for password details (`tomcatPassword` will be ignored and picked up from this secret). The secret has to contain the keys `tomcat-password` | `""`                     |
+| `tomcatAllowRemoteManagement`  | Enable remote access to management interface                                                                                                                     | `0`                      |
+| `catalinaOpts`                 | Java runtime option used by tomcat JVM                                                                                                                           | `""`                     |
+| `command`                      | Override default container command (useful when using custom images)                                                                                             | `[]`                     |
+| `args`                         | Override default container args (useful when using custom images)                                                                                                | `[]`                     |
+| `extraEnvVars`                 | Extra environment variables to be set on Tomcat container                                                                                                        | `[]`                     |
+| `extraEnvVarsCM`               | Name of existing ConfigMap containing extra environment variables                                                                                                | `""`                     |
+| `extraEnvVarsSecret`           | Name of existing Secret containing extra environment variables                                                                                                   | `""`                     |
 
 ### Tomcat deployment parameters
 

--- a/bitnami/tomcat/README.md
+++ b/bitnami/tomcat/README.md
@@ -79,26 +79,26 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Tomcat parameters
 
-| Name                           | Description                                                                                                                                                      | Value                    |
-| ------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------ |
-| `image.registry`               | Tomcat image registry                                                                                                                                            | `REGISTRY_NAME`          |
-| `image.repository`             | Tomcat image repository                                                                                                                                          | `REPOSITORY_NAME/tomcat` |
-| `image.digest`                 | Tomcat image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag                                                           | `""`                     |
-| `image.pullPolicy`             | Tomcat image pull policy                                                                                                                                         | `IfNotPresent`           |
-| `image.pullSecrets`            | Specify docker-registry secret names as an array                                                                                                                 | `[]`                     |
-| `image.debug`                  | Specify if debug logs should be enabled                                                                                                                          | `false`                  |
-| `automountServiceAccountToken` | Mount Service Account token in pod                                                                                                                               | `false`                  |
-| `hostAliases`                  | Deployment pod host aliases                                                                                                                                      | `[]`                     |
-| `tomcatUsername`               | Tomcat admin user                                                                                                                                                | `user`                   |
-| `tomcatPassword`               | Tomcat admin password                                                                                                                                            | `""`                     |
-| `existingSecret`               | Use existing secret for password details (`tomcatPassword` will be ignored and picked up from this secret). The secret has to contain the keys `tomcat-password` | `""`                     |
-| `tomcatAllowRemoteManagement`  | Enable remote access to management interface                                                                                                                     | `0`                      |
-| `catalinaOpts`                 | Java runtime option used by tomcat JVM                                                                                                                           | `""`                     |
-| `command`                      | Override default container command (useful when using custom images)                                                                                             | `[]`                     |
-| `args`                         | Override default container args (useful when using custom images)                                                                                                | `[]`                     |
-| `extraEnvVars`                 | Extra environment variables to be set on Tomcat container                                                                                                        | `[]`                     |
-| `extraEnvVarsCM`               | Name of existing ConfigMap containing extra environment variables                                                                                                | `""`                     |
-| `extraEnvVarsSecret`           | Name of existing Secret containing extra environment variables                                                                                                   | `""`                     |
+| Name                           | Description                                                                                                                                                     | Value                    |
+| ------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------ |
+| `image.registry`               | Tomcat image registry                                                                                                                                           | `REGISTRY_NAME`          |
+| `image.repository`             | Tomcat image repository                                                                                                                                         | `REPOSITORY_NAME/tomcat` |
+| `image.digest`                 | Tomcat image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag                                                          | `""`                     |
+| `image.pullPolicy`             | Tomcat image pull policy                                                                                                                                        | `IfNotPresent`           |
+| `image.pullSecrets`            | Specify docker-registry secret names as an array                                                                                                                | `[]`                     |
+| `image.debug`                  | Specify if debug logs should be enabled                                                                                                                         | `false`                  |
+| `automountServiceAccountToken` | Mount Service Account token in pod                                                                                                                              | `false`                  |
+| `hostAliases`                  | Deployment pod host aliases                                                                                                                                     | `[]`                     |
+| `tomcatUsername`               | Tomcat admin user                                                                                                                                               | `user`                   |
+| `tomcatPassword`               | Tomcat admin password                                                                                                                                           | `""`                     |
+| `existingSecret`               | Use existing secret for password details (`tomcatPassword` will be ignored and picked up from this secret). The secret has to contain the key `tomcat-password` | `""`                     |
+| `tomcatAllowRemoteManagement`  | Enable remote access to management interface                                                                                                                    | `0`                      |
+| `catalinaOpts`                 | Java runtime option used by tomcat JVM                                                                                                                          | `""`                     |
+| `command`                      | Override default container command (useful when using custom images)                                                                                            | `[]`                     |
+| `args`                         | Override default container args (useful when using custom images)                                                                                               | `[]`                     |
+| `extraEnvVars`                 | Extra environment variables to be set on Tomcat container                                                                                                       | `[]`                     |
+| `extraEnvVarsCM`               | Name of existing ConfigMap containing extra environment variables                                                                                               | `""`                     |
+| `extraEnvVarsSecret`           | Name of existing Secret containing extra environment variables                                                                                                  | `""`                     |
 
 ### Tomcat deployment parameters
 

--- a/bitnami/tomcat/templates/_helpers.tpl
+++ b/bitnami/tomcat/templates/_helpers.tpl
@@ -48,6 +48,13 @@ Return the proper Docker Image Registry Secret Names
 {{- end -}}
 
 {{/*
+Return the Tomcat credential secret name
+*/}}
+{{- define "tomcat.secretName" -}}
+{{- coalesce .Values.existingSecret (include "common.names.fullname" .) -}}
+{{- end -}}
+
+{{/*
 Check if there are rolling tags in the images
 */}}
 {{- define "tomcat.checkRollingTags" -}}

--- a/bitnami/tomcat/templates/_pod.tpl
+++ b/bitnami/tomcat/templates/_pod.tpl
@@ -82,7 +82,7 @@ containers:
       - name: TOMCAT_PASSWORD
         valueFrom:
           secretKeyRef:
-            name: {{ template "common.names.fullname" . }}
+            name: {{ include "tomcat.secretName" . }}
             key: tomcat-password
       - name: TOMCAT_ALLOW_REMOTE_MANAGEMENT
         value: {{ .Values.tomcatAllowRemoteManagement | quote }}

--- a/bitnami/tomcat/templates/secrets.yaml
+++ b/bitnami/tomcat/templates/secrets.yaml
@@ -3,6 +3,7 @@ Copyright VMware, Inc.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
+{{- if not .Values.existingSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -15,3 +16,4 @@ metadata:
 type: Opaque
 data:
   tomcat-password: {{ include "common.secrets.passwords.manage" (dict "secret" (include "common.names.fullname" .) "key" "tomcat-password" "providedValues" (list "tomcatPassword") "length" 10 "strong" false "context" $) }}
+{{- end }}

--- a/bitnami/tomcat/values.yaml
+++ b/bitnami/tomcat/values.yaml
@@ -92,7 +92,7 @@ tomcatUsername: user
 ## ref: https://github.com/bitnami/containers/tree/main/bitnami/tomcat#creating-a-custom-user
 ##
 tomcatPassword: ""
-## @param existingSecret Use existing secret for password details (`tomcatPassword` will be ignored and picked up from this secret). The secret has to contain the keys `tomcat-password`
+## @param existingSecret Use existing secret for password details (`tomcatPassword` will be ignored and picked up from this secret). The secret has to contain the key `tomcat-password`
 ##
 existingSecret: ""
 ## @param tomcatAllowRemoteManagement Enable remote access to management interface

--- a/bitnami/tomcat/values.yaml
+++ b/bitnami/tomcat/values.yaml
@@ -92,6 +92,9 @@ tomcatUsername: user
 ## ref: https://github.com/bitnami/containers/tree/main/bitnami/tomcat#creating-a-custom-user
 ##
 tomcatPassword: ""
+## @param existingSecret Use existing secret for password details (`tomcatPassword` will be ignored and picked up from this secret). The secret has to contain the keys `tomcat-password`
+##
+existingSecret: ""
 ## @param tomcatAllowRemoteManagement Enable remote access to management interface
 ## ref: https://github.com/bitnami/charts/tree/main/bitnami/tomcat#configuration
 ##


### PR DESCRIPTION
### Description of the change

Add existing secret management

### Benefits

Be able to use an existing kubernetes secret to set the tomcat password

### Possible drawbacks

No drawback identified

### Applicable issues

No applicable issue

### Additional information

Tested locally to prevent any regression

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
