### PR TITLE
[bitnami/milvus] feat: :sparkles: :lock: Add automatic adaptation for Openshift restricted-v2 SCC

### DIFF
--- a/bitnami/milvus/Chart.lock
+++ b/bitnami/milvus/Chart.lock
@@ -7,9 +7,9 @@ dependencies:
   version: 26.11.4
 - name: minio
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 13.7.1
+  version: 13.7.2
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.16.1
-digest: sha256:576bb11d2757dc0741f710ffe77c7363985e5564e8ace96b06a3ba117b91e61b
-generated: "2024-03-04T11:11:56.310281+01:00"
+  version: 2.18.0
+digest: sha256:9b25d0efb33b871f4a72fb0c3c1f647d7179b9df9239774327824e773033baa0
+generated: "2024-03-05T14:48:54.993353404+01:00"

--- a/bitnami/milvus/Chart.yaml
+++ b/bitnami/milvus/Chart.yaml
@@ -48,4 +48,4 @@ maintainers:
 name: milvus
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/milvus
-version: 6.0.1
+version: 6.1.0

--- a/bitnami/milvus/README.md
+++ b/bitnami/milvus/README.md
@@ -58,11 +58,12 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Global parameters
 
-| Name                      | Description                                     | Value |
-| ------------------------- | ----------------------------------------------- | ----- |
-| `global.imageRegistry`    | Global Docker image registry                    | `""`  |
-| `global.imagePullSecrets` | Global Docker registry secret names as an array | `[]`  |
-| `global.storageClass`     | Global StorageClass for Persistent Volume(s)    | `""`  |
+| Name                                                  | Description                                                                                                                                                                                                                                                                                                                                                         | Value      |
+| ----------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- |
+| `global.imageRegistry`                                | Global Docker image registry                                                                                                                                                                                                                                                                                                                                        | `""`       |
+| `global.imagePullSecrets`                             | Global Docker registry secret names as an array                                                                                                                                                                                                                                                                                                                     | `[]`       |
+| `global.storageClass`                                 | Global StorageClass for Persistent Volume(s)                                                                                                                                                                                                                                                                                                                        | `""`       |
+| `global.compatibility.openshift.adaptSecurityContext` | Adapt the securityContext sections of the deployment to make them compatible with Openshift restricted-v2 SCC: remove runAsUser, runAsGroup and fsGroup and let the platform use their allowed default IDs. Possible values: auto (apply if the detected running cluster is Openshift), force (perform the adaptation always), disabled (do not perform adaptation) | `disabled` |
 
 ### Common parameters
 

--- a/bitnami/milvus/templates/_helpers.tpl
+++ b/bitnami/milvus/templates/_helpers.tpl
@@ -953,7 +953,7 @@ Init container definition for waiting for the database to be ready
   imagePullPolicy: {{ .context.Values.milvus.image.pullPolicy }}
   {{- $block := index .context.Values .component }}
   {{- if $block.containerSecurityContext.enabled }}
-  securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" $block.containerSecurityContext "context" $) | nindent 4 }}
+  securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" $block.containerSecurityContext "context" .context) | nindent 4 }}
   {{- end }}
   command:
     - bash

--- a/bitnami/milvus/templates/_helpers.tpl
+++ b/bitnami/milvus/templates/_helpers.tpl
@@ -707,7 +707,7 @@ Init container definition for waiting for the database to be ready
   image: {{ template "milvus.wait-container.image" . }}
   imagePullPolicy: {{ .Values.waitContainer.image.pullPolicy }}
   {{- if .Values.waitContainer.containerSecurityContext.enabled }}
-  securityContext: {{- omit .Values.waitContainer.containerSecurityContext "enabled" | toYaml | nindent 4 }}
+  securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.waitContainer.containerSecurityContext "context" $) | nindent 4 }}
   {{- end }}
   command:
     - bash
@@ -783,7 +783,7 @@ Init container definition for waiting for the database to be ready
   image: {{ template "milvus.wait-container.image" . }}
   imagePullPolicy: {{ .Values.waitContainer.image.pullPolicy }}
   {{- if .Values.waitContainer.containerSecurityContext.enabled }}
