### PR TITLE
[bitnami/matomo] Separate config for cronjobs

### DIFF
--- a/.vib/matomo/runtime-parameters.yaml
+++ b/.vib/matomo/runtime-parameters.yaml
@@ -9,4 +9,8 @@ service:
 readinessProbe:
   initialDelaySeconds: 90
 cronjobs:
-  enabled: false
+  archive:
+    enabled: false
+  taskScheduler:
+    enabled: false
+

--- a/bitnami/matomo/Chart.lock
+++ b/bitnami/matomo/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 15.2.3
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.18.0
-digest: sha256:36b99a6536d40d96d4c809ef7082c57d4c54b2fffc824e977d271c85a43e7d4c
-generated: "2024-03-05T14:42:29.102103887+01:00"
+  version: 2.19.0
+digest: sha256:0e127f3d77e7a4ce7319a884351d47f994cb46acb28630255a4dde0db9339f08
+generated: "2024-03-13T17:11:31.42487085+01:00"

--- a/bitnami/matomo/Chart.yaml
+++ b/bitnami/matomo/Chart.yaml
@@ -39,4 +39,4 @@ maintainers:
 name: matomo
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/matomo
-version: 5.5.1
+version: 6.0.0

--- a/bitnami/matomo/README.md
+++ b/bitnami/matomo/README.md
@@ -398,6 +398,8 @@ helm install my-release --set persistence.existingClaim=PVC_NAME oci://REGISTRY_
 | `cronjobs.taskScheduler.podAnnotations`                                    | Additional pod annotations                                                                                        | `{}`             |
 | `cronjobs.taskScheduler.podLabels`                                         | Additional pod labels                                                                                             | `{}`             |
 | `cronjobs.taskScheduler.resources`                                         | Set container requests and limits for different resources like CPU or memory (essential for production workloads) | `{}`             |
+| `cronjobs.taskScheduler.persistence.enable`                                | Enable persistence using Persistent Volume Claims                                                                 | `true`           |
+| `cronjobs.taskScheduler.persistence.existingClaim`                         | A manually managed Persistent Volume Claim                                                                        | `""`             |
 | `cronjobs.archive.enabled`                                                 | Whether to enable scheduled mail-to-task CronJob                                                                  | `true`           |
 | `cronjobs.archive.schedule`                                                | Kubernetes CronJob schedule                                                                                       | `*/5 * * * *`    |
 | `cronjobs.archive.suspend`                                                 | Whether to create suspended CronJob                                                                               | `false`          |
@@ -416,6 +418,8 @@ helm install my-release --set persistence.existingClaim=PVC_NAME oci://REGISTRY_
 | `cronjobs.archive.podAnnotations`                                          | Additional pod annotations                                                                                        | `{}`             |
 | `cronjobs.archive.podLabels`                                               | Additional pod labels                                                                                             | `{}`             |
 | `cronjobs.archive.resources`                                               | Set container requests and limits for different resources like CPU or memory (essential for production workloads) | `{}`             |
+| `cronjobs.archive.persistence.enable`                                      | Enable persistence using Persistent Volume Claims                                                                 | `true`           |
+| `cronjobs.archive.persistence.existingClaim`                               | A manually managed Persistent Volume Claim                                                                        | `""`             |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/bitnami/matomo/README.md
+++ b/bitnami/matomo/README.md
@@ -405,6 +405,7 @@ helm install my-release --set persistence.existingClaim=PVC_NAME oci://REGISTRY_
 | `cronjobs.taskScheduler.podSecurityContext.sysctls`                        | Set kernel settings using the sysctl interface                                                                    | `[]`             |
 | `cronjobs.taskScheduler.podSecurityContext.supplementalGroups`             | Set filesystem extra groups                                                                                       | `[]`             |
 | `cronjobs.taskScheduler.podSecurityContext.fsGroup`                        | Task scheduler cronjob pods' group ID                                                                             | `1001`           |
+| `cronjobs.taskScheduler.extraEnvVars`                                      | Extra environment variables for the taskScheduler CronJob                                                         | `[]`             |
 | `cronjobs.archive.enabled`                                                 | Whether to enable scheduled mail-to-task CronJob                                                                  | `true`           |
 | `cronjobs.archive.schedule`                                                | Kubernetes CronJob schedule                                                                                       | `*/5 * * * *`    |
 | `cronjobs.archive.suspend`                                                 | Whether to create suspended CronJob                                                                               | `false`          |
