### PR TITLE
[bitnami/ejbca] fix: :bug: :lock: Expose missing ports in deployment spec

### DIFF
--- a/bitnami/ejbca/Chart.lock
+++ b/bitnami/ejbca/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: mariadb
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 18.0.0
+  version: 18.0.1
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 2.19.1
-digest: sha256:d4a5b4d10829995b65babed865ed4566593c0ff40ad037ddb93657b025415b1c
-generated: "2024-04-02T15:57:32.267423+02:00"
+digest: sha256:49b51c2f2275af6d2452b917203099c2c0464f5c28288eda31867d2f6aaacf16
+generated: "2024-04-09T16:26:41.907989257+02:00"

--- a/bitnami/ejbca/Chart.yaml
+++ b/bitnami/ejbca/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: ejbca
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/ejbca
-version: 14.0.0
+version: 14.0.1

--- a/bitnami/ejbca/templates/deployment.yaml
+++ b/bitnami/ejbca/templates/deployment.yaml
@@ -176,6 +176,11 @@ spec:
               containerPort: {{ .Values.containerPorts.http }}
             - name: https
               containerPort: {{ .Values.containerPorts.https }}
+            {{- /* Currently hardcoded in EJBCA logic: https://github.com/bitnami/containers/blob/main/bitnami/ejbca/8/debian-12/rootfs/opt/bitnami/scripts/libejbca.sh#L212 */}}
+            - name: https-pub
+              containerPort: 8442
+            - name: ajp
+              containerPort: 8009
             {{- if .Values.extraContainerPorts }}
             {{- include "common.tplvalues.render" (dict "value" .Values.extraContainerPorts "context" $) | nindent 12 }}
             {{- end }}


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change
This PR adds to the deployment spec the ports that were missing, such as the ajp port. These ports are currently hardcoded in the container logic (as they add no value to the application)

<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

Improved security of the application
<!-- What benefits will be realized by the code change? -->

### Possible drawbacks
n/a
<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Additional information

Thanks to @jlmartinnavarro
<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
