### PR TITLE
[bitnami/mediawiki] Upgrade MariaDB subchart

### DIFF
--- a/bitnami/mediawiki/Chart.lock
+++ b/bitnami/mediawiki/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: mariadb
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 15.2.3
+  version: 16.5.0
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.18.0
-digest: sha256:75a50c85a663339c9980f1dd1a659f6f50e95c860859f89256030b286101ccc7
-generated: "2024-03-05T14:44:40.449564229+01:00"
+  version: 2.19.0
+digest: sha256:2ea191d4e0df17e44a41815ef48be4d681eeb2f6f7aff99b7d5e2821c3dd331c
+generated: "2024-03-18T17:05:24.099164+01:00"

--- a/bitnami/mediawiki/Chart.yaml
+++ b/bitnami/mediawiki/Chart.yaml
@@ -17,7 +17,7 @@ dependencies:
   repository: oci://registry-1.docker.io/bitnamicharts
   tags:
   - mediawiki-database
-  version: 15.x.x
+  version: 16.x.x
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
   tags:
@@ -39,4 +39,4 @@ maintainers:
 name: mediawiki
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/mediawiki
-version: 18.5.0
+version: 19.0.0

--- a/bitnami/mediawiki/README.md
+++ b/bitnami/mediawiki/README.md
@@ -382,6 +382,10 @@ Find more information about how to deal with common errors related to Bitnami's 
 
 ## Upgrading
 
+### To 19.0.0
+
+This major release bumps the and MariaDB chart version to [16.x.x](https://github.com/bitnami/charts/pull/23054); no major issues are expected during the upgrade
+
 ### To 18.0.0
 
 This major release bumps the MariaDB version to 11.2. No major issues are expected during the upgrade.


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Upgrade MariaDB subchart to version 16.x.x

### Benefits

Use the latest version of the MariaDB chart with latest features such as networkPolicy or automatic adaptation for Openshift.

### Possible drawbacks

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #24288


- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
