### PR TITLE
Replace VMware by Broadcom copyright text

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 name: 🐞 Bug

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 name: "\U0001F680 Feature request"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 version: 2

--- a/.github/workflows/assign-asset-label.yml
+++ b/.github/workflows/assign-asset-label.yml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 name: '[Support] Assign asset label'

--- a/.github/workflows/cd-pipeline.yml
+++ b/.github/workflows/cd-pipeline.yml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 name: '[CI/CD] CD Pipeline'

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 name: '[CI/CD] CI Pipeline'

--- a/.github/workflows/clossing-issues.yml
+++ b/.github/workflows/clossing-issues.yml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 name: '[Support] Close Solved issues'

--- a/.github/workflows/comments.yml
+++ b/.github/workflows/comments.yml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 name: '[Support] Comments based card movements'

--- a/.github/workflows/license-headers.yml
+++ b/.github/workflows/license-headers.yml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 name: '[License] Check license headers'

--- a/.github/workflows/markdown-linter.yml
+++ b/.github/workflows/markdown-linter.yml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 name: '[CI/CD] Markdown linter'

--- a/.github/workflows/move-closed-issues.yml
+++ b/.github/workflows/move-closed-issues.yml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 name: '[Support] Move closed issues'

--- a/.github/workflows/pr-review-hack.yml
+++ b/.github/workflows/pr-review-hack.yml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 # This is a hack to run reusable workflows in the main repo context and not from the forked repository.

--- a/.github/workflows/pr-reviews-requested.yml
+++ b/.github/workflows/pr-reviews-requested.yml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 name: '[Support] Review based card movements'

--- a/.github/workflows/pr-reviews.yml
+++ b/.github/workflows/pr-reviews.yml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 name: '[Support] PR review comment card movements'

--- a/.github/workflows/reasign.yml
+++ b/.github/workflows/reasign.yml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 name: '[Support] Review based card movements'

--- a/.github/workflows/retry-failed-releases.yml
+++ b/.github/workflows/retry-failed-releases.yml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 name: '[CI/CD] Retry release PRs'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 name: '[Support] Close stale issues and PRs'

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 # This workflow is built to manage the triage support by using GH issues.

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ---
@@ -11,7 +11,7 @@ header:
 
       content: |
         {{- /*
-        Copyright VMware, Inc.
+        Copyright Broadcom, Inc. All Rights Reserved.
         SPDX-License-Identifier: APACHE-2.0
         */}}
 
@@ -29,7 +29,7 @@ header:
       copyright-owner: VMware, Inc.
 
       content: |
-        # Copyright VMware, Inc.
+        # Copyright Broadcom, Inc. All Rights Reserved.
         # SPDX-License-Identifier: APACHE-2.0
 
     paths:

--- a/.vib/airflow/cypress/cypress/e2e/airflow.cy.js
+++ b/.vib/airflow/cypress/cypress/e2e/airflow.cy.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/airflow/cypress/cypress/support/commands.js
+++ b/.vib/airflow/cypress/cypress/support/commands.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/airflow/cypress/cypress/support/e2e.js
+++ b/.vib/airflow/cypress/cypress/support/e2e.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/airflow/cypress/cypress/support/utils.js
+++ b/.vib/airflow/cypress/cypress/support/utils.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/airflow/goss/goss.yaml
+++ b/.vib/airflow/goss/goss.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 command:

--- a/.vib/apache/cypress/cypress/e2e/apache.cy.js
+++ b/.vib/apache/cypress/cypress/e2e/apache.cy.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/apache/cypress/cypress/support/e2e.js
+++ b/.vib/apache/cypress/cypress/support/e2e.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/apache/goss/goss.yaml
+++ b/.vib/apache/goss/goss.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 http:

--- a/.vib/apisix/cypress/cypress/e2e/apisix.cy.js
+++ b/.vib/apisix/cypress/cypress/e2e/apisix.cy.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/apisix/cypress/cypress/support/commands.js
+++ b/.vib/apisix/cypress/cypress/support/commands.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/apisix/cypress/cypress/support/e2e.js
+++ b/.vib/apisix/cypress/cypress/support/e2e.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/apisix/cypress/cypress/support/utils.js
+++ b/.vib/apisix/cypress/cypress/support/utils.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/apisix/goss/goss.yaml
+++ b/.vib/apisix/goss/goss.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 http:

--- a/.vib/appsmith/cypress/cypress/e2e/appsmith.cy.js
+++ b/.vib/appsmith/cypress/cypress/e2e/appsmith.cy.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/appsmith/cypress/cypress/support/commands.js
+++ b/.vib/appsmith/cypress/cypress/support/commands.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/appsmith/cypress/cypress/support/e2e.js
+++ b/.vib/appsmith/cypress/cypress/support/e2e.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/appsmith/cypress/cypress/support/utils.js
+++ b/.vib/appsmith/cypress/cypress/support/utils.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/appsmith/goss/goss.yaml
+++ b/.vib/appsmith/goss/goss.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 http:

--- a/.vib/argo-cd/cypress/cypress/e2e/argo_cd.cy.js
+++ b/.vib/argo-cd/cypress/cypress/e2e/argo_cd.cy.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/argo-cd/cypress/cypress/support/commands.js
+++ b/.vib/argo-cd/cypress/cypress/support/commands.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/argo-cd/cypress/cypress/support/e2e.js
+++ b/.vib/argo-cd/cypress/cypress/support/e2e.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/argo-cd/cypress/cypress/support/utils.js
+++ b/.vib/argo-cd/cypress/cypress/support/utils.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/argo-cd/goss/goss.yaml
+++ b/.vib/argo-cd/goss/goss.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 http:

--- a/.vib/argo-workflows/cypress/cypress/e2e/argo_workflows.cy.js
+++ b/.vib/argo-workflows/cypress/cypress/e2e/argo_workflows.cy.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/argo-workflows/cypress/cypress/support/commands.js
+++ b/.vib/argo-workflows/cypress/cypress/support/commands.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/argo-workflows/cypress/cypress/support/e2e.js
+++ b/.vib/argo-workflows/cypress/cypress/support/e2e.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/argo-workflows/cypress/cypress/support/utils.js
+++ b/.vib/argo-workflows/cypress/cypress/support/utils.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/aspnet-core/cypress/cypress/e2e/aspnet-core.cy.js
+++ b/.vib/aspnet-core/cypress/cypress/e2e/aspnet-core.cy.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/aspnet-core/cypress/cypress/support/e2e.js
+++ b/.vib/aspnet-core/cypress/cypress/support/e2e.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/aspnet-core/goss/goss.yaml
+++ b/.vib/aspnet-core/goss/goss.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 file:

--- a/.vib/cassandra/goss/goss.yaml
+++ b/.vib/cassandra/goss/goss.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 file:

--- a/.vib/cert-manager/ginkgo/certmanager_test.go
+++ b/.vib/cert-manager/ginkgo/certmanager_test.go
@@ -1,4 +1,4 @@
-// Copyright VMware, Inc.
+// Copyright Broadcom, Inc. All Rights Reserved.
 // SPDX-License-Identifier: APACHE-2.0
 
 package integration

--- a/.vib/cert-manager/ginkgo/integration_suite_test.go
+++ b/.vib/cert-manager/ginkgo/integration_suite_test.go
@@ -1,4 +1,4 @@
-// Copyright VMware, Inc.
+// Copyright Broadcom, Inc. All Rights Reserved.
 // SPDX-License-Identifier: APACHE-2.0
 
 package integration

--- a/.vib/cert-manager/goss/goss.yaml
+++ b/.vib/cert-manager/goss/goss.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 command:

--- a/.vib/clickhouse/cypress/cypress/e2e/clickhouse.cy.js
+++ b/.vib/clickhouse/cypress/cypress/e2e/clickhouse.cy.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/clickhouse/cypress/cypress/support/commands.js
+++ b/.vib/clickhouse/cypress/cypress/support/commands.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/clickhouse/cypress/cypress/support/e2e.js
+++ b/.vib/clickhouse/cypress/cypress/support/e2e.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/clickhouse/goss/goss.yaml
+++ b/.vib/clickhouse/goss/goss.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 file:

--- a/.vib/concourse/cypress/cypress/e2e/concourse.cy.js
+++ b/.vib/concourse/cypress/cypress/e2e/concourse.cy.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/concourse/cypress/cypress/support/commands.js
+++ b/.vib/concourse/cypress/cypress/support/commands.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/concourse/cypress/cypress/support/e2e.js
+++ b/.vib/concourse/cypress/cypress/support/e2e.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/concourse/goss/web/goss.yaml
+++ b/.vib/concourse/goss/web/goss.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 command:

--- a/.vib/concourse/goss/worker/goss.yaml
+++ b/.vib/concourse/goss/worker/goss.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 file:

--- a/.vib/consul/cypress/cypress/e2e/consul.cy.js
+++ b/.vib/consul/cypress/cypress/e2e/consul.cy.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/consul/cypress/cypress/support/commands.js
+++ b/.vib/consul/cypress/cypress/support/commands.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/consul/cypress/cypress/support/e2e.js
+++ b/.vib/consul/cypress/cypress/support/e2e.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/consul/cypress/cypress/support/utils.js
+++ b/.vib/consul/cypress/cypress/support/utils.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/consul/goss/goss.yaml
+++ b/.vib/consul/goss/goss.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 file:   

--- a/.vib/contour/ginkgo/contour.go
+++ b/.vib/contour/ginkgo/contour.go
@@ -1,4 +1,4 @@
-// Copyright VMware, Inc.
+// Copyright Broadcom, Inc. All Rights Reserved.
 // SPDX-License-Identifier: APACHE-2.0
 
 package integration

--- a/.vib/contour/ginkgo/integration_suite_test.go
+++ b/.vib/contour/ginkgo/integration_suite_test.go
@@ -1,4 +1,4 @@
-// Copyright VMware, Inc.
+// Copyright Broadcom, Inc. All Rights Reserved.
 // SPDX-License-Identifier: APACHE-2.0
 
 package integration

--- a/.vib/contour/goss/goss.yaml
+++ b/.vib/contour/goss/goss.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 http:

--- a/.vib/deepspeed/goss/goss.yaml
+++ b/.vib/deepspeed/goss/goss.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 {{- $nodes := .Vars.worker.replicaCount }}

--- a/.vib/discourse/cypress/cypress/e2e/discourse.cy.js
+++ b/.vib/discourse/cypress/cypress/e2e/discourse.cy.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/discourse/cypress/cypress/support/commands.js
+++ b/.vib/discourse/cypress/cypress/support/commands.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/discourse/cypress/cypress/support/e2e.js
+++ b/.vib/discourse/cypress/cypress/support/e2e.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/discourse/cypress/cypress/support/utils.js
+++ b/.vib/discourse/cypress/cypress/support/utils.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/discourse/goss/goss.yaml
+++ b/.vib/discourse/goss/goss.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 file:

--- a/.vib/dokuwiki/cypress/cypress/e2e/dokuwiki.cy.js
+++ b/.vib/dokuwiki/cypress/cypress/e2e/dokuwiki.cy.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/dokuwiki/cypress/cypress/support/commands.js
+++ b/.vib/dokuwiki/cypress/cypress/support/commands.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/dokuwiki/cypress/cypress/support/e2e.js
+++ b/.vib/dokuwiki/cypress/cypress/support/e2e.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/dokuwiki/cypress/cypress/support/utils.js
+++ b/.vib/dokuwiki/cypress/cypress/support/utils.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/dokuwiki/goss/goss.yaml
+++ b/.vib/dokuwiki/goss/goss.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 file:

--- a/.vib/drupal/cypress/cypress/e2e/drupal.cy.js
+++ b/.vib/drupal/cypress/cypress/e2e/drupal.cy.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/drupal/cypress/cypress/support/commands.js
+++ b/.vib/drupal/cypress/cypress/support/commands.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/drupal/cypress/cypress/support/e2e.js
+++ b/.vib/drupal/cypress/cypress/support/e2e.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/drupal/cypress/cypress/support/utils.js
+++ b/.vib/drupal/cypress/cypress/support/utils.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/drupal/goss/goss.yaml
+++ b/.vib/drupal/goss/goss.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 http:

--- a/.vib/ejbca/cypress/cypress/e2e/ejbca.cy.js
+++ b/.vib/ejbca/cypress/cypress/e2e/ejbca.cy.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/ejbca/cypress/cypress/plugins/index.js
+++ b/.vib/ejbca/cypress/cypress/plugins/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/ejbca/cypress/cypress/support/commands.js
+++ b/.vib/ejbca/cypress/cypress/support/commands.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/ejbca/cypress/cypress/support/e2e.js
+++ b/.vib/ejbca/cypress/cypress/support/e2e.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/ejbca/goss/goss-wait.yaml
+++ b/.vib/ejbca/goss/goss-wait.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 command:

--- a/.vib/ejbca/goss/goss.yaml
+++ b/.vib/ejbca/goss/goss.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 http:

--- a/.vib/elasticsearch/cypress/cypress/e2e/elasticsearch.cy.js
+++ b/.vib/elasticsearch/cypress/cypress/e2e/elasticsearch.cy.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/elasticsearch/cypress/cypress/support/e2e.js
+++ b/.vib/elasticsearch/cypress/cypress/support/e2e.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/elasticsearch/cypress/cypress/support/utils.js
+++ b/.vib/elasticsearch/cypress/cypress/support/utils.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/elasticsearch/goss/goss.yaml
+++ b/.vib/elasticsearch/goss/goss.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 file:   

--- a/.vib/etcd/goss/goss.yaml
+++ b/.vib/etcd/goss/goss.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 http:

--- a/.vib/external-dns/cypress/cypress/e2e/external_dns.cy.js
+++ b/.vib/external-dns/cypress/cypress/e2e/external_dns.cy.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/external-dns/cypress/cypress/support/e2e.js
+++ b/.vib/external-dns/cypress/cypress/support/e2e.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/external-dns/goss/goss.yaml
+++ b/.vib/external-dns/goss/goss.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 http:

--- a/.vib/flink/cypress/cypress/e2e/flink.cy.js
+++ b/.vib/flink/cypress/cypress/e2e/flink.cy.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/flink/cypress/cypress/support/e2e.js
+++ b/.vib/flink/cypress/cypress/support/e2e.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/flink/goss/goss.yaml
+++ b/.vib/flink/goss/goss.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 addr:

--- a/.vib/fluent-bit/goss/goss.yaml
+++ b/.vib/fluent-bit/goss/goss.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 http:

--- a/.vib/fluentd/goss/goss-wait.yaml
+++ b/.vib/fluentd/goss/goss-wait.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 command:

--- a/.vib/fluentd/goss/goss.yaml
+++ b/.vib/fluentd/goss/goss.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 file:

--- a/.vib/flux/goss/goss-wait.yaml
+++ b/.vib/flux/goss/goss-wait.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 addr:

--- a/.vib/flux/goss/goss.yaml
+++ b/.vib/flux/goss/goss.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 command:

--- a/.vib/ghost/cypress/cypress/e2e/ghost.cy.js
+++ b/.vib/ghost/cypress/cypress/e2e/ghost.cy.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/ghost/cypress/cypress/support/commands.js
+++ b/.vib/ghost/cypress/cypress/support/commands.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/ghost/cypress/cypress/support/e2e.js
+++ b/.vib/ghost/cypress/cypress/support/e2e.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/ghost/cypress/cypress/support/utils.js
+++ b/.vib/ghost/cypress/cypress/support/utils.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/ghost/goss/goss.yaml
+++ b/.vib/ghost/goss/goss.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 http:

--- a/.vib/gitea/cypress/cypress/e2e/gitea.cy.js
+++ b/.vib/gitea/cypress/cypress/e2e/gitea.cy.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/gitea/cypress/cypress/support/commands.js
+++ b/.vib/gitea/cypress/cypress/support/commands.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/gitea/cypress/cypress/support/e2e.js
+++ b/.vib/gitea/cypress/cypress/support/e2e.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/gitea/cypress/cypress/support/utils.js
+++ b/.vib/gitea/cypress/cypress/support/utils.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/gitea/goss/goss.yaml
+++ b/.vib/gitea/goss/goss.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 addr:

--- a/.vib/grafana-loki/cypress/cypress/e2e/grafana_loki.cy.js
+++ b/.vib/grafana-loki/cypress/cypress/e2e/grafana_loki.cy.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/grafana-loki/cypress/cypress/support/e2e.js
+++ b/.vib/grafana-loki/cypress/cypress/support/e2e.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/grafana-loki/cypress/cypress/support/utils.js
+++ b/.vib/grafana-loki/cypress/cypress/support/utils.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/grafana-loki/goss/promtail/goss.yaml
+++ b/.vib/grafana-loki/goss/promtail/goss.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 file:

--- a/.vib/grafana-loki/goss/querier/goss.yaml
+++ b/.vib/grafana-loki/goss/querier/goss.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 file:

--- a/.vib/grafana-mimir/cypress/cypress/e2e/grafana_mimir.cy.js
+++ b/.vib/grafana-mimir/cypress/cypress/e2e/grafana_mimir.cy.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/grafana-mimir/cypress/cypress/support/e2e.js
+++ b/.vib/grafana-mimir/cypress/cypress/support/e2e.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/grafana-mimir/cypress/cypress/support/utils.js
+++ b/.vib/grafana-mimir/cypress/cypress/support/utils.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/grafana-mimir/goss/goss.yaml
+++ b/.vib/grafana-mimir/goss/goss.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 file:

--- a/.vib/grafana-operator/cypress/cypress/e2e/grafana_operator.cy.js
+++ b/.vib/grafana-operator/cypress/cypress/e2e/grafana_operator.cy.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/grafana-operator/cypress/cypress/support/commands.js
+++ b/.vib/grafana-operator/cypress/cypress/support/commands.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/grafana-operator/cypress/cypress/support/e2e.js
+++ b/.vib/grafana-operator/cypress/cypress/support/e2e.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/grafana-operator/cypress/cypress/support/utils.js
+++ b/.vib/grafana-operator/cypress/cypress/support/utils.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/grafana-operator/goss/goss.yaml
+++ b/.vib/grafana-operator/goss/goss.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 http:

--- a/.vib/grafana-tempo/cypress/cypress/e2e/grafana_tempo.cy.js
+++ b/.vib/grafana-tempo/cypress/cypress/e2e/grafana_tempo.cy.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/grafana-tempo/cypress/cypress/plugins/index.js
+++ b/.vib/grafana-tempo/cypress/cypress/plugins/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/grafana-tempo/cypress/cypress/support/e2e.js
+++ b/.vib/grafana-tempo/cypress/cypress/support/e2e.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/grafana-tempo/goss/goss.yaml
+++ b/.vib/grafana-tempo/goss/goss.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 addr:

--- a/.vib/grafana/cypress/cypress/e2e/grafana.cy.js
+++ b/.vib/grafana/cypress/cypress/e2e/grafana.cy.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/grafana/cypress/cypress/support/commands.js
+++ b/.vib/grafana/cypress/cypress/support/commands.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/grafana/cypress/cypress/support/e2e.js
+++ b/.vib/grafana/cypress/cypress/support/e2e.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/grafana/cypress/cypress/support/utils.js
+++ b/.vib/grafana/cypress/cypress/support/utils.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/grafana/goss/goss.yaml
+++ b/.vib/grafana/goss/goss.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 file:

--- a/.vib/haproxy/cypress/cypress/e2e/haproxy.cy.js
+++ b/.vib/haproxy/cypress/cypress/e2e/haproxy.cy.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/haproxy/cypress/cypress/support/e2e.js
+++ b/.vib/haproxy/cypress/cypress/support/e2e.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/haproxy/goss/goss.yaml
+++ b/.vib/haproxy/goss/goss.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 command:

--- a/.vib/harbor/cypress/cypress/e2e/harbor.cy.js
+++ b/.vib/harbor/cypress/cypress/e2e/harbor.cy.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/harbor/cypress/cypress/support/commands.js
+++ b/.vib/harbor/cypress/cypress/support/commands.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/harbor/cypress/cypress/support/e2e.js
+++ b/.vib/harbor/cypress/cypress/support/e2e.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/harbor/cypress/cypress/support/utils.js
+++ b/.vib/harbor/cypress/cypress/support/utils.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/harbor/goss/goss.yaml
+++ b/.vib/harbor/goss/goss.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 file:

--- a/.vib/influxdb/cypress/cypress/e2e/influxdb.cy.js
+++ b/.vib/influxdb/cypress/cypress/e2e/influxdb.cy.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/influxdb/cypress/cypress/support/commands.js
+++ b/.vib/influxdb/cypress/cypress/support/commands.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/influxdb/cypress/cypress/support/e2e.js
+++ b/.vib/influxdb/cypress/cypress/support/e2e.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/influxdb/cypress/cypress/support/utils.js
+++ b/.vib/influxdb/cypress/cypress/support/utils.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/influxdb/goss/goss.yaml
+++ b/.vib/influxdb/goss/goss.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 file:

--- a/.vib/jaeger/cypress/cypress/e2e/jaeger.cy.js
+++ b/.vib/jaeger/cypress/cypress/e2e/jaeger.cy.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/jaeger/cypress/cypress/support/e2e.js
+++ b/.vib/jaeger/cypress/cypress/support/e2e.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/jaeger/goss/goss.yaml
+++ b/.vib/jaeger/goss/goss.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 addr:

--- a/.vib/jenkins/cypress/cypress/e2e/jenkins.cy.js
+++ b/.vib/jenkins/cypress/cypress/e2e/jenkins.cy.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/jenkins/cypress/cypress/support/commands.js
+++ b/.vib/jenkins/cypress/cypress/support/commands.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/jenkins/cypress/cypress/support/e2e.js
+++ b/.vib/jenkins/cypress/cypress/support/e2e.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/jenkins/cypress/cypress/support/utils.js
+++ b/.vib/jenkins/cypress/cypress/support/utils.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/jenkins/goss/goss.yaml
+++ b/.vib/jenkins/goss/goss.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 command:

--- a/.vib/joomla/cypress/cypress/e2e/joomla.cy.js
+++ b/.vib/joomla/cypress/cypress/e2e/joomla.cy.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/joomla/cypress/cypress/support/commands.js
+++ b/.vib/joomla/cypress/cypress/support/commands.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/joomla/cypress/cypress/support/e2e.js
+++ b/.vib/joomla/cypress/cypress/support/e2e.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/joomla/cypress/cypress/support/utils.js
+++ b/.vib/joomla/cypress/cypress/support/utils.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/joomla/goss/goss.yaml
+++ b/.vib/joomla/goss/goss.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 file:

--- a/.vib/jupyterhub/cypress/cypress/e2e/jupyterhub.cy.js
+++ b/.vib/jupyterhub/cypress/cypress/e2e/jupyterhub.cy.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/jupyterhub/cypress/cypress/support/commands.js
+++ b/.vib/jupyterhub/cypress/cypress/support/commands.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/jupyterhub/cypress/cypress/support/e2e.js
+++ b/.vib/jupyterhub/cypress/cypress/support/e2e.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/jupyterhub/cypress/cypress/support/utils.js
+++ b/.vib/jupyterhub/cypress/cypress/support/utils.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/jupyterhub/goss/goss.yaml
+++ b/.vib/jupyterhub/goss/goss.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 http:

--- a/.vib/kafka/goss/goss.yaml
+++ b/.vib/kafka/goss/goss.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 file:

--- a/.vib/keycloak/cypress/cypress/e2e/keycloak.cy.js
+++ b/.vib/keycloak/cypress/cypress/e2e/keycloak.cy.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/keycloak/cypress/cypress/support/commands.js
+++ b/.vib/keycloak/cypress/cypress/support/commands.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/keycloak/cypress/cypress/support/e2e.js
+++ b/.vib/keycloak/cypress/cypress/support/e2e.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/keycloak/cypress/cypress/support/utils.js
+++ b/.vib/keycloak/cypress/cypress/support/utils.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/keycloak/goss/goss.yaml
+++ b/.vib/keycloak/goss/goss.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 file:

--- a/.vib/kibana/cypress/cypress/e2e/kibana.cy.js
+++ b/.vib/kibana/cypress/cypress/e2e/kibana.cy.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/kibana/cypress/cypress/support/commands.js
+++ b/.vib/kibana/cypress/cypress/support/commands.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/kibana/cypress/cypress/support/e2e.js
+++ b/.vib/kibana/cypress/cypress/support/e2e.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/kibana/cypress/cypress/support/utils.js
+++ b/.vib/kibana/cypress/cypress/support/utils.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/kibana/goss/goss.yaml
+++ b/.vib/kibana/goss/goss.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 file:

--- a/.vib/kong/cypress/cypress/e2e/kong.cy.js
+++ b/.vib/kong/cypress/cypress/e2e/kong.cy.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/kong/cypress/cypress/support/e2e.js
+++ b/.vib/kong/cypress/cypress/support/e2e.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/kong/cypress/cypress/support/utils.js
+++ b/.vib/kong/cypress/cypress/support/utils.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/kong/goss/goss.yaml
+++ b/.vib/kong/goss/goss.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 http:

--- a/.vib/kube-prometheus/cypress/cypress/e2e/kube_prometheus.cy.js
+++ b/.vib/kube-prometheus/cypress/cypress/e2e/kube_prometheus.cy.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/kube-prometheus/cypress/cypress/support/e2e.js
+++ b/.vib/kube-prometheus/cypress/cypress/support/e2e.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/kube-prometheus/goss/goss.yaml
+++ b/.vib/kube-prometheus/goss/goss.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 command:

--- a/.vib/kube-state-metrics/goss/goss.yaml
+++ b/.vib/kube-state-metrics/goss/goss.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 http:

--- a/.vib/kubeapps/cypress/cypress/e2e/kubeapps.cy.js
+++ b/.vib/kubeapps/cypress/cypress/e2e/kubeapps.cy.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/kubeapps/cypress/cypress/support/commands.js
+++ b/.vib/kubeapps/cypress/cypress/support/commands.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/kubeapps/cypress/cypress/support/e2e.js
+++ b/.vib/kubeapps/cypress/cypress/support/e2e.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/kubeapps/cypress/cypress/support/utils.js
+++ b/.vib/kubeapps/cypress/cypress/support/utils.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/kubeapps/goss/goss.yaml
+++ b/.vib/kubeapps/goss/goss.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 http:

--- a/.vib/kuberay/cypress/cypress/e2e/kuberay.cy.js
+++ b/.vib/kuberay/cypress/cypress/e2e/kuberay.cy.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/kuberay/cypress/cypress/support/commands.js
+++ b/.vib/kuberay/cypress/cypress/support/commands.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/kuberay/cypress/cypress/support/e2e.js
+++ b/.vib/kuberay/cypress/cypress/support/e2e.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/kuberay/goss/goss.yaml
+++ b/.vib/kuberay/goss/goss.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 http:

--- a/.vib/kubernetes-event-exporter/ginkgo/integration_suite_test.go
+++ b/.vib/kubernetes-event-exporter/ginkgo/integration_suite_test.go
@@ -1,4 +1,4 @@
-// Copyright VMware, Inc.
+// Copyright Broadcom, Inc. All Rights Reserved.
 // SPDX-License-Identifier: APACHE-2.0
 
 package integration

--- a/.vib/kubernetes-event-exporter/ginkgo/kubernetes_event_exporter.go
+++ b/.vib/kubernetes-event-exporter/ginkgo/kubernetes_event_exporter.go
@@ -1,4 +1,4 @@
-// Copyright VMware, Inc.
+// Copyright Broadcom, Inc. All Rights Reserved.
 // SPDX-License-Identifier: APACHE-2.0
 
 package integration

--- a/.vib/kubernetes-event-exporter/goss/goss.yaml
+++ b/.vib/kubernetes-event-exporter/goss/goss.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 file:

--- a/.vib/logstash/cypress/cypress/e2e/logstash.cy.js
+++ b/.vib/logstash/cypress/cypress/e2e/logstash.cy.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/logstash/cypress/cypress/support/e2e.js
+++ b/.vib/logstash/cypress/cypress/support/e2e.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/logstash/goss/goss.yaml
+++ b/.vib/logstash/goss/goss.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 http:

--- a/.vib/magento/cypress/cypress/e2e/magento.cy.js
+++ b/.vib/magento/cypress/cypress/e2e/magento.cy.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/magento/cypress/cypress/support/commands.js
+++ b/.vib/magento/cypress/cypress/support/commands.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/magento/cypress/cypress/support/e2e.js
+++ b/.vib/magento/cypress/cypress/support/e2e.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/magento/cypress/cypress/support/utils.js
+++ b/.vib/magento/cypress/cypress/support/utils.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/magento/goss/goss.yaml
+++ b/.vib/magento/goss/goss.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 command:

--- a/.vib/mariadb-galera/goss/goss.yaml
+++ b/.vib/mariadb-galera/goss/goss.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 file:

--- a/.vib/mariadb/goss/goss.yaml
+++ b/.vib/mariadb/goss/goss.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 file:

--- a/.vib/mastodon/cypress/cypress/e2e/mastodon.cy.js
+++ b/.vib/mastodon/cypress/cypress/e2e/mastodon.cy.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/mastodon/cypress/cypress/support/commands.js
+++ b/.vib/mastodon/cypress/cypress/support/commands.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/mastodon/cypress/cypress/support/e2e.js
+++ b/.vib/mastodon/cypress/cypress/support/e2e.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/mastodon/cypress/cypress/support/utils.js
+++ b/.vib/mastodon/cypress/cypress/support/utils.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/mastodon/goss/goss.yaml
+++ b/.vib/mastodon/goss/goss.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 command:

--- a/.vib/matomo/cypress/cypress/e2e/matomo.cy.js
+++ b/.vib/matomo/cypress/cypress/e2e/matomo.cy.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/matomo/cypress/cypress/support/commands.js
+++ b/.vib/matomo/cypress/cypress/support/commands.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/matomo/cypress/cypress/support/e2e.js
+++ b/.vib/matomo/cypress/cypress/support/e2e.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/matomo/cypress/cypress/support/utils.js
+++ b/.vib/matomo/cypress/cypress/support/utils.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/matomo/goss/goss.yaml
+++ b/.vib/matomo/goss/goss.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 file:

--- a/.vib/mediawiki/cypress/cypress/e2e/mediawiki.cy.js
+++ b/.vib/mediawiki/cypress/cypress/e2e/mediawiki.cy.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/mediawiki/cypress/cypress/support/commands.js
+++ b/.vib/mediawiki/cypress/cypress/support/commands.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/mediawiki/cypress/cypress/support/e2e.js
+++ b/.vib/mediawiki/cypress/cypress/support/e2e.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/mediawiki/cypress/cypress/support/utils.js
+++ b/.vib/mediawiki/cypress/cypress/support/utils.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/mediawiki/goss/goss.yaml
+++ b/.vib/mediawiki/goss/goss.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 file:

--- a/.vib/memcached/goss/goss.yaml
+++ b/.vib/memcached/goss/goss.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 file:

--- a/.vib/metallb/ginkgo/integration_suite_test.go
+++ b/.vib/metallb/ginkgo/integration_suite_test.go
@@ -1,4 +1,4 @@
-// Copyright VMware, Inc.
+// Copyright Broadcom, Inc. All Rights Reserved.
 // SPDX-License-Identifier: APACHE-2.0
 
 package integration

--- a/.vib/metallb/ginkgo/metallb_test.go
+++ b/.vib/metallb/ginkgo/metallb_test.go
@@ -1,4 +1,4 @@
-// Copyright VMware, Inc.
+// Copyright Broadcom, Inc. All Rights Reserved.
 // SPDX-License-Identifier: APACHE-2.0
 
 package integration

--- a/.vib/metallb/goss/goss.yaml
+++ b/.vib/metallb/goss/goss.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 command:

--- a/.vib/metrics-server/goss/goss.yaml
+++ b/.vib/metrics-server/goss/goss.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 http:

--- a/.vib/milvus/cypress/cypress/e2e/milvus.cy.js
+++ b/.vib/milvus/cypress/cypress/e2e/milvus.cy.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/milvus/cypress/cypress/support/commands.js
+++ b/.vib/milvus/cypress/cypress/support/commands.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/milvus/cypress/cypress/support/e2e.js
+++ b/.vib/milvus/cypress/cypress/support/e2e.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/milvus/cypress/cypress/support/utils.js
+++ b/.vib/milvus/cypress/cypress/support/utils.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/milvus/goss/goss.yaml
+++ b/.vib/milvus/goss/goss.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 http:

--- a/.vib/minio/cypress/cypress/e2e/minio.cy.js
+++ b/.vib/minio/cypress/cypress/e2e/minio.cy.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/minio/cypress/cypress/support/commands.js
+++ b/.vib/minio/cypress/cypress/support/commands.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/minio/cypress/cypress/support/e2e.js
+++ b/.vib/minio/cypress/cypress/support/e2e.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/minio/cypress/cypress/support/utils.js
+++ b/.vib/minio/cypress/cypress/support/utils.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/minio/goss/goss.yaml
+++ b/.vib/minio/goss/goss.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 http:

--- a/.vib/mlflow/cypress/cypress/e2e/mlflow.cy.js
+++ b/.vib/mlflow/cypress/cypress/e2e/mlflow.cy.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/mlflow/cypress/cypress/support/commands.js
+++ b/.vib/mlflow/cypress/cypress/support/commands.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/mlflow/cypress/cypress/support/e2e.js
+++ b/.vib/mlflow/cypress/cypress/support/e2e.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/mlflow/goss/goss.yaml
+++ b/.vib/mlflow/goss/goss.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 file:

--- a/.vib/mongodb-sharded/goss/goss.yaml
+++ b/.vib/mongodb-sharded/goss/goss.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 command:

--- a/.vib/mongodb/goss/goss.yaml
+++ b/.vib/mongodb/goss/goss.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 file:

--- a/.vib/moodle/cypress/cypress/e2e/moodle.cy.js
+++ b/.vib/moodle/cypress/cypress/e2e/moodle.cy.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/moodle/cypress/cypress/support/commands.js
+++ b/.vib/moodle/cypress/cypress/support/commands.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/moodle/cypress/cypress/support/e2e.js
+++ b/.vib/moodle/cypress/cypress/support/e2e.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/moodle/cypress/cypress/support/utils.js
+++ b/.vib/moodle/cypress/cypress/support/utils.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/moodle/goss/goss.yaml
+++ b/.vib/moodle/goss/goss.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 file:

--- a/.vib/multus-cni/goss/goss.yaml
+++ b/.vib/multus-cni/goss/goss.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 # This application performs modifications at host-level, injecting new configuration files. Therefore the

--- a/.vib/mysql/goss/goss.yaml
+++ b/.vib/mysql/goss/goss.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 command:

--- a/.vib/nats/cypress/cypress/e2e/nats.cy.js
+++ b/.vib/nats/cypress/cypress/e2e/nats.cy.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/nats/cypress/cypress/support/e2e.js
+++ b/.vib/nats/cypress/cypress/support/e2e.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/nats/goss/goss.yaml
+++ b/.vib/nats/goss/goss.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 file:

--- a/.vib/nginx-ingress-controller/ginkgo/integration_suite_test.go
+++ b/.vib/nginx-ingress-controller/ginkgo/integration_suite_test.go
@@ -1,4 +1,4 @@
-// Copyright VMware, Inc.
+// Copyright Broadcom, Inc. All Rights Reserved.
 // SPDX-License-Identifier: APACHE-2.0
 
 package integration

--- a/.vib/nginx-ingress-controller/ginkgo/nginx_ingress_controller_test.go
+++ b/.vib/nginx-ingress-controller/ginkgo/nginx_ingress_controller_test.go
@@ -1,4 +1,4 @@
-// Copyright VMware, Inc.
+// Copyright Broadcom, Inc. All Rights Reserved.
 // SPDX-License-Identifier: APACHE-2.0
 
 package integration

--- a/.vib/nginx-ingress-controller/goss/goss.yaml
+++ b/.vib/nginx-ingress-controller/goss/goss.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 http:

--- a/.vib/nginx/cypress/cypress/e2e/nginx.cy.js
+++ b/.vib/nginx/cypress/cypress/e2e/nginx.cy.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/nginx/cypress/cypress/support/e2e.js
+++ b/.vib/nginx/cypress/cypress/support/e2e.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/nginx/goss/goss.yaml
+++ b/.vib/nginx/goss/goss.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 http:

--- a/.vib/node-exporter/cypress/cypress/e2e/node_exporter.cy.js
+++ b/.vib/node-exporter/cypress/cypress/e2e/node_exporter.cy.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/node-exporter/cypress/cypress/support/e2e.js
+++ b/.vib/node-exporter/cypress/cypress/support/e2e.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/node-exporter/goss/goss.yaml
+++ b/.vib/node-exporter/goss/goss.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 file:

--- a/.vib/oauth2-proxy/cypress/cypress/e2e/oauth2-proxy.cy.js
+++ b/.vib/oauth2-proxy/cypress/cypress/e2e/oauth2-proxy.cy.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/oauth2-proxy/cypress/cypress/support/commands.js
+++ b/.vib/oauth2-proxy/cypress/cypress/support/commands.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/oauth2-proxy/cypress/cypress/support/e2e.js
+++ b/.vib/oauth2-proxy/cypress/cypress/support/e2e.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/oauth2-proxy/goss/goss.yaml
+++ b/.vib/oauth2-proxy/goss/goss.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 http:

--- a/.vib/odoo/cypress/cypress/e2e/odoo.cy.js
+++ b/.vib/odoo/cypress/cypress/e2e/odoo.cy.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/odoo/cypress/cypress/support/commands.js
+++ b/.vib/odoo/cypress/cypress/support/commands.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/odoo/cypress/cypress/support/e2e.js
+++ b/.vib/odoo/cypress/cypress/support/e2e.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/odoo/cypress/cypress/support/utils.js
+++ b/.vib/odoo/cypress/cypress/support/utils.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/odoo/goss/goss.yaml
+++ b/.vib/odoo/goss/goss.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 file:

--- a/.vib/opencart/cypress/cypress/e2e/opencart.cy.js
+++ b/.vib/opencart/cypress/cypress/e2e/opencart.cy.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/opencart/cypress/cypress/support/commands.js
+++ b/.vib/opencart/cypress/cypress/support/commands.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/opencart/cypress/cypress/support/e2e.js
+++ b/.vib/opencart/cypress/cypress/support/e2e.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/opencart/cypress/cypress/support/utils.js
+++ b/.vib/opencart/cypress/cypress/support/utils.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/opencart/goss/goss.yaml
+++ b/.vib/opencart/goss/goss.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 http:

--- a/.vib/opensearch/cypress/cypress/e2e/opensearch.cy.js
+++ b/.vib/opensearch/cypress/cypress/e2e/opensearch.cy.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/opensearch/cypress/cypress/support/e2e.js
+++ b/.vib/opensearch/cypress/cypress/support/e2e.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/opensearch/cypress/cypress/support/utils.js
+++ b/.vib/opensearch/cypress/cypress/support/utils.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/opensearch/goss/goss.yaml
+++ b/.vib/opensearch/goss/goss.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 file:

--- a/.vib/parse/cypress/cypress/e2e/parse.cy.js
+++ b/.vib/parse/cypress/cypress/e2e/parse.cy.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/parse/cypress/cypress/support/e2e.js
+++ b/.vib/parse/cypress/cypress/support/e2e.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/parse/cypress/cypress/support/utils.js
+++ b/.vib/parse/cypress/cypress/support/utils.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/parse/goss/dashboard/goss.yaml
+++ b/.vib/parse/goss/dashboard/goss.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 file:

--- a/.vib/parse/goss/server/goss.yaml
+++ b/.vib/parse/goss/server/goss.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 file:

--- a/.vib/phpbb/cypress/cypress/e2e/phpbb.cy.js
+++ b/.vib/phpbb/cypress/cypress/e2e/phpbb.cy.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/phpbb/cypress/cypress/support/commands.js
+++ b/.vib/phpbb/cypress/cypress/support/commands.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/phpbb/cypress/cypress/support/e2e.js
+++ b/.vib/phpbb/cypress/cypress/support/e2e.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/phpbb/cypress/cypress/support/utils.js
+++ b/.vib/phpbb/cypress/cypress/support/utils.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/phpbb/goss/goss.yaml
+++ b/.vib/phpbb/goss/goss.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 file:

--- a/.vib/phpmyadmin/cypress/cypress/e2e/phpmyadmin.cy.js
+++ b/.vib/phpmyadmin/cypress/cypress/e2e/phpmyadmin.cy.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/phpmyadmin/cypress/cypress/support/commands.js
+++ b/.vib/phpmyadmin/cypress/cypress/support/commands.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/phpmyadmin/cypress/cypress/support/e2e.js
+++ b/.vib/phpmyadmin/cypress/cypress/support/e2e.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/phpmyadmin/cypress/cypress/support/utils.js
+++ b/.vib/phpmyadmin/cypress/cypress/support/utils.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/phpmyadmin/goss/goss.yaml
+++ b/.vib/phpmyadmin/goss/goss.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 file:

--- a/.vib/pinniped/ginkgo/integration_suite_test.go
+++ b/.vib/pinniped/ginkgo/integration_suite_test.go
@@ -1,4 +1,4 @@
-// Copyright VMware, Inc.
+// Copyright Broadcom, Inc. All Rights Reserved.
 // SPDX-License-Identifier: APACHE-2.0
 
 package integration

--- a/.vib/pinniped/ginkgo/pinniped_test.go
+++ b/.vib/pinniped/ginkgo/pinniped_test.go
@@ -1,4 +1,4 @@
-// Copyright VMware, Inc.
+// Copyright Broadcom, Inc. All Rights Reserved.
 // SPDX-License-Identifier: APACHE-2.0
 
 package integration

--- a/.vib/pinniped/ginkgo/scripts/pinniped-auth.sh
+++ b/.vib/pinniped/ginkgo/scripts/pinniped-auth.sh
@@ -1,5 +1,5 @@
 #/bin/bash
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 # Run pinniped cli to obtain custom kubeconfig and auth into the cluster

--- a/.vib/postgresql-ha/goss/pgpool/goss.yaml
+++ b/.vib/postgresql-ha/goss/pgpool/goss.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 command:

--- a/.vib/postgresql-ha/goss/repmgr/goss.yaml
+++ b/.vib/postgresql-ha/goss/repmgr/goss.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 file:

--- a/.vib/postgresql/goss/goss.yaml
+++ b/.vib/postgresql/goss/goss.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 command:

--- a/.vib/prestashop/cypress/cypress/e2e/prestashop.cy.js
+++ b/.vib/prestashop/cypress/cypress/e2e/prestashop.cy.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/prestashop/cypress/cypress/support/commands.js
+++ b/.vib/prestashop/cypress/cypress/support/commands.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/prestashop/cypress/cypress/support/e2e.js
+++ b/.vib/prestashop/cypress/cypress/support/e2e.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/prestashop/cypress/cypress/support/utils.js
+++ b/.vib/prestashop/cypress/cypress/support/utils.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/prestashop/goss/goss.yaml
+++ b/.vib/prestashop/goss/goss.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 http:

--- a/.vib/prometheus/cypress/cypress/e2e/prometheus.cy.js
+++ b/.vib/prometheus/cypress/cypress/e2e/prometheus.cy.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/prometheus/cypress/cypress/support/e2e.js
+++ b/.vib/prometheus/cypress/cypress/support/e2e.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/prometheus/goss/goss.yaml
+++ b/.vib/prometheus/goss/goss.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 command:

--- a/.vib/pytorch/goss/goss.yaml
+++ b/.vib/pytorch/goss/goss.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 file:

--- a/.vib/rabbitmq-cluster-operator/cypress/cypress/e2e/rabbitmq_cluster_operator.cy.js
+++ b/.vib/rabbitmq-cluster-operator/cypress/cypress/e2e/rabbitmq_cluster_operator.cy.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/rabbitmq-cluster-operator/cypress/cypress/support/commands.js
+++ b/.vib/rabbitmq-cluster-operator/cypress/cypress/support/commands.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/rabbitmq-cluster-operator/cypress/cypress/support/e2e.js
+++ b/.vib/rabbitmq-cluster-operator/cypress/cypress/support/e2e.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/rabbitmq-cluster-operator/cypress/cypress/support/utils.js
+++ b/.vib/rabbitmq-cluster-operator/cypress/cypress/support/utils.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/rabbitmq-cluster-operator/goss/goss.yaml
+++ b/.vib/rabbitmq-cluster-operator/goss/goss.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 http:

--- a/.vib/rabbitmq/cypress/cypress/e2e/rabbitmq.cy.js
+++ b/.vib/rabbitmq/cypress/cypress/e2e/rabbitmq.cy.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/rabbitmq/cypress/cypress/support/commands.js
+++ b/.vib/rabbitmq/cypress/cypress/support/commands.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/rabbitmq/cypress/cypress/support/e2e.js
+++ b/.vib/rabbitmq/cypress/cypress/support/e2e.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/rabbitmq/cypress/cypress/support/utils.js
+++ b/.vib/rabbitmq/cypress/cypress/support/utils.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/rabbitmq/goss/goss.yaml
+++ b/.vib/rabbitmq/goss/goss.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 addr:

--- a/.vib/redis-cluster/goss/goss.yaml
+++ b/.vib/redis-cluster/goss/goss.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 {{- $auth := printf "REDISCLI_AUTH=%s" .Vars.password }}

--- a/.vib/redis/goss/goss.yaml
+++ b/.vib/redis/goss/goss.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 {{- $auth := printf "REDISCLI_AUTH='%s'" .Vars.auth.password }}

--- a/.vib/redmine/cypress/cypress/e2e/redmine.cy.js
+++ b/.vib/redmine/cypress/cypress/e2e/redmine.cy.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/redmine/cypress/cypress/support/commands.js
+++ b/.vib/redmine/cypress/cypress/support/commands.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/redmine/cypress/cypress/support/e2e.js
+++ b/.vib/redmine/cypress/cypress/support/e2e.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/redmine/cypress/cypress/support/utils.js
+++ b/.vib/redmine/cypress/cypress/support/utils.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/redmine/goss/goss.yaml
+++ b/.vib/redmine/goss/goss.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 file:

--- a/.vib/schema-registry/cypress/cypress/e2e/schema_registry.cy.js
+++ b/.vib/schema-registry/cypress/cypress/e2e/schema_registry.cy.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/schema-registry/cypress/cypress/support/e2e.js
+++ b/.vib/schema-registry/cypress/cypress/support/e2e.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/schema-registry/goss/goss.yaml
+++ b/.vib/schema-registry/goss/goss.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 file:

--- a/.vib/sealed-secrets/cypress/cypress/e2e/sealed_secrets.cy.js
+++ b/.vib/sealed-secrets/cypress/cypress/e2e/sealed_secrets.cy.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/sealed-secrets/cypress/cypress/support/e2e.js
+++ b/.vib/sealed-secrets/cypress/cypress/support/e2e.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/sealed-secrets/ginkgo/integration_suite_test.go
+++ b/.vib/sealed-secrets/ginkgo/integration_suite_test.go
@@ -1,4 +1,4 @@
-// Copyright VMware, Inc.
+// Copyright Broadcom, Inc. All Rights Reserved.
 // SPDX-License-Identifier: APACHE-2.0
 
 package integration

--- a/.vib/sealed-secrets/ginkgo/sealed_secrets_test.go
+++ b/.vib/sealed-secrets/ginkgo/sealed_secrets_test.go
@@ -1,4 +1,4 @@
-// Copyright VMware, Inc.
+// Copyright Broadcom, Inc. All Rights Reserved.
 // SPDX-License-Identifier: APACHE-2.0
 
 package integration

--- a/.vib/seaweedfs/cypress/cypress/e2e/seaweedfs.cy.js
+++ b/.vib/seaweedfs/cypress/cypress/e2e/seaweedfs.cy.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/seaweedfs/cypress/cypress/support/e2e.js
+++ b/.vib/seaweedfs/cypress/cypress/support/e2e.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/solr/cypress/cypress/e2e/solr.cy.js
+++ b/.vib/solr/cypress/cypress/e2e/solr.cy.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/solr/cypress/cypress/support/commands.js
+++ b/.vib/solr/cypress/cypress/support/commands.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/solr/cypress/cypress/support/e2e.js
+++ b/.vib/solr/cypress/cypress/support/e2e.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/solr/cypress/cypress/support/utils.js
+++ b/.vib/solr/cypress/cypress/support/utils.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/solr/goss/goss.yaml
+++ b/.vib/solr/goss/goss.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 command:

--- a/.vib/sonarqube/cypress/cypress/e2e/sonarqube.cy.js
+++ b/.vib/sonarqube/cypress/cypress/e2e/sonarqube.cy.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/sonarqube/cypress/cypress/support/commands.js
+++ b/.vib/sonarqube/cypress/cypress/support/commands.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/sonarqube/cypress/cypress/support/e2e.js
+++ b/.vib/sonarqube/cypress/cypress/support/e2e.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/sonarqube/cypress/cypress/support/utils.js
+++ b/.vib/sonarqube/cypress/cypress/support/utils.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/sonarqube/goss/goss.yaml
+++ b/.vib/sonarqube/goss/goss.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 file:

--- a/.vib/spark/cypress/cypress/e2e/spark.cy.js
+++ b/.vib/spark/cypress/cypress/e2e/spark.cy.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/spark/cypress/cypress/support/e2e.js
+++ b/.vib/spark/cypress/cypress/support/e2e.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/spark/goss/goss.yaml
+++ b/.vib/spark/goss/goss.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 command:

--- a/.vib/spring-cloud-dataflow/cypress/cypress/e2e/spring_cloud_dataflow.cy.js
+++ b/.vib/spring-cloud-dataflow/cypress/cypress/e2e/spring_cloud_dataflow.cy.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/spring-cloud-dataflow/cypress/cypress/support/commands.js
+++ b/.vib/spring-cloud-dataflow/cypress/cypress/support/commands.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/spring-cloud-dataflow/cypress/cypress/support/e2e.js
+++ b/.vib/spring-cloud-dataflow/cypress/cypress/support/e2e.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/spring-cloud-dataflow/cypress/cypress/support/utils.js
+++ b/.vib/spring-cloud-dataflow/cypress/cypress/support/utils.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/spring-cloud-dataflow/goss/goss.yaml
+++ b/.vib/spring-cloud-dataflow/goss/goss.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 http:

--- a/.vib/supabase/cypress/cypress/e2e/supabase.cy.js
+++ b/.vib/supabase/cypress/cypress/e2e/supabase.cy.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/supabase/cypress/cypress/support/e2e.js
+++ b/.vib/supabase/cypress/cypress/support/e2e.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/supabase/cypress/cypress/support/utils.js
+++ b/.vib/supabase/cypress/cypress/support/utils.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/supabase/goss/goss.yaml
+++ b/.vib/supabase/goss/goss.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 http:

--- a/.vib/tensorflow-resnet/cypress/cypress/e2e/tensorflow_resnet.cy.js
+++ b/.vib/tensorflow-resnet/cypress/cypress/e2e/tensorflow_resnet.cy.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/tensorflow-resnet/cypress/cypress/support/commands.js
+++ b/.vib/tensorflow-resnet/cypress/cypress/support/commands.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/tensorflow-resnet/cypress/cypress/support/e2e.js
+++ b/.vib/tensorflow-resnet/cypress/cypress/support/e2e.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/tensorflow-resnet/goss/goss.yaml
+++ b/.vib/tensorflow-resnet/goss/goss.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 addr:

--- a/.vib/thanos/cypress/cypress/e2e/thanos.cy.js
+++ b/.vib/thanos/cypress/cypress/e2e/thanos.cy.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/thanos/cypress/cypress/support/commands.js
+++ b/.vib/thanos/cypress/cypress/support/commands.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/thanos/cypress/cypress/support/e2e.js
+++ b/.vib/thanos/cypress/cypress/support/e2e.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/tomcat/cypress/cypress/e2e/tomcat.cy.js
+++ b/.vib/tomcat/cypress/cypress/e2e/tomcat.cy.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/tomcat/cypress/cypress/support/commands.js
+++ b/.vib/tomcat/cypress/cypress/support/commands.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/tomcat/cypress/cypress/support/e2e.js
+++ b/.vib/tomcat/cypress/cypress/support/e2e.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/tomcat/cypress/cypress/support/utils.js
+++ b/.vib/tomcat/cypress/cypress/support/utils.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/tomcat/goss/goss.yaml
+++ b/.vib/tomcat/goss/goss.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 command:

--- a/.vib/vault/cypress/cypress/e2e/vault.cy.js
+++ b/.vib/vault/cypress/cypress/e2e/vault.cy.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/vault/cypress/cypress/support/commands.js
+++ b/.vib/vault/cypress/cypress/support/commands.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/vault/cypress/cypress/support/e2e.js
+++ b/.vib/vault/cypress/cypress/support/e2e.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/vault/cypress/cypress/support/utils.js
+++ b/.vib/vault/cypress/cypress/support/utils.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/vault/goss/goss.yaml
+++ b/.vib/vault/goss/goss.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 file:

--- a/.vib/whereabouts/goss/goss.yaml
+++ b/.vib/whereabouts/goss/goss.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 # This application performs modifications at host-level, injecting new configuration files. Therefore the

--- a/.vib/wildfly/cypress/cypress/e2e/wildfly.cy.js
+++ b/.vib/wildfly/cypress/cypress/e2e/wildfly.cy.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/wildfly/cypress/cypress/support/e2e.js
+++ b/.vib/wildfly/cypress/cypress/support/e2e.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/wildfly/goss/goss.yaml
+++ b/.vib/wildfly/goss/goss.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 file:

--- a/.vib/wordpress/cypress/cypress/e2e/wordpress.cy.js
+++ b/.vib/wordpress/cypress/cypress/e2e/wordpress.cy.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/wordpress/cypress/cypress/support/commands.js
+++ b/.vib/wordpress/cypress/cypress/support/commands.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/wordpress/cypress/cypress/support/e2e.js
+++ b/.vib/wordpress/cypress/cypress/support/e2e.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/wordpress/cypress/cypress/support/utils.js
+++ b/.vib/wordpress/cypress/cypress/support/utils.js
@@ -1,5 +1,5 @@
 /*
- * Copyright VMware, Inc.
+ * Copyright Broadcom, Inc. All Rights Reserved.
  * SPDX-License-Identifier: APACHE-2.0
  */
 

--- a/.vib/wordpress/goss/goss-wait.yaml
+++ b/.vib/wordpress/goss/goss-wait.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 addr:

--- a/.vib/wordpress/goss/goss.yaml
+++ b/.vib/wordpress/goss/goss.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 file:

--- a/.vib/zookeeper/goss/goss.yaml
+++ b/.vib/zookeeper/goss/goss.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 file:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ When submitting a PR make sure that it:
 
 ```yaml
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 ```
@@ -87,7 +87,7 @@ There are five major technical requirements to add a new Helm chart to our catal
 
 ```yaml
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 ```
@@ -95,7 +95,7 @@ SPDX-License-Identifier: APACHE-2.0
 - The exception to the license header rule above are `Chart.yaml` and `values.yaml` files, that use the following format instead:
 
 ```yaml
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 ```
 

--- a/bitnami/airflow/Chart.yaml
+++ b/bitnami/airflow/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/airflow/templates/_git_helpers.tpl
+++ b/bitnami/airflow/templates/_git_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/airflow/templates/_helpers.tpl
+++ b/bitnami/airflow/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/airflow/templates/config/configmap.yaml
+++ b/bitnami/airflow/templates/config/configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/airflow/templates/config/secret-external-db.yaml
+++ b/bitnami/airflow/templates/config/secret-external-db.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/airflow/templates/config/secret-external-redis.yaml
+++ b/bitnami/airflow/templates/config/secret-external-redis.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/airflow/templates/config/secret-ldap.yaml
+++ b/bitnami/airflow/templates/config/secret-ldap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/airflow/templates/config/secret.yaml
+++ b/bitnami/airflow/templates/config/secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/airflow/templates/extra-list.yaml
+++ b/bitnami/airflow/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/airflow/templates/metrics/deployment.yaml
+++ b/bitnami/airflow/templates/metrics/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/airflow/templates/metrics/networkpolicy.yaml
+++ b/bitnami/airflow/templates/metrics/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/airflow/templates/metrics/service.yaml
+++ b/bitnami/airflow/templates/metrics/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/airflow/templates/metrics/servicemonitor.yaml
+++ b/bitnami/airflow/templates/metrics/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/airflow/templates/rbac/role.yaml
+++ b/bitnami/airflow/templates/rbac/role.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/airflow/templates/rbac/rolebinding.yaml
+++ b/bitnami/airflow/templates/rbac/rolebinding.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/airflow/templates/rbac/serviceaccount.yaml
+++ b/bitnami/airflow/templates/rbac/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/airflow/templates/scheduler/deployment.yaml
+++ b/bitnami/airflow/templates/scheduler/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/airflow/templates/scheduler/networkpolicy.yaml
+++ b/bitnami/airflow/templates/scheduler/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/airflow/templates/scheduler/poddisruptionbudget.yaml
+++ b/bitnami/airflow/templates/scheduler/poddisruptionbudget.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/airflow/templates/scheduler/service-headless.yaml
+++ b/bitnami/airflow/templates/scheduler/service-headless.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/airflow/templates/web/deployment.yaml
+++ b/bitnami/airflow/templates/web/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/airflow/templates/web/ingress.yaml
+++ b/bitnami/airflow/templates/web/ingress.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/airflow/templates/web/networkpolicy.yaml
+++ b/bitnami/airflow/templates/web/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/airflow/templates/web/poddisruptionbudget.yaml
+++ b/bitnami/airflow/templates/web/poddisruptionbudget.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/airflow/templates/web/service.yaml
+++ b/bitnami/airflow/templates/web/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/airflow/templates/web/tls-secrets.yaml
+++ b/bitnami/airflow/templates/web/tls-secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/airflow/templates/worker/horizontalpodautoscaler.yaml
+++ b/bitnami/airflow/templates/worker/horizontalpodautoscaler.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/airflow/templates/worker/networkpolicy.yaml
+++ b/bitnami/airflow/templates/worker/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/airflow/templates/worker/poddisruptionbudget.yaml
+++ b/bitnami/airflow/templates/worker/poddisruptionbudget.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/airflow/templates/worker/service-headless.yaml
+++ b/bitnami/airflow/templates/worker/service-headless.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/airflow/templates/worker/statefulset.yaml
+++ b/bitnami/airflow/templates/worker/statefulset.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/airflow/values.yaml
+++ b/bitnami/airflow/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters

--- a/bitnami/apache/Chart.yaml
+++ b/bitnami/apache/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/apache/templates/_helpers.tpl
+++ b/bitnami/apache/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/apache/templates/configmap-vhosts.yaml
+++ b/bitnami/apache/templates/configmap-vhosts.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/apache/templates/configmap.yaml
+++ b/bitnami/apache/templates/configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/apache/templates/deployment.yaml
+++ b/bitnami/apache/templates/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/apache/templates/extra-list.yaml
+++ b/bitnami/apache/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/apache/templates/hpa.yaml
+++ b/bitnami/apache/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/apache/templates/ingress.yaml
+++ b/bitnami/apache/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/apache/templates/metrics-svc.yaml
+++ b/bitnami/apache/templates/metrics-svc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/apache/templates/networkpolicy.yaml
+++ b/bitnami/apache/templates/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/apache/templates/pdb.yaml
+++ b/bitnami/apache/templates/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/apache/templates/prometheusrules.yaml
+++ b/bitnami/apache/templates/prometheusrules.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/apache/templates/serviceaccount.yaml
+++ b/bitnami/apache/templates/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/apache/templates/servicemonitor.yaml
+++ b/bitnami/apache/templates/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/apache/templates/svc.yaml
+++ b/bitnami/apache/templates/svc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/apache/templates/tls-secrets.yaml
+++ b/bitnami/apache/templates/tls-secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/apache/values.yaml
+++ b/bitnami/apache/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters

--- a/bitnami/apisix/Chart.yaml
+++ b/bitnami/apisix/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/apisix/templates/_helpers.tpl
+++ b/bitnami/apisix/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/apisix/templates/control-plane/api-token-secret.yaml
+++ b/bitnami/apisix/templates/control-plane/api-token-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/apisix/templates/control-plane/clusterrolebinding.yaml
+++ b/bitnami/apisix/templates/control-plane/clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/apisix/templates/control-plane/clusterroles.yaml
+++ b/bitnami/apisix/templates/control-plane/clusterroles.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/apisix/templates/control-plane/configmap.yaml
+++ b/bitnami/apisix/templates/control-plane/configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/apisix/templates/control-plane/dep-ds.yaml
+++ b/bitnami/apisix/templates/control-plane/dep-ds.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/apisix/templates/control-plane/extra-configmap.yaml
+++ b/bitnami/apisix/templates/control-plane/extra-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/apisix/templates/control-plane/hpa.yaml
+++ b/bitnami/apisix/templates/control-plane/hpa.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/apisix/templates/control-plane/ingress-tls-secret.yaml
+++ b/bitnami/apisix/templates/control-plane/ingress-tls-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/apisix/templates/control-plane/ingress.yaml
+++ b/bitnami/apisix/templates/control-plane/ingress.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/apisix/templates/control-plane/networkpolicy.yaml
+++ b/bitnami/apisix/templates/control-plane/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/apisix/templates/control-plane/pdb.yaml
+++ b/bitnami/apisix/templates/control-plane/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/apisix/templates/control-plane/service-account.yaml
+++ b/bitnami/apisix/templates/control-plane/service-account.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/apisix/templates/control-plane/service.yaml
+++ b/bitnami/apisix/templates/control-plane/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/apisix/templates/control-plane/servicemonitor.yaml
+++ b/bitnami/apisix/templates/control-plane/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/apisix/templates/control-plane/vpa.yaml
+++ b/bitnami/apisix/templates/control-plane/vpa.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/apisix/templates/dashboard/configmap.yaml
+++ b/bitnami/apisix/templates/dashboard/configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/apisix/templates/dashboard/deployment.yaml
+++ b/bitnami/apisix/templates/dashboard/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/apisix/templates/dashboard/extra-configmap.yaml
+++ b/bitnami/apisix/templates/dashboard/extra-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/apisix/templates/dashboard/hpa.yaml
+++ b/bitnami/apisix/templates/dashboard/hpa.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/apisix/templates/dashboard/ingress-tls-secret.yaml
+++ b/bitnami/apisix/templates/dashboard/ingress-tls-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/apisix/templates/dashboard/ingress.yaml
+++ b/bitnami/apisix/templates/dashboard/ingress.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/apisix/templates/dashboard/networkpolicy.yaml
+++ b/bitnami/apisix/templates/dashboard/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/apisix/templates/dashboard/pdb.yaml
+++ b/bitnami/apisix/templates/dashboard/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/apisix/templates/dashboard/secret.yaml
+++ b/bitnami/apisix/templates/dashboard/secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/apisix/templates/dashboard/service-account.yaml
+++ b/bitnami/apisix/templates/dashboard/service-account.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/apisix/templates/dashboard/service.yaml
+++ b/bitnami/apisix/templates/dashboard/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/apisix/templates/dashboard/vpa.yaml
+++ b/bitnami/apisix/templates/dashboard/vpa.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/apisix/templates/data-plane/clusterrolebinding.yaml
+++ b/bitnami/apisix/templates/data-plane/clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/apisix/templates/data-plane/clusterroles.yaml
+++ b/bitnami/apisix/templates/data-plane/clusterroles.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/apisix/templates/data-plane/configmap.yaml
+++ b/bitnami/apisix/templates/data-plane/configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/apisix/templates/data-plane/dep-ds.yaml
+++ b/bitnami/apisix/templates/data-plane/dep-ds.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/apisix/templates/data-plane/extra-configmap.yaml
+++ b/bitnami/apisix/templates/data-plane/extra-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/apisix/templates/data-plane/hpa.yaml
+++ b/bitnami/apisix/templates/data-plane/hpa.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/apisix/templates/data-plane/ingress-tls-secret.yaml
+++ b/bitnami/apisix/templates/data-plane/ingress-tls-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/apisix/templates/data-plane/ingress.yaml
+++ b/bitnami/apisix/templates/data-plane/ingress.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/apisix/templates/data-plane/networkpolicy.yaml
+++ b/bitnami/apisix/templates/data-plane/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/apisix/templates/data-plane/pdb.yaml
+++ b/bitnami/apisix/templates/data-plane/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/apisix/templates/data-plane/service-account.yaml
+++ b/bitnami/apisix/templates/data-plane/service-account.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/apisix/templates/data-plane/service.yaml
+++ b/bitnami/apisix/templates/data-plane/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/apisix/templates/data-plane/servicemonitor.yaml
+++ b/bitnami/apisix/templates/data-plane/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/apisix/templates/data-plane/vpa.yaml
+++ b/bitnami/apisix/templates/data-plane/vpa.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/apisix/templates/external-etcd.yaml
+++ b/bitnami/apisix/templates/external-etcd.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/apisix/templates/extra-list.yaml
+++ b/bitnami/apisix/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/apisix/templates/ingress-controller/clusterrolebinding.yaml
+++ b/bitnami/apisix/templates/ingress-controller/clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/apisix/templates/ingress-controller/clusterroles.yaml
+++ b/bitnami/apisix/templates/ingress-controller/clusterroles.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/apisix/templates/ingress-controller/configmap.yaml
+++ b/bitnami/apisix/templates/ingress-controller/configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/apisix/templates/ingress-controller/deployment.yaml
+++ b/bitnami/apisix/templates/ingress-controller/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/apisix/templates/ingress-controller/extra-configmap.yaml
+++ b/bitnami/apisix/templates/ingress-controller/extra-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/apisix/templates/ingress-controller/hpa.yaml
+++ b/bitnami/apisix/templates/ingress-controller/hpa.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/apisix/templates/ingress-controller/ingress-tls-secret.yaml
+++ b/bitnami/apisix/templates/ingress-controller/ingress-tls-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/apisix/templates/ingress-controller/ingress.yaml
+++ b/bitnami/apisix/templates/ingress-controller/ingress.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/apisix/templates/ingress-controller/networkpolicy.yaml
+++ b/bitnami/apisix/templates/ingress-controller/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/apisix/templates/ingress-controller/pdb.yaml
+++ b/bitnami/apisix/templates/ingress-controller/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/apisix/templates/ingress-controller/service-account.yaml
+++ b/bitnami/apisix/templates/ingress-controller/service-account.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/apisix/templates/ingress-controller/service.yaml
+++ b/bitnami/apisix/templates/ingress-controller/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/apisix/templates/ingress-controller/servicemonitor.yaml
+++ b/bitnami/apisix/templates/ingress-controller/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/apisix/templates/ingress-controller/vpa.yaml
+++ b/bitnami/apisix/templates/ingress-controller/vpa.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/apisix/templates/tls-secret.yaml
+++ b/bitnami/apisix/templates/tls-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/apisix/values.yaml
+++ b/bitnami/apisix/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters

--- a/bitnami/appsmith/Chart.yaml
+++ b/bitnami/appsmith/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/appsmith/templates/_helpers.tpl
+++ b/bitnami/appsmith/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/appsmith/templates/backend/deployment.yaml
+++ b/bitnami/appsmith/templates/backend/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/appsmith/templates/backend/externalredis-secret.yaml
+++ b/bitnami/appsmith/templates/backend/externalredis-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/appsmith/templates/backend/networkpolicy.yaml
+++ b/bitnami/appsmith/templates/backend/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/appsmith/templates/backend/pvc.yaml
+++ b/bitnami/appsmith/templates/backend/pvc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/appsmith/templates/backend/redirect-configmap.yaml
+++ b/bitnami/appsmith/templates/backend/redirect-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/appsmith/templates/backend/secret.yaml
+++ b/bitnami/appsmith/templates/backend/secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/appsmith/templates/backend/service.yaml
+++ b/bitnami/appsmith/templates/backend/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/appsmith/templates/client/deployment.yaml
+++ b/bitnami/appsmith/templates/client/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/appsmith/templates/client/ingress.yaml
+++ b/bitnami/appsmith/templates/client/ingress.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/appsmith/templates/client/networkpolicy.yaml
+++ b/bitnami/appsmith/templates/client/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/appsmith/templates/client/service.yaml
+++ b/bitnami/appsmith/templates/client/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/appsmith/templates/client/tls-secret.yaml
+++ b/bitnami/appsmith/templates/client/tls-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/appsmith/templates/externaldb-secrets.yaml
+++ b/bitnami/appsmith/templates/externaldb-secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/appsmith/templates/extra-list.yaml
+++ b/bitnami/appsmith/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/appsmith/templates/rts/deployment.yaml
+++ b/bitnami/appsmith/templates/rts/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/appsmith/templates/rts/networkpolicy.yaml
+++ b/bitnami/appsmith/templates/rts/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/appsmith/templates/rts/service.yaml
+++ b/bitnami/appsmith/templates/rts/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/appsmith/templates/service-account.yaml
+++ b/bitnami/appsmith/templates/service-account.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/appsmith/values.yaml
+++ b/bitnami/appsmith/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters

--- a/bitnami/argo-cd/Chart.yaml
+++ b/bitnami/argo-cd/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/argo-cd/templates/_helpers.tpl
+++ b/bitnami/argo-cd/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/argo-cd/templates/application-controller/clusterrole.yaml
+++ b/bitnami/argo-cd/templates/application-controller/clusterrole.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/argo-cd/templates/application-controller/clusterrolebinding.yaml
+++ b/bitnami/argo-cd/templates/application-controller/clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/argo-cd/templates/application-controller/deployment.yaml
+++ b/bitnami/argo-cd/templates/application-controller/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/argo-cd/templates/application-controller/metrics-svc.yaml
+++ b/bitnami/argo-cd/templates/application-controller/metrics-svc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/argo-cd/templates/application-controller/networkpolicy.yaml
+++ b/bitnami/argo-cd/templates/application-controller/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/argo-cd/templates/application-controller/prometheus-rule.yaml
+++ b/bitnami/argo-cd/templates/application-controller/prometheus-rule.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/argo-cd/templates/application-controller/role.yaml
+++ b/bitnami/argo-cd/templates/application-controller/role.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/argo-cd/templates/application-controller/rolebinding.yaml
+++ b/bitnami/argo-cd/templates/application-controller/rolebinding.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/argo-cd/templates/application-controller/service-account.yaml
+++ b/bitnami/argo-cd/templates/application-controller/service-account.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/argo-cd/templates/application-controller/service.yaml
+++ b/bitnami/argo-cd/templates/application-controller/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/argo-cd/templates/application-controller/servicemonitor.yaml
+++ b/bitnami/argo-cd/templates/application-controller/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/argo-cd/templates/applicationset/deployment.yaml
+++ b/bitnami/argo-cd/templates/applicationset/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/argo-cd/templates/applicationset/ingress-webhook.yaml
+++ b/bitnami/argo-cd/templates/applicationset/ingress-webhook.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/argo-cd/templates/applicationset/metrics-svc.yaml
+++ b/bitnami/argo-cd/templates/applicationset/metrics-svc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/argo-cd/templates/applicationset/networkpolicy.yaml
+++ b/bitnami/argo-cd/templates/applicationset/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/argo-cd/templates/applicationset/role.yaml
+++ b/bitnami/argo-cd/templates/applicationset/role.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/argo-cd/templates/applicationset/rolebinding.yaml
+++ b/bitnami/argo-cd/templates/applicationset/rolebinding.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/argo-cd/templates/applicationset/service-account.yaml
+++ b/bitnami/argo-cd/templates/applicationset/service-account.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/argo-cd/templates/applicationset/service.yaml
+++ b/bitnami/argo-cd/templates/applicationset/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/argo-cd/templates/applicationset/servicemonitor.yaml
+++ b/bitnami/argo-cd/templates/applicationset/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/argo-cd/templates/argocd-cm.yaml
+++ b/bitnami/argo-cd/templates/argocd-cm.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/argo-cd/templates/argocd-secret.yaml
+++ b/bitnami/argo-cd/templates/argocd-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/argo-cd/templates/cluster-configs.yaml
+++ b/bitnami/argo-cd/templates/cluster-configs.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/argo-cd/templates/dex/deployment.yaml
+++ b/bitnami/argo-cd/templates/dex/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/argo-cd/templates/dex/metrics-svc.yaml
+++ b/bitnami/argo-cd/templates/dex/metrics-svc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/argo-cd/templates/dex/networkpolicy.yaml
+++ b/bitnami/argo-cd/templates/dex/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/argo-cd/templates/dex/role.yaml
+++ b/bitnami/argo-cd/templates/dex/role.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/argo-cd/templates/dex/rolebinding.yaml
+++ b/bitnami/argo-cd/templates/dex/rolebinding.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/argo-cd/templates/dex/service-account.yaml
+++ b/bitnami/argo-cd/templates/dex/service-account.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/argo-cd/templates/dex/service.yaml
+++ b/bitnami/argo-cd/templates/dex/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/argo-cd/templates/dex/servicemonitor.yaml
+++ b/bitnami/argo-cd/templates/dex/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/argo-cd/templates/extra-list.yaml
+++ b/bitnami/argo-cd/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/argo-cd/templates/gpg-keys-cm.yaml
+++ b/bitnami/argo-cd/templates/gpg-keys-cm.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/argo-cd/templates/known-hosts-cm.yaml
+++ b/bitnami/argo-cd/templates/known-hosts-cm.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/argo-cd/templates/notifications/bots/slack/deployment.yaml
+++ b/bitnami/argo-cd/templates/notifications/bots/slack/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/argo-cd/templates/notifications/bots/slack/networkpolicy.yaml
+++ b/bitnami/argo-cd/templates/notifications/bots/slack/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/argo-cd/templates/notifications/bots/slack/role.yaml
+++ b/bitnami/argo-cd/templates/notifications/bots/slack/role.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/argo-cd/templates/notifications/bots/slack/rolebinding.yaml
+++ b/bitnami/argo-cd/templates/notifications/bots/slack/rolebinding.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/argo-cd/templates/notifications/bots/slack/service-account.yaml
+++ b/bitnami/argo-cd/templates/notifications/bots/slack/service-account.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/argo-cd/templates/notifications/bots/slack/service.yaml
+++ b/bitnami/argo-cd/templates/notifications/bots/slack/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/argo-cd/templates/notifications/deployment.yaml
+++ b/bitnami/argo-cd/templates/notifications/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/argo-cd/templates/notifications/metrics-svc.yaml
+++ b/bitnami/argo-cd/templates/notifications/metrics-svc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/argo-cd/templates/notifications/networkpolicy.yaml
+++ b/bitnami/argo-cd/templates/notifications/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/argo-cd/templates/notifications/role.yaml
+++ b/bitnami/argo-cd/templates/notifications/role.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/argo-cd/templates/notifications/rolebinding.yaml
+++ b/bitnami/argo-cd/templates/notifications/rolebinding.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/argo-cd/templates/notifications/service-account.yaml
+++ b/bitnami/argo-cd/templates/notifications/service-account.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/argo-cd/templates/notifications/servicemonitor.yaml
+++ b/bitnami/argo-cd/templates/notifications/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/argo-cd/templates/rbac-cm.yaml
+++ b/bitnami/argo-cd/templates/rbac-cm.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/argo-cd/templates/repo-server/deployment.yaml
+++ b/bitnami/argo-cd/templates/repo-server/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/argo-cd/templates/repo-server/hpa.yaml
+++ b/bitnami/argo-cd/templates/repo-server/hpa.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/argo-cd/templates/repo-server/metrics-svc.yaml
+++ b/bitnami/argo-cd/templates/repo-server/metrics-svc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/argo-cd/templates/repo-server/networkpolicy.yaml
+++ b/bitnami/argo-cd/templates/repo-server/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/argo-cd/templates/repo-server/repository-credentials-secret.yaml
+++ b/bitnami/argo-cd/templates/repo-server/repository-credentials-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/argo-cd/templates/repo-server/role.yaml
+++ b/bitnami/argo-cd/templates/repo-server/role.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/argo-cd/templates/repo-server/rolebinding.yaml
+++ b/bitnami/argo-cd/templates/repo-server/rolebinding.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/argo-cd/templates/repo-server/service-account.yaml
+++ b/bitnami/argo-cd/templates/repo-server/service-account.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/argo-cd/templates/repo-server/service.yaml
+++ b/bitnami/argo-cd/templates/repo-server/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/argo-cd/templates/repo-server/servicemonitor.yaml
+++ b/bitnami/argo-cd/templates/repo-server/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/argo-cd/templates/server/clusterrole.yaml
+++ b/bitnami/argo-cd/templates/server/clusterrole.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/argo-cd/templates/server/clusterrolebinding.yaml
+++ b/bitnami/argo-cd/templates/server/clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/argo-cd/templates/server/deployment.yaml
+++ b/bitnami/argo-cd/templates/server/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/argo-cd/templates/server/grpc-tls-secret.yaml
+++ b/bitnami/argo-cd/templates/server/grpc-tls-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/argo-cd/templates/server/hpa.yaml
+++ b/bitnami/argo-cd/templates/server/hpa.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/argo-cd/templates/server/ingress-grcp.yaml
+++ b/bitnami/argo-cd/templates/server/ingress-grcp.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/argo-cd/templates/server/ingress.yaml
+++ b/bitnami/argo-cd/templates/server/ingress.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/argo-cd/templates/server/metrics-svc.yaml
+++ b/bitnami/argo-cd/templates/server/metrics-svc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/argo-cd/templates/server/networkpolicy.yaml
+++ b/bitnami/argo-cd/templates/server/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/argo-cd/templates/server/role.yaml
+++ b/bitnami/argo-cd/templates/server/role.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/argo-cd/templates/server/rolebinding.yaml
+++ b/bitnami/argo-cd/templates/server/rolebinding.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/argo-cd/templates/server/service-account.yaml
+++ b/bitnami/argo-cd/templates/server/service-account.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/argo-cd/templates/server/service.yaml
+++ b/bitnami/argo-cd/templates/server/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/argo-cd/templates/server/servicemonitor.yaml
+++ b/bitnami/argo-cd/templates/server/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/argo-cd/templates/server/tls-secret.yaml
+++ b/bitnami/argo-cd/templates/server/tls-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/argo-cd/templates/styles-cm.yaml
+++ b/bitnami/argo-cd/templates/styles-cm.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/argo-cd/templates/tls-certs-cm.yaml
+++ b/bitnami/argo-cd/templates/tls-certs-cm.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/argo-cd/values.yaml
+++ b/bitnami/argo-cd/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters

--- a/bitnami/argo-workflows/Chart.yaml
+++ b/bitnami/argo-workflows/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/argo-workflows/templates/_helpers.tpl
+++ b/bitnami/argo-workflows/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/argo-workflows/templates/configmap.yaml
+++ b/bitnami/argo-workflows/templates/configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/argo-workflows/templates/controller/aggregate-cluster-roles.yaml
+++ b/bitnami/argo-workflows/templates/controller/aggregate-cluster-roles.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/argo-workflows/templates/controller/clusterrolebinding.yaml
+++ b/bitnami/argo-workflows/templates/controller/clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/argo-workflows/templates/controller/controller-cluster-roles.yaml
+++ b/bitnami/argo-workflows/templates/controller/controller-cluster-roles.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/argo-workflows/templates/controller/database-secret.yaml
+++ b/bitnami/argo-workflows/templates/controller/database-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/argo-workflows/templates/controller/deployment.yaml
+++ b/bitnami/argo-workflows/templates/controller/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/argo-workflows/templates/controller/networkpolicy.yaml
+++ b/bitnami/argo-workflows/templates/controller/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/argo-workflows/templates/controller/pdb.yaml
+++ b/bitnami/argo-workflows/templates/controller/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/argo-workflows/templates/controller/service-account.yaml
+++ b/bitnami/argo-workflows/templates/controller/service-account.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/argo-workflows/templates/controller/service.yaml
+++ b/bitnami/argo-workflows/templates/controller/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/argo-workflows/templates/controller/servicemonitor.yaml
+++ b/bitnami/argo-workflows/templates/controller/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/argo-workflows/templates/controller/workflow-role.yaml
+++ b/bitnami/argo-workflows/templates/controller/workflow-role.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/argo-workflows/templates/controller/workflow-rolebinding.yaml
+++ b/bitnami/argo-workflows/templates/controller/workflow-rolebinding.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/argo-workflows/templates/controller/workflow-serviceaccount.yaml
+++ b/bitnami/argo-workflows/templates/controller/workflow-serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/argo-workflows/templates/extra-list.yaml
+++ b/bitnami/argo-workflows/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/argo-workflows/templates/server/cluster-role.yaml
+++ b/bitnami/argo-workflows/templates/server/cluster-role.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/argo-workflows/templates/server/clusterrolebinding.yaml
+++ b/bitnami/argo-workflows/templates/server/clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/argo-workflows/templates/server/deployment.yaml
+++ b/bitnami/argo-workflows/templates/server/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/argo-workflows/templates/server/ingress.yaml
+++ b/bitnami/argo-workflows/templates/server/ingress.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/argo-workflows/templates/server/networkpolicy.yaml
+++ b/bitnami/argo-workflows/templates/server/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/argo-workflows/templates/server/pdb.yaml
+++ b/bitnami/argo-workflows/templates/server/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/argo-workflows/templates/server/service-account.yaml
+++ b/bitnami/argo-workflows/templates/server/service-account.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/argo-workflows/templates/server/service.yaml
+++ b/bitnami/argo-workflows/templates/server/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/argo-workflows/templates/server/tls-secrets.yaml
+++ b/bitnami/argo-workflows/templates/server/tls-secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/argo-workflows/values.yaml
+++ b/bitnami/argo-workflows/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters

--- a/bitnami/aspnet-core/Chart.yaml
+++ b/bitnami/aspnet-core/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/aspnet-core/templates/_helpers.tpl
+++ b/bitnami/aspnet-core/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/aspnet-core/templates/deployment.yaml
+++ b/bitnami/aspnet-core/templates/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/aspnet-core/templates/extra-list.yaml
+++ b/bitnami/aspnet-core/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/aspnet-core/templates/health-ingress.yaml
+++ b/bitnami/aspnet-core/templates/health-ingress.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/aspnet-core/templates/hpa.yaml
+++ b/bitnami/aspnet-core/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/aspnet-core/templates/ingress.yaml
+++ b/bitnami/aspnet-core/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/aspnet-core/templates/networkpolicy.yaml
+++ b/bitnami/aspnet-core/templates/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/aspnet-core/templates/pdb.yaml
+++ b/bitnami/aspnet-core/templates/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/aspnet-core/templates/serviceaccount.yaml
+++ b/bitnami/aspnet-core/templates/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/aspnet-core/templates/svc.yaml
+++ b/bitnami/aspnet-core/templates/svc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/aspnet-core/templates/tls-secret.yaml
+++ b/bitnami/aspnet-core/templates/tls-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/aspnet-core/values.yaml
+++ b/bitnami/aspnet-core/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters

--- a/bitnami/cassandra/Chart.yaml
+++ b/bitnami/cassandra/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/cassandra/templates/_helpers.tpl
+++ b/bitnami/cassandra/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/cassandra/templates/cassandra-secret.yaml
+++ b/bitnami/cassandra/templates/cassandra-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/cassandra/templates/extra-list.yaml
+++ b/bitnami/cassandra/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/cassandra/templates/headless-svc.yaml
+++ b/bitnami/cassandra/templates/headless-svc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/cassandra/templates/metrics-configmap.yaml
+++ b/bitnami/cassandra/templates/metrics-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/cassandra/templates/networkpolicy.yaml
+++ b/bitnami/cassandra/templates/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/cassandra/templates/pdb.yaml
+++ b/bitnami/cassandra/templates/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/cassandra/templates/service.yaml
+++ b/bitnami/cassandra/templates/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/cassandra/templates/serviceaccount.yaml
+++ b/bitnami/cassandra/templates/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/cassandra/templates/servicemonitor.yaml
+++ b/bitnami/cassandra/templates/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/cassandra/templates/statefulset.yaml
+++ b/bitnami/cassandra/templates/statefulset.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/cassandra/templates/tls-secret.yaml
+++ b/bitnami/cassandra/templates/tls-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/cassandra/values.yaml
+++ b/bitnami/cassandra/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters

--- a/bitnami/cert-manager/Chart.yaml
+++ b/bitnami/cert-manager/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/cert-manager/templates/_helpers.tpl
+++ b/bitnami/cert-manager/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/cert-manager/templates/cainjector/deployment.yaml
+++ b/bitnami/cert-manager/templates/cainjector/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/cert-manager/templates/cainjector/networkpolicy.yaml
+++ b/bitnami/cert-manager/templates/cainjector/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/cert-manager/templates/cainjector/rbac.yaml
+++ b/bitnami/cert-manager/templates/cainjector/rbac.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/cert-manager/templates/cainjector/serviceaccount.yaml
+++ b/bitnami/cert-manager/templates/cainjector/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/cert-manager/templates/controller/deployment.yaml
+++ b/bitnami/cert-manager/templates/controller/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/cert-manager/templates/controller/networkpolicy.yaml
+++ b/bitnami/cert-manager/templates/controller/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/cert-manager/templates/controller/rbac.yaml
+++ b/bitnami/cert-manager/templates/controller/rbac.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/cert-manager/templates/controller/service.yaml
+++ b/bitnami/cert-manager/templates/controller/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/cert-manager/templates/controller/serviceaccount.yaml
+++ b/bitnami/cert-manager/templates/controller/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/cert-manager/templates/controller/servicemonitor.yaml
+++ b/bitnami/cert-manager/templates/controller/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/cert-manager/templates/extra-list.yaml
+++ b/bitnami/cert-manager/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/cert-manager/templates/webhook/deployment.yaml
+++ b/bitnami/cert-manager/templates/webhook/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/cert-manager/templates/webhook/mutating-webhook.yaml
+++ b/bitnami/cert-manager/templates/webhook/mutating-webhook.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/cert-manager/templates/webhook/networkpolicy.yaml
+++ b/bitnami/cert-manager/templates/webhook/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/cert-manager/templates/webhook/rbac.yaml
+++ b/bitnami/cert-manager/templates/webhook/rbac.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/cert-manager/templates/webhook/service.yaml
+++ b/bitnami/cert-manager/templates/webhook/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/cert-manager/templates/webhook/serviceaccount.yaml
+++ b/bitnami/cert-manager/templates/webhook/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/cert-manager/templates/webhook/validating-webhook.yaml
+++ b/bitnami/cert-manager/templates/webhook/validating-webhook.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/cert-manager/values.yaml
+++ b/bitnami/cert-manager/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## Global Docker image parameters

--- a/bitnami/clickhouse/Chart.yaml
+++ b/bitnami/clickhouse/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/clickhouse/templates/_helpers.tpl
+++ b/bitnami/clickhouse/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/clickhouse/templates/configmap-extra.yaml
+++ b/bitnami/clickhouse/templates/configmap-extra.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/clickhouse/templates/configmap-users-extra.yaml
+++ b/bitnami/clickhouse/templates/configmap-users-extra.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/clickhouse/templates/configmap.yaml
+++ b/bitnami/clickhouse/templates/configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/clickhouse/templates/extra-list.yaml
+++ b/bitnami/clickhouse/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/clickhouse/templates/ingress-tls-secrets.yaml
+++ b/bitnami/clickhouse/templates/ingress-tls-secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/clickhouse/templates/ingress.yaml
+++ b/bitnami/clickhouse/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/clickhouse/templates/init-scripts-secret.yaml
+++ b/bitnami/clickhouse/templates/init-scripts-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/clickhouse/templates/networkpolicy.yaml
+++ b/bitnami/clickhouse/templates/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/clickhouse/templates/prometheusrule.yaml
+++ b/bitnami/clickhouse/templates/prometheusrule.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/clickhouse/templates/scripts-configmap.yaml
+++ b/bitnami/clickhouse/templates/scripts-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/clickhouse/templates/secret.yaml
+++ b/bitnami/clickhouse/templates/secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/clickhouse/templates/service-account.yaml
+++ b/bitnami/clickhouse/templates/service-account.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/clickhouse/templates/service-external-access.yaml
+++ b/bitnami/clickhouse/templates/service-external-access.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/clickhouse/templates/service-headless.yaml
+++ b/bitnami/clickhouse/templates/service-headless.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/clickhouse/templates/service.yaml
+++ b/bitnami/clickhouse/templates/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/clickhouse/templates/servicemonitor.yaml
+++ b/bitnami/clickhouse/templates/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/clickhouse/templates/start-scripts-secret.yaml
+++ b/bitnami/clickhouse/templates/start-scripts-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/clickhouse/templates/statefulset.yaml
+++ b/bitnami/clickhouse/templates/statefulset.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/clickhouse/templates/tls-secret.yaml
+++ b/bitnami/clickhouse/templates/tls-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/clickhouse/values.yaml
+++ b/bitnami/clickhouse/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters

--- a/bitnami/common/Chart.yaml
+++ b/bitnami/common/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/common/templates/_affinities.tpl
+++ b/bitnami/common/templates/_affinities.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/common/templates/_capabilities.tpl
+++ b/bitnami/common/templates/_capabilities.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/common/templates/_compatibility.tpl
+++ b/bitnami/common/templates/_compatibility.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/common/templates/_errors.tpl
+++ b/bitnami/common/templates/_errors.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/common/templates/_images.tpl
+++ b/bitnami/common/templates/_images.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/common/templates/_ingress.tpl
+++ b/bitnami/common/templates/_ingress.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/common/templates/_labels.tpl
+++ b/bitnami/common/templates/_labels.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/common/templates/_names.tpl
+++ b/bitnami/common/templates/_names.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/common/templates/_resources.tpl
+++ b/bitnami/common/templates/_resources.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/common/templates/_secrets.tpl
+++ b/bitnami/common/templates/_secrets.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/common/templates/_storage.tpl
+++ b/bitnami/common/templates/_storage.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/common/templates/_tplvalues.tpl
+++ b/bitnami/common/templates/_tplvalues.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/common/templates/_utils.tpl
+++ b/bitnami/common/templates/_utils.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/common/templates/_warnings.tpl
+++ b/bitnami/common/templates/_warnings.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/common/templates/validations/_cassandra.tpl
+++ b/bitnami/common/templates/validations/_cassandra.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/common/templates/validations/_mariadb.tpl
+++ b/bitnami/common/templates/validations/_mariadb.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/common/templates/validations/_mongodb.tpl
+++ b/bitnami/common/templates/validations/_mongodb.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/common/templates/validations/_mysql.tpl
+++ b/bitnami/common/templates/validations/_mysql.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/common/templates/validations/_postgresql.tpl
+++ b/bitnami/common/templates/validations/_postgresql.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/common/templates/validations/_redis.tpl
+++ b/bitnami/common/templates/validations/_redis.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/common/templates/validations/_validations.tpl
+++ b/bitnami/common/templates/validations/_validations.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/common/values.yaml
+++ b/bitnami/common/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## bitnami/common

--- a/bitnami/concourse/Chart.yaml
+++ b/bitnami/concourse/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/concourse/templates/_helpers.tpl
+++ b/bitnami/concourse/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/concourse/templates/config/secret-external-db.yaml
+++ b/bitnami/concourse/templates/config/secret-external-db.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/concourse/templates/extra-list.yaml
+++ b/bitnami/concourse/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/concourse/templates/web/configmap.yaml
+++ b/bitnami/concourse/templates/web/configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/concourse/templates/web/deployment.yaml
+++ b/bitnami/concourse/templates/web/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/concourse/templates/web/gateway-service.yaml
+++ b/bitnami/concourse/templates/web/gateway-service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/concourse/templates/web/ingress.yaml
+++ b/bitnami/concourse/templates/web/ingress.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/concourse/templates/web/networkpolicy.yaml
+++ b/bitnami/concourse/templates/web/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/concourse/templates/web/podsecuritypolicy.yaml
+++ b/bitnami/concourse/templates/web/podsecuritypolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/concourse/templates/web/role.yaml
+++ b/bitnami/concourse/templates/web/role.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/concourse/templates/web/rolebinding.yaml
+++ b/bitnami/concourse/templates/web/rolebinding.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/concourse/templates/web/secret.yaml
+++ b/bitnami/concourse/templates/web/secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/concourse/templates/web/service-account.yaml
+++ b/bitnami/concourse/templates/web/service-account.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/concourse/templates/web/service.yaml
+++ b/bitnami/concourse/templates/web/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/concourse/templates/web/tls-secrets.yaml
+++ b/bitnami/concourse/templates/web/tls-secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/concourse/templates/worker/deployment.yaml
+++ b/bitnami/concourse/templates/worker/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/concourse/templates/worker/horizontalpodautoscaler.yaml
+++ b/bitnami/concourse/templates/worker/horizontalpodautoscaler.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/concourse/templates/worker/networkpolicy.yaml
+++ b/bitnami/concourse/templates/worker/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/concourse/templates/worker/poddisruptionbudget.yaml
+++ b/bitnami/concourse/templates/worker/poddisruptionbudget.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/concourse/templates/worker/podsecuritypolicy.yaml
+++ b/bitnami/concourse/templates/worker/podsecuritypolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/concourse/templates/worker/role.yaml
+++ b/bitnami/concourse/templates/worker/role.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/concourse/templates/worker/rolebinding.yaml
+++ b/bitnami/concourse/templates/worker/rolebinding.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/concourse/templates/worker/secret.yaml
+++ b/bitnami/concourse/templates/worker/secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/concourse/templates/worker/service-account.yaml
+++ b/bitnami/concourse/templates/worker/service-account.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/concourse/templates/worker/service.yaml
+++ b/bitnami/concourse/templates/worker/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/concourse/templates/worker/statefulset.yaml
+++ b/bitnami/concourse/templates/worker/statefulset.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/concourse/values.yaml
+++ b/bitnami/concourse/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters

--- a/bitnami/consul/Chart.yaml
+++ b/bitnami/consul/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/consul/templates/_helpers.tpl
+++ b/bitnami/consul/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/consul/templates/configmap.yaml
+++ b/bitnami/consul/templates/configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/consul/templates/consul-headless-service.yaml
+++ b/bitnami/consul/templates/consul-headless-service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/consul/templates/extra-list.yaml
+++ b/bitnami/consul/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/consul/templates/gossip-secret.yaml
+++ b/bitnami/consul/templates/gossip-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/consul/templates/ingress.yaml
+++ b/bitnami/consul/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/consul/templates/metrics-svc.yaml
+++ b/bitnami/consul/templates/metrics-svc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/consul/templates/networkpolicy.yaml
+++ b/bitnami/consul/templates/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/consul/templates/pdb.yaml
+++ b/bitnami/consul/templates/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/consul/templates/service.yaml
+++ b/bitnami/consul/templates/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/consul/templates/serviceaccount.yaml
+++ b/bitnami/consul/templates/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/consul/templates/servicemonitor.yaml
+++ b/bitnami/consul/templates/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/consul/templates/statefulset.yaml
+++ b/bitnami/consul/templates/statefulset.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/consul/templates/tls-secrets.yaml
+++ b/bitnami/consul/templates/tls-secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/consul/values.yaml
+++ b/bitnami/consul/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters

--- a/bitnami/contour/Chart.yaml
+++ b/bitnami/contour/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/contour/templates/_helpers.tpl
+++ b/bitnami/contour/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/contour/templates/certgen/job.yaml
+++ b/bitnami/contour/templates/certgen/job.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/contour/templates/certgen/networkpolicy.yaml
+++ b/bitnami/contour/templates/certgen/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/contour/templates/certgen/rbac.yaml
+++ b/bitnami/contour/templates/certgen/rbac.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/contour/templates/certgen/serviceaccount.yaml
+++ b/bitnami/contour/templates/certgen/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/contour/templates/contour/configmap.yaml
+++ b/bitnami/contour/templates/contour/configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/contour/templates/contour/deployment.yaml
+++ b/bitnami/contour/templates/contour/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/contour/templates/contour/ingressclass.yaml
+++ b/bitnami/contour/templates/contour/ingressclass.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/contour/templates/contour/networkpolicy.yaml
+++ b/bitnami/contour/templates/contour/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/contour/templates/contour/rbac.yaml
+++ b/bitnami/contour/templates/contour/rbac.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/contour/templates/contour/service.yaml
+++ b/bitnami/contour/templates/contour/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/contour/templates/contour/serviceaccount.yaml
+++ b/bitnami/contour/templates/contour/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/contour/templates/contour/servicemonitor.yaml
+++ b/bitnami/contour/templates/contour/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/contour/templates/default-backend/deployment.yaml
+++ b/bitnami/contour/templates/default-backend/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/contour/templates/default-backend/ingress.yaml
+++ b/bitnami/contour/templates/default-backend/ingress.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/contour/templates/default-backend/networkpolicy.yaml
+++ b/bitnami/contour/templates/default-backend/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/contour/templates/default-backend/poddisruptionbudget.yaml
+++ b/bitnami/contour/templates/default-backend/poddisruptionbudget.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/contour/templates/default-backend/service.yaml
+++ b/bitnami/contour/templates/default-backend/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/contour/templates/default-backend/tls-secrets.yaml
+++ b/bitnami/contour/templates/default-backend/tls-secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/contour/templates/envoy/daemonset.yaml
+++ b/bitnami/contour/templates/envoy/daemonset.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/contour/templates/envoy/deployment.yaml
+++ b/bitnami/contour/templates/envoy/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/contour/templates/envoy/extra-list.yaml
+++ b/bitnami/contour/templates/envoy/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/contour/templates/envoy/hpa.yaml
+++ b/bitnami/contour/templates/envoy/hpa.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/contour/templates/envoy/networkpolicy.yaml
+++ b/bitnami/contour/templates/envoy/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/contour/templates/envoy/prometheusrule.yaml
+++ b/bitnami/contour/templates/envoy/prometheusrule.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/contour/templates/envoy/service.yaml
+++ b/bitnami/contour/templates/envoy/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/contour/templates/envoy/serviceaccount.yaml
+++ b/bitnami/contour/templates/envoy/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/contour/templates/envoy/servicemonitor.yaml
+++ b/bitnami/contour/templates/envoy/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/contour/templates/service_helpers.yaml
+++ b/bitnami/contour/templates/service_helpers.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/contour/values.yaml
+++ b/bitnami/contour/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters

--- a/bitnami/deepspeed/Chart.yaml
+++ b/bitnami/deepspeed/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/deepspeed/templates/_helpers.tpl
+++ b/bitnami/deepspeed/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/deepspeed/templates/client/client-dep-job.yaml
+++ b/bitnami/deepspeed/templates/client/client-dep-job.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/deepspeed/templates/client/hostfile-configmap.yaml
+++ b/bitnami/deepspeed/templates/client/hostfile-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/deepspeed/templates/client/networkpolicy.yaml
+++ b/bitnami/deepspeed/templates/client/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/deepspeed/templates/client/pvc.yaml
+++ b/bitnami/deepspeed/templates/client/pvc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/deepspeed/templates/client/service-account.yaml
+++ b/bitnami/deepspeed/templates/client/service-account.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/deepspeed/templates/client/source-configmap.yaml
+++ b/bitnami/deepspeed/templates/client/source-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/deepspeed/templates/client/ssh-client-configmap.yaml
+++ b/bitnami/deepspeed/templates/client/ssh-client-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/deepspeed/templates/extra-list.yaml
+++ b/bitnami/deepspeed/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/deepspeed/templates/ssh-keys-secret.yaml
+++ b/bitnami/deepspeed/templates/ssh-keys-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/deepspeed/templates/worker/networkpolicy.yaml
+++ b/bitnami/deepspeed/templates/worker/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/deepspeed/templates/worker/service-account.yaml
+++ b/bitnami/deepspeed/templates/worker/service-account.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/deepspeed/templates/worker/ssh-server-configmap.yaml
+++ b/bitnami/deepspeed/templates/worker/ssh-server-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/deepspeed/templates/worker/worker-headless-svc.yaml
+++ b/bitnami/deepspeed/templates/worker/worker-headless-svc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/deepspeed/templates/worker/worker-service.yaml
+++ b/bitnami/deepspeed/templates/worker/worker-service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/deepspeed/templates/worker/worker-statefulset.yaml
+++ b/bitnami/deepspeed/templates/worker/worker-statefulset.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/deepspeed/values.yaml
+++ b/bitnami/deepspeed/values.yaml
@@ -1,4 +1,4 @@
-## Copyright VMware, Inc.
+## Copyright Broadcom, Inc. All Rights Reserved.
 ## SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters

--- a/bitnami/discourse/Chart.yaml
+++ b/bitnami/discourse/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/discourse/templates/_helpers.tpl
+++ b/bitnami/discourse/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/discourse/templates/configmaps.yaml
+++ b/bitnami/discourse/templates/configmaps.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/discourse/templates/deployment.yaml
+++ b/bitnami/discourse/templates/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/discourse/templates/extra-list.yaml
+++ b/bitnami/discourse/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/discourse/templates/ingress.yaml
+++ b/bitnami/discourse/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/discourse/templates/networkpolicy.yaml
+++ b/bitnami/discourse/templates/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/discourse/templates/pvc.yaml
+++ b/bitnami/discourse/templates/pvc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/discourse/templates/secrets-database.yaml
+++ b/bitnami/discourse/templates/secrets-database.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/discourse/templates/secrets-discourse.yaml
+++ b/bitnami/discourse/templates/secrets-discourse.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/discourse/templates/secrets-redis.yaml
+++ b/bitnami/discourse/templates/secrets-redis.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/discourse/templates/service.yaml
+++ b/bitnami/discourse/templates/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/discourse/templates/serviceaccount.yaml
+++ b/bitnami/discourse/templates/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/discourse/templates/tls-secrets.yaml
+++ b/bitnami/discourse/templates/tls-secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/discourse/values.yaml
+++ b/bitnami/discourse/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters

--- a/bitnami/dokuwiki/Chart.yaml
+++ b/bitnami/dokuwiki/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/dokuwiki/templates/_helpers.tpl
+++ b/bitnami/dokuwiki/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/dokuwiki/templates/deployment.yaml
+++ b/bitnami/dokuwiki/templates/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/dokuwiki/templates/dokuwiki-pvc.yaml
+++ b/bitnami/dokuwiki/templates/dokuwiki-pvc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/dokuwiki/templates/extra-list.yaml
+++ b/bitnami/dokuwiki/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/dokuwiki/templates/ingress.yaml
+++ b/bitnami/dokuwiki/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/dokuwiki/templates/networkpolicy.yaml
+++ b/bitnami/dokuwiki/templates/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/dokuwiki/templates/postinit-configmap.yaml
+++ b/bitnami/dokuwiki/templates/postinit-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/dokuwiki/templates/secrets.yaml
+++ b/bitnami/dokuwiki/templates/secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/dokuwiki/templates/serviceaccount.yaml
+++ b/bitnami/dokuwiki/templates/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/dokuwiki/templates/svc.yaml
+++ b/bitnami/dokuwiki/templates/svc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/dokuwiki/templates/tls-secrets.yaml
+++ b/bitnami/dokuwiki/templates/tls-secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/dokuwiki/values.yaml
+++ b/bitnami/dokuwiki/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters

--- a/bitnami/drupal/Chart.yaml
+++ b/bitnami/drupal/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/drupal/templates/_helpers.tpl
+++ b/bitnami/drupal/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/drupal/templates/deployment.yaml
+++ b/bitnami/drupal/templates/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/drupal/templates/externaldb-secrets.yaml
+++ b/bitnami/drupal/templates/externaldb-secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/drupal/templates/extra-list.yaml
+++ b/bitnami/drupal/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/drupal/templates/ingress.yaml
+++ b/bitnami/drupal/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/drupal/templates/metrics-svc.yaml
+++ b/bitnami/drupal/templates/metrics-svc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/drupal/templates/networkpolicy.yaml
+++ b/bitnami/drupal/templates/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/drupal/templates/prometheusrule.yaml
+++ b/bitnami/drupal/templates/prometheusrule.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/drupal/templates/pv.yaml
+++ b/bitnami/drupal/templates/pv.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/drupal/templates/pvc.yaml
+++ b/bitnami/drupal/templates/pvc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/drupal/templates/secrets.yaml
+++ b/bitnami/drupal/templates/secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/drupal/templates/serviceaccount.yaml
+++ b/bitnami/drupal/templates/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/drupal/templates/servicemonitor.yaml
+++ b/bitnami/drupal/templates/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/drupal/templates/svc.yaml
+++ b/bitnami/drupal/templates/svc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/drupal/templates/tls-secrets.yaml
+++ b/bitnami/drupal/templates/tls-secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/drupal/values.yaml
+++ b/bitnami/drupal/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters

--- a/bitnami/ejbca/Chart.yaml
+++ b/bitnami/ejbca/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/ejbca/templates/_helpers.tpl
+++ b/bitnami/ejbca/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/ejbca/templates/deployment.yaml
+++ b/bitnami/ejbca/templates/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/ejbca/templates/externaldb-secrets.yaml
+++ b/bitnami/ejbca/templates/externaldb-secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/ejbca/templates/extra-list.yaml
+++ b/bitnami/ejbca/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/ejbca/templates/ingress.yaml
+++ b/bitnami/ejbca/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/ejbca/templates/networkpolicy.yaml
+++ b/bitnami/ejbca/templates/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/ejbca/templates/pvc.yaml
+++ b/bitnami/ejbca/templates/pvc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/ejbca/templates/secrets.yaml
+++ b/bitnami/ejbca/templates/secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/ejbca/templates/serviceaccount.yaml
+++ b/bitnami/ejbca/templates/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/ejbca/templates/svc.yaml
+++ b/bitnami/ejbca/templates/svc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/ejbca/values.yaml
+++ b/bitnami/ejbca/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters

--- a/bitnami/elasticsearch/Chart.yaml
+++ b/bitnami/elasticsearch/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/elasticsearch/templates/_helpers.tpl
+++ b/bitnami/elasticsearch/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/elasticsearch/templates/configmap.yaml
+++ b/bitnami/elasticsearch/templates/configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/elasticsearch/templates/coordinating/hpa.yaml
+++ b/bitnami/elasticsearch/templates/coordinating/hpa.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/elasticsearch/templates/coordinating/networkpolicy.yaml
+++ b/bitnami/elasticsearch/templates/coordinating/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/elasticsearch/templates/coordinating/pdb.yaml
+++ b/bitnami/elasticsearch/templates/coordinating/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/elasticsearch/templates/coordinating/serviceaccount.yaml
+++ b/bitnami/elasticsearch/templates/coordinating/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/elasticsearch/templates/coordinating/statefulset.yaml
+++ b/bitnami/elasticsearch/templates/coordinating/statefulset.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/elasticsearch/templates/coordinating/svc-headless.yaml
+++ b/bitnami/elasticsearch/templates/coordinating/svc-headless.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/elasticsearch/templates/data/hpa.yaml
+++ b/bitnami/elasticsearch/templates/data/hpa.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/elasticsearch/templates/data/networkpolicy.yaml
+++ b/bitnami/elasticsearch/templates/data/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/elasticsearch/templates/data/pdb.yaml
+++ b/bitnami/elasticsearch/templates/data/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/elasticsearch/templates/data/serviceaccount.yaml
+++ b/bitnami/elasticsearch/templates/data/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/elasticsearch/templates/data/statefulset.yaml
+++ b/bitnami/elasticsearch/templates/data/statefulset.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/elasticsearch/templates/data/svc-headless.yaml
+++ b/bitnami/elasticsearch/templates/data/svc-headless.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/elasticsearch/templates/extra-list.yaml
+++ b/bitnami/elasticsearch/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/elasticsearch/templates/ingest/hpa.yaml
+++ b/bitnami/elasticsearch/templates/ingest/hpa.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/elasticsearch/templates/ingest/ingress.yaml
+++ b/bitnami/elasticsearch/templates/ingest/ingress.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/elasticsearch/templates/ingest/networkpolicy.yaml
+++ b/bitnami/elasticsearch/templates/ingest/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/elasticsearch/templates/ingest/pdb.yaml
+++ b/bitnami/elasticsearch/templates/ingest/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/elasticsearch/templates/ingest/service.yaml
+++ b/bitnami/elasticsearch/templates/ingest/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/elasticsearch/templates/ingest/serviceaccount.yaml
+++ b/bitnami/elasticsearch/templates/ingest/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/elasticsearch/templates/ingest/statefulset.yaml
+++ b/bitnami/elasticsearch/templates/ingest/statefulset.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/elasticsearch/templates/ingest/svc-headless.yaml
+++ b/bitnami/elasticsearch/templates/ingest/svc-headless.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/elasticsearch/templates/ingress-tls-secrets.yaml
+++ b/bitnami/elasticsearch/templates/ingress-tls-secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/elasticsearch/templates/ingress.yaml
+++ b/bitnami/elasticsearch/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/elasticsearch/templates/initialization-configmap.yaml
+++ b/bitnami/elasticsearch/templates/initialization-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/elasticsearch/templates/master/hpa.yaml
+++ b/bitnami/elasticsearch/templates/master/hpa.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/elasticsearch/templates/master/networkpolicy.yaml
+++ b/bitnami/elasticsearch/templates/master/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/elasticsearch/templates/master/pdb.yaml
+++ b/bitnami/elasticsearch/templates/master/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/elasticsearch/templates/master/serviceaccount.yaml
+++ b/bitnami/elasticsearch/templates/master/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/elasticsearch/templates/master/statefulset.yaml
+++ b/bitnami/elasticsearch/templates/master/statefulset.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/elasticsearch/templates/master/svc-headless.yaml
+++ b/bitnami/elasticsearch/templates/master/svc-headless.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/elasticsearch/templates/metrics/deployment.yaml
+++ b/bitnami/elasticsearch/templates/metrics/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/elasticsearch/templates/metrics/networkpolicy.yaml
+++ b/bitnami/elasticsearch/templates/metrics/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/elasticsearch/templates/metrics/prometheusrule.yaml
+++ b/bitnami/elasticsearch/templates/metrics/prometheusrule.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/elasticsearch/templates/metrics/service.yaml
+++ b/bitnami/elasticsearch/templates/metrics/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/elasticsearch/templates/metrics/serviceaccount.yaml
+++ b/bitnami/elasticsearch/templates/metrics/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/elasticsearch/templates/metrics/servicemonitor.yaml
+++ b/bitnami/elasticsearch/templates/metrics/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/elasticsearch/templates/secrets.yaml
+++ b/bitnami/elasticsearch/templates/secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/elasticsearch/templates/service.yaml
+++ b/bitnami/elasticsearch/templates/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/elasticsearch/templates/tls-secret.yaml
+++ b/bitnami/elasticsearch/templates/tls-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/elasticsearch/values.yaml
+++ b/bitnami/elasticsearch/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters

--- a/bitnami/etcd/Chart.yaml
+++ b/bitnami/etcd/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/etcd/templates/_helpers.tpl
+++ b/bitnami/etcd/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/etcd/templates/configmap.yaml
+++ b/bitnami/etcd/templates/configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/etcd/templates/cronjob.yaml
+++ b/bitnami/etcd/templates/cronjob.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/etcd/templates/extra-list.yaml
+++ b/bitnami/etcd/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/etcd/templates/networkpolicy.yaml
+++ b/bitnami/etcd/templates/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/etcd/templates/pdb.yaml
+++ b/bitnami/etcd/templates/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/etcd/templates/podmonitor.yaml
+++ b/bitnami/etcd/templates/podmonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/etcd/templates/prometheusrule.yaml
+++ b/bitnami/etcd/templates/prometheusrule.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/etcd/templates/secrets.yaml
+++ b/bitnami/etcd/templates/secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/etcd/templates/serviceaccount.yaml
+++ b/bitnami/etcd/templates/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/etcd/templates/snapshot-pvc.yaml
+++ b/bitnami/etcd/templates/snapshot-pvc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/etcd/templates/statefulset.yaml
+++ b/bitnami/etcd/templates/statefulset.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/etcd/templates/svc-headless.yaml
+++ b/bitnami/etcd/templates/svc-headless.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/etcd/templates/svc.yaml
+++ b/bitnami/etcd/templates/svc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/etcd/templates/token-secrets.yaml
+++ b/bitnami/etcd/templates/token-secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/etcd/values.yaml
+++ b/bitnami/etcd/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters

--- a/bitnami/external-dns/Chart.yaml
+++ b/bitnami/external-dns/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/external-dns/templates/_helpers.tpl
+++ b/bitnami/external-dns/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/external-dns/templates/clusterrole.yaml
+++ b/bitnami/external-dns/templates/clusterrole.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/external-dns/templates/clusterrolebinding.yaml
+++ b/bitnami/external-dns/templates/clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/external-dns/templates/configmap.yaml
+++ b/bitnami/external-dns/templates/configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/external-dns/templates/dep-ds.yaml
+++ b/bitnami/external-dns/templates/dep-ds.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/external-dns/templates/extra-list.yaml
+++ b/bitnami/external-dns/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/external-dns/templates/networkpolicy.yaml
+++ b/bitnami/external-dns/templates/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/external-dns/templates/pdb.yaml
+++ b/bitnami/external-dns/templates/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/external-dns/templates/podmonitor.yaml
+++ b/bitnami/external-dns/templates/podmonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/external-dns/templates/psp-clusterrole.yaml
+++ b/bitnami/external-dns/templates/psp-clusterrole.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/external-dns/templates/psp-clusterrolebinding.yaml
+++ b/bitnami/external-dns/templates/psp-clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/external-dns/templates/psp.yaml
+++ b/bitnami/external-dns/templates/psp.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/external-dns/templates/role.yaml
+++ b/bitnami/external-dns/templates/role.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/external-dns/templates/rolebindings.yaml
+++ b/bitnami/external-dns/templates/rolebindings.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/external-dns/templates/secret.yaml
+++ b/bitnami/external-dns/templates/secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/external-dns/templates/service.yaml
+++ b/bitnami/external-dns/templates/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/external-dns/templates/serviceaccount.yaml
+++ b/bitnami/external-dns/templates/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/external-dns/templates/servicemonitor.yaml
+++ b/bitnami/external-dns/templates/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/external-dns/templates/tls-secret.yaml
+++ b/bitnami/external-dns/templates/tls-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/external-dns/values.yaml
+++ b/bitnami/external-dns/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters

--- a/bitnami/flink/Chart.yaml
+++ b/bitnami/flink/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/flink/templates/_helpers.tpl
+++ b/bitnami/flink/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/flink/templates/extra-list.yaml
+++ b/bitnami/flink/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/flink/templates/jobmanager/deployment.yaml
+++ b/bitnami/flink/templates/jobmanager/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/flink/templates/jobmanager/networkpolicy.yaml
+++ b/bitnami/flink/templates/jobmanager/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/flink/templates/jobmanager/service.yml
+++ b/bitnami/flink/templates/jobmanager/service.yml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/flink/templates/jobmanager/serviceaccount.yaml
+++ b/bitnami/flink/templates/jobmanager/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/flink/templates/taskmanager/headless-service.yml
+++ b/bitnami/flink/templates/taskmanager/headless-service.yml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/flink/templates/taskmanager/networkpolicy.yaml
+++ b/bitnami/flink/templates/taskmanager/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/flink/templates/taskmanager/service.yml
+++ b/bitnami/flink/templates/taskmanager/service.yml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/flink/templates/taskmanager/serviceaccount.yaml
+++ b/bitnami/flink/templates/taskmanager/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/flink/templates/taskmanager/statefulset.yaml
+++ b/bitnami/flink/templates/taskmanager/statefulset.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/flink/values.yaml
+++ b/bitnami/flink/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters

--- a/bitnami/fluent-bit/Chart.yaml
+++ b/bitnami/fluent-bit/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/fluent-bit/templates/_helpers.tpl
+++ b/bitnami/fluent-bit/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/fluent-bit/templates/clusterrole.yaml
+++ b/bitnami/fluent-bit/templates/clusterrole.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/fluent-bit/templates/clusterrolebinding.yaml
+++ b/bitnami/fluent-bit/templates/clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/fluent-bit/templates/configmap.yaml
+++ b/bitnami/fluent-bit/templates/configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/fluent-bit/templates/daemonset.yaml
+++ b/bitnami/fluent-bit/templates/daemonset.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/fluent-bit/templates/deployment.yaml
+++ b/bitnami/fluent-bit/templates/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/fluent-bit/templates/extra-list.yaml
+++ b/bitnami/fluent-bit/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/fluent-bit/templates/hpa.yaml
+++ b/bitnami/fluent-bit/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/fluent-bit/templates/ingress.yaml
+++ b/bitnami/fluent-bit/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/fluent-bit/templates/networkpolicy.yaml
+++ b/bitnami/fluent-bit/templates/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/fluent-bit/templates/pdb.yaml
+++ b/bitnami/fluent-bit/templates/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/fluent-bit/templates/service-account.yaml
+++ b/bitnami/fluent-bit/templates/service-account.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/fluent-bit/templates/service.yml
+++ b/bitnami/fluent-bit/templates/service.yml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/fluent-bit/templates/servicemonitor.yaml
+++ b/bitnami/fluent-bit/templates/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/fluent-bit/templates/tls-secret.yaml
+++ b/bitnami/fluent-bit/templates/tls-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/fluent-bit/templates/vpa.yaml
+++ b/bitnami/fluent-bit/templates/vpa.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/fluent-bit/values.yaml
+++ b/bitnami/fluent-bit/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters

--- a/bitnami/fluentd/Chart.yaml
+++ b/bitnami/fluentd/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/fluentd/templates/_helpers.tpl
+++ b/bitnami/fluentd/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/fluentd/templates/aggregator-configmap.yaml
+++ b/bitnami/fluentd/templates/aggregator-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/fluentd/templates/aggregator-hpa.yaml
+++ b/bitnami/fluentd/templates/aggregator-hpa.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/fluentd/templates/aggregator-init-configmap.yaml
+++ b/bitnami/fluentd/templates/aggregator-init-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/fluentd/templates/aggregator-networkpolicy.yaml
+++ b/bitnami/fluentd/templates/aggregator-networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/fluentd/templates/aggregator-statefulset.yaml
+++ b/bitnami/fluentd/templates/aggregator-statefulset.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/fluentd/templates/aggregator-svc-headless.yaml
+++ b/bitnami/fluentd/templates/aggregator-svc-headless.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/fluentd/templates/aggregator-svc.yaml
+++ b/bitnami/fluentd/templates/aggregator-svc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/fluentd/templates/extra-list.yaml
+++ b/bitnami/fluentd/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/fluentd/templates/forwarder-clusterrole.yaml
+++ b/bitnami/fluentd/templates/forwarder-clusterrole.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/fluentd/templates/forwarder-clusterrolebinding.yaml
+++ b/bitnami/fluentd/templates/forwarder-clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/fluentd/templates/forwarder-configmap.yaml
+++ b/bitnami/fluentd/templates/forwarder-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/fluentd/templates/forwarder-daemonset.yaml
+++ b/bitnami/fluentd/templates/forwarder-daemonset.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/fluentd/templates/forwarder-init-configmap.yaml
+++ b/bitnami/fluentd/templates/forwarder-init-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/fluentd/templates/forwarder-networkpolicy.yaml
+++ b/bitnami/fluentd/templates/forwarder-networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/fluentd/templates/forwarder-psp.yaml
+++ b/bitnami/fluentd/templates/forwarder-psp.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/fluentd/templates/forwarder-svc.yaml
+++ b/bitnami/fluentd/templates/forwarder-svc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/fluentd/templates/ingress.yaml
+++ b/bitnami/fluentd/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/fluentd/templates/metrics-svc.yaml
+++ b/bitnami/fluentd/templates/metrics-svc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/fluentd/templates/serviceaccount.yaml
+++ b/bitnami/fluentd/templates/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/fluentd/templates/servicemonitor.yaml
+++ b/bitnami/fluentd/templates/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/fluentd/templates/tls-certs.yaml
+++ b/bitnami/fluentd/templates/tls-certs.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/fluentd/values.yaml
+++ b/bitnami/fluentd/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters

--- a/bitnami/flux/Chart.yaml
+++ b/bitnami/flux/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/flux/templates/_helpers.tpl
+++ b/bitnami/flux/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/flux/templates/extra-list.yaml
+++ b/bitnami/flux/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/flux/templates/helm-controller/clusterrolebinding.yaml
+++ b/bitnami/flux/templates/helm-controller/clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/flux/templates/helm-controller/clusterroles.yaml
+++ b/bitnami/flux/templates/helm-controller/clusterroles.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/flux/templates/helm-controller/deployment.yaml
+++ b/bitnami/flux/templates/helm-controller/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/flux/templates/helm-controller/networkpolicy.yaml
+++ b/bitnami/flux/templates/helm-controller/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/flux/templates/helm-controller/pdb.yaml
+++ b/bitnami/flux/templates/helm-controller/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/flux/templates/helm-controller/rolebinding.yaml
+++ b/bitnami/flux/templates/helm-controller/rolebinding.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/flux/templates/helm-controller/roles.yaml
+++ b/bitnami/flux/templates/helm-controller/roles.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/flux/templates/helm-controller/service-account.yaml
+++ b/bitnami/flux/templates/helm-controller/service-account.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/flux/templates/helm-controller/service-metrics.yaml
+++ b/bitnami/flux/templates/helm-controller/service-metrics.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/flux/templates/helm-controller/servicemonitor.yaml
+++ b/bitnami/flux/templates/helm-controller/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/flux/templates/image-automation-controller/clusterrolebinding.yaml
+++ b/bitnami/flux/templates/image-automation-controller/clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/flux/templates/image-automation-controller/clusterroles.yaml
+++ b/bitnami/flux/templates/image-automation-controller/clusterroles.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/flux/templates/image-automation-controller/deployment.yaml
+++ b/bitnami/flux/templates/image-automation-controller/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/flux/templates/image-automation-controller/networkpolicy.yaml
+++ b/bitnami/flux/templates/image-automation-controller/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/flux/templates/image-automation-controller/pdb.yaml
+++ b/bitnami/flux/templates/image-automation-controller/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/flux/templates/image-automation-controller/rolebinding.yaml
+++ b/bitnami/flux/templates/image-automation-controller/rolebinding.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/flux/templates/image-automation-controller/roles.yaml
+++ b/bitnami/flux/templates/image-automation-controller/roles.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/flux/templates/image-automation-controller/service-account.yaml
+++ b/bitnami/flux/templates/image-automation-controller/service-account.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/flux/templates/image-automation-controller/service-metrics.yaml
+++ b/bitnami/flux/templates/image-automation-controller/service-metrics.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/flux/templates/image-automation-controller/servicemonitor.yaml
+++ b/bitnami/flux/templates/image-automation-controller/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/flux/templates/image-reflector-controller/clusterrolebinding.yaml
+++ b/bitnami/flux/templates/image-reflector-controller/clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/flux/templates/image-reflector-controller/clusterroles.yaml
+++ b/bitnami/flux/templates/image-reflector-controller/clusterroles.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/flux/templates/image-reflector-controller/deployment.yaml
+++ b/bitnami/flux/templates/image-reflector-controller/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/flux/templates/image-reflector-controller/networkpolicy.yaml
+++ b/bitnami/flux/templates/image-reflector-controller/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/flux/templates/image-reflector-controller/pdb.yaml
+++ b/bitnami/flux/templates/image-reflector-controller/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/flux/templates/image-reflector-controller/pvc.yaml
+++ b/bitnami/flux/templates/image-reflector-controller/pvc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/flux/templates/image-reflector-controller/rolebinding.yaml
+++ b/bitnami/flux/templates/image-reflector-controller/rolebinding.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/flux/templates/image-reflector-controller/roles.yaml
+++ b/bitnami/flux/templates/image-reflector-controller/roles.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/flux/templates/image-reflector-controller/service-account.yaml
+++ b/bitnami/flux/templates/image-reflector-controller/service-account.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/flux/templates/image-reflector-controller/service-metrics.yaml
+++ b/bitnami/flux/templates/image-reflector-controller/service-metrics.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/flux/templates/image-reflector-controller/servicemonitor.yaml
+++ b/bitnami/flux/templates/image-reflector-controller/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/flux/templates/kustomize-controller/clusterrolebinding.yaml
+++ b/bitnami/flux/templates/kustomize-controller/clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/flux/templates/kustomize-controller/clusterroles.yaml
+++ b/bitnami/flux/templates/kustomize-controller/clusterroles.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/flux/templates/kustomize-controller/deployment.yaml
+++ b/bitnami/flux/templates/kustomize-controller/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/flux/templates/kustomize-controller/networkpolicy.yaml
+++ b/bitnami/flux/templates/kustomize-controller/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/flux/templates/kustomize-controller/pdb.yaml
+++ b/bitnami/flux/templates/kustomize-controller/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/flux/templates/kustomize-controller/rolebinding.yaml
+++ b/bitnami/flux/templates/kustomize-controller/rolebinding.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/flux/templates/kustomize-controller/roles.yaml
+++ b/bitnami/flux/templates/kustomize-controller/roles.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/flux/templates/kustomize-controller/service-account.yaml
+++ b/bitnami/flux/templates/kustomize-controller/service-account.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/flux/templates/kustomize-controller/service-metrics.yaml
+++ b/bitnami/flux/templates/kustomize-controller/service-metrics.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/flux/templates/kustomize-controller/servicemonitor.yaml
+++ b/bitnami/flux/templates/kustomize-controller/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/flux/templates/notification-controller/clusterrolebinding.yaml
+++ b/bitnami/flux/templates/notification-controller/clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/flux/templates/notification-controller/clusterroles.yaml
+++ b/bitnami/flux/templates/notification-controller/clusterroles.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/flux/templates/notification-controller/deployment.yaml
+++ b/bitnami/flux/templates/notification-controller/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/flux/templates/notification-controller/networkpolicy.yaml
+++ b/bitnami/flux/templates/notification-controller/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/flux/templates/notification-controller/pdb.yaml
+++ b/bitnami/flux/templates/notification-controller/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/flux/templates/notification-controller/rolebinding.yaml
+++ b/bitnami/flux/templates/notification-controller/rolebinding.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/flux/templates/notification-controller/roles.yaml
+++ b/bitnami/flux/templates/notification-controller/roles.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/flux/templates/notification-controller/service-account.yaml
+++ b/bitnami/flux/templates/notification-controller/service-account.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/flux/templates/notification-controller/service-metrics.yaml
+++ b/bitnami/flux/templates/notification-controller/service-metrics.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/flux/templates/notification-controller/service-receiver.yaml
+++ b/bitnami/flux/templates/notification-controller/service-receiver.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/flux/templates/notification-controller/service-webhook.yaml
+++ b/bitnami/flux/templates/notification-controller/service-webhook.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/flux/templates/notification-controller/servicemonitor.yaml
+++ b/bitnami/flux/templates/notification-controller/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/flux/templates/source-controller/clusterrolebinding.yaml
+++ b/bitnami/flux/templates/source-controller/clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/flux/templates/source-controller/clusterroles.yaml
+++ b/bitnami/flux/templates/source-controller/clusterroles.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/flux/templates/source-controller/deployment.yaml
+++ b/bitnami/flux/templates/source-controller/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/flux/templates/source-controller/networkpolicy.yaml
+++ b/bitnami/flux/templates/source-controller/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/flux/templates/source-controller/pdb.yaml
+++ b/bitnami/flux/templates/source-controller/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/flux/templates/source-controller/pvc.yaml
+++ b/bitnami/flux/templates/source-controller/pvc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/flux/templates/source-controller/rolebinding.yaml
+++ b/bitnami/flux/templates/source-controller/rolebinding.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/flux/templates/source-controller/roles.yaml
+++ b/bitnami/flux/templates/source-controller/roles.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/flux/templates/source-controller/service-account.yaml
+++ b/bitnami/flux/templates/source-controller/service-account.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/flux/templates/source-controller/service-metrics.yaml
+++ b/bitnami/flux/templates/source-controller/service-metrics.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/flux/templates/source-controller/service.yaml
+++ b/bitnami/flux/templates/source-controller/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/flux/templates/source-controller/servicemonitor.yaml
+++ b/bitnami/flux/templates/source-controller/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/flux/values.yaml
+++ b/bitnami/flux/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters

--- a/bitnami/ghost/Chart.yaml
+++ b/bitnami/ghost/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/ghost/templates/_helpers.tpl
+++ b/bitnami/ghost/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/ghost/templates/deployment.yaml
+++ b/bitnami/ghost/templates/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/ghost/templates/external-db-secrets.yaml
+++ b/bitnami/ghost/templates/external-db-secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/ghost/templates/extra-list.yaml
+++ b/bitnami/ghost/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/ghost/templates/ingress.yaml
+++ b/bitnami/ghost/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/ghost/templates/networkpolicy.yaml
+++ b/bitnami/ghost/templates/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/ghost/templates/pvc.yaml
+++ b/bitnami/ghost/templates/pvc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/ghost/templates/secrets.yaml
+++ b/bitnami/ghost/templates/secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/ghost/templates/service-account.yaml
+++ b/bitnami/ghost/templates/service-account.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/ghost/templates/svc.yaml
+++ b/bitnami/ghost/templates/svc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/ghost/templates/tls-secrets.yaml
+++ b/bitnami/ghost/templates/tls-secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/ghost/values.yaml
+++ b/bitnami/ghost/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters

--- a/bitnami/gitea/Chart.yaml
+++ b/bitnami/gitea/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/gitea/templates/_helpers.tpl
+++ b/bitnami/gitea/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/gitea/templates/deployment.yaml
+++ b/bitnami/gitea/templates/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/gitea/templates/externaldb-secrets.yaml
+++ b/bitnami/gitea/templates/externaldb-secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/gitea/templates/extra-list.yaml
+++ b/bitnami/gitea/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/gitea/templates/ingress.yaml
+++ b/bitnami/gitea/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/gitea/templates/networkpolicy.yaml
+++ b/bitnami/gitea/templates/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/gitea/templates/pv.yaml
+++ b/bitnami/gitea/templates/pv.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/gitea/templates/pvc.yaml
+++ b/bitnami/gitea/templates/pvc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/gitea/templates/secrets.yaml
+++ b/bitnami/gitea/templates/secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/gitea/templates/service-account.yaml
+++ b/bitnami/gitea/templates/service-account.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/gitea/templates/svc.yaml
+++ b/bitnami/gitea/templates/svc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/gitea/templates/tls-secrets.yaml
+++ b/bitnami/gitea/templates/tls-secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/gitea/values.yaml
+++ b/bitnami/gitea/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters

--- a/bitnami/grafana-loki/Chart.yaml
+++ b/bitnami/grafana-loki/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/grafana-loki/templates/_helpers.tpl
+++ b/bitnami/grafana-loki/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-loki/templates/compactor/deployment.yaml
+++ b/bitnami/grafana-loki/templates/compactor/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-loki/templates/compactor/networkpolicy.yaml
+++ b/bitnami/grafana-loki/templates/compactor/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-loki/templates/compactor/pvc.yaml
+++ b/bitnami/grafana-loki/templates/compactor/pvc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-loki/templates/compactor/service.yaml
+++ b/bitnami/grafana-loki/templates/compactor/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-loki/templates/compactor/servicemonitor.yaml
+++ b/bitnami/grafana-loki/templates/compactor/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-loki/templates/distributor/deployment.yaml
+++ b/bitnami/grafana-loki/templates/distributor/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-loki/templates/distributor/networkpolicy.yaml
+++ b/bitnami/grafana-loki/templates/distributor/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-loki/templates/distributor/service.yaml
+++ b/bitnami/grafana-loki/templates/distributor/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-loki/templates/distributor/servicemonitor.yaml
+++ b/bitnami/grafana-loki/templates/distributor/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-loki/templates/extra-list.yaml
+++ b/bitnami/grafana-loki/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-loki/templates/gateway/configmap-http.yaml
+++ b/bitnami/grafana-loki/templates/gateway/configmap-http.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-loki/templates/gateway/deployment.yaml
+++ b/bitnami/grafana-loki/templates/gateway/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-loki/templates/gateway/ingress.yaml
+++ b/bitnami/grafana-loki/templates/gateway/ingress.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-loki/templates/gateway/networkpolicy.yaml
+++ b/bitnami/grafana-loki/templates/gateway/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-loki/templates/gateway/secret.yaml
+++ b/bitnami/grafana-loki/templates/gateway/secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-loki/templates/gateway/service.yaml
+++ b/bitnami/grafana-loki/templates/gateway/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-loki/templates/gateway/tls-secret.yaml
+++ b/bitnami/grafana-loki/templates/gateway/tls-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-loki/templates/gossip-ring-headless-service.yaml
+++ b/bitnami/grafana-loki/templates/gossip-ring-headless-service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-loki/templates/index-gateway/networkpolicy.yaml
+++ b/bitnami/grafana-loki/templates/index-gateway/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-loki/templates/index-gateway/service.yaml
+++ b/bitnami/grafana-loki/templates/index-gateway/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-loki/templates/index-gateway/servicemonitor.yaml
+++ b/bitnami/grafana-loki/templates/index-gateway/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-loki/templates/index-gateway/statefulset.yaml
+++ b/bitnami/grafana-loki/templates/index-gateway/statefulset.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-loki/templates/ingester/networkpolicy.yaml
+++ b/bitnami/grafana-loki/templates/ingester/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-loki/templates/ingester/service.yaml
+++ b/bitnami/grafana-loki/templates/ingester/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-loki/templates/ingester/servicemonitor.yaml
+++ b/bitnami/grafana-loki/templates/ingester/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-loki/templates/ingester/statefulset.yaml
+++ b/bitnami/grafana-loki/templates/ingester/statefulset.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-loki/templates/loki-configmap.yaml
+++ b/bitnami/grafana-loki/templates/loki-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-loki/templates/promtail/clusterrole.yaml
+++ b/bitnami/grafana-loki/templates/promtail/clusterrole.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-loki/templates/promtail/clusterrolebinding.yaml
+++ b/bitnami/grafana-loki/templates/promtail/clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-loki/templates/promtail/daemonset.yaml
+++ b/bitnami/grafana-loki/templates/promtail/daemonset.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-loki/templates/promtail/networkpolicy.yaml
+++ b/bitnami/grafana-loki/templates/promtail/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-loki/templates/promtail/secret.yaml
+++ b/bitnami/grafana-loki/templates/promtail/secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-loki/templates/promtail/service-account.yaml
+++ b/bitnami/grafana-loki/templates/promtail/service-account.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-loki/templates/promtail/service.yaml
+++ b/bitnami/grafana-loki/templates/promtail/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-loki/templates/promtail/servicemonitor.yaml
+++ b/bitnami/grafana-loki/templates/promtail/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-loki/templates/querier/networkpolicy.yaml
+++ b/bitnami/grafana-loki/templates/querier/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-loki/templates/querier/service.yaml
+++ b/bitnami/grafana-loki/templates/querier/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-loki/templates/querier/servicemonitor.yaml
+++ b/bitnami/grafana-loki/templates/querier/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-loki/templates/querier/statefulset.yaml
+++ b/bitnami/grafana-loki/templates/querier/statefulset.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-loki/templates/query-frontend/deployment.yaml
+++ b/bitnami/grafana-loki/templates/query-frontend/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-loki/templates/query-frontend/headless-service.yaml
+++ b/bitnami/grafana-loki/templates/query-frontend/headless-service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-loki/templates/query-frontend/networkpolicy.yaml
+++ b/bitnami/grafana-loki/templates/query-frontend/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-loki/templates/query-frontend/service.yaml
+++ b/bitnami/grafana-loki/templates/query-frontend/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-loki/templates/query-frontend/servicemonitor.yaml
+++ b/bitnami/grafana-loki/templates/query-frontend/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-loki/templates/query-scheduler/deployment.yaml
+++ b/bitnami/grafana-loki/templates/query-scheduler/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-loki/templates/query-scheduler/networkpolicy.yaml
+++ b/bitnami/grafana-loki/templates/query-scheduler/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-loki/templates/query-scheduler/service.yaml
+++ b/bitnami/grafana-loki/templates/query-scheduler/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-loki/templates/ruler/networkpolicy.yaml
+++ b/bitnami/grafana-loki/templates/ruler/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-loki/templates/ruler/service.yaml
+++ b/bitnami/grafana-loki/templates/ruler/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-loki/templates/ruler/servicemonitor.yaml
+++ b/bitnami/grafana-loki/templates/ruler/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-loki/templates/ruler/statefulset.yaml
+++ b/bitnami/grafana-loki/templates/ruler/statefulset.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-loki/templates/service-account.yaml
+++ b/bitnami/grafana-loki/templates/service-account.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-loki/templates/table-manager/deployment.yaml
+++ b/bitnami/grafana-loki/templates/table-manager/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-loki/templates/table-manager/networkpolicy.yaml
+++ b/bitnami/grafana-loki/templates/table-manager/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-loki/templates/table-manager/service.yaml
+++ b/bitnami/grafana-loki/templates/table-manager/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-loki/templates/table-manager/servicemonitor.yaml
+++ b/bitnami/grafana-loki/templates/table-manager/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-loki/values.yaml
+++ b/bitnami/grafana-loki/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters

--- a/bitnami/grafana-mimir/Chart.yaml
+++ b/bitnami/grafana-mimir/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/grafana-mimir/templates/_helpers.tpl
+++ b/bitnami/grafana-mimir/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-mimir/templates/alertmanager/headless-service.yaml
+++ b/bitnami/grafana-mimir/templates/alertmanager/headless-service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-mimir/templates/alertmanager/networkpolicy.yaml
+++ b/bitnami/grafana-mimir/templates/alertmanager/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-mimir/templates/alertmanager/pdb.yaml
+++ b/bitnami/grafana-mimir/templates/alertmanager/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-mimir/templates/alertmanager/service.yaml
+++ b/bitnami/grafana-mimir/templates/alertmanager/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-mimir/templates/alertmanager/servicemonitor.yaml
+++ b/bitnami/grafana-mimir/templates/alertmanager/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-mimir/templates/alertmanager/statefulset.yaml
+++ b/bitnami/grafana-mimir/templates/alertmanager/statefulset.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-mimir/templates/compactor/networkpolicy.yaml
+++ b/bitnami/grafana-mimir/templates/compactor/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-mimir/templates/compactor/pdb.yaml
+++ b/bitnami/grafana-mimir/templates/compactor/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-mimir/templates/compactor/service.yaml
+++ b/bitnami/grafana-mimir/templates/compactor/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-mimir/templates/compactor/servicemonitor.yaml
+++ b/bitnami/grafana-mimir/templates/compactor/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-mimir/templates/compactor/statefulset.yaml
+++ b/bitnami/grafana-mimir/templates/compactor/statefulset.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-mimir/templates/distributor/deployment.yaml
+++ b/bitnami/grafana-mimir/templates/distributor/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-mimir/templates/distributor/headless-service.yaml
+++ b/bitnami/grafana-mimir/templates/distributor/headless-service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-mimir/templates/distributor/networkpolicy.yaml
+++ b/bitnami/grafana-mimir/templates/distributor/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-mimir/templates/distributor/pdb.yaml
+++ b/bitnami/grafana-mimir/templates/distributor/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-mimir/templates/distributor/service.yaml
+++ b/bitnami/grafana-mimir/templates/distributor/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-mimir/templates/distributor/servicemonitor.yaml
+++ b/bitnami/grafana-mimir/templates/distributor/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-mimir/templates/extra-list.yaml
+++ b/bitnami/grafana-mimir/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-mimir/templates/gateway/configmap-http.yaml
+++ b/bitnami/grafana-mimir/templates/gateway/configmap-http.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-mimir/templates/gateway/deployment.yaml
+++ b/bitnami/grafana-mimir/templates/gateway/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-mimir/templates/gateway/ingress.yaml
+++ b/bitnami/grafana-mimir/templates/gateway/ingress.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-mimir/templates/gateway/networkpolicy.yaml
+++ b/bitnami/grafana-mimir/templates/gateway/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-mimir/templates/gateway/pdb.yaml
+++ b/bitnami/grafana-mimir/templates/gateway/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-mimir/templates/gateway/secret.yaml
+++ b/bitnami/grafana-mimir/templates/gateway/secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-mimir/templates/gateway/service.yaml
+++ b/bitnami/grafana-mimir/templates/gateway/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-mimir/templates/gateway/tls-secret.yaml
+++ b/bitnami/grafana-mimir/templates/gateway/tls-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-mimir/templates/gossip-ring-headless-service.yaml
+++ b/bitnami/grafana-mimir/templates/gossip-ring-headless-service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-mimir/templates/ingester/headless-service.yaml
+++ b/bitnami/grafana-mimir/templates/ingester/headless-service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-mimir/templates/ingester/networkpolicy.yaml
+++ b/bitnami/grafana-mimir/templates/ingester/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-mimir/templates/ingester/pdb.yaml
+++ b/bitnami/grafana-mimir/templates/ingester/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-mimir/templates/ingester/service.yaml
+++ b/bitnami/grafana-mimir/templates/ingester/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-mimir/templates/ingester/servicemonitor.yaml
+++ b/bitnami/grafana-mimir/templates/ingester/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-mimir/templates/ingester/statefulset.yaml
+++ b/bitnami/grafana-mimir/templates/ingester/statefulset.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-mimir/templates/mimir-configmap.yaml
+++ b/bitnami/grafana-mimir/templates/mimir-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-mimir/templates/overrides-exporter/deployment.yaml
+++ b/bitnami/grafana-mimir/templates/overrides-exporter/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-mimir/templates/overrides-exporter/headless-service.yaml
+++ b/bitnami/grafana-mimir/templates/overrides-exporter/headless-service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-mimir/templates/overrides-exporter/networkpolicy.yaml
+++ b/bitnami/grafana-mimir/templates/overrides-exporter/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-mimir/templates/overrides-exporter/pdb.yaml
+++ b/bitnami/grafana-mimir/templates/overrides-exporter/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-mimir/templates/overrides-exporter/service.yaml
+++ b/bitnami/grafana-mimir/templates/overrides-exporter/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-mimir/templates/overrides-exporter/servicemonitor.yaml
+++ b/bitnami/grafana-mimir/templates/overrides-exporter/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-mimir/templates/querier/deployment.yaml
+++ b/bitnami/grafana-mimir/templates/querier/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-mimir/templates/querier/headless-service.yaml
+++ b/bitnami/grafana-mimir/templates/querier/headless-service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-mimir/templates/querier/networkpolicy.yaml
+++ b/bitnami/grafana-mimir/templates/querier/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-mimir/templates/querier/pdb.yaml
+++ b/bitnami/grafana-mimir/templates/querier/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-mimir/templates/querier/service.yaml
+++ b/bitnami/grafana-mimir/templates/querier/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-mimir/templates/querier/servicemonitor.yaml
+++ b/bitnami/grafana-mimir/templates/querier/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-mimir/templates/query-frontend/deployment.yaml
+++ b/bitnami/grafana-mimir/templates/query-frontend/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-mimir/templates/query-frontend/headless-service.yaml
+++ b/bitnami/grafana-mimir/templates/query-frontend/headless-service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-mimir/templates/query-frontend/networkpolicy.yaml
+++ b/bitnami/grafana-mimir/templates/query-frontend/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-mimir/templates/query-frontend/pdb.yaml
+++ b/bitnami/grafana-mimir/templates/query-frontend/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-mimir/templates/query-frontend/service.yaml
+++ b/bitnami/grafana-mimir/templates/query-frontend/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-mimir/templates/query-frontend/servicemonitor.yaml
+++ b/bitnami/grafana-mimir/templates/query-frontend/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-mimir/templates/query-scheduler/deployment.yaml
+++ b/bitnami/grafana-mimir/templates/query-scheduler/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-mimir/templates/query-scheduler/headless-service.yaml
+++ b/bitnami/grafana-mimir/templates/query-scheduler/headless-service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-mimir/templates/query-scheduler/networkpolicy.yaml
+++ b/bitnami/grafana-mimir/templates/query-scheduler/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-mimir/templates/query-scheduler/pdb.yaml
+++ b/bitnami/grafana-mimir/templates/query-scheduler/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-mimir/templates/query-scheduler/service.yaml
+++ b/bitnami/grafana-mimir/templates/query-scheduler/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-mimir/templates/query-scheduler/servicemonitor.yaml
+++ b/bitnami/grafana-mimir/templates/query-scheduler/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-mimir/templates/ruler/deployment.yaml
+++ b/bitnami/grafana-mimir/templates/ruler/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-mimir/templates/ruler/networkpolicy.yaml
+++ b/bitnami/grafana-mimir/templates/ruler/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-mimir/templates/ruler/pdb.yaml
+++ b/bitnami/grafana-mimir/templates/ruler/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-mimir/templates/ruler/service.yaml
+++ b/bitnami/grafana-mimir/templates/ruler/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-mimir/templates/ruler/servicemonitor.yaml
+++ b/bitnami/grafana-mimir/templates/ruler/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-mimir/templates/service-account.yaml
+++ b/bitnami/grafana-mimir/templates/service-account.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-mimir/templates/store-gateway/headless-service.yaml
+++ b/bitnami/grafana-mimir/templates/store-gateway/headless-service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-mimir/templates/store-gateway/networkpolicy.yaml
+++ b/bitnami/grafana-mimir/templates/store-gateway/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-mimir/templates/store-gateway/pdb.yaml
+++ b/bitnami/grafana-mimir/templates/store-gateway/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-mimir/templates/store-gateway/service.yaml
+++ b/bitnami/grafana-mimir/templates/store-gateway/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-mimir/templates/store-gateway/servicemonitor.yaml
+++ b/bitnami/grafana-mimir/templates/store-gateway/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-mimir/templates/store-gateway/statefulset.yaml
+++ b/bitnami/grafana-mimir/templates/store-gateway/statefulset.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-mimir/values.yaml
+++ b/bitnami/grafana-mimir/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters

--- a/bitnami/grafana-operator/Chart.yaml
+++ b/bitnami/grafana-operator/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/grafana-operator/templates/_helpers.tpl
+++ b/bitnami/grafana-operator/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-operator/templates/deployment.yaml
+++ b/bitnami/grafana-operator/templates/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-operator/templates/extra-list.yaml
+++ b/bitnami/grafana-operator/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-operator/templates/grafana.yaml
+++ b/bitnami/grafana-operator/templates/grafana.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-operator/templates/networkpolicy.yaml
+++ b/bitnami/grafana-operator/templates/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-operator/templates/rbac-clustescope.yaml
+++ b/bitnami/grafana-operator/templates/rbac-clustescope.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-operator/templates/rbac-namespace.yaml
+++ b/bitnami/grafana-operator/templates/rbac-namespace.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-operator/templates/serviceaccount.yaml
+++ b/bitnami/grafana-operator/templates/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-operator/templates/servicemonitor.yaml
+++ b/bitnami/grafana-operator/templates/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-operator/values.yaml
+++ b/bitnami/grafana-operator/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters

--- a/bitnami/grafana-tempo/Chart.yaml
+++ b/bitnami/grafana-tempo/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/grafana-tempo/templates/_helpers.tpl
+++ b/bitnami/grafana-tempo/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-tempo/templates/compactor/deployment.yaml
+++ b/bitnami/grafana-tempo/templates/compactor/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-tempo/templates/compactor/networkpolicy.yaml
+++ b/bitnami/grafana-tempo/templates/compactor/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-tempo/templates/compactor/service.yaml
+++ b/bitnami/grafana-tempo/templates/compactor/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-tempo/templates/compactor/servicemonitor.yaml
+++ b/bitnami/grafana-tempo/templates/compactor/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-tempo/templates/distributor/deployment.yaml
+++ b/bitnami/grafana-tempo/templates/distributor/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-tempo/templates/distributor/networkpolicy.yaml
+++ b/bitnami/grafana-tempo/templates/distributor/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-tempo/templates/distributor/service.yaml
+++ b/bitnami/grafana-tempo/templates/distributor/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-tempo/templates/distributor/servicemonitor.yaml
+++ b/bitnami/grafana-tempo/templates/distributor/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-tempo/templates/extra-list.yaml
+++ b/bitnami/grafana-tempo/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-tempo/templates/gossip-ring-headless-service.yaml
+++ b/bitnami/grafana-tempo/templates/gossip-ring-headless-service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-tempo/templates/ingester/networkpolicy.yaml
+++ b/bitnami/grafana-tempo/templates/ingester/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-tempo/templates/ingester/service.yaml
+++ b/bitnami/grafana-tempo/templates/ingester/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-tempo/templates/ingester/servicemonitor.yaml
+++ b/bitnami/grafana-tempo/templates/ingester/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-tempo/templates/ingester/statefulset.yaml
+++ b/bitnami/grafana-tempo/templates/ingester/statefulset.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-tempo/templates/metrics-generator/deployment.yaml
+++ b/bitnami/grafana-tempo/templates/metrics-generator/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-tempo/templates/metrics-generator/networkpolicy.yaml
+++ b/bitnami/grafana-tempo/templates/metrics-generator/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-tempo/templates/metrics-generator/service.yaml
+++ b/bitnami/grafana-tempo/templates/metrics-generator/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-tempo/templates/metrics-generator/servicemonitor.yaml
+++ b/bitnami/grafana-tempo/templates/metrics-generator/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-tempo/templates/overrides-configmap.yaml
+++ b/bitnami/grafana-tempo/templates/overrides-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-tempo/templates/querier/deployment.yaml
+++ b/bitnami/grafana-tempo/templates/querier/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-tempo/templates/querier/networkpolicy.yaml
+++ b/bitnami/grafana-tempo/templates/querier/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-tempo/templates/querier/service.yaml
+++ b/bitnami/grafana-tempo/templates/querier/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-tempo/templates/querier/servicemonitor.yaml
+++ b/bitnami/grafana-tempo/templates/querier/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-tempo/templates/query-frontend/deployment.yaml
+++ b/bitnami/grafana-tempo/templates/query-frontend/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-tempo/templates/query-frontend/headless-service.yaml
+++ b/bitnami/grafana-tempo/templates/query-frontend/headless-service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-tempo/templates/query-frontend/networkpolicy.yaml
+++ b/bitnami/grafana-tempo/templates/query-frontend/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-tempo/templates/query-frontend/query-configmap.yaml
+++ b/bitnami/grafana-tempo/templates/query-frontend/query-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-tempo/templates/query-frontend/service.yaml
+++ b/bitnami/grafana-tempo/templates/query-frontend/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-tempo/templates/query-frontend/servicemonitor.yaml
+++ b/bitnami/grafana-tempo/templates/query-frontend/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-tempo/templates/service-account.yaml
+++ b/bitnami/grafana-tempo/templates/service-account.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-tempo/templates/tempo-configmap.yaml
+++ b/bitnami/grafana-tempo/templates/tempo-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-tempo/templates/vulture/deployment.yaml
+++ b/bitnami/grafana-tempo/templates/vulture/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-tempo/templates/vulture/networkpolicy.yaml
+++ b/bitnami/grafana-tempo/templates/vulture/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-tempo/templates/vulture/service.yaml
+++ b/bitnami/grafana-tempo/templates/vulture/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-tempo/templates/vulture/servicemonitor.yaml
+++ b/bitnami/grafana-tempo/templates/vulture/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana-tempo/values.yaml
+++ b/bitnami/grafana-tempo/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters

--- a/bitnami/grafana/Chart.yaml
+++ b/bitnami/grafana/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/grafana/templates/_helpers.tpl
+++ b/bitnami/grafana/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana/templates/configmap.yaml
+++ b/bitnami/grafana/templates/configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana/templates/dashboard-provider.yaml
+++ b/bitnami/grafana/templates/dashboard-provider.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana/templates/datasources-secret.yaml
+++ b/bitnami/grafana/templates/datasources-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana/templates/deployment.yaml
+++ b/bitnami/grafana/templates/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana/templates/extra-list.yaml
+++ b/bitnami/grafana/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana/templates/ingress.yaml
+++ b/bitnami/grafana/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana/templates/ldap-secret.yaml
+++ b/bitnami/grafana/templates/ldap-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana/templates/networkpolicy.yaml
+++ b/bitnami/grafana/templates/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana/templates/prometheusrules.yaml
+++ b/bitnami/grafana/templates/prometheusrules.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana/templates/pvc.yaml
+++ b/bitnami/grafana/templates/pvc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana/templates/secret.yaml
+++ b/bitnami/grafana/templates/secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana/templates/service.yaml
+++ b/bitnami/grafana/templates/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana/templates/serviceaccount.yaml
+++ b/bitnami/grafana/templates/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana/templates/servicemonitor.yaml
+++ b/bitnami/grafana/templates/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana/templates/smtp-secret.yaml
+++ b/bitnami/grafana/templates/smtp-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana/templates/tls-secret.yaml
+++ b/bitnami/grafana/templates/tls-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/grafana/values.yaml
+++ b/bitnami/grafana/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters

--- a/bitnami/haproxy/Chart.yaml
+++ b/bitnami/haproxy/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/haproxy/templates/_helpers.tpl
+++ b/bitnami/haproxy/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/haproxy/templates/configmap.yaml
+++ b/bitnami/haproxy/templates/configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/haproxy/templates/deployment.yaml
+++ b/bitnami/haproxy/templates/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/haproxy/templates/extra-list.yaml
+++ b/bitnami/haproxy/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/haproxy/templates/hpa.yaml
+++ b/bitnami/haproxy/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/haproxy/templates/ingress.yaml
+++ b/bitnami/haproxy/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/haproxy/templates/networkpolicy.yaml
+++ b/bitnami/haproxy/templates/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/haproxy/templates/pdb.yaml
+++ b/bitnami/haproxy/templates/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/haproxy/templates/service-account.yaml
+++ b/bitnami/haproxy/templates/service-account.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/haproxy/templates/service.yaml
+++ b/bitnami/haproxy/templates/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/haproxy/values.yaml
+++ b/bitnami/haproxy/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters

--- a/bitnami/harbor/Chart.yaml
+++ b/bitnami/harbor/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/harbor/templates/_helpers.tpl
+++ b/bitnami/harbor/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/harbor/templates/core/core-cm-envvars.yaml
+++ b/bitnami/harbor/templates/core/core-cm-envvars.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/harbor/templates/core/core-cm.yaml
+++ b/bitnami/harbor/templates/core/core-cm.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/harbor/templates/core/core-config-override-secret.yaml
+++ b/bitnami/harbor/templates/core/core-config-override-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/harbor/templates/core/core-dpl.yaml
+++ b/bitnami/harbor/templates/core/core-dpl.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/harbor/templates/core/core-networkpolicy.yaml
+++ b/bitnami/harbor/templates/core/core-networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/harbor/templates/core/core-secret-envvars.yaml
+++ b/bitnami/harbor/templates/core/core-secret-envvars.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/harbor/templates/core/core-secret.yaml
+++ b/bitnami/harbor/templates/core/core-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/harbor/templates/core/core-svc.yaml
+++ b/bitnami/harbor/templates/core/core-svc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/harbor/templates/exporter/exporter-cm-envvars.yaml
+++ b/bitnami/harbor/templates/exporter/exporter-cm-envvars.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/harbor/templates/exporter/exporter-dpl.yaml
+++ b/bitnami/harbor/templates/exporter/exporter-dpl.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/harbor/templates/exporter/exporter-networkpolicy.yaml
+++ b/bitnami/harbor/templates/exporter/exporter-networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/harbor/templates/exporter/exporter-secret-envvars.yaml
+++ b/bitnami/harbor/templates/exporter/exporter-secret-envvars.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/harbor/templates/exporter/exporter-svc.yaml
+++ b/bitnami/harbor/templates/exporter/exporter-svc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/harbor/templates/extra-list.yaml
+++ b/bitnami/harbor/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/harbor/templates/ingress/core-ingress.yaml
+++ b/bitnami/harbor/templates/ingress/core-ingress.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/harbor/templates/ingress/tls-secret.yaml
+++ b/bitnami/harbor/templates/ingress/tls-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/harbor/templates/internal/internal-crt-secret.yaml
+++ b/bitnami/harbor/templates/internal/internal-crt-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/harbor/templates/jobservice/jobservice-cm-envvars.yaml
+++ b/bitnami/harbor/templates/jobservice/jobservice-cm-envvars.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/harbor/templates/jobservice/jobservice-config-secret.yaml
+++ b/bitnami/harbor/templates/jobservice/jobservice-config-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/harbor/templates/jobservice/jobservice-dpl.yaml
+++ b/bitnami/harbor/templates/jobservice/jobservice-dpl.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/harbor/templates/jobservice/jobservice-networkpolicy.yaml
+++ b/bitnami/harbor/templates/jobservice/jobservice-networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/harbor/templates/jobservice/jobservice-pvc.yaml
+++ b/bitnami/harbor/templates/jobservice/jobservice-pvc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/harbor/templates/jobservice/jobservice-secret-envvars.yaml
+++ b/bitnami/harbor/templates/jobservice/jobservice-secret-envvars.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/harbor/templates/jobservice/jobservice-secrets.yaml
+++ b/bitnami/harbor/templates/jobservice/jobservice-secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/harbor/templates/jobservice/jobservice-svc.yaml
+++ b/bitnami/harbor/templates/jobservice/jobservice-svc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/harbor/templates/metrics/metrics-svcmonitor.yaml
+++ b/bitnami/harbor/templates/metrics/metrics-svcmonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/harbor/templates/nginx/configmap-http.yaml
+++ b/bitnami/harbor/templates/nginx/configmap-http.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/harbor/templates/nginx/configmap-https.yaml
+++ b/bitnami/harbor/templates/nginx/configmap-https.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/harbor/templates/nginx/deployment.yaml
+++ b/bitnami/harbor/templates/nginx/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/harbor/templates/nginx/networkpolicy.yaml
+++ b/bitnami/harbor/templates/nginx/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/harbor/templates/nginx/service.yaml
+++ b/bitnami/harbor/templates/nginx/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/harbor/templates/nginx/tls-secret.yaml
+++ b/bitnami/harbor/templates/nginx/tls-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/harbor/templates/portal/portal-cm.yaml
+++ b/bitnami/harbor/templates/portal/portal-cm.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/harbor/templates/portal/portal-dpl.yaml
+++ b/bitnami/harbor/templates/portal/portal-dpl.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/harbor/templates/portal/portal-networkpolicy.yaml
+++ b/bitnami/harbor/templates/portal/portal-networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/harbor/templates/portal/portal-svc.yaml
+++ b/bitnami/harbor/templates/portal/portal-svc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/harbor/templates/registry/registry-cm.yaml
+++ b/bitnami/harbor/templates/registry/registry-cm.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/harbor/templates/registry/registry-ctl-cm-envvars.yaml
+++ b/bitnami/harbor/templates/registry/registry-ctl-cm-envvars.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/harbor/templates/registry/registry-dpl.yaml
+++ b/bitnami/harbor/templates/registry/registry-dpl.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/harbor/templates/registry/registry-networkpolicy.yaml
+++ b/bitnami/harbor/templates/registry/registry-networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/harbor/templates/registry/registry-pvc.yaml
+++ b/bitnami/harbor/templates/registry/registry-pvc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/harbor/templates/registry/registry-secret.yaml
+++ b/bitnami/harbor/templates/registry/registry-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/harbor/templates/registry/registry-svc.yaml
+++ b/bitnami/harbor/templates/registry/registry-svc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/harbor/templates/trivy/trivy-cm-envvars.yaml
+++ b/bitnami/harbor/templates/trivy/trivy-cm-envvars.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/harbor/templates/trivy/trivy-networkpolicy.yaml
+++ b/bitnami/harbor/templates/trivy/trivy-networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/harbor/templates/trivy/trivy-secret-envvars.yaml
+++ b/bitnami/harbor/templates/trivy/trivy-secret-envvars.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/harbor/templates/trivy/trivy-sts.yaml
+++ b/bitnami/harbor/templates/trivy/trivy-sts.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/harbor/templates/trivy/trivy-svc.yaml
+++ b/bitnami/harbor/templates/trivy/trivy-svc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/harbor/values.yaml
+++ b/bitnami/harbor/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters

--- a/bitnami/influxdb/Chart.yaml
+++ b/bitnami/influxdb/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/influxdb/templates/_helpers.tpl
+++ b/bitnami/influxdb/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/influxdb/templates/configmap-backup.yaml
+++ b/bitnami/influxdb/templates/configmap-backup.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/influxdb/templates/configmap-initdb-scripts.yaml
+++ b/bitnami/influxdb/templates/configmap-initdb-scripts.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/influxdb/templates/configmap.yaml
+++ b/bitnami/influxdb/templates/configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/influxdb/templates/cronjob-backup.yaml
+++ b/bitnami/influxdb/templates/cronjob-backup.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/influxdb/templates/deployment.yaml
+++ b/bitnami/influxdb/templates/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/influxdb/templates/extra-list.yaml
+++ b/bitnami/influxdb/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/influxdb/templates/ingress.yaml
+++ b/bitnami/influxdb/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/influxdb/templates/networkpolicy.yaml
+++ b/bitnami/influxdb/templates/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/influxdb/templates/psp-role.yaml
+++ b/bitnami/influxdb/templates/psp-role.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/influxdb/templates/psp-rolebinding.yaml
+++ b/bitnami/influxdb/templates/psp-rolebinding.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/influxdb/templates/psp.yaml
+++ b/bitnami/influxdb/templates/psp.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/influxdb/templates/pvc-backup.yaml
+++ b/bitnami/influxdb/templates/pvc-backup.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/influxdb/templates/pvc.yaml
+++ b/bitnami/influxdb/templates/pvc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/influxdb/templates/secrets-backup.yaml
+++ b/bitnami/influxdb/templates/secrets-backup.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/influxdb/templates/secrets.yaml
+++ b/bitnami/influxdb/templates/secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/influxdb/templates/service-collectd.yaml
+++ b/bitnami/influxdb/templates/service-collectd.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/influxdb/templates/service-metrics.yaml
+++ b/bitnami/influxdb/templates/service-metrics.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/influxdb/templates/service.yaml
+++ b/bitnami/influxdb/templates/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/influxdb/templates/serviceaccount.yaml
+++ b/bitnami/influxdb/templates/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/influxdb/templates/servicemonitor.yaml
+++ b/bitnami/influxdb/templates/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/influxdb/values.yaml
+++ b/bitnami/influxdb/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters

--- a/bitnami/jaeger/Chart.yaml
+++ b/bitnami/jaeger/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/jaeger/templates/_helpers.tpl
+++ b/bitnami/jaeger/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/jaeger/templates/agent/deployment.yaml
+++ b/bitnami/jaeger/templates/agent/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/jaeger/templates/agent/networkpolicy.yaml
+++ b/bitnami/jaeger/templates/agent/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/jaeger/templates/agent/service.yml
+++ b/bitnami/jaeger/templates/agent/service.yml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/jaeger/templates/agent/serviceaccount.yaml
+++ b/bitnami/jaeger/templates/agent/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/jaeger/templates/collector/deployment.yaml
+++ b/bitnami/jaeger/templates/collector/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/jaeger/templates/collector/networkpolicy.yaml
+++ b/bitnami/jaeger/templates/collector/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/jaeger/templates/collector/service.yml
+++ b/bitnami/jaeger/templates/collector/service.yml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/jaeger/templates/collector/serviceaccount.yaml
+++ b/bitnami/jaeger/templates/collector/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/jaeger/templates/migrate-job.yaml
+++ b/bitnami/jaeger/templates/migrate-job.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/jaeger/templates/migrate-networkpolicy.yaml
+++ b/bitnami/jaeger/templates/migrate-networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/jaeger/templates/query/deployment.yaml
+++ b/bitnami/jaeger/templates/query/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/jaeger/templates/query/networkpolicy.yaml
+++ b/bitnami/jaeger/templates/query/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/jaeger/templates/query/service.yml
+++ b/bitnami/jaeger/templates/query/service.yml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/jaeger/templates/query/serviceaccount.yaml
+++ b/bitnami/jaeger/templates/query/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/jaeger/values.yaml
+++ b/bitnami/jaeger/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters

--- a/bitnami/jenkins/Chart.yaml
+++ b/bitnami/jenkins/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/jenkins/templates/_helpers.tpl
+++ b/bitnami/jenkins/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/jenkins/templates/agent-listener-svc.yaml
+++ b/bitnami/jenkins/templates/agent-listener-svc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/jenkins/templates/casc-cm.yaml
+++ b/bitnami/jenkins/templates/casc-cm.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/jenkins/templates/controller-svc.yaml
+++ b/bitnami/jenkins/templates/controller-svc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/jenkins/templates/deployment.yaml
+++ b/bitnami/jenkins/templates/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/jenkins/templates/extra-list.yaml
+++ b/bitnami/jenkins/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/jenkins/templates/ingress.yaml
+++ b/bitnami/jenkins/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/jenkins/templates/networkpolicy.yaml
+++ b/bitnami/jenkins/templates/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/jenkins/templates/pvc.yaml
+++ b/bitnami/jenkins/templates/pvc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/jenkins/templates/role.yaml
+++ b/bitnami/jenkins/templates/role.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/jenkins/templates/rolebinding.yaml
+++ b/bitnami/jenkins/templates/rolebinding.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/jenkins/templates/secrets.yaml
+++ b/bitnami/jenkins/templates/secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/jenkins/templates/serviceaccount.yaml
+++ b/bitnami/jenkins/templates/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/jenkins/templates/tls-secret.yaml
+++ b/bitnami/jenkins/templates/tls-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/jenkins/values.yaml
+++ b/bitnami/jenkins/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters

--- a/bitnami/joomla/Chart.yaml
+++ b/bitnami/joomla/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/joomla/templates/_helpers.tpl
+++ b/bitnami/joomla/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/joomla/templates/deployment.yaml
+++ b/bitnami/joomla/templates/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/joomla/templates/externaldb-secrets.yaml
+++ b/bitnami/joomla/templates/externaldb-secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/joomla/templates/extra-list.yaml
+++ b/bitnami/joomla/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/joomla/templates/ingress.yaml
+++ b/bitnami/joomla/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/joomla/templates/joomla-pvc.yaml
+++ b/bitnami/joomla/templates/joomla-pvc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/joomla/templates/networkpolicy.yaml
+++ b/bitnami/joomla/templates/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/joomla/templates/secrets.yaml
+++ b/bitnami/joomla/templates/secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/joomla/templates/serviceaccount.yaml
+++ b/bitnami/joomla/templates/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/joomla/templates/svc.yaml
+++ b/bitnami/joomla/templates/svc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/joomla/templates/tls-secrets.yaml
+++ b/bitnami/joomla/templates/tls-secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/joomla/values.yaml
+++ b/bitnami/joomla/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters

--- a/bitnami/jupyterhub/Chart.yaml
+++ b/bitnami/jupyterhub/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/jupyterhub/templates/_helpers.tpl
+++ b/bitnami/jupyterhub/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/jupyterhub/templates/extra-list.yaml
+++ b/bitnami/jupyterhub/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/jupyterhub/templates/hub/configmap.yaml
+++ b/bitnami/jupyterhub/templates/hub/configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/jupyterhub/templates/hub/deployment.yaml
+++ b/bitnami/jupyterhub/templates/hub/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/jupyterhub/templates/hub/externaldb-secrets.yaml
+++ b/bitnami/jupyterhub/templates/hub/externaldb-secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/jupyterhub/templates/hub/networkpolicy.yaml
+++ b/bitnami/jupyterhub/templates/hub/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/jupyterhub/templates/hub/pdb.yaml
+++ b/bitnami/jupyterhub/templates/hub/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/jupyterhub/templates/hub/role.yaml
+++ b/bitnami/jupyterhub/templates/hub/role.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/jupyterhub/templates/hub/rolebinding.yaml
+++ b/bitnami/jupyterhub/templates/hub/rolebinding.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/jupyterhub/templates/hub/secret.yaml
+++ b/bitnami/jupyterhub/templates/hub/secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/jupyterhub/templates/hub/service-account.yaml
+++ b/bitnami/jupyterhub/templates/hub/service-account.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/jupyterhub/templates/hub/service.yaml
+++ b/bitnami/jupyterhub/templates/hub/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/jupyterhub/templates/hub/servicemonitor.yaml
+++ b/bitnami/jupyterhub/templates/hub/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/jupyterhub/templates/image-puller/daemonset.yaml
+++ b/bitnami/jupyterhub/templates/image-puller/daemonset.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/jupyterhub/templates/image-puller/networkpolicy.yaml
+++ b/bitnami/jupyterhub/templates/image-puller/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/jupyterhub/templates/image-puller/service-account.yaml
+++ b/bitnami/jupyterhub/templates/image-puller/service-account.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/jupyterhub/templates/proxy/deployment.yaml
+++ b/bitnami/jupyterhub/templates/proxy/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/jupyterhub/templates/proxy/ingress.yaml
+++ b/bitnami/jupyterhub/templates/proxy/ingress.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/jupyterhub/templates/proxy/networkpolicy.yaml
+++ b/bitnami/jupyterhub/templates/proxy/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/jupyterhub/templates/proxy/pdb.yaml
+++ b/bitnami/jupyterhub/templates/proxy/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/jupyterhub/templates/proxy/service-account.yaml
+++ b/bitnami/jupyterhub/templates/proxy/service-account.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/jupyterhub/templates/proxy/service-api.yaml
+++ b/bitnami/jupyterhub/templates/proxy/service-api.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/jupyterhub/templates/proxy/service-metrics.yaml
+++ b/bitnami/jupyterhub/templates/proxy/service-metrics.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/jupyterhub/templates/proxy/service-public.yaml
+++ b/bitnami/jupyterhub/templates/proxy/service-public.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/jupyterhub/templates/proxy/servicemonitor.yaml
+++ b/bitnami/jupyterhub/templates/proxy/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/jupyterhub/templates/proxy/tls-secret.yaml
+++ b/bitnami/jupyterhub/templates/proxy/tls-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/jupyterhub/templates/singleuser/networkpolicy.yaml
+++ b/bitnami/jupyterhub/templates/singleuser/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/jupyterhub/templates/singleuser/service-account.yaml
+++ b/bitnami/jupyterhub/templates/singleuser/service-account.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/jupyterhub/values.yaml
+++ b/bitnami/jupyterhub/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters

--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/kafka/templates/_helpers.tpl
+++ b/bitnami/kafka/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kafka/templates/broker/config-secrets.yaml
+++ b/bitnami/kafka/templates/broker/config-secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kafka/templates/broker/configmap.yaml
+++ b/bitnami/kafka/templates/broker/configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kafka/templates/broker/pdb.yaml
+++ b/bitnami/kafka/templates/broker/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kafka/templates/broker/statefulset.yaml
+++ b/bitnami/kafka/templates/broker/statefulset.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kafka/templates/broker/svc-external-access.yaml
+++ b/bitnami/kafka/templates/broker/svc-external-access.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kafka/templates/broker/svc-headless.yaml
+++ b/bitnami/kafka/templates/broker/svc-headless.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kafka/templates/controller-eligible/config-secrets.yaml
+++ b/bitnami/kafka/templates/controller-eligible/config-secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kafka/templates/controller-eligible/configmap.yaml
+++ b/bitnami/kafka/templates/controller-eligible/configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kafka/templates/controller-eligible/pdb.yaml
+++ b/bitnami/kafka/templates/controller-eligible/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kafka/templates/controller-eligible/statefulset.yaml
+++ b/bitnami/kafka/templates/controller-eligible/statefulset.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kafka/templates/controller-eligible/svc-external-access.yaml
+++ b/bitnami/kafka/templates/controller-eligible/svc-external-access.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kafka/templates/controller-eligible/svc-headless.yaml
+++ b/bitnami/kafka/templates/controller-eligible/svc-headless.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kafka/templates/extra-list.yaml
+++ b/bitnami/kafka/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kafka/templates/log4j-configmap.yaml
+++ b/bitnami/kafka/templates/log4j-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kafka/templates/metrics/deployment.yaml
+++ b/bitnami/kafka/templates/metrics/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kafka/templates/metrics/jmx-configmap.yaml
+++ b/bitnami/kafka/templates/metrics/jmx-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kafka/templates/metrics/jmx-servicemonitor.yaml
+++ b/bitnami/kafka/templates/metrics/jmx-servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kafka/templates/metrics/jmx-svc.yaml
+++ b/bitnami/kafka/templates/metrics/jmx-svc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kafka/templates/metrics/prometheusrule.yaml
+++ b/bitnami/kafka/templates/metrics/prometheusrule.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kafka/templates/metrics/serviceaccount.yaml
+++ b/bitnami/kafka/templates/metrics/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kafka/templates/metrics/servicemonitor.yaml
+++ b/bitnami/kafka/templates/metrics/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kafka/templates/metrics/svc.yaml
+++ b/bitnami/kafka/templates/metrics/svc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kafka/templates/networkpolicy.yaml
+++ b/bitnami/kafka/templates/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kafka/templates/provisioning/job.yaml
+++ b/bitnami/kafka/templates/provisioning/job.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kafka/templates/provisioning/serviceaccount.yaml
+++ b/bitnami/kafka/templates/provisioning/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kafka/templates/provisioning/tls-secret.yaml
+++ b/bitnami/kafka/templates/provisioning/tls-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kafka/templates/rbac/role.yaml
+++ b/bitnami/kafka/templates/rbac/role.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kafka/templates/rbac/rolebinding.yaml
+++ b/bitnami/kafka/templates/rbac/rolebinding.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kafka/templates/rbac/serviceaccount.yaml
+++ b/bitnami/kafka/templates/rbac/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kafka/templates/scripts-configmap.yaml
+++ b/bitnami/kafka/templates/scripts-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kafka/templates/secrets.yaml
+++ b/bitnami/kafka/templates/secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kafka/templates/svc.yaml
+++ b/bitnami/kafka/templates/svc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kafka/templates/tls-secret.yaml
+++ b/bitnami/kafka/templates/tls-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kafka/values.yaml
+++ b/bitnami/kafka/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters

--- a/bitnami/keycloak/Chart.yaml
+++ b/bitnami/keycloak/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/keycloak/templates/_helpers.tpl
+++ b/bitnami/keycloak/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/keycloak/templates/admin-ingress.yaml
+++ b/bitnami/keycloak/templates/admin-ingress.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/keycloak/templates/configmap-env-vars.yaml
+++ b/bitnami/keycloak/templates/configmap-env-vars.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/keycloak/templates/configmap.yaml
+++ b/bitnami/keycloak/templates/configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/keycloak/templates/extra-list.yaml
+++ b/bitnami/keycloak/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/keycloak/templates/headless-service.yaml
+++ b/bitnami/keycloak/templates/headless-service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/keycloak/templates/hpa.yaml
+++ b/bitnami/keycloak/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/keycloak/templates/ingress.yaml
+++ b/bitnami/keycloak/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/keycloak/templates/init-scripts-configmap.yaml
+++ b/bitnami/keycloak/templates/init-scripts-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/keycloak/templates/keycloak-config-cli-configmap.yaml
+++ b/bitnami/keycloak/templates/keycloak-config-cli-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/keycloak/templates/keycloak-config-cli-job.yaml
+++ b/bitnami/keycloak/templates/keycloak-config-cli-job.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/keycloak/templates/metrics-service.yaml
+++ b/bitnami/keycloak/templates/metrics-service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/keycloak/templates/networkpolicy.yaml
+++ b/bitnami/keycloak/templates/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/keycloak/templates/pdb.yaml
+++ b/bitnami/keycloak/templates/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/keycloak/templates/prometheusrule.yaml
+++ b/bitnami/keycloak/templates/prometheusrule.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/keycloak/templates/role.yaml
+++ b/bitnami/keycloak/templates/role.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/keycloak/templates/rolebinding.yaml
+++ b/bitnami/keycloak/templates/rolebinding.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/keycloak/templates/secret-external-db.yaml
+++ b/bitnami/keycloak/templates/secret-external-db.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/keycloak/templates/secrets.yaml
+++ b/bitnami/keycloak/templates/secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/keycloak/templates/service.yaml
+++ b/bitnami/keycloak/templates/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/keycloak/templates/serviceaccount.yaml
+++ b/bitnami/keycloak/templates/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/keycloak/templates/servicemonitor.yaml
+++ b/bitnami/keycloak/templates/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/keycloak/templates/statefulset.yaml
+++ b/bitnami/keycloak/templates/statefulset.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/keycloak/templates/tls-pass-secret.yaml
+++ b/bitnami/keycloak/templates/tls-pass-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/keycloak/templates/tls-secret.yaml
+++ b/bitnami/keycloak/templates/tls-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/keycloak/values.yaml
+++ b/bitnami/keycloak/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters

--- a/bitnami/kiam/Chart.yaml
+++ b/bitnami/kiam/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/kiam/templates/_helpers.tpl
+++ b/bitnami/kiam/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kiam/templates/agent/agent-daemonset.yaml
+++ b/bitnami/kiam/templates/agent/agent-daemonset.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kiam/templates/agent/agent-networkpolicy.yaml
+++ b/bitnami/kiam/templates/agent/agent-networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kiam/templates/agent/agent-psp-clusterrole.yaml
+++ b/bitnami/kiam/templates/agent/agent-psp-clusterrole.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kiam/templates/agent/agent-psp-clusterrolebinding.yaml
+++ b/bitnami/kiam/templates/agent/agent-psp-clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kiam/templates/agent/agent-psp.yaml
+++ b/bitnami/kiam/templates/agent/agent-psp.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kiam/templates/agent/agent-secret.yaml
+++ b/bitnami/kiam/templates/agent/agent-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kiam/templates/agent/agent-service-account.yaml
+++ b/bitnami/kiam/templates/agent/agent-service-account.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kiam/templates/agent/agent-service.yaml
+++ b/bitnami/kiam/templates/agent/agent-service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kiam/templates/agent/agent-servicemonitor.yaml
+++ b/bitnami/kiam/templates/agent/agent-servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kiam/templates/extra-list.yaml
+++ b/bitnami/kiam/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kiam/templates/server/server-daemonset.yaml
+++ b/bitnami/kiam/templates/server/server-daemonset.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kiam/templates/server/server-deployment.yaml
+++ b/bitnami/kiam/templates/server/server-deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kiam/templates/server/server-networkpolicy.yaml
+++ b/bitnami/kiam/templates/server/server-networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kiam/templates/server/server-psp-clusterrole.yaml
+++ b/bitnami/kiam/templates/server/server-psp-clusterrole.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kiam/templates/server/server-psp-clusterrolebinding.yaml
+++ b/bitnami/kiam/templates/server/server-psp-clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kiam/templates/server/server-psp.yaml
+++ b/bitnami/kiam/templates/server/server-psp.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kiam/templates/server/server-read-clusterrole.yaml
+++ b/bitnami/kiam/templates/server/server-read-clusterrole.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kiam/templates/server/server-read-clusterrolebinding.yaml
+++ b/bitnami/kiam/templates/server/server-read-clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kiam/templates/server/server-secret.yaml
+++ b/bitnami/kiam/templates/server/server-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kiam/templates/server/server-service-account.yaml
+++ b/bitnami/kiam/templates/server/server-service-account.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kiam/templates/server/server-service.yaml
+++ b/bitnami/kiam/templates/server/server-service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kiam/templates/server/server-servicemonitor.yaml
+++ b/bitnami/kiam/templates/server/server-servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kiam/templates/server/server-write-clusterrole.yaml
+++ b/bitnami/kiam/templates/server/server-write-clusterrole.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kiam/templates/server/server-write-clusterrolebinding.yaml
+++ b/bitnami/kiam/templates/server/server-write-clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kiam/values.yaml
+++ b/bitnami/kiam/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters

--- a/bitnami/kibana/Chart.yaml
+++ b/bitnami/kibana/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/kibana/templates/_helpers.tpl
+++ b/bitnami/kibana/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kibana/templates/configmap.yaml
+++ b/bitnami/kibana/templates/configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kibana/templates/deployment.yaml
+++ b/bitnami/kibana/templates/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kibana/templates/extra-list.yaml
+++ b/bitnami/kibana/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kibana/templates/ingress.yaml
+++ b/bitnami/kibana/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kibana/templates/networkpolicy.yaml
+++ b/bitnami/kibana/templates/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kibana/templates/plugins-configmap.yaml
+++ b/bitnami/kibana/templates/plugins-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kibana/templates/pvc.yaml
+++ b/bitnami/kibana/templates/pvc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kibana/templates/saved-objects-configmap.yaml
+++ b/bitnami/kibana/templates/saved-objects-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kibana/templates/secret.yaml
+++ b/bitnami/kibana/templates/secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kibana/templates/service.yaml
+++ b/bitnami/kibana/templates/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kibana/templates/serviceaccount.yaml
+++ b/bitnami/kibana/templates/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kibana/templates/servicemonitor.yaml
+++ b/bitnami/kibana/templates/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kibana/templates/tls-secret.yaml
+++ b/bitnami/kibana/templates/tls-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kibana/values.yaml
+++ b/bitnami/kibana/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters

--- a/bitnami/kong/Chart.yaml
+++ b/bitnami/kong/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/kong/templates/_helpers.tpl
+++ b/bitnami/kong/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kong/templates/declarative-config-configmap.yaml
+++ b/bitnami/kong/templates/declarative-config-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kong/templates/dep-ds.yaml
+++ b/bitnami/kong/templates/dep-ds.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kong/templates/external-database-secret.yaml
+++ b/bitnami/kong/templates/external-database-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kong/templates/extra-list.yaml
+++ b/bitnami/kong/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kong/templates/hpa.yaml
+++ b/bitnami/kong/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kong/templates/ingress-controller-rbac.yaml
+++ b/bitnami/kong/templates/ingress-controller-rbac.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kong/templates/ingress-controller-serviceaccount.yaml
+++ b/bitnami/kong/templates/ingress-controller-serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kong/templates/ingress.yaml
+++ b/bitnami/kong/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kong/templates/kong-prometheus-role.yaml
+++ b/bitnami/kong/templates/kong-prometheus-role.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kong/templates/kong-prometheus-rolebinding.yaml
+++ b/bitnami/kong/templates/kong-prometheus-rolebinding.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kong/templates/kong-script-configmap.yaml
+++ b/bitnami/kong/templates/kong-script-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kong/templates/metrics-exporter-configmap.yaml
+++ b/bitnami/kong/templates/metrics-exporter-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kong/templates/metrics-script-configmap.yaml
+++ b/bitnami/kong/templates/metrics-script-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kong/templates/metrics-service.yaml
+++ b/bitnami/kong/templates/metrics-service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kong/templates/migrate-job-networkpolicy.yaml
+++ b/bitnami/kong/templates/migrate-job-networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kong/templates/migrate-job.yaml
+++ b/bitnami/kong/templates/migrate-job.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kong/templates/networkpolicy.yaml
+++ b/bitnami/kong/templates/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kong/templates/pdb.yaml
+++ b/bitnami/kong/templates/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kong/templates/service.yaml
+++ b/bitnami/kong/templates/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kong/templates/servicemonitor.yaml
+++ b/bitnami/kong/templates/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kong/templates/tls-secrets.yaml
+++ b/bitnami/kong/templates/tls-secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kong/values.yaml
+++ b/bitnami/kong/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters

--- a/bitnami/kube-prometheus/Chart.yaml
+++ b/bitnami/kube-prometheus/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/kube-prometheus/templates/_helpers.tpl
+++ b/bitnami/kube-prometheus/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kube-prometheus/templates/alertmanager/alertmanager.yaml
+++ b/bitnami/kube-prometheus/templates/alertmanager/alertmanager.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kube-prometheus/templates/alertmanager/ingress.yaml
+++ b/bitnami/kube-prometheus/templates/alertmanager/ingress.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kube-prometheus/templates/alertmanager/networkpolicy.yaml
+++ b/bitnami/kube-prometheus/templates/alertmanager/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kube-prometheus/templates/alertmanager/pdb.yaml
+++ b/bitnami/kube-prometheus/templates/alertmanager/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kube-prometheus/templates/alertmanager/psp-clusterrole.yaml
+++ b/bitnami/kube-prometheus/templates/alertmanager/psp-clusterrole.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kube-prometheus/templates/alertmanager/psp-clusterrolebinding.yaml
+++ b/bitnami/kube-prometheus/templates/alertmanager/psp-clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kube-prometheus/templates/alertmanager/psp.yaml
+++ b/bitnami/kube-prometheus/templates/alertmanager/psp.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kube-prometheus/templates/alertmanager/secrets.yaml
+++ b/bitnami/kube-prometheus/templates/alertmanager/secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kube-prometheus/templates/alertmanager/service.yaml
+++ b/bitnami/kube-prometheus/templates/alertmanager/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kube-prometheus/templates/alertmanager/serviceaccount.yaml
+++ b/bitnami/kube-prometheus/templates/alertmanager/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kube-prometheus/templates/alertmanager/servicemonitor.yaml
+++ b/bitnami/kube-prometheus/templates/alertmanager/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kube-prometheus/templates/alertmanager/tls-secrets.yaml
+++ b/bitnami/kube-prometheus/templates/alertmanager/tls-secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kube-prometheus/templates/blackbox-exporter/configmap.yaml
+++ b/bitnami/kube-prometheus/templates/blackbox-exporter/configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kube-prometheus/templates/blackbox-exporter/deployment.yaml
+++ b/bitnami/kube-prometheus/templates/blackbox-exporter/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kube-prometheus/templates/blackbox-exporter/networkpolicy.yaml
+++ b/bitnami/kube-prometheus/templates/blackbox-exporter/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kube-prometheus/templates/blackbox-exporter/service.yaml
+++ b/bitnami/kube-prometheus/templates/blackbox-exporter/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kube-prometheus/templates/blackbox-exporter/serviceaccount.yaml
+++ b/bitnami/kube-prometheus/templates/blackbox-exporter/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kube-prometheus/templates/exporters/core-dns/service.yaml
+++ b/bitnami/kube-prometheus/templates/exporters/core-dns/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kube-prometheus/templates/exporters/core-dns/servicemonitor.yaml
+++ b/bitnami/kube-prometheus/templates/exporters/core-dns/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kube-prometheus/templates/exporters/kube-apiserver/servicemonitor.yaml
+++ b/bitnami/kube-prometheus/templates/exporters/kube-apiserver/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kube-prometheus/templates/exporters/kube-controller-manager/endpoints.yaml
+++ b/bitnami/kube-prometheus/templates/exporters/kube-controller-manager/endpoints.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kube-prometheus/templates/exporters/kube-controller-manager/service.yaml
+++ b/bitnami/kube-prometheus/templates/exporters/kube-controller-manager/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kube-prometheus/templates/exporters/kube-controller-manager/servicemonitor.yaml
+++ b/bitnami/kube-prometheus/templates/exporters/kube-controller-manager/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kube-prometheus/templates/exporters/kube-proxy/endpoints.yaml
+++ b/bitnami/kube-prometheus/templates/exporters/kube-proxy/endpoints.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kube-prometheus/templates/exporters/kube-proxy/service.yaml
+++ b/bitnami/kube-prometheus/templates/exporters/kube-proxy/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kube-prometheus/templates/exporters/kube-proxy/servicemonitor.yaml
+++ b/bitnami/kube-prometheus/templates/exporters/kube-proxy/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kube-prometheus/templates/exporters/kube-scheduler/endpoints.yaml
+++ b/bitnami/kube-prometheus/templates/exporters/kube-scheduler/endpoints.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kube-prometheus/templates/exporters/kube-scheduler/service.yaml
+++ b/bitnami/kube-prometheus/templates/exporters/kube-scheduler/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kube-prometheus/templates/exporters/kube-scheduler/servicemonitor.yaml
+++ b/bitnami/kube-prometheus/templates/exporters/kube-scheduler/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kube-prometheus/templates/exporters/kubelet/servicemonitor.yaml
+++ b/bitnami/kube-prometheus/templates/exporters/kubelet/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kube-prometheus/templates/extra-list.yaml
+++ b/bitnami/kube-prometheus/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kube-prometheus/templates/prometheus-operator/clusterrole.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus-operator/clusterrole.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kube-prometheus/templates/prometheus-operator/clusterrolebinding.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus-operator/clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kube-prometheus/templates/prometheus-operator/configmap.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus-operator/configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kube-prometheus/templates/prometheus-operator/deployment.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus-operator/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kube-prometheus/templates/prometheus-operator/networkpolicy.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus-operator/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kube-prometheus/templates/prometheus-operator/psp-clusterrole.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus-operator/psp-clusterrole.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kube-prometheus/templates/prometheus-operator/psp-clusterrolebinding.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus-operator/psp-clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kube-prometheus/templates/prometheus-operator/psp.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus-operator/psp.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kube-prometheus/templates/prometheus-operator/service.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus-operator/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kube-prometheus/templates/prometheus-operator/serviceaccount.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus-operator/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kube-prometheus/templates/prometheus-operator/servicemonitor.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus-operator/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kube-prometheus/templates/prometheus/additionalPrometheusRules.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus/additionalPrometheusRules.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kube-prometheus/templates/prometheus/additionalScrapeJobs.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus/additionalScrapeJobs.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kube-prometheus/templates/prometheus/clusterrole.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus/clusterrole.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kube-prometheus/templates/prometheus/clusterrolebinding.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus/clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kube-prometheus/templates/prometheus/config-reloader-service.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus/config-reloader-service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kube-prometheus/templates/prometheus/config-reloader-servicemonitor.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus/config-reloader-servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kube-prometheus/templates/prometheus/ingress.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus/ingress.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kube-prometheus/templates/prometheus/networkpolicy.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kube-prometheus/templates/prometheus/pdb.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kube-prometheus/templates/prometheus/prometheus.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus/prometheus.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kube-prometheus/templates/prometheus/psp-clusterrole.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus/psp-clusterrole.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kube-prometheus/templates/prometheus/psp-clusterrolebinding.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus/psp-clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kube-prometheus/templates/prometheus/psp.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus/psp.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kube-prometheus/templates/prometheus/service.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kube-prometheus/templates/prometheus/serviceaccount.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kube-prometheus/templates/prometheus/servicemonitor.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kube-prometheus/templates/prometheus/thanos-ingress.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus/thanos-ingress.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kube-prometheus/templates/prometheus/thanos-service.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus/thanos-service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kube-prometheus/templates/prometheus/tls-secrets.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus/tls-secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kube-prometheus/values.yaml
+++ b/bitnami/kube-prometheus/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters

--- a/bitnami/kube-state-metrics/Chart.yaml
+++ b/bitnami/kube-state-metrics/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/kube-state-metrics/templates/_helpers.tpl
+++ b/bitnami/kube-state-metrics/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kube-state-metrics/templates/clusterrole.yaml
+++ b/bitnami/kube-state-metrics/templates/clusterrole.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kube-state-metrics/templates/clusterrolebinding.yaml
+++ b/bitnami/kube-state-metrics/templates/clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kube-state-metrics/templates/deployment.yaml
+++ b/bitnami/kube-state-metrics/templates/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kube-state-metrics/templates/extra-list.yaml
+++ b/bitnami/kube-state-metrics/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kube-state-metrics/templates/networkpolicy.yaml
+++ b/bitnami/kube-state-metrics/templates/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kube-state-metrics/templates/psp-clusterrole.yaml
+++ b/bitnami/kube-state-metrics/templates/psp-clusterrole.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kube-state-metrics/templates/psp-clusterrolebinding.yaml
+++ b/bitnami/kube-state-metrics/templates/psp-clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kube-state-metrics/templates/psp.yaml
+++ b/bitnami/kube-state-metrics/templates/psp.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kube-state-metrics/templates/service.yaml
+++ b/bitnami/kube-state-metrics/templates/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kube-state-metrics/templates/serviceaccount.yaml
+++ b/bitnami/kube-state-metrics/templates/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kube-state-metrics/templates/servicemonitor.yaml
+++ b/bitnami/kube-state-metrics/templates/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kube-state-metrics/values.yaml
+++ b/bitnami/kube-state-metrics/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters

--- a/bitnami/kubeapps/Chart.yaml
+++ b/bitnami/kubeapps/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/kubeapps/templates/_helpers.tpl
+++ b/bitnami/kubeapps/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kubeapps/templates/apprepository/apprepositories-secret.yaml
+++ b/bitnami/kubeapps/templates/apprepository/apprepositories-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kubeapps/templates/apprepository/apprepositories.yaml
+++ b/bitnami/kubeapps/templates/apprepository/apprepositories.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kubeapps/templates/apprepository/deployment.yaml
+++ b/bitnami/kubeapps/templates/apprepository/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kubeapps/templates/apprepository/networkpolicy.yaml
+++ b/bitnami/kubeapps/templates/apprepository/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kubeapps/templates/apprepository/rbac.yaml
+++ b/bitnami/kubeapps/templates/apprepository/rbac.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kubeapps/templates/apprepository/serviceaccount.yaml
+++ b/bitnami/kubeapps/templates/apprepository/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kubeapps/templates/dashboard/configmap.yaml
+++ b/bitnami/kubeapps/templates/dashboard/configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kubeapps/templates/dashboard/deployment.yaml
+++ b/bitnami/kubeapps/templates/dashboard/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kubeapps/templates/dashboard/networkpolicy.yaml
+++ b/bitnami/kubeapps/templates/dashboard/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kubeapps/templates/dashboard/service.yaml
+++ b/bitnami/kubeapps/templates/dashboard/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kubeapps/templates/extra-list.yaml
+++ b/bitnami/kubeapps/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kubeapps/templates/frontend/configmap.yaml
+++ b/bitnami/kubeapps/templates/frontend/configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kubeapps/templates/frontend/deployment.yaml
+++ b/bitnami/kubeapps/templates/frontend/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kubeapps/templates/frontend/networkpolicy.yaml
+++ b/bitnami/kubeapps/templates/frontend/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kubeapps/templates/frontend/oauth2-secret.yaml
+++ b/bitnami/kubeapps/templates/frontend/oauth2-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kubeapps/templates/frontend/service.yaml
+++ b/bitnami/kubeapps/templates/frontend/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kubeapps/templates/ingress-api.yaml
+++ b/bitnami/kubeapps/templates/ingress-api.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kubeapps/templates/ingress.yaml
+++ b/bitnami/kubeapps/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kubeapps/templates/kubeappsapis/configmap.yaml
+++ b/bitnami/kubeapps/templates/kubeappsapis/configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kubeapps/templates/kubeappsapis/deployment.yaml
+++ b/bitnami/kubeapps/templates/kubeappsapis/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kubeapps/templates/kubeappsapis/networkpolicy.yaml
+++ b/bitnami/kubeapps/templates/kubeappsapis/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kubeapps/templates/kubeappsapis/rbac.yaml
+++ b/bitnami/kubeapps/templates/kubeappsapis/rbac.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kubeapps/templates/kubeappsapis/rbac_fluxv2.yaml
+++ b/bitnami/kubeapps/templates/kubeappsapis/rbac_fluxv2.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kubeapps/templates/kubeappsapis/service.yaml
+++ b/bitnami/kubeapps/templates/kubeappsapis/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kubeapps/templates/kubeappsapis/serviceaccount.yaml
+++ b/bitnami/kubeapps/templates/kubeappsapis/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kubeapps/templates/shared/config.yaml
+++ b/bitnami/kubeapps/templates/shared/config.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kubeapps/templates/shared/helm-global-repos-namespace.yaml
+++ b/bitnami/kubeapps/templates/shared/helm-global-repos-namespace.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kubeapps/templates/tls-secrets.yaml
+++ b/bitnami/kubeapps/templates/tls-secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kubeapps/values.yaml
+++ b/bitnami/kubeapps/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters

--- a/bitnami/kuberay/Chart.yaml
+++ b/bitnami/kuberay/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/kuberay/templates/_helpers.tpl
+++ b/bitnami/kuberay/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kuberay/templates/apiserver/clusterrolebinding.yaml
+++ b/bitnami/kuberay/templates/apiserver/clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kuberay/templates/apiserver/clusterroles.yaml
+++ b/bitnami/kuberay/templates/apiserver/clusterroles.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kuberay/templates/apiserver/deployment.yaml
+++ b/bitnami/kuberay/templates/apiserver/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kuberay/templates/apiserver/hpa.yaml
+++ b/bitnami/kuberay/templates/apiserver/hpa.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kuberay/templates/apiserver/ingress-tls-secret.yaml
+++ b/bitnami/kuberay/templates/apiserver/ingress-tls-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kuberay/templates/apiserver/ingress.yaml
+++ b/bitnami/kuberay/templates/apiserver/ingress.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kuberay/templates/apiserver/networkpolicy.yaml
+++ b/bitnami/kuberay/templates/apiserver/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kuberay/templates/apiserver/pdb.yaml
+++ b/bitnami/kuberay/templates/apiserver/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kuberay/templates/apiserver/role.yaml
+++ b/bitnami/kuberay/templates/apiserver/role.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kuberay/templates/apiserver/rolebinding.yaml
+++ b/bitnami/kuberay/templates/apiserver/rolebinding.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kuberay/templates/apiserver/service-account.yaml
+++ b/bitnami/kuberay/templates/apiserver/service-account.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kuberay/templates/apiserver/service.yaml
+++ b/bitnami/kuberay/templates/apiserver/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kuberay/templates/apiserver/servicemonitor.yaml
+++ b/bitnami/kuberay/templates/apiserver/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kuberay/templates/apiserver/vpa.yaml
+++ b/bitnami/kuberay/templates/apiserver/vpa.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kuberay/templates/cluster/raycluster.yaml
+++ b/bitnami/kuberay/templates/cluster/raycluster.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kuberay/templates/cluster/service-account.yaml
+++ b/bitnami/kuberay/templates/cluster/service-account.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kuberay/templates/extra-list.yaml
+++ b/bitnami/kuberay/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kuberay/templates/operator/clusterrolebinding.yaml
+++ b/bitnami/kuberay/templates/operator/clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kuberay/templates/operator/clusterroles.yaml
+++ b/bitnami/kuberay/templates/operator/clusterroles.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kuberay/templates/operator/deployment.yaml
+++ b/bitnami/kuberay/templates/operator/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kuberay/templates/operator/hpa.yaml
+++ b/bitnami/kuberay/templates/operator/hpa.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kuberay/templates/operator/ingress-tls-secret.yaml
+++ b/bitnami/kuberay/templates/operator/ingress-tls-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kuberay/templates/operator/ingress.yaml
+++ b/bitnami/kuberay/templates/operator/ingress.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kuberay/templates/operator/networkpolicy.yaml
+++ b/bitnami/kuberay/templates/operator/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kuberay/templates/operator/pdb.yaml
+++ b/bitnami/kuberay/templates/operator/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kuberay/templates/operator/role.yaml
+++ b/bitnami/kuberay/templates/operator/role.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kuberay/templates/operator/rolebinding.yaml
+++ b/bitnami/kuberay/templates/operator/rolebinding.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kuberay/templates/operator/service-account.yaml
+++ b/bitnami/kuberay/templates/operator/service-account.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kuberay/templates/operator/service.yaml
+++ b/bitnami/kuberay/templates/operator/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kuberay/templates/operator/servicemonitor.yaml
+++ b/bitnami/kuberay/templates/operator/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kuberay/templates/operator/vpa.yaml
+++ b/bitnami/kuberay/templates/operator/vpa.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kuberay/values.yaml
+++ b/bitnami/kuberay/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters

--- a/bitnami/kubernetes-event-exporter/Chart.yaml
+++ b/bitnami/kubernetes-event-exporter/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/kubernetes-event-exporter/templates/_helpers.tpl
+++ b/bitnami/kubernetes-event-exporter/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kubernetes-event-exporter/templates/clusterrole.yaml
+++ b/bitnami/kubernetes-event-exporter/templates/clusterrole.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kubernetes-event-exporter/templates/configmap.yaml
+++ b/bitnami/kubernetes-event-exporter/templates/configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kubernetes-event-exporter/templates/deployment.yaml
+++ b/bitnami/kubernetes-event-exporter/templates/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kubernetes-event-exporter/templates/extra-list.yaml
+++ b/bitnami/kubernetes-event-exporter/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kubernetes-event-exporter/templates/metrics-service.yaml
+++ b/bitnami/kubernetes-event-exporter/templates/metrics-service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kubernetes-event-exporter/templates/networkpolicy.yaml
+++ b/bitnami/kubernetes-event-exporter/templates/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kubernetes-event-exporter/templates/prometheusrule.yaml
+++ b/bitnami/kubernetes-event-exporter/templates/prometheusrule.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kubernetes-event-exporter/templates/rbac-leader-election.yaml
+++ b/bitnami/kubernetes-event-exporter/templates/rbac-leader-election.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kubernetes-event-exporter/templates/rbac.yaml
+++ b/bitnami/kubernetes-event-exporter/templates/rbac.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kubernetes-event-exporter/templates/serviceaccount.yaml
+++ b/bitnami/kubernetes-event-exporter/templates/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kubernetes-event-exporter/templates/servicemonitor.yaml
+++ b/bitnami/kubernetes-event-exporter/templates/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kubernetes-event-exporter/templates/vpa.yaml
+++ b/bitnami/kubernetes-event-exporter/templates/vpa.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/kubernetes-event-exporter/values.yaml
+++ b/bitnami/kubernetes-event-exporter/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters

--- a/bitnami/logstash/Chart.yaml
+++ b/bitnami/logstash/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/logstash/templates/_helpers.tpl
+++ b/bitnami/logstash/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/logstash/templates/configuration-cm.yaml
+++ b/bitnami/logstash/templates/configuration-cm.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/logstash/templates/extra-list.yaml
+++ b/bitnami/logstash/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/logstash/templates/headless-svc.yaml
+++ b/bitnami/logstash/templates/headless-svc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/logstash/templates/ingress.yaml
+++ b/bitnami/logstash/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/logstash/templates/networkpolicy.yaml
+++ b/bitnami/logstash/templates/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/logstash/templates/pdb.yaml
+++ b/bitnami/logstash/templates/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/logstash/templates/serviceaccount.yaml
+++ b/bitnami/logstash/templates/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/logstash/templates/sts.yaml
+++ b/bitnami/logstash/templates/sts.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/logstash/templates/svc.yaml
+++ b/bitnami/logstash/templates/svc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/logstash/templates/tls-secret.yaml
+++ b/bitnami/logstash/templates/tls-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/logstash/values.yaml
+++ b/bitnami/logstash/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters

--- a/bitnami/magento/Chart.yaml
+++ b/bitnami/magento/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/magento/templates/_certificates.tpl
+++ b/bitnami/magento/templates/_certificates.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/magento/templates/_helpers.tpl
+++ b/bitnami/magento/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/magento/templates/deployment.yaml
+++ b/bitnami/magento/templates/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/magento/templates/externaldb-secrets.yaml
+++ b/bitnami/magento/templates/externaldb-secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/magento/templates/extra-list.yaml
+++ b/bitnami/magento/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/magento/templates/hpa.yaml
+++ b/bitnami/magento/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/magento/templates/ingress.yaml
+++ b/bitnami/magento/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/magento/templates/metrics-svc.yaml
+++ b/bitnami/magento/templates/metrics-svc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/magento/templates/networkpolicy.yaml
+++ b/bitnami/magento/templates/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/magento/templates/pv.yaml
+++ b/bitnami/magento/templates/pv.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/magento/templates/pvc.yaml
+++ b/bitnami/magento/templates/pvc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/magento/templates/secrets.yaml
+++ b/bitnami/magento/templates/secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/magento/templates/serviceaccount.yaml
+++ b/bitnami/magento/templates/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/magento/templates/svc.yaml
+++ b/bitnami/magento/templates/svc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/magento/templates/tls-secrets.yaml
+++ b/bitnami/magento/templates/tls-secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/magento/values.yaml
+++ b/bitnami/magento/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters

--- a/bitnami/mariadb-galera/Chart.yaml
+++ b/bitnami/mariadb-galera/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/mariadb-galera/templates/_helpers.tpl
+++ b/bitnami/mariadb-galera/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mariadb-galera/templates/configmap.yaml
+++ b/bitnami/mariadb-galera/templates/configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mariadb-galera/templates/extra-list.yaml
+++ b/bitnami/mariadb-galera/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mariadb-galera/templates/headless-svc.yaml
+++ b/bitnami/mariadb-galera/templates/headless-svc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mariadb-galera/templates/initialization-configmap.yaml
+++ b/bitnami/mariadb-galera/templates/initialization-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mariadb-galera/templates/metrics-svc.yaml
+++ b/bitnami/mariadb-galera/templates/metrics-svc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mariadb-galera/templates/networkpolicy.yaml
+++ b/bitnami/mariadb-galera/templates/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mariadb-galera/templates/pdb.yaml
+++ b/bitnami/mariadb-galera/templates/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mariadb-galera/templates/prometheusrules.yaml
+++ b/bitnami/mariadb-galera/templates/prometheusrules.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mariadb-galera/templates/role.yaml
+++ b/bitnami/mariadb-galera/templates/role.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mariadb-galera/templates/rolebinding.yaml
+++ b/bitnami/mariadb-galera/templates/rolebinding.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mariadb-galera/templates/secrets.yaml
+++ b/bitnami/mariadb-galera/templates/secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mariadb-galera/templates/serviceaccount.yaml
+++ b/bitnami/mariadb-galera/templates/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mariadb-galera/templates/servicemonitor.yaml
+++ b/bitnami/mariadb-galera/templates/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mariadb-galera/templates/statefulset.yaml
+++ b/bitnami/mariadb-galera/templates/statefulset.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mariadb-galera/templates/svc.yaml
+++ b/bitnami/mariadb-galera/templates/svc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mariadb-galera/templates/tls-secrets.yaml
+++ b/bitnami/mariadb-galera/templates/tls-secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mariadb-galera/values.yaml
+++ b/bitnami/mariadb-galera/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters

--- a/bitnami/mariadb/Chart.yaml
+++ b/bitnami/mariadb/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/mariadb/templates/_helpers.tpl
+++ b/bitnami/mariadb/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mariadb/templates/extra-list.yaml
+++ b/bitnami/mariadb/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mariadb/templates/networkpolicy.yaml
+++ b/bitnami/mariadb/templates/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mariadb/templates/primary/configmap.yaml
+++ b/bitnami/mariadb/templates/primary/configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mariadb/templates/primary/initialization-configmap.yaml
+++ b/bitnami/mariadb/templates/primary/initialization-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mariadb/templates/primary/pdb.yaml
+++ b/bitnami/mariadb/templates/primary/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mariadb/templates/primary/statefulset.yaml
+++ b/bitnami/mariadb/templates/primary/statefulset.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mariadb/templates/primary/svc.yaml
+++ b/bitnami/mariadb/templates/primary/svc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mariadb/templates/prometheusrules.yaml
+++ b/bitnami/mariadb/templates/prometheusrules.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mariadb/templates/role.yaml
+++ b/bitnami/mariadb/templates/role.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mariadb/templates/rolebinding.yaml
+++ b/bitnami/mariadb/templates/rolebinding.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mariadb/templates/secondary/configmap.yaml
+++ b/bitnami/mariadb/templates/secondary/configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mariadb/templates/secondary/pdb.yaml
+++ b/bitnami/mariadb/templates/secondary/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mariadb/templates/secondary/statefulset.yaml
+++ b/bitnami/mariadb/templates/secondary/statefulset.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mariadb/templates/secondary/svc.yaml
+++ b/bitnami/mariadb/templates/secondary/svc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mariadb/templates/secrets.yaml
+++ b/bitnami/mariadb/templates/secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mariadb/templates/serviceaccount.yaml
+++ b/bitnami/mariadb/templates/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mariadb/templates/servicemonitor.yaml
+++ b/bitnami/mariadb/templates/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mariadb/values.yaml
+++ b/bitnami/mariadb/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters

--- a/bitnami/mastodon/Chart.yaml
+++ b/bitnami/mastodon/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/mastodon/templates/_helpers.tpl
+++ b/bitnami/mastodon/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mastodon/templates/apache-configmap.yaml
+++ b/bitnami/mastodon/templates/apache-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mastodon/templates/default-configmap.yaml
+++ b/bitnami/mastodon/templates/default-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mastodon/templates/default-secret.yaml
+++ b/bitnami/mastodon/templates/default-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mastodon/templates/externaldb-secret.yaml
+++ b/bitnami/mastodon/templates/externaldb-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mastodon/templates/externalelasticsearch-secret.yaml
+++ b/bitnami/mastodon/templates/externalelasticsearch-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mastodon/templates/externalredis-secret.yaml
+++ b/bitnami/mastodon/templates/externalredis-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mastodon/templates/externals3-secret.yaml
+++ b/bitnami/mastodon/templates/externals3-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mastodon/templates/extra-configmap.yaml
+++ b/bitnami/mastodon/templates/extra-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mastodon/templates/extra-list.yaml
+++ b/bitnami/mastodon/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mastodon/templates/extra-secret.yaml
+++ b/bitnami/mastodon/templates/extra-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mastodon/templates/init-job/init-job-configmap.yaml
+++ b/bitnami/mastodon/templates/init-job/init-job-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mastodon/templates/init-job/init-job.yaml
+++ b/bitnami/mastodon/templates/init-job/init-job.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mastodon/templates/init-job/networkpolicy.yaml
+++ b/bitnami/mastodon/templates/init-job/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mastodon/templates/pvc.yaml
+++ b/bitnami/mastodon/templates/pvc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mastodon/templates/service-account.yaml
+++ b/bitnami/mastodon/templates/service-account.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mastodon/templates/sidekiq/deployment.yaml
+++ b/bitnami/mastodon/templates/sidekiq/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mastodon/templates/sidekiq/networkpolicy.yaml
+++ b/bitnami/mastodon/templates/sidekiq/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mastodon/templates/smtp-secret.yaml
+++ b/bitnami/mastodon/templates/smtp-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mastodon/templates/streaming/deployment.yaml
+++ b/bitnami/mastodon/templates/streaming/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mastodon/templates/streaming/networkpolicy.yaml
+++ b/bitnami/mastodon/templates/streaming/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mastodon/templates/streaming/service.yaml
+++ b/bitnami/mastodon/templates/streaming/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mastodon/templates/tootctlMediaManagement/configmap.yaml
+++ b/bitnami/mastodon/templates/tootctlMediaManagement/configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mastodon/templates/tootctlMediaManagement/cronjob.yaml
+++ b/bitnami/mastodon/templates/tootctlMediaManagement/cronjob.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mastodon/templates/tootctlMediaManagement/networkpolicy.yaml
+++ b/bitnami/mastodon/templates/tootctlMediaManagement/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mastodon/templates/web/deployment.yaml
+++ b/bitnami/mastodon/templates/web/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mastodon/templates/web/networkpolicy.yaml
+++ b/bitnami/mastodon/templates/web/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mastodon/templates/web/service.yaml
+++ b/bitnami/mastodon/templates/web/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mastodon/values.yaml
+++ b/bitnami/mastodon/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters

--- a/bitnami/matomo/Chart.yaml
+++ b/bitnami/matomo/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/matomo/templates/_helpers.tpl
+++ b/bitnami/matomo/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/matomo/templates/cronjob.yaml
+++ b/bitnami/matomo/templates/cronjob.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/matomo/templates/deployment.yaml
+++ b/bitnami/matomo/templates/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/matomo/templates/externaldb-secrets.yaml
+++ b/bitnami/matomo/templates/externaldb-secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/matomo/templates/extra-list.yaml
+++ b/bitnami/matomo/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/matomo/templates/ingress.yaml
+++ b/bitnami/matomo/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/matomo/templates/networkpolicy.yaml
+++ b/bitnami/matomo/templates/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/matomo/templates/postinit-configmap.yaml
+++ b/bitnami/matomo/templates/postinit-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/matomo/templates/pv.yaml
+++ b/bitnami/matomo/templates/pv.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/matomo/templates/pvc.yaml
+++ b/bitnami/matomo/templates/pvc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/matomo/templates/secrets.yaml
+++ b/bitnami/matomo/templates/secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/matomo/templates/svc.yaml
+++ b/bitnami/matomo/templates/svc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/matomo/templates/tls-secrets.yaml
+++ b/bitnami/matomo/templates/tls-secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/matomo/values.yaml
+++ b/bitnami/matomo/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters

--- a/bitnami/mediawiki/Chart.yaml
+++ b/bitnami/mediawiki/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/mediawiki/templates/_helpers.tpl
+++ b/bitnami/mediawiki/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mediawiki/templates/deployment.yaml
+++ b/bitnami/mediawiki/templates/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mediawiki/templates/externaldb-secrets.yaml
+++ b/bitnami/mediawiki/templates/externaldb-secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mediawiki/templates/extra-list.yaml
+++ b/bitnami/mediawiki/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mediawiki/templates/ingress.yaml
+++ b/bitnami/mediawiki/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mediawiki/templates/mediawiki-pvc.yaml
+++ b/bitnami/mediawiki/templates/mediawiki-pvc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mediawiki/templates/metrics-svc.yaml
+++ b/bitnami/mediawiki/templates/metrics-svc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mediawiki/templates/networkpolicy.yaml
+++ b/bitnami/mediawiki/templates/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mediawiki/templates/secrets.yaml
+++ b/bitnami/mediawiki/templates/secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mediawiki/templates/serviceaccount.yaml
+++ b/bitnami/mediawiki/templates/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mediawiki/templates/servicemonitor.yaml
+++ b/bitnami/mediawiki/templates/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mediawiki/templates/svc.yaml
+++ b/bitnami/mediawiki/templates/svc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mediawiki/templates/tls-secrets.yaml
+++ b/bitnami/mediawiki/templates/tls-secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mediawiki/values.yaml
+++ b/bitnami/mediawiki/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters

--- a/bitnami/memcached/Chart.yaml
+++ b/bitnami/memcached/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/memcached/templates/_helpers.tpl
+++ b/bitnami/memcached/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/memcached/templates/deployment.yaml
+++ b/bitnami/memcached/templates/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/memcached/templates/extra-list.yaml
+++ b/bitnami/memcached/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/memcached/templates/hpa.yaml
+++ b/bitnami/memcached/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/memcached/templates/metrics-svc.yaml
+++ b/bitnami/memcached/templates/metrics-svc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/memcached/templates/networkpolicy.yaml
+++ b/bitnami/memcached/templates/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/memcached/templates/pdb.yaml
+++ b/bitnami/memcached/templates/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/memcached/templates/secrets.yaml
+++ b/bitnami/memcached/templates/secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/memcached/templates/service.yaml
+++ b/bitnami/memcached/templates/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/memcached/templates/serviceaccount.yaml
+++ b/bitnami/memcached/templates/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/memcached/templates/servicemonitor.yaml
+++ b/bitnami/memcached/templates/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/memcached/templates/statefulset.yaml
+++ b/bitnami/memcached/templates/statefulset.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/memcached/values.yaml
+++ b/bitnami/memcached/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters

--- a/bitnami/metallb/Chart.yaml
+++ b/bitnami/metallb/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/metallb/templates/_helpers.tpl
+++ b/bitnami/metallb/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/metallb/templates/controller/configmap.yaml
+++ b/bitnami/metallb/templates/controller/configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/metallb/templates/controller/deployment.yaml
+++ b/bitnami/metallb/templates/controller/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/metallb/templates/controller/networkpolicy.yaml
+++ b/bitnami/metallb/templates/controller/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/metallb/templates/controller/psp.yaml
+++ b/bitnami/metallb/templates/controller/psp.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/metallb/templates/controller/rbac.yaml
+++ b/bitnami/metallb/templates/controller/rbac.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/metallb/templates/controller/service.yaml
+++ b/bitnami/metallb/templates/controller/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/metallb/templates/controller/serviceaccount.yaml
+++ b/bitnami/metallb/templates/controller/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/metallb/templates/controller/servicemonitor.yaml
+++ b/bitnami/metallb/templates/controller/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/metallb/templates/controller/webhooks.yaml
+++ b/bitnami/metallb/templates/controller/webhooks.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/metallb/templates/extra-list.yaml
+++ b/bitnami/metallb/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/metallb/templates/prometheus/metallb.alerts.yaml
+++ b/bitnami/metallb/templates/prometheus/metallb.alerts.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/metallb/templates/rbac.yaml
+++ b/bitnami/metallb/templates/rbac.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/metallb/templates/speaker/daemonset.yaml
+++ b/bitnami/metallb/templates/speaker/daemonset.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/metallb/templates/speaker/networkpolicy.yaml
+++ b/bitnami/metallb/templates/speaker/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/metallb/templates/speaker/psp.yaml
+++ b/bitnami/metallb/templates/speaker/psp.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/metallb/templates/speaker/rbac.yaml
+++ b/bitnami/metallb/templates/speaker/rbac.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/metallb/templates/speaker/secret.yaml
+++ b/bitnami/metallb/templates/speaker/secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/metallb/templates/speaker/service.yaml
+++ b/bitnami/metallb/templates/speaker/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/metallb/templates/speaker/serviceaccount.yaml
+++ b/bitnami/metallb/templates/speaker/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/metallb/templates/speaker/servicemonitor.yaml
+++ b/bitnami/metallb/templates/speaker/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/metallb/values.yaml
+++ b/bitnami/metallb/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters

--- a/bitnami/metrics-server/Chart.yaml
+++ b/bitnami/metrics-server/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/metrics-server/templates/_helpers.tpl
+++ b/bitnami/metrics-server/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/metrics-server/templates/auth-delegator-crb.yaml
+++ b/bitnami/metrics-server/templates/auth-delegator-crb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/metrics-server/templates/cluster-role.yaml
+++ b/bitnami/metrics-server/templates/cluster-role.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/metrics-server/templates/deployment.yaml
+++ b/bitnami/metrics-server/templates/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/metrics-server/templates/extra-list.yaml
+++ b/bitnami/metrics-server/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/metrics-server/templates/metrics-api-service.yaml
+++ b/bitnami/metrics-server/templates/metrics-api-service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/metrics-server/templates/metrics-server-crb.yaml
+++ b/bitnami/metrics-server/templates/metrics-server-crb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/metrics-server/templates/networkpolicy.yaml
+++ b/bitnami/metrics-server/templates/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/metrics-server/templates/pdb.yaml
+++ b/bitnami/metrics-server/templates/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/metrics-server/templates/role-binding.yaml
+++ b/bitnami/metrics-server/templates/role-binding.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/metrics-server/templates/serviceaccount.yaml
+++ b/bitnami/metrics-server/templates/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/metrics-server/templates/svc.yaml
+++ b/bitnami/metrics-server/templates/svc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/metrics-server/values.yaml
+++ b/bitnami/metrics-server/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters

--- a/bitnami/milvus/Chart.yaml
+++ b/bitnami/milvus/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/milvus/templates/_helpers.tpl
+++ b/bitnami/milvus/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/milvus/templates/attu/deployment.yaml
+++ b/bitnami/milvus/templates/attu/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/milvus/templates/attu/hpa.yaml
+++ b/bitnami/milvus/templates/attu/hpa.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/milvus/templates/attu/ingress-tls-secret.yaml
+++ b/bitnami/milvus/templates/attu/ingress-tls-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/milvus/templates/attu/ingress.yaml
+++ b/bitnami/milvus/templates/attu/ingress.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/milvus/templates/attu/networkpolicy.yaml
+++ b/bitnami/milvus/templates/attu/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/milvus/templates/attu/pdb.yaml
+++ b/bitnami/milvus/templates/attu/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/milvus/templates/attu/service-account.yaml
+++ b/bitnami/milvus/templates/attu/service-account.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/milvus/templates/attu/service.yaml
+++ b/bitnami/milvus/templates/attu/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/milvus/templates/attu/vpa.yaml
+++ b/bitnami/milvus/templates/attu/vpa.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/milvus/templates/configmap.yaml
+++ b/bitnami/milvus/templates/configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/milvus/templates/data-coordinator/configmap.yaml
+++ b/bitnami/milvus/templates/data-coordinator/configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/milvus/templates/data-coordinator/deployment.yaml
+++ b/bitnami/milvus/templates/data-coordinator/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/milvus/templates/data-coordinator/extra-configmap.yaml
+++ b/bitnami/milvus/templates/data-coordinator/extra-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/milvus/templates/data-coordinator/hpa.yaml
+++ b/bitnami/milvus/templates/data-coordinator/hpa.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/milvus/templates/data-coordinator/networkpolicy.yaml
+++ b/bitnami/milvus/templates/data-coordinator/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/milvus/templates/data-coordinator/pdb.yaml
+++ b/bitnami/milvus/templates/data-coordinator/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/milvus/templates/data-coordinator/service-account.yaml
+++ b/bitnami/milvus/templates/data-coordinator/service-account.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/milvus/templates/data-coordinator/service.yaml
+++ b/bitnami/milvus/templates/data-coordinator/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/milvus/templates/data-coordinator/servicemonitor.yaml
+++ b/bitnami/milvus/templates/data-coordinator/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/milvus/templates/data-coordinator/vpa.yaml
+++ b/bitnami/milvus/templates/data-coordinator/vpa.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/milvus/templates/data-node/configmap.yaml
+++ b/bitnami/milvus/templates/data-node/configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/milvus/templates/data-node/deployment.yaml
+++ b/bitnami/milvus/templates/data-node/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/milvus/templates/data-node/extra-configmap.yaml
+++ b/bitnami/milvus/templates/data-node/extra-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/milvus/templates/data-node/hpa.yaml
+++ b/bitnami/milvus/templates/data-node/hpa.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/milvus/templates/data-node/networkpolicy.yaml
+++ b/bitnami/milvus/templates/data-node/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/milvus/templates/data-node/pdb.yaml
+++ b/bitnami/milvus/templates/data-node/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/milvus/templates/data-node/service-account.yaml
+++ b/bitnami/milvus/templates/data-node/service-account.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/milvus/templates/data-node/service.yaml
+++ b/bitnami/milvus/templates/data-node/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/milvus/templates/data-node/servicemonitor.yaml
+++ b/bitnami/milvus/templates/data-node/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/milvus/templates/data-node/vpa.yaml
+++ b/bitnami/milvus/templates/data-node/vpa.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/milvus/templates/externaletcd-secret.yaml
+++ b/bitnami/milvus/templates/externaletcd-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/milvus/templates/externalkafka-secret.yaml
+++ b/bitnami/milvus/templates/externalkafka-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/milvus/templates/externals3-secret.yaml
+++ b/bitnami/milvus/templates/externals3-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/milvus/templates/extra-configmap.yaml
+++ b/bitnami/milvus/templates/extra-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/milvus/templates/extra-list.yaml
+++ b/bitnami/milvus/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/milvus/templates/index-coordinator/configmap.yaml
+++ b/bitnami/milvus/templates/index-coordinator/configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/milvus/templates/index-coordinator/deployment.yaml
+++ b/bitnami/milvus/templates/index-coordinator/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/milvus/templates/index-coordinator/extra-configmap.yaml
+++ b/bitnami/milvus/templates/index-coordinator/extra-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/milvus/templates/index-coordinator/hpa.yaml
+++ b/bitnami/milvus/templates/index-coordinator/hpa.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/milvus/templates/index-coordinator/networkpolicy.yaml
+++ b/bitnami/milvus/templates/index-coordinator/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/milvus/templates/index-coordinator/pdb.yaml
+++ b/bitnami/milvus/templates/index-coordinator/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/milvus/templates/index-coordinator/service-account.yaml
+++ b/bitnami/milvus/templates/index-coordinator/service-account.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/milvus/templates/index-coordinator/service.yaml
+++ b/bitnami/milvus/templates/index-coordinator/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/milvus/templates/index-coordinator/servicemonitor.yaml
+++ b/bitnami/milvus/templates/index-coordinator/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/milvus/templates/index-coordinator/vpa.yaml
+++ b/bitnami/milvus/templates/index-coordinator/vpa.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/milvus/templates/index-node/configmap.yaml
+++ b/bitnami/milvus/templates/index-node/configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/milvus/templates/index-node/deployment.yaml
+++ b/bitnami/milvus/templates/index-node/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/milvus/templates/index-node/extra-configmap.yaml
+++ b/bitnami/milvus/templates/index-node/extra-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/milvus/templates/index-node/hpa.yaml
+++ b/bitnami/milvus/templates/index-node/hpa.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/milvus/templates/index-node/networkpolicy.yaml
+++ b/bitnami/milvus/templates/index-node/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/milvus/templates/index-node/pdb.yaml
+++ b/bitnami/milvus/templates/index-node/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/milvus/templates/index-node/service-account.yaml
+++ b/bitnami/milvus/templates/index-node/service-account.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/milvus/templates/index-node/service.yaml
+++ b/bitnami/milvus/templates/index-node/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/milvus/templates/index-node/servicemonitor.yaml
+++ b/bitnami/milvus/templates/index-node/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/milvus/templates/index-node/vpa.yaml
+++ b/bitnami/milvus/templates/index-node/vpa.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/milvus/templates/init-job-networkpolicy.yaml
+++ b/bitnami/milvus/templates/init-job-networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/milvus/templates/init-job.yaml
+++ b/bitnami/milvus/templates/init-job.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/milvus/templates/proxy/configmap.yaml
+++ b/bitnami/milvus/templates/proxy/configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/milvus/templates/proxy/deployment.yaml
+++ b/bitnami/milvus/templates/proxy/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/milvus/templates/proxy/extra-configmap.yaml
+++ b/bitnami/milvus/templates/proxy/extra-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/milvus/templates/proxy/hpa.yaml
+++ b/bitnami/milvus/templates/proxy/hpa.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/milvus/templates/proxy/networkpolicy.yaml
+++ b/bitnami/milvus/templates/proxy/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/milvus/templates/proxy/pdb.yaml
+++ b/bitnami/milvus/templates/proxy/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/milvus/templates/proxy/service-account.yaml
+++ b/bitnami/milvus/templates/proxy/service-account.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/milvus/templates/proxy/service.yaml
+++ b/bitnami/milvus/templates/proxy/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/milvus/templates/proxy/servicemonitor.yaml
+++ b/bitnami/milvus/templates/proxy/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/milvus/templates/proxy/vpa.yaml
+++ b/bitnami/milvus/templates/proxy/vpa.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/milvus/templates/query-coordinator/configmap.yaml
+++ b/bitnami/milvus/templates/query-coordinator/configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/milvus/templates/query-coordinator/deployment.yaml
+++ b/bitnami/milvus/templates/query-coordinator/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/milvus/templates/query-coordinator/extra-configmap.yaml
+++ b/bitnami/milvus/templates/query-coordinator/extra-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/milvus/templates/query-coordinator/hpa.yaml
+++ b/bitnami/milvus/templates/query-coordinator/hpa.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/milvus/templates/query-coordinator/networkpolicy.yaml
+++ b/bitnami/milvus/templates/query-coordinator/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/milvus/templates/query-coordinator/pdb.yaml
+++ b/bitnami/milvus/templates/query-coordinator/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/milvus/templates/query-coordinator/service-account.yaml
+++ b/bitnami/milvus/templates/query-coordinator/service-account.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/milvus/templates/query-coordinator/service.yaml
+++ b/bitnami/milvus/templates/query-coordinator/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/milvus/templates/query-coordinator/servicemonitor.yaml
+++ b/bitnami/milvus/templates/query-coordinator/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/milvus/templates/query-coordinator/vpa.yaml
+++ b/bitnami/milvus/templates/query-coordinator/vpa.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/milvus/templates/query-node/configmap.yaml
+++ b/bitnami/milvus/templates/query-node/configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/milvus/templates/query-node/deployment.yaml
+++ b/bitnami/milvus/templates/query-node/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/milvus/templates/query-node/extra-configmap.yaml
+++ b/bitnami/milvus/templates/query-node/extra-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/milvus/templates/query-node/hpa.yaml
+++ b/bitnami/milvus/templates/query-node/hpa.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/milvus/templates/query-node/networkpolicy.yaml
+++ b/bitnami/milvus/templates/query-node/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/milvus/templates/query-node/pdb.yaml
+++ b/bitnami/milvus/templates/query-node/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/milvus/templates/query-node/service-account.yaml
+++ b/bitnami/milvus/templates/query-node/service-account.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/milvus/templates/query-node/service.yaml
+++ b/bitnami/milvus/templates/query-node/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/milvus/templates/query-node/servicemonitor.yaml
+++ b/bitnami/milvus/templates/query-node/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/milvus/templates/query-node/vpa.yaml
+++ b/bitnami/milvus/templates/query-node/vpa.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/milvus/templates/root-coordinator/configmap.yaml
+++ b/bitnami/milvus/templates/root-coordinator/configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/milvus/templates/root-coordinator/deployment.yaml
+++ b/bitnami/milvus/templates/root-coordinator/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/milvus/templates/root-coordinator/extra-configmap.yaml
+++ b/bitnami/milvus/templates/root-coordinator/extra-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/milvus/templates/root-coordinator/hpa.yaml
+++ b/bitnami/milvus/templates/root-coordinator/hpa.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/milvus/templates/root-coordinator/networkpolicy.yaml
+++ b/bitnami/milvus/templates/root-coordinator/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/milvus/templates/root-coordinator/pdb.yaml
+++ b/bitnami/milvus/templates/root-coordinator/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/milvus/templates/root-coordinator/service-account.yaml
+++ b/bitnami/milvus/templates/root-coordinator/service-account.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/milvus/templates/root-coordinator/service.yaml
+++ b/bitnami/milvus/templates/root-coordinator/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/milvus/templates/root-coordinator/servicemonitor.yaml
+++ b/bitnami/milvus/templates/root-coordinator/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/milvus/templates/root-coordinator/vpa.yaml
+++ b/bitnami/milvus/templates/root-coordinator/vpa.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/milvus/templates/secret.yaml
+++ b/bitnami/milvus/templates/secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/milvus/values.yaml
+++ b/bitnami/milvus/values.yaml
@@ -1,4 +1,4 @@
-## Copyright VMware, Inc.
+## Copyright Broadcom, Inc. All Rights Reserved.
 ## SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters

--- a/bitnami/minio/Chart.yaml
+++ b/bitnami/minio/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/minio/templates/_helpers.tpl
+++ b/bitnami/minio/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/minio/templates/api-ingress.yaml
+++ b/bitnami/minio/templates/api-ingress.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/minio/templates/distributed/headless-svc.yaml
+++ b/bitnami/minio/templates/distributed/headless-svc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/minio/templates/distributed/pdb.yaml
+++ b/bitnami/minio/templates/distributed/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/minio/templates/distributed/statefulset.yaml
+++ b/bitnami/minio/templates/distributed/statefulset.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/minio/templates/extra-list.yaml
+++ b/bitnami/minio/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/minio/templates/ingress.yaml
+++ b/bitnami/minio/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/minio/templates/networkpolicy.yaml
+++ b/bitnami/minio/templates/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/minio/templates/prometheusrule.yaml
+++ b/bitnami/minio/templates/prometheusrule.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/minio/templates/provisioning-configmap.yaml
+++ b/bitnami/minio/templates/provisioning-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/minio/templates/provisioning-job.yaml
+++ b/bitnami/minio/templates/provisioning-job.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/minio/templates/provisioning-networkpolicy.yaml
+++ b/bitnami/minio/templates/provisioning-networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/minio/templates/pvc.yaml
+++ b/bitnami/minio/templates/pvc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/minio/templates/secrets.yaml
+++ b/bitnami/minio/templates/secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/minio/templates/service.yaml
+++ b/bitnami/minio/templates/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/minio/templates/serviceaccount.yaml
+++ b/bitnami/minio/templates/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/minio/templates/servicemonitor.yaml
+++ b/bitnami/minio/templates/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/minio/templates/standalone/deployment.yaml
+++ b/bitnami/minio/templates/standalone/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/minio/templates/tls-secrets.yaml
+++ b/bitnami/minio/templates/tls-secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/minio/values.yaml
+++ b/bitnami/minio/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters

--- a/bitnami/mlflow/Chart.yaml
+++ b/bitnami/mlflow/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/mlflow/templates/_helpers.tpl
+++ b/bitnami/mlflow/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mlflow/templates/extra-list.yaml
+++ b/bitnami/mlflow/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mlflow/templates/run/dep-job.yaml
+++ b/bitnami/mlflow/templates/run/dep-job.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mlflow/templates/run/networkpolicy.yaml
+++ b/bitnami/mlflow/templates/run/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mlflow/templates/run/pvc.yaml
+++ b/bitnami/mlflow/templates/run/pvc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mlflow/templates/run/service-account.yaml
+++ b/bitnami/mlflow/templates/run/service-account.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mlflow/templates/run/source-configmap.yaml
+++ b/bitnami/mlflow/templates/run/source-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mlflow/templates/tracking/auth-secret.yaml
+++ b/bitnami/mlflow/templates/tracking/auth-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mlflow/templates/tracking/configmap-overrides.yaml
+++ b/bitnami/mlflow/templates/tracking/configmap-overrides.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mlflow/templates/tracking/deployment.yaml
+++ b/bitnami/mlflow/templates/tracking/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mlflow/templates/tracking/externaldb-secret.yaml
+++ b/bitnami/mlflow/templates/tracking/externaldb-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mlflow/templates/tracking/externals3-secret.yaml
+++ b/bitnami/mlflow/templates/tracking/externals3-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mlflow/templates/tracking/hpa.yaml
+++ b/bitnami/mlflow/templates/tracking/hpa.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mlflow/templates/tracking/ingress-tls-secrets.yaml
+++ b/bitnami/mlflow/templates/tracking/ingress-tls-secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mlflow/templates/tracking/ingress.yaml
+++ b/bitnami/mlflow/templates/tracking/ingress.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mlflow/templates/tracking/networkpolicy.yaml
+++ b/bitnami/mlflow/templates/tracking/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mlflow/templates/tracking/pdb.yaml
+++ b/bitnami/mlflow/templates/tracking/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mlflow/templates/tracking/pvc.yaml
+++ b/bitnami/mlflow/templates/tracking/pvc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mlflow/templates/tracking/service-account.yaml
+++ b/bitnami/mlflow/templates/tracking/service-account.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mlflow/templates/tracking/service.yaml
+++ b/bitnami/mlflow/templates/tracking/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mlflow/templates/tracking/servicemonitor.yaml
+++ b/bitnami/mlflow/templates/tracking/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mlflow/templates/tracking/tls-secret.yaml
+++ b/bitnami/mlflow/templates/tracking/tls-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mlflow/templates/tracking/vpa.yaml
+++ b/bitnami/mlflow/templates/tracking/vpa.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mlflow/values.yaml
+++ b/bitnami/mlflow/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters

--- a/bitnami/mongodb-sharded/Chart.yaml
+++ b/bitnami/mongodb-sharded/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/mongodb-sharded/templates/_helpers.tpl
+++ b/bitnami/mongodb-sharded/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mongodb-sharded/templates/config-server/config-server-configmap.yaml
+++ b/bitnami/mongodb-sharded/templates/config-server/config-server-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mongodb-sharded/templates/config-server/config-server-poddisruptionbudget.yaml
+++ b/bitnami/mongodb-sharded/templates/config-server/config-server-poddisruptionbudget.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mongodb-sharded/templates/config-server/config-server-podmonitor.yaml
+++ b/bitnami/mongodb-sharded/templates/config-server/config-server-podmonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mongodb-sharded/templates/config-server/config-server-statefulset.yaml
+++ b/bitnami/mongodb-sharded/templates/config-server/config-server-statefulset.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mongodb-sharded/templates/extra-list.yaml
+++ b/bitnami/mongodb-sharded/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mongodb-sharded/templates/headless-service.yaml
+++ b/bitnami/mongodb-sharded/templates/headless-service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mongodb-sharded/templates/mongos/mongos-configmap.yaml
+++ b/bitnami/mongodb-sharded/templates/mongos/mongos-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mongodb-sharded/templates/mongos/mongos-dep-sts.yaml
+++ b/bitnami/mongodb-sharded/templates/mongos/mongos-dep-sts.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mongodb-sharded/templates/mongos/mongos-poddisruptionbudget.yaml
+++ b/bitnami/mongodb-sharded/templates/mongos/mongos-poddisruptionbudget.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mongodb-sharded/templates/mongos/mongos-podmonitor.yaml
+++ b/bitnami/mongodb-sharded/templates/mongos/mongos-podmonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mongodb-sharded/templates/mongos/mongos-service-per-replica.yaml
+++ b/bitnami/mongodb-sharded/templates/mongos/mongos-service-per-replica.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mongodb-sharded/templates/mongos/mongos-service.yaml
+++ b/bitnami/mongodb-sharded/templates/mongos/mongos-service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mongodb-sharded/templates/networkpolicy.yaml
+++ b/bitnami/mongodb-sharded/templates/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mongodb-sharded/templates/replicaset-entrypoint-configmap.yaml
+++ b/bitnami/mongodb-sharded/templates/replicaset-entrypoint-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mongodb-sharded/templates/secrets.yaml
+++ b/bitnami/mongodb-sharded/templates/secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mongodb-sharded/templates/serviceaccount.yaml
+++ b/bitnami/mongodb-sharded/templates/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mongodb-sharded/templates/shard/shard-arbiter-configmap.yaml
+++ b/bitnami/mongodb-sharded/templates/shard/shard-arbiter-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mongodb-sharded/templates/shard/shard-arbiter-statefulset.yaml
+++ b/bitnami/mongodb-sharded/templates/shard/shard-arbiter-statefulset.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mongodb-sharded/templates/shard/shard-data-configmap.yaml
+++ b/bitnami/mongodb-sharded/templates/shard/shard-data-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mongodb-sharded/templates/shard/shard-data-poddisruptionbudget.yaml
+++ b/bitnami/mongodb-sharded/templates/shard/shard-data-poddisruptionbudget.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mongodb-sharded/templates/shard/shard-data-podmonitor.yaml
+++ b/bitnami/mongodb-sharded/templates/shard/shard-data-podmonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mongodb-sharded/templates/shard/shard-data-statefulset.yaml
+++ b/bitnami/mongodb-sharded/templates/shard/shard-data-statefulset.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mongodb-sharded/values.yaml
+++ b/bitnami/mongodb-sharded/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters

--- a/bitnami/mongodb/Chart.yaml
+++ b/bitnami/mongodb/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/mongodb/templates/_helpers.tpl
+++ b/bitnami/mongodb/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mongodb/templates/arbiter/configmap.yaml
+++ b/bitnami/mongodb/templates/arbiter/configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mongodb/templates/arbiter/headless-svc.yaml
+++ b/bitnami/mongodb/templates/arbiter/headless-svc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mongodb/templates/arbiter/pdb.yaml
+++ b/bitnami/mongodb/templates/arbiter/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mongodb/templates/arbiter/statefulset.yaml
+++ b/bitnami/mongodb/templates/arbiter/statefulset.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mongodb/templates/backup/cronjob.yaml
+++ b/bitnami/mongodb/templates/backup/cronjob.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mongodb/templates/backup/pvc.yaml
+++ b/bitnami/mongodb/templates/backup/pvc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mongodb/templates/common-scripts-cm.yaml
+++ b/bitnami/mongodb/templates/common-scripts-cm.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mongodb/templates/configmap.yaml
+++ b/bitnami/mongodb/templates/configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mongodb/templates/extra-list.yaml
+++ b/bitnami/mongodb/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mongodb/templates/hidden/configmap.yaml
+++ b/bitnami/mongodb/templates/hidden/configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mongodb/templates/hidden/external-access-svc.yaml
+++ b/bitnami/mongodb/templates/hidden/external-access-svc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mongodb/templates/hidden/headless-svc.yaml
+++ b/bitnami/mongodb/templates/hidden/headless-svc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mongodb/templates/hidden/pdb.yaml
+++ b/bitnami/mongodb/templates/hidden/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mongodb/templates/hidden/statefulset.yaml
+++ b/bitnami/mongodb/templates/hidden/statefulset.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mongodb/templates/initialization-configmap.yaml
+++ b/bitnami/mongodb/templates/initialization-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mongodb/templates/metrics-svc.yaml
+++ b/bitnami/mongodb/templates/metrics-svc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mongodb/templates/networkpolicy.yaml
+++ b/bitnami/mongodb/templates/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mongodb/templates/prometheusrule.yaml
+++ b/bitnami/mongodb/templates/prometheusrule.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mongodb/templates/psp.yaml
+++ b/bitnami/mongodb/templates/psp.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mongodb/templates/replicaset/external-access-svc.yaml
+++ b/bitnami/mongodb/templates/replicaset/external-access-svc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mongodb/templates/replicaset/headless-svc.yaml
+++ b/bitnami/mongodb/templates/replicaset/headless-svc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mongodb/templates/replicaset/pdb.yaml
+++ b/bitnami/mongodb/templates/replicaset/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mongodb/templates/replicaset/scripts-configmap.yaml
+++ b/bitnami/mongodb/templates/replicaset/scripts-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mongodb/templates/replicaset/statefulset.yaml
+++ b/bitnami/mongodb/templates/replicaset/statefulset.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mongodb/templates/replicaset/svc.yaml
+++ b/bitnami/mongodb/templates/replicaset/svc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mongodb/templates/role.yaml
+++ b/bitnami/mongodb/templates/role.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mongodb/templates/rolebinding.yaml
+++ b/bitnami/mongodb/templates/rolebinding.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mongodb/templates/secrets-ca.yaml
+++ b/bitnami/mongodb/templates/secrets-ca.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mongodb/templates/secrets.yaml
+++ b/bitnami/mongodb/templates/secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mongodb/templates/serviceaccount.yaml
+++ b/bitnami/mongodb/templates/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mongodb/templates/servicemonitor.yaml
+++ b/bitnami/mongodb/templates/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mongodb/templates/standalone/dep-sts.yaml
+++ b/bitnami/mongodb/templates/standalone/dep-sts.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mongodb/templates/standalone/pvc.yaml
+++ b/bitnami/mongodb/templates/standalone/pvc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mongodb/templates/standalone/svc.yaml
+++ b/bitnami/mongodb/templates/standalone/svc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mongodb/values.yaml
+++ b/bitnami/mongodb/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters

--- a/bitnami/moodle/Chart.yaml
+++ b/bitnami/moodle/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/moodle/templates/_helpers.tpl
+++ b/bitnami/moodle/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/moodle/templates/deployment.yaml
+++ b/bitnami/moodle/templates/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/moodle/templates/externaldb-secrets.yaml
+++ b/bitnami/moodle/templates/externaldb-secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/moodle/templates/extra-list.yaml
+++ b/bitnami/moodle/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/moodle/templates/ingress.yaml
+++ b/bitnami/moodle/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/moodle/templates/metrics-svc.yaml
+++ b/bitnami/moodle/templates/metrics-svc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/moodle/templates/networkpolicy.yaml
+++ b/bitnami/moodle/templates/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/moodle/templates/pv.yaml
+++ b/bitnami/moodle/templates/pv.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/moodle/templates/pvc.yaml
+++ b/bitnami/moodle/templates/pvc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/moodle/templates/secrets.yaml
+++ b/bitnami/moodle/templates/secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/moodle/templates/serviceaccount.yaml
+++ b/bitnami/moodle/templates/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/moodle/templates/storageclass.yaml
+++ b/bitnami/moodle/templates/storageclass.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/moodle/templates/svc.yaml
+++ b/bitnami/moodle/templates/svc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/moodle/templates/tls-secrets.yaml
+++ b/bitnami/moodle/templates/tls-secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/moodle/values.yaml
+++ b/bitnami/moodle/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters

--- a/bitnami/multus-cni/Chart.yaml
+++ b/bitnami/multus-cni/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/multus-cni/templates/_helpers.tpl
+++ b/bitnami/multus-cni/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/multus-cni/templates/clusterrole.yaml
+++ b/bitnami/multus-cni/templates/clusterrole.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/multus-cni/templates/clusterrolebinding.yaml
+++ b/bitnami/multus-cni/templates/clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/multus-cni/templates/daemonset.yaml
+++ b/bitnami/multus-cni/templates/daemonset.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/multus-cni/templates/extra-list.yaml
+++ b/bitnami/multus-cni/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/multus-cni/templates/networkpolicy.yaml
+++ b/bitnami/multus-cni/templates/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/multus-cni/templates/service-account.yaml
+++ b/bitnami/multus-cni/templates/service-account.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/multus-cni/values.yaml
+++ b/bitnami/multus-cni/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters

--- a/bitnami/mysql/Chart.yaml
+++ b/bitnami/mysql/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/mysql/templates/_helpers.tpl
+++ b/bitnami/mysql/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mysql/templates/extra-list.yaml
+++ b/bitnami/mysql/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mysql/templates/metrics-svc.yaml
+++ b/bitnami/mysql/templates/metrics-svc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mysql/templates/networkpolicy.yaml
+++ b/bitnami/mysql/templates/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mysql/templates/primary/configmap.yaml
+++ b/bitnami/mysql/templates/primary/configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mysql/templates/primary/initialization-configmap.yaml
+++ b/bitnami/mysql/templates/primary/initialization-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mysql/templates/primary/pdb.yaml
+++ b/bitnami/mysql/templates/primary/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mysql/templates/primary/startdb-configmap.yaml
+++ b/bitnami/mysql/templates/primary/startdb-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mysql/templates/primary/statefulset.yaml
+++ b/bitnami/mysql/templates/primary/statefulset.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mysql/templates/primary/svc-headless.yaml
+++ b/bitnami/mysql/templates/primary/svc-headless.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mysql/templates/primary/svc.yaml
+++ b/bitnami/mysql/templates/primary/svc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mysql/templates/prometheusrule.yaml
+++ b/bitnami/mysql/templates/prometheusrule.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mysql/templates/role.yaml
+++ b/bitnami/mysql/templates/role.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mysql/templates/rolebinding.yaml
+++ b/bitnami/mysql/templates/rolebinding.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mysql/templates/secondary/configmap.yaml
+++ b/bitnami/mysql/templates/secondary/configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mysql/templates/secondary/pdb.yaml
+++ b/bitnami/mysql/templates/secondary/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mysql/templates/secondary/statefulset.yaml
+++ b/bitnami/mysql/templates/secondary/statefulset.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mysql/templates/secondary/svc-headless.yaml
+++ b/bitnami/mysql/templates/secondary/svc-headless.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mysql/templates/secondary/svc.yaml
+++ b/bitnami/mysql/templates/secondary/svc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mysql/templates/secrets.yaml
+++ b/bitnami/mysql/templates/secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mysql/templates/serviceaccount.yaml
+++ b/bitnami/mysql/templates/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mysql/templates/servicemonitor.yaml
+++ b/bitnami/mysql/templates/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/mysql/values.yaml
+++ b/bitnami/mysql/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters

--- a/bitnami/nats/Chart.yaml
+++ b/bitnami/nats/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/nats/templates/_helpers.tpl
+++ b/bitnami/nats/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/nats/templates/deployment.yaml
+++ b/bitnami/nats/templates/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/nats/templates/extra-list.yaml
+++ b/bitnami/nats/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/nats/templates/headless-svc.yaml
+++ b/bitnami/nats/templates/headless-svc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/nats/templates/ingress.yaml
+++ b/bitnami/nats/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/nats/templates/metrics-svc.yaml
+++ b/bitnami/nats/templates/metrics-svc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/nats/templates/networkpolicy.yaml
+++ b/bitnami/nats/templates/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/nats/templates/poddisruptionbudget.yaml
+++ b/bitnami/nats/templates/poddisruptionbudget.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/nats/templates/secrets.yaml
+++ b/bitnami/nats/templates/secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/nats/templates/service.yaml
+++ b/bitnami/nats/templates/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/nats/templates/serviceaccount.yaml
+++ b/bitnami/nats/templates/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/nats/templates/servicemonitor.yaml
+++ b/bitnami/nats/templates/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/nats/templates/statefulset.yaml
+++ b/bitnami/nats/templates/statefulset.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/nats/templates/tls-secret.yaml
+++ b/bitnami/nats/templates/tls-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/nats/values.yaml
+++ b/bitnami/nats/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters

--- a/bitnami/nginx-ingress-controller/Chart.yaml
+++ b/bitnami/nginx-ingress-controller/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/nginx-ingress-controller/templates/_helpers.tpl
+++ b/bitnami/nginx-ingress-controller/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/nginx-ingress-controller/templates/addheaders-configmap.yaml
+++ b/bitnami/nginx-ingress-controller/templates/addheaders-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/nginx-ingress-controller/templates/clusterrole.yaml
+++ b/bitnami/nginx-ingress-controller/templates/clusterrole.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/nginx-ingress-controller/templates/clusterrolebinding.yaml
+++ b/bitnami/nginx-ingress-controller/templates/clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/nginx-ingress-controller/templates/controller-configmap.yaml
+++ b/bitnami/nginx-ingress-controller/templates/controller-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/nginx-ingress-controller/templates/controller-daemonset.yaml
+++ b/bitnami/nginx-ingress-controller/templates/controller-daemonset.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/nginx-ingress-controller/templates/controller-deployment.yaml
+++ b/bitnami/nginx-ingress-controller/templates/controller-deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/nginx-ingress-controller/templates/controller-hpa.yaml
+++ b/bitnami/nginx-ingress-controller/templates/controller-hpa.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/nginx-ingress-controller/templates/controller-metrics-service.yaml
+++ b/bitnami/nginx-ingress-controller/templates/controller-metrics-service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/nginx-ingress-controller/templates/controller-networkpolicy.yaml
+++ b/bitnami/nginx-ingress-controller/templates/controller-networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/nginx-ingress-controller/templates/controller-poddisruptionbudget.yaml
+++ b/bitnami/nginx-ingress-controller/templates/controller-poddisruptionbudget.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/nginx-ingress-controller/templates/controller-prometheusrules.yaml
+++ b/bitnami/nginx-ingress-controller/templates/controller-prometheusrules.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/nginx-ingress-controller/templates/controller-service.yaml
+++ b/bitnami/nginx-ingress-controller/templates/controller-service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/nginx-ingress-controller/templates/controller-servicemonitor.yaml
+++ b/bitnami/nginx-ingress-controller/templates/controller-servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/nginx-ingress-controller/templates/default-backend-configmap.yaml
+++ b/bitnami/nginx-ingress-controller/templates/default-backend-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/nginx-ingress-controller/templates/default-backend-deployment.yaml
+++ b/bitnami/nginx-ingress-controller/templates/default-backend-deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/nginx-ingress-controller/templates/default-backend-networkpolicy.yaml
+++ b/bitnami/nginx-ingress-controller/templates/default-backend-networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/nginx-ingress-controller/templates/default-backend-poddisruptionbudget.yaml
+++ b/bitnami/nginx-ingress-controller/templates/default-backend-poddisruptionbudget.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/nginx-ingress-controller/templates/default-backend-service.yaml
+++ b/bitnami/nginx-ingress-controller/templates/default-backend-service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/nginx-ingress-controller/templates/dh-param-secret.yaml
+++ b/bitnami/nginx-ingress-controller/templates/dh-param-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/nginx-ingress-controller/templates/extra-list.yaml
+++ b/bitnami/nginx-ingress-controller/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/nginx-ingress-controller/templates/ingressclass.yaml
+++ b/bitnami/nginx-ingress-controller/templates/ingressclass.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/nginx-ingress-controller/templates/podsecuritypolicy.yaml
+++ b/bitnami/nginx-ingress-controller/templates/podsecuritypolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/nginx-ingress-controller/templates/proxyheaders-configmap.yaml
+++ b/bitnami/nginx-ingress-controller/templates/proxyheaders-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/nginx-ingress-controller/templates/role.yaml
+++ b/bitnami/nginx-ingress-controller/templates/role.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/nginx-ingress-controller/templates/rolebinding.yaml
+++ b/bitnami/nginx-ingress-controller/templates/rolebinding.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/nginx-ingress-controller/templates/serviceaccount.yaml
+++ b/bitnami/nginx-ingress-controller/templates/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/nginx-ingress-controller/templates/tcp-configmap.yaml
+++ b/bitnami/nginx-ingress-controller/templates/tcp-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/nginx-ingress-controller/templates/udp-configmap.yaml
+++ b/bitnami/nginx-ingress-controller/templates/udp-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/nginx-ingress-controller/values.yaml
+++ b/bitnami/nginx-ingress-controller/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters

--- a/bitnami/nginx/Chart.yaml
+++ b/bitnami/nginx/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/nginx/templates/_helpers.tpl
+++ b/bitnami/nginx/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/nginx/templates/deployment.yaml
+++ b/bitnami/nginx/templates/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/nginx/templates/extra-list.yaml
+++ b/bitnami/nginx/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/nginx/templates/health-ingress.yaml
+++ b/bitnami/nginx/templates/health-ingress.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/nginx/templates/hpa.yaml
+++ b/bitnami/nginx/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/nginx/templates/ingress-tls-secret.yaml
+++ b/bitnami/nginx/templates/ingress-tls-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/nginx/templates/ingress.yaml
+++ b/bitnami/nginx/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/nginx/templates/networkpolicy.yaml
+++ b/bitnami/nginx/templates/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/nginx/templates/pdb.yaml
+++ b/bitnami/nginx/templates/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/nginx/templates/prometheusrules.yaml
+++ b/bitnami/nginx/templates/prometheusrules.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/nginx/templates/server-block-configmap.yaml
+++ b/bitnami/nginx/templates/server-block-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/nginx/templates/serviceaccount.yaml
+++ b/bitnami/nginx/templates/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/nginx/templates/servicemonitor.yaml
+++ b/bitnami/nginx/templates/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/nginx/templates/svc.yaml
+++ b/bitnami/nginx/templates/svc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/nginx/templates/tls-secret.yaml
+++ b/bitnami/nginx/templates/tls-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/nginx/values.yaml
+++ b/bitnami/nginx/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters

--- a/bitnami/node-exporter/Chart.yaml
+++ b/bitnami/node-exporter/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/node-exporter/templates/_helpers.tpl
+++ b/bitnami/node-exporter/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/node-exporter/templates/daemonset.yaml
+++ b/bitnami/node-exporter/templates/daemonset.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/node-exporter/templates/deployment.yaml
+++ b/bitnami/node-exporter/templates/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/node-exporter/templates/extra-list.yaml
+++ b/bitnami/node-exporter/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/node-exporter/templates/networkpolicy.yaml
+++ b/bitnami/node-exporter/templates/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/node-exporter/templates/psp-clusterrole.yaml
+++ b/bitnami/node-exporter/templates/psp-clusterrole.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/node-exporter/templates/psp-clusterrolebinding.yaml
+++ b/bitnami/node-exporter/templates/psp-clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/node-exporter/templates/psp.yaml
+++ b/bitnami/node-exporter/templates/psp.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/node-exporter/templates/service.yaml
+++ b/bitnami/node-exporter/templates/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/node-exporter/templates/serviceaccount.yaml
+++ b/bitnami/node-exporter/templates/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/node-exporter/templates/servicemonitor.yaml
+++ b/bitnami/node-exporter/templates/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/node-exporter/values.yaml
+++ b/bitnami/node-exporter/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters

--- a/bitnami/oauth2-proxy/Chart.yaml
+++ b/bitnami/oauth2-proxy/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/oauth2-proxy/templates/_helpers.tpl
+++ b/bitnami/oauth2-proxy/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/oauth2-proxy/templates/configmap.yaml
+++ b/bitnami/oauth2-proxy/templates/configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/oauth2-proxy/templates/deployment.yaml
+++ b/bitnami/oauth2-proxy/templates/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/oauth2-proxy/templates/externalredis-secret.yaml
+++ b/bitnami/oauth2-proxy/templates/externalredis-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/oauth2-proxy/templates/extra-list.yaml
+++ b/bitnami/oauth2-proxy/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/oauth2-proxy/templates/ingress.yaml
+++ b/bitnami/oauth2-proxy/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/oauth2-proxy/templates/networkpolicy.yaml
+++ b/bitnami/oauth2-proxy/templates/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/oauth2-proxy/templates/pdb.yaml
+++ b/bitnami/oauth2-proxy/templates/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/oauth2-proxy/templates/secret-authenticated-emails-file.yaml
+++ b/bitnami/oauth2-proxy/templates/secret-authenticated-emails-file.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/oauth2-proxy/templates/secret-google.yaml
+++ b/bitnami/oauth2-proxy/templates/secret-google.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/oauth2-proxy/templates/secret-htpasswd-file.yaml
+++ b/bitnami/oauth2-proxy/templates/secret-htpasswd-file.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/oauth2-proxy/templates/secret.yaml
+++ b/bitnami/oauth2-proxy/templates/secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/oauth2-proxy/templates/service-account.yaml
+++ b/bitnami/oauth2-proxy/templates/service-account.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/oauth2-proxy/templates/service.yaml
+++ b/bitnami/oauth2-proxy/templates/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/oauth2-proxy/templates/tls-secrets.yaml
+++ b/bitnami/oauth2-proxy/templates/tls-secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/oauth2-proxy/values.yaml
+++ b/bitnami/oauth2-proxy/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters

--- a/bitnami/odoo/Chart.yaml
+++ b/bitnami/odoo/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/odoo/templates/_helpers.tpl
+++ b/bitnami/odoo/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/odoo/templates/deployment.yaml
+++ b/bitnami/odoo/templates/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/odoo/templates/externaldb-secrets.yaml
+++ b/bitnami/odoo/templates/externaldb-secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/odoo/templates/extra-list.yaml
+++ b/bitnami/odoo/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/odoo/templates/hpa.yaml
+++ b/bitnami/odoo/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/odoo/templates/ingress.yaml
+++ b/bitnami/odoo/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/odoo/templates/networkpolicy.yaml
+++ b/bitnami/odoo/templates/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/odoo/templates/pdb.yaml
+++ b/bitnami/odoo/templates/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/odoo/templates/postinit-configmap.yaml
+++ b/bitnami/odoo/templates/postinit-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/odoo/templates/pvc.yaml
+++ b/bitnami/odoo/templates/pvc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/odoo/templates/secrets.yaml
+++ b/bitnami/odoo/templates/secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/odoo/templates/serviceaccount.yaml
+++ b/bitnami/odoo/templates/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/odoo/templates/svc.yaml
+++ b/bitnami/odoo/templates/svc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/odoo/templates/tls-secrets.yaml
+++ b/bitnami/odoo/templates/tls-secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/odoo/values.yaml
+++ b/bitnami/odoo/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters

--- a/bitnami/opencart/Chart.yaml
+++ b/bitnami/opencart/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/opencart/templates/_helpers.tpl
+++ b/bitnami/opencart/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/opencart/templates/deployment.yaml
+++ b/bitnami/opencart/templates/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/opencart/templates/externaldb-secrets.yaml
+++ b/bitnami/opencart/templates/externaldb-secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/opencart/templates/extra-list.yaml
+++ b/bitnami/opencart/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/opencart/templates/ingress.yaml
+++ b/bitnami/opencart/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/opencart/templates/networkpolicy.yaml
+++ b/bitnami/opencart/templates/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/opencart/templates/pv.yaml
+++ b/bitnami/opencart/templates/pv.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/opencart/templates/pvc.yaml
+++ b/bitnami/opencart/templates/pvc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/opencart/templates/secrets.yaml
+++ b/bitnami/opencart/templates/secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/opencart/templates/serviceaccount.yaml
+++ b/bitnami/opencart/templates/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/opencart/templates/svc.yaml
+++ b/bitnami/opencart/templates/svc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/opencart/templates/tls-secrets.yaml
+++ b/bitnami/opencart/templates/tls-secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/opencart/values.yaml
+++ b/bitnami/opencart/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters

--- a/bitnami/opensearch/Chart.yaml
+++ b/bitnami/opensearch/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/opensearch/templates/_helpers.tpl
+++ b/bitnami/opensearch/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/opensearch/templates/configmap.yaml
+++ b/bitnami/opensearch/templates/configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/opensearch/templates/coordinating/hpa.yaml
+++ b/bitnami/opensearch/templates/coordinating/hpa.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/opensearch/templates/coordinating/networkpolicy.yaml
+++ b/bitnami/opensearch/templates/coordinating/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/opensearch/templates/coordinating/pdb.yaml
+++ b/bitnami/opensearch/templates/coordinating/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/opensearch/templates/coordinating/serviceaccount.yaml
+++ b/bitnami/opensearch/templates/coordinating/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/opensearch/templates/coordinating/statefulset.yaml
+++ b/bitnami/opensearch/templates/coordinating/statefulset.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/opensearch/templates/coordinating/svc-headless.yaml
+++ b/bitnami/opensearch/templates/coordinating/svc-headless.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/opensearch/templates/coordinating/vpa.yaml
+++ b/bitnami/opensearch/templates/coordinating/vpa.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/opensearch/templates/dashboards/deployment.yaml
+++ b/bitnami/opensearch/templates/dashboards/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/opensearch/templates/dashboards/hpa.yaml
+++ b/bitnami/opensearch/templates/dashboards/hpa.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/opensearch/templates/dashboards/ingress-tls-secret.yaml
+++ b/bitnami/opensearch/templates/dashboards/ingress-tls-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/opensearch/templates/dashboards/ingress.yaml
+++ b/bitnami/opensearch/templates/dashboards/ingress.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/opensearch/templates/dashboards/networkpolicy.yaml
+++ b/bitnami/opensearch/templates/dashboards/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/opensearch/templates/dashboards/pdb.yaml
+++ b/bitnami/opensearch/templates/dashboards/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/opensearch/templates/dashboards/pvc.yaml
+++ b/bitnami/opensearch/templates/dashboards/pvc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/opensearch/templates/dashboards/service.yaml
+++ b/bitnami/opensearch/templates/dashboards/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/opensearch/templates/dashboards/serviceaccount.yaml
+++ b/bitnami/opensearch/templates/dashboards/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/opensearch/templates/dashboards/tls-secret.yaml
+++ b/bitnami/opensearch/templates/dashboards/tls-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/opensearch/templates/dashboards/vpa.yaml
+++ b/bitnami/opensearch/templates/dashboards/vpa.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/opensearch/templates/data/hpa.yaml
+++ b/bitnami/opensearch/templates/data/hpa.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/opensearch/templates/data/networkpolicy.yaml
+++ b/bitnami/opensearch/templates/data/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/opensearch/templates/data/pdb.yaml
+++ b/bitnami/opensearch/templates/data/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/opensearch/templates/data/serviceaccount.yaml
+++ b/bitnami/opensearch/templates/data/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/opensearch/templates/data/statefulset.yaml
+++ b/bitnami/opensearch/templates/data/statefulset.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/opensearch/templates/data/svc-headless.yaml
+++ b/bitnami/opensearch/templates/data/svc-headless.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/opensearch/templates/data/vpa.yaml
+++ b/bitnami/opensearch/templates/data/vpa.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/opensearch/templates/extra-list.yaml
+++ b/bitnami/opensearch/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/opensearch/templates/ingest/hpa.yaml
+++ b/bitnami/opensearch/templates/ingest/hpa.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/opensearch/templates/ingest/ingress.yaml
+++ b/bitnami/opensearch/templates/ingest/ingress.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/opensearch/templates/ingest/networkpolicy.yaml
+++ b/bitnami/opensearch/templates/ingest/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/opensearch/templates/ingest/pdb.yaml
+++ b/bitnami/opensearch/templates/ingest/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/opensearch/templates/ingest/service.yaml
+++ b/bitnami/opensearch/templates/ingest/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/opensearch/templates/ingest/serviceaccount.yaml
+++ b/bitnami/opensearch/templates/ingest/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/opensearch/templates/ingest/statefulset.yaml
+++ b/bitnami/opensearch/templates/ingest/statefulset.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/opensearch/templates/ingest/svc-headless.yaml
+++ b/bitnami/opensearch/templates/ingest/svc-headless.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/opensearch/templates/ingest/vpa.yaml
+++ b/bitnami/opensearch/templates/ingest/vpa.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/opensearch/templates/ingress-tls-secrets.yaml
+++ b/bitnami/opensearch/templates/ingress-tls-secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/opensearch/templates/ingress.yaml
+++ b/bitnami/opensearch/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/opensearch/templates/initialization-configmap.yaml
+++ b/bitnami/opensearch/templates/initialization-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/opensearch/templates/master/hpa.yaml
+++ b/bitnami/opensearch/templates/master/hpa.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/opensearch/templates/master/networkpolicy.yaml
+++ b/bitnami/opensearch/templates/master/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/opensearch/templates/master/pdb.yaml
+++ b/bitnami/opensearch/templates/master/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/opensearch/templates/master/serviceaccount.yaml
+++ b/bitnami/opensearch/templates/master/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/opensearch/templates/master/statefulset.yaml
+++ b/bitnami/opensearch/templates/master/statefulset.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/opensearch/templates/master/svc-headless.yaml
+++ b/bitnami/opensearch/templates/master/svc-headless.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/opensearch/templates/master/vpa.yaml
+++ b/bitnami/opensearch/templates/master/vpa.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/opensearch/templates/secrets.yaml
+++ b/bitnami/opensearch/templates/secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/opensearch/templates/service.yaml
+++ b/bitnami/opensearch/templates/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/opensearch/templates/tls-secret.yaml
+++ b/bitnami/opensearch/templates/tls-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/opensearch/values.yaml
+++ b/bitnami/opensearch/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters

--- a/bitnami/parse/Chart.yaml
+++ b/bitnami/parse/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/parse/templates/_helpers.tpl
+++ b/bitnami/parse/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/parse/templates/cloud-code-configmap.yaml
+++ b/bitnami/parse/templates/cloud-code-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/parse/templates/dashboard-deployment.yaml
+++ b/bitnami/parse/templates/dashboard-deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/parse/templates/dashboard-networkpolicy.yaml
+++ b/bitnami/parse/templates/dashboard-networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/parse/templates/dashboard-svc.yaml
+++ b/bitnami/parse/templates/dashboard-svc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/parse/templates/extra-list.yaml
+++ b/bitnami/parse/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/parse/templates/ingress.yaml
+++ b/bitnami/parse/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/parse/templates/pvc.yaml
+++ b/bitnami/parse/templates/pvc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/parse/templates/secrets.yaml
+++ b/bitnami/parse/templates/secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/parse/templates/server-deployment.yaml
+++ b/bitnami/parse/templates/server-deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/parse/templates/server-networkpolicy.yaml
+++ b/bitnami/parse/templates/server-networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/parse/templates/server-svc.yaml
+++ b/bitnami/parse/templates/server-svc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/parse/templates/service-account.yaml
+++ b/bitnami/parse/templates/service-account.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/parse/templates/tls-secret.yaml
+++ b/bitnami/parse/templates/tls-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/parse/values.yaml
+++ b/bitnami/parse/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters

--- a/bitnami/phpbb/Chart.yaml
+++ b/bitnami/phpbb/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/phpbb/templates/_helpers.tpl
+++ b/bitnami/phpbb/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/phpbb/templates/deployment.yaml
+++ b/bitnami/phpbb/templates/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/phpbb/templates/externaldb-secrets.yaml
+++ b/bitnami/phpbb/templates/externaldb-secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/phpbb/templates/extra-list.yaml
+++ b/bitnami/phpbb/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/phpbb/templates/ingress.yaml
+++ b/bitnami/phpbb/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/phpbb/templates/networkpolicy.yaml
+++ b/bitnami/phpbb/templates/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/phpbb/templates/phpbb-pvc.yaml
+++ b/bitnami/phpbb/templates/phpbb-pvc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/phpbb/templates/secrets.yaml
+++ b/bitnami/phpbb/templates/secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/phpbb/templates/serviceaccount.yaml
+++ b/bitnami/phpbb/templates/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/phpbb/templates/svc.yaml
+++ b/bitnami/phpbb/templates/svc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/phpbb/templates/tls-secrets.yaml
+++ b/bitnami/phpbb/templates/tls-secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/phpbb/values.yaml
+++ b/bitnami/phpbb/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters

--- a/bitnami/phpmyadmin/Chart.yaml
+++ b/bitnami/phpmyadmin/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/phpmyadmin/templates/_helpers.tpl
+++ b/bitnami/phpmyadmin/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/phpmyadmin/templates/certs.yaml
+++ b/bitnami/phpmyadmin/templates/certs.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/phpmyadmin/templates/deployment.yaml
+++ b/bitnami/phpmyadmin/templates/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/phpmyadmin/templates/extra-list.yaml
+++ b/bitnami/phpmyadmin/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/phpmyadmin/templates/ingress.yaml
+++ b/bitnami/phpmyadmin/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/phpmyadmin/templates/metrics-svc.yaml
+++ b/bitnami/phpmyadmin/templates/metrics-svc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/phpmyadmin/templates/networkpolicy.yaml
+++ b/bitnami/phpmyadmin/templates/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/phpmyadmin/templates/service.yaml
+++ b/bitnami/phpmyadmin/templates/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/phpmyadmin/templates/serviceaccount.yaml
+++ b/bitnami/phpmyadmin/templates/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/phpmyadmin/templates/servicemonitor.yaml
+++ b/bitnami/phpmyadmin/templates/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/phpmyadmin/templates/tls-secrets.yaml
+++ b/bitnami/phpmyadmin/templates/tls-secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/phpmyadmin/values.yaml
+++ b/bitnami/phpmyadmin/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters

--- a/bitnami/pinniped/Chart.yaml
+++ b/bitnami/pinniped/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/pinniped/templates/_helpers.tpl
+++ b/bitnami/pinniped/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/pinniped/templates/concierge/apiservice-identity.yaml
+++ b/bitnami/pinniped/templates/concierge/apiservice-identity.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/pinniped/templates/concierge/apiservice-login.yaml
+++ b/bitnami/pinniped/templates/concierge/apiservice-login.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/pinniped/templates/concierge/configmap.yaml
+++ b/bitnami/pinniped/templates/concierge/configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/pinniped/templates/concierge/credential-issuer.yaml
+++ b/bitnami/pinniped/templates/concierge/credential-issuer.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/pinniped/templates/concierge/deployment.yaml
+++ b/bitnami/pinniped/templates/concierge/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/pinniped/templates/concierge/impersonation-proxy-service-account.yaml
+++ b/bitnami/pinniped/templates/concierge/impersonation-proxy-service-account.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/pinniped/templates/concierge/kube-cert-agent-service-account.yaml
+++ b/bitnami/pinniped/templates/concierge/kube-cert-agent-service-account.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/pinniped/templates/concierge/networkpolicy.yaml
+++ b/bitnami/pinniped/templates/concierge/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/pinniped/templates/concierge/rbac.yaml
+++ b/bitnami/pinniped/templates/concierge/rbac.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/pinniped/templates/concierge/service-account.yaml
+++ b/bitnami/pinniped/templates/concierge/service-account.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/pinniped/templates/concierge/service-api.yaml
+++ b/bitnami/pinniped/templates/concierge/service-api.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/pinniped/templates/concierge/service-proxy.yaml
+++ b/bitnami/pinniped/templates/concierge/service-proxy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/pinniped/templates/extra-list.yaml
+++ b/bitnami/pinniped/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/pinniped/templates/supervisor/apiservice-clientsecret.yaml
+++ b/bitnami/pinniped/templates/supervisor/apiservice-clientsecret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/pinniped/templates/supervisor/configmap.yaml
+++ b/bitnami/pinniped/templates/supervisor/configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/pinniped/templates/supervisor/deployment.yaml
+++ b/bitnami/pinniped/templates/supervisor/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/pinniped/templates/supervisor/ingress.yaml
+++ b/bitnami/pinniped/templates/supervisor/ingress.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/pinniped/templates/supervisor/networkpolicy.yaml
+++ b/bitnami/pinniped/templates/supervisor/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/pinniped/templates/supervisor/rbac.yaml
+++ b/bitnami/pinniped/templates/supervisor/rbac.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/pinniped/templates/supervisor/service-account.yaml
+++ b/bitnami/pinniped/templates/supervisor/service-account.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/pinniped/templates/supervisor/service-api.yaml
+++ b/bitnami/pinniped/templates/supervisor/service-api.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/pinniped/templates/supervisor/service.yaml
+++ b/bitnami/pinniped/templates/supervisor/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/pinniped/templates/supervisor/tls-secret.yaml
+++ b/bitnami/pinniped/templates/supervisor/tls-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/pinniped/values.yaml
+++ b/bitnami/pinniped/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters

--- a/bitnami/postgresql-ha/Chart.yaml
+++ b/bitnami/postgresql-ha/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/postgresql-ha/templates/_helpers.tpl
+++ b/bitnami/postgresql-ha/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/postgresql-ha/templates/backup/cronjob.yaml
+++ b/bitnami/postgresql-ha/templates/backup/cronjob.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/postgresql-ha/templates/backup/pvc.yaml
+++ b/bitnami/postgresql-ha/templates/backup/pvc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/postgresql-ha/templates/extra-list.yaml
+++ b/bitnami/postgresql-ha/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/postgresql-ha/templates/ldap-secrets.yaml
+++ b/bitnami/postgresql-ha/templates/ldap-secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/postgresql-ha/templates/metrics-configmap.yaml
+++ b/bitnami/postgresql-ha/templates/metrics-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/postgresql-ha/templates/pgpool/configmap.yaml
+++ b/bitnami/postgresql-ha/templates/pgpool/configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/postgresql-ha/templates/pgpool/custom-users-secrets.yaml
+++ b/bitnami/postgresql-ha/templates/pgpool/custom-users-secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/postgresql-ha/templates/pgpool/deployment.yaml
+++ b/bitnami/postgresql-ha/templates/pgpool/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/postgresql-ha/templates/pgpool/initdb-scripts-configmap.yaml
+++ b/bitnami/postgresql-ha/templates/pgpool/initdb-scripts-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/postgresql-ha/templates/pgpool/networkpolicy.yaml
+++ b/bitnami/postgresql-ha/templates/pgpool/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/postgresql-ha/templates/pgpool/pdb.yaml
+++ b/bitnami/postgresql-ha/templates/pgpool/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/postgresql-ha/templates/pgpool/secrets.yaml
+++ b/bitnami/postgresql-ha/templates/pgpool/secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/postgresql-ha/templates/pgpool/service.yaml
+++ b/bitnami/postgresql-ha/templates/pgpool/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/postgresql-ha/templates/podsecuritypolicy.yaml
+++ b/bitnami/postgresql-ha/templates/podsecuritypolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/postgresql-ha/templates/postgresql/configmap.yaml
+++ b/bitnami/postgresql-ha/templates/postgresql/configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/postgresql-ha/templates/postgresql/extended-configmap.yaml
+++ b/bitnami/postgresql-ha/templates/postgresql/extended-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/postgresql-ha/templates/postgresql/hooks-scripts-configmap.yaml
+++ b/bitnami/postgresql-ha/templates/postgresql/hooks-scripts-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/postgresql-ha/templates/postgresql/initdb-scripts-configmap.yaml
+++ b/bitnami/postgresql-ha/templates/postgresql/initdb-scripts-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/postgresql-ha/templates/postgresql/metrics-service.yaml
+++ b/bitnami/postgresql-ha/templates/postgresql/metrics-service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/postgresql-ha/templates/postgresql/networkpolicy.yaml
+++ b/bitnami/postgresql-ha/templates/postgresql/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/postgresql-ha/templates/postgresql/pdb.yaml
+++ b/bitnami/postgresql-ha/templates/postgresql/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/postgresql-ha/templates/postgresql/secrets.yaml
+++ b/bitnami/postgresql-ha/templates/postgresql/secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/postgresql-ha/templates/postgresql/service-headless.yaml
+++ b/bitnami/postgresql-ha/templates/postgresql/service-headless.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/postgresql-ha/templates/postgresql/service-witness.yaml
+++ b/bitnami/postgresql-ha/templates/postgresql/service-witness.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/postgresql-ha/templates/postgresql/service.yaml
+++ b/bitnami/postgresql-ha/templates/postgresql/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/postgresql-ha/templates/postgresql/servicemonitor.yaml
+++ b/bitnami/postgresql-ha/templates/postgresql/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/postgresql-ha/templates/postgresql/statefulset.yaml
+++ b/bitnami/postgresql-ha/templates/postgresql/statefulset.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/postgresql-ha/templates/postgresql/witness-statefulset.yaml
+++ b/bitnami/postgresql-ha/templates/postgresql/witness-statefulset.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/postgresql-ha/templates/role.yaml
+++ b/bitnami/postgresql-ha/templates/role.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/postgresql-ha/templates/rolebinding.yaml
+++ b/bitnami/postgresql-ha/templates/rolebinding.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/postgresql-ha/templates/serviceaccount.yaml
+++ b/bitnami/postgresql-ha/templates/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/postgresql-ha/templates/tls-secrets.yaml
+++ b/bitnami/postgresql-ha/templates/tls-secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/postgresql-ha/values.yaml
+++ b/bitnami/postgresql-ha/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters

--- a/bitnami/postgresql/Chart.yaml
+++ b/bitnami/postgresql/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/postgresql/templates/_helpers.tpl
+++ b/bitnami/postgresql/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/postgresql/templates/backup/cronjob.yaml
+++ b/bitnami/postgresql/templates/backup/cronjob.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/postgresql/templates/backup/networkpolicy.yaml
+++ b/bitnami/postgresql/templates/backup/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/postgresql/templates/backup/pvc.yaml
+++ b/bitnami/postgresql/templates/backup/pvc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/postgresql/templates/extra-list.yaml
+++ b/bitnami/postgresql/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/postgresql/templates/primary/configmap.yaml
+++ b/bitnami/postgresql/templates/primary/configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/postgresql/templates/primary/extended-configmap.yaml
+++ b/bitnami/postgresql/templates/primary/extended-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/postgresql/templates/primary/initialization-configmap.yaml
+++ b/bitnami/postgresql/templates/primary/initialization-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/postgresql/templates/primary/metrics-configmap.yaml
+++ b/bitnami/postgresql/templates/primary/metrics-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/postgresql/templates/primary/metrics-svc.yaml
+++ b/bitnami/postgresql/templates/primary/metrics-svc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/postgresql/templates/primary/networkpolicy.yaml
+++ b/bitnami/postgresql/templates/primary/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/postgresql/templates/primary/servicemonitor.yaml
+++ b/bitnami/postgresql/templates/primary/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/postgresql/templates/primary/statefulset.yaml
+++ b/bitnami/postgresql/templates/primary/statefulset.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/postgresql/templates/primary/svc-headless.yaml
+++ b/bitnami/postgresql/templates/primary/svc-headless.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/postgresql/templates/primary/svc.yaml
+++ b/bitnami/postgresql/templates/primary/svc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/postgresql/templates/prometheusrule.yaml
+++ b/bitnami/postgresql/templates/prometheusrule.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/postgresql/templates/psp.yaml
+++ b/bitnami/postgresql/templates/psp.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/postgresql/templates/read/extended-configmap.yaml
+++ b/bitnami/postgresql/templates/read/extended-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/postgresql/templates/read/metrics-configmap.yaml
+++ b/bitnami/postgresql/templates/read/metrics-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/postgresql/templates/read/metrics-svc.yaml
+++ b/bitnami/postgresql/templates/read/metrics-svc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/postgresql/templates/read/networkpolicy.yaml
+++ b/bitnami/postgresql/templates/read/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/postgresql/templates/read/servicemonitor.yaml
+++ b/bitnami/postgresql/templates/read/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/postgresql/templates/read/statefulset.yaml
+++ b/bitnami/postgresql/templates/read/statefulset.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/postgresql/templates/read/svc-headless.yaml
+++ b/bitnami/postgresql/templates/read/svc-headless.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/postgresql/templates/read/svc.yaml
+++ b/bitnami/postgresql/templates/read/svc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/postgresql/templates/role.yaml
+++ b/bitnami/postgresql/templates/role.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/postgresql/templates/rolebinding.yaml
+++ b/bitnami/postgresql/templates/rolebinding.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/postgresql/templates/secrets.yaml
+++ b/bitnami/postgresql/templates/secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/postgresql/templates/serviceaccount.yaml
+++ b/bitnami/postgresql/templates/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/postgresql/templates/tls-secrets.yaml
+++ b/bitnami/postgresql/templates/tls-secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/postgresql/values.yaml
+++ b/bitnami/postgresql/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters

--- a/bitnami/prestashop/Chart.yaml
+++ b/bitnami/prestashop/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/prestashop/templates/_helpers.tpl
+++ b/bitnami/prestashop/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/prestashop/templates/deployment.yaml
+++ b/bitnami/prestashop/templates/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/prestashop/templates/externaldb-secrets.yaml
+++ b/bitnami/prestashop/templates/externaldb-secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/prestashop/templates/extra-list.yaml
+++ b/bitnami/prestashop/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/prestashop/templates/ingress.yaml
+++ b/bitnami/prestashop/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/prestashop/templates/networkpolicy.yaml
+++ b/bitnami/prestashop/templates/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/prestashop/templates/pv.yaml
+++ b/bitnami/prestashop/templates/pv.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/prestashop/templates/pvc.yaml
+++ b/bitnami/prestashop/templates/pvc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/prestashop/templates/secrets.yaml
+++ b/bitnami/prestashop/templates/secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/prestashop/templates/serviceaccount.yaml
+++ b/bitnami/prestashop/templates/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/prestashop/templates/svc.yaml
+++ b/bitnami/prestashop/templates/svc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/prestashop/templates/tls-secrets.yaml
+++ b/bitnami/prestashop/templates/tls-secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/prestashop/values.yaml
+++ b/bitnami/prestashop/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters

--- a/bitnami/prometheus/Chart.yaml
+++ b/bitnami/prometheus/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/prometheus/templates/_helpers.tpl
+++ b/bitnami/prometheus/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/prometheus/templates/_scrape_config.tpl
+++ b/bitnami/prometheus/templates/_scrape_config.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/prometheus/templates/alertmanager/configmap.yaml
+++ b/bitnami/prometheus/templates/alertmanager/configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/prometheus/templates/alertmanager/ingress.yaml
+++ b/bitnami/prometheus/templates/alertmanager/ingress.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/prometheus/templates/alertmanager/networkpolicy.yaml
+++ b/bitnami/prometheus/templates/alertmanager/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/prometheus/templates/alertmanager/pdb.yaml
+++ b/bitnami/prometheus/templates/alertmanager/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/prometheus/templates/alertmanager/service-account.yaml
+++ b/bitnami/prometheus/templates/alertmanager/service-account.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/prometheus/templates/alertmanager/service-headless.yaml
+++ b/bitnami/prometheus/templates/alertmanager/service-headless.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/prometheus/templates/alertmanager/service.yaml
+++ b/bitnami/prometheus/templates/alertmanager/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/prometheus/templates/alertmanager/statefulset.yaml
+++ b/bitnami/prometheus/templates/alertmanager/statefulset.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/prometheus/templates/extra-list.yaml
+++ b/bitnami/prometheus/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/prometheus/templates/server/clusterrole.yaml
+++ b/bitnami/prometheus/templates/server/clusterrole.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/prometheus/templates/server/clusterrolebinding.yaml
+++ b/bitnami/prometheus/templates/server/clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/prometheus/templates/server/configmap.yaml
+++ b/bitnami/prometheus/templates/server/configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/prometheus/templates/server/deployment.yaml
+++ b/bitnami/prometheus/templates/server/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/prometheus/templates/server/ingress.yaml
+++ b/bitnami/prometheus/templates/server/ingress.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/prometheus/templates/server/networkpolicy.yaml
+++ b/bitnami/prometheus/templates/server/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/prometheus/templates/server/pdb.yaml
+++ b/bitnami/prometheus/templates/server/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/prometheus/templates/server/pvc.yaml
+++ b/bitnami/prometheus/templates/server/pvc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/prometheus/templates/server/service-account.yaml
+++ b/bitnami/prometheus/templates/server/service-account.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/prometheus/templates/server/service.yaml
+++ b/bitnami/prometheus/templates/server/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/prometheus/templates/server/thanos-ingress.yaml
+++ b/bitnami/prometheus/templates/server/thanos-ingress.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/prometheus/templates/server/thanos-service.yaml
+++ b/bitnami/prometheus/templates/server/thanos-service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/prometheus/templates/tls-secret.yaml
+++ b/bitnami/prometheus/templates/tls-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/prometheus/values.yaml
+++ b/bitnami/prometheus/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters

--- a/bitnami/pytorch/Chart.yaml
+++ b/bitnami/pytorch/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/pytorch/templates/_helpers.tpl
+++ b/bitnami/pytorch/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/pytorch/templates/configmap.yaml
+++ b/bitnami/pytorch/templates/configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/pytorch/templates/deployment.yaml
+++ b/bitnami/pytorch/templates/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/pytorch/templates/extra-list.yaml
+++ b/bitnami/pytorch/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/pytorch/templates/headless-svc.yaml
+++ b/bitnami/pytorch/templates/headless-svc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/pytorch/templates/networkpolicy.yaml
+++ b/bitnami/pytorch/templates/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/pytorch/templates/pvc.yaml
+++ b/bitnami/pytorch/templates/pvc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/pytorch/templates/service.yaml
+++ b/bitnami/pytorch/templates/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/pytorch/templates/serviceaccount.yaml
+++ b/bitnami/pytorch/templates/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/pytorch/templates/statefulset.yaml
+++ b/bitnami/pytorch/templates/statefulset.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/pytorch/values.yaml
+++ b/bitnami/pytorch/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters

--- a/bitnami/rabbitmq-cluster-operator/Chart.yaml
+++ b/bitnami/rabbitmq-cluster-operator/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/rabbitmq-cluster-operator/templates/_helpers.tpl
+++ b/bitnami/rabbitmq-cluster-operator/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/rabbitmq-cluster-operator/templates/cluster-operator/aggregate-cluster-roles.yaml
+++ b/bitnami/rabbitmq-cluster-operator/templates/cluster-operator/aggregate-cluster-roles.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/rabbitmq-cluster-operator/templates/cluster-operator/clusterrole.yaml
+++ b/bitnami/rabbitmq-cluster-operator/templates/cluster-operator/clusterrole.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/rabbitmq-cluster-operator/templates/cluster-operator/clusterrolebinding.yaml
+++ b/bitnami/rabbitmq-cluster-operator/templates/cluster-operator/clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/rabbitmq-cluster-operator/templates/cluster-operator/deployment.yaml
+++ b/bitnami/rabbitmq-cluster-operator/templates/cluster-operator/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/rabbitmq-cluster-operator/templates/cluster-operator/metrics-service.yaml
+++ b/bitnami/rabbitmq-cluster-operator/templates/cluster-operator/metrics-service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/rabbitmq-cluster-operator/templates/cluster-operator/networkpolicy.yaml
+++ b/bitnami/rabbitmq-cluster-operator/templates/cluster-operator/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/rabbitmq-cluster-operator/templates/cluster-operator/podmonitor.yaml
+++ b/bitnami/rabbitmq-cluster-operator/templates/cluster-operator/podmonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/rabbitmq-cluster-operator/templates/cluster-operator/role.yaml
+++ b/bitnami/rabbitmq-cluster-operator/templates/cluster-operator/role.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/rabbitmq-cluster-operator/templates/cluster-operator/rolebinding.yaml
+++ b/bitnami/rabbitmq-cluster-operator/templates/cluster-operator/rolebinding.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/rabbitmq-cluster-operator/templates/cluster-operator/service-account.yaml
+++ b/bitnami/rabbitmq-cluster-operator/templates/cluster-operator/service-account.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/rabbitmq-cluster-operator/templates/cluster-operator/servicemonitor.yaml
+++ b/bitnami/rabbitmq-cluster-operator/templates/cluster-operator/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/rabbitmq-cluster-operator/templates/extra-list.yaml
+++ b/bitnami/rabbitmq-cluster-operator/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/rabbitmq-cluster-operator/templates/issuer.yaml
+++ b/bitnami/rabbitmq-cluster-operator/templates/issuer.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/aggregate-cluster-roles.yaml
+++ b/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/aggregate-cluster-roles.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/certificate.yaml
+++ b/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/certificate.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/clusterrole.yaml
+++ b/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/clusterrole.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/clusterrolebinding.yaml
+++ b/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/deployment.yaml
+++ b/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/metrics-service.yaml
+++ b/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/metrics-service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/networkpolicy.yaml
+++ b/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/podmonitor.yaml
+++ b/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/podmonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/role.yaml
+++ b/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/role.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/rolebinding.yaml
+++ b/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/rolebinding.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/service-account.yaml
+++ b/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/service-account.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/servicemonitor.yaml
+++ b/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/validating-webhook-configuration.yaml
+++ b/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/validating-webhook-configuration.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/webhook-service.yaml
+++ b/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/webhook-service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/rabbitmq-cluster-operator/values.yaml
+++ b/bitnami/rabbitmq-cluster-operator/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters

--- a/bitnami/rabbitmq/Chart.yaml
+++ b/bitnami/rabbitmq/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/rabbitmq/templates/_helpers.tpl
+++ b/bitnami/rabbitmq/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/rabbitmq/templates/config-secret.yaml
+++ b/bitnami/rabbitmq/templates/config-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/rabbitmq/templates/extra-list.yaml
+++ b/bitnami/rabbitmq/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/rabbitmq/templates/ingress-tls-secrets.yaml
+++ b/bitnami/rabbitmq/templates/ingress-tls-secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/rabbitmq/templates/ingress.yaml
+++ b/bitnami/rabbitmq/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/rabbitmq/templates/init-configmap.yaml
+++ b/bitnami/rabbitmq/templates/init-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/rabbitmq/templates/networkpolicy.yaml
+++ b/bitnami/rabbitmq/templates/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/rabbitmq/templates/pdb.yaml
+++ b/bitnami/rabbitmq/templates/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/rabbitmq/templates/prometheusrule.yaml
+++ b/bitnami/rabbitmq/templates/prometheusrule.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/rabbitmq/templates/role.yaml
+++ b/bitnami/rabbitmq/templates/role.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/rabbitmq/templates/rolebinding.yaml
+++ b/bitnami/rabbitmq/templates/rolebinding.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/rabbitmq/templates/secrets.yaml
+++ b/bitnami/rabbitmq/templates/secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/rabbitmq/templates/serviceaccount.yaml
+++ b/bitnami/rabbitmq/templates/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/rabbitmq/templates/servicemonitor.yaml
+++ b/bitnami/rabbitmq/templates/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/rabbitmq/templates/statefulset.yaml
+++ b/bitnami/rabbitmq/templates/statefulset.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/rabbitmq/templates/svc-headless.yaml
+++ b/bitnami/rabbitmq/templates/svc-headless.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/rabbitmq/templates/svc.yaml
+++ b/bitnami/rabbitmq/templates/svc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/rabbitmq/templates/tls-secrets.yaml
+++ b/bitnami/rabbitmq/templates/tls-secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/rabbitmq/templates/validation.yaml
+++ b/bitnami/rabbitmq/templates/validation.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/rabbitmq/values.yaml
+++ b/bitnami/rabbitmq/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters

--- a/bitnami/redis-cluster/Chart.yaml
+++ b/bitnami/redis-cluster/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/redis-cluster/templates/_helpers.tpl
+++ b/bitnami/redis-cluster/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/redis-cluster/templates/configmap.yaml
+++ b/bitnami/redis-cluster/templates/configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/redis-cluster/templates/extra-list.yaml
+++ b/bitnami/redis-cluster/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/redis-cluster/templates/headless-svc.yaml
+++ b/bitnami/redis-cluster/templates/headless-svc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/redis-cluster/templates/metrics-prometheus.yaml
+++ b/bitnami/redis-cluster/templates/metrics-prometheus.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/redis-cluster/templates/metrics-svc.yaml
+++ b/bitnami/redis-cluster/templates/metrics-svc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/redis-cluster/templates/networkpolicy.yaml
+++ b/bitnami/redis-cluster/templates/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/redis-cluster/templates/poddisruptionbudget.yaml
+++ b/bitnami/redis-cluster/templates/poddisruptionbudget.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/redis-cluster/templates/prometheusrule.yaml
+++ b/bitnami/redis-cluster/templates/prometheusrule.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/redis-cluster/templates/psp.yaml
+++ b/bitnami/redis-cluster/templates/psp.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/redis-cluster/templates/redis-role.yaml
+++ b/bitnami/redis-cluster/templates/redis-role.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/redis-cluster/templates/redis-rolebinding.yaml
+++ b/bitnami/redis-cluster/templates/redis-rolebinding.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/redis-cluster/templates/redis-serviceaccount.yaml
+++ b/bitnami/redis-cluster/templates/redis-serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/redis-cluster/templates/redis-statefulset.yaml
+++ b/bitnami/redis-cluster/templates/redis-statefulset.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/redis-cluster/templates/redis-svc.yaml
+++ b/bitnami/redis-cluster/templates/redis-svc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/redis-cluster/templates/scripts-configmap.yaml
+++ b/bitnami/redis-cluster/templates/scripts-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/redis-cluster/templates/secret.yaml
+++ b/bitnami/redis-cluster/templates/secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/redis-cluster/templates/svc-cluster-external-access.yaml
+++ b/bitnami/redis-cluster/templates/svc-cluster-external-access.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/redis-cluster/templates/tls-secret.yaml
+++ b/bitnami/redis-cluster/templates/tls-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/redis-cluster/templates/update-cluster.yaml
+++ b/bitnami/redis-cluster/templates/update-cluster.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/redis-cluster/values.yaml
+++ b/bitnami/redis-cluster/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters

--- a/bitnami/redis/Chart.yaml
+++ b/bitnami/redis/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/redis/templates/_helpers.tpl
+++ b/bitnami/redis/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/redis/templates/configmap.yaml
+++ b/bitnami/redis/templates/configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/redis/templates/extra-list.yaml
+++ b/bitnami/redis/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/redis/templates/headless-svc.yaml
+++ b/bitnami/redis/templates/headless-svc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/redis/templates/health-configmap.yaml
+++ b/bitnami/redis/templates/health-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/redis/templates/master/application.yaml
+++ b/bitnami/redis/templates/master/application.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/redis/templates/master/psp.yaml
+++ b/bitnami/redis/templates/master/psp.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/redis/templates/master/pvc.yaml
+++ b/bitnami/redis/templates/master/pvc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/redis/templates/master/service.yaml
+++ b/bitnami/redis/templates/master/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/redis/templates/master/serviceaccount.yaml
+++ b/bitnami/redis/templates/master/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/redis/templates/metrics-svc.yaml
+++ b/bitnami/redis/templates/metrics-svc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/redis/templates/networkpolicy.yaml
+++ b/bitnami/redis/templates/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/redis/templates/pdb.yaml
+++ b/bitnami/redis/templates/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/redis/templates/podmonitor.yaml
+++ b/bitnami/redis/templates/podmonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/redis/templates/prometheusrule.yaml
+++ b/bitnami/redis/templates/prometheusrule.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/redis/templates/replicas/application.yaml
+++ b/bitnami/redis/templates/replicas/application.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/redis/templates/replicas/hpa.yaml
+++ b/bitnami/redis/templates/replicas/hpa.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/redis/templates/replicas/service.yaml
+++ b/bitnami/redis/templates/replicas/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/redis/templates/replicas/serviceaccount.yaml
+++ b/bitnami/redis/templates/replicas/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/redis/templates/role.yaml
+++ b/bitnami/redis/templates/role.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/redis/templates/rolebinding.yaml
+++ b/bitnami/redis/templates/rolebinding.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/redis/templates/scripts-configmap.yaml
+++ b/bitnami/redis/templates/scripts-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/redis/templates/secret-svcbind.yaml
+++ b/bitnami/redis/templates/secret-svcbind.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/redis/templates/secret.yaml
+++ b/bitnami/redis/templates/secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/redis/templates/sentinel/hpa.yaml
+++ b/bitnami/redis/templates/sentinel/hpa.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/redis/templates/sentinel/node-services.yaml
+++ b/bitnami/redis/templates/sentinel/node-services.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/redis/templates/sentinel/ports-configmap.yaml
+++ b/bitnami/redis/templates/sentinel/ports-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/redis/templates/sentinel/service.yaml
+++ b/bitnami/redis/templates/sentinel/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/redis/templates/sentinel/statefulset.yaml
+++ b/bitnami/redis/templates/sentinel/statefulset.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/redis/templates/serviceaccount.yaml
+++ b/bitnami/redis/templates/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/redis/templates/servicemonitor.yaml
+++ b/bitnami/redis/templates/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/redis/templates/tls-secret.yaml
+++ b/bitnami/redis/templates/tls-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/redis/values.yaml
+++ b/bitnami/redis/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters

--- a/bitnami/redmine/Chart.yaml
+++ b/bitnami/redmine/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/redmine/templates/_certificates.tpl
+++ b/bitnami/redmine/templates/_certificates.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/redmine/templates/_helpers.tpl
+++ b/bitnami/redmine/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/redmine/templates/cronjob.yaml
+++ b/bitnami/redmine/templates/cronjob.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/redmine/templates/deployment.yaml
+++ b/bitnami/redmine/templates/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/redmine/templates/externaldb-secret.yaml
+++ b/bitnami/redmine/templates/externaldb-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/redmine/templates/extra-list.yaml
+++ b/bitnami/redmine/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/redmine/templates/ingress.yaml
+++ b/bitnami/redmine/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/redmine/templates/mail-receiver-configmap.yaml
+++ b/bitnami/redmine/templates/mail-receiver-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/redmine/templates/networkpolicy.yaml
+++ b/bitnami/redmine/templates/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/redmine/templates/pdb.yaml
+++ b/bitnami/redmine/templates/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/redmine/templates/postinit-configmap.yaml
+++ b/bitnami/redmine/templates/postinit-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/redmine/templates/pvc.yaml
+++ b/bitnami/redmine/templates/pvc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/redmine/templates/secrets.yaml
+++ b/bitnami/redmine/templates/secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/redmine/templates/serviceaccount.yaml
+++ b/bitnami/redmine/templates/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/redmine/templates/svc.yaml
+++ b/bitnami/redmine/templates/svc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/redmine/templates/tls-secrets.yaml
+++ b/bitnami/redmine/templates/tls-secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/redmine/values.yaml
+++ b/bitnami/redmine/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters

--- a/bitnami/schema-registry/Chart.yaml
+++ b/bitnami/schema-registry/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/schema-registry/templates/_helpers.tpl
+++ b/bitnami/schema-registry/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/schema-registry/templates/configmap.yaml
+++ b/bitnami/schema-registry/templates/configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/schema-registry/templates/external-kafka-secrets.yaml
+++ b/bitnami/schema-registry/templates/external-kafka-secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/schema-registry/templates/extra-list.yaml
+++ b/bitnami/schema-registry/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/schema-registry/templates/headless-service.yaml
+++ b/bitnami/schema-registry/templates/headless-service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/schema-registry/templates/hpa.yaml
+++ b/bitnami/schema-registry/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/schema-registry/templates/ingress.yaml
+++ b/bitnami/schema-registry/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/schema-registry/templates/log4j-configmap.yaml
+++ b/bitnami/schema-registry/templates/log4j-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/schema-registry/templates/networkpolicy.yaml
+++ b/bitnami/schema-registry/templates/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/schema-registry/templates/pdb.yaml
+++ b/bitnami/schema-registry/templates/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/schema-registry/templates/service.yaml
+++ b/bitnami/schema-registry/templates/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/schema-registry/templates/serviceaccount.yaml
+++ b/bitnami/schema-registry/templates/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/schema-registry/templates/statefulset.yaml
+++ b/bitnami/schema-registry/templates/statefulset.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/schema-registry/templates/tls-secret.yaml
+++ b/bitnami/schema-registry/templates/tls-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/schema-registry/values.yaml
+++ b/bitnami/schema-registry/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 

--- a/bitnami/sealed-secrets/Chart.yaml
+++ b/bitnami/sealed-secrets/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/sealed-secrets/templates/_helpers.tpl
+++ b/bitnami/sealed-secrets/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/sealed-secrets/templates/clusterrole.yaml
+++ b/bitnami/sealed-secrets/templates/clusterrole.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/sealed-secrets/templates/clusterrolebinding.yaml
+++ b/bitnami/sealed-secrets/templates/clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/sealed-secrets/templates/deployment.yaml
+++ b/bitnami/sealed-secrets/templates/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/sealed-secrets/templates/extra-list.yaml
+++ b/bitnami/sealed-secrets/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/sealed-secrets/templates/ingress.yaml
+++ b/bitnami/sealed-secrets/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/sealed-secrets/templates/networkpolicy.yaml
+++ b/bitnami/sealed-secrets/templates/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/sealed-secrets/templates/pdb.yaml
+++ b/bitnami/sealed-secrets/templates/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/sealed-secrets/templates/psp-clusterrole.yaml
+++ b/bitnami/sealed-secrets/templates/psp-clusterrole.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/sealed-secrets/templates/psp-clusterrolebinding.yaml
+++ b/bitnami/sealed-secrets/templates/psp-clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/sealed-secrets/templates/psp.yaml
+++ b/bitnami/sealed-secrets/templates/psp.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/sealed-secrets/templates/role.yaml
+++ b/bitnami/sealed-secrets/templates/role.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/sealed-secrets/templates/rolebinding.yaml
+++ b/bitnami/sealed-secrets/templates/rolebinding.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/sealed-secrets/templates/service.yaml
+++ b/bitnami/sealed-secrets/templates/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/sealed-secrets/templates/serviceaccount.yaml
+++ b/bitnami/sealed-secrets/templates/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/sealed-secrets/templates/servicemonitor.yaml
+++ b/bitnami/sealed-secrets/templates/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/sealed-secrets/templates/tls-secret.yaml
+++ b/bitnami/sealed-secrets/templates/tls-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/sealed-secrets/values.yaml
+++ b/bitnami/sealed-secrets/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters

--- a/bitnami/seaweedfs/Chart.yaml
+++ b/bitnami/seaweedfs/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/seaweedfs/templates/_helpers.tpl
+++ b/bitnami/seaweedfs/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/seaweedfs/templates/ca-cert.yaml
+++ b/bitnami/seaweedfs/templates/ca-cert.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/seaweedfs/templates/client-cert.yaml
+++ b/bitnami/seaweedfs/templates/client-cert.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/seaweedfs/templates/externaldb-secrets.yaml
+++ b/bitnami/seaweedfs/templates/externaldb-secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/seaweedfs/templates/extra-list.yaml
+++ b/bitnami/seaweedfs/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/seaweedfs/templates/filer/cert.yaml
+++ b/bitnami/seaweedfs/templates/filer/cert.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/seaweedfs/templates/filer/configmap.yaml
+++ b/bitnami/seaweedfs/templates/filer/configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/seaweedfs/templates/filer/headless-service.yaml
+++ b/bitnami/seaweedfs/templates/filer/headless-service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/seaweedfs/templates/filer/hpa.yaml
+++ b/bitnami/seaweedfs/templates/filer/hpa.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/seaweedfs/templates/filer/ingress-tls-secret.yaml
+++ b/bitnami/seaweedfs/templates/filer/ingress-tls-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/seaweedfs/templates/filer/ingress.yaml
+++ b/bitnami/seaweedfs/templates/filer/ingress.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/seaweedfs/templates/filer/metrics-service.yaml
+++ b/bitnami/seaweedfs/templates/filer/metrics-service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/seaweedfs/templates/filer/networkpolicy.yaml
+++ b/bitnami/seaweedfs/templates/filer/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/seaweedfs/templates/filer/pdb.yaml
+++ b/bitnami/seaweedfs/templates/filer/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/seaweedfs/templates/filer/service.yaml
+++ b/bitnami/seaweedfs/templates/filer/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/seaweedfs/templates/filer/servicemonitor.yaml
+++ b/bitnami/seaweedfs/templates/filer/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/seaweedfs/templates/filer/statefulset.yaml
+++ b/bitnami/seaweedfs/templates/filer/statefulset.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/seaweedfs/templates/master/cert.yaml
+++ b/bitnami/seaweedfs/templates/master/cert.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/seaweedfs/templates/master/configmap.yaml
+++ b/bitnami/seaweedfs/templates/master/configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/seaweedfs/templates/master/headless-service.yaml
+++ b/bitnami/seaweedfs/templates/master/headless-service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/seaweedfs/templates/master/hpa.yaml
+++ b/bitnami/seaweedfs/templates/master/hpa.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/seaweedfs/templates/master/ingress-tls-secret.yaml
+++ b/bitnami/seaweedfs/templates/master/ingress-tls-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/seaweedfs/templates/master/ingress.yaml
+++ b/bitnami/seaweedfs/templates/master/ingress.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/seaweedfs/templates/master/metrics-service.yaml
+++ b/bitnami/seaweedfs/templates/master/metrics-service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/seaweedfs/templates/master/networkpolicy.yaml
+++ b/bitnami/seaweedfs/templates/master/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/seaweedfs/templates/master/pdb.yaml
+++ b/bitnami/seaweedfs/templates/master/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/seaweedfs/templates/master/service.yaml
+++ b/bitnami/seaweedfs/templates/master/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/seaweedfs/templates/master/servicemonitor.yaml
+++ b/bitnami/seaweedfs/templates/master/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/seaweedfs/templates/master/statefulset.yaml
+++ b/bitnami/seaweedfs/templates/master/statefulset.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/seaweedfs/templates/s3/auth-secret.yaml
+++ b/bitnami/seaweedfs/templates/s3/auth-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/seaweedfs/templates/s3/deployment.yaml
+++ b/bitnami/seaweedfs/templates/s3/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/seaweedfs/templates/s3/hpa.yaml
+++ b/bitnami/seaweedfs/templates/s3/hpa.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/seaweedfs/templates/s3/ingress-tls-secret.yaml
+++ b/bitnami/seaweedfs/templates/s3/ingress-tls-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/seaweedfs/templates/s3/ingress.yaml
+++ b/bitnami/seaweedfs/templates/s3/ingress.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/seaweedfs/templates/s3/metrics-service.yaml
+++ b/bitnami/seaweedfs/templates/s3/metrics-service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/seaweedfs/templates/s3/networkpolicy.yaml
+++ b/bitnami/seaweedfs/templates/s3/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/seaweedfs/templates/s3/pdb.yaml
+++ b/bitnami/seaweedfs/templates/s3/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/seaweedfs/templates/s3/service.yaml
+++ b/bitnami/seaweedfs/templates/s3/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/seaweedfs/templates/s3/servicemonitor.yaml
+++ b/bitnami/seaweedfs/templates/s3/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/seaweedfs/templates/security-configmap.yaml
+++ b/bitnami/seaweedfs/templates/security-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/seaweedfs/templates/service-account.yaml
+++ b/bitnami/seaweedfs/templates/service-account.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/seaweedfs/templates/tls-secret.yaml
+++ b/bitnami/seaweedfs/templates/tls-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/seaweedfs/templates/volume/cert.yaml
+++ b/bitnami/seaweedfs/templates/volume/cert.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/seaweedfs/templates/volume/configmap.yaml
+++ b/bitnami/seaweedfs/templates/volume/configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/seaweedfs/templates/volume/headless-service.yaml
+++ b/bitnami/seaweedfs/templates/volume/headless-service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/seaweedfs/templates/volume/hpa.yaml
+++ b/bitnami/seaweedfs/templates/volume/hpa.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/seaweedfs/templates/volume/ingress-tls-secret.yaml
+++ b/bitnami/seaweedfs/templates/volume/ingress-tls-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/seaweedfs/templates/volume/ingress.yaml
+++ b/bitnami/seaweedfs/templates/volume/ingress.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/seaweedfs/templates/volume/metrics-service.yaml
+++ b/bitnami/seaweedfs/templates/volume/metrics-service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/seaweedfs/templates/volume/networkpolicy.yaml
+++ b/bitnami/seaweedfs/templates/volume/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/seaweedfs/templates/volume/pdb.yaml
+++ b/bitnami/seaweedfs/templates/volume/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/seaweedfs/templates/volume/service.yaml
+++ b/bitnami/seaweedfs/templates/volume/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/seaweedfs/templates/volume/servicemonitor.yaml
+++ b/bitnami/seaweedfs/templates/volume/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/seaweedfs/templates/volume/statefulset.yaml
+++ b/bitnami/seaweedfs/templates/volume/statefulset.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/seaweedfs/templates/webadv/cert.yaml
+++ b/bitnami/seaweedfs/templates/webadv/cert.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/seaweedfs/templates/webadv/deployment.yaml
+++ b/bitnami/seaweedfs/templates/webadv/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/seaweedfs/templates/webadv/hpa.yaml
+++ b/bitnami/seaweedfs/templates/webadv/hpa.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/seaweedfs/templates/webadv/ingress-tls-secret.yaml
+++ b/bitnami/seaweedfs/templates/webadv/ingress-tls-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/seaweedfs/templates/webadv/ingress.yaml
+++ b/bitnami/seaweedfs/templates/webadv/ingress.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/seaweedfs/templates/webadv/networkpolicy.yaml
+++ b/bitnami/seaweedfs/templates/webadv/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/seaweedfs/templates/webadv/pdb.yaml
+++ b/bitnami/seaweedfs/templates/webadv/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/seaweedfs/templates/webadv/service.yaml
+++ b/bitnami/seaweedfs/templates/webadv/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/seaweedfs/templates/webadv/tls-secret.yaml
+++ b/bitnami/seaweedfs/templates/webadv/tls-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/seaweedfs/values.yaml
+++ b/bitnami/seaweedfs/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters

--- a/bitnami/solr/Chart.yaml
+++ b/bitnami/solr/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/solr/templates/_helpers.tpl
+++ b/bitnami/solr/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/solr/templates/extra-list.yaml
+++ b/bitnami/solr/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/solr/templates/ingress-tls-secrets.yaml
+++ b/bitnami/solr/templates/ingress-tls-secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/solr/templates/ingress.yaml
+++ b/bitnami/solr/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/solr/templates/metrics-deployment.yaml
+++ b/bitnami/solr/templates/metrics-deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/solr/templates/metrics-svc.yaml
+++ b/bitnami/solr/templates/metrics-svc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/solr/templates/networkpolicy.yaml
+++ b/bitnami/solr/templates/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/solr/templates/pdb.yaml
+++ b/bitnami/solr/templates/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/solr/templates/prometheusrule.yaml
+++ b/bitnami/solr/templates/prometheusrule.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/solr/templates/scripts-configmap.yaml
+++ b/bitnami/solr/templates/scripts-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/solr/templates/secrets.yaml
+++ b/bitnami/solr/templates/secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/solr/templates/service-account.yaml
+++ b/bitnami/solr/templates/service-account.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/solr/templates/servicemonitor.yaml
+++ b/bitnami/solr/templates/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/solr/templates/statefulset.yaml
+++ b/bitnami/solr/templates/statefulset.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/solr/templates/svc-headless.yaml
+++ b/bitnami/solr/templates/svc-headless.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/solr/templates/svc.yaml
+++ b/bitnami/solr/templates/svc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/solr/templates/tls-secrets.yaml
+++ b/bitnami/solr/templates/tls-secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/solr/values.yaml
+++ b/bitnami/solr/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters

--- a/bitnami/sonarqube/Chart.yaml
+++ b/bitnami/sonarqube/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/sonarqube/templates/_helpers.tpl
+++ b/bitnami/sonarqube/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/sonarqube/templates/deployment.yaml
+++ b/bitnami/sonarqube/templates/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/sonarqube/templates/externaldb-secret.yaml
+++ b/bitnami/sonarqube/templates/externaldb-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/sonarqube/templates/extra-list.yaml
+++ b/bitnami/sonarqube/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/sonarqube/templates/ingress.yaml
+++ b/bitnami/sonarqube/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/sonarqube/templates/install_plugins.yaml
+++ b/bitnami/sonarqube/templates/install_plugins.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/sonarqube/templates/jmx-configmap.yaml
+++ b/bitnami/sonarqube/templates/jmx-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/sonarqube/templates/jmx-metrics-svc.yaml
+++ b/bitnami/sonarqube/templates/jmx-metrics-svc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/sonarqube/templates/jmx-servicemonitor.yaml
+++ b/bitnami/sonarqube/templates/jmx-servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/sonarqube/templates/networkpolicy.yaml
+++ b/bitnami/sonarqube/templates/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/sonarqube/templates/pvc.yaml
+++ b/bitnami/sonarqube/templates/pvc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/sonarqube/templates/secret.yaml
+++ b/bitnami/sonarqube/templates/secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/sonarqube/templates/service-account.yaml
+++ b/bitnami/sonarqube/templates/service-account.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/sonarqube/templates/service.yaml
+++ b/bitnami/sonarqube/templates/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/sonarqube/templates/tls-secret.yaml
+++ b/bitnami/sonarqube/templates/tls-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/sonarqube/values.yaml
+++ b/bitnami/sonarqube/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters

--- a/bitnami/spark/Chart.yaml
+++ b/bitnami/spark/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/spark/templates/_helpers.tpl
+++ b/bitnami/spark/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/spark/templates/extra-list.yaml
+++ b/bitnami/spark/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/spark/templates/headless-svc.yaml
+++ b/bitnami/spark/templates/headless-svc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/spark/templates/hpa-worker.yaml
+++ b/bitnami/spark/templates/hpa-worker.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/spark/templates/ingress.yaml
+++ b/bitnami/spark/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/spark/templates/init-configmap.yaml
+++ b/bitnami/spark/templates/init-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/spark/templates/networkpolicy-master.yaml
+++ b/bitnami/spark/templates/networkpolicy-master.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/spark/templates/networkpolicy-worker.yaml
+++ b/bitnami/spark/templates/networkpolicy-worker.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/spark/templates/podmonitor.yaml
+++ b/bitnami/spark/templates/podmonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/spark/templates/prometheusrule.yaml
+++ b/bitnami/spark/templates/prometheusrule.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/spark/templates/secret.yaml
+++ b/bitnami/spark/templates/secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/spark/templates/serviceaccount.yaml
+++ b/bitnami/spark/templates/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/spark/templates/statefulset-master.yaml
+++ b/bitnami/spark/templates/statefulset-master.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/spark/templates/statefulset-worker.yaml
+++ b/bitnami/spark/templates/statefulset-worker.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/spark/templates/svc-master.yaml
+++ b/bitnami/spark/templates/svc-master.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/spark/templates/tls-secrets.yaml
+++ b/bitnami/spark/templates/tls-secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/spark/values.yaml
+++ b/bitnami/spark/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters

--- a/bitnami/spring-cloud-dataflow/Chart.yaml
+++ b/bitnami/spring-cloud-dataflow/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/spring-cloud-dataflow/templates/_helpers.tpl
+++ b/bitnami/spring-cloud-dataflow/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/spring-cloud-dataflow/templates/externalrabbitmq-secrets.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/externalrabbitmq-secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/spring-cloud-dataflow/templates/extra-list.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/spring-cloud-dataflow/templates/prometheus-proxy/deployment.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/prometheus-proxy/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/spring-cloud-dataflow/templates/prometheus-proxy/hpa.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/prometheus-proxy/hpa.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/spring-cloud-dataflow/templates/prometheus-proxy/networkpolicy.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/prometheus-proxy/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/spring-cloud-dataflow/templates/prometheus-proxy/pdb.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/prometheus-proxy/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/spring-cloud-dataflow/templates/prometheus-proxy/service.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/prometheus-proxy/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/spring-cloud-dataflow/templates/prometheus-proxy/servicemonitor-metrics.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/prometheus-proxy/servicemonitor-metrics.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/spring-cloud-dataflow/templates/role.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/role.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/spring-cloud-dataflow/templates/rolebinding.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/rolebinding.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/spring-cloud-dataflow/templates/scripts-configmap.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/scripts-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/spring-cloud-dataflow/templates/server/configmap.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/server/configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/spring-cloud-dataflow/templates/server/deployment.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/server/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/spring-cloud-dataflow/templates/server/externaldb-secret.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/server/externaldb-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/spring-cloud-dataflow/templates/server/hpa.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/server/hpa.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/spring-cloud-dataflow/templates/server/ingress.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/server/ingress.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/spring-cloud-dataflow/templates/server/networkpolicy.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/server/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/spring-cloud-dataflow/templates/server/pdb.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/server/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/spring-cloud-dataflow/templates/server/service.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/server/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/spring-cloud-dataflow/templates/server/tls-secret.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/server/tls-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/spring-cloud-dataflow/templates/serviceaccount.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/spring-cloud-dataflow/templates/skipper/configmap.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/skipper/configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/spring-cloud-dataflow/templates/skipper/deployment.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/skipper/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/spring-cloud-dataflow/templates/skipper/externaldb-secret.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/skipper/externaldb-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/spring-cloud-dataflow/templates/skipper/hpa.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/skipper/hpa.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/spring-cloud-dataflow/templates/skipper/networkpolicy.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/skipper/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/spring-cloud-dataflow/templates/skipper/pdb.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/skipper/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/spring-cloud-dataflow/templates/skipper/service.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/skipper/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/spring-cloud-dataflow/values.yaml
+++ b/bitnami/spring-cloud-dataflow/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters

--- a/bitnami/supabase/Chart.yaml
+++ b/bitnami/supabase/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/supabase/templates/_helpers.tpl
+++ b/bitnami/supabase/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/supabase/templates/auth/default-configmap.yaml
+++ b/bitnami/supabase/templates/auth/default-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/supabase/templates/auth/deployment.yaml
+++ b/bitnami/supabase/templates/auth/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/supabase/templates/auth/extra-configmap.yaml
+++ b/bitnami/supabase/templates/auth/extra-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/supabase/templates/auth/networkpolicy.yaml
+++ b/bitnami/supabase/templates/auth/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/supabase/templates/auth/service.yaml
+++ b/bitnami/supabase/templates/auth/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/supabase/templates/externaldb-secrets.yaml
+++ b/bitnami/supabase/templates/externaldb-secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/supabase/templates/extra-list.yaml
+++ b/bitnami/supabase/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/supabase/templates/jwt-init-job.yaml
+++ b/bitnami/supabase/templates/jwt-init-job.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/supabase/templates/jwt-job-networkpolicy.yaml
+++ b/bitnami/supabase/templates/jwt-job-networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/supabase/templates/jwt-rbac.yaml
+++ b/bitnami/supabase/templates/jwt-rbac.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/supabase/templates/jwt-secret.yaml
+++ b/bitnami/supabase/templates/jwt-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/supabase/templates/jwt-service-account.yaml
+++ b/bitnami/supabase/templates/jwt-service-account.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/supabase/templates/kong/declarative-conf-configmap.yaml
+++ b/bitnami/supabase/templates/kong/declarative-conf-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/supabase/templates/meta/default-configmap.yaml
+++ b/bitnami/supabase/templates/meta/default-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/supabase/templates/meta/deployment.yaml
+++ b/bitnami/supabase/templates/meta/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/supabase/templates/meta/extra-configmap.yaml
+++ b/bitnami/supabase/templates/meta/extra-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/supabase/templates/meta/networkpolicy.yaml
+++ b/bitnami/supabase/templates/meta/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/supabase/templates/meta/service.yaml
+++ b/bitnami/supabase/templates/meta/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/supabase/templates/realtime/default-configmap.yaml
+++ b/bitnami/supabase/templates/realtime/default-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/supabase/templates/realtime/deployment.yaml
+++ b/bitnami/supabase/templates/realtime/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/supabase/templates/realtime/extra-configmap.yaml
+++ b/bitnami/supabase/templates/realtime/extra-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/supabase/templates/realtime/networkpolicy.yaml
+++ b/bitnami/supabase/templates/realtime/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/supabase/templates/realtime/secret.yaml
+++ b/bitnami/supabase/templates/realtime/secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/supabase/templates/realtime/service.yaml
+++ b/bitnami/supabase/templates/realtime/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/supabase/templates/rest/default-configmap.yaml
+++ b/bitnami/supabase/templates/rest/default-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/supabase/templates/rest/deployment.yaml
+++ b/bitnami/supabase/templates/rest/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/supabase/templates/rest/extra-configmap.yaml
+++ b/bitnami/supabase/templates/rest/extra-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/supabase/templates/rest/networkpolicy.yaml
+++ b/bitnami/supabase/templates/rest/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/supabase/templates/rest/service.yaml
+++ b/bitnami/supabase/templates/rest/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/supabase/templates/service-account.yaml
+++ b/bitnami/supabase/templates/service-account.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/supabase/templates/storage/default-configmap.yaml
+++ b/bitnami/supabase/templates/storage/default-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/supabase/templates/storage/deployment.yaml
+++ b/bitnami/supabase/templates/storage/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/supabase/templates/storage/extra-configmap.yaml
+++ b/bitnami/supabase/templates/storage/extra-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/supabase/templates/storage/networkpolicy.yaml
+++ b/bitnami/supabase/templates/storage/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/supabase/templates/storage/pvc.yaml
+++ b/bitnami/supabase/templates/storage/pvc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/supabase/templates/storage/service.yaml
+++ b/bitnami/supabase/templates/storage/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/supabase/templates/studio/default-configmap.yaml
+++ b/bitnami/supabase/templates/studio/default-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/supabase/templates/studio/deployment.yaml
+++ b/bitnami/supabase/templates/studio/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/supabase/templates/studio/extra-configmap.yaml
+++ b/bitnami/supabase/templates/studio/extra-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/supabase/templates/studio/ingress.yaml
+++ b/bitnami/supabase/templates/studio/ingress.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/supabase/templates/studio/networkpolicy.yaml
+++ b/bitnami/supabase/templates/studio/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/supabase/templates/studio/service.yaml
+++ b/bitnami/supabase/templates/studio/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/supabase/templates/studio/tls-secret.yaml
+++ b/bitnami/supabase/templates/studio/tls-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/supabase/values.yaml
+++ b/bitnami/supabase/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters

--- a/bitnami/tensorflow-resnet/Chart.yaml
+++ b/bitnami/tensorflow-resnet/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/tensorflow-resnet/templates/_helpers.tpl
+++ b/bitnami/tensorflow-resnet/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/tensorflow-resnet/templates/deployment.yaml
+++ b/bitnami/tensorflow-resnet/templates/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/tensorflow-resnet/templates/extra-list.yaml
+++ b/bitnami/tensorflow-resnet/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/tensorflow-resnet/templates/networkpolicy.yaml
+++ b/bitnami/tensorflow-resnet/templates/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/tensorflow-resnet/templates/service.yaml
+++ b/bitnami/tensorflow-resnet/templates/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/tensorflow-resnet/templates/serviceaccount.yaml
+++ b/bitnami/tensorflow-resnet/templates/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/tensorflow-resnet/values.yaml
+++ b/bitnami/tensorflow-resnet/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters

--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/thanos/templates/_helpers.tpl
+++ b/bitnami/thanos/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/alert-rule/absent_rules.yml
+++ b/bitnami/thanos/templates/alert-rule/absent_rules.yml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/alert-rule/compaction.yml
+++ b/bitnami/thanos/templates/alert-rule/compaction.yml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/alert-rule/query.yml
+++ b/bitnami/thanos/templates/alert-rule/query.yml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/alert-rule/receive.yml
+++ b/bitnami/thanos/templates/alert-rule/receive.yml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/alert-rule/replicate.yml
+++ b/bitnami/thanos/templates/alert-rule/replicate.yml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/alert-rule/ruler.yml
+++ b/bitnami/thanos/templates/alert-rule/ruler.yml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/alert-rule/sidecar.yml
+++ b/bitnami/thanos/templates/alert-rule/sidecar.yml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/alert-rule/store_gateway.yml
+++ b/bitnami/thanos/templates/alert-rule/store_gateway.yml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/bucketweb/deployment.yaml
+++ b/bitnami/thanos/templates/bucketweb/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/bucketweb/hpa.yaml
+++ b/bitnami/thanos/templates/bucketweb/hpa.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/bucketweb/ingress.yaml
+++ b/bitnami/thanos/templates/bucketweb/ingress.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/bucketweb/networkpolicy.yaml
+++ b/bitnami/thanos/templates/bucketweb/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/bucketweb/pdb.yaml
+++ b/bitnami/thanos/templates/bucketweb/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/bucketweb/service.yaml
+++ b/bitnami/thanos/templates/bucketweb/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/bucketweb/serviceaccount.yaml
+++ b/bitnami/thanos/templates/bucketweb/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/bucketweb/servicemonitor.yaml
+++ b/bitnami/thanos/templates/bucketweb/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/bucketweb/tls-secrets.yaml
+++ b/bitnami/thanos/templates/bucketweb/tls-secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/compactor/_pod-template.tpl
+++ b/bitnami/thanos/templates/compactor/_pod-template.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/compactor/cronjob.yaml
+++ b/bitnami/thanos/templates/compactor/cronjob.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/compactor/deployment.yaml
+++ b/bitnami/thanos/templates/compactor/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/compactor/ingress.yaml
+++ b/bitnami/thanos/templates/compactor/ingress.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/compactor/networkpolicy.yaml
+++ b/bitnami/thanos/templates/compactor/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/compactor/pvc.yaml
+++ b/bitnami/thanos/templates/compactor/pvc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/compactor/service.yaml
+++ b/bitnami/thanos/templates/compactor/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/compactor/serviceaccount.yaml
+++ b/bitnami/thanos/templates/compactor/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/compactor/servicemonitor.yaml
+++ b/bitnami/thanos/templates/compactor/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/compactor/tls-secrets.yaml
+++ b/bitnami/thanos/templates/compactor/tls-secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/extra-list.yaml
+++ b/bitnami/thanos/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/grpc-tls-secrets.yaml
+++ b/bitnami/thanos/templates/grpc-tls-secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/http-certs-secret.yaml
+++ b/bitnami/thanos/templates/http-certs-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/httpconfig-secret.yaml
+++ b/bitnami/thanos/templates/httpconfig-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/objstore-secret.yaml
+++ b/bitnami/thanos/templates/objstore-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/prometheusrule.yaml
+++ b/bitnami/thanos/templates/prometheusrule.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/query-frontend/configmap.yaml
+++ b/bitnami/thanos/templates/query-frontend/configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/query-frontend/deployment.yaml
+++ b/bitnami/thanos/templates/query-frontend/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/query-frontend/hpa.yaml
+++ b/bitnami/thanos/templates/query-frontend/hpa.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/query-frontend/ingress.yaml
+++ b/bitnami/thanos/templates/query-frontend/ingress.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/query-frontend/networkpolicy.yaml
+++ b/bitnami/thanos/templates/query-frontend/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/query-frontend/pdb.yaml
+++ b/bitnami/thanos/templates/query-frontend/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/query-frontend/psp-clusterrole.yaml
+++ b/bitnami/thanos/templates/query-frontend/psp-clusterrole.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/query-frontend/psp-clusterrolebinding.yaml
+++ b/bitnami/thanos/templates/query-frontend/psp-clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/query-frontend/psp.yaml
+++ b/bitnami/thanos/templates/query-frontend/psp.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/query-frontend/service.yaml
+++ b/bitnami/thanos/templates/query-frontend/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/query-frontend/serviceaccount.yaml
+++ b/bitnami/thanos/templates/query-frontend/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/query-frontend/servicemonitor.yaml
+++ b/bitnami/thanos/templates/query-frontend/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/query-frontend/tls-secrets.yaml
+++ b/bitnami/thanos/templates/query-frontend/tls-secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/query/deployment.yaml
+++ b/bitnami/thanos/templates/query/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/query/hpa.yaml
+++ b/bitnami/thanos/templates/query/hpa.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/query/ingress-grpc.yaml
+++ b/bitnami/thanos/templates/query/ingress-grpc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/query/ingress.yaml
+++ b/bitnami/thanos/templates/query/ingress.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/query/networkpolicy.yaml
+++ b/bitnami/thanos/templates/query/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/query/pdb.yaml
+++ b/bitnami/thanos/templates/query/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/query/psp-clusterrole.yaml
+++ b/bitnami/thanos/templates/query/psp-clusterrole.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/query/psp-clusterrolebinding.yaml
+++ b/bitnami/thanos/templates/query/psp-clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/query/psp.yaml
+++ b/bitnami/thanos/templates/query/psp.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/query/sd-configmap.yaml
+++ b/bitnami/thanos/templates/query/sd-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/query/service-grpc-headless.yaml
+++ b/bitnami/thanos/templates/query/service-grpc-headless.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/query/service-grpc.yaml
+++ b/bitnami/thanos/templates/query/service-grpc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/query/service-headless.yaml
+++ b/bitnami/thanos/templates/query/service-headless.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/query/service.yaml
+++ b/bitnami/thanos/templates/query/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/query/serviceaccount.yaml
+++ b/bitnami/thanos/templates/query/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/query/servicemonitor.yaml
+++ b/bitnami/thanos/templates/query/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/query/tls-secrets-grpc.yaml
+++ b/bitnami/thanos/templates/query/tls-secrets-grpc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/query/tls-secrets.yaml
+++ b/bitnami/thanos/templates/query/tls-secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/receive-distributor/deployment.yaml
+++ b/bitnami/thanos/templates/receive-distributor/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/receive-distributor/hpa.yaml
+++ b/bitnami/thanos/templates/receive-distributor/hpa.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/receive-distributor/pdb.yaml
+++ b/bitnami/thanos/templates/receive-distributor/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/receive-distributor/serviceaccount.yaml
+++ b/bitnami/thanos/templates/receive-distributor/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/receive-distributor/servicemonitor.yaml
+++ b/bitnami/thanos/templates/receive-distributor/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/receive/configmap.yaml
+++ b/bitnami/thanos/templates/receive/configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/receive/hpa.yaml
+++ b/bitnami/thanos/templates/receive/hpa.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/receive/ingress.yaml
+++ b/bitnami/thanos/templates/receive/ingress.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/receive/networkpolicy.yaml
+++ b/bitnami/thanos/templates/receive/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/receive/pdb.yaml
+++ b/bitnami/thanos/templates/receive/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/receive/service-headless.yaml
+++ b/bitnami/thanos/templates/receive/service-headless.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/receive/service.yaml
+++ b/bitnami/thanos/templates/receive/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/receive/serviceaccount.yaml
+++ b/bitnami/thanos/templates/receive/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/receive/servicemonitor.yaml
+++ b/bitnami/thanos/templates/receive/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/receive/statefulset.yaml
+++ b/bitnami/thanos/templates/receive/statefulset.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/receive/tls-secrets.yaml
+++ b/bitnami/thanos/templates/receive/tls-secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/ruler/configmap.yaml
+++ b/bitnami/thanos/templates/ruler/configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/ruler/hpa.yaml
+++ b/bitnami/thanos/templates/ruler/hpa.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/ruler/ingress.yaml
+++ b/bitnami/thanos/templates/ruler/ingress.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/ruler/networkpolicy.yaml
+++ b/bitnami/thanos/templates/ruler/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/ruler/pdb.yaml
+++ b/bitnami/thanos/templates/ruler/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/ruler/secret.yaml
+++ b/bitnami/thanos/templates/ruler/secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/ruler/service-headless.yaml
+++ b/bitnami/thanos/templates/ruler/service-headless.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/ruler/service.yaml
+++ b/bitnami/thanos/templates/ruler/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/ruler/serviceaccount.yaml
+++ b/bitnami/thanos/templates/ruler/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/ruler/servicemonitor.yaml
+++ b/bitnami/thanos/templates/ruler/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/ruler/statefulset.yaml
+++ b/bitnami/thanos/templates/ruler/statefulset.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/ruler/tls-secrets.yaml
+++ b/bitnami/thanos/templates/ruler/tls-secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/storegateway/configmap.yaml
+++ b/bitnami/thanos/templates/storegateway/configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/storegateway/hpa-sharded.yaml
+++ b/bitnami/thanos/templates/storegateway/hpa-sharded.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/storegateway/hpa.yaml
+++ b/bitnami/thanos/templates/storegateway/hpa.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/storegateway/ingress-grpc.yaml
+++ b/bitnami/thanos/templates/storegateway/ingress-grpc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/storegateway/ingress.yaml
+++ b/bitnami/thanos/templates/storegateway/ingress.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/storegateway/networkpolicy.yaml
+++ b/bitnami/thanos/templates/storegateway/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/storegateway/pdb-sharded.yaml
+++ b/bitnami/thanos/templates/storegateway/pdb-sharded.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/storegateway/pdb.yaml
+++ b/bitnami/thanos/templates/storegateway/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/storegateway/service-headless.yaml
+++ b/bitnami/thanos/templates/storegateway/service-headless.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/storegateway/service-sharded.yaml
+++ b/bitnami/thanos/templates/storegateway/service-sharded.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/storegateway/service.yaml
+++ b/bitnami/thanos/templates/storegateway/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/storegateway/serviceaccount.yaml
+++ b/bitnami/thanos/templates/storegateway/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/storegateway/servicemonitor.yaml
+++ b/bitnami/thanos/templates/storegateway/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/storegateway/statefulset-sharded.yaml
+++ b/bitnami/thanos/templates/storegateway/statefulset-sharded.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/storegateway/statefulset.yaml
+++ b/bitnami/thanos/templates/storegateway/statefulset.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/templates/storegateway/tls-secrets.yaml
+++ b/bitnami/thanos/templates/storegateway/tls-secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/thanos/values.yaml
+++ b/bitnami/thanos/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters

--- a/bitnami/tomcat/Chart.yaml
+++ b/bitnami/tomcat/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/tomcat/templates/_helpers.tpl
+++ b/bitnami/tomcat/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/tomcat/templates/_pod.tpl
+++ b/bitnami/tomcat/templates/_pod.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/tomcat/templates/deployment.yaml
+++ b/bitnami/tomcat/templates/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/tomcat/templates/extra-list.yaml
+++ b/bitnami/tomcat/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/tomcat/templates/ingress.yaml
+++ b/bitnami/tomcat/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/tomcat/templates/jmx-configmap.yaml
+++ b/bitnami/tomcat/templates/jmx-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/tomcat/templates/networkpolicy.yaml
+++ b/bitnami/tomcat/templates/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/tomcat/templates/podmonitor.yaml
+++ b/bitnami/tomcat/templates/podmonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/tomcat/templates/prometheusrule.yaml
+++ b/bitnami/tomcat/templates/prometheusrule.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/tomcat/templates/pvc.yaml
+++ b/bitnami/tomcat/templates/pvc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/tomcat/templates/secrets.yaml
+++ b/bitnami/tomcat/templates/secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/tomcat/templates/serviceaccount.yaml
+++ b/bitnami/tomcat/templates/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/tomcat/templates/statefulset.yaml
+++ b/bitnami/tomcat/templates/statefulset.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/tomcat/templates/svc-headless.yaml
+++ b/bitnami/tomcat/templates/svc-headless.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/tomcat/templates/svc.yaml
+++ b/bitnami/tomcat/templates/svc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/tomcat/templates/tls-secrets.yaml
+++ b/bitnami/tomcat/templates/tls-secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/tomcat/values.yaml
+++ b/bitnami/tomcat/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters

--- a/bitnami/vault/Chart.yaml
+++ b/bitnami/vault/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/vault/templates/_helpers.tpl
+++ b/bitnami/vault/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/vault/templates/csi-provider/clusterrole.yaml
+++ b/bitnami/vault/templates/csi-provider/clusterrole.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/vault/templates/csi-provider/configmap.yaml
+++ b/bitnami/vault/templates/csi-provider/configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/vault/templates/csi-provider/daemonset.yaml
+++ b/bitnami/vault/templates/csi-provider/daemonset.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/vault/templates/csi-provider/networkpolicy.yaml
+++ b/bitnami/vault/templates/csi-provider/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/vault/templates/csi-provider/role.yaml
+++ b/bitnami/vault/templates/csi-provider/role.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/vault/templates/csi-provider/rolebinding.yaml
+++ b/bitnami/vault/templates/csi-provider/rolebinding.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/vault/templates/csi-provider/service-account.yaml
+++ b/bitnami/vault/templates/csi-provider/service-account.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/vault/templates/extra-list.yaml
+++ b/bitnami/vault/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/vault/templates/injector/clusterrolebinding.yaml
+++ b/bitnami/vault/templates/injector/clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/vault/templates/injector/clusterroles.yaml
+++ b/bitnami/vault/templates/injector/clusterroles.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/vault/templates/injector/deployment.yaml
+++ b/bitnami/vault/templates/injector/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/vault/templates/injector/hpa.yaml
+++ b/bitnami/vault/templates/injector/hpa.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/vault/templates/injector/mutating-webhook.yaml
+++ b/bitnami/vault/templates/injector/mutating-webhook.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/vault/templates/injector/networkpolicy.yaml
+++ b/bitnami/vault/templates/injector/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/vault/templates/injector/pdb.yaml
+++ b/bitnami/vault/templates/injector/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/vault/templates/injector/role.yaml
+++ b/bitnami/vault/templates/injector/role.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/vault/templates/injector/rolebinding.yaml
+++ b/bitnami/vault/templates/injector/rolebinding.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/vault/templates/injector/service-account.yaml
+++ b/bitnami/vault/templates/injector/service-account.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/vault/templates/injector/service.yaml
+++ b/bitnami/vault/templates/injector/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/vault/templates/server/active-service.yaml
+++ b/bitnami/vault/templates/server/active-service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/vault/templates/server/clusterrolebinding.yaml
+++ b/bitnami/vault/templates/server/clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/vault/templates/server/configmap.yaml
+++ b/bitnami/vault/templates/server/configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/vault/templates/server/ingress.yaml
+++ b/bitnami/vault/templates/server/ingress.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/vault/templates/server/networkpolicy.yaml
+++ b/bitnami/vault/templates/server/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/vault/templates/server/pdb.yaml
+++ b/bitnami/vault/templates/server/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/vault/templates/server/rolebinding.yaml
+++ b/bitnami/vault/templates/server/rolebinding.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/vault/templates/server/roles.yaml
+++ b/bitnami/vault/templates/server/roles.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/vault/templates/server/service-account.yaml
+++ b/bitnami/vault/templates/server/service-account.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/vault/templates/server/service-headless.yaml
+++ b/bitnami/vault/templates/server/service-headless.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/vault/templates/server/service.yaml
+++ b/bitnami/vault/templates/server/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/vault/templates/server/servicemonitor.yaml
+++ b/bitnami/vault/templates/server/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/vault/templates/server/statefulset.yaml
+++ b/bitnami/vault/templates/server/statefulset.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/vault/templates/server/tls-secret.yaml
+++ b/bitnami/vault/templates/server/tls-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/vault/values.yaml
+++ b/bitnami/vault/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters

--- a/bitnami/whereabouts/Chart.yaml
+++ b/bitnami/whereabouts/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/whereabouts/templates/_helpers.tpl
+++ b/bitnami/whereabouts/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/whereabouts/templates/clusterrole.yaml
+++ b/bitnami/whereabouts/templates/clusterrole.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/whereabouts/templates/clusterrolebinding.yaml
+++ b/bitnami/whereabouts/templates/clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/whereabouts/templates/daemonset.yaml
+++ b/bitnami/whereabouts/templates/daemonset.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/whereabouts/templates/extra-list.yaml
+++ b/bitnami/whereabouts/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/whereabouts/templates/networkpolicy.yaml
+++ b/bitnami/whereabouts/templates/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/whereabouts/templates/service-account.yaml
+++ b/bitnami/whereabouts/templates/service-account.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/whereabouts/values.yaml
+++ b/bitnami/whereabouts/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters

--- a/bitnami/wildfly/Chart.yaml
+++ b/bitnami/wildfly/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/wildfly/templates/_helpers.tpl
+++ b/bitnami/wildfly/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/wildfly/templates/deployment.yaml
+++ b/bitnami/wildfly/templates/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/wildfly/templates/extra-list.yaml
+++ b/bitnami/wildfly/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/wildfly/templates/ingress.yaml
+++ b/bitnami/wildfly/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/wildfly/templates/management-ingress.yaml
+++ b/bitnami/wildfly/templates/management-ingress.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/wildfly/templates/networkpolicy.yaml
+++ b/bitnami/wildfly/templates/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/wildfly/templates/pvc.yaml
+++ b/bitnami/wildfly/templates/pvc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/wildfly/templates/secrets.yaml
+++ b/bitnami/wildfly/templates/secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/wildfly/templates/serviceaccount.yaml
+++ b/bitnami/wildfly/templates/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/wildfly/templates/svc.yaml
+++ b/bitnami/wildfly/templates/svc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/wildfly/templates/tls-secrets.yaml
+++ b/bitnami/wildfly/templates/tls-secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/wildfly/values.yaml
+++ b/bitnami/wildfly/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters

--- a/bitnami/wordpress/Chart.yaml
+++ b/bitnami/wordpress/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/wordpress/templates/_helpers.tpl
+++ b/bitnami/wordpress/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/wordpress/templates/config-secret.yaml
+++ b/bitnami/wordpress/templates/config-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/wordpress/templates/deployment.yaml
+++ b/bitnami/wordpress/templates/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/wordpress/templates/externaldb-secrets.yaml
+++ b/bitnami/wordpress/templates/externaldb-secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/wordpress/templates/extra-list.yaml
+++ b/bitnami/wordpress/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/wordpress/templates/hpa.yaml
+++ b/bitnami/wordpress/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/wordpress/templates/httpd-configmap.yaml
+++ b/bitnami/wordpress/templates/httpd-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/wordpress/templates/ingress-secondary.yaml
+++ b/bitnami/wordpress/templates/ingress-secondary.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/wordpress/templates/ingress.yaml
+++ b/bitnami/wordpress/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/wordpress/templates/metrics-svc.yaml
+++ b/bitnami/wordpress/templates/metrics-svc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/wordpress/templates/networkpolicy.yaml
+++ b/bitnami/wordpress/templates/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/wordpress/templates/pdb.yaml
+++ b/bitnami/wordpress/templates/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/wordpress/templates/postinit-configmap.yaml
+++ b/bitnami/wordpress/templates/postinit-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/wordpress/templates/pvc.yaml
+++ b/bitnami/wordpress/templates/pvc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/wordpress/templates/secrets.yaml
+++ b/bitnami/wordpress/templates/secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/wordpress/templates/serviceaccount.yaml
+++ b/bitnami/wordpress/templates/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/wordpress/templates/servicemonitor.yaml
+++ b/bitnami/wordpress/templates/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/wordpress/templates/svc.yaml
+++ b/bitnami/wordpress/templates/svc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/wordpress/templates/tls-secrets.yaml
+++ b/bitnami/wordpress/templates/tls-secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/wordpress/values.yaml
+++ b/bitnami/wordpress/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters

--- a/bitnami/zookeeper/Chart.yaml
+++ b/bitnami/zookeeper/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/zookeeper/templates/_helpers.tpl
+++ b/bitnami/zookeeper/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/zookeeper/templates/configmap.yaml
+++ b/bitnami/zookeeper/templates/configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/zookeeper/templates/extra-list.yaml
+++ b/bitnami/zookeeper/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/zookeeper/templates/metrics-svc.yaml
+++ b/bitnami/zookeeper/templates/metrics-svc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/zookeeper/templates/networkpolicy.yaml
+++ b/bitnami/zookeeper/templates/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/zookeeper/templates/pdb.yaml
+++ b/bitnami/zookeeper/templates/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/zookeeper/templates/prometheusrule.yaml
+++ b/bitnami/zookeeper/templates/prometheusrule.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/zookeeper/templates/scripts-configmap.yaml
+++ b/bitnami/zookeeper/templates/scripts-configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/zookeeper/templates/secrets.yaml
+++ b/bitnami/zookeeper/templates/secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/zookeeper/templates/serviceaccount.yaml
+++ b/bitnami/zookeeper/templates/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/zookeeper/templates/servicemonitor.yaml
+++ b/bitnami/zookeeper/templates/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/zookeeper/templates/statefulset.yaml
+++ b/bitnami/zookeeper/templates/statefulset.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/zookeeper/templates/svc-headless.yaml
+++ b/bitnami/zookeeper/templates/svc-headless.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/zookeeper/templates/svc.yaml
+++ b/bitnami/zookeeper/templates/svc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/zookeeper/templates/tls-secrets.yaml
+++ b/bitnami/zookeeper/templates/tls-secrets.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/zookeeper/values.yaml
+++ b/bitnami/zookeeper/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters

--- a/template/CHART_NAME/Chart.yaml
+++ b/template/CHART_NAME/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/template/CHART_NAME/templates/_helpers.tpl
+++ b/template/CHART_NAME/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/template/CHART_NAME/templates/clusterrolebinding.yaml
+++ b/template/CHART_NAME/templates/clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/template/CHART_NAME/templates/configmap.yaml
+++ b/template/CHART_NAME/templates/configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/template/CHART_NAME/templates/daemonset.yaml
+++ b/template/CHART_NAME/templates/daemonset.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/template/CHART_NAME/templates/deployment.yaml
+++ b/template/CHART_NAME/templates/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/template/CHART_NAME/templates/extra-list.yaml
+++ b/template/CHART_NAME/templates/extra-list.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/template/CHART_NAME/templates/hpa.yaml
+++ b/template/CHART_NAME/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/template/CHART_NAME/templates/ingress.yaml
+++ b/template/CHART_NAME/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/template/CHART_NAME/templates/networkpolicy.yaml
+++ b/template/CHART_NAME/templates/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/template/CHART_NAME/templates/pdb.yaml
+++ b/template/CHART_NAME/templates/pdb.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/template/CHART_NAME/templates/pvc.yaml
+++ b/template/CHART_NAME/templates/pvc.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/template/CHART_NAME/templates/role.yaml
+++ b/template/CHART_NAME/templates/role.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/template/CHART_NAME/templates/secret.yaml
+++ b/template/CHART_NAME/templates/secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/template/CHART_NAME/templates/service-account.yaml
+++ b/template/CHART_NAME/templates/service-account.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/template/CHART_NAME/templates/service.yaml
+++ b/template/CHART_NAME/templates/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/template/CHART_NAME/templates/servicemonitor.yaml
+++ b/template/CHART_NAME/templates/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/template/CHART_NAME/templates/statefulset.yaml
+++ b/template/CHART_NAME/templates/statefulset.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/template/CHART_NAME/templates/tls-secret.yaml
+++ b/template/CHART_NAME/templates/tls-secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/template/CHART_NAME/values.yaml
+++ b/template/CHART_NAME/values.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters


### PR DESCRIPTION
### Description of the change
To keep the consistency between both copyrights (README and headers), this PR replaces _Copyright VMware, Inc._ with _Copyright Broadcom, Inc. All Rights Reserved._