### PR TITLE
[bitnami/minio] Allow bucket versioning in standalone mode 

### DIFF
--- a/bitnami/minio/Chart.yaml
+++ b/bitnami/minio/Chart.yaml
@@ -34,4 +34,4 @@ maintainers:
 name: minio
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/minio
-version: 14.2.1
+version: 14.3.0

--- a/bitnami/minio/templates/provisioning-job.yaml
+++ b/bitnami/minio/templates/provisioning-job.yaml
@@ -176,7 +176,6 @@ spec:
               mc admin group {{ $groupStatus }} {{ $minioAlias }} {{ $group.name }};
               {{- end }}
 
-              {{- $isDistributedMode := (eq .Values.mode "distributed") }}
               {{- range $bucket := .Values.provisioning.buckets }}
               {{- $target := printf "%s/%s" $minioAlias $bucket.name }}
               {{- $region := ternary (printf "--region=%s" $bucket.region) ("") (not (empty $bucket.region)) }}
@@ -195,7 +194,6 @@ spec:
               {{- end }}
               {{- end }}
 
-              {{- if $isDistributedMode }}
               {{- if (or ((empty $bucket.withLock)) (not $bucket.withLock)) }}
               {{- $versioning := default "Suspended" $bucket.versioning }}
               {{- if kindIs "bool" $bucket.versioning }}
@@ -207,7 +205,6 @@ spec:
               mc version suspend {{ $minioAlias }}/{{ $bucket.name }};
               {{- else if ne $versioning "Unchanged" }}
               {{- fail (printf "Invalid value '%s' for versioning of bucket '%s'" $versioning $bucket.name) }}
-              {{- end }}
               {{- end }}
               {{- end }}
 

--- a/bitnami/minio/templates/provisioning-job.yaml
+++ b/bitnami/minio/templates/provisioning-job.yaml
@@ -217,7 +217,7 @@ spec:
               {{- range $name, $value := $bucket.tags }}
               {{- $tags = (printf "%s=%s" $name $value) | append $tags }}
               {{- end }}
-              {{- $tags := join "&" $tags | quote }}
+              {{- $tags = join "&" $tags | quote }}
               mc tag set {{ $target }} {{ $tags }};
               {{- end }}
               {{- end }}


### PR DESCRIPTION
### Description of the change

Allows enabling [versioning](https://min.io/docs/minio/linux/administration/object-management/object-versioning.html?ref=docs-redirect) for provisioned buckets. 

### Applicable issues

- fixes #25341

### Additional information

Tested locally: https://github.com/bitnami/charts/issues/25341#issuecomment-2073518947

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
