### PR TITLE
[bitnami/postgresql] Remove RW emptyDir for postgresql logs

### DIFF
--- a/bitnami/postgresql/Chart.yaml
+++ b/bitnami/postgresql/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: postgresql
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/postgresql
-version: 15.2.5
+version: 15.2.6

--- a/bitnami/postgresql/templates/primary/statefulset.yaml
+++ b/bitnami/postgresql/templates/primary/statefulset.yaml
@@ -466,9 +466,6 @@ spec:
             - name: empty-dir
               mountPath: /opt/bitnami/postgresql/tmp
               subPath: app-tmp-dir
-            - name: empty-dir
-              mountPath: /opt/bitnami/postgresql/logs
-              subPath: app-logs-dir
             {{- if or .Values.primary.initdb.scriptsConfigMap .Values.primary.initdb.scripts }}
             - name: custom-init-scripts
               mountPath: /docker-entrypoint-initdb.d/

--- a/bitnami/postgresql/templates/read/statefulset.yaml
+++ b/bitnami/postgresql/templates/read/statefulset.yaml
@@ -393,9 +393,6 @@ spec:
             - name: empty-dir
               mountPath: /opt/bitnami/postgresql/tmp
               subPath: app-tmp-dir
-            - name: empty-dir
-              mountPath: /opt/bitnami/postgresql/logs
-              subPath: app-logs-dir
             {{- if .Values.auth.usePasswordFiles }}
             - name: postgresql-password
               mountPath: /opt/bitnami/postgresql/secrets/


### PR DESCRIPTION
### Description of the change

The PostgreSQL logs are not shown to STDOUT. The RW `emptyDir` for postgresql logs is not needed:

```console
$ docker run --rm --entrypoint /bin/bash bitnami/postgresql -c 'ls -l /opt/bitnami/postgresql/logs'
total 0
lrwxrwxrwx 1 root root 11 Feb 21 13:27 postgresql.log -> /dev/stdout
```

### Possible drawbacks

* There might be other PostgreSQL log files, depending on specific user configs.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- related to #24700

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] n/a ~Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)~
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
