### PR TITLE
[bitnami/clickhouse] fix: :bug: :lock: Add shard label to avoid Compute Unit collision

### DIFF
--- a/bitnami/clickhouse/Chart.yaml
+++ b/bitnami/clickhouse/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: clickhouse
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/clickhouse
-version: 6.0.1
+version: 6.0.2

--- a/bitnami/clickhouse/templates/service-headless.yaml
+++ b/bitnami/clickhouse/templates/service-headless.yaml
@@ -21,45 +21,45 @@ spec:
   ports:
     - name: http
       targetPort: http
-      port: {{ .Values.service.ports.http }}
+      port: {{ .Values.containerPorts.http }}
       protocol: TCP
     - name: tcp
       targetPort: tcp
-      port: {{ .Values.service.ports.tcp }}
+      port: {{ .Values.containerPorts.tcp }}
       protocol: TCP
     {{- if .Values.tls.enabled }}
     - name: tcp-secure
       targetPort: tcp-secure
-      port: {{ .Values.service.ports.tcpSecure }}
+      port: {{ .Values.containerPorts.tcpSecure }}
       protocol: TCP
     {{- end }}
     {{- if .Values.keeper.enabled }}
     - name: tcp-keeper
       targetPort: tcp-keeper
-      port: {{ .Values.service.ports.keeper }}
+      port: {{ .Values.containerPorts.keeper }}
       protocol: TCP
     - name: tcp-keeperinter
       targetPort: tcp-keeperinter
-      port: {{ .Values.service.ports.keeperInter }}
+      port: {{ .Values.containerPorts.keeperInter }}
       protocol: TCP
     {{- if .Values.tls.enabled }}
     - name: tcp-keepertls
       targetPort: tcp-keepertls
-      port: {{ .Values.service.ports.keeperSecure }}
+      port: {{ .Values.containerPorts.keeperSecure }}
       protocol: TCP
     {{- end }}
     {{- end }}
     - name: tcp-mysql
       targetPort: tcp-mysql
-      port: {{ .Values.service.ports.mysql }}
+      port: {{ .Values.containerPorts.mysql }}
       protocol: TCP
     - name: tcp-postgresql
       targetPort: tcp-postgresql
-      port: {{ .Values.service.ports.postgresql }}
+      port: {{ .Values.containerPorts.postgresql }}
       protocol: TCP
     - name: http-intersrv
       targetPort: http-intersrv
-      port: {{ .Values.service.ports.interserver }}
+      port: {{ .Values.containerPorts.interserver }}
       protocol: TCP
     {{- if .Values.service.extraPorts }}
     {{- include "common.tplvalues.render" (dict "value" .Values.service.extraPorts "context" $) | nindent 4 }}

--- a/bitnami/clickhouse/templates/statefulset.yaml
+++ b/bitnami/clickhouse/templates/statefulset.yaml
@@ -12,6 +12,7 @@ metadata:
   namespace: {{ include "common.names.namespace" $ | quote }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" $.Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: clickhouse
+    shard: {{ $i | quote }}
   {{- if $.Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $.Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change
This PR adds a `shard` label to the clickhouse statefulsets, so we ensure that each compute unit has its own set of labels.
<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits
Better security in the chart
<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Additional information

Thanks to @jlmartinnavarro
<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
