### PR TITLE
Use AWS role to publish index.yaml file in S3

### DIFF
--- a/.github/workflows/sync-chart-index.yaml
+++ b/.github/workflows/sync-chart-index.yaml
@@ -19,6 +19,6 @@ jobs:
         AWS_DEFAULT_REGION: ${{ secrets.AWS_REGION }}
       run: |
         # Configure AWS account
-        export $(printf "AWS_ACCESS_KEY_ID=%s AWS_SECRET_ACCESS_KEY=%s AWS_SESSION_TOKEN=%s" $(aws sts assume-role --role-arn ${AWS_ASSUME_ROLE_ARN} --role-session-name GitHubCharts --query "Credentials.[AccessKeyId,SecretAccessKey,SessionToken]" --output text))
+        export $(printf "AWS_ACCESS_KEY_ID=%s AWS_SECRET_ACCESS_KEY=%s AWS_SESSION_TOKEN=%s" $(aws sts assume-role --role-arn ${AWS_ASSUME_ROLE_ARN} --role-session-name GitHubIndex --query "Credentials.[AccessKeyId,SecretAccessKey,SessionToken]" --output text))
         aws s3 cp --follow-symlinks bitnami/index.yaml s3://${{ secrets.AWS_S3_BUCKET }}/bitnami/
         aws s3 cp --follow-symlinks bitnami/index.html s3://${{ secrets.AWS_S3_BUCKET }}/

--- a/.github/workflows/sync-chart-index.yaml
+++ b/.github/workflows/sync-chart-index.yaml
@@ -11,9 +11,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-    - name: Install s3cmd
-      run: sudo apt-get install -y s3cmd
     - name: Upload to S3
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_PUBLISH_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_PUBLISH_SECRET_ACCESS_KEY }}
+        AWS_ASSUME_ROLE_ARN: ${{ secrets.AWS_PUBLISH_ROLE_ARN }}
+        AWS_DEFAULT_REGION: ${{ secrets.AWS_REGION }}
       run: |
-        s3cmd put --region=${{ secrets.AWS_REGION }} --access_key=${{ secrets.AWS_ACCESS_KEY_ID }} --secret_key=${{ secrets.AWS_SECRET_ACCESS_KEY }} --follow-symlinks bitnami/index.yaml s3://${{ secrets.AWS_S3_BUCKET }}/bitnami/
-        s3cmd put --region=${{ secrets.AWS_REGION }} --access_key=${{ secrets.AWS_ACCESS_KEY_ID }} --secret_key=${{ secrets.AWS_SECRET_ACCESS_KEY }} --follow-symlinks bitnami/index.html s3://${{ secrets.AWS_S3_BUCKET }}/
+        # Configure AWS account
+        export $(printf "AWS_ACCESS_KEY_ID=%s AWS_SECRET_ACCESS_KEY=%s AWS_SESSION_TOKEN=%s" $(aws sts assume-role --role-arn ${AWS_ASSUME_ROLE_ARN} --role-session-name GitHubCharts --query "Credentials.[AccessKeyId,SecretAccessKey,SessionToken]" --output text))
+        aws s3 cp --follow-symlinks bitnami/index.yaml s3://${{ secrets.AWS_S3_BUCKET }}/bitnami/
+        aws s3 cp --follow-symlinks bitnami/index.html s3://${{ secrets.AWS_S3_BUCKET }}/


### PR DESCRIPTION
### Description of the change

Change AWS accounts and assume roles to publish the helm charts in the index branch.

### Benefits

Restrict the use of these credentials and only request the permissions needed.

### Possible drawbacks

None