-  securityContext: {{- omit .Values.waitContainer.containerSecurityContext "enabled" | toYaml | nindent 4 }}
+  securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.waitContainer.containerSecurityContext "context" $) | nindent 4 }}
   {{- end }}
   command:
     - bash
@@ -835,7 +835,7 @@ Init container definition for waiting for the database to be ready
   image: {{ template "milvus.image" . }} {{/* Bitnami shell does not have wait-for-port */}}
   imagePullPolicy: {{ .Values.waitContainer.image.pullPolicy }}
   {{- if .Values.waitContainer.containerSecurityContext.enabled }}
-  securityContext: {{- omit .Values.waitContainer.containerSecurityContext "enabled" | toYaml | nindent 4 }}
+  securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.waitContainer.containerSecurityContext "context" $) | nindent 4 }}
   {{- end }}
   command:
     - bash
@@ -897,7 +897,7 @@ Init container definition for waiting for the database to be ready
   image: {{ template "milvus.image" . }} {{/* Bitnami shell does not have wait-for-port */}}
   imagePullPolicy: {{ .Values.waitContainer.image.pullPolicy }}
   {{- if .Values.waitContainer.containerSecurityContext.enabled }}
-  securityContext: {{- omit .Values.waitContainer.containerSecurityContext "enabled" | toYaml | nindent 4 }}
+  securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.waitContainer.containerSecurityContext "context" $) | nindent 4 }}
   {{- end }}
   command:
     - bash
@@ -953,7 +953,7 @@ Init container definition for waiting for the database to be ready
   imagePullPolicy: {{ .context.Values.milvus.image.pullPolicy }}
   {{- $block := index .context.Values .component }}
   {{- if $block.containerSecurityContext.enabled }}
-  securityContext: {{- omit $block.containerSecurityContext "enabled" | toYaml | nindent 4 }}
+  securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" $block.containerSecurityContext "context" $) | nindent 4 }}
   {{- end }}
   command:
     - bash

--- a/bitnami/milvus/templates/attu/deployment.yaml
+++ b/bitnami/milvus/templates/attu/deployment.yaml
@@ -74,7 +74,7 @@ spec:
       schedulerName: {{ .Values.attu.schedulerName }}
       {{- end }}
       {{- if .Values.attu.podSecurityContext.enabled }}
-      securityContext: {{- omit .Values.attu.podSecurityContext "enabled" | toYaml | nindent 8 }}
+      securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.attu.podSecurityContext "context" $) | nindent 8 }}
       {{- end }}
       initContainers:
         {{- if .Values.attu.enableDefaultInitContainers }}
@@ -88,7 +88,7 @@ spec:
           image: {{ template "milvus.attu.image" . }}
           imagePullPolicy: {{ .Values.attu.image.pullPolicy }}
           {{- if .Values.attu.containerSecurityContext.enabled }}
-          securityContext: {{- omit .Values.attu.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+          securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.attu.containerSecurityContext "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.diagnosticMode.enabled }}
           command: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.command "context" $) | nindent 12 }}

--- a/bitnami/milvus/templates/data-coordinator/deployment.yaml
+++ b/bitnami/milvus/templates/data-coordinator/deployment.yaml
@@ -76,7 +76,7 @@ spec:
       schedulerName: {{ .Values.dataCoord.schedulerName }}
       {{- end }}
       {{- if .Values.dataCoord.podSecurityContext.enabled }}
-      securityContext: {{- omit .Values.dataCoord.podSecurityContext "enabled" | toYaml | nindent 8 }}
+      securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.dataCoord.podSecurityContext "context" $) | nindent 8 }}
       {{- end }}
       initContainers:
         {{- if .Values.dataCoord.enableDefaultInitContainers }}
@@ -93,7 +93,7 @@ spec:
           image: {{ template "milvus.image" . }}
           imagePullPolicy: {{ .Values.milvus.image.pullPolicy }}
           {{- if .Values.dataCoord.containerSecurityContext.enabled }}
-          securityContext: {{- omit .Values.dataCoord.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+          securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.dataCoord.containerSecurityContext "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.diagnosticMode.enabled }}
           command: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.command "context" $) | nindent 12 }}

