### PR TITLE
[bitnami/argo-workflows] Update bundled PostgreSQL

### DIFF
--- a/bitnami/argo-workflows/Chart.lock
+++ b/bitnami/argo-workflows/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: postgresql
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 13.4.6
+  version: 14.3.1
 - name: mysql
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 9.23.0
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.18.0
-digest: sha256:77d229377530fbf2269397dc8549df3157ffb709febea54dfe7b23e188beb0b4
-generated: "2024-03-06T13:15:04.753952324Z"
+  version: 2.19.0
+digest: sha256:d37da19ede398780bb91d8f3b661f3c49b3ca3b8153f9a281563f21708cdebba
+generated: "2024-03-08T12:47:48.091277+01:00"

--- a/bitnami/argo-workflows/Chart.yaml
+++ b/bitnami/argo-workflows/Chart.yaml
@@ -17,7 +17,7 @@ dependencies:
 - condition: postgresql.enabled
   name: postgresql
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 13.x.x
+  version: 14.x.x
 - condition: mysql.enabled
   name: mysql
   repository: oci://registry-1.docker.io/bitnamicharts
@@ -42,4 +42,4 @@ maintainers:
 name: argo-workflows
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/argo-workflows
-version: 6.8.1
+version: 7.0.0

--- a/bitnami/argo-workflows/README.md
+++ b/bitnami/argo-workflows/README.md
@@ -588,6 +588,10 @@ Find more information about how to deal with common errors related to Bitnami's 
 
 ## Upgrading
 
+### To 7.0.0
+
+This major release bumps the PostgreSQL chart version to [14.x.x](https://github.com/bitnami/charts/pull/22750); no major issues are expected during the upgrade.
+
 ### To 6.0.0
 
 This major updates the PostgreSQL subchart to its newest major, 13.0.0. [Here](https://github.com/bitnami/charts/tree/master/bitnami/postgresql#to-1300) you can find more information about the changes introduced in that version.


### PR DESCRIPTION
This PR updates the bundled bitnami/postgresql subchart to its new major (see https://github.com/bitnami/charts/pull/22750), bumping the jupyterhub version in a major as well