### PR TITLE
[bitnami/grafana-mimir] Increase test timeout

### DIFF
--- a/.vib/grafana-mimir/goss/goss.yaml
+++ b/.vib/grafana-mimir/goss/goss.yaml
@@ -43,7 +43,7 @@ addr:
     reachable: true
 command:
   check-mimirtool:
-    timeout: 60000
+    timeout: 120000
     exec: cd /tmp && mimirtool bucket-validation --object-count 1000
     exit-status: 0
   {{- $uid := .Vars.storeGateway.containerSecurityContext.runAsUser }}


### PR DESCRIPTION
### Description of the change
Increase timeout as the command takes 80s to run in Openshift:

```
2024-04-03T10:24:14Z [TRACE] SUCCESS: Command => check-mimirtool (exit-status 0 0) [79.81]
```

### Checklist
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