--- a/bitnami/milvus/templates/data-node/deployment.yaml
+++ b/bitnami/milvus/templates/data-node/deployment.yaml
@@ -76,7 +76,7 @@ spec:
       schedulerName: {{ .Values.dataNode.schedulerName }}
       {{- end }}
       {{- if .Values.dataNode.podSecurityContext.enabled }}
-      securityContext: {{- omit .Values.dataNode.podSecurityContext "enabled" | toYaml | nindent 8 }}
+      securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.dataNode.podSecurityContext "context" $) | nindent 8 }}
       {{- end }}
       initContainers:
         {{- if .Values.dataNode.enableDefaultInitContainers }}
@@ -93,7 +93,7 @@ spec:
           image: {{ template "milvus.image" . }}
           imagePullPolicy: {{ .Values.milvus.image.pullPolicy }}
           {{- if .Values.dataNode.containerSecurityContext.enabled }}
-          securityContext: {{- omit .Values.dataNode.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+          securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.dataNode.containerSecurityContext "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.diagnosticMode.enabled }}
           command: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.command "context" $) | nindent 12 }}

--- a/bitnami/milvus/templates/index-coordinator/deployment.yaml
+++ b/bitnami/milvus/templates/index-coordinator/deployment.yaml
@@ -76,7 +76,7 @@ spec:
       schedulerName: {{ .Values.indexCoord.schedulerName }}
       {{- end }}
       {{- if .Values.indexCoord.podSecurityContext.enabled }}
-      securityContext: {{- omit .Values.indexCoord.podSecurityContext "enabled" | toYaml | nindent 8 }}
+      securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.indexCoord.podSecurityContext "context" $) | nindent 8 }}
       {{- end }}
       initContainers:
         {{- if .Values.indexCoord.enableDefaultInitContainers }}
@@ -93,7 +93,7 @@ spec:
           image: {{ template "milvus.image" . }}
           imagePullPolicy: {{ .Values.milvus.image.pullPolicy }}
           {{- if .Values.indexCoord.containerSecurityContext.enabled }}
-          securityContext: {{- omit .Values.indexCoord.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+          securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.indexCoord.containerSecurityContext "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.diagnosticMode.enabled }}
           command: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.command "context" $) | nindent 12 }}

--- a/bitnami/milvus/templates/index-node/deployment.yaml
+++ b/bitnami/milvus/templates/index-node/deployment.yaml
@@ -76,7 +76,7 @@ spec:
       schedulerName: {{ .Values.indexNode.schedulerName }}
       {{- end }}
       {{- if .Values.indexNode.podSecurityContext.enabled }}
-      securityContext: {{- omit .Values.indexNode.podSecurityContext "enabled" | toYaml | nindent 8 }}
+      securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.indexNode.podSecurityContext "context" $) | nindent 8 }}
       {{- end }}
       initContainers:
         {{- if .Values.indexNode.enableDefaultInitContainers }}
@@ -93,7 +93,7 @@ spec:
           image: {{ template "milvus.image" . }}
           imagePullPolicy: {{ .Values.milvus.image.pullPolicy }}
           {{- if .Values.indexNode.containerSecurityContext.enabled }}
-          securityContext: {{- omit .Values.indexNode.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+          securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.indexNode.containerSecurityContext "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.diagnosticMode.enabled }}
           command: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.command "context" $) | nindent 12 }}

--- a/bitnami/milvus/templates/init-job.yaml
+++ b/bitnami/milvus/templates/init-job.yaml
@@ -33,7 +33,7 @@ spec:
       {{- include "milvus.imagePullSecrets" . | nindent 6 }}
       restartPolicy: OnFailure
       {{- if .Values.initJob.podSecurityContext.enabled }}
-      securityContext: {{- omit .Values.initJob.podSecurityContext "enabled" | toYaml | nindent 8 }}
+      securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.initJob.podSecurityContext "context" $) | nindent 8 }}
       {{- end }}
       automountServiceAccountToken: {{ .Values.initJob.automountServiceAccountToken }}
       {{- if .Values.initJob.hostAliases }}
