### PR TITLE
[bitnami/appsmith] Update chart deps

### DIFF
--- a/bitnami/appsmith/Chart.lock
+++ b/bitnami/appsmith/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: redis
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 18.18.1
+  version: 18.19.2
 - name: mongodb
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 14.13.0
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 2.19.0
-digest: sha256:834f13eb7f08303c391f6dc2b417508b01926c1b791716e78fa8f5424df12300
-generated: "2024-03-08T15:54:28.802590007Z"
+digest: sha256:c8a4c5aa9c436f68b1a7bfe06e8f7e7c77d1d412b5c9750564181f4adaafe230
+generated: "2024-03-13T11:48:27.195438+01:00"

--- a/bitnami/appsmith/Chart.yaml
+++ b/bitnami/appsmith/Chart.yaml
@@ -37,4 +37,4 @@ maintainers:
 name: appsmith
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/appsmith
-version: 2.8.2
+version: 2.8.3


### PR DESCRIPTION
### Description of the change

This PR update AppSmith chart deps to use latest version of Redis.

### Possible drawbacks

None

### Applicable issues

None

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
