### PR TITLE
[bitnami/flux] Update runtime-params to support Openshift testing

### DIFF
--- a/.vib/flux/runtime-parameters.yaml
+++ b/.vib/flux/runtime-parameters.yaml
@@ -92,7 +92,7 @@ extraDeploy:
       interval: 5m
       url: https://github.com/mdhont/podinfo
       ref:
-        branch: master
+        branch: '{{ ternary "openshift" "master" (.Capabilities.APIVersions.Has "security.openshift.io/v1") }}'
   - apiVersion: kustomize.toolkit.fluxcd.io/v1
     kind: Kustomization
     metadata:
@@ -140,6 +140,10 @@ extraDeploy:
             namespace: '{{ include "common.names.namespace" . }}'
           interval: 1m
       values:
+        global:
+          compatibility:
+            openshift:
+              adaptSecurityContext: auto
         fullnameOverride: vib-dokuwiki
         persistence:
           enabled: false


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->
In #21589 we modified the `podinfo` repo used, which was configured to use the secContext necessary for our tests to run in non-Openshift cluster. 

After creating a custom `openshift` branch in the used repo, this PR adapts the `extraDeploy` params to support Openshift as a testing platform. This required changes both in `bitnami/flux` and `bitnami/dokuwiki` repos.

### Benefits

<!-- What benefits will be realized by the code change? -->
The runtime parameters can now be used in an Openshift testing deployment.
### Possible drawbacks

<!-- Describe any known limitations with your change -->
None

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
