### PR TITLE
[bitnami/elasticsearch] Bump chart version again

### DIFF
--- a/bitnami/elasticsearch/Chart.yaml
+++ b/bitnami/elasticsearch/Chart.yaml
@@ -34,4 +34,4 @@ maintainers:
 name: elasticsearch
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/elasticsearch
-version: 19.19.3
+version: 19.19.4


### PR DESCRIPTION
Follow-up of #23845. The version was not actually bumped on `main`; the conflict was auto-resolved silently.