@@ -430,6 +431,7 @@ helm install my-release --set persistence.existingClaim=PVC_NAME oci://REGISTRY_
 | `cronjobs.archive.podSecurityContext.sysctls`                              | Set kernel settings using the sysctl interface                                                                    | `[]`             |
 | `cronjobs.archive.podSecurityContext.supplementalGroups`                   | Set filesystem extra groups                                                                                       | `[]`             |
 | `cronjobs.archive.podSecurityContext.fsGroup`                              | Archive cronjob pods' group ID                                                                                    | `1001`           |
+| `cronjobs.archive.extraEnvVars`                                            | Extra environment variables for the archive CronJob                                                               | `[]`             |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/bitnami/matomo/README.md
+++ b/bitnami/matomo/README.md
@@ -400,6 +400,11 @@ helm install my-release --set persistence.existingClaim=PVC_NAME oci://REGISTRY_
 | `cronjobs.taskScheduler.resources`                                         | Set container requests and limits for different resources like CPU or memory (essential for production workloads) | `{}`             |
 | `cronjobs.taskScheduler.persistence.enable`                                | Enable persistence using Persistent Volume Claims                                                                 | `true`           |
 | `cronjobs.taskScheduler.persistence.existingClaim`                         | A manually managed Persistent Volume Claim                                                                        | `""`             |
+| `cronjobs.taskScheduler.podSecurityContext.enabled`                        | Enable Task scheduler cronjob pods' Security Context                                                              | `true`           |
+| `cronjobs.taskScheduler.podSecurityContext.fsGroupChangePolicy`            | Set filesystem group change policy                                                                                | `Always`         |
+| `cronjobs.taskScheduler.podSecurityContext.sysctls`                        | Set kernel settings using the sysctl interface                                                                    | `[]`             |
+| `cronjobs.taskScheduler.podSecurityContext.supplementalGroups`             | Set filesystem extra groups                                                                                       | `[]`             |
+| `cronjobs.taskScheduler.podSecurityContext.fsGroup`                        | Task scheduler cronjob pods' group ID                                                                             | `1001`           |
 | `cronjobs.archive.enabled`                                                 | Whether to enable scheduled mail-to-task CronJob                                                                  | `true`           |
 | `cronjobs.archive.schedule`                                                | Kubernetes CronJob schedule                                                                                       | `*/5 * * * *`    |
 | `cronjobs.archive.suspend`                                                 | Whether to create suspended CronJob                                                                               | `false`          |
@@ -420,6 +425,11 @@ helm install my-release --set persistence.existingClaim=PVC_NAME oci://REGISTRY_
 | `cronjobs.archive.resources`                                               | Set container requests and limits for different resources like CPU or memory (essential for production workloads) | `{}`             |
 | `cronjobs.archive.persistence.enable`                                      | Enable persistence using Persistent Volume Claims                                                                 | `true`           |
 | `cronjobs.archive.persistence.existingClaim`                               | A manually managed Persistent Volume Claim                                                                        | `""`             |
+| `cronjobs.archive.podSecurityContext.enabled`                              | Enable Archive cronjob pods' Security Context                                                                     | `true`           |
+| `cronjobs.archive.podSecurityContext.fsGroupChangePolicy`                  | Set filesystem group change policy                                                                                | `Always`         |
+| `cronjobs.archive.podSecurityContext.sysctls`                              | Set kernel settings using the sysctl interface                                                                    | `[]`             |
+| `cronjobs.archive.podSecurityContext.supplementalGroups`                   | Set filesystem extra groups                                                                                       | `[]`             |
+| `cronjobs.archive.podSecurityContext.fsGroup`                              | Archive cronjob pods' group ID                                                                                    | `1001`           |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/bitnami/matomo/README.md
+++ b/bitnami/matomo/README.md
@@ -462,6 +462,11 @@ Find more information about how to deal with common errors related to Bitnami's 
 
 ## Upgrading
 
+### To 6.0.0
+
+Moved persistence config for the cronjobs from `persistence` to `cronjobs.archive.persistence` and `cronjobs.taskScheduler.persistence` respectively.
+Moved resource config for the archive cronjob from `resources` to `cronjobs.archive.resources`.
+
 ### To 4.0.0
 
 This major release bumps the MariaDB version to 11.2. No major issues are expected during the upgrade.

--- a/bitnami/matomo/templates/cronjob.yaml
+++ b/bitnami/matomo/templates/cronjob.yaml
@@ -145,9 +145,9 @@ spec:
             {{- end }}
             {{- end }}
             - name: matomo-data