@@ -116,7 +116,7 @@ spec:
                   key: {{ include "milvus.secretPasswordKey" . }}
             {{- end }}
           {{- if .Values.initJob.containerSecurityContext.enabled }}
-          securityContext: {{- omit .Values.initJob.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+          securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.initJob.containerSecurityContext "context" $) | nindent 12 }}
           {{- end }}
           {{- if or .Values.initJob.extraEnvVarsCM .Values.initJob.extraEnvVarsSecret }}
           envFrom:

--- a/bitnami/milvus/templates/proxy/deployment.yaml
+++ b/bitnami/milvus/templates/proxy/deployment.yaml
@@ -76,7 +76,7 @@ spec:
       schedulerName: {{ .Values.proxy.schedulerName }}
       {{- end }}
       {{- if .Values.proxy.podSecurityContext.enabled }}
-      securityContext: {{- omit .Values.proxy.podSecurityContext "enabled" | toYaml | nindent 8 }}
+      securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.proxy.podSecurityContext "context" $) | nindent 8 }}
       {{- end }}
       initContainers:
         {{- if .Values.proxy.enableDefaultInitContainers }}
@@ -93,7 +93,7 @@ spec:
           image: {{ template "milvus.image" . }}
           imagePullPolicy: {{ .Values.milvus.image.pullPolicy }}
           {{- if .Values.proxy.containerSecurityContext.enabled }}
-          securityContext: {{- omit .Values.proxy.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+          securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.proxy.containerSecurityContext "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.diagnosticMode.enabled }}
           command: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.command "context" $) | nindent 12 }}

--- a/bitnami/milvus/templates/query-coordinator/deployment.yaml
+++ b/bitnami/milvus/templates/query-coordinator/deployment.yaml
@@ -76,7 +76,7 @@ spec:
       schedulerName: {{ .Values.queryCoord.schedulerName }}
       {{- end }}
       {{- if .Values.queryCoord.podSecurityContext.enabled }}
-      securityContext: {{- omit .Values.queryCoord.podSecurityContext "enabled" | toYaml | nindent 8 }}
+      securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.queryCoord.podSecurityContext "context" $) | nindent 8 }}
       {{- end }}
       initContainers:
         {{- if .Values.queryCoord.enableDefaultInitContainers }}
@@ -93,7 +93,7 @@ spec:
           image: {{ template "milvus.image" . }}
           imagePullPolicy: {{ .Values.milvus.image.pullPolicy }}
           {{- if .Values.queryCoord.containerSecurityContext.enabled }}
-          securityContext: {{- omit .Values.queryCoord.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+          securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.queryCoord.containerSecurityContext "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.diagnosticMode.enabled }}
           command: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.command "context" $) | nindent 12 }}

--- a/bitnami/milvus/templates/query-node/deployment.yaml
+++ b/bitnami/milvus/templates/query-node/deployment.yaml
@@ -76,7 +76,7 @@ spec:
       schedulerName: {{ .Values.queryNode.schedulerName }}
       {{- end }}
       {{- if .Values.queryNode.podSecurityContext.enabled }}
-      securityContext: {{- omit .Values.queryNode.podSecurityContext "enabled" | toYaml | nindent 8 }}
+      securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.queryNode.podSecurityContext "context" $) | nindent 8 }}
       {{- end }}
       initContainers:
         {{- if .Values.queryNode.enableDefaultInitContainers }}
@@ -93,7 +93,7 @@ spec:
           image: {{ template "milvus.image" . }}
           imagePullPolicy: {{ .Values.milvus.image.pullPolicy }}
           {{- if .Values.queryNode.containerSecurityContext.enabled }}
-          securityContext: {{- omit .Values.queryNode.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+          securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.queryNode.containerSecurityContext "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.diagnosticMode.enabled }}
           command: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.command "context" $) | nindent 12 }}

--- a/bitnami/milvus/templates/root-coordinator/deployment.yaml
+++ b/bitnami/milvus/templates/root-coordinator/deployment.yaml
@@ -76,7 +76,7 @@ spec:
       schedulerName: {{ .Values.rootCoord.schedulerName }}
       {{- end }}
       {{- if .Values.rootCoord.podSecurityContext.enabled }}
