### PR TITLE
[bitnami/mediawiki] Fix a deploy issue with fluxcd-2.2.3

### DIFF
--- a/bitnami/mediawiki/Chart.yaml
+++ b/bitnami/mediawiki/Chart.yaml
@@ -39,4 +39,4 @@ maintainers:
 name: mediawiki
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/mediawiki
-version: 20.0.0
+version: 20.0.1

--- a/bitnami/mediawiki/templates/deployment.yaml
+++ b/bitnami/mediawiki/templates/deployment.yaml
@@ -193,7 +193,6 @@ spec:
             {{- end }}
           {{- end }}
           ports:
-          ports:
             - name: http
               containerPort: {{ .Values.containerPorts.http }}
             - name: https


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Remove a duplicated ports definition in template/deployment.yaml. This caused an error when using
fluxcd-2.2.3:

```
testwiki                        False           False   Helm install failed for release test/testwiki with chart mediawiki@20.0.0: error while running post render on files: map[string]interface {}(nil): yaml: unmarshal errors:
                                                          line 161: mapping key "ports" already defined at line 160  
``` 

<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

Fixes deployment problem when using fluxcd-2.2.3.

### Possible drawbacks

<!-- Describe any known limitations with your change -->
None that I am aware of.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
I have tested the patch with fluxcd-2.2.3. Problem is gone when the extra ports is removed.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
