### PR TITLE
[bitnami/argo-cd]: fixing creation of service monitors

### DIFF
--- a/bitnami/argo-cd/Chart.yaml
+++ b/bitnami/argo-cd/Chart.yaml
@@ -39,4 +39,4 @@ maintainers:
 name: argo-cd
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/argo-cd
-version: 6.0.6
+version: 6.0.7

--- a/bitnami/argo-cd/templates/application-controller/prometheus-rule.yaml
+++ b/bitnami/argo-cd/templates/application-controller/prometheus-rule.yaml
@@ -8,7 +8,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   name: {{ include "argocd.application-controller" . }}
-  namespace: {{ default include "common.names.namespace" . .Values.controller.metrics.rules.namespace | quote }}
+  namespace: {{ default ( include "common.names.namespace" . ) .Values.controller.metrics.rules.namespace | quote }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- if .Values.controller.metrics.rules.selector }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.controller.metrics.rules.selector "context" $ ) | nindent 4 }}

--- a/bitnami/argo-cd/templates/application-controller/servicemonitor.yaml
+++ b/bitnami/argo-cd/templates/application-controller/servicemonitor.yaml
@@ -8,7 +8,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "argocd.application-controller" . }}
-  namespace: {{ default include "common.names.namespace" . .Values.controller.metrics.serviceMonitor.namespace | quote }}
+  namespace: {{ default ( include "common.names.namespace" . ) .Values.controller.metrics.serviceMonitor.namespace | quote }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- if .Values.controller.metrics.serviceMonitor.selector }}
     {{- include "common.tplvalues.render" (dict "value" .Values.controller.metrics.serviceMonitor.selector "context" $) | nindent 4 }}

--- a/bitnami/argo-cd/templates/applicationset/servicemonitor.yaml
+++ b/bitnami/argo-cd/templates/applicationset/servicemonitor.yaml
@@ -8,7 +8,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "argocd.applicationSet" . }}
-  namespace: {{ default include "common.names.namespace" . .Values.applicationSet.metrics.serviceMonitor.namespace | quote }}
+  namespace: {{ default ( include "common.names.namespace" . ) .Values.applicationSet.metrics.serviceMonitor.namespace | quote }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- if .Values.applicationSet.metrics.serviceMonitor.selector }}
     {{- include "common.tplvalues.render" (dict "value" .Values.applicationSet.metrics.serviceMonitor.selector "context" $) | nindent 4 }}

--- a/bitnami/argo-cd/templates/dex/servicemonitor.yaml
+++ b/bitnami/argo-cd/templates/dex/servicemonitor.yaml
@@ -8,7 +8,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "argocd.dex" . }}
-  namespace: {{ default include "common.names.namespace" . .Values.dex.metrics.serviceMonitor.namespace | quote }}
+  namespace: {{ default include ( "common.names.namespace" . ) .Values.dex.metrics.serviceMonitor.namespace | quote }}
   {{- $versionLabel := dict "app.kubernetes.io/version" ( include "common.images.version" ( dict "imageRoot" .Values.dex.image "chart" .Chart ) ) }}
   {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.commonLabels $versionLabel ) "context" . ) }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}

--- a/bitnami/argo-cd/templates/notifications/servicemonitor.yaml
+++ b/bitnami/argo-cd/templates/notifications/servicemonitor.yaml
@@ -8,7 +8,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "argocd.notifications" . }}
-  namespace: {{ default include "common.names.namespace" . .Values.notifications.metrics.serviceMonitor.namespace | quote }}
+  namespace: {{ default ( include "common.names.namespace" . ) .Values.notifications.metrics.serviceMonitor.namespace | quote }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- if .Values.notifications.metrics.serviceMonitor.selector }}
     {{- include "common.tplvalues.render" (dict "value" .Values.notifications.metrics.serviceMonitor.selector "context" $) | nindent 4 }}

--- a/bitnami/argo-cd/templates/repo-server/servicemonitor.yaml
+++ b/bitnami/argo-cd/templates/repo-server/servicemonitor.yaml
@@ -8,7 +8,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "argocd.repo-server" . }}
-  namespace: {{ default include "common.names.namespace" . .Values.repoServer.metrics.serviceMonitor.namespace | quote }}
+  namespace: {{ default ( include "common.names.namespace" . ) .Values.repoServer.metrics.serviceMonitor.namespace | quote }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- if .Values.repoServer.metrics.serviceMonitor.selector }}
     {{- include "common.tplvalues.render" (dict "value" .Values.repoServer.metrics.serviceMonitor.selector "context" $) | nindent 4 }}

--- a/bitnami/argo-cd/templates/server/servicemonitor.yaml
+++ b/bitnami/argo-cd/templates/server/servicemonitor.yaml
@@ -8,7 +8,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "argocd.server" . }}
-  namespace: {{ default include "common.names.namespace" . .Values.server.metrics.serviceMonitor.namespace | quote }}
+  namespace: {{ default ( include "common.names.namespace" . ) .Values.server.metrics.serviceMonitor.namespace | quote }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- if .Values.server.metrics.serviceMonitor.selector }}
     {{- include "common.tplvalues.render" (dict "value" .Values.server.metrics.serviceMonitor.selector "context" $) | nindent 4 }}


### PR DESCRIPTION
### Description of the change

Enabling the metrics and serviceMonitor for one of the services lead to an helm error, becaus of an invalid statement. Fixing the statement by adding missing brackets.

### Benefits

ServiceMonitor can be enabled again

### Possible drawbacks

None

### Applicable issues

None

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
