### PR TITLE
[bitnami/flink] Update extraDeploy for Openshift tests

### DIFF
--- a/.vib/flink/runtime-parameters.yaml
+++ b/.vib/flink/runtime-parameters.yaml
@@ -37,17 +37,17 @@ extraDeploy:
                 - -ec
                 - |
                   #!/bin/bash
-    
+
                   set -o errexit
                   set -o nounset
                   set -o pipefail
-    
+
                   . /opt/bitnami/scripts/libos.sh
-    
+
                   # Set the endpoint URL
                   host=flink-jobmanager
                   port={{ .Values.jobmanager.service.ports.rpc }}
-    
+
                   jobmanager_ready() {
                       # Test the TCP connection with a timeout
                       if timeout 5 bash -c "</dev/tcp/$host/$port"; then
@@ -56,7 +56,7 @@ extraDeploy:
                           return 1
                       fi
                   }
-    
+
                   echo "0" > /tmp/ready
                   info "Waiting for the Jobmanager instance"
                   if ! retry_while "jobmanager_ready" 12 30; then
@@ -89,19 +89,12 @@ extraDeploy:
                 timeoutSeconds: 1
                 failureThreshold: 15
                 successThreshold: 1
-              securityContext:
-                runAsUser: 1001
-                runAsNonRoot: true
-                privileged: false
-                readOnlyRootFilesystem: false
-                allowPrivilegeEscalation: false
-                capabilities:
-                  drop: ["ALL"]
-                seccompProfile:
-                  type: "RuntimeDefault"
+              securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.jobmanager.containerSecurityContext "context" $) | nindent 8 }}
               volumeMounts:
                 - name: flink-config-volume
                   mountPath: /opt/bitnami/flink/conf
+                - name: tmp
+                  mountPath: /tmp
           volumes:
             - name: flink-config-volume
               configMap:
@@ -109,6 +102,9 @@ extraDeploy:
                 items:
                   - key: config.yaml
                     path: config.yaml
+            - name: tmp
+              emptyDir:
+                sizeLimit: 100Mi
 
   - |
     apiVersion: v1

--- a/.vib/flink/runtime-parameters.yaml
+++ b/.vib/flink/runtime-parameters.yaml
@@ -89,7 +89,7 @@ extraDeploy:
                 timeoutSeconds: 1
                 failureThreshold: 15
                 successThreshold: 1
-              securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.jobmanager.containerSecurityContext "context" $) | nindent 8 }}
+              securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.jobmanager.containerSecurityContext "context" $) | nindent 12 }}
               volumeMounts:
                 - name: flink-config-volume
                   mountPath: /opt/bitnami/flink/conf
@@ -103,8 +103,7 @@ extraDeploy:
                   - key: config.yaml
                     path: config.yaml
             - name: tmp
-              emptyDir:
-                sizeLimit: 100Mi
+              emptyDir: {}
 
   - |
     apiVersion: v1

--- a/bitnami/flink/Chart.yaml
+++ b/bitnami/flink/Chart.yaml
@@ -28,4 +28,4 @@ maintainers:
 name: flink
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/flink
-version: 1.0.1
+version: 1.0.1-run-vib-tests

--- a/bitnami/flink/Chart.yaml
+++ b/bitnami/flink/Chart.yaml
@@ -28,4 +28,4 @@ maintainers:
 name: flink
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/flink
-version: 1.0.1-run-vib-tests
+version: 1.0.1


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Fixes tests on top of Openshift by setting the correct security settings on `extraDeploy` objects. Adds a new `emptyDir` volume so the k8s job object can write the `/tmp/ready` file.

### Benefits

Flink can be properly tested on Openshift environments.

### Possible drawbacks

Not expected

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
