### PR TITLE
[bitnami/kafka] :lady_beetle: Fix password replace for >10 users

### DIFF
--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -16,7 +16,7 @@ annotations:
     - name: os-shell
       image: docker.io/bitnami/os-shell:12-debian-12-r18
 apiVersion: v2
-appVersion: 3.7.1
+appVersion: 3.7.0
 dependencies:
 - condition: zookeeper.enabled
   name: zookeeper
@@ -42,4 +42,4 @@ maintainers:
 name: kafka
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/kafka
-version: 28.0.3
+version: 28.0.4

--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -16,7 +16,7 @@ annotations:
     - name: os-shell
       image: docker.io/bitnami/os-shell:12-debian-12-r18
 apiVersion: v2
-appVersion: 3.7.0
+appVersion: 3.7.1
 dependencies:
 - condition: zookeeper.enabled
   name: zookeeper

--- a/bitnami/kafka/templates/scripts-configmap.yaml
+++ b/bitnami/kafka/templates/scripts-configmap.yaml
@@ -306,7 +306,7 @@ data:
       {{- if (include "kafka.client.saslEnabled" .)}}
       read -r -a passwords <<<"$(tr ',;' ' ' <<<"${KAFKA_CLIENT_PASSWORDS:-}")"
       for ((i = 0; i < ${#passwords[@]}; i++)); do
-          replace_placeholder "password-placeholder-${i}" "${passwords[i]}"
+          replace_placeholder "password-placeholder-${i}\"" "${passwords[i]}\""
       done
       {{- end }}
       {{- if .Values.sasl.zookeeper.user }}


### PR DESCRIPTION
Fixes #25132 

Matching on `"` at the end for the `password-placeholder` ensures that only `password-placeholder-1` is matched and not `password-placeholder-10`, `password-placeholder-11`, etc.