### PR TITLE
[bitnami/kubeapps] Update chart deps

### DIFF
--- a/bitnami/kubeapps/Chart.lock
+++ b/bitnami/kubeapps/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: redis
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 18.18.1
+  version: 18.19.2
 - name: postgresql
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 13.4.6
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 2.19.0
-digest: sha256:b72db75e897921864ef40eb80aaf9b7cb6be3d564da48d67066d9556b9b20d9a
-generated: "2024-03-08T15:52:47.835050167Z"
+digest: sha256:b4965a22517e61212e78abb8d1cbe86e800c8664b3139e2047f4bd62b3e55b24
+generated: "2024-03-13T11:51:34.216594+01:00"

--- a/bitnami/kubeapps/Chart.yaml
+++ b/bitnami/kubeapps/Chart.yaml
@@ -52,4 +52,4 @@ maintainers:
 name: kubeapps
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/kubeapps
-version: 14.7.1
+version: 14.7.2


### PR DESCRIPTION
### Description of the change

This PR update Kubeapps chart deps to use latest version of Redis.

### Possible drawbacks

None

### Applicable issues

None

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
