### PR TITLE
[bitnami/spring-cloud-dataflow] Address external RabbitMQ inconsistencies

### DIFF
--- a/bitnami/spring-cloud-dataflow/Chart.yaml
+++ b/bitnami/spring-cloud-dataflow/Chart.yaml
@@ -53,4 +53,4 @@ maintainers:
 name: spring-cloud-dataflow
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/spring-cloud-dataflow
-version: 26.11.0
+version: 26.12.0

--- a/bitnami/spring-cloud-dataflow/templates/NOTES.txt
+++ b/bitnami/spring-cloud-dataflow/templates/NOTES.txt
@@ -84,7 +84,8 @@ To access Spring Cloud Data Flow dashboard from outside the cluster execute the 
 {{/* Rabbitmq required password */}}
 {{- if or .Values.rabbitmq.enabled (and .Values.externalRabbitmq.enabled (not $existingRabbitmqSecret)) -}}
   {{- $rabbitmqValidations := list -}}
-  {{- $rabbitmqValidations = append $rabbitmqValidations (dict "valueKey" "rabbitmq.auth.password" "secret" $secretNameRabbitmq "field" "rabbitmq-password") -}}
+  {{- $passwordValueKey := ternary "rabbitmq.auth.password" "externalRabbitmq.password" .Values.rabbitmq.enabled }}
+  {{- $rabbitmqValidations = append $rabbitmqValidations (dict "valueKey" $passwordValueKey "secret" $secretNameRabbitmq "field" "rabbitmq-password") -}}
   {{- if .Values.rabbitmq.enabled -}}
     {{- $rabbitmqValidations = append $rabbitmqValidations (dict "valueKey" "rabbitmq.auth.erlangCookie" "secret" $secretNameRabbitmq "field" "rabbitmq-erlang-cookie") -}}
   {{- end -}}

--- a/bitnami/spring-cloud-dataflow/templates/NOTES.txt
+++ b/bitnami/spring-cloud-dataflow/templates/NOTES.txt
@@ -74,19 +74,22 @@ To access Spring Cloud Data Flow dashboard from outside the cluster execute the 
 
 {{- $passwordErrors := list -}}
 {{- $secretNameMariadb := include "scdf.mariadb.fullname" . -}}
-{{- $secretNameRabbitmq := include "scdf.rabbitmq.fullname" . -}}
-{{- $secretNameExternalRabbitmq := printf "%s-%s" (include "common.names.fullname" .) "externalrabbitmq" -}}
+{{- $secretNameRabbitmq := include "scdf.rabbitmq.secretName" . -}}
+{{- $existingRabbitmqSecret := coalesce .Values.externalRabbitmq.existingSecret .Values.externalRabbitmq.existingPasswordSecret -}}
 
 {{/* Mysql required password */}}
 {{- $passwordMysqlErrors := include "common.validations.values.mariadb.passwords" (dict "secret" $secretNameMariadb "subchart" true "context" $) -}}
 {{- $passwordErrors = append $passwordErrors $passwordMysqlErrors -}}
 
 {{/* Rabbitmq required password */}}
