### PR TITLE
[bitnami/redis] Improve restart behavior in sentinel mode

### DIFF
--- a/bitnami/redis/Chart.yaml
+++ b/bitnami/redis/Chart.yaml
@@ -36,4 +36,4 @@ maintainers:
 name: redis
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/redis
-version: 19.0.2
+version: 19.1.0

--- a/bitnami/redis/templates/scripts-configmap.yaml
+++ b/bitnami/redis/templates/scripts-configmap.yaml
@@ -126,15 +126,12 @@ data:
     master_in_sentinel="$(get_sentinel_master_info)"
     redisRetVal=$?
 
-    {{- if .Values.sentinel.persistence.enabled }}
     if [[ -f /opt/bitnami/redis-sentinel/etc/sentinel.conf ]]; then
         master_in_persisted_conf="$(awk '/monitor/ {print $4}' /opt/bitnami/redis-sentinel/etc/sentinel.conf)"
         master_port_in_persisted_conf="$(awk '/monitor/ {print $5}' /opt/bitnami/redis-sentinel/etc/sentinel.conf)"
         info "Found previous master ${master_in_persisted_conf}:${master_port_in_persisted_conf} in /opt/bitnami/redis-sentinel/etc/sentinel.conf"
         debug "$(cat /opt/bitnami/redis-sentinel/etc/sentinel.conf | grep monitor)"
-        touch /opt/bitnami/redis-sentinel/etc/.node_read
     fi
-    {{- end }}
 
     if [[ $redisRetVal -ne 0 ]]; then
         if [[ "$master_in_persisted_conf" == "$(get_full_hostname "$HOSTNAME")" ]]; then
@@ -316,10 +313,10 @@ data:
         value="${value//\?/\\?}"
         [[ "$value" = "" ]] && value="\"$value\""
 
