### PR TITLE
[bitnami/mongodb] Simplify and fix externalAccess configuration

### DIFF
--- a/bitnami/mongodb/Chart.yaml
+++ b/bitnami/mongodb/Chart.yaml
@@ -39,4 +39,4 @@ maintainers:
 name: mongodb
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/mongodb
-version: 15.1.5
+version: 15.2.0

--- a/bitnami/mongodb/templates/backup/cronjob.yaml
+++ b/bitnami/mongodb/templates/backup/cronjob.yaml
@@ -103,8 +103,8 @@ spec:
                 {{- if .Values.externalAccess.service.loadBalancerIPs }}
                 - -i {{ join "," .Values.externalAccess.service.loadBalancerIPs }}
                 {{- end }}
-                {{- if .Values.tls.extraDnsNames }}
-                - -n {{ join "," .Values.tls.extraDnsNames }}
+                {{- if or .Values.tls.extraDnsNames .Values.externalAccess.publicNames }}
+                - -n {{ join "," ( concat .Values.tls.extraDnsNames .Values.externalAccess.publicNames ) }}
                 {{- end }}
               {{- if .Values.tls.resources }}
               resources: {{- toYaml .Values.tls.resources | nindent 16 }}

--- a/bitnami/mongodb/templates/hidden/statefulset.yaml
+++ b/bitnami/mongodb/templates/hidden/statefulset.yaml
@@ -158,8 +158,8 @@ spec:
             {{- if .Values.externalAccess.hidden.service.loadBalancerIPs }}
             - -i {{ join "," .Values.externalAccess.hidden.service.loadBalancerIPs }}
             {{- end }}
-            {{- if .Values.tls.extraDnsNames }}
-            - -n {{ join "," .Values.tls.extraDnsNames }}
+            {{- if or .Values.tls.extraDnsNames .Values.externalAccess.publicNames }}
+            - -n {{ join "," ( concat  .Values.tls.extraDnsNames .Values.externalAccess.publicNames ) }}
             {{- end }}
           {{- if .Values.tls.resources }}
           resources: {{- toYaml .Values.tls.resources | nindent 12 }}

--- a/bitnami/mongodb/templates/replicaset/external-access-svc.yaml
+++ b/bitnami/mongodb/templates/replicaset/external-access-svc.yaml
@@ -19,8 +19,9 @@ metadata:
   labels: {{- include "common.labels.standard" ( dict "customLabels" $root.Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: mongodb
     pod: {{ $targetPod }}
-  {{- if or $root.Values.externalAccess.service.annotations $root.Values.commonAnnotations }}
-  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list $root.Values.externalAccess.service.annotations $root.Values.commonAnnotations ) "context" $ ) }}
+  {{- if or $root.Values.externalAccess.service.annotations $root.Values.commonAnnotations $root.Values.externalAccess.service.annotationsList}}
+  {{- $exclusiveAnnotations := ternary ( dict ) (index $root.Values.externalAccess.service.annotationsList $i) ( lt (len $root.Values.externalAccess.service.annotationsList ) $i ) }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list $root.Values.externalAccess.service.annotations $root.Values.commonAnnotations $exclusiveAnnotations ) "context" $ ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:

--- a/bitnami/mongodb/templates/replicaset/scripts-configmap.yaml
+++ b/bitnami/mongodb/templates/replicaset/scripts-configmap.yaml
@@ -73,7 +73,7 @@ data:
     export MONGODB_ADVERTISED_HOSTNAME="$(<${SHARED_FILE})"
     {{- else }}
     ID="${MY_POD_NAME#"{{ $fullname }}-"}"
-    export MONGODB_ADVERTISED_HOSTNAME=$(echo '{{ .Values.externalAccess.service.loadBalancerIPs }}' | tr -d '[]' | cut -d ' ' -f "$(($ID + 1))")
+    export MONGODB_ADVERTISED_HOSTNAME=$(echo '{{ coalesce .Values.externalAccess.publicNames .Values.externalAccess.service.loadBalancerIPs }}' | tr -d '[]' | cut -d ' ' -f "$(($ID + 1))")
     {{- end }}
     {{- else if eq .Values.externalAccess.service.type "NodePort" }}
     ID="${MY_POD_NAME#"{{ $fullname }}-"}"