-{{- if or (.Values.rabbitmq.enabled) (and (.Values.externalRabbitmq.enabled) (not .Values.externalRabbitmq.existingPasswordSecret)) -}}
-{{- $requiredRabbitmqPassword := dict "valueKey" "rabbitmq.auth.password" "secret" $secretNameRabbitmq "field" "rabbitmq-password" -}}
-{{- $requiredErlangPassword := dict "valueKey" "rabbitmq.auth.erlangCookie" "secret" $secretNameRabbitmq "field" "rabbitmq-erlang-cookie" -}}
-{{- $requiredRabbitmqPasswordErrors := include "common.validations.values.multiple.empty" (dict "required" (list $requiredRabbitmqPassword $requiredErlangPassword) "context" $) -}}
-{{- $passwordErrors =  append $passwordErrors $requiredRabbitmqPasswordErrors -}}
+{{- if or .Values.rabbitmq.enabled (and .Values.externalRabbitmq.enabled (not $existingRabbitmqSecret)) -}}
+  {{- $rabbitmqValidations := list -}}
+  {{- $rabbitmqValidations = append $rabbitmqValidations (dict "valueKey" "rabbitmq.auth.password" "secret" $secretNameRabbitmq "field" "rabbitmq-password") -}}
+  {{- if .Values.rabbitmq.enabled -}}
+    {{- $rabbitmqValidations = append $rabbitmqValidations (dict "valueKey" "rabbitmq.auth.erlangCookie" "secret" $secretNameRabbitmq "field" "rabbitmq-erlang-cookie") -}}
+  {{- end -}}
+  {{- $requiredRabbitmqPasswordErrors := include "common.validations.values.multiple.empty" (dict "required" $rabbitmqValidations "context" $) -}}
+  {{- $passwordErrors =  append $passwordErrors $requiredRabbitmqPasswordErrors -}}
 {{- end }}
 
 {{- include "common.errors.upgrade.passwords.empty" (dict "validationErrors" $passwordErrors "context" $) -}}
@@ -102,8 +105,8 @@ To access Spring Cloud Data Flow dashboard from outside the cluster execute the 
     {{- $requiredSkipperExternalDbPassword := dict "valueKey" "externalDatabase.skipper.password" "secret" $secretNameSkipperExternalDb "field" "datasource-password" -}}
     {{- $passwordWarnings = append $passwordWarnings $requiredSkipperExternalDbPassword -}}
   {{- end -}}
-  {{- if and (.Values.externalRabbitmq.enabled) (not .Values.rabbitmq.enabled) (not .Values.externalRabbitmq.existingPasswordSecret) -}}
-    {{- $requiredExternalRabbitmqPassword := dict "valueKey" "externalRabbitmq.password" "secret" $secretNameExternalRabbitmq "field" "rabbitmq-password" -}}
+  {{- if and .Values.externalRabbitmq.enabled (not .Values.rabbitmq.enabled) (not $existingRabbitmqSecret) -}}
+    {{- $requiredExternalRabbitmqPassword := dict "valueKey" "externalRabbitmq.password" "secret" $secretNameRabbitmq "field" "rabbitmq-password" -}}
     {{- $passwordWarnings = append $passwordWarnings $requiredExternalRabbitmqPassword -}}
   {{- end -}}
 

--- a/bitnami/spring-cloud-dataflow/templates/_helpers.tpl
+++ b/bitnami/spring-cloud-dataflow/templates/_helpers.tpl
@@ -336,12 +336,13 @@ Return the RabbitMQ username
 Return the RabbitMQ secret name
 */}}
 {{- define "scdf.rabbitmq.secretName" -}}
-{{- if .Values.externalRabbitmq.existingPasswordSecret -}}
-    {{- printf "%s" .Values.externalRabbitmq.existingPasswordSecret -}}
+{{- $secretName := coalesce .Values.externalRabbitmq.existingSecret .Values.externalRabbitmq.existingPasswordSecret -}}
+{{- if $secretName -}}
+    {{- printf "%s" $secretName -}}
 {{- else if .Values.rabbitmq.enabled }}
     {{- printf "%s" (include "scdf.rabbitmq.fullname" .) -}}
 {{- else -}}
-    {{- printf "%s-%s" (include "common.names.fullname" .) "externalrabbitmq" -}}
+    {{- printf "%s-externalrabbitmq" (include "common.names.fullname" .) -}}
 {{- end -}}
 {{- end -}}
 

