### PR TITLE
[Bitnami/Argo-Workflow] Fix duplicate part-of key

### DIFF
--- a/bitnami/argo-workflows/Chart.yaml
+++ b/bitnami/argo-workflows/Chart.yaml
@@ -42,4 +42,4 @@ maintainers:
 name: argo-workflows
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/argo-workflows
-version: 8.0.0
+version: 8.0.1

--- a/bitnami/argo-workflows/templates/controller/deployment.yaml
+++ b/bitnami/argo-workflows/templates/controller/deployment.yaml
@@ -36,7 +36,6 @@ spec:
         {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
         {{- end }}
       labels: {{- include "common.labels.standard" ( dict "customLabels" $podLabels "context" $ ) | nindent 8 }}
-        app.kubernetes.io/part-of: argo-workflows
         app.kubernetes.io/component: controller
         app.kubernetes.io/part-of: argo-workflows
     spec:


### PR DESCRIPTION
Removed duplicate part-of key from controller deployment template. Was causing chart to fail.
