### PR TITLE
[bitnami/cassandra] Set Java VM memory in testing

### DIFF
--- a/.vib/cassandra/runtime-parameters.yaml
+++ b/.vib/cassandra/runtime-parameters.yaml
@@ -2,6 +2,10 @@ dbUser:
   user: test_cassandra
   password: ComplicatedPassword123!4
 replicaCount: 2
+jvm:
+##  Values to be used for a VIB instance of size S4
+  maxHeapSize: "1987M"
+  newHeapSize: "200M"
 cluster:
   seedCount: 2
   numTokens: 256


### PR DESCRIPTION
### Description of the change

Set Java VM memory settings for testing.

### Benefits

This prevents the automatic computation of these settings, which was causing an internal issue if the size of the cluster is greater than the expected.

### Possible drawbacks

NA

### Applicable issues

NA

### Additional information

NA

### Checklist

- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
