### PR TITLE
[bitnami/external-dns] Fix boolean flag --pihole-tls-skip-verify

### DIFF
--- a/bitnami/external-dns/Chart.yaml
+++ b/bitnami/external-dns/Chart.yaml
@@ -28,4 +28,4 @@ maintainers:
 name: external-dns
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/external-dns
-version: 7.0.0
+version: 7.0.1

--- a/bitnami/external-dns/templates/dep-ds.yaml
+++ b/bitnami/external-dns/templates/dep-ds.yaml
@@ -290,7 +290,7 @@ spec:
             - --pihole-server={{ .Values.pihole.server }}
               {{- end }}
               {{- if .Values.pihole.tlsSkipVerify }}
-            - --pihole-tls-skip-verify={{ .Values.pihole.tlsSkipVerify }}
+            - --pihole-tls-skip-verify
               {{- end }}
             {{- end }}
             {{- if eq .Values.provider "rfc2136" }}
@@ -664,7 +664,7 @@ spec:
                 secretKeyRef:
                   name: {{ template "external-dns.secretName" . }}
                   key: pihole_password
-            {{- end }}  
+            {{- end }}
             {{- if eq .Values.provider "ns1" }}
             # NS1 environment variables
             {{- if or (.Values.ns1.apiKey) (.Values.ns1.secretName) }}


### PR DESCRIPTION
### Description of the change

Fixes flag boolean flag `--pihole-tls-skip-verify`.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #24529 

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
