### PR TITLE
[bitnami/odoo] Add pre-install/pre-upgrade job for module installation.

### DIFF
--- a/bitnami/odoo/Chart.yaml
+++ b/bitnami/odoo/Chart.yaml
@@ -34,4 +34,4 @@ maintainers:
 name: odoo
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/odoo
-version: 26.0.0
+version: 26.1.0

--- a/bitnami/odoo/README.md
+++ b/bitnami/odoo/README.md
@@ -348,7 +348,7 @@ See the [Parameters](#parameters) section to configure the PVC or to disable per
 
 | Name                               | Description                                                          | Value   |
 | ---------------------------------- | -------------------------------------------------------------------- | ------- |
-| `upgradeJob.enabled`               | Enable Odoo upgrade job                                              | `true`  |
+| `upgradeJob.enabled`               | Enable Odoo upgrade job                                              | `false` |
 | `upgradeJob.odooSkipModulesUpdate` | Skip Odoo update wizard                                              | `false` |
 | `upgradeJob.debug`                 | Enable debug mode                                                    | `true`  |
 | `upgradeJob.command`               | Override default container command (useful when using custom images) | `[]`    |

--- a/bitnami/odoo/README.md
+++ b/bitnami/odoo/README.md
@@ -145,6 +145,7 @@ See the [Parameters](#parameters) section to configure the PVC or to disable per
 | `odooEmail`             | Odoo user email                                                      | `user@example.com` |
 | `odooPassword`          | Odoo user password                                                   | `""`               |
 | `odooSkipInstall`       | Skip Odoo installation wizard                                        | `false`            |
+| `odooSkipModulesUpdate` | Skip Odoo update wizard                                              | `true`             |
 | `odooDatabaseFilter`    | Filter odoo database by using a regex                                | `.*`               |
 | `loadDemoData`          | Whether to load demo data for all modules during initialization      | `false`            |
 | `customPostInitScripts` | Custom post-init.d user scripts                                      | `{}`               |
@@ -342,6 +343,16 @@ See the [Parameters](#parameters) section to configure the PVC or to disable per
 | `networkPolicy.extraEgress`             | Add extra ingress rules to the NetworkPolicy                    | `[]`   |
 | `networkPolicy.ingressNSMatchLabels`    | Labels to match to allow traffic from other namespaces          | `{}`   |
 | `networkPolicy.ingressNSPodMatchLabels` | Pod labels to match to allow traffic from other namespaces      | `{}`   |
+
+### Odoo Upgrade Job parameters
+
+| Name                               | Description                                                          | Value   |
+| ---------------------------------- | -------------------------------------------------------------------- | ------- |
+| `upgradeJob.enabled`               | Enable Odoo upgrade job                                              | `true`  |
+| `upgradeJob.odooSkipModulesUpdate` | Skip Odoo update wizard                                              | `false` |
+| `upgradeJob.debug`                 | Enable debug mode                                                    | `true`  |
+| `upgradeJob.command`               | Override default container command (useful when using custom images) | `[]`    |
+| `upgradeJob.args`                  | Override default container args (useful when using custom images)    | `[]`    |
 
 The above parameters map to the env variables defined in [bitnami/odoo](https://github.com/bitnami/containers/tree/main/bitnami/odoo). For more information please refer to the [bitnami/odoo](https://github.com/bitnami/containers/tree/main/bitnami/odoo) image documentation.
 

--- a/bitnami/odoo/templates/addons-install-job.yaml
+++ b/bitnami/odoo/templates/addons-install-job.yaml
@@ -93,7 +93,7 @@ spec:
         volumeMounts:
           - name: odoo-data
             mountPath: /bitnami/odoo
-      restartPolicy: OnFailure
+      restartPolicy: Never
       volumes:
         - name: odoo-data
           {{- if .Values.persistence.enabled }}

--- a/bitnami/odoo/templates/addons-install-job.yaml
+++ b/bitnami/odoo/templates/addons-install-job.yaml
@@ -1,0 +1,105 @@
+{{- /*
+Copyright VMware, Inc.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+{{- if .Values.upgradeJob.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "common.names.fullname" . }}-addons-install
+  namespace: {{ .Release.Namespace | quote }}
+  labels: {{- include "common.labels.standard" (dict "customLabels" .Values.commonLabels "context" $) | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "-1"
+spec:
+  template:
+    spec:
+      {{- include "odoo.imagePullSecrets" . | nindent 6 }}
+      containers:
+      - name: odoo-addons-install
+        image: {{ template "odoo.image" . }}
+        imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
+        {{- if .Values.upgradeJob.command }}
+        command: {{- include "common.tplvalues.render" (dict "value" .Values.command "context" $) | nindent 10 }}
+        {{- end }}
+        {{- if .Values.upgradeJob.args }}
+        args: {{- include "common.tplvalues.render" (dict "value" .Values.upgradeJob.args "context" $) | nindent 10 }}
+        {{- end }}
+        env:
+          - name: BITNAMI_DEBUG
+            value: {{ ternary "true" "false" .Values.upgradeJob.debug | quote }}
+          - name: ALLOW_EMPTY_PASSWORD
+            value: {{ ternary "yes" "no" .Values.allowEmptyPassword | quote }}
+          - name: ODOO_DATABASE_HOST
+            value: {{ template "odoo.databaseHost" . }}
+          - name: ODOO_DATABASE_PORT_NUMBER
+            value: {{ template "odoo.databasePort" . }}
+          - name: ODOO_DATABASE_NAME
+            value: {{ template "odoo.databaseName" . }}
+          - name: ODOO_DATABASE_USER
+            value: {{ template "odoo.databaseUser" . }}
+          - name: ODOO_DATABASE_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: {{ include "odoo.databaseSecretName" . }}
+                key: {{ include "odoo.databaseSecretPasswordKey" . }}
+          - name: ODOO_EMAIL
+            value: {{ .Values.odooEmail | quote }}
+          - name: ODOO_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: {{ template "odoo.secretName" . }}
+                key: odoo-password
+          - name: ODOO_SKIP_BOOTSTRAP
+            value: {{ ternary "yes" "no" .Values.odooSkipInstall | quote }}
+          - name: ODOO_SKIP_MODULES_UPDATE
+            value: {{ ternary "yes" "no" .Values.upgradeJob.odooSkipModulesUpdate | quote }}
+          - name: ODOO_LOAD_DEMO_DATA
+            value: {{ ternary "yes" "no" .Values.loadDemoData | quote }}
+          - name: WITHOUT_DEMO
+            value: {{ default "" .Values.withoutDemo | quote }}
+          - name: ODOO_SMTP_HOST
+            value: {{ default "" .Values.smtpHost | quote }}
+          - name: ODOO_SMTP_PORT_NUMBER
+            value: {{ default "" .Values.smtpPort | quote }}
+          - name: ODOO_SMTP_USER
+            value: {{ default "" .Values.smtpUser | quote }}
+          - name: ODOO_SMTP_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: {{ template "odoo.smtpSecretName" . }}
+                key: smtp-password
+          - name: ODOO_SMTP_PROTOCOL
+            value: {{ default "" .Values.smtpProtocol | quote }}
+          {{- if .Values.extraEnvVars }}
+          {{- include "common.tplvalues.render" (dict "value" .Values.extraEnvVars "context" $) | nindent 10 }}
+          {{- end }}
+        envFrom:
+          {{- if .Values.extraEnvVarsCM }}
+          - configMapRef:
+              name: {{ include "common.tplvalues.render" (dict "value" .Values.extraEnvVarsCM "context" $) }}
+          {{- end }}
+          {{- if .Values.extraEnvVarsSecret }}
+          - secretRef:
+              name: {{ include "common.tplvalues.render" (dict "value" .Values.extraEnvVarsSecret "context" $) }}
+          {{- end }}
+        {{- if .Values.resources }}
+        resources: {{- toYaml .Values.resources | nindent 12 }}
+        {{- else if ne .Values.resourcesPreset "none" }}
+        resources: {{- include "common.resources.preset" (dict "type" .Values.resourcesPreset) | nindent 12 }}
+        {{- end }}
+        volumeMounts:
+          - name: odoo-data
+            mountPath: /bitnami/odoo
+      restartPolicy: OnFailure
+      volumes:
+        - name: odoo-data
+          {{- if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ (tpl .Values.persistence.existingClaim $) | default (include "common.names.fullname" .) }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+{{- end }}

--- a/bitnami/odoo/templates/addons-install-job.yaml
+++ b/bitnami/odoo/templates/addons-install-job.yaml
@@ -1,98 +1,104 @@
 {{- /*
-Copyright VMware, Inc.
-SPDX-License-Identifier: APACHE-2.0
+  Copyright VMware, Inc.
+  SPDX-License-Identifier: APACHE-2.0
 */}}
+
 {{- if .Values.upgradeJob.enabled }}
 apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ include "common.names.fullname" . }}-addons-install
   namespace: {{ .Release.Namespace | quote }}
-  labels: {{- include "common.labels.standard" (dict "customLabels" .Values.commonLabels "context" $) | nindent 4 }}
+  labels: 
+    {{- include "common.labels.standard" (dict "customLabels" .Values.commonLabels "context" $) | nindent 4 }}
   annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-delete-policy": before-hook-creation
-    "helm.sh/hook-weight": "-1"
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation
+    helm.sh/hook-weight: "-1"
 spec:
   template:
     spec:
       {{- include "odoo.imagePullSecrets" . | nindent 6 }}
       containers:
-      - name: odoo-addons-install
-        image: {{ template "odoo.image" . }}
-        imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
-        {{- if .Values.upgradeJob.command }}
-        command: {{- include "common.tplvalues.render" (dict "value" .Values.command "context" $) | nindent 10 }}
-        {{- end }}
-        {{- if .Values.upgradeJob.args }}
-        args: {{- include "common.tplvalues.render" (dict "value" .Values.upgradeJob.args "context" $) | nindent 10 }}
-        {{- end }}
-        env:
-          - name: BITNAMI_DEBUG
-            value: {{ ternary "true" "false" .Values.upgradeJob.debug | quote }}
-          - name: ALLOW_EMPTY_PASSWORD
-            value: {{ ternary "yes" "no" .Values.allowEmptyPassword | quote }}
-          - name: ODOO_DATABASE_HOST
-            value: {{ template "odoo.databaseHost" . }}
-          - name: ODOO_DATABASE_PORT_NUMBER
-            value: {{ template "odoo.databasePort" . }}
-          - name: ODOO_DATABASE_NAME
-            value: {{ template "odoo.databaseName" . }}
-          - name: ODOO_DATABASE_USER
-            value: {{ template "odoo.databaseUser" . }}
-          - name: ODOO_DATABASE_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: {{ include "odoo.databaseSecretName" . }}
-                key: {{ include "odoo.databaseSecretPasswordKey" . }}
-          - name: ODOO_EMAIL
-            value: {{ .Values.odooEmail | quote }}
-          - name: ODOO_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: {{ template "odoo.secretName" . }}
-                key: odoo-password
-          - name: ODOO_SKIP_BOOTSTRAP
-            value: {{ ternary "yes" "no" .Values.odooSkipInstall | quote }}
-          - name: ODOO_SKIP_MODULES_UPDATE
-            value: {{ ternary "yes" "no" .Values.upgradeJob.odooSkipModulesUpdate | quote }}
-          - name: ODOO_LOAD_DEMO_DATA
-            value: {{ ternary "yes" "no" .Values.loadDemoData | quote }}
-          - name: WITHOUT_DEMO
-            value: {{ default "" .Values.withoutDemo | quote }}
-          - name: ODOO_SMTP_HOST
-            value: {{ default "" .Values.smtpHost | quote }}
-          - name: ODOO_SMTP_PORT_NUMBER
-            value: {{ default "" .Values.smtpPort | quote }}
-          - name: ODOO_SMTP_USER
-            value: {{ default "" .Values.smtpUser | quote }}
-          - name: ODOO_SMTP_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: {{ template "odoo.smtpSecretName" . }}
-                key: smtp-password
-          - name: ODOO_SMTP_PROTOCOL
-            value: {{ default "" .Values.smtpProtocol | quote }}
-          {{- if .Values.extraEnvVars }}
-          {{- include "common.tplvalues.render" (dict "value" .Values.extraEnvVars "context" $) | nindent 10 }}
+        - name: odoo-addons-install
+          image: {{ template "odoo.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
+          {{- if .Values.upgradeJob.command }}
+          command: 
+            {{- include "common.tplvalues.render" (dict "value" .Values.command "context" $) | nindent 12 }}
           {{- end }}
-        envFrom:
-          {{- if .Values.extraEnvVarsCM }}
-          - configMapRef:
-              name: {{ include "common.tplvalues.render" (dict "value" .Values.extraEnvVarsCM "context" $) }}
+          {{- if .Values.upgradeJob.args }}
+          args: 
+            {{- include "common.tplvalues.render" (dict "value" .Values.upgradeJob.args "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.extraEnvVarsSecret }}
-          - secretRef:
-              name: {{ include "common.tplvalues.render" (dict "value" .Values.extraEnvVarsSecret "context" $) }}
+          env:
+            - name: BITNAMI_DEBUG
+              value: {{ ternary "true" "false" .Values.upgradeJob.debug | quote }}
+            - name: ALLOW_EMPTY_PASSWORD
+              value: {{ ternary "yes" "no" .Values.allowEmptyPassword | quote }}
+            - name: ODOO_DATABASE_HOST
+              value: {{ template "odoo.databaseHost" . }}
+            - name: ODOO_DATABASE_PORT_NUMBER
+              value: {{ template "odoo.databasePort" . }}
+            - name: ODOO_DATABASE_NAME
+              value: {{ template "odoo.databaseName" . }}
+            - name: ODOO_DATABASE_USER
+              value: {{ template "odoo.databaseUser" . }}
+            - name: ODOO_DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "odoo.databaseSecretName" . }}
+                  key: {{ include "odoo.databaseSecretPasswordKey" . }}
+            - name: ODOO_EMAIL
+              value: {{ .Values.odooEmail | quote }}
+            - name: ODOO_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "odoo.secretName" . }}
+                  key: odoo-password
+            - name: ODOO_SKIP_BOOTSTRAP
+              value: {{ ternary "yes" "no" .Values.odooSkipInstall | quote }}
+            - name: ODOO_SKIP_MODULES_UPDATE
+              value: {{ ternary "yes" "no" .Values.upgradeJob.odooSkipModulesUpdate | quote }}
+            - name: ODOO_LOAD_DEMO_DATA
+              value: {{ ternary "yes" "no" .Values.loadDemoData | quote }}
+            - name: WITHOUT_DEMO
+              value: {{ default "" .Values.withoutDemo | quote }}
+            - name: ODOO_SMTP_HOST
+              value: {{ default "" .Values.smtpHost | quote }}
+            - name: ODOO_SMTP_PORT_NUMBER
+              value: {{ default "" .Values.smtpPort | quote }}
+            - name: ODOO_SMTP_USER
+              value: {{ default "" .Values.smtpUser | quote }}
+            - name: ODOO_SMTP_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "odoo.smtpSecretName" . }}
+                  key: smtp-password
+            - name: ODOO_SMTP_PROTOCOL
+              value: {{ default "" .Values.smtpProtocol | quote }}
+            {{- if .Values.extraEnvVars }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.extraEnvVars "context" $) | nindent 12 }}
+            {{- end }}
+          envFrom:
+            {{- if .Values.extraEnvVarsCM }}
+            - configMapRef:
+                name: {{ include "common.tplvalues.render" (dict "value" .Values.extraEnvVarsCM "context" $) }}
+            {{- end }}
+            {{- if .Values.extraEnvVarsSecret }}
+            - secretRef:
+                name: {{ include "common.tplvalues.render" (dict "value" .Values.extraEnvVarsSecret "context" $) }}
+            {{- end }}
+          {{- if .Values.resources }}
+          resources: 
+            {{- toYaml .Values.resources | nindent 14 }}
+          {{- else if ne .Values.resourcesPreset "none" }}
+          resources: 
+            {{- include "common.resources.preset" (dict "type" .Values.resourcesPreset) | nindent 14 }}
           {{- end }}
