### PR TITLE
[bitnami/nats] Give the application some time to sync the data during the tests

### DIFF
--- a/.vib/nats/ginkgo/nats_test.go
+++ b/.vib/nats/ginkgo/nats_test.go
@@ -68,6 +68,9 @@ var _ = Describe("NATS", Ordered, func() {
 				return c.BatchV1().Jobs(namespace).Get(ctx, createDBJobName, getOpts)
 			}, timeout, PollingInterval).Should(WithTransform(getSucceededJobs, Equal(int32(1))))
 
+			// Give the application some time to sync the data
+			time.Sleep(5*time.Second)
+
 			By("scaling down to 0 replicas")
 			ss, err = utils.StsScale(ctx, c, ss, 0)
 			Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->

Delaying the removal of pods during the tests to allow the application sync the data and make them more stable

### Benefits

<!-- What benefits will be realized by the code change? -->

This other PR will succeed with the changes 

https://github.com/bitnami/charts/pull/23810

### Possible drawbacks

<!-- Describe any known limitations with your change -->

None

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes https://github.com/bitnami/charts/pull/23810

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
Pods are removed quickly and changes are not synced

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [NA] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [NA] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