--- a/bitnami/spring-cloud-dataflow/templates/externalrabbitmq-secrets.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/externalrabbitmq-secrets.yaml
@@ -3,11 +3,12 @@ Copyright VMware, Inc.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- if and (.Values.externalRabbitmq.enabled) (not .Values.rabbitmq.enabled) (not .Values.externalRabbitmq.existingPasswordSecret) }}
+{{- $secretName := coalesce .Values.externalRabbitmq.existingSecret .Values.externalRabbitmq.existingPasswordSecret -}}
+{{- if and (.Values.externalRabbitmq.enabled) (not .Values.rabbitmq.enabled) (not $secretName) }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ printf "%s-%s" (include "common.names.fullname" .) "externalrabbitmq" }}
+  name: {{ printf "%s-externalrabbitmq" (include "common.names.fullname" .) }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
   namespace: {{ include "common.names.namespace" . | quote }}
   {{- if .Values.commonAnnotations }}

--- a/bitnami/spring-cloud-dataflow/templates/skipper/configmap.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/skipper/configmap.yaml
@@ -39,7 +39,6 @@ data:
               kubernetes:
                 accounts:
                   {{ .Values.skipper.configuration.accountName }}:
-                    {{- $environmentVariables := include "scdf.deployer.environmentVariables" . }}
                     {{- if or (.Values.rabbitmq.enabled) (.Values.externalRabbitmq.enabled) }}
                     {{- $rabbitmqHost := include "scdf.rabbitmq.host" . }}
                     {{- $rabbitmqPort := include "scdf.rabbitmq.port" . }}
@@ -49,8 +48,14 @@ data:
                       - SPRING_RABBITMQ_HOST={{ $rabbitmqHost }}
                       - SPRING_RABBITMQ_PORT={{ $rabbitmqPort }}
                       - SPRING_RABBITMQ_USERNAME={{ $rabbitmqUser }}
-                      - SPRING_RABBITMQ_PASSWORD=${rabbitmq-password}
                       - SPRING_RABBITMQ_VIRTUAL_HOST={{ $rabbitmqVhost }}
+                      {{- $secretName := coalesce .Values.externalRabbitmq.existingSecret .Values.externalRabbitmq.existingPasswordSecret -}}
+                      {{- if and (not .Values.rabbitmq.enabled) .Values.externalRabbitmq.enabled $secretName .Values.externalRabbitmq.existingSecretPasswordKey }}
+                      - SPRING_RABBITMQ_PASSWORD={{ printf "${%s}" .Values.externalRabbitmq.existingSecretPasswordKey }}
+                      {{- else }}
+                      - SPRING_RABBITMQ_PASSWORD=${rabbitmq-password}
+                      {{- end }}
+                      {{- $environmentVariables := include "scdf.deployer.environmentVariables" . }}
                       {{- if $environmentVariables }}
                       {{- $environmentVariables | nindent 22 }}
                       {{- end }}

--- a/bitnami/spring-cloud-dataflow/values.yaml
+++ b/bitnami/spring-cloud-dataflow/values.yaml
@@ -1970,9 +1970,15 @@ externalRabbitmq:
   ## vhost: /
   ##
   vhost: ""
-  ## @param externalRabbitmq.existingPasswordSecret Existing secret with RabbitMQ password. It will be saved in a kubernetes secret
+  ## @param externalRabbitmq.existingPasswordSecret Existing secret with RabbitMQ password (DEPRECATED: use externalRabbitmq.existingSecret instead)
   ##
   existingPasswordSecret: ""
+  ## @param externalRabbitmq.existingSecret Name of the existing secret containing RabbitMQ credentials
+  ##
+  existingSecret: ""
+  ## @param externalRabbitmq.existingSecretPasswordKey Key of the above existing secret with RabbitMQ password, defaults to `password`
+  ##
+  existingSecretPasswordKey: ""
 ## @section Kafka chart parameters
 
 ## Kafka chart configuration


### PR DESCRIPTION
### Description of the change

This PR ensures it's possible to indicate the secret key containing the RabbitMQ password when connecting to an existing RabbitMQ server using existing secrets. It also ensure it's not mandatory to provide `rabbitmq.auth.erlangCookie` nor `rabbitmq.auth.password` when using an existing RabbitMQ server.

### Benefits

Consistency between how to configure an external db and an external Rabbitmq

### Possible drawbacks

None

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes https://github.com/bitnami/charts/issues/24474
- fixes https://github.com/bitnami/charts/issues/24475

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
