### PR TITLE
[bitnami/spring-cloud-dataflow] Remove Skipper ConfigMap and Secrets when Skipper is disabled

### DIFF
--- a/bitnami/spring-cloud-dataflow/Chart.yaml
+++ b/bitnami/spring-cloud-dataflow/Chart.yaml
@@ -53,4 +53,4 @@ maintainers:
 name: spring-cloud-dataflow
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/spring-cloud-dataflow
-version: 28.0.0
+version: 28.0.1

--- a/bitnami/spring-cloud-dataflow/templates/skipper/configmap.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/skipper/configmap.yaml
@@ -3,7 +3,7 @@ Copyright VMware, Inc.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- if (include "scdf.skipper.createConfigmap" .) }}
+{{- if and (include "scdf.skipper.createConfigmap" .) (.Values.skipper.enabled) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/bitnami/spring-cloud-dataflow/templates/skipper/externaldb-secret.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/skipper/externaldb-secret.yaml
@@ -4,7 +4,7 @@ SPDX-License-Identifier: APACHE-2.0
 */}}
 
 {{- $secretName := coalesce .Values.externalDatabase.skipper.existingSecret .Values.externalDatabase.existingPasswordSecret -}}
-{{- if and (not .Values.mariadb.enabled) (not $secretName) }}
+{{- if and (not .Values.mariadb.enabled) (not $secretName) (.Values.skipper.enabled) }}
 apiVersion: v1
 kind: Secret
 metadata:


### PR DESCRIPTION
### Description of the change

This change was made to fix a discovered issue from the values documentation mentioning that `externalDatabase.existingPasswordSecret` and `externalDatabase.existingPasswordKey` is deprecated in favor of using `existingSecret` and `existingSecretPasswordKey` within `dataflow` and `skipper`. When changing to the expected way but having skipper disabled, the skipper `externaldb-secret.yaml` is still included and fails to base64 encode the password since it is empty. The best solution was not to include the file at all. I applied the same logic to skippers `configmap.yaml` since it is not used when enabled.

### Benefits

This change fixes an issue when disabling skipper and mariadb but not including a password for the skipper database. The following is a bare minimum values.yaml that would break before the changes:

```yaml
skipper:
  enabled: false

mariadb:
  enabled: false

externalDatabase:
  hibernateDialect: org.hibernate.dialect.SQLServer2016Dialect
  driver: com.microsoft.sqlserver.jdbc.SQLServerDriver
  dataflow:
    url: 'jdbc:sqlserver://host.docker.internal;databaseName=spring;encrypt=false'
    username: test
    password: test
```

### Possible drawbacks

There should be no drawbacks for this change as it only applies when skipper is disabled.

### Applicable issues

No issue created for this.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
