### PR TITLE
[bitnami/matomo] Fix cronjobs.archive.resources backwards compatibility

### DIFF
--- a/bitnami/matomo/Chart.yaml
+++ b/bitnami/matomo/Chart.yaml
@@ -39,4 +39,4 @@ maintainers:
 name: matomo
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/matomo
-version: 5.5.0
+version: 5.5.1

--- a/bitnami/matomo/templates/cronjob.yaml
+++ b/bitnami/matomo/templates/cronjob.yaml
@@ -111,6 +111,11 @@ spec:
                 {{- end }}
               {{- if not (empty .Values.cronjobs.archive.resources) }}
               resources: {{- toYaml .Values.cronjobs.archive.resources | nindent 16 }}
+              {{- else }}
+              # Fallback to the main resources request/limit to preserve backwards compatibility. This behaviour might be DEPRECATED
+              # in upcoming versions of the chart
+              resources:
+                {{- toYaml .Values.resources | nindent 16 }}
               {{- end }}
           volumes:
             {{- if .Values.certificates.customCAs }}

--- a/bitnami/matomo/values.yaml
+++ b/bitnami/matomo/values.yaml
@@ -1068,6 +1068,8 @@ cronjobs:
     ##
     podLabels: {}
     ## @param cronjobs.archive.resources Set container requests and limits for different resources like CPU or memory (essential for production workloads)
+    # NOTE: If not defined, this will fallback to the main resources request/limit to preserve backwards compatibility. This behaviour might be DEPRECATED
+    # in upcoming versions of the chart
     ## Example:
     ## resources:
     ##   requests:


### PR DESCRIPTION
### Description of the change

Follow-up of https://github.com/bitnami/charts/pull/23903 to fix backwards compatibility.

### Benefits

When `.Values.cronjobs.archive.resources` is not specified, the backwards compatibility still works.

### Possible drawbacks

None

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- Follow-up of https://github.com/bitnami/charts/pull/23903

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