@@ -113,7 +113,6 @@ data:
       {{- $fullname := include "mongodb.fullname" . }}
       {{- $releaseNamespace := include "mongodb.namespace" . }}
       {{- $clusterDomain := .Values.clusterDomain }}
-      {{- $loadBalancerIPListLength := len .Values.externalAccess.service.loadBalancerIPs }}
       {{- $mongoList := list }}
       {{- range $e, $i := until $replicaCount }}
       {{- $mongoList = append $mongoList (printf "%s-%d.%s-headless.%s.svc.%s:%d" $fullname $i $fullname $releaseNamespace $clusterDomain $portNumber) }}

--- a/bitnami/mongodb/templates/replicaset/statefulset.yaml
+++ b/bitnami/mongodb/templates/replicaset/statefulset.yaml
@@ -158,8 +158,8 @@ spec:
             {{- if .Values.externalAccess.service.loadBalancerIPs }}
             - -i {{ join "," .Values.externalAccess.service.loadBalancerIPs }}
             {{- end }}
-            {{- if .Values.tls.extraDnsNames }}
-            - -n {{ join "," .Values.tls.extraDnsNames }}
+            {{- if or .Values.tls.extraDnsNames .Values.externalAccess.publicNames }}
+            - -n {{ join "," ( concat .Values.tls.extraDnsNames .Values.externalAccess.publicNames ) }}
             {{- end }}
           {{- if .Values.tls.resources }}
           resources: {{- toYaml .Values.tls.resources | nindent 12 }}
@@ -243,7 +243,7 @@ spec:
             - name: K8S_SERVICE_NAME
               value: "{{ include "mongodb.service.nameOverride" . }}"
             - name: MONGODB_INITIAL_PRIMARY_HOST
-              value: {{ printf "%s-0.$(K8S_SERVICE_NAME).$(MY_POD_NAMESPACE).svc.%s" (include "mongodb.fullname" .) .Values.clusterDomain }}
+              value: {{ ternary ( printf "%s-0.$(K8S_SERVICE_NAME).$(MY_POD_NAMESPACE).svc.%s" (include "mongodb.fullname" .) .Values.clusterDomain ) ( first .Values.externalAccess.publicNames ) ( empty .Values.externalAccess.publicNames ) }}
             - name: MONGODB_REPLICA_SET_NAME
               value: {{ .Values.replicaSetName | quote }}
             {{- if and .Values.replicaSetHostnames (not .Values.externalAccess.enabled) }}

--- a/bitnami/mongodb/templates/standalone/dep-sts.yaml
+++ b/bitnami/mongodb/templates/standalone/dep-sts.yaml
@@ -152,8 +152,8 @@ spec:
             {{- if .Values.externalAccess.service.loadBalancerIPs }}
             - -i {{ join "," .Values.externalAccess.service.loadBalancerIPs }}
             {{- end }}
-            {{- if .Values.tls.extraDnsNames }}
-            - -n {{ join "," .Values.tls.extraDnsNames }}
+            {{- if or .Values.tls.extraDnsNames .Values.externalAccess.publicNames }}
+            - -n {{ join "," ( concat .Values.tls.extraDnsNames .Values.externalAccess.publicNames ) }}
             {{- end }}
           {{- if .Values.tls.resources }}
           resources: {{- toYaml .Values.tls.resources | nindent 12 }}

--- a/bitnami/mongodb/values.yaml
+++ b/bitnami/mongodb/values.yaml
@@ -129,7 +129,7 @@ diagnosticMode:
 image:
   registry: docker.io
   repository: bitnami/mongodb
-  tag: 7.0.8-debian-12-r2
+  tag: 7.0.8-debian-12-r4
   digest: ""
   ## Specify a imagePullPolicy
   ## ref: https://kubernetes.io/docs/concepts/containers/images/#pre-pulled-images
@@ -823,6 +823,9 @@ externalAccess:
   ## @param externalAccess.enabled Enable Kubernetes external cluster access to MongoDB(&reg;) nodes (only for replicaset architecture)
   ##
   enabled: false
+  ## @param externalAccess.publicNames Array of public names. The size should be equal to the number of replicas.
+  ## 
+  publicNames: []
   ## External IPs auto-discovery configuration
   ## An init container is used to auto-detect LB IPs or node ports by querying the K8s API
   ## Note: RBAC might be required
