### PR TITLE
[bitnami/node-exporter] Update PSP annotation to dynamic value

### DIFF
--- a/bitnami/node-exporter/Chart.yaml
+++ b/bitnami/node-exporter/Chart.yaml
@@ -28,4 +28,4 @@ maintainers:
 name: node-exporter
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/node-exporter
-version: 4.1.2
+version: 4.2.0

--- a/bitnami/node-exporter/Chart.yaml
+++ b/bitnami/node-exporter/Chart.yaml
@@ -28,4 +28,4 @@ maintainers:
 name: node-exporter
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/node-exporter
-version: 4.1.1
+version: 4.1.2

--- a/bitnami/node-exporter/README.md
+++ b/bitnami/node-exporter/README.md
@@ -212,6 +212,7 @@ Installing the Node Exporter chart in `Deployment` mode will overwrite `hostNetw
 | `serviceMonitor.honorLabels`                        | honorLabels chooses the metric's labels on collisions with target labels                                                                                                                                          | `false`                         |
 | `serviceMonitor.attachMetadata`                     | Attaches node metadata to discovered targets                                                                                                                                                                      | `{}`                            |
 | `serviceMonitor.sampleLimit`                        | Per-scrape limit on number of scraped samples that will be accepted.                                                                                                                                              | `""`                            |
+| `podSecurityPolicy.annotations`                     | Annotations for Pod Security Policy. Evaluated as a template.                                                                                                                                                     | `{}`                            |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example the following command sets the `minReadySeconds` of the Node Exporter Pods to `120` seconds.
 

--- a/bitnami/node-exporter/templates/psp.yaml
+++ b/bitnami/node-exporter/templates/psp.yaml
@@ -10,8 +10,9 @@ metadata:
   name: {{ template "common.names.fullname.namespace" . }}
   namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
-  {{- if .Values.commonAnnotations }}
-  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- if or .Values.podSecurityPolicy.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.podSecurityPolicy.annotations .Values.commonAnnotations ) "context" . ) }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
   privileged: false

--- a/bitnami/node-exporter/values.yaml
+++ b/bitnami/node-exporter/values.yaml
@@ -567,3 +567,12 @@ serviceMonitor:
   ## @param serviceMonitor.sampleLimit Per-scrape limit on number of scraped samples that will be accepted.
   ##
   sampleLimit: ""
+## Pod Security Policy for Node Exporter to use.
+## WARNING: PodSecurityPolicy is deprecated in Kubernetes v1.21 or later, unavailable in v1.25 or later
+## @param podSecurityPolicy.annotations Annotations for Pod Security Policy. Evaluated as a template. 
+## annotations:
+##   seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+##   seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default
+##
+podSecurityPolicy:
+  annotations: {}

--- a/bitnami/node-exporter/values.yaml
+++ b/bitnami/node-exporter/values.yaml
@@ -570,6 +570,7 @@ serviceMonitor:
 ## Pod Security Policy for Node Exporter to use.
 ## WARNING: PodSecurityPolicy is deprecated in Kubernetes v1.21 or later, unavailable in v1.25 or later
 ## @param podSecurityPolicy.annotations Annotations for Pod Security Policy. Evaluated as a template. 
+## e.g:
 ## annotations:
 ##   seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
 ##   seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

This change introduces a specific dynamic annotation in the PodSecurityPolicy for the node-exporter Helm chart, specifically to resolve an issue with the seccomp profile settings. By allowing these values to be configurable:

```
seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default
```
we enable users to specify the required seccomp profiles, thus enhancing the chart's adaptability to different security requirements and Kubernetes cluster configurations.

### Benefits

- Increased Compatibility: The update ensures that the node-exporter can be deployed in environments with strict PodSecurityPolicies that enforce seccomp profiles, thereby expanding the chart's usability.
- Security Compliance: Users can align the seccomp profiles with their organization's security policies, ensuring compliance without needing to manually edit or override the deployed policies.
- Flexibility: By making the seccomp profile annotations configurable, the Helm chart can be easily adjusted to meet future changes in Kubernetes security practices or updates in seccomp.

### Possible drawbacks

- Complexity: Introducing additional configuration options can increase the complexity of the chart, potentially making it more challenging for new users to configure.

### Applicable issues

- fixes #21510

### Additional information

To mitigate conflicts and maintain compatibility with existing deployments, the default configuration will retain an empty annotation. The necessity for this change is highlighted by the issue described in #21510. The proposed example annotation is a crucial adjustment to prevent the PodSecurityPolicy from blocking the Daemonset from spawning new pods. This adjustment was tested in my local cluster and successfully resolved the specific PSP configuration issue encountered. This ensures that the chart remains flexible and adaptable to diverse security environments without introducing disruptions to current users.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
