### PR TITLE
[bitnami/mlflow] Remove string constraint from NetworkPolicy extraIngress/extraEgress

### DIFF
--- a/bitnami/mlflow/Chart.yaml
+++ b/bitnami/mlflow/Chart.yaml
@@ -43,4 +43,4 @@ name: mlflow
 sources:
 - https://github.com/bitnami/containers/tree/main/bitnami/mlflow
 - https://github.com/mlflow/mlflow
-version: 0.11.0
+version: 0.11.1

--- a/bitnami/mlflow/values.schema.json
+++ b/bitnami/mlflow/values.schema.json
@@ -948,17 +948,13 @@
                             "type": "array",
                             "description": "Add extra ingress rules to the NetworkPolicy",
                             "default": "[]",
-                            "items": {
-                                "type": "string"
-                            }
+                            "items": {}
                         },
                         "extraEgress": {
                             "type": "array",
                             "description": "Add extra ingress rules to the NetworkPolicy",
                             "default": "[]",
-                            "items": {
-                                "type": "string"
-                            }
+                            "items": {}
                         }
                     }
                 },
@@ -1584,17 +1580,13 @@
                             "type": "array",
                             "description": "Add extra ingress rules to the NetworkPolicy",
                             "default": "[]",
-                            "items": {
-                                "type": "string"
-                            }
+                            "items": {}
                         },
                         "extraEgress": {
                             "type": "array",
                             "description": "Add extra ingress rules to the NetworkPolicy",
                             "default": "[]",
-                            "items": {
-                                "type": "string"
-                            }
+                            "items": {}
                         }
                     }
                 },


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Removes the `string` constraint for extraIngress and extraEgress network policy values.

Before this change, I was unable to use either `extraIngress` or `extraEgress` as I was getting this error:

```
Invalid type. Expected: string, given: object
```

<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

Allows for usage of `extraIngress` or `extraEgress`

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

N/A

<!-- Describe any known limitations with your change -->

### Applicable issues

* Fixes #24049
* Reverts some changes originally implemented in #23555

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
