### PR TITLE
[bitnami/influxdb] fix the indent of the resources

### DIFF
--- a/bitnami/influxdb/Chart.yaml
+++ b/bitnami/influxdb/Chart.yaml
@@ -37,4 +37,4 @@ maintainers:
 name: influxdb
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/influxdb
-version: 6.0.1
+version: 6.0.2

--- a/bitnami/influxdb/templates/cronjob-backup.yaml
+++ b/bitnami/influxdb/templates/cronjob-backup.yaml
@@ -86,9 +86,9 @@ spec:
               command:
                 - "/tmp/backup.sh"
               {{- if .Values.backup.cronjob.resources }}
-              resources: {{- toYaml .Values.backup.cronjob.resources | nindent 12 }}
+              resources: {{- toYaml .Values.backup.cronjob.resources | nindent 16 }}
               {{- else if ne .Values.backup.cronjob.resourcesPreset "none" }}
-              resources: {{- include "common.resources.preset" (dict "type" .Values.backup.cronjob.resourcesPreset) | nindent 12 }}
+              resources: {{- include "common.resources.preset" (dict "type" .Values.backup.cronjob.resourcesPreset) | nindent 16 }}
               {{- end }}
               volumeMounts:
                 - name: empty-dir
@@ -113,9 +113,9 @@ spec:
                 - "/bin/true"
               {{- end }}
               {{- if .Values.backup.cronjob.resources }}
-              resources: {{- toYaml .Values.backup.cronjob.resources | nindent 12 }}
+              resources: {{- toYaml .Values.backup.cronjob.resources | nindent 16 }}
               {{- else if ne .Values.backup.cronjob.resourcesPreset "none" }}
-              resources: {{- include "common.resources.preset" (dict "type" .Values.backup.cronjob.resourcesPreset) | nindent 12 }}
+              resources: {{- include "common.resources.preset" (dict "type" .Values.backup.cronjob.resourcesPreset) | nindent 16 }}
               {{- end }}
               {{- if .Values.backup.cronjob.containerSecurityContext.enabled }}
               securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.backup.cronjob.containerSecurityContext "context" $) | nindent 16 }}
@@ -131,9 +131,9 @@ spec:
                 - "/tmp/upload-google.sh"
               {{- end }}
               {{- if .Values.backup.uploadProviders.google.resources }}
-              resources: {{- toYaml .Values.backup.uploadProviders.google.resources | nindent 12 }}
+              resources: {{- toYaml .Values.backup.uploadProviders.google.resources | nindent 16 }}
               {{- else if ne .Values.backup.uploadProviders.google.resourcesPreset "none" }}
-              resources: {{- include "common.resources.preset" (dict "type" .Values.backup.uploadProviders.google.resourcesPreset) | nindent 12 }}
+              resources: {{- include "common.resources.preset" (dict "type" .Values.backup.uploadProviders.google.resourcesPreset) | nindent 16 }}
               {{- end }}
               volumeMounts:
                 - name: empty-dir
@@ -161,9 +161,9 @@ spec:
               - "/tmp/upload-azure.sh"
               {{- end }}
               {{- if .Values.backup.uploadProviders.azure.resources }}
-              resources: {{- toYaml .Values.backup.uploadProviders.azure.resources | nindent 12 }}
+              resources: {{- toYaml .Values.backup.uploadProviders.azure.resources | nindent 16 }}
               {{- else if ne .Values.backup.uploadProviders.azure.resourcesPreset "none" }}
-              resources: {{- include "common.resources.preset" (dict "type" .Values.backup.uploadProviders.azure.resourcesPreset) | nindent 12 }}
+              resources: {{- include "common.resources.preset" (dict "type" .Values.backup.uploadProviders.azure.resourcesPreset) | nindent 16 }}
               {{- end }}
               env:
                 - name: AZURE_STORAGE_CONNECTION_STRING
@@ -199,9 +199,9 @@ spec:
               - "/tmp/upload-aws.sh"
               {{- end }}
               {{- if .Values.backup.uploadProviders.aws.resources }}
-              resources: {{- toYaml .Values.backup.uploadProviders.aws.resources | nindent 12 }}
+              resources: {{- toYaml .Values.backup.uploadProviders.aws.resources | nindent 16 }}
               {{- else if ne .Values.backup.uploadProviders.aws.resourcesPreset "none" }}
-              resources: {{- include "common.resources.preset" (dict "type" .Values.backup.uploadProviders.aws.resourcesPreset) | nindent 12 }}
+              resources: {{- include "common.resources.preset" (dict "type" .Values.backup.uploadProviders.aws.resourcesPreset) | nindent 16 }}
               {{- end }}
               env:
                 - name: AWS_ACCESS_KEY_ID


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Fix the mistake made in #24361 with the wrong indent.

### Benefits

The backup works again

### Possible drawbacks

none

### Applicable issues

- fixes #24361 

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
