### PR TITLE
[bitnami/rabbitmq-cluster-operator] fix: correct network policy port for metrics

### DIFF
--- a/bitnami/rabbitmq-cluster-operator/Chart.yaml
+++ b/bitnami/rabbitmq-cluster-operator/Chart.yaml
@@ -37,4 +37,4 @@ maintainers:
 name: rabbitmq-cluster-operator
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/rabbitmq-cluster-operator
-version: 3.19.0
+version: 3.19.1

--- a/bitnami/rabbitmq-cluster-operator/templates/cluster-operator/networkpolicy.yaml
+++ b/bitnami/rabbitmq-cluster-operator/templates/cluster-operator/networkpolicy.yaml
@@ -62,7 +62,7 @@ spec:
   ingress:
     {{- if .Values.clusterOperator.metrics.enabled }}
     - ports:
-        - port: {{ .Values.clusterOperator.metrics.containerPorts.http }}
+        - port: {{ .Values.clusterOperator.containerPorts.metrics }}
       {{- if not .Values.clusterOperator.networkPolicy.allowExternal }}
       from:
         - podSelector:

--- a/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/networkpolicy.yaml
+++ b/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/networkpolicy.yaml
@@ -67,7 +67,7 @@ spec:
         {{/* Webhook port is hardcoded in the operator code */}}
         - port: 9443
         {{- if .Values.msgTopologyOperator.metrics.enabled }}
-        - port: {{ .Values.msgTopologyOperator.metrics.containerPorts.metrics }}
+        - port: {{ .Values.msgTopologyOperator.containerPorts.metrics }}
         {{- end }}
       {{- if not .Values.msgTopologyOperator.networkPolicy.allowExternal }}
       from:


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

This change fixes the network policies templates, which reference an incorrect metrics port (when `metrics.enabled` is true). This affects both the cluster and messaging topology operators.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #23427

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
