### PR TITLE
[bitnami/rabbitmq-cluster-operator] feat: :sparkles: :lock: Add automatic adaptation for Openshift restricted-v2 SCC

### DIFF
--- a/bitnami/rabbitmq-cluster-operator/Chart.lock
+++ b/bitnami/rabbitmq-cluster-operator/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.16.1
-digest: sha256:f808a6fdc9c374d158ad7ff2f2c53a6c409e41da778d768b232dd20f86ef8b47
-generated: "2024-02-21T14:29:17.284012858Z"
+  version: 2.18.0
+digest: sha256:f489ae7394a4eceb24fb702901483c67a5b4fff605f19d5e2545e3a6778e1280
+generated: "2024-03-05T15:31:47.119308256+01:00"

--- a/bitnami/rabbitmq-cluster-operator/Chart.yaml
+++ b/bitnami/rabbitmq-cluster-operator/Chart.yaml
@@ -37,4 +37,4 @@ maintainers:
 name: rabbitmq-cluster-operator
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/rabbitmq-cluster-operator
-version: 3.19.1
+version: 3.20.0

--- a/bitnami/rabbitmq-cluster-operator/README.md
+++ b/bitnami/rabbitmq-cluster-operator/README.md
@@ -136,11 +136,12 @@ This solution allows to easily deploy multiple RabbitMQ instances compared to th
 
 ### Global parameters
 
-| Name                      | Description                                     | Value |
-| ------------------------- | ----------------------------------------------- | ----- |
-| `global.imageRegistry`    | Global Docker image registry                    | `""`  |
-| `global.imagePullSecrets` | Global Docker registry secret names as an array | `[]`  |
-| `global.storageClass`     | Global StorageClass for Persistent Volume(s)    | `""`  |
+| Name                                                  | Description                                                                                                                                                                                                                                                                                                                                                         | Value      |
+| ----------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- |
+| `global.imageRegistry`                                | Global Docker image registry                                                                                                                                                                                                                                                                                                                                        | `""`       |
+| `global.imagePullSecrets`                             | Global Docker registry secret names as an array                                                                                                                                                                                                                                                                                                                     | `[]`       |
+| `global.storageClass`                                 | Global StorageClass for Persistent Volume(s)                                                                                                                                                                                                                                                                                                                        | `""`       |
+| `global.compatibility.openshift.adaptSecurityContext` | Adapt the securityContext sections of the deployment to make them compatible with Openshift restricted-v2 SCC: remove runAsUser, runAsGroup and fsGroup and let the platform use their allowed default IDs. Possible values: auto (apply if the detected running cluster is Openshift), force (perform the adaptation always), disabled (do not perform adaptation) | `disabled` |
 
 ### Common parameters
 

--- a/bitnami/rabbitmq-cluster-operator/templates/cluster-operator/deployment.yaml
+++ b/bitnami/rabbitmq-cluster-operator/templates/cluster-operator/deployment.yaml
@@ -62,7 +62,7 @@ spec:
       priorityClassName: {{ .Values.clusterOperator.priorityClassName | quote }}
       {{- end }}
       {{- if .Values.clusterOperator.podSecurityContext.enabled }}
-      securityContext: {{- omit .Values.clusterOperator.podSecurityContext "enabled" | toYaml | nindent 8 }}
+      securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.clusterOperator.podSecurityContext "context" $) | nindent 8 }}
       {{- end }}
       {{- if .Values.clusterOperator.terminationGracePeriodSeconds }}
       terminationGracePeriodSeconds: {{ .Values.clusterOperator.terminationGracePeriodSeconds }}
@@ -76,7 +76,7 @@ spec:
           image: {{ template "rmqco.clusterOperator.image" . }}
           imagePullPolicy: {{ .Values.clusterOperator.image.pullPolicy }}
           {{- if .Values.clusterOperator.containerSecurityContext.enabled }}
-          securityContext: {{- omit .Values.clusterOperator.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+          securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.clusterOperator.containerSecurityContext "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.clusterOperator.command }}
           command: {{- include "common.tplvalues.render" (dict "value" .Values.clusterOperator.command "context" $) | nindent 12 }}

--- a/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/deployment.yaml
+++ b/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/deployment.yaml
@@ -65,7 +65,7 @@ spec:
       priorityClassName: {{ .Values.msgTopologyOperator.priorityClassName | quote }}
       {{- end }}
       {{- if .Values.msgTopologyOperator.podSecurityContext.enabled }}
-      securityContext: {{- omit .Values.msgTopologyOperator.podSecurityContext "enabled" | toYaml | nindent 8 }}
+      securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.msgTopologyOperator.podSecurityContext "context" $) | nindent 8 }}
       {{- end }}
       {{- if .Values.msgTopologyOperator.terminationGracePeriodSeconds }}
       terminationGracePeriodSeconds: {{ .Values.msgTopologyOperator.terminationGracePeriodSeconds }}
