### PR TITLE
[bitnami/schema-registry] Add missing namespace metadata to headless-service.yaml

### DIFF
--- a/bitnami/schema-registry/Chart.yaml
+++ b/bitnami/schema-registry/Chart.yaml
@@ -34,4 +34,4 @@ maintainers:
 name: schema-registry
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/schema-registry
-version: 17.1.0
+version: 17.1.1

--- a/bitnami/schema-registry/templates/headless-service.yaml
+++ b/bitnami/schema-registry/templates/headless-service.yaml
@@ -7,6 +7,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ printf "%s-headless" (include "common.names.fullname" .) }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
   {{- if or .Values.service.headless.annotations .Values.commonAnnotations }}
   {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.service.headless.annotations .Values.commonAnnotations ) "context" . ) }}


### PR DESCRIPTION


### Description of the change

This PR adds the `metadata.namespace` value to the `template/headless-service.yaml` to align with the other templates within the chart.

### Benefits

Improves consistency and compatibility with ArgoCD

### Possible drawbacks

### Applicable issues

- fixes #24263 

### Additional information

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
