### PR TITLE
[bitnami/thanos] Enable Ingress only when component is enabled

### DIFF
--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: thanos
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/thanos
-version: 15.0.4
+version: 15.0.5

--- a/bitnami/thanos/templates/bucketweb/ingress.yaml
+++ b/bitnami/thanos/templates/bucketweb/ingress.yaml
@@ -3,7 +3,7 @@ Copyright VMware, Inc.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- if .Values.bucketweb.ingress.enabled -}}
+{{- if and .Values.bucketweb.enabled .Values.bucketweb.ingress.enabled -}}
 apiVersion: {{ include "common.capabilities.ingress.apiVersion" . }}
 kind: Ingress
 metadata:

--- a/bitnami/thanos/templates/compactor/ingress.yaml
+++ b/bitnami/thanos/templates/compactor/ingress.yaml
@@ -3,7 +3,7 @@ Copyright VMware, Inc.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- if .Values.compactor.ingress.enabled -}}
+{{- if and .Values.compactor.enabled .Values.compactor.ingress.enabled -}}
 apiVersion: {{ include "common.capabilities.ingress.apiVersion" . }}
 kind: Ingress
 metadata:

--- a/bitnami/thanos/templates/query-frontend/ingress.yaml
+++ b/bitnami/thanos/templates/query-frontend/ingress.yaml
@@ -3,7 +3,7 @@ Copyright VMware, Inc.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- if .Values.queryFrontend.ingress.enabled -}}
+{{- if and .Values.queryFrontend.enabled .Values.queryFrontend.ingress.enabled -}}
 apiVersion: {{ include "common.capabilities.ingress.apiVersion" . }}
 kind: Ingress
 metadata:

--- a/bitnami/thanos/templates/query/ingress.yaml
+++ b/bitnami/thanos/templates/query/ingress.yaml
@@ -3,7 +3,7 @@ Copyright VMware, Inc.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- if .Values.query.ingress.enabled -}}
+{{- if and .Values.query.enabled .Values.query.ingress.enabled -}}
 apiVersion: {{ include "common.capabilities.ingress.apiVersion" . }}
 kind: Ingress
 metadata:

--- a/bitnami/thanos/templates/ruler/ingress.yaml
+++ b/bitnami/thanos/templates/ruler/ingress.yaml
@@ -3,7 +3,7 @@ Copyright VMware, Inc.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- if .Values.ruler.ingress.enabled -}}
+{{- if and .Values.ruler.enabled .Values.ruler.ingress.enabled -}}
 apiVersion: {{ include "common.capabilities.ingress.apiVersion" . }}
 kind: Ingress
 metadata:

--- a/bitnami/thanos/templates/storegateway/ingress.yaml
+++ b/bitnami/thanos/templates/storegateway/ingress.yaml
@@ -3,7 +3,7 @@ Copyright VMware, Inc.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- if .Values.storegateway.ingress.enabled -}}
+{{- if and .Values.storegateway.enabled .Values.storegateway.ingress.enabled -}}
 apiVersion: {{ include "common.capabilities.ingress.apiVersion" . }}
 kind: Ingress
 metadata:


### PR DESCRIPTION
### Description of the change

When some Thanos component is disabled and Ingress of this component is enabled, the Ingress component should not be rendered.

E.g. In general values file (same for multiple instances) I will create a general configuration of component bucketweb. Then in values file for each instance I will just enable or disable this bucketweb component.

```yaml
# values.general.yaml

bucketweb:
  enabled: false
  ingress:
    enabled: true
```

```yaml
# values.cluster-1.yaml

# In this case Ingress resource will be rendered as whole
# component is enabled and ingress is enabled in general by default

bucketweb:
  enabled: true
```

```yaml
# values.cluster-2.yaml

# In this case Ingress resource won't be rendered as whole
# component is disabled even ingress is enabled in general by default

bucketweb:
  enabled: false
```

Values applied in way `helm install thanos bitnami/thanos -f values.general.yaml -f values.cluster-N.yaml`

### Benefits

It will reduce the necessary configuration for multiple instances of the same Chart using different values ​​files from general to specific.

### Possible drawbacks

N/A

### Applicable issues

N/A

### Additional information

N/A

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
