### PR TITLE
[bitnami/janusgraph] Add metrics port in networkPolicy ingress

### DIFF
--- a/bitnami/janusgraph/Chart.yaml
+++ b/bitnami/janusgraph/Chart.yaml
@@ -35,4 +35,4 @@ name: janusgraph
 sources:
 - https://github.com/bitnami/containers/tree/main/bitnami/janusgraph
 - https://github.com/janusgraph/janusgraph
-version: 0.1.3
+version: 0.1.4

--- a/bitnami/janusgraph/templates/_helpers.tpl
+++ b/bitnami/janusgraph/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright VMware, Inc.
+Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 

--- a/bitnami/janusgraph/templates/networkpolicy.yaml
+++ b/bitnami/janusgraph/templates/networkpolicy.yaml
@@ -54,6 +54,9 @@ spec:
   ingress:
     - ports:
         - port: {{ .Values.containerPorts.gremlin }}
+        {{- if .Values.metrics.enabled }}
+        - port: {{ .Values.metrics.containerPorts.metrics }}
+        {{- end }}
       {{- if not .Values.networkPolicy.allowExternal }}
       from:
         - podSelector:


### PR DESCRIPTION
### Description of the change

Fixes issue with JanusGraph network policy missing the metrics ingress port.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
