### PR TITLE
[bitnami/rabbitmq] Fix invalid secret pointer in RabbitMQ ServiceAccount

### DIFF
--- a/bitnami/rabbitmq/Chart.yaml
+++ b/bitnami/rabbitmq/Chart.yaml
@@ -30,4 +30,4 @@ maintainers:
 name: rabbitmq
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/rabbitmq
-version: 13.0.0
+version: 13.0.1

--- a/bitnami/rabbitmq/templates/serviceaccount.yaml
+++ b/bitnami/rabbitmq/templates/serviceaccount.yaml
@@ -16,6 +16,6 @@ metadata:
   {{- end }}
 automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 secrets:
-  - name: {{ include "common.names.fullname" . }}
+  - name: {{ template "rabbitmq.secretPasswordName" . }}
 {{- end }}
 


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Updates the created ServiceAccount to take into consideration if the user has configured the `auth.existingPasswordSecret`value. Use this value if so, otherwise use the value of the generated secret.

### Benefits

Correctly links to the secret when one is specified.

### Possible drawbacks

None identified

### Applicable issues

- fixes #24738

### Additional information

Is giving the ServiceAccount access to the secret even needed?

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
