### PR TITLE
[bitnami/postgresql-ha] Bump chart version

### DIFF
--- a/bitnami/postgresql-ha/Chart.yaml
+++ b/bitnami/postgresql-ha/Chart.yaml
@@ -40,4 +40,4 @@ maintainers:
 name: postgresql-ha
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/postgresql-ha
-version: 14.0.4
+version: 14.0.5


### PR DESCRIPTION
#25207 conflicted with #25165 and the resulting commit to `main` c3b1082 did not bump the chart version.