### PR TITLE
bitnami/kibana - Adapt the securityContext also for the init container

### DIFF
--- a/bitnami/kibana/Chart.yaml
+++ b/bitnami/kibana/Chart.yaml
@@ -32,4 +32,4 @@ maintainers:
 name: kibana
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/kibana
-version: 11.0.1
+version: 11.0.2

--- a/bitnami/kibana/templates/deployment.yaml
+++ b/bitnami/kibana/templates/deployment.yaml
@@ -101,7 +101,7 @@ spec:
           image: {{ include "kibana.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
           {{- if .Values.containerSecurityContext.enabled }}
-          securityContext: {{- omit .Values.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+          securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.containerSecurityContext "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.resources }}
           resources: {{- toYaml .Values.resources | nindent 12 }}


### PR DESCRIPTION
### Description of the change

The kibana chart includes a mechanism to adapt the `securityContext` when used on OpenShift. This mechanism was used only for the main container, but not for the initContainer. According to K8S's behavior, the `securityContext` of the initContainer is also applied to the main container. As a result, when passing secrets to the container, kibana fails to open the file due to permissions. The fix applies the same mechanism for the initContainer.

### Benefits

Without this change, kibana is unable to access the provided certificates. The chart offers a workaround of disabling the `securityContext` altogether. But, I believe it's less desiarable.

### Possible drawbacks

Don't know any

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #24762

### Additional information


### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [ X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [ X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
