### PR TITLE
[bitnami/cassandra] fix: :bug: Honor memory limits in jvm heap sizes

### DIFF
--- a/.vib/cassandra/runtime-parameters.yaml
+++ b/.vib/cassandra/runtime-parameters.yaml
@@ -2,10 +2,6 @@ dbUser:
   user: test_cassandra
   password: ComplicatedPassword123!4
 replicaCount: 2
-jvm:
-##  Values to be used for a VIB instance of size S4
-  maxHeapSize: "1987M"
-  newHeapSize: "200M"
 cluster:
   seedCount: 2
   numTokens: 256

--- a/bitnami/cassandra/Chart.yaml
+++ b/bitnami/cassandra/Chart.yaml
@@ -32,4 +32,4 @@ maintainers:
 name: cassandra
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/cassandra
-version: 11.0.3
+version: 11.1.0

--- a/bitnami/cassandra/templates/NOTES.txt
+++ b/bitnami/cassandra/templates/NOTES.txt
@@ -90,3 +90,4 @@ To connect to your database from outside the cluster execute the following comma
 {{- include "common.warnings.rollingTag" .Values.volumePermissions.image }}
 {{- include "cassandra.validateValues" . }}
 {{- include "common.warnings.resources" (dict "sections" (list "metrics" "" "tls" "volumePermissions") "context" $) }}
+{{- include "cassandra.warnings.jvm" . }}

--- a/bitnami/cassandra/templates/_helpers.tpl
+++ b/bitnami/cassandra/templates/_helpers.tpl
@@ -153,7 +153,78 @@ Return true if encryption via TLS should be configured
 {{- end -}}
 
 {{/*
-Return the Cassandra TLS credentials secret
+Convert memory to M
+Usage:
+{{ include "cassandra.memory.convertToM" (dict "value" "3Gi") }}
+*/}}
+{{- define "cassandra.memory.convertToM" -}}
+{{- $res := 0 -}}
+{{- if regexMatch "G" .value -}}
+{{- /* Multiply by 1000 if it is Gigabytes */ -}}
+{{- $res = regexFind "[0-9.]+" .value | float64 | mulf 1000 | int -}}
+{{- else -}}
+{{- /* Assume M for the rest, so simply extract the number and convert to int */ -}}
+{{- $res = regexFind "[0-9]+" .value | int -}}
+{{- end -}}
+{{- $res -}}
+{{- end -}}
+
+{{/*
+Return memory limit if resources or resourcesPreset has been set (in M)
+*/}}
+{{- define "cassandra.memory.getLimitInM" -}}
+{{- $res := "" -}}
+{{- if .Values.resources -}}
+    {{- /* We need to go step by step to avoid nil pointer exceptions */ -}}
+    {{- if .Values.resources.limits -}}
+        {{- if .Values.resources.limits.memory -}}
+            {{- $res = .Values.resources.limits.memory -}}
+        {{- end -}}
+    {{- end }}
+{{- else if (ne .Values.resourcesPreset "none") -}}
+    {{- $preset := include "common.resources.preset" (dict "type" .Values.resourcesPreset) | fromYaml -}}
+    {{- $res = $preset.limits.memory -}}
+{{- end -}}
+{{- if $res -}}
+    {{- /* Convert to M */ -}}
+    {{- include "cassandra.memory.convertToM" (dict "value" $res) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Calculate Max Heap Size based on the given values
+*/}}
+{{- define "cassandra.memory.calculateMaxHeapSize" -}}
+{{- if .Values.jvm.maxHeapSize -}}
+{{- /* Honor value explicitly set */ -}}
+{{- print .Values.jvm.maxHeapSize -}}
+{{- else -}}
+{{- /* Calculate based on resources set */ -}}
+{{- /* Reference: https://docs.oracle.com/javase/8/docs/technotes/guides/vm/gc-ergonomics.html */ -}}
+{{- $res := include "cassandra.memory.getLimitInM" . -}}
+{{- $res = div $res 4 | min 1000 -}}
+{{- printf "%vM" $res -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Calculate New Heap Size based on the given values
+*/}}
+{{- define "cassandra.memory.calculateNewHeapSize" -}}
+{{- if .Values.jvm.newHeapSize -}}
+{{- /* Honor value explicitly set */ -}}
+{{- print .Values.jvm.newHeapSize -}}
+{{- else -}}
+{{- /* Calculate based on resources set */ -}}
+{{- /* Reference: https://docs.oracle.com/javase/8/docs/technotes/guides/vm/gc-ergonomics.html */ -}}
+{{- $res := include "cassandra.memory.getLimitInM" . -}}
+{{- $res = div $res 64 | max 256 -}}
+{{- printf "%vM" $res -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the Cassandra TLS    credentials secret
 */}}
 {{- define "cassandra.tlsSecretName" -}}
 {{- $secretName := coalesce .Values.tls.existingSecret .Values.tls.tlsEncryptionSecretName -}}
