### PR TITLE
[bitnami/cassandra] Fix ServiceMonitor namespace

### DIFF
--- a/bitnami/cassandra/Chart.yaml
+++ b/bitnami/cassandra/Chart.yaml
@@ -32,4 +32,4 @@ maintainers:
 name: cassandra
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/cassandra
-version: 11.1.0
+version: 11.1.1

--- a/bitnami/cassandra/templates/servicemonitor.yaml
+++ b/bitnami/cassandra/templates/servicemonitor.yaml
@@ -8,7 +8,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "common.names.fullname" . }}
-  namespace: {{ default include "common.names.namespace" . .Values.metrics.serviceMonitor.namespace | quote }}
+  namespace: {{ default ( include "common.names.namespace" . ) .Values.metrics.serviceMonitor.namespace | quote }}
   {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.metrics.serviceMonitor.labels .Values.commonLabels ) "context" . ) }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     {{- if .Values.metrics.serviceMonitor.additionalLabels }}


### PR DESCRIPTION
### Description of the change

Fix typo

### Benefits

Chart can be installed wiith serviceMonitor enabled.

### Possible drawbacks

None
### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #23408

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