-        {{- if .Values.resources }}
-        resources: {{- toYaml .Values.resources | nindent 12 }}
-        {{- else if ne .Values.resourcesPreset "none" }}
-        resources: {{- include "common.resources.preset" (dict "type" .Values.resourcesPreset) | nindent 12 }}
-        {{- end }}
-        volumeMounts:
-          - name: odoo-data
-            mountPath: /bitnami/odoo
+          volumeMounts:
+            - name: odoo-data
+              mountPath: /bitnami/odoo
       restartPolicy: Never
       volumes:
         - name: odoo-data
@@ -102,4 +108,5 @@ spec:
           {{- else }}
           emptyDir: {}
           {{- end }}
+      backoffLimit: 1
 {{- end }}

--- a/bitnami/odoo/templates/deployment.yaml
+++ b/bitnami/odoo/templates/deployment.yaml
@@ -164,6 +164,8 @@ spec:
                   key: odoo-password
             - name: ODOO_SKIP_BOOTSTRAP
               value: {{ ternary "yes" "no" .Values.odooSkipInstall | quote }}
+            - name: ODOO_SKIP_MODULES_UPDATE
+              value: {{ ternary "yes" "no" .Values.odooSkipModulesUpdate | quote }}
             - name: ODOO_LOAD_DEMO_DATA
               value: {{ ternary "yes" "no" .Values.loadDemoData | quote }}
             {{- if .Values.withoutDemo }}

