### PR TITLE
[bitnami/wordpress] Update bundled MariaDB

### DIFF
--- a/bitnami/wordpress/Chart.lock
+++ b/bitnami/wordpress/Chart.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 6.12.2
 - name: mariadb
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 15.2.3
+  version: 16.4.0
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 2.16.1
-digest: sha256:23fdb5a6c8028d093fe3f173dec8c3a74a3e2c3a577bc46d49ef6e51fcfda125
-generated: "2024-02-28T10:03:42.70089227Z"
+digest: sha256:e4d45968eab52eda1462ee23bafe228f8f819938c444eb0461e1c298bd5134e8
+generated: "2024-03-04T11:07:44.608472+01:00"

--- a/bitnami/wordpress/Chart.yaml
+++ b/bitnami/wordpress/Chart.yaml
@@ -21,7 +21,7 @@ dependencies:
 - condition: mariadb.enabled
   name: mariadb
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 15.x.x
+  version: 16.x.x
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
   tags:
@@ -44,4 +44,4 @@ maintainers:
 name: wordpress
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/wordpress
-version: 19.4.3
+version: 20.0.0

--- a/bitnami/wordpress/README.md
+++ b/bitnami/wordpress/README.md
@@ -629,6 +629,10 @@ To enable the new features, it is not possible to do it by upgrading an existing
 
 ## Upgrading
 
+### To 20.0.0
+
+This major release bumps the and MariaDB chart version to [16.x.x](https://github.com/bitnami/charts/pull/23054); no major issues are expected during the upgrade.
+
 ### To 19.0.0
 
 This major release bumps the MariaDB version to 11.2. No major issues are expected during the upgrade.


### PR DESCRIPTION
This PR updates the bundled bitnami/mariadb subchart to the new major (see https://github.com/bitnami/charts/pull/23054), bumping the wordpress version in a major as well