### PR TITLE
Update deployment.yaml - Remove Duplicate Key

### DIFF
--- a/bitnami/argo-workflows/templates/controller/deployment.yaml
+++ b/bitnami/argo-workflows/templates/controller/deployment.yaml
@@ -36,7 +36,6 @@ spec:
         {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
         {{- end }}
       labels: {{- include "common.labels.standard" ( dict "customLabels" $podLabels "context" $ ) | nindent 8 }}
-        app.kubernetes.io/part-of: argo-workflows
         app.kubernetes.io/component: controller
         app.kubernetes.io/part-of: argo-workflows
     spec:


### PR DESCRIPTION
Fix For:

Helm upgrade failed: error while running post render on files: map[string]interface {}(nil): yaml: unmarshal errors: mapping key "app.kubernetes.io/part-of" already defined.