### PR TITLE
[bitnami/argo-cd] Remove null port in application-controller NetworkPolicy

### DIFF
--- a/bitnami/argo-cd/Chart.yaml
+++ b/bitnami/argo-cd/Chart.yaml
@@ -39,4 +39,4 @@ maintainers:
 name: argo-cd
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/argo-cd
-version: 6.0.10
+version: 6.0.11

--- a/bitnami/argo-cd/templates/application-controller/networkpolicy.yaml
+++ b/bitnami/argo-cd/templates/application-controller/networkpolicy.yaml
@@ -61,7 +61,6 @@ spec:
   {{- end }}
   ingress:
     - ports:
-        - port: {{ .Values.controller.containerPorts.controller }}
         - port: {{ .Values.controller.containerPorts.metrics }}
       {{- if not .Values.controller.networkPolicy.allowExternal }}
       from:


### PR DESCRIPTION
### Description of the change

Fix small bug in the application-controller NetworkPolicy implemented in #23359. One ingress port is null, the parameter was removed as part of #25043.

```console
$ helm template oci://registry-1.docker.io/bitnamicharts/argo-cd --version 6.0.10 -s templates/application-controller/networkpolicy.yaml | grep port
    - ports:
        - port:
        - port: 8082
```

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] n/a ~Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)~
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
