### PR TITLE
[bitnami/mongodb-sharded] Fix: Add missing version, kind to volumeClaimTemplates

### DIFF
--- a/bitnami/mongodb-sharded/Chart.yaml
+++ b/bitnami/mongodb-sharded/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: mongodb-sharded
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/mongodb-sharded
-version: 7.7.2
+version: 7.7.3

--- a/bitnami/mongodb-sharded/templates/config-server/config-server-statefulset.yaml
+++ b/bitnami/mongodb-sharded/templates/config-server/config-server-statefulset.yaml
@@ -401,7 +401,9 @@ spec:
         {{- end }}
   {{- if and .Values.configsvr.persistence.enabled }}
   volumeClaimTemplates:
-    - metadata:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
         name: datadir
         {{- if or .Values.configsvr.persistence.annotations .Values.commonAnnotations .Values.configsvr.persistence.resourcePolicy }}
         {{- if or .Values.commonAnnotations .Values.configsvr.persistence.annotations .Values.configsvr.persistence.resourcePolicy }}

--- a/bitnami/mongodb-sharded/templates/shard/shard-data-statefulset.yaml
+++ b/bitnami/mongodb-sharded/templates/shard/shard-data-statefulset.yaml
@@ -408,7 +408,9 @@ spec:
         {{- end }}
   {{- if and $.Values.shardsvr.persistence.enabled }}
   volumeClaimTemplates:
-    - metadata:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
         name: datadir
         {{- if or $.Values.shardsvr.persistence.annotations $.Values.commonAnnotations $.Values.shardsvr.persistence.resourcePolicy }}
         {{- if or $.Values.commonAnnotations $.Values.shardsvr.persistence.annotations $.Values.shardsvr.persistence.resourcePolicy }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change
Applies same fix from https://github.com/bitnami/charts/pull/15816 to mongodb-sharded chart.

<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits
Prevents deployments via ArgoCD from showing as constantly OutOfSync.
<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
Fixes same issue as described in https://github.com/bitnami/charts/issues/15526 for mongodb-sharded

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
