### PR TITLE
[bitnami/apisix] Fix disable tls on controlPlane and dataPlane

### DIFF
--- a/bitnami/apisix/Chart.yaml
+++ b/bitnami/apisix/Chart.yaml
@@ -45,4 +45,4 @@ sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/apisix
 - https://github.com/bitnami/charts/tree/main/bitnami/apisix-dashboard
 - https://github.com/bitnami/charts/tree/main/bitnami/apisix-ingress-controller
-version: 3.0.0
+version: 3.0.1

--- a/bitnami/apisix/templates/data-plane/dep-ds.yaml
+++ b/bitnami/apisix/templates/data-plane/dep-ds.yaml
@@ -178,8 +178,10 @@ spec:
             - name: empty-dir
               mountPath: /tmp
               subPath: tmp-dir
+           {{- if .Values.dataPlane.tls.enabled }}
             - name: certs
               mountPath: /bitnami/certs
+           {{- end }}
            {{- if and .Values.controlPlane.enabled .Values.controlPlane.tls.enabled}}
             - name: control-plane-certs
               mountPath: /etc/ssl/certs/{{ .Values.controlPlane.tls.certCAFilename }}

--- a/bitnami/apisix/templates/data-plane/dep-ds.yaml
+++ b/bitnami/apisix/templates/data-plane/dep-ds.yaml
@@ -180,7 +180,7 @@ spec:
               subPath: tmp-dir
             - name: certs
               mountPath: /bitnami/certs
-           {{- if or .Values.controlPlane.enabled .Values.controlPlane.tls.enabled}}
+           {{- if and .Values.controlPlane.enabled .Values.controlPlane.tls.enabled}}
             - name: control-plane-certs
               mountPath: /etc/ssl/certs/{{ .Values.controlPlane.tls.certCAFilename }}
               subPath: {{ .Values.controlPlane.tls.certCAFilename }}
@@ -207,7 +207,7 @@ spec:
         {{- end }}
         - name: empty-dir
           emptyDir: {}
-        {{- if or .Values.controlPlane.enabled .Values.controlPlane.tls.enabled }}
+        {{- if and .Values.controlPlane.enabled .Values.controlPlane.tls.enabled }}
         - name: control-plane-certs
           secret:
             secretName: {{ template "apisix.control-plane.tlsSecretName" . }}

--- a/bitnami/apisix/templates/tls-secret.yaml
+++ b/bitnami/apisix/templates/tls-secret.yaml
@@ -4,7 +4,7 @@ SPDX-License-Identifier: APACHE-2.0
 */}}
 
 {{- $ca := genCA "apisix-ca" 365 }}
-{{- if and .Values.controlPlane.enabled (not .Values.controlPlane.tls.existingSecret) }}
+{{- if and .Values.controlPlane.enabled .Values.controlPlane.tls.enabled (not .Values.controlPlane.tls.existingSecret) }}
 {{/* For the control plane, it is mandatory to have TLS for the config server */}}
 apiVersion: v1
 kind: Secret


### PR DESCRIPTION
### Description of the change

Honor the property `controlPlane.tls.enabled` to generate or not the Secret **apisix-control-plane-tls**.
Honor the property `dataPlane.tls.enabled` when is set to false to don't mount the certificates on the data-plane.  

### Benefits

Allows disable the tls on control-plane and data-plane. 

### Possible drawbacks

None IMO

### Applicable issues

- fixes #24594 

### Additional information

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
