### PR TITLE
[bitnami/grafana-loki] Persistence parameters for Index Gateway

### DIFF
--- a/bitnami/grafana-loki/Chart.yaml
+++ b/bitnami/grafana-loki/Chart.yaml
@@ -57,4 +57,4 @@ maintainers:
 name: grafana-loki
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/grafana-loki
-version: 3.0.3
+version: 3.1.0

--- a/bitnami/grafana-loki/README.md
+++ b/bitnami/grafana-loki/README.md
@@ -510,6 +510,18 @@ The [Bitnami grafana-loki](https://github.com/bitnami/containers/tree/main/bitna
 | `indexGateway.sidecars`                                          | Add additional sidecar containers to the index-gateway pod(s)                                                                                                                                                                               | `[]`             |
 | `indexGateway.initContainers`                                    | Add additional init containers to the index-gateway pod(s)                                                                                                                                                                                  | `[]`             |
 
+### index-gateway Persistence Parameters
+
+| Name                                    | Description                                                                  | Value               |
+| --------------------------------------- | ---------------------------------------------------------------------------- | ------------------- |
+| `indexGateway.persistence.enabled`      | Enable persistence in index-gateway instances                                | `false`             |
+| `indexGateway.persistence.storageClass` | PVC Storage Class for index-gateway's data volume                            | `""`                |
+| `indexGateway.persistence.subPath`      | The subdirectory of the volume to mount to                                   | `""`                |
+| `indexGateway.persistence.accessModes`  | PVC Access modes                                                             | `["ReadWriteOnce"]` |
+| `indexGateway.persistence.size`         | PVC Storage Request for index-gateway's data volume                          | `8Gi`               |
+| `indexGateway.persistence.annotations`  | Additional PVC annotations                                                   | `{}`                |
+| `indexGateway.persistence.selector`     | Selector to match an existing Persistent Volume for index-gateway's data PVC | `{}`                |
+
 ### index-gateway Traffic Exposure Parameters
 
 | Name                                                 | Description                                                      | Value       |

--- a/bitnami/grafana-loki/templates/index-gateway/statefulset.yaml
+++ b/bitnami/grafana-loki/templates/index-gateway/statefulset.yaml
@@ -160,6 +160,8 @@ spec:
             - name: loki-config
               mountPath: {{ .Values.loki.dataDir }}/conf/loki.yaml
               subPath: loki.yaml
+            - name: data
+              mountPath: {{ .Values.loki.dataDir }}
           {{- if .Values.indexGateway.extraVolumeMounts }}
           {{- include "common.tplvalues.render" (dict "value" .Values.indexGateway.extraVolumeMounts "context" $) | nindent 12 }}
           {{- end }}
@@ -175,4 +177,33 @@ spec:
         {{- if .Values.indexGateway.extraVolumes }}
         {{- include "common.tplvalues.render" (dict "value" .Values.indexGateway.extraVolumes "context" $) | nindent 8 }}
         {{- end }}
+  {{- if not .Values.indexGateway.persistence.enabled }}
+        - name: data
+          emptyDir: {}
+  {{- else }}
+  volumeClaimTemplates:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: data
+        {{- if .Values.commonLabels }}
+        labels: {{- include "common.tplvalues.render" (dict "value" .Values.commonLabels "context" $) | nindent 10 }}
+        {{- end }}
+        {{- if or .Values.indexGateway.persistence.annotations .Values.commonAnnotations }}
+        {{- $claimAnnotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.indexGateway.persistence.annotations .Values.commonAnnotations ) "context" . ) }}
+        annotations: {{- include "common.tplvalues.render" ( dict "value" $claimAnnotations "context" $) | nindent 10 }}
+        {{- end }}
+      spec:
+        accessModes:
+        {{- range .Values.indexGateway.persistence.accessModes }}
+          - {{ . | quote }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.indexGateway.persistence.size | quote }}
+        {{- if .Values.indexGateway.persistence.selector }}
+        selector: {{- include "common.tplvalues.render" (dict "value" .Values.indexGateway.persistence.selector "context" $) | nindent 10 }}
+        {{- end }}
+        {{- include "common.storage.class" (dict "persistence" .Values.indexGateway.persistence "global" .Values.global) | nindent 8 }}
+  {{- end }}
 {{- end }}

--- a/bitnami/grafana-loki/values.yaml
+++ b/bitnami/grafana-loki/values.yaml
@@ -1428,6 +1428,45 @@ indexGateway:
   ##    command: ['sh', '-c', 'echo "hello world"']
   ##
   initContainers: []
+  ## @section index-gateway Persistence Parameters
+  ##
+
+  ## Enable persistence using Persistent Volume Claims
+  ## ref: https://kubernetes.io/docs/concepts/storage/persistent-volumes/
+  ##
+  persistence:
+    ## @param indexGateway.persistence.enabled Enable persistence in index-gateway instances
+    ##
+    enabled: false
+    ## @param indexGateway.persistence.storageClass PVC Storage Class for index-gateway's data volume
+    ## If defined, storageClassName: <storageClass>
+    ## If set to "-", storageClassName: "", which disables dynamic provisioning
+    ## If undefined (the default) or set to null, no storageClassName spec is
+    ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+    ##   GKE, AWS & OpenStack)
+    ##
+    storageClass: ""
+    ## @param indexGateway.persistence.subPath The subdirectory of the volume to mount to
+    ##
+    subPath: ""
+    ## @param indexGateway.persistence.accessModes PVC Access modes
+    ##
+    accessModes:
+      - ReadWriteOnce
+    ## @param indexGateway.persistence.size PVC Storage Request for index-gateway's data volume
+    ##
+    size: 8Gi
+    ## @param indexGateway.persistence.annotations Additional PVC annotations
+    ##
+    annotations: {}
+    ## @param indexGateway.persistence.selector Selector to match an existing Persistent Volume for index-gateway's data PVC
+    ## If set, the PVC can't have a PV dynamically provisioned for it
+    ## E.g.
+    ## selector:
+    ##   matchLabels:
+    ##     app: my-app
+    ##
+    selector: {}
   ## @section index-gateway Traffic Exposure Parameters
   ##
 


### PR DESCRIPTION
### Description of the change

This PR adds Helm values to the `bitnami/grafana-loki` chart to allow setting persistence parameters for the index gateway component. The [index gateway service](https://grafana.com/docs/loki/next/get-started/components/#index-gateway) downloads TSDB or BoltDB index files from object storage and is [recommended](https://grafana.com/docs/loki/latest/operations/storage/boltdb-shipper/#index-gateway) to be deployed as a StatefulSet with persistent storage. The official `grafana/loki-distributed` chart currently [allows](https://github.com/grafana/helm-charts/blob/a50f643c5df38a21af9548608617b9dbefc72759/charts/loki-distributed/templates/index-gateway/statefulset-index-gateway.yaml) to do that.

### Benefits

As per above, allows setting persistence parameters for the index gateway component of Grafana Loki.

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

### Additional information

Index Gateway's persistence is disabled by default to prevent automatic creation of additional PVCs to keep the chart as close to the previous behavior as possible.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
