### PR TITLE
bitnami/rabbitmq-cluster-operator: rename http-webhook port to https-webhook

### DIFF
--- a/bitnami/rabbitmq-cluster-operator/Chart.yaml
+++ b/bitnami/rabbitmq-cluster-operator/Chart.yaml
@@ -37,4 +37,4 @@ maintainers:
 name: rabbitmq-cluster-operator
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/rabbitmq-cluster-operator
-version: 4.2.5
+version: 4.2.6

--- a/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/deployment.yaml
+++ b/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/deployment.yaml
@@ -128,7 +128,7 @@ spec:
           resources: {{- include "common.resources.preset" (dict "type" .Values.msgTopologyOperator.resourcesPreset) | nindent 12 }}
           {{- end }}
           ports:
-            - name: http-webhook
+            - name: https-webhook
               containerPort: 9443
               protocol: TCP
             - name: http-metrics

--- a/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/webhook-service.yaml
+++ b/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/webhook-service.yaml
@@ -39,9 +39,9 @@ spec:
   sessionAffinityConfig: {{- include "common.tplvalues.render" (dict "value" .Values.msgTopologyOperator.service.sessionAffinityConfig "context" $) | nindent 4 }}
   {{- end }}
   ports:
-    - name: http
+    - name: https
       port: {{ .Values.msgTopologyOperator.service.ports.webhook }}
-      targetPort: http-webhook
+      targetPort: https-webhook
       protocol: TCP
       {{- if (and (or (eq .Values.msgTopologyOperator.service.type "NodePort") (eq .Values.msgTopologyOperator.service.type "LoadBalancer")) (not (empty .Values.msgTopologyOperator.service.nodePorts.http))) }}
       nodePort: {{ .Values.msgTopologyOperator.service.nodePorts.http }}


### PR DESCRIPTION
### Description of the change

rabbitmq-cluster-operator: rename http-webhook port to https-webhook

### Benefits

You are able to deploy RabbitmqCluster CRDs in a k8s cluster with Istio enabled.

### Possible drawbacks

none

### Applicable issues

Didn't find any.

### Additional information

Istio does magic based on the name of the port and expects http traffic on http-<name> ports, not https. This results in a "connection reset by peer" when trying to deploy a RabbitmqCluster resource, when it tries to invoke the message topology operator's webhook.
And the webhook is actually https traffic, not http.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
