### PR TITLE
[bitnami/argo-cd] Update chart deps

### DIFF
--- a/bitnami/argo-cd/Chart.lock
+++ b/bitnami/argo-cd/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: redis
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 18.18.1
+  version: 18.19.2
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 2.19.0
-digest: sha256:e9fe657e127583b3a97b7a90c3e354b16295d5eec9439b2866ac798947d85210
-generated: "2024-03-08T15:54:30.279003307Z"
+digest: sha256:ff1e1b55a7c191f1cb2d2b6519ae7fcb7b66e0274cd574357aaf6de4c518d937
+generated: "2024-03-13T10:27:07.636777+01:00"

--- a/bitnami/argo-cd/Chart.yaml
+++ b/bitnami/argo-cd/Chart.yaml
@@ -39,4 +39,4 @@ maintainers:
 name: argo-cd
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/argo-cd
-version: 5.10.3
+version: 5.10.4


### PR DESCRIPTION
### Description of the change

This PR update ArgoCD chart deps to use latest version of Redis.

### Possible drawbacks

None

### Applicable issues

None

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
