### PR TITLE
[bitnami/keycloak]: add url env vars to fix admin ingress access

### DIFF
--- a/bitnami/keycloak/Chart.yaml
+++ b/bitnami/keycloak/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright VMware, Inc.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:

--- a/bitnami/keycloak/Chart.yaml
+++ b/bitnami/keycloak/Chart.yaml
@@ -33,4 +33,4 @@ maintainers:
 name: keycloak
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/keycloak
-version: 21.0.4
+version: 21.1.0

--- a/bitnami/keycloak/templates/statefulset.yaml
+++ b/bitnami/keycloak/templates/statefulset.yaml
@@ -213,8 +213,12 @@ spec:
               value: {{ .Values.extraStartupArgs | quote }}
             {{- end }}
             {{- if .Values.adminIngress.enabled }}
-            - name: KC_HOSTNAME_ADMIN
-              value: {{ include "common.tplvalues.render" (dict "value" .Values.adminIngress.hostname "context" $) }}
+            - name: KC_HOSTNAME_ADMIN_URL
+              value: "http{{ if .Values.adminIngress.tls }}s{{ end }}://{{ include "common.tplvalues.render" (dict "value" .Values.adminIngress.hostname "context" $) }}"
+            {{- end }}
+            {{- if and .Values.adminIngress.enabled (not .Values.ingress.enabled) }}
+            - name: KC_HOSTNAME_URL
+              value: "http{{ if .Values.adminIngress.tls }}s{{ end }}://{{ include "common.tplvalues.render" (dict "value" .Values.adminIngress.hostname "context" $) }}"
             {{- end }}
             {{- if .Values.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.extraEnvVars "context" $) | nindent 12 }}


### PR DESCRIPTION
### Description of the change

Replace KC_HOSTNAME_ADMIN by KC_HOSTNAME_ADMIN_URL to include the scheme (http or https) and add KC_HOSTNAME_URL for the frontend to function correctly. These variable allow the front to function correctly if we have the tls option enabled. Before this commit the front was always attempting to load some resources over http while it may be exposed in https.

### Benefits
Keycloak admin ingress works if tls/https is configured

### Possible drawbacks

If some users defined `KC_HOSTNAME` or `KC_HOSTNAME_URL` in extraEnv it could prevent keycloak to start, I reduced the risk by adding this variable only if the ingress is not enabled though

### Applicable issues

### Additional information

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
