### PR TITLE
[bitnami/thanos] fix: use https for queryURL when ingress is tls

### DIFF
--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: thanos
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/thanos
-version: 15.0.0
+version: 15.0.1

--- a/bitnami/thanos/templates/_helpers.tpl
+++ b/bitnami/thanos/templates/_helpers.tpl
@@ -255,7 +255,7 @@ Return the queryURL used by Thanos Ruler.
 */}}
 {{- define "thanos.ruler.queryURL" -}}
 {{- if and .Values.queryFrontend.enabled .Values.queryFrontend.ingress.enabled .Values.queryFrontend.ingress.hostname .Values.queryFrontend.ingress.overrideAlertQueryURL -}}
-{{- printf "http://%s" (tpl .Values.queryFrontend.ingress.hostname .) -}}
+    {{- printf "%s://%s" (ternary "https" "http" .Values.queryFrontend.ingress.tls) (tpl .Values.queryFrontend.ingress.hostname .) -}}
 {{- else -}}
 {{- if .Values.ruler.queryURL -}}
     {{- printf "%s" (tpl .Values.ruler.queryURL $) -}}

--- a/bitnami/thanos/templates/query/deployment.yaml
+++ b/bitnami/thanos/templates/query/deployment.yaml
@@ -159,9 +159,7 @@ spec:
             {{- if .Values.query.grpc.client.serverName }}
             - --grpc-client-server-name={{ .Values.query.grpc.client.serverName }}
             {{- end }}
-            {{- if and .Values.queryFrontend.enabled .Values.queryFrontend.ingress.enabled .Values.queryFrontend.ingress.hostname .Values.queryFrontend.ingress.overrideAlertQueryURL }}
-            - --alert.query-url=http://{{ tpl .Values.queryFrontend.ingress.hostname . }}
-            {{- end }}
+            - --alert.query-url={{- template "thanos.ruler.queryURL" .}}
             {{- if .Values.query.extraFlags }}
             {{- include "common.tplvalues.render" (dict "value" .Values.query.extraFlags "context" $) | nindent 12 }}
             {{- end }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->
Use `https://` prefix for ruler alert URL when `queryFrontend.ingress.tls` is set to `true`. 

### Benefits

<!-- What benefits will be realized by the code change? -->
Compute a valid URL based on ingress configuration.

### Possible drawbacks

<!-- Describe any known limitations with your change -->
This bugfix might break some configurations in some edge cases.  

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
