### PR TITLE
[bitnami/argo-workflows] Remove dup part of server deployment

### DIFF
--- a/bitnami/argo-workflows/Chart.yaml
+++ b/bitnami/argo-workflows/Chart.yaml
@@ -42,4 +42,4 @@ maintainers:
 name: argo-workflows
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/argo-workflows
-version: 8.0.4
+version: 8.0.5

--- a/bitnami/argo-workflows/templates/server/deployment.yaml
+++ b/bitnami/argo-workflows/templates/server/deployment.yaml
@@ -39,7 +39,6 @@ spec:
       labels: {{- include "common.labels.standard" ( dict "customLabels" $podLabels "context" $ ) | nindent 8 }}
         app.kubernetes.io/part-of: argo-workflows
         app.kubernetes.io/component: server
-        app.kubernetes.io/part-of: argo-workflows
     spec:
       {{- if .Values.server.schedulerName }}
       schedulerName: {{ .Values.server.schedulerName | quote }}


### PR DESCRIPTION
### Description of the change

Remove duplicate part-of key from server deployment. Chart is unusable by default with some CI/CD tool because of duplicates.


### Possible drawbacks

None.

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
