### PR TITLE
[bitnami/rabbitmq] Add rbac.rules

### DIFF
--- a/bitnami/rabbitmq/Chart.yaml
+++ b/bitnami/rabbitmq/Chart.yaml
@@ -30,4 +30,4 @@ maintainers:
 name: rabbitmq
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/rabbitmq
-version: 14.0.2
+version: 14.1.0

--- a/bitnami/rabbitmq/README.md
+++ b/bitnami/rabbitmq/README.md
@@ -544,6 +544,7 @@ You can enable this `initContainer` by setting `volumePermissions.enabled` to `t
 | `serviceAccount.automountServiceAccountToken` | Auto-mount the service account token in the pod                                            | `false` |
 | `serviceAccount.annotations`                  | Annotations for service account. Evaluated as a template. Only used if `create` is `true`. | `{}`    |
 | `rbac.create`                                 | Whether RBAC rules should be created                                                       | `true`  |
+| `rbac.rules`                                  | Custom RBAC rules                                                                          | `[]`    |
 
 ### Persistence parameters
 

--- a/bitnami/rabbitmq/templates/role.yaml
+++ b/bitnami/rabbitmq/templates/role.yaml
@@ -20,4 +20,7 @@ rules:
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["create"]
+  {{- if .Values.rbac.rules }}
+  {{- include "common.tplvalues.render" ( dict "value" .Values.rbac.rules "context" $ ) | nindent 2 }}
+  {{- end }}
 {{- end }}

--- a/bitnami/rabbitmq/values.yaml
+++ b/bitnami/rabbitmq/values.yaml
@@ -913,6 +913,18 @@ rbac:
   ## that allows RabbitMQ pods querying the K8s API
   ##
   create: true
+  ## @param rbac.rules Custom RBAC rules
+  ## Example:
+  ## rules:
+  ##   - apiGroups:
+  ##       - ""
+  ##     resources:
+  ##       - pods
+  ##     verbs:
+  ##       - get
+  ##       - list
+  ##
+  rules: []
 ## @section Persistence parameters
 ##
 persistence:


### PR DESCRIPTION
### Description of the change

Add `rbac.rules` value

### Benefits

Allow users to set additional rules to the rabbitmq role.

### Possible drawbacks

None

### Applicable issues


- fixes #25387

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
