### PR TITLE
[bitnami/consul] Fix condition for creation tls-secrets if existingSecret is specified

### DIFF
--- a/bitnami/consul/Chart.yaml
+++ b/bitnami/consul/Chart.yaml
@@ -32,4 +32,4 @@ maintainers:
 name: consul
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/consul
-version: 11.1.1
+version: 11.1.2

--- a/bitnami/consul/templates/tls-secrets.yaml
+++ b/bitnami/consul/templates/tls-secrets.yaml
@@ -21,7 +21,7 @@ data:
   tls.key: {{ .key | b64enc }}
 ---
 {{- end }}
-{{- else if and .Values.ingress.tls .Values.ingress.selfSigned }}
+{{- else if and .Values.ingress.tls .Values.ingress.selfSigned (not .Values.ingress.existingSecret) }}
 {{- $secretName := printf "%s-tls" (tpl .Values.ingress.hostname .) | trunc 63 | trimSuffix "-" }}
 {{- $ca := genCA "consul-ca" 365 }}
 {{- $cert := genSignedCert (tpl .Values.ingress.hostname .) nil (list (tpl .Values.ingress.hostname .)) 365 $ca }}


### PR DESCRIPTION
### Description of the change

Fix condition for creation tls-secrets if existingSecret is specified - Don't create tls-secret

### Benefits

Don't create not needed secret.

### Possible drawbacks

None

### Applicable issues

None

### Additional information

None

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)