### PR TITLE
[bitnami/grafana-operator] fix: :bug: Honor allowExternalEgress in networkPolicy

### DIFF
--- a/bitnami/grafana-operator/Chart.yaml
+++ b/bitnami/grafana-operator/Chart.yaml
@@ -30,4 +30,4 @@ maintainers:
 name: grafana-operator
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/grafana-operator
-version: 4.0.3
+version: 4.0.4

--- a/bitnami/grafana-operator/templates/networkpolicy.yaml
+++ b/bitnami/grafana-operator/templates/networkpolicy.yaml
@@ -21,7 +21,7 @@ spec:
     - Ingress
     - Egress
   egress:
-    {{- if .Values.networkPolicy.allowExternalEgress }}
+    {{- if .Values.operator.networkPolicy.allowExternalEgress }}
     - {}
     {{- else }}
     - ports:

--- a/bitnami/grafana-operator/templates/networkpolicy.yaml
+++ b/bitnami/grafana-operator/templates/networkpolicy.yaml
@@ -21,6 +21,9 @@ spec:
     - Ingress
     - Egress
   egress:
+    {{- if .Values.networkPolicy.allowExternalEgress }}
+    - {}
+    {{- else }}
     - ports:
         # Allow dns resolution
         - port: 53
@@ -35,6 +38,7 @@ spec:
         - port: 3000 
     {{- if .Values.operator.networkPolicy.extraEgress }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.operator.networkPolicy.extraEgress "context" $ ) | nindent 4 }}
+    {{- end }}
     {{- end }}
   ingress:
     - ports:


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change
This PR adds the necessary section in grafana-operator networkPolicy to allow egress traffic when `allowExternalEgress: true`. This may have been overlooked when adding the networkPolicy section.
<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes https://github.com/bitnami/charts/issues/25150

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
