### PR TITLE
[bitnami/wordpress] Preserve default PHP config from container build

### DIFF
--- a/bitnami/wordpress/Chart.yaml
+++ b/bitnami/wordpress/Chart.yaml
@@ -44,4 +44,4 @@ maintainers:
 name: wordpress
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/wordpress
-version: 22.1.3
+version: 22.1.4

--- a/bitnami/wordpress/templates/deployment.yaml
+++ b/bitnami/wordpress/templates/deployment.yaml
@@ -144,6 +144,10 @@ spec:
               info "Custom htaccess mounted, creating folder in volume"
               mkdir -p /emptydir/apache-conf-dir/vhosts/htaccess
               {{- end }}
+
+              info "Copying default PHP config"
+              cp -r --preserve=mode /opt/bitnami/php/etc /emptydir/php-conf-dir
+
               info "Copy operation completed"
           volumeMounts:
             - name: empty-dir


### PR DESCRIPTION
### Description of the change

Preserve the default PHP config from container build, in particular, activate the memcached extension: [link](https://github.com/bitnami/containers/blob/26cd3f32780387f8cb275fa544bbd7824d0198b1/bitnami/wordpress/6/debian-12/rootfs/opt/bitnami/scripts/wordpress/postunpack.sh#L57).

### Applicable issues

- fixes #24605
- related to #24537
### Checklist

### Testing

#### Before

`/wp-admin/plugins.php`:
![image](https://github.com/bitnami/charts/assets/1057973/ae963041-bb41-4765-8d10-2401b3a2481a)

```
$ grep memcached /opt/bitnami/php/etc/php.ini
;extension = memcached
```

#### After

```
$ grep memcached /opt/bitnami/php/etc/php.ini
extension = memcached
```

---

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] n/a ~Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)~
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
