### PR TITLE
[bitnami/vault] fix: don't create unused CSI Provider or injector resources

### DIFF
--- a/bitnami/vault/Chart.yaml
+++ b/bitnami/vault/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: vault
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/vault
-version: 0.12.2
+version: 0.12.3

--- a/bitnami/vault/templates/csi-provider/networkpolicy.yaml
+++ b/bitnami/vault/templates/csi-provider/networkpolicy.yaml
@@ -3,7 +3,7 @@ Copyright VMware, Inc.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- if .Values.csiProvider.networkPolicy.enabled }}
+{{- if and .Values.csiProvider.enabled .Values.csiProvider.networkPolicy.enabled }}
 kind: NetworkPolicy
 apiVersion: {{ include "common.capabilities.networkPolicy.apiVersion" . }}
 metadata:

--- a/bitnami/vault/templates/csi-provider/service-account.yaml
+++ b/bitnami/vault/templates/csi-provider/service-account.yaml
@@ -3,7 +3,7 @@ Copyright VMware, Inc.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- if .Values.csiProvider.serviceAccount.create }}
+{{- if and .Values.csiProvider.enabled .Values.csiProvider.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/bitnami/vault/templates/injector/hpa.yaml
+++ b/bitnami/vault/templates/injector/hpa.yaml
@@ -3,7 +3,7 @@ Copyright VMware, Inc.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- if .Values.injector.autoscaling.enabled }}
+{{- if and .Values.injector.enabled .Values.injector.autoscaling.enabled }}
 apiVersion: {{ include "common.capabilities.hpa.apiVersion" ( dict "context" $ ) }}
 kind: HorizontalPodAutoscaler
 metadata:

--- a/bitnami/vault/templates/injector/networkpolicy.yaml
+++ b/bitnami/vault/templates/injector/networkpolicy.yaml
@@ -3,7 +3,7 @@ Copyright VMware, Inc.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- if .Values.injector.networkPolicy.enabled }}
+{{- if and .Values.injector.enabled .Values.injector.networkPolicy.enabled }}
 kind: NetworkPolicy
 apiVersion: {{ include "common.capabilities.networkPolicy.apiVersion" . }}
 metadata:

--- a/bitnami/vault/templates/injector/pdb.yaml
+++ b/bitnami/vault/templates/injector/pdb.yaml
@@ -3,7 +3,7 @@ Copyright VMware, Inc.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- if .Values.injector.pdb.create }}
+{{- if and .Values.injector.enabled .Values.injector.pdb.create }}
 apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:

--- a/bitnami/vault/templates/injector/service-account.yaml
+++ b/bitnami/vault/templates/injector/service-account.yaml
@@ -3,7 +3,7 @@ Copyright VMware, Inc.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- if .Values.injector.serviceAccount.create }}
+{{- if and .Values.injector.enabled .Values.injector.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:


### PR DESCRIPTION
### Description of the change

Some auxiliary resources like service accounts and network policies are still created when using the default values (where CSI Provider and injector are not deployed). With this change, those resources will only be created when actually needed.

### Benefits

* Unused resources will not be deployed.

### Possible drawbacks

* There may be a corner case (not identified) when the CSI Provider and injector are deployed without those auxiliary resources.

### Applicable issues

None

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
