### PR TITLE
[bitnami/*] Use AWS role to publish bitnami helm charts

### DIFF
--- a/.github/workflows/cd-pipeline.yml
+++ b/.github/workflows/cd-pipeline.yml
@@ -110,9 +110,11 @@ jobs:
         env: 
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_PUBLISH_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_PUBLISH_SECRET_ACCESS_KEY }}
-          AWS_ROLE_ARN: ${{ secrets.AWS_PUBLISH_ROLE_ARN }}
+          AWS_ASSUME_ROLE_ARN: ${{ secrets.AWS_PUBLISH_ROLE_ARN }}
           AWS_DEFAULT_REGION: us-east-1
         run: |
+          # Configure AWS account
+          export $(printf "AWS_ACCESS_KEY_ID=%s AWS_SECRET_ACCESS_KEY=%s AWS_SESSION_TOKEN=%s" $(aws sts assume-role --role-arn ${AWS_ASSUME_ROLE_ARN} --role-session-name GitHubCharts --query "Credentials.[AccessKeyId,SecretAccessKey,SessionToken]" --output text))
           # Extract chart release metadata from the publish report file
           vib_publish_report_file=$(find ~/artifacts -name "report.json" -print -quit)
           chart_name=$(jq -re '.actions|map(select(.action_id == "helm-publish"))[0] | .application.name' $vib_publish_report_file)

--- a/.github/workflows/cd-pipeline.yml
+++ b/.github/workflows/cd-pipeline.yml
@@ -82,8 +82,9 @@ jobs:
           config: charts/.vib/
         env:
           VIB_ENV_S3_URL: s3://${{ secrets.AWS_S3_BUCKET }}/bitnami
-          VIB_ENV_S3_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          VIB_ENV_S3_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          VIB_ENV_S3_ACCESS_KEY_ID: ${{ secrets.AWS_PUBLISH_ACCESS_KEY_ID }}
+          VIB_ENV_S3_SECRET_ACCESS_KEY: ${{ secrets.AWS_PUBLISH_SECRET_ACCESS_KEY }}
+          VIB_ENV_S3_ROLE_ARN: ${{ secrets.AWS_PUBLISH_ROLE_ARN }}
   update-index:
     runs-on: ubuntu-latest
     needs:
@@ -107,8 +108,9 @@ jobs:
       - id: update-index
         name: Fetch chart and update index
         env: 
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_PUBLISH_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_PUBLISH_SECRET_ACCESS_KEY }}
+          AWS_ROLE_ARN: ${{ secrets.AWS_PUBLISH_ROLE_ARN }}
           AWS_DEFAULT_REGION: us-east-1
         run: |
           # Extract chart release metadata from the publish report file

--- a/.vib/airflow/vib-publish.json
+++ b/.vib/airflow/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/apache/vib-publish.json
+++ b/.vib/apache/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/apisix/vib-publish.json
+++ b/.vib/apisix/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/appsmith/vib-publish.json
+++ b/.vib/appsmith/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/argo-cd/vib-publish.json
+++ b/.vib/argo-cd/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/argo-workflows/vib-publish.json
+++ b/.vib/argo-workflows/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/aspnet-core/vib-publish.json
+++ b/.vib/aspnet-core/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/cassandra/vib-publish.json
+++ b/.vib/cassandra/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/cert-manager/vib-publish.json
+++ b/.vib/cert-manager/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/clickhouse/vib-publish.json
+++ b/.vib/clickhouse/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/common/vib-publish.json
+++ b/.vib/common/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/concourse/vib-publish.json
+++ b/.vib/concourse/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/consul/vib-publish.json
+++ b/.vib/consul/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/contour/vib-publish.json
+++ b/.vib/contour/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/deepspeed/vib-publish.json
+++ b/.vib/deepspeed/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/discourse/vib-publish.json
+++ b/.vib/discourse/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/dokuwiki/vib-publish.json
+++ b/.vib/dokuwiki/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/drupal/vib-publish.json
+++ b/.vib/drupal/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/ejbca/vib-publish.json
+++ b/.vib/ejbca/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/elasticsearch/vib-publish.json
+++ b/.vib/elasticsearch/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/etcd/vib-publish.json
+++ b/.vib/etcd/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/external-dns/vib-publish.json
+++ b/.vib/external-dns/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/flink/vib-publish.json
+++ b/.vib/flink/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/fluent-bit/vib-publish.json
+++ b/.vib/fluent-bit/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/fluentd/vib-publish.json
+++ b/.vib/fluentd/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/flux/vib-publish.json
+++ b/.vib/flux/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/ghost/vib-publish.json
+++ b/.vib/ghost/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/gitea/vib-publish.json
+++ b/.vib/gitea/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/grafana-loki/vib-publish.json
+++ b/.vib/grafana-loki/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/grafana-mimir/vib-publish.json
+++ b/.vib/grafana-mimir/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/grafana-operator/vib-publish.json
+++ b/.vib/grafana-operator/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/grafana-tempo/vib-publish.json
+++ b/.vib/grafana-tempo/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/grafana/vib-publish.json
+++ b/.vib/grafana/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/haproxy/vib-publish.json
+++ b/.vib/haproxy/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/harbor/vib-publish.json
+++ b/.vib/harbor/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/influxdb/vib-publish.json
+++ b/.vib/influxdb/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/jaeger/vib-publish.json
+++ b/.vib/jaeger/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/jenkins/vib-publish.json
+++ b/.vib/jenkins/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/joomla/vib-publish.json
+++ b/.vib/joomla/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/jupyterhub/vib-publish.json
+++ b/.vib/jupyterhub/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/kafka/vib-publish.json
+++ b/.vib/kafka/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/keycloak/vib-publish.json
+++ b/.vib/keycloak/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/kiam/vib-publish.json
+++ b/.vib/kiam/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/kibana/vib-publish.json
+++ b/.vib/kibana/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/kong/vib-publish.json
+++ b/.vib/kong/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/kube-prometheus/vib-publish.json
+++ b/.vib/kube-prometheus/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/kube-state-metrics/vib-publish.json
+++ b/.vib/kube-state-metrics/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/kubeapps/vib-publish.json
+++ b/.vib/kubeapps/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/kuberay/vib-publish.json
+++ b/.vib/kuberay/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/kubernetes-event-exporter/vib-publish.json
+++ b/.vib/kubernetes-event-exporter/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/logstash/vib-publish.json
+++ b/.vib/logstash/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/magento/vib-publish.json
+++ b/.vib/magento/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/mariadb-galera/vib-publish.json
+++ b/.vib/mariadb-galera/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/mariadb/vib-publish.json
+++ b/.vib/mariadb/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/mastodon/vib-publish.json
+++ b/.vib/mastodon/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/matomo/vib-publish.json
+++ b/.vib/matomo/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/mediawiki/vib-publish.json
+++ b/.vib/mediawiki/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/memcached/vib-publish.json
+++ b/.vib/memcached/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/metallb/vib-publish.json
+++ b/.vib/metallb/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/metrics-server/vib-publish.json
+++ b/.vib/metrics-server/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/milvus/vib-publish.json
+++ b/.vib/milvus/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/minio/vib-publish.json
+++ b/.vib/minio/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/mlflow/vib-publish.json
+++ b/.vib/mlflow/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/mongodb-sharded/vib-publish.json
+++ b/.vib/mongodb-sharded/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/mongodb/vib-publish.json
+++ b/.vib/mongodb/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/moodle/vib-publish.json
+++ b/.vib/moodle/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/multus-cni/vib-publish.json
+++ b/.vib/multus-cni/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/mysql/vib-publish.json
+++ b/.vib/mysql/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/nats/vib-publish.json
+++ b/.vib/nats/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/nginx-ingress-controller/vib-publish.json
+++ b/.vib/nginx-ingress-controller/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/nginx/vib-publish.json
+++ b/.vib/nginx/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/node-exporter/vib-publish.json
+++ b/.vib/node-exporter/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/oauth2-proxy/vib-publish.json
+++ b/.vib/oauth2-proxy/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/odoo/vib-publish.json
+++ b/.vib/odoo/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/opencart/vib-publish.json
+++ b/.vib/opencart/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/opensearch/vib-publish.json
+++ b/.vib/opensearch/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/parse/vib-publish.json
+++ b/.vib/parse/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/phpbb/vib-publish.json
+++ b/.vib/phpbb/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/phpmyadmin/vib-publish.json
+++ b/.vib/phpmyadmin/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/pinniped/vib-publish.json
+++ b/.vib/pinniped/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/postgresql-ha/vib-publish.json
+++ b/.vib/postgresql-ha/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/postgresql/vib-publish.json
+++ b/.vib/postgresql/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/prestashop/vib-publish.json
+++ b/.vib/prestashop/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/prometheus/vib-publish.json
+++ b/.vib/prometheus/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/pytorch/vib-publish.json
+++ b/.vib/pytorch/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/rabbitmq-cluster-operator/vib-publish.json
+++ b/.vib/rabbitmq-cluster-operator/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/rabbitmq/vib-publish.json
+++ b/.vib/rabbitmq/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/redis-cluster/vib-publish.json
+++ b/.vib/redis-cluster/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/redis/vib-publish.json
+++ b/.vib/redis/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/redmine/vib-publish.json
+++ b/.vib/redmine/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/schema-registry/vib-publish.json
+++ b/.vib/schema-registry/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/sealed-secrets/vib-publish.json
+++ b/.vib/sealed-secrets/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/seaweedfs/vib-publish.json
+++ b/.vib/seaweedfs/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/solr/vib-publish.json
+++ b/.vib/solr/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/sonarqube/vib-publish.json
+++ b/.vib/sonarqube/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/spark/vib-publish.json
+++ b/.vib/spark/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/spring-cloud-dataflow/vib-publish.json
+++ b/.vib/spring-cloud-dataflow/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/supabase/vib-publish.json
+++ b/.vib/supabase/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/tensorflow-resnet/vib-publish.json
+++ b/.vib/tensorflow-resnet/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/thanos/vib-publish.json
+++ b/.vib/thanos/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/tomcat/vib-publish.json
+++ b/.vib/tomcat/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/vault/vib-publish.json
+++ b/.vib/vault/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/whereabouts/vib-publish.json
+++ b/.vib/whereabouts/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/wildfly/vib-publish.json
+++ b/.vib/wildfly/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/wordpress/vib-publish.json
+++ b/.vib/wordpress/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }

--- a/.vib/zookeeper/vib-publish.json
+++ b/.vib/zookeeper/vib-publish.json
@@ -26,7 +26,8 @@
               "url": "{VIB_ENV_S3_URL}",
               "authn": {
                 "access_key_id": "{VIB_ENV_S3_ACCESS_KEY_ID}",
-                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}"
+                "secret_access_key": "{VIB_ENV_S3_SECRET_ACCESS_KEY}",
+                "role": "{VIB_ENV_S3_ROLE_ARN}"
               }
             }
           }


### PR DESCRIPTION
### Description of the change

Change AWS accounts and assume roles to publish the helm charts.

### Benefits

Restrict the use of these credentials and only request the permissions needed.

### Possible drawbacks

None

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
