### PR TITLE
[bitnami/cassandra] fix: :bug: :lock: Do not expose tls internode port unless encryption is set

### DIFF
--- a/bitnami/cassandra/Chart.yaml
+++ b/bitnami/cassandra/Chart.yaml
@@ -32,4 +32,4 @@ maintainers:
 name: cassandra
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/cassandra
-version: 11.0.2
+version: 11.0.3

--- a/bitnami/cassandra/templates/service.yaml
+++ b/bitnami/cassandra/templates/service.yaml
@@ -42,13 +42,16 @@ spec:
       {{- else if eq .Values.service.type "ClusterIP" }}
       nodePort: null
       {{- end }}
+    {{- if .Values.metrics.enabled }}
     - name: metrics
       port: {{ .Values.service.ports.metrics }}
+      targetPort: metrics
       {{- if and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) (not (empty .Values.service.nodePorts.metrics)) }}
       nodePort: {{ .Values.service.nodePorts.metrics }}
       {{- else if eq .Values.service.type "ClusterIP" }}
       nodePort: null
       {{- end }}
+    {{- end }}
     {{- if .Values.service.extraPorts }}
     {{- include "common.tplvalues.render" (dict "value" .Values.service.extraPorts "context" $) | nindent 4 }}
     {{- end }}

--- a/bitnami/cassandra/templates/statefulset.yaml
+++ b/bitnami/cassandra/templates/statefulset.yaml
@@ -423,6 +423,7 @@ spec:
               {{- else if .Values.hostPorts.intra }}
               hostPort: {{ .Values.hostPorts.intra }}
               {{- end }}
+            {{- if (ne (include "cassandra.internode.tlsEncryption" .) "none") }}
             - name: tls
               containerPort: {{ .Values.containerPorts.tls | default "7001" }}
               {{- if .Values.hostNetwork }}
@@ -430,6 +431,7 @@ spec:
               {{- else if .Values.hostPorts.tls }}
               hostPort: {{ .Values.hostPorts.tls }}
               {{- end }}
+            {{- end }}
             - name: jmx
               containerPort: {{ .Values.containerPorts.jmx | default "7199" }}
               {{- if .Values.hostNetwork }}


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change
This PR hides the tls port when internode encryption is disabled. This makes the container ports and the deployment ports definition to be consistent. This PR also exposes the service metrics port only when metrics.enabled=true
<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

Improved security of the application
<!-- What benefits will be realized by the code change? -->

### Possible drawbacks
n/a
<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Additional information

Thanks to @jlmartinnavarro
<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