@@ -85,7 +85,7 @@ spec:
           image: {{ template "rmqco.msgTopologyOperator.image" . }}
           imagePullPolicy: {{ .Values.msgTopologyOperator.image.pullPolicy }}
           {{- if .Values.msgTopologyOperator.containerSecurityContext.enabled }}
-          securityContext: {{- omit .Values.msgTopologyOperator.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+          securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.msgTopologyOperator.containerSecurityContext "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.msgTopologyOperator.command }}
           command: {{- include "common.tplvalues.render" (dict "value" .Values.msgTopologyOperator.command "context" $) | nindent 12 }}

--- a/bitnami/rabbitmq-cluster-operator/values.yaml
+++ b/bitnami/rabbitmq-cluster-operator/values.yaml
@@ -19,6 +19,15 @@ global:
   ##
   imagePullSecrets: []
   storageClass: ""
+  ## Compatibility adaptations for Kubernetes platforms
+  ##
+  compatibility:
+    ## Compatibility adaptations for Openshift
+    ##
+    openshift:
+      ## @param global.compatibility.openshift.adaptSecurityContext Adapt the securityContext sections of the deployment to make them compatible with Openshift restricted-v2 SCC: remove runAsUser, runAsGroup and fsGroup and let the platform use their allowed default IDs. Possible values: auto (apply if the detected running cluster is Openshift), force (perform the adaptation always), disabled (do not perform adaptation)
+      ##
+      adaptSecurityContext: disabled
 ## @section Common parameters
 ##
 


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Currently, our charts fail in Openshift restricted-v2 SCC with the following error:

```
  Warning  FailedCreate  13d (x17 over 13d)      replicaset-controller  Error creating: pods "d58bf646c-" is forbidden: unable to validate against any security context constraint: [provider "anyuid": Forbidden: not usable by user or serviceaccount, provider restricted-v2: .spec.securityContext.fsGroup: Invalid value: []int64{1001}: 1001 is not an allowed group, provider restricted-v2: .initContainers[0].runAsUser: Invalid value: 1001: must be in the ranges: [1000680000, 1000689999], provider restricted-v2: .initContainers[1].runAsUser: Invalid value: 1001: must be in the ranges: [1000680000, 1000689999], provider restricted-v2: .containers[0].runAsUser: Invalid value: 1001: must be in the ranges: [1000680000, 1000689999], provider "restricted": Forbidden: not usable by user or serviceaccount, provider "nonroot-v2": Forbidden: not usable by user or serviceaccount, provider "nonroot": Forbidden: not usable by user or serviceaccount, provider "hostmount-anyuid": Forbidden: not usable by user or serviceaccount, provider "machine-api-termination-handler": Forbidden: not usable by user or serviceaccount, provider "hostnetwork-v2": Forbidden: not usable by user or serviceaccount, provider "hostnetwork": Forbidden: not usable by user or serviceaccount, provider "hostaccess": Forbidden: not usable by user or serviceaccount, provider "hostpath-provisioner": Forbidden: not usable by user or serviceaccount, provider "privileged": Forbidden: not usable by user or serviceaccount]
```

This is because the `fsGroup`, `runAsUser` and `runAsGroup` values are set to 1001 by default, which is incompatible with the range the restricted-v2 SCC expects. Depending on the Openshift installation the range of values changes, so we cannot always assure that `[1000680000, 1000689999]` will be the valid range.

In order to make our deployment easy for users, we added support in bitnami/common https://github.com/bitnami/charts/pull/24040 for an automatic adaptation of the rendered `securityContext` objects so these conflicting values are not present.

This PR adds support for this new bitnami/common feature. Adding the value `global.compatibility.openshift.adaptSecurityContext`. It also changes the securityContext objects to use the `common.compatibility.renderSecurityContext` helper. In order to not break existing installations, this value is set to `disabled` by default. We expect to change this default in a future major bump.

<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

Charts work out of the box with the most restricted Openshift SCC.
<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

Not at the moment, as the feature is not enabled.
<!-- Describe any known limitations with your change -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
