### PR TITLE
[bitnami/mongodb] Fix validations and Autodiscovery

### DIFF
--- a/bitnami/mongodb/Chart.yaml
+++ b/bitnami/mongodb/Chart.yaml
@@ -39,4 +39,4 @@ maintainers:
 name: mongodb
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/mongodb
-version: 15.1.4
+version: 15.1.5

--- a/bitnami/mongodb/templates/NOTES.txt
+++ b/bitnami/mongodb/templates/NOTES.txt
@@ -33,38 +33,6 @@ In order to replicate the container startup scripts execute this command:
 {{- $mongoList = append $mongoList (printf "%s-%d.%s-headless.%s.svc.%s:%d" $fullname $i $fullname $releaseNamespace $clusterDomain $portNumber) }}
 {{- end }}
 
-{{- if and (eq .Values.architecture "replicaset") .Values.externalAccess.enabled (not .Values.externalAccess.autoDiscovery.enabled) (not (eq $replicaCount $loadBalancerIPListLength )) (eq .Values.externalAccess.service.type "LoadBalancer") }}
-
-####################################################################################
-### ERROR: You enabled external access to MongoDB&reg; nodes without specifying  ###
-###   the array of load balancer IPs for MongoDB&reg; nodes.                     ###
-####################################################################################
-
-This deployment will be incomplete until you configure the array of load balancer
-IPs for MongoDB&reg; nodes. To complete your deployment follow the steps below:
-
-1. Wait for the load balancer IPs (it may take a few minutes for them to be available):
-
-    kubectl get svc --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ template "mongodb.name" . }},app.kubernetes.io/instance={{ .Release.Name }},app.kubernetes.io/component=mongodb" -w
-
-2. Obtain the load balancer IPs and upgrade your chart:
-
-    {{- range $e, $i := until $replicaCount }}
-    LOAD_BALANCER_IP_{{ add $i 1 }}="$(kubectl get svc --namespace {{ $releaseNamespace }} {{ $fullname }}-{{ $i }}-external -o jsonpath='{.status.loadBalancer.ingress[0].ip}')"
-    {{- end }}
-
-3. Upgrade you chart:
-
-    helm upgrade --namespace {{ .Release.Namespace }} {{ .Release.Name }} oci://registry-1.docker.io/bitnamicharts/{{ .Chart.Name }} \
-      --set mongodb.replicaCount={{ $replicaCount }} \
-      --set mongodb.externalAccess.enabled=true \
-      {{- range $i, $e := until $replicaCount }}
-      --set mongodb.externalAccess.service.loadBalancerIPs[{{ $i }}]=$LOAD_BALANCER_IP_{{ add $i 1 }} \
-      {{- end }}
-      --set mongodb.externalAccess.service.type=LoadBalancer
-
-{{- else }}
-
 {{- if and (or (and (eq .Values.architecture "standalone") (or (eq .Values.service.type "LoadBalancer") (eq .Values.service.type "NodePort"))) (and (eq .Values.architecture "replicaset") .Values.externalAccess.enabled)) (not .Values.auth.enabled) }}
 -------------------------------------------------------------------------------
  WARNING
@@ -72,7 +40,7 @@ IPs for MongoDB&reg; nodes. To complete your deployment follow the steps below:
     By not enabling "mongodb.auth.enabled" you have most likely exposed the
     MongoDB&reg; service externally without any authentication mechanism.
 
-    For security reasons, we strongly suggest that you enable authentiation
+    For security reasons, we strongly suggest that you enable authentication
     setting the "mongodb.auth.enabled" parameter to "true".
 
 -------------------------------------------------------------------------------
@@ -107,7 +75,6 @@ To get the password for "{{ $user }}" run:
 
     export MONGODB_PASSWORD=$(kubectl get secret --namespace {{ include "mongodb.namespace" $ }} {{ include "mongodb.secretName" $ }} -o jsonpath="{.data.mongodb-passwords}" | base64 -d | awk -F',' '{print ${{ add 1 $index }}}')
 
-{{- end }}
 {{- end }}
 
 To connect to your database, create a MongoDB&reg; client container:

--- a/bitnami/mongodb/templates/networkpolicy.yaml
+++ b/bitnami/mongodb/templates/networkpolicy.yaml
@@ -41,6 +41,21 @@ spec:
       to:
         - podSelector:
             matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 14 }}
+    {{- if (and .Values.externalAccess.enabled .Values.externalAccess.autoDiscovery.enabled) }}
+    {{- $kubernetesEndpoints := lookup "v1" "Endpoints" (include "common.names.namespace" .) "kubernetes" }}
+    {{- range $kubernetesEndpoints.subsets }}
+    # Allow connection to API server, required by auto-discovery containers
+    - ports:
+      {{- range .ports }}
+        - port: {{ .port }}
+      {{- end }}
+      to:
+        {{- range .addresses }}
+        - ipBlock:
+            cidr: {{ printf "%s/32" .ip }}
+        {{- end }}
+    {{- end }}
+    {{- end }}
     {{- if .Values.networkPolicy.extraEgress }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.rts.networkPolicy.extraEgress "context" $ ) | nindent 4 }}
     {{- end }}


### PR DESCRIPTION
### Description of the change

Tune validations keeping in mind the auto-discovery function. Little fix in network policies to allow traffic to the K8S API server.

### Benefits

Keep it clean and promote auto-discovery function.

### Possible drawbacks

None

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
