### PR TITLE
[bitnami/redmine] Update bundled PostgreSQL and MariaDB

### DIFF
--- a/bitnami/redmine/Chart.lock
+++ b/bitnami/redmine/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: postgresql
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 13.4.6
+  version: 14.2.3
 - name: mariadb
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 15.2.3
+  version: 16.4.0
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 2.16.1
-digest: sha256:387470d14a95f24121f5e6e15d2a19a9dfb5a8725e198cba8f40ff5fb9eb4706
-generated: "2024-02-21T14:31:03.679817633Z"
+digest: sha256:b92b22bda50bb38b60a6b3970f367c70dfaed0674f0eaf6e11395059b7a007c9
+generated: "2024-03-04T10:56:39.111126+01:00"

--- a/bitnami/redmine/Chart.yaml
+++ b/bitnami/redmine/Chart.yaml
@@ -15,11 +15,11 @@ dependencies:
 - condition: postgresql.enabled
   name: postgresql
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 13.x.x
+  version: 14.x.x
 - condition: mariadb.enabled
   name: mariadb
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 15.x.x
+  version: 16.x.x
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
   tags:
@@ -43,4 +43,4 @@ maintainers:
 name: redmine
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/redmine
-version: 26.5.2
+version: 27.0.0

--- a/bitnami/redmine/README.md
+++ b/bitnami/redmine/README.md
@@ -580,6 +580,10 @@ Find more information about how to deal with common errors related to Bitnami's 
 
 ## Upgrading
 
+### To 27.0.0
+
+This major release bumps the PostgreSQL chart version to [14.x.x](https://github.com/bitnami/charts/pull/22750) and MariaDB to [16.x.x](https://github.com/bitnami/charts/pull/23054); no major issues are expected during the upgrade.
+
 ### To 26.0.0
 
 This major release bumps the MariaDB version to 11.2. No major issues are expected during the upgrade.


### PR DESCRIPTION
This PR updates the bundled bitnami/postgresql and bitnami/mariadb subcharts to the new major (see https://github.com/bitnami/charts/pull/22750 and https://github.com/bitnami/charts/pull/23054), bumping the redmine version in a major as well