### PR TITLE
bitnami/keycloak add else when '.Values.enableDefaultInitContainers: false', otherwise all initContainers are disabled

### DIFF
--- a/bitnami/keycloak/Chart.yaml
+++ b/bitnami/keycloak/Chart.yaml
@@ -33,4 +33,4 @@ maintainers:
 name: keycloak
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/keycloak
-version: 21.0.2
+version: 21.0.3

--- a/bitnami/keycloak/templates/statefulset.yaml
+++ b/bitnami/keycloak/templates/statefulset.yaml
@@ -116,6 +116,11 @@ spec:
         {{- if .Values.initContainers }}
         {{- include "common.tplvalues.render" (dict "value" .Values.initContainers "context" $) | nindent 8 }}
         {{- end }}
+      {{- else if and (eq .Values.enableDefaultInitContainers false) (.Values.initContainers) }}
+      initContainers:
+        {{- if .Values.initContainers }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.initContainers "context" $) | nindent 8 }}
+        {{- end }}
       {{- end }}
       containers:
         - name: keycloak


### PR DESCRIPTION
### Description of the change

Adds an 'else' to the .Values.enableDefaultInitContainers allowing for initContainers to still be specified, even if the default initContainers are disabled.

### Benefits

It is understood that folks sometimes want to specify initContainers and that is good, so we should still allow initContainers to be specified, even if someone decides to disable the default initContainers (needed to run 3rd party images).

### Possible drawbacks

None come to mind.  It's a pretty small change with big benefit.

### Applicable issues

- fixes #24544

### Additional information

I'm not a pro at helm chart template files, so please check my work.  Suggestions welcome!

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [ ] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)

### Notes
Been awhile since I commited a change... if something else is needed just let me know.