@@ -230,4 +301,18 @@ Get the metrics config map name.
 */}}
 {{- define "cassandra.metricsConfConfigMap" -}}
     {{- printf "%s-metrics-conf" (include "common.names.fullname" . ) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Print warning if jvm memory not set
+*/}}
+{{- define "cassandra.warnings.jvm" -}}
+{{- if not .Values.jvm.maxHeapSize }}
+WARNING: JVM Max Heap Size not set in value jvm.maxHeapSize. When not set, the chart will calculate the following size:
+     MIN(Memory Limit (if set) / 4, 1024M)
+{{- end }}
+{{- if not .Values.jvm.maxHeapSize }}
+WARNING: JVM New Heap Size not set in value jvm.newHeapSize. When not set, the chart will calculate the following size:
+     MAX(Memory Limit (if set) / 64, 256M)
+{{- end }}
 {{- end -}}

--- a/bitnami/cassandra/templates/statefulset.yaml
+++ b/bitnami/cassandra/templates/statefulset.yaml
@@ -306,13 +306,13 @@ spec:
             {{- end }}
             - name: CASSANDRA_RACK
               value: {{ .Values.cluster.rack }}
-            {{- if .Values.jvm.maxHeapSize }}
+            {{- if or .Values.jvm.maxHeapSize (include "cassandra.memory.getLimitInM" .) }}
             - name: MAX_HEAP_SIZE
-              value: {{ .Values.jvm.maxHeapSize | quote }}
+              value: {{ include "cassandra.memory.calculateMaxHeapSize" . | quote }}
             {{- end }}
-            {{- if .Values.jvm.newHeapSize }}
+            {{- if or .Values.jvm.newHeapSize (include "cassandra.memory.getLimitInM" .) }}
             - name: HEAP_NEWSIZE
-              value: {{ .Values.jvm.newHeapSize | quote }}
+              value: {{ include "cassandra.memory.calculateNewHeapSize" . | quote }}
             {{- end }}
             {{- if .Values.jvm.extraOpts }}
             - name: JVM_EXTRA_OPTS


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change
Right now, the Cassandra chart is crashing in several platforms since we enabled resources presets. This is because how the JVM Max Heap Size and New Heap Size are being calculated. Up until now, the container is using the host physical memory instead of the one set in the `resources` section. 

Example in minikube:

```
kubectl get pods -o=jsonpath='{range .items[*]}{"\n"}{.metadata.name}{":\t"}{.spec.containers[*].resources}'               

cassandra-0:    {"limits":{"cpu":"1500m","ephemeral-storage":"1Gi","memory":"3Gi"},"requests":{"cpu":"1","ephemeral-storage":"50Mi","memory":"2Gi"}}
```

The limit is set to 3Gi, but if we enter the container and launch `free`, we see the following:

```
I have no name!@cassandra-0:/$ free -h 
               total        used        free      shared  buff/cache   available
Mem:            15Gi       5.3Gi       2.0Gi        63Mi       8.7Gi        10Gi
Swap:          4.0Gi        10Mi       4.0Gi
```

In order to fix this, we modified the chart so, when the values in the `jvm` section are not set, perform a calculation based on the `resources` using this guide as a reference: 

https://docs.oracle.com/javase/8/docs/technotes/guides/vm/gc-ergonomics.html

- Max heap size: `MIN(Memory Limit (if set) / 4, 1024M)`
- New heap size: `MAX(Memory Limit (if set) / 64, 256M)`

As a result, in the example above now the container gets heap variables injected

```
            - name: MAX_HEAP_SIZE
              value: "768M"
            - name: HEAP_NEWSIZE
              value: "256M"
```


The PR also adds a warning in the NOTES.txt section explaining the formula used.

<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

Avoid memory overflow and container killed

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks


<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [ ] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [ ] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
