### PR TITLE
[bitnami/keycloak] fix: :bug: :lock: Expose missing ports in deployment spec and fix headless service

### DIFF
--- a/bitnami/keycloak/Chart.lock
+++ b/bitnami/keycloak/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: postgresql
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 15.1.4
+  version: 15.2.5
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.19.0
-digest: sha256:16674d4d43b5651357502f06b504f7554b47337d7446ecfdc14065b5b816efc0
-generated: "2024-03-26T10:36:27.963298589+01:00"
+  version: 2.19.1
+digest: sha256:ec63da0c5f4922c9348e8277c74fcec3da3da640a17737de156a612877e476d5
+generated: "2024-04-10T16:43:39.040230697+02:00"

--- a/bitnami/keycloak/Chart.yaml
+++ b/bitnami/keycloak/Chart.yaml
@@ -33,4 +33,4 @@ maintainers:
 name: keycloak
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/keycloak
-version: 21.0.0
+version: 21.0.1

--- a/bitnami/keycloak/templates/headless-service.yaml
+++ b/bitnami/keycloak/templates/headless-service.yaml
@@ -19,12 +19,12 @@ spec:
   clusterIP: None
   ports:
     - name: http
-      port: {{ coalesce .Values.service.ports.http .Values.service.port }}
+      port: {{ .Values.containerPorts.http }}
       protocol: TCP
       targetPort: http
     {{- if .Values.tls.enabled }}
     - name: https
-      port: {{ coalesce .Values.service.ports.https .Values.service.httpsPort }}
+      port: {{ .Values.containerPorts.https }}
       protocol: TCP
       targetPort: https
     {{- end }}

--- a/bitnami/keycloak/templates/statefulset.yaml
+++ b/bitnami/keycloak/templates/statefulset.yaml
@@ -245,6 +245,9 @@ spec:
             - name: infinispan
               containerPort: {{ .Values.containerPorts.infinispan }}
               protocol: TCP
+            {{- /* Constant in code: https://github.com/keycloak/keycloak/blob/ce8e925c1ad9bf7a3180d1496e181aeea0ab5f8a/operator/src/main/java/org/keycloak/operator/Constants.java#L60 */}}
+            - name: discovery
+              containerPort: 7800
             {{- if .Values.extraContainerPorts }}
             {{- include "common.tplvalues.render" (dict "value" .Values.extraContainerPorts "context" $) | nindent 12 }}
             {{- end }}


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change
This PR adds to the deployment spec the ports that were missing, such as the discovery port. It also changes the headless service to not use the service ports but the container ports instead.

<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

Improved security of the application
<!-- What benefits will be realized by the code change? -->

### Possible drawbacks
n/a
<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Additional information

Thanks to @jlmartinnavarro
<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
