### PR TITLE
[bitnami/postgres] don't include backup netpol when backup aren't enabled

### DIFF
--- a/bitnami/postgresql/Chart.yaml
+++ b/bitnami/postgresql/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: postgresql
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/postgresql
-version: 15.1.0
+version: 15.1.1

--- a/bitnami/postgresql/templates/backup/networkpolicy.yaml
+++ b/bitnami/postgresql/templates/backup/networkpolicy.yaml
@@ -3,7 +3,7 @@ Copyright VMware, Inc.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- if .Values.backup.cronjob.networkPolicy.enabled }}
+{{- if and .Values.backup.enabled .Values.backup.cronjob.networkPolicy.enabled }}
 kind: NetworkPolicy
 apiVersion: {{ include "common.capabilities.networkPolicy.apiVersion" . }}
 metadata:


### PR DESCRIPTION
### Description of the change

This change modifies the `bitnami/postgres` chart to not include backup network policies when backups aren't enabled.

### Benefits

This will prevent unnecessary network policies from being applied when they aren't needed, which could potentially improve performance and reduce confusion.

### Possible drawbacks

None identified. This change should only affect situations where backups aren't enabled.

### Applicable issues

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)