-              {{- if .Values.persistence.enabled }}
+              {{- if .Values.cronjobs.archive.persistence.enabled }}
               persistentVolumeClaim:
-                claimName: {{ .Values.persistence.existingClaim | default (printf "%s-matomo" (include "common.names.fullname" .)) }}
+                claimName: {{ .Values.cronjobs.archive.persistence.existingClaim | default (printf "%s-matomo" (include "common.names.fullname" .)) }}
               {{- else }}
               emptyDir: {}
               {{- end }}
@@ -299,9 +299,9 @@ spec:
             {{- end }}
             {{- end }}
             - name: matomo-data
-              {{- if .Values.persistence.enabled }}
+              {{- if .Values.cronjobs.taskScheduler.persistence.enabled }}
               persistentVolumeClaim:
-                claimName: {{ .Values.persistence.existingClaim | default (printf "%s-matomo" (include "common.names.fullname" .)) }}
+                claimName: {{ .Values.cronjobs.taskScheduler.persistence.existingClaim | default (printf "%s-matomo" (include "common.names.fullname" .)) }}
               {{- else }}
               emptyDir: {}
               {{- end }}

--- a/bitnami/matomo/templates/cronjob.yaml
+++ b/bitnami/matomo/templates/cronjob.yaml
@@ -40,6 +40,9 @@ spec:
           {{- end }}
           initContainers:
             {{ include "matomo.initContainers" . | nindent 12 }}
+          {{- if .Values.cronjobs.archive.podSecurityContext.enabled }}
+          securityContext: {{- omit .Values.cronjobs.archive.podSecurityContext "enabled" | toYaml | nindent 16 }}
+          {{- end }}
           containers:
             - name: {{ include "common.names.fullname" . }}-archive
               image: {{ template "matomo.image" . }}
@@ -199,6 +202,9 @@ spec:
           restartPolicy: OnFailure
           initContainers:
             {{ include "matomo.initContainers" . | nindent 12 }}
+          {{- if .Values.cronjobs.taskScheduler.podSecurityContext.enabled }}
+          securityContext: {{- omit .Values.cronjobs.taskScheduler.podSecurityContext "enabled" | toYaml | nindent 16 }}
+          {{- end }}
           containers:
             - name: {{ include "common.names.fullname" . }}-scheduled-tasks
               image: {{ template "matomo.image" . }}

--- a/bitnami/matomo/templates/cronjob.yaml
+++ b/bitnami/matomo/templates/cronjob.yaml
@@ -86,6 +86,9 @@ spec:
                     secretKeyRef:
                       name: {{ include "matomo.databaseSecretName" . }}
                       key: {{ include "matomo.databasePasswordKey" . | quote }}
+                {{- if gt (len .Values.cronjobs.archive.extraEnvVars) 0  }}
+                {{- toYaml .Values.cronjobs.archive.extraEnvVars | nindent 16 }}
+                {{- end }}
               volumeMounts:
                 - name: matomo-data
                   mountPath: /bitnami/matomo
@@ -248,6 +251,9 @@ spec:
                     secretKeyRef:
                       name: {{ include "matomo.databaseSecretName" . }}
                       key: {{ include "matomo.databasePasswordKey" . | quote }}
+                {{- if gt (len .Values.cronjobs.taskScheduler.extraEnvVars) 0  }}
+                {{- toYaml .Values.cronjobs.taskScheduler.extraEnvVars | nindent 16 }}
+                {{- end }}
               volumeMounts:
                 - name: matomo-data
                   mountPath: /bitnami/matomo

--- a/bitnami/matomo/values.yaml
+++ b/bitnami/matomo/values.yaml
@@ -1025,6 +1025,21 @@ cronjobs:
     persistence:
       enable: true
       existingClaim: ""
+
+    ## Configure Pods Security Context for the taskScheduler CronJob
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
+    ## @param cronjobs.taskScheduler.podSecurityContext.enabled Enable Task scheduler cronjob pods' Security Context
+    ## @param cronjobs.taskScheduler.podSecurityContext.fsGroupChangePolicy Set filesystem group change policy
+    ## @param cronjobs.taskScheduler.podSecurityContext.sysctls Set kernel settings using the sysctl interface
+    ## @param cronjobs.taskScheduler.podSecurityContext.supplementalGroups Set filesystem extra groups
+    ## @param cronjobs.taskScheduler.podSecurityContext.fsGroup Task scheduler cronjob pods' group ID
+    ##
+    podSecurityContext:
+      enabled: true
+      fsGroupChangePolicy: Always
+      sysctls: []
+      supplementalGroups: []
+      fsGroup: 1001
   archive:
     ## @param cronjobs.archive.enabled Whether to enable scheduled mail-to-task CronJob
     ##
