### PR TITLE
[bitnami/contour] Adding missing named port for shutdown-manager container

### DIFF
--- a/bitnami/contour/Chart.yaml
+++ b/bitnami/contour/Chart.yaml
@@ -32,4 +32,4 @@ maintainers:
 name: contour
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/contour
-version: 17.0.9
+version: 17.0.10

--- a/bitnami/contour/templates/envoy/deployment.yaml
+++ b/bitnami/contour/templates/envoy/deployment.yaml
@@ -101,7 +101,7 @@ spec:
             {{- end }}
           {{- end }}
           ports:
-            - containerPort: {{ coalesce .Values.envoy.shutdownManager.port .Values.envoy.shutdownManager.containerPorts.http }}
+            - containerPort: {{ coalesce .Values.envoy.shutdownManager.containerPorts.http .Values.envoy.shutdownManager.port }}
               name: http-shutdown
               protocol: TCP
           {{- if .Values.envoy.shutdownManager.containerSecurityContext.enabled }}

--- a/bitnami/contour/templates/envoy/deployment.yaml
+++ b/bitnami/contour/templates/envoy/deployment.yaml
@@ -100,6 +100,10 @@ spec:
                 name: {{ include "common.tplvalues.render" ( dict "value" .Values.contour.extraEnvVarsSecret "context" $ ) }}
             {{- end }}
           {{- end }}
+          ports:
+            - containerPort: {{ coalesce .Values.envoy.shutdownManager.port .Values.envoy.shutdownManager.containerPorts.http }}
+              name: http-shutdown
+              protocol: TCP
           {{- if .Values.envoy.shutdownManager.containerSecurityContext.enabled }}
           securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.envoy.shutdownManager.containerSecurityContext "context" $) | nindent 12 }}
           {{- end }}


### PR DESCRIPTION
### Description of the change

This fixes bitnami/contour envoy deployment spec when `envoy.kind: deployment` is set. Currently the deployment will fail due to `Readiness probe errored: strconv.Atoi: parsing "http-shutdown": invalid syntax`. The shutdown-manager container liveness and readiness probes were switched to use a named port which does not exist in the container spec. This adds the port using the existing values defined for --serve-port on the shutdown-manager.

### Benefits

Fixes chart deployment failure when `envoy.kind: deployment` is set.

### Possible drawbacks

None, this fixes the deployment using the same values that already exist and were previously set before the switch to a named port.

### Applicable issues

- fixes #25507 

### Additional information

none

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