-      securityContext: {{- omit .Values.rootCoord.podSecurityContext "enabled" | toYaml | nindent 8 }}
+      securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.rootCoord.podSecurityContext "context" $) | nindent 8 }}
       {{- end }}
       initContainers:
         {{- if .Values.rootCoord.enableDefaultInitContainers }}
@@ -93,7 +93,7 @@ spec:
           image: {{ template "milvus.image" . }}
           imagePullPolicy: {{ .Values.milvus.image.pullPolicy }}
           {{- if .Values.rootCoord.containerSecurityContext.enabled }}
-          securityContext: {{- omit .Values.rootCoord.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+          securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.rootCoord.containerSecurityContext "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.diagnosticMode.enabled }}
           command: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.command "context" $) | nindent 12 }}

--- a/bitnami/milvus/values.yaml
+++ b/bitnami/milvus/values.yaml
@@ -19,6 +19,15 @@ global:
   ##
   imagePullSecrets: []
   storageClass: ""
+  ## Compatibility adaptations for Kubernetes platforms
+  ##
+  compatibility:
+    ## Compatibility adaptations for Openshift
+    ##
+    openshift:
+      ## @param global.compatibility.openshift.adaptSecurityContext Adapt the securityContext sections of the deployment to make them compatible with Openshift restricted-v2 SCC: remove runAsUser, runAsGroup and fsGroup and let the platform use their allowed default IDs. Possible values: auto (apply if the detected running cluster is Openshift), force (perform the adaptation always), disabled (do not perform adaptation)
+      ##
+      adaptSecurityContext: disabled
 ## @section Common parameters
 ##
 


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Currently, our charts fail in Openshift restricted-v2 SCC with the following error:

```
  Warning  FailedCreate  13d (x17 over 13d)      replicaset-controller  Error creating: pods "d58bf646c-" is forbidden: unable to validate against any security context constraint: [provider "anyuid": Forbidden: not usable by user or serviceaccount, provider restricted-v2: .spec.securityContext.fsGroup: Invalid value: []int64{1001}: 1001 is not an allowed group, provider restricted-v2: .initContainers[0].runAsUser: Invalid value: 1001: must be in the ranges: [1000680000, 1000689999], provider restricted-v2: .initContainers[1].runAsUser: Invalid value: 1001: must be in the ranges: [1000680000, 1000689999], provider restricted-v2: .containers[0].runAsUser: Invalid value: 1001: must be in the ranges: [1000680000, 1000689999], provider "restricted": Forbidden: not usable by user or serviceaccount, provider "nonroot-v2": Forbidden: not usable by user or serviceaccount, provider "nonroot": Forbidden: not usable by user or serviceaccount, provider "hostmount-anyuid": Forbidden: not usable by user or serviceaccount, provider "machine-api-termination-handler": Forbidden: not usable by user or serviceaccount, provider "hostnetwork-v2": Forbidden: not usable by user or serviceaccount, provider "hostnetwork": Forbidden: not usable by user or serviceaccount, provider "hostaccess": Forbidden: not usable by user or serviceaccount, provider "hostpath-provisioner": Forbidden: not usable by user or serviceaccount, provider "privileged": Forbidden: not usable by user or serviceaccount]
```

This is because the `fsGroup`, `runAsUser` and `runAsGroup` values are set to 1001 by default, which is incompatible with the range the restricted-v2 SCC expects. Depending on the Openshift installation the range of values changes, so we cannot always assure that `[1000680000, 1000689999]` will be the valid range.

In order to make our deployment easy for users, we added support in bitnami/common https://github.com/bitnami/charts/pull/24040 for an automatic adaptation of the rendered `securityContext` objects so these conflicting values are not present.

This PR adds support for this new bitnami/common feature. Adding the value `global.compatibility.openshift.adaptSecurityContext`. It also changes the securityContext objects to use the `common.compatibility.renderSecurityContext` helper. In order to not break existing installations, this value is set to `disabled` by default. We expect to change this default in a future major bump.

<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

Charts work out of the box with the most restricted Openshift SCC.
<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

Not at the moment, as the feature is not enabled.
<!-- Describe any known limitations with your change -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