--- a/bitnami/odoo/templates/externaldb-secrets.yaml
+++ b/bitnami/odoo/templates/externaldb-secrets.yaml
@@ -10,8 +10,15 @@ metadata:
   name: {{ printf "%s-externaldb" (include "common.names.fullname" .) | trunc 63 | trimSuffix "-" }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
-  {{- if .Values.commonAnnotations }}
-  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- if or .Values.commonAnnotations .Values.upgradeJob.enabled }}
+  annotations:
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.commonAnnotations "context" $) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.upgradeJob.enabled }}
+    helm.sh/hook: pre-install
+    helm.sh/hook-weight: "-5"
+    {{- end }}
   {{- end }}
 type: Opaque
 data:

--- a/bitnami/odoo/templates/pvc.yaml
+++ b/bitnami/odoo/templates/pvc.yaml
@@ -11,6 +11,10 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
   annotations:
+    {{- if .Values.upgradeJob.enabled }}
+    helm.sh/hook: pre-install
+    helm.sh/hook-weight: "-5"
+    {{- end }}
     {{- if .Values.persistence.resourcePolicy }}
     helm.sh/resource-policy: {{ .Values.persistence.resourcePolicy | quote }}
     {{- end }}

--- a/bitnami/odoo/templates/secrets.yaml
+++ b/bitnami/odoo/templates/secrets.yaml
@@ -10,8 +10,15 @@ metadata:
   name: {{ template "common.names.fullname" . }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
-  {{- if .Values.commonAnnotations }}
-  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- if or .Values.commonAnnotations .Values.upgradeJob.enabled }}
+  annotations:
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.commonAnnotations "context" $) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.upgradeJob.enabled }}
+    helm.sh/hook: pre-install
+    helm.sh/hook-weight: "-5"
+    {{- end }}
   {{- end }}
 type: Opaque
 data:

