### PR TITLE
[bitnami/nginx] fix: correct ternary when tls is enabled

### DIFF
--- a/bitnami/nginx/Chart.yaml
+++ b/bitnami/nginx/Chart.yaml
@@ -34,4 +34,4 @@ maintainers:
 name: nginx
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/nginx
-version: 16.0.1
+version: 16.0.2

--- a/bitnami/nginx/templates/deployment.yaml
+++ b/bitnami/nginx/templates/deployment.yaml
@@ -252,21 +252,21 @@ spec:
           {{- else if .Values.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.livenessProbe "enabled") "context" $) | nindent 12 }}
             tcpSocket:
-              port: {{ ternary "http" "https" .Values.tls.enabled }}
+              port: {{ ternary "https" "http" .Values.tls.enabled }}
           {{- end }}
           {{- if .Values.customReadinessProbe }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customReadinessProbe "context" $) | nindent 12 }}
           {{- else if .Values.readinessProbe.enabled }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.readinessProbe "enabled") "context" $) | nindent 12 }}
             tcpSocket:
-              port: {{ ternary "http" "https" .Values.tls.enabled }}
+              port: {{ ternary "https" "http" .Values.tls.enabled }}
           {{- end }}
           {{- if .Values.customStartupProbe }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customStartupProbe "context" $) | nindent 12 }}
           {{- else if .Values.startupProbe.enabled }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.startupProbe "enabled") "context" $) | nindent 12 }}
             tcpSocket:
-              port: {{ ternary "http" "https" .Values.tls.enabled }}
+              port: {{ ternary "https" "http" .Values.tls.enabled }}
           {{- end }}
           {{- end }}
           {{- if .Values.resources }}


### PR DESCRIPTION
### Description of the change

In deployment.yaml file, it seems that the ternary used by probes is incorrect since the use of the value ```tls.enabled``` done by commit e3d035dfe226568e07b40b6f561d591199e2706f. When we deactivate the TLS, the deployment could not start because a connection attempt is done in HTTPS and not HTTP.

### Benefits

Fix issue when TLS is disabled.

### Possible drawbacks

HTTPS doesn't work as intended, I didn't test this kind of configuration

### Applicable issues

-

### Additional information

-

### Checklist


- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
