### PR TITLE
[bitnami/milvus] Update bundled MinIO

### DIFF
--- a/bitnami/milvus/Chart.lock
+++ b/bitnami/milvus/Chart.lock
@@ -1,15 +1,15 @@
 dependencies:
 - name: etcd
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 9.14.2
+  version: 9.14.3
 - name: kafka
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 26.11.2
+  version: 26.11.4
 - name: minio
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 12.13.2
+  version: 13.7.1
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 2.16.1
-digest: sha256:833b8fb09bac14a3ad8fb2dbebf38ac4031e8982ad813a451781bfa8a87cf982
-generated: "2024-02-23T13:42:48.206437757Z"
+digest: sha256:576bb11d2757dc0741f710ffe77c7363985e5564e8ace96b06a3ba117b91e61b
+generated: "2024-03-04T11:11:56.310281+01:00"

--- a/bitnami/milvus/Chart.yaml
+++ b/bitnami/milvus/Chart.yaml
@@ -27,7 +27,7 @@ dependencies:
 - condition: minio.enabled
   name: minio
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 12.x.x
+  version: 13.x.x
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
   tags:
@@ -48,4 +48,4 @@ maintainers:
 name: milvus
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/milvus
-version: 5.6.3
+version: 6.0.0

--- a/bitnami/milvus/README.md
+++ b/bitnami/milvus/README.md
@@ -1794,6 +1794,10 @@ wrj2wDbCDCFmfqnSJ+dKI3vFLlEz44sAV8jX/kd4Y6ZTQhlLbYc=
 
 ## Upgrading
 
+### To 6.0.0
+
+This major release bumps the MinIO chart version to [13.x.x](https://github.com/bitnami/charts/pull/22058/); no major issues are expected during the upgrade.
+
 ### To 4.0.0
 
 This major updates the Kafka subchart to its newest major, 26.0.0. For more information on this subchart's major, please refer to [Kafka upgrade notes](https://github.com/bitnami/charts/tree/main/bitnami/kafka#to-2600).


### PR DESCRIPTION
This PR updates the bundled bitnami/mariadb subchart to the new major (see https://github.com/bitnami/charts/pull/22058), bumping the milvus version in a major as well