### PR TITLE
[bitnami/mariadb-galera] chore: :recycle: Move all emptydirs to one

### DIFF
--- a/bitnami/mariadb-galera/Chart.yaml
+++ b/bitnami/mariadb-galera/Chart.yaml
@@ -33,4 +33,4 @@ maintainers:
 name: mariadb-galera
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/mariadb-galera
-version: 11.5.0
+version: 11.6.0

--- a/bitnami/mariadb-galera/templates/statefulset.yaml
+++ b/bitnami/mariadb-galera/templates/statefulset.yaml
@@ -351,14 +351,18 @@ spec:
             - name: mariadb-galera-credentials
               mountPath: /opt/bitnami/mariadb/secrets/
             {{- end }}
-            - name: tmp-dir
+            - name: empty-dir
               mountPath: /tmp
-            - name: app-conf-dir
+              subPath: tmp-dir
+            - name: empty-dir
               mountPath: /opt/bitnami/mariadb/conf
-            - name: app-tmp-dir
+              subPath: app-conf-dir
+            - name: empty-dir
               mountPath: /opt/bitnami/mariadb/tmp
-            - name: app-logs-dir
+              subPath: app-tmp-dir
+            - name: empty-dir
               mountPath: /opt/bitnami/mariadb/logs
+              subPath: app-logs-dir
             {{- if .Values.extraVolumeMounts }}
             {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
             {{- end }}
@@ -427,8 +431,9 @@ spec:
             - name: mariadb-galera-credentials
               mountPath: /opt/bitnami/mysqld-exporter/secrets/
           {{- end }}
-            - name: tmp-dir
+            - name: empty-dir
               mountPath: /tmp
+              subPath: app-tmp-dir
         {{- end }}
         {{- if .Values.sidecars }}
         {{- include "common.tplvalues.render" (dict "value" .Values.sidecars "context" $) | nindent 8 }}
@@ -464,13 +469,7 @@ spec:
           configMap:
             name: {{ template "mariadb-galera.initdbScriptsCM" . }}
         {{- end }}
-        - name: app-conf-dir
-          emptyDir: {}
-        - name: app-tmp-dir
-          emptyDir: {}
-        - name: app-logs-dir
-          emptyDir: {}
-        - name: tmp-dir
+        - name: empty-dir
           emptyDir: {}
         {{- if .Values.extraVolumes }}
         {{- toYaml .Values.extraVolumes | nindent 8 }}


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

This PR refactors all the readonlyrootfs emptydirs to one
<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [ ] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [ ] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