@@ -918,7 +921,7 @@ externalAccess:
     ## - 10.10.10.0/24
     ##
     loadBalancerSourceRanges: []
-    ## @param externalAccess.service.allocateLoadBalancerNodePorts Wheter to allocate node ports when service type is LoadBalancer
+    ## @param externalAccess.service.allocateLoadBalancerNodePorts Whether to allocate node ports when service type is LoadBalancer
     ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#load-balancer-nodeport-allocation
     ##
     allocateLoadBalancerNodePorts: true
@@ -942,9 +945,16 @@ externalAccess:
     ## @param externalAccess.service.extraPorts Extra ports to expose (normally used with the `sidecar` value)
     ##
     extraPorts: []
-    ## @param externalAccess.service.annotations Service annotations for external access
+    ## @param externalAccess.service.annotations Service annotations for external access. These annotations are common for all services created.
     ##
     annotations: {}
+    ## @param externalAccess.service.annotationsList Service annotations for eache external service. This value contains a list allowing different annotations per each external service.
+    ## Eg:
+    ##   annotationsList:
+    ##     - external-dns.alpha.kubernetes.io/hostname: mongodb-0.example.com
+    ##     - external-dns.alpha.kubernetes.io/hostname: mongodb-1.example.com
+    ##
+    annotationsList: []
     ## @param externalAccess.service.sessionAffinity Control where client requests go, to the same pod or round-robin
     ## Values: ClientIP or None
     ## ref: https://kubernetes.io/docs/concepts/services-networking/service/


### PR DESCRIPTION
### Description of the change

Allow the use of external certificates signed for external names. Current chart requires several internal names and IPs signed in the certificates provided by the user. That restriction makes almost impossible the use of this chart with external names and TLS enabled.

### Benefits

Allow the use of external certificates and names in MongoDB chart.

### Possible drawbacks

None

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #16719

### Additional information

These changes were tested in the following scenario:
1. Empty cluster created with k3d:
```console
$ k3d cluster create
```
2. Certificates and secrets have been created with following script:
```bash
#!/bin/bash
if [[ ! -f  ca.crt ]]; then
  openssl genrsa -out ca.key 2048
  openssl req -x509 -new -nodes -key ca.key -subj "/CN=example.com" -sha256 -days 1024 -out ca.crt
fi

for i in 0 1 arbiter; do
  if [[ ! -f "mongodb-${i}.crt" ]]; then
    openssl genrsa -out "mongodb-${i}.key" 2048
    openssl req -new -key "mongodb-${i}.key" -subj "/CN=mongodb-${i}.example.com" -out "mongodb-${i}.csr"
    openssl x509 -req -in "mongodb-${i}.csr" -CA ca.crt -CAkey ca.key -CAcreateserial -out "mongodb-${i}.crt" -days 1024 -sha256
  fi
  kubectl create secret tls "mongodb-${i}-pem"  --cert="mongodb-${i}.crt" --key="mongodb-${i}.key"
  kubectl patch secret "mongodb-${i}-pem" -p="{\"data\":{\"ca.crt\": \"$(cat ca.crt | base64 -w0 )\"}}"
done
```
3. To avoid  issues with name resolution this configuration has been added to the `coredns` configmap:
```
rewrite name mongodb-0.example.com mongodb-0.mongodb-headless.default.svc.cluster.local
rewrite name mongodb-1.example.com mongodb-1.mongodb-headless.default.svc.cluster.local
```
4. Values used:
```yaml
architecture: replicaset
replicaCount: 2
tls:
  enabled: true
  autoGenerated: false
  replicaset:
    existingSecrets:
      - mongodb-0-cert
      - mongodb-1-cert
  arbiter:
    existingSecret: mongodb-arbiter-cert
externalAccess:
  enabled: true
  service:
    loadBalancerIPs:
      - 10.10.0.3
      - 10.10.0.4
    annotationsList:
      - external-dns.alpha.kubernetes.io/hostname: mongodb-0.example.com
      - external-dns.alpha.kubernetes.io/hostname: mongodb-1.example.com
  publicNames:
    - mongodb-0.example.com
    - mongodb-1.example.com
```

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
