### PR TITLE
[bitnami/postgresql-ha] Remove RW emptyDir for postgresql logs

### DIFF
--- a/bitnami/postgresql-ha/Chart.yaml
+++ b/bitnami/postgresql-ha/Chart.yaml
@@ -40,4 +40,4 @@ maintainers:
 name: postgresql-ha
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/postgresql-ha
-version: 14.0.3
+version: 14.0.4

--- a/bitnami/postgresql-ha/templates/postgresql/statefulset.yaml
+++ b/bitnami/postgresql-ha/templates/postgresql/statefulset.yaml
@@ -448,9 +448,6 @@ spec:
               mountPath: /opt/bitnami/postgresql/tmp
               subPath: app-tmp-dir
             - name: empty-dir
-              mountPath: /opt/bitnami/postgresql/logs
-              subPath: app-logs-dir
-            - name: empty-dir
               mountPath: /opt/bitnami/repmgr/conf
               subPath: repmgr-conf-dir
             - name: empty-dir

--- a/bitnami/postgresql-ha/templates/postgresql/witness-statefulset.yaml
+++ b/bitnami/postgresql-ha/templates/postgresql/witness-statefulset.yaml
@@ -410,9 +410,6 @@ spec:
               mountPath: /opt/bitnami/postgresql/tmp
               subPath: app-tmp-dir
             - name: empty-dir
-              mountPath: /opt/bitnami/postgresql/logs
-              subPath: app-logs-dir
-            - name: empty-dir
               mountPath: /opt/bitnami/repmgr/conf
               subPath: repmgr-conf-dir
             - name: empty-dir


### PR DESCRIPTION
### Description of the change

The PostgreSQL logs are not shown to STDOUT. The RW `emptyDir` for postgresql logs is not needed:

```console
$ docker run --rm --entrypoint /bin/bash bitnami/postgresql -c 'ls -l /opt/bitnami/postgresql/logs'
total 0
lrwxrwxrwx 1 root root 11 Feb 21 13:27 postgresql.log -> /dev/stdout
```

### Possible drawbacks

* There might be other PostgreSQL log files, depending on specific user configs.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #24700

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] n/a ~Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)~
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
