### PR TITLE
Fixed issue  [bitnami/airflow] nil pointer evaluating interface {}.gl…

### DIFF
--- a/bitnami/airflow/Chart.yaml
+++ b/bitnami/airflow/Chart.yaml
@@ -47,4 +47,4 @@ maintainers:
 name: airflow
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/airflow
-version: 17.2.1
+version: 17.2.2

--- a/bitnami/airflow/templates/_git_helpers.tpl
+++ b/bitnami/airflow/templates/_git_helpers.tpl
@@ -68,7 +68,7 @@ Usage:
   image: {{ include "git.image" .context | quote }}
   imagePullPolicy: {{ .context.Values.git.image.pullPolicy | quote }}
 {{- if .securityContext.enabled }}
-  securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .securityContext "context" $) | nindent 4 }}
+  securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .securityContext "context" .context) | nindent 4 }}
 {{- end }}
 {{- if .context.Values.git.clone.resources }}
   resources: {{- toYaml .context.Values.git.clone.resources | nindent 4 }}
@@ -136,7 +136,7 @@ Usage:
   image: {{ include "git.image" .context | quote }}
   imagePullPolicy: {{ .context.Values.git.image.pullPolicy | quote }}
 {{- if .securityContext.enabled }}
-  securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .securityContext "context" $) | nindent 4 }}
+  securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .securityContext "context" .context) | nindent 4 }}
 {{- end }}
 {{- if .context.Values.git.sync.resources }}
   resources: {{- toYaml .context.Values.git.sync.resources | nindent 4 }}


### PR DESCRIPTION
Fixed issue  [bitnami/airflow] nil pointer evaluating interface {}.global #24283

See issue #24283 

### Description of the change

The change fix wrong call made by the helpers function that call "renderSecurityContext" with $, but $ is null in the helper function. Instead of $ it has to use ".context".

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

### Applicable issues

- fixes #24283 

### Additional information


### Checklist
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