-        replace_in_file "/opt/bitnami/redis-sentinel/etc/sentinel.conf" "^#*\s*${key} .*" "${key} ${value}" false
+        replace_in_file "/opt/bitnami/redis-sentinel/etc/prepare-sentinel.conf" "^#*\s*${key} .*" "${key} ${value}" false
     }
     sentinel_conf_add() {
-        echo $'\n'"$@" >> "/opt/bitnami/redis-sentinel/etc/sentinel.conf"
+        echo $'\n'"$@" >> "/opt/bitnami/redis-sentinel/etc/prepare-sentinel.conf"
     }
     host_id() {
         echo "$1" | openssl sha1 | awk '{print $2}'
@@ -338,32 +335,25 @@ data:
 
     master_in_persisted_conf="$(get_full_hostname "$HOSTNAME")"
 
-    {{- if .Values.sentinel.persistence.enabled }}
     if [[ -f /opt/bitnami/redis-sentinel/etc/sentinel.conf ]]; then
-        check_lock_file() {
-            [[ -f /opt/bitnami/redis-sentinel/etc/.node_read ]]
-        }
-        retry_while "check_lock_file"
-        rm -f /opt/bitnami/redis-sentinel/etc/.node_read
         master_in_persisted_conf="$(awk '/monitor/ {print $4}' /opt/bitnami/redis-sentinel/etc/sentinel.conf)"
         info "Found previous master $master_in_persisted_conf in /opt/bitnami/redis-sentinel/etc/sentinel.conf"
         debug "$(cat /opt/bitnami/redis-sentinel/etc/sentinel.conf | grep monitor)"
     fi
-    {{- end }}
-    if ! get_sentinel_master_info && [[ "$master_in_persisted_conf" == "$(get_full_hostname "$HOSTNAME")" ]]; then
-        # No master found, lets create a master node
-        export REDIS_REPLICATION_MODE="master"
-
-        REDIS_MASTER_HOST=$(get_full_hostname "$HOSTNAME")
-        REDIS_MASTER_PORT_NUMBER="$REDISPORT"
-    else
-        export REDIS_REPLICATION_MODE="replica"
-
-        # Fetches current master's host and port
-        REDIS_SENTINEL_INFO=($(get_sentinel_master_info))
+    REDIS_SENTINEL_INFO=($(get_sentinel_master_info))
+    if [ "$?" -eq "0" ]; then
+        # current master's host and port obtained from other Sentinel
         info "printing REDIS_SENTINEL_INFO=(${REDIS_SENTINEL_INFO[0]},${REDIS_SENTINEL_INFO[1]})"
         REDIS_MASTER_HOST=${REDIS_SENTINEL_INFO[0]}
         REDIS_MASTER_PORT_NUMBER=${REDIS_SENTINEL_INFO[1]}
+    else
+        REDIS_MASTER_HOST="$master_in_persisted_conf"
+        REDIS_MASTER_PORT_NUMBER="$REDISPORT"
+    fi
+    if [[ "$REDIS_MASTER_HOST" == "$(get_full_hostname "$HOSTNAME")" ]]; then
+        export REDIS_REPLICATION_MODE="master"
+    else
+        export REDIS_REPLICATION_MODE="replica"
     fi
 
     {{- if .Values.sentinel.service.createMaster }}
@@ -378,14 +368,16 @@ data:
       REDIS_MASTER_PORT_NUMBER="${REDIS_EXTERNAL_MASTER_PORT}"
     fi
 
-    cp /opt/bitnami/redis-sentinel/mounted-etc/sentinel.conf /opt/bitnami/redis-sentinel/etc/sentinel.conf
+    # To prevent incomplete configuration and as the redis container accesses /opt/bitnami/redis-sentinel/etc/sentinel.conf 
+    # as well, prepare the new config in `prepare-sentinel.conf` and move it atomically to the ultimate destination when it is complete.
+    cp /opt/bitnami/redis-sentinel/mounted-etc/sentinel.conf /opt/bitnami/redis-sentinel/etc/prepare-sentinel.conf
     {{- if .Values.auth.enabled }}
-    printf "\nsentinel auth-pass %s %s" "{{ .Values.sentinel.masterSet }}" "$REDIS_PASSWORD" >> /opt/bitnami/redis-sentinel/etc/sentinel.conf
+    printf "\nsentinel auth-pass %s %s" "{{ .Values.sentinel.masterSet }}" "$REDIS_PASSWORD" >> /opt/bitnami/redis-sentinel/etc/prepare-sentinel.conf
     {{- if and .Values.auth.enabled .Values.auth.sentinel }}
-    printf "\nrequirepass %s" "$REDIS_PASSWORD" >> /opt/bitnami/redis-sentinel/etc/sentinel.conf
+    printf "\nrequirepass %s" "$REDIS_PASSWORD" >> /opt/bitnami/redis-sentinel/etc/prepare-sentinel.conf
     {{- end }}
     {{- end }}
-    printf "\nsentinel myid %s" "$(host_id "$HOSTNAME")" >> /opt/bitnami/redis-sentinel/etc/sentinel.conf
+    printf "\nsentinel myid %s" "$(host_id "$HOSTNAME")" >> /opt/bitnami/redis-sentinel/etc/prepare-sentinel.conf
 
     if [[ -z "$REDIS_MASTER_HOST" ]] || [[ -z "$REDIS_MASTER_PORT_NUMBER" ]]
     then
@@ -421,18 +413,18 @@ data:
         add_known_replica "$hostname" "$ip"
     done
 
-    echo "" >> /opt/bitnami/redis-sentinel/etc/sentinel.conf
+    echo "" >> /opt/bitnami/redis-sentinel/etc/prepare-sentinel.conf
     {{- if not (contains "sentinel announce-hostnames" .Values.sentinel.configuration) }}
-    echo "sentinel announce-hostnames yes" >> /opt/bitnami/redis-sentinel/etc/sentinel.conf
+    echo "sentinel announce-hostnames yes" >> /opt/bitnami/redis-sentinel/etc/prepare-sentinel.conf
     {{- end }}
     {{- if not (contains "sentinel resolve-hostnames" .Values.sentinel.configuration) }}
-    echo "sentinel resolve-hostnames yes" >> /opt/bitnami/redis-sentinel/etc/sentinel.conf
+    echo "sentinel resolve-hostnames yes" >> /opt/bitnami/redis-sentinel/etc/prepare-sentinel.conf
     {{- end }}
     {{- if not (contains "sentinel announce-port" .Values.sentinel.configuration) }}
-    echo "sentinel announce-port $SERVPORT" >> /opt/bitnami/redis-sentinel/etc/sentinel.conf
+    echo "sentinel announce-port $SERVPORT" >> /opt/bitnami/redis-sentinel/etc/prepare-sentinel.conf
     {{- end }}
     {{- if not (contains "sentinel announce-ip" .Values.sentinel.configuration) }}
-    echo "sentinel announce-ip $(get_full_hostname "$HOSTNAME")" >> /opt/bitnami/redis-sentinel/etc/sentinel.conf
+    echo "sentinel announce-ip $(get_full_hostname "$HOSTNAME")" >> /opt/bitnami/redis-sentinel/etc/prepare-sentinel.conf
     {{- end }}
 
     {{- if .Values.tls.enabled }}
@@ -450,6 +442,7 @@ data:
     {{- if .Values.sentinel.preExecCmds }}
     {{ .Values.sentinel.preExecCmds | nindent 4 }}
     {{- end }}
+    mv /opt/bitnami/redis-sentinel/etc/prepare-sentinel.conf /opt/bitnami/redis-sentinel/etc/sentinel.conf
     exec redis-server /opt/bitnami/redis-sentinel/etc/sentinel.conf {{- if .Values.tls.enabled }} "${ARGS[@]}" {{- end }} --sentinel
   prestop-sentinel.sh: |
     #!/bin/bash

--- a/bitnami/redis/templates/sentinel/statefulset.yaml
+++ b/bitnami/redis/templates/sentinel/statefulset.yaml
@@ -278,10 +278,8 @@ spec:
               mountPath: /opt/bitnami/scripts/start-scripts
             - name: health
               mountPath: /health
-            {{- if .Values.sentinel.persistence.enabled }}
             - name: sentinel-data
               mountPath: /opt/bitnami/redis-sentinel/etc
-            {{- end }}
             {{- if .Values.auth.usePasswordFiles }}
             - name: redis-password
               mountPath: /opt/bitnami/redis/secrets/


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->

When containers crash or get killed and are restarted, their respective start script will run. Moreover, we can't rely on them being started in an ordered manner (for example, see #24380 or #8878). The following changes improve how we handle such a situation:

- `start-sentinel.sh`: If persistent config was enabled, restart did not work correctly on replica nodes. The script terminated with an error.

  Fix this by relying on the information from the config file if no sentinel is reachable.

- `start-sentinel.sh`: Hide incomplete Sentinel config files

  Creating the new config file at startup was done in place. This may lead to an incomplete config file if an error occurs or the startup script is killed. Improve this by preparing the config file using a different name (`prepare-sentinel.conf`) and move it to the final destination once complete.

  This allows to remove the lock file used when reading the sentinel's config at the startup of the redis container.

- `start-node.sh`/`start-sentinel.sh`: Use sentinel config file written to the respective volume as an additional source of information.

  Unify how we get the information about which node should become master at startup (logic introduced by #9282 for sentinel persistence):

  1. information obtained from other running sentinel (highest precedence)
  2. master information found in `/opt/bitnami/redis-sentinel/etc/sentinel.conf`
  3. assume the current node is master (lowest precedence)

  This logic is always the same regardless of whether the config is stored on an emptyDir volume
  (the default) or whether it is on a persistent volume (if the sentinel persistence feature is
  used)


### Benefits

- More consistent restart behavior
- Fixes some problems with persistent Sentinel config mode
- Startup scripts don't need conditional code for persistent config anymore

### Possible drawbacks

It's hard to replicate all possible failure scenarios. In all scenarios I tested, these changes kept the current state or
were an improvement, but it is possible that there are scenarios in which they are not.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #24380

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

Test results for various config option (for the results before this change, see https://github.com/bitnami/charts/issues/24380#issuecomment-2037727248)

#### Sentinel 3 nodes (Use hostnames, no sentinel persistence)

##### Initial Deployment

Ready after: 1m16s\
State: consistent Redis & Sentinel state\
Additional crashes/restarts: None

##### Kill all Sentinel Containers

Ready after: 20s\
State: consistent Redis & Sentinel state\
Additional crashes/restarts: None

##### Kill all Sentinel & Redis Containers

Ready after: 22s\
State: consistent Redis & Sentinel state\
Additional crashes/restarts: None

##### Scale to 0 and back to 3

Ready after: 1m16s\
State: consistent Redis & Sentinel state\
Additional crashes/restarts: None


#### Sentinel 3 nodes, Use IP addresses (no sentinel persistence)

same results as with using host names

#### Sentinel 3 nodes, Sentinel persistence (Use hostnames)

##### Initial Deployment

Ready after: 1m21s\
State: consistent Redis & Sentinel state\
Additional crashes/restarts: None

##### Kill all Sentinel Containers

Ready after: 21s\
State: consistent Redis & Sentinel state\
Additional crashes/restarts: None

##### Kill all Sentinel & Redis Containers

Ready after: 22s\
State: consistent Redis & Sentinel state\
Additional crashes/restarts: None

##### Scale to 0 and back to 3

Ready after: 1m16s\
State: consistent Redis & Sentinel state\
Additional crashes/restarts: None

#### Sentinel 3 nodes, Sentinel persistence, Use IP Addresses

same results as with using host names, with the exception of:

##### Scale to 0 and back to 3

Ready after: 1m16s
State: **consistent after quorum reached and new master is elected** (no master at previous IP, nodes start as replica)\
Additional crashes/restarts: None

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
