### PR TITLE
[bitnami/kafka] change probe path for kafka-exporter to /healthz

### DIFF
--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -42,4 +42,4 @@ maintainers:
 name: kafka
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/kafka
-version: 28.2.0
+version: 28.2.1

--- a/bitnami/kafka/templates/metrics/deployment.yaml
+++ b/bitnami/kafka/templates/metrics/deployment.yaml
@@ -141,7 +141,7 @@ spec:
           {{- else if .Values.metrics.kafka.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.metrics.kafka.livenessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
-              path: /metrics
+              path: /healthz
               port: metrics
           {{- end }}
           {{- if .Values.metrics.kafka.customReadinessProbe }}
@@ -149,7 +149,7 @@ spec:
           {{- else if .Values.metrics.kafka.readinessProbe.enabled }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.metrics.kafka.readinessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
-              path: /metrics
+              path: /healthz
               port: metrics
           {{- end }}
           {{- if .Values.metrics.kafka.customStartupProbe }}
@@ -157,7 +157,7 @@ spec:
           {{- else if .Values.metrics.kafka.startupProbe.enabled }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.metrics.kafka.startupProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
-              path: /metrics
+              path: /healthz
               port: metrics
           {{- end }}
           {{- if .Values.metrics.kafka.resources }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Before this change, default liveness- and readiness probes for kafka-exporter polled /metrics, which causes high CPU usage and frequent events about timeouts (because the default probe timeout is 1s and the amount of data gathered and transferred for no reason sometimes took more on my cluster).

Changing this to /healthz makes this probe stable again and CPU usage decreases significantly (on my test cluster).

The /healthz endpoint is not documented (or I couldn't find it) but it is used in the original author's [own helm chart](https://github.com/danielqsj/kafka_exporter/blob/2e60c05d09b934c477e86426c36a59b2e40a90c1/charts/kafka-exporter/templates/deployment.yaml#L98C1-L98C29) for both liveness and readiness.

### Benefits

- less timeouts and unnecessary restarts
- less CPU cycles wasted

### Possible drawbacks

- the actual upstream code behind /healthz is rather [minimal](https://github.com/danielqsj/kafka_exporter/blob/2e60c05d09b934c477e86426c36a59b2e40a90c1/kafka_exporter.go#L919), but probably sufficient to know that the main process is up and listening.

### Applicable issues

no issues filed for this.

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
