### PR TITLE
[bitnami/rabbitmq-cluster-operator] Add aggregate cluster roles

### DIFF
--- a/bitnami/rabbitmq-cluster-operator/Chart.yaml
+++ b/bitnami/rabbitmq-cluster-operator/Chart.yaml
@@ -37,4 +37,4 @@ maintainers:
 name: rabbitmq-cluster-operator
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/rabbitmq-cluster-operator
-version: 4.0.0
+version: 4.1.0

--- a/bitnami/rabbitmq-cluster-operator/templates/cluster-operator/aggregate-cluster-roles.yaml
+++ b/bitnami/rabbitmq-cluster-operator/templates/cluster-operator/aggregate-cluster-roles.yaml
@@ -1,0 +1,31 @@
+{{- /*
+Copyright VMware, Inc.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+{{- if .Values.clusterOperator.rbac.create -}}
+{{- $readonlyVerbs := list "get" "list" "watch" }}
+{{- $allVerbs := list "create" "delete" "deletecollection" "get" "list" "patch" "update" "watch" }}
+{{- $roles := dict "view" $readonlyVerbs "edit" $allVerbs "admin" $allVerbs }}
+{{- range $role, $verbs := $roles -}}
+---
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" $ }}
+kind: ClusterRole
+metadata:
+  name: {{ template "common.names.fullname.namespace" $ }}-{{ $role }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" $.Values.commonLabels "context" $ ) | nindent 4 }}
+    app.kubernetes.io/component: rabbitmq-operator
+    app.kubernetes.io/part-of: rabbitmq
+    rbac.authorization.k8s.io/aggregate-to-{{ $role }}: "true"
+  {{- if $.Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" $.Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+rules:
+  - apiGroups:
+      - rabbitmq.com
+    resources:
+      - rabbitmqclusters
+      - rabbitmqclusters/finalizers
+    verbs: {{ $verbs | toYaml | nindent 6 }}
+{{ end }}
+{{- end }}

--- a/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/aggregate-cluster-roles.yaml
+++ b/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/aggregate-cluster-roles.yaml
@@ -1,0 +1,44 @@
+{{- /*
+Copyright VMware, Inc.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+{{- if and .Values.msgTopologyOperator.enabled .Values.msgTopologyOperator.rbac.create -}}
+{{- $readonlyVerbs := list "get" "list" "watch" }}
+{{- $allVerbs := list "create" "delete" "deletecollection" "get" "list" "patch" "update" "watch" }}
+{{- $roles := dict "view" $readonlyVerbs "edit" $allVerbs "admin" $allVerbs }}
+{{- $versionLabel := dict "app.kubernetes.io/version" ( include "common.images.version" ( dict "imageRoot" .Values.msgTopologyOperator.image "chart" .Chart ) ) }}
+{{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.commonLabels $versionLabel ) "context" . ) }}
+{{- range $role, $verbs := $roles -}}
+---
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" $ }}
+kind: ClusterRole
+metadata:
+  name: {{ template "rmqco.msgTopologyOperator.fullname.namespace" $ }}-{{ $role }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
+    app.kubernetes.io/component: messaging-topology-operator
+    app.kubernetes.io/part-of: rabbitmq
+    rbac.authorization.k8s.io/aggregate-to-{{ $role }}: "true"
+  {{- if $.Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" $.Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+rules:
+  - apiGroups:
+      - rabbitmq.com
+    resources:
+      - bindings
+      - exchanges
+      - federations
+      - operatorpolicies
+      - permissions
+      - policies
+      - queues
+      - schemareplications
+      - shovels
+      - superstreams
+      - topicpermissions
+      - users
+      - vhosts
+    verbs: {{ $verbs | toYaml | nindent 6 }}
+{{ end }}
+{{- end -}}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

This change adds aggregate cluster roles for `admin`, `edit` and `view` built-in roles, so that operated resources can be managed by processess or individuals carrying those roles on the namespace.

The rationale is that operated resources are in the same security group with standard namespaced resources, such as `Deployments`, and most users would expect to be able to view and manage them freely on namespaces they have access to.

### Benefits

This improves out-of-the-box experience for users utilizing RBAC on the cluster and using non-admin kubeconfigs.
For example, without this change, even `kubectl get all` on a namespace will produce error messages for anyone with a `view` role.

### Possible drawbacks

Some may not desire this behavior (though I cannot come up with a scenario).

### Applicable issues

n/a

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm) - no new variables introduced
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
