### PR TITLE
[bitnami/osclass] Mark Osclass chart as deprecated

### DIFF
--- a/bitnami/osclass/Chart.yaml
+++ b/bitnami/osclass/Chart.yaml
@@ -26,7 +26,7 @@ dependencies:
   - bitnami-common
   version: 2.x.x
 deprecated: true
-description: Osclass allows you to easily create a classifieds site without any technical knowledge. It provides support for presenting general ads or specialized ads, is customizable, extensible and multilingual.
+description: DEPRECATED Osclass allows you to easily create a classifieds site without any technical knowledge. It provides support for presenting general ads or specialized ads, is customizable, extensible and multilingual.
 home: https://bitnami.com
 icon: https://bitnami.com/assets/stacks/osclass/img/osclass-stack-220x234.png
 keywords:
@@ -39,4 +39,4 @@ maintainers: []
 name: osclass
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/osclass
-version: 18.2.5
+version: 18.2.6

--- a/bitnami/osclass/README.md
+++ b/bitnami/osclass/README.md
@@ -8,6 +8,10 @@ Osclass allows you to easily create a classifieds site without any technical kno
 
 Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
 
+## This Helm chart is deprecated
+
+The Osclass chart will no longer be released in our catalog.
+
 ## TL;DR
 
 ```console


### PR DESCRIPTION
### Description of the change

Osclass helm chart will be deprecated.

### Additional information

follow-up #23423

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
