### PR TITLE
[bitnami/jaeger] Rollback runtime-parameters to use jaegertracing/example-hotrod

### DIFF
--- a/.vib/jaeger/runtime-parameters.yaml
+++ b/.vib/jaeger/runtime-parameters.yaml
@@ -1,7 +1,7 @@
 query:
-  sidecars:
+  sidecars: |-
     - name: hotrod-example
-      image: davidbhlm/hotrod-example:1.53
+      image: jaegertracing/example-hotrod:{{ .Chart.AppVersion }}
       args: ['all']
       env:
         - name: OTEL_EXPORTER_OTLP_ENDPOINT
@@ -10,6 +10,9 @@ query:
         runAsNonRoot: true
         privileged: false
         allowPrivilegeEscalation: false
+        {{- if not (.Capabilities.APIVersions.Has "security.openshift.io/v1") }}
+        runAsUser: 1001
+        {{- end }}
         capabilities:
           drop: [ "ALL" ]
         seccompProfile:


### PR DESCRIPTION
### Description of the change

Reverts #21894

Instead of using the custom image `davidbhlm/example-hotrod`, which only added `USER 1001` to the `jaegertracing/example-hotrod` image, uses the default image but adds `runAsUser` when the environment is not OpenShift.

Additionally, uses the image version matching the current Jaeger release.

### Benefits

- Fixes issues when testing ARM
- No need to manually update the image version

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