@@ -1099,3 +1114,18 @@ cronjobs:
     persistence:
       enable: true
       existingClaim: ""
+
+    ## Configure Pods Security Context for the archive CronJob
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
+    ## @param cronjobs.archive.podSecurityContext.enabled Enable Archive cronjob pods' Security Context
+    ## @param cronjobs.archive.podSecurityContext.fsGroupChangePolicy Set filesystem group change policy
+    ## @param cronjobs.archive.podSecurityContext.sysctls Set kernel settings using the sysctl interface
+    ## @param cronjobs.archive.podSecurityContext.supplementalGroups Set filesystem extra groups
+    ## @param cronjobs.archive.podSecurityContext.fsGroup Archive cronjob pods' group ID
+    ##
+    podSecurityContext:
+      enabled: true
+      fsGroupChangePolicy: Always
+      sysctls: []
+      supplementalGroups: []
+      fsGroup: 1001

--- a/bitnami/matomo/values.yaml
+++ b/bitnami/matomo/values.yaml
@@ -1016,6 +1016,15 @@ cronjobs:
     ##     memory: 1024Mi
     ##
     resources: {}
+
+    ## Persistence using Persistent Volume Claims for the taskScheduler CronJob
+    ## ref: https://kubernetes.io/docs/concepts/storage/persistent-volumes/
+    ## @param cronjobs.taskScheduler.persistence.enable Enable persistence using Persistent Volume Claims
+    ## @param cronjobs.taskScheduler.persistence.existingClaim A manually managed Persistent Volume Claim
+    ##
+    persistence:
+      enable: true
+      existingClaim: ""
   archive:
     ## @param cronjobs.archive.enabled Whether to enable scheduled mail-to-task CronJob
     ##
@@ -1067,6 +1076,7 @@ cronjobs:
     ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
     ##
     podLabels: {}
+
     ## @param cronjobs.archive.resources Set container requests and limits for different resources like CPU or memory (essential for production workloads)
     # NOTE: If not defined, this will fallback to the main resources request/limit to preserve backwards compatibility. This behaviour might be DEPRECATED
     # in upcoming versions of the chart
@@ -1080,3 +1090,12 @@ cronjobs:
     ##     memory: 1024Mi
     ##
     resources: {}
+
+    ## Persistence using Persistent Volume Claims for the archive CronJob
+    ## ref: https://kubernetes.io/docs/concepts/storage/persistent-volumes/
+    ## @param cronjobs.archive.persistence.enable Enable persistence using Persistent Volume Claims
+    ## @param cronjobs.archive.persistence.existingClaim A manually managed Persistent Volume Claim
+    ##
+    persistence:
+      enable: true
+      existingClaim: ""

--- a/bitnami/matomo/values.yaml
+++ b/bitnami/matomo/values.yaml
@@ -1040,6 +1040,9 @@ cronjobs:
       sysctls: []
       supplementalGroups: []
       fsGroup: 1001
+
+    ## @param cronjobs.taskScheduler.extraEnvVars Extra environment variables for the taskScheduler CronJob
+    extraEnvVars: []
   archive:
     ## @param cronjobs.archive.enabled Whether to enable scheduled mail-to-task CronJob
     ##
@@ -1129,3 +1132,6 @@ cronjobs:
       sysctls: []
       supplementalGroups: []
       fsGroup: 1001
+
+    ## @param cronjobs.archive.extraEnvVars Extra environment variables for the archive CronJob
+    extraEnvVars: []


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

I wanted to be able to have separate config for the cronjobs compared to the matomo deployment.
So I extracted persistent volume and resources config.
I also added `podSecurityContext` and `extraEnvVars` for both cronjobs

### Benefits

One major benefit is that you can now disable persistence for the cronjobs since they were unable to be scheduled if you had persistence on matomo and `ReadWriteOnce` volumes.
And otherwise this adds more ability to setup the cronjobs a bit differently than the matomo deployment to match the needs of the cluster.

### Possible drawbacks

There's a bit more config now which might be perceived as complex. But I think that the benefits overcomes the drawbacks.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

This will cause some disruption of the config where some config were moved from one place to another so I opted to bump a minor version for this.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
