### PR TITLE
[bitnami/harbor] Update chart deps

### DIFF
--- a/bitnami/harbor/Chart.lock
+++ b/bitnami/harbor/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: redis
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 18.18.1
+  version: 18.19.2
 - name: postgresql
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 14.3.1
+  version: 14.3.3
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 2.19.0
-digest: sha256:a8a993eb233e14fd1a7d83ea4a5f366367849c7c2c43aaa28c4f3e6b40ac6f21
-generated: "2024-03-08T15:52:39.507487675Z"
+digest: sha256:ef8c5318de55f20f28fd5f98a2201bf883baab63e2faf37ef4b4d05ec14a0635
+generated: "2024-03-13T11:50:50.241389+01:00"

--- a/bitnami/harbor/Chart.yaml
+++ b/bitnami/harbor/Chart.yaml
@@ -55,4 +55,4 @@ maintainers:
 name: harbor
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/harbor
-version: 20.1.1
+version: 20.1.2


### PR DESCRIPTION
### Description of the change

This PR update Harbor chart deps to use latest version of Redis.

### Possible drawbacks

None

### Applicable issues

None

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
