### PR TITLE
[bitnami/flink] Ensure data port is set in configuration

### DIFF
--- a/bitnami/flink/Chart.yaml
+++ b/bitnami/flink/Chart.yaml
@@ -28,4 +28,4 @@ maintainers:
 name: flink
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/flink
-version: 1.0.1
+version: 1.0.2

--- a/bitnami/flink/templates/taskmanager/statefulset.yaml
+++ b/bitnami/flink/templates/taskmanager/statefulset.yaml
@@ -106,6 +106,8 @@ spec:
               value: {{ .Values.jobmanager.service.ports.rpc | quote }}
             - name: FLINK_CFG_JOBMANAGER_BIND__HOST
               value: 0.0.0.0
+            - name: FLINK_CFG_TASKMANAGER_DATA_PORT
+              value: {{ .Values.taskmanager.containerPorts.data | quote }}
             - name: FLINK_CFG_TASKMANAGER_RPC_PORT
               value: {{ .Values.taskmanager.containerPorts.rpc | quote }}
             {{- $releaseNamespace := include "common.names.namespace" . }}


### PR DESCRIPTION
### Description of the change

This PR ensures the `taskmanager.data.port` property is properly configured based on the container port chosen in the values.

Before:

```yaml
taskmanager.bind-host: 0.0.0.0
taskmanager.host: flink-taskmanager-0.flink-taskmanager-headless.default.svc.cluster.local
taskmanager.rpc.port: 6122
```

After:

```yaml
taskmanager.bind-host: 0.0.0.0
taskmanager.data.port: 6121
taskmanager.host: flink-taskmanager-0.flink-taskmanager-headless.default.svc.cluster.local
taskmanager.rpc.port: 6122
```

### Benefits

Configuration aligned with chart values.

### Possible drawbacks

None

### Applicable issues

It might help with https://github.com/bitnami/charts/issues/24784#event-12337147216

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
