### PR TITLE
[bitnami/grafana] fix: :bug: Change mount-point of providers to conf.default

### DIFF
--- a/bitnami/grafana/Chart.yaml
+++ b/bitnami/grafana/Chart.yaml
@@ -31,4 +31,4 @@ maintainers:
 name: grafana
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/grafana
-version: 9.11.0
+version: 9.11.1

--- a/bitnami/grafana/templates/deployment.yaml
+++ b/bitnami/grafana/templates/deployment.yaml
@@ -191,7 +191,7 @@ spec:
               mountPath: /opt/bitnami/grafana/data
             {{- if .Values.dashboardsProvider.enabled }}
             - name: dashboards-provider
-              mountPath: /opt/bitnami/grafana/conf/provisioning/dashboards
+              mountPath: /opt/bitnami/grafana/conf.default/provisioning/dashboards
             {{- end }}
             {{- range .Values.dashboardsConfigMaps }}
             - name: {{ include "common.tplvalues.render" ( dict "value" .configMapName "context" $ ) }}
@@ -204,19 +204,19 @@ spec:
             {{- end }}
             {{- if or (.Values.datasources.secretName) (.Values.datasources.secretDefinition) }}
             - name: datasources
-              mountPath: /opt/bitnami/grafana/conf/provisioning/datasources
+              mountPath: /opt/bitnami/grafana/conf.default/provisioning/datasources
             {{- end }}
             {{- if .Values.notifiers.configMapName }}
             - name: notifiers
-              mountPath: /opt/bitnami/grafana/conf/provisioning/notifiers
+              mountPath: /opt/bitnami/grafana/conf.default/provisioning/notifiers
             {{- end }}
             {{- if .Values.alerting.configMapName }}
             - name: alerting
-              mountPath: /opt/bitnami/grafana/conf/provisioning/alerting
+              mountPath: /opt/bitnami/grafana/conf.default/provisioning/alerting
             {{- end }}
             {{- if .Values.ldap.enabled }}
             - name: ldap
-              mountPath: /opt/bitnami/grafana/conf/ldap.toml
+              mountPath: /opt/bitnami/grafana/conf.default/ldap.toml
               subPath: ldap.toml
             {{- end }}
             {{- if and .Values.ldap.tls.enabled .Values.ldap.tls.certificatesSecret }}


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

This PR fixes the mount point of the providers to allow conflicts when building the empty-dir based conf folder (which is necessary for readonlyrootfs support)
<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes https://github.com/bitnami/charts/issues/24042

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
