### PR TITLE
[bitnami/thanos] Update bundled MinIO

### DIFF
--- a/bitnami/thanos/Chart.lock
+++ b/bitnami/thanos/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: minio
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 12.13.2
+  version: 13.8.4
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.18.0
-digest: sha256:6fcd075d30037dd44f6aa101b50642422729ce59f6e5f51a633d5f9f9cfc5d0e
-generated: "2024-03-05T15:52:05.180711014+01:00"
+  version: 2.19.0
+digest: sha256:4e1c09c9a7d08f73cb0408c22405ba3fa9b7ac292c4c23c5e8ec6fd54ee7e15f
+generated: "2024-03-15T14:47:26.852295+01:00"

--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -15,7 +15,7 @@ dependencies:
 - condition: minio.enabled
   name: minio
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 12.x.x
+  version: 13.x.x
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
   tags:
@@ -35,4 +35,4 @@ maintainers:
 name: thanos
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/thanos
-version: 13.4.1
+version: 14.0.0

--- a/bitnami/thanos/README.md
+++ b/bitnami/thanos/README.md
@@ -1596,6 +1596,10 @@ Find more information about how to deal with common errors related to Bitnami's 
 
 ## Upgrading
 
+### To 14.0.0
+
+This major release bumps the MinIO chart version to [13.x.x](https://github.com/bitnami/charts/pull/22058/); no major issues are expected during the upgrade.
+
 ### To 13.0.0
 
 This major version changes the NetworkPolicy objects and creates one per Thanos component. The `networkPolicy` common value was removed in favor of `COMPONENT.networkPolicy`. Also, NetworkPolicy objects are deployed by default. This can be changed by setting `COMPONENT.networkPolicy.enabled=false` being `COMPONENT` one of the Thanos components.


### PR DESCRIPTION
This PR updates the bundled bitnami/minio subchart to the new major (see https://github.com/bitnami/charts/pull/22058), bumping the Thanos version in a major as well