### PR TITLE
[bitnami/harbor] Update bundled PostgreSQL

### DIFF
--- a/bitnami/harbor/Chart.lock
+++ b/bitnami/harbor/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: redis
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 18.16.0
+  version: 18.17.0
 - name: postgresql
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 13.4.6
+  version: 14.2.3
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 2.16.1
-digest: sha256:2a9719403f2833b2208587e6a4cf17531b753b9d267ed1d93ffe410ab3995c4d
-generated: "2024-02-21T17:26:27.16248766Z"
+digest: sha256:6dd58522e0a8be40f46332bf520b35b66c224723c8e7ddf36f33f9910988e822
+generated: "2024-03-04T10:39:13.292757+01:00"

--- a/bitnami/harbor/Chart.yaml
+++ b/bitnami/harbor/Chart.yaml
@@ -35,7 +35,7 @@ dependencies:
 - condition: postgresql.enabled
   name: postgresql
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 13.x.x
+  version: 14.x.x
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
   tags:
@@ -55,4 +55,4 @@ maintainers:
 name: harbor
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/harbor
-version: 19.9.0
+version: 20.0.0

--- a/bitnami/harbor/README.md
+++ b/bitnami/harbor/README.md
@@ -1177,6 +1177,10 @@ Find more information about how to deal with common errors related to Bitnami's 
 
 ## Upgrading
 
+### To 20.0.0
+
+This major release bumps the PostgreSQL chart version to [14.x.x](https://github.com/bitnami/charts/pull/22750); no major issues are expected during the upgrade.
+
 ### To 19.0.0
 
 This major updates the PostgreSQL subchart to its newest major, 13.0.0. [Here](https://github.com/bitnami/charts/tree/master/bitnami/postgresql#to-1300) you can find more information about the changes introduced in that version.


### PR DESCRIPTION
This PR updates the bundled bitnami/postgresql subchart to its new major (see https://github.com/bitnami/charts/pull/22750), bumping the harbor version in a major as well