### PR TITLE
[bitnami/apisix] fix: :bug: :lock: Do not expose http-metrics unless metrics.enabled=true

### DIFF
--- a/bitnami/apisix/Chart.yaml
+++ b/bitnami/apisix/Chart.yaml
@@ -45,4 +45,4 @@ sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/apisix
 - https://github.com/bitnami/charts/tree/main/bitnami/apisix-dashboard
 - https://github.com/bitnami/charts/tree/main/bitnami/apisix-ingress-controller
-version: 3.0.1
+version: 3.0.2

--- a/bitnami/apisix/templates/control-plane/dep-ds.yaml
+++ b/bitnami/apisix/templates/control-plane/dep-ds.yaml
@@ -138,8 +138,10 @@ spec:
               containerPort: {{ .Values.controlPlane.containerPorts.configServer }}
             - name: http-control
               containerPort: {{ .Values.controlPlane.containerPorts.control }}
+            {{- if .Values.controlPlane.metrics.enabled }}
             - name: http-metrics
               containerPort: {{ .Values.controlPlane.containerPorts.metrics }}
+            {{- end }}
           {{- if not .Values.diagnosticMode.enabled }}
           {{- if .Values.controlPlane.customLivenessProbe }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.controlPlane.customLivenessProbe "context" $) | nindent 12 }}

--- a/bitnami/apisix/templates/data-plane/dep-ds.yaml
+++ b/bitnami/apisix/templates/data-plane/dep-ds.yaml
@@ -140,8 +140,10 @@ spec:
               containerPort: {{ .Values.dataPlane.containerPorts.https }}
             - name: http-control
               containerPort: {{ .Values.dataPlane.containerPorts.control }}
+            {{- if .Values.dataPlane.metrics.enabled }}
             - name: http-metrics
               containerPort: {{ .Values.dataPlane.containerPorts.metrics }}
+            {{- end }}
           {{- if not .Values.diagnosticMode.enabled }}
           {{- if .Values.dataPlane.customLivenessProbe }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.dataPlane.customLivenessProbe "context" $) | nindent 12 }}


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change
Currently, the http-metrics port was shown in the ports: section regardless metrics.enabled was set to true or not. This PR adds an if statement to show the port only when strictly necessary.

<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

Improved security of the application
<!-- What benefits will be realized by the code change? -->

### Possible drawbacks
n/a
<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Additional information

Thanks to @jlmartinnavarro
<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