--- a/bitnami/odoo/values.yaml
+++ b/bitnami/odoo/values.yaml
@@ -114,6 +114,9 @@ odooPassword: ""
 ## @param odooSkipInstall Skip Odoo installation wizard
 ##
 odooSkipInstall: false
+## @param odooSkipModulesUpdate Skip Odoo update wizard
+##
+odooSkipModulesUpdate: true
 ## @param odooDatabaseFilter Filter odoo database by using a regex
 ##
 odooDatabaseFilter: .*
@@ -811,3 +814,17 @@ networkPolicy:
   ##
   ingressNSMatchLabels: {}
   ingressNSPodMatchLabels: {}
+## @section Odoo Upgrade Job parameters
+##
+
+## @param upgradeJob.enabled Enable Odoo upgrade job
+## @param upgradeJob.odooSkipModulesUpdate Skip Odoo update wizard
+## @param upgradeJob.debug Enable debug mode
+## @param upgradeJob.command Override default container command (useful when using custom images)
+## @param upgradeJob.args Override default container args (useful when using custom images)
+upgradeJob:
+  enabled: false
+  odooSkipModulesUpdate: false
+  debug: true
+  command: []
+  args: []


### PR DESCRIPTION
### Description of the change

This PR introduces a new Kubernetes job defined in the Odoo Helm chart, which is triggered during the pre-install and pre-upgrade phases. The job, named `odoo-addons-install`, utilizes arguments (`args`) and environment variables (`env`) from the `values` file to configure and run the Odoo modules installation. This setup ensures that all necessary modules are installed and configured before any system updates or upgrades are applied, improving stability and consistency across deployments.

### Benefits

This job enhances the stability and reliability of the Odoo system by ensuring all necessary modules are pre-installed, which prevents conflicts during upgrades.

### Checklist
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm] (https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
