### PR TITLE
[bitnami/elasticsearch] Fix values for ELASTICSEARCH_NODE_ROLES

### DIFF
--- a/bitnami/elasticsearch/Chart.yaml
+++ b/bitnami/elasticsearch/Chart.yaml
@@ -34,4 +34,4 @@ maintainers:
 name: elasticsearch
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/elasticsearch
-version: 19.19.2
+version: 19.19.3

--- a/bitnami/elasticsearch/templates/coordinating/statefulset.yaml
+++ b/bitnami/elasticsearch/templates/coordinating/statefulset.yaml
@@ -144,7 +144,7 @@ spec:
             - name: ELASTICSEARCH_IS_DEDICATED_NODE
               value: "yes"
             - name: ELASTICSEARCH_NODE_ROLES
-              value: {{ ternary "" (join "," .Values.coordinating.extraRoles) (empty .Values.coordinating.extraRoles) | quote }}
+              value: {{ .Values.coordinating.extraRoles | join "," | quote }}
             - name: ELASTICSEARCH_TRANSPORT_PORT_NUMBER
               value: {{ .Values.containerPorts.transport | quote }}
             - name: ELASTICSEARCH_HTTP_PORT_NUMBER

--- a/bitnami/elasticsearch/templates/data/statefulset.yaml
+++ b/bitnami/elasticsearch/templates/data/statefulset.yaml
@@ -163,9 +163,8 @@ spec:
                   fieldPath: metadata.name
             - name: ELASTICSEARCH_IS_DEDICATED_NODE
               value: "yes"
-            {{- $roles := ternary "data" (list "data" .Values.data.extraRoles) (empty .Values.data.extraRoles) }}
             - name: ELASTICSEARCH_NODE_ROLES
-              value: {{ join "," $roles | quote }}
+              value: {{ prepend .Values.data.extraRoles "data" | join "," | quote }}
             - name: ELASTICSEARCH_TRANSPORT_PORT_NUMBER
               value: {{ .Values.containerPorts.transport | quote }}
             - name: ELASTICSEARCH_HTTP_PORT_NUMBER

--- a/bitnami/elasticsearch/templates/ingest/statefulset.yaml
+++ b/bitnami/elasticsearch/templates/ingest/statefulset.yaml
@@ -141,9 +141,8 @@ spec:
                   fieldPath: metadata.name
             - name: ELASTICSEARCH_IS_DEDICATED_NODE
               value: "yes"
-            {{- $roles := ternary "ingest" (list "ingest" .Values.ingest.extraRoles) (empty .Values.ingest.extraRoles) }}
             - name: ELASTICSEARCH_NODE_ROLES
-              value: {{ join "," $roles | quote }}
+              value: {{ prepend .Values.ingest.extraRoles "ingest" | join "," | quote }}
             - name: ELASTICSEARCH_TRANSPORT_PORT_NUMBER
               value: {{ .Values.containerPorts.transport | quote }}
             - name: ELASTICSEARCH_HTTP_PORT_NUMBER

--- a/bitnami/elasticsearch/templates/master/statefulset.yaml
+++ b/bitnami/elasticsearch/templates/master/statefulset.yaml
@@ -163,9 +163,8 @@ spec:
                   fieldPath: metadata.name
             - name: ELASTICSEARCH_IS_DEDICATED_NODE
               value: {{ ternary "yes" "no" .Values.master.masterOnly | quote }}
-            {{- $roles := ternary "master" (list "master" .Values.master.extraRoles) (empty .Values.master.extraRoles) }}
             - name: ELASTICSEARCH_NODE_ROLES
-              value: {{ join "," $roles | quote }}
+              value: {{ prepend .Values.master.extraRoles "master" | join "," | quote }}
             - name: ELASTICSEARCH_TRANSPORT_PORT_NUMBER
               value: {{ .Values.containerPorts.transport | quote }}
             - name: ELASTICSEARCH_HTTP_PORT_NUMBER


### PR DESCRIPTION
### Description of the change

This PR fixes an issue with `extraRoles` and `ELASTICSEARCH_NODE_ROLES`. The value is not properly rendered (note the square brackets in the extra role):

```shell
$ helm template . --set 'master.extraRoles[0]=remote_cluster_client' | grep -B1 remote_cluster_client
            - name: ELASTICSEARCH_NODE_ROLES
              value: "master,[remote_cluster_client]"
```

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #23562

### Additional information

Tested with:

```shell
$ helm template . | grep -A1 ELASTICSEARCH_NODE_ROLES
            - name: ELASTICSEARCH_NODE_ROLES
              value: ""
--
            - name: ELASTICSEARCH_NODE_ROLES
              value: "data"
--
            - name: ELASTICSEARCH_NODE_ROLES
              value: "ingest"
--
            - name: ELASTICSEARCH_NODE_ROLES
              value: "master"
```
```shell
$ helm template . --set 'master.extraRoles[0]=remote_cluster_client' --set 'data.extraRoles[0]=remote_cluster_client' --set 'coordinating.extraRoles[0]=remote_cluster_client' --set 'ingest.extraRoles[0]=remote_cluster_client' | grep -A1 ELASTICSEARCH_NODE_ROLES
            - name: ELASTICSEARCH_NODE_ROLES
              value: "remote_cluster_client"
--
            - name: ELASTICSEARCH_NODE_ROLES
              value: "data,remote_cluster_client"
--
            - name: ELASTICSEARCH_NODE_ROLES
              value: "ingest,remote_cluster_client"
--
            - name: ELASTICSEARCH_NODE_ROLES
              value: "master,remote_cluster_client"
```

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] n/a ~Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)~
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
