### PR TITLE
[bitnami/haproxy] Add externalIPs (#25564)

### DIFF
--- a/bitnami/haproxy/Chart.yaml
+++ b/bitnami/haproxy/Chart.yaml
@@ -28,4 +28,4 @@ maintainers:
 name: haproxy
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/haproxy
-version: 1.0.4
+version: 1.0.5

--- a/bitnami/haproxy/Chart.yaml
+++ b/bitnami/haproxy/Chart.yaml
@@ -28,4 +28,4 @@ maintainers:
 name: haproxy
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/haproxy
-version: 1.0.5
+version: 1.1.0

--- a/bitnami/haproxy/README.md
+++ b/bitnami/haproxy/README.md
@@ -208,8 +208,8 @@ As an alternative, use one of the preset configurations for pod affinity, pod an
 | `service.clusterIP`                     | haproxy service Cluster IP                                                                                                       | `""`                     |
 | `service.loadBalancerIP`                | haproxy service Load Balancer IP                                                                                                 | `""`                     |
 | `service.loadBalancerSourceRanges`      | haproxy service Load Balancer sources                                                                                            | `[]`                     |
-| `service.externalIPs`                   | External IPs                                                                                                                     | `[]`                     |
 | `service.externalTrafficPolicy`         | haproxy service external traffic policy                                                                                          | `Cluster`                |
+| `service.externalIPs`                   | External IPs                                                                                                                     | `[]`                     |
 | `service.annotations`                   | Additional custom annotations for haproxy service                                                                                | `{}`                     |
 | `service.sessionAffinity`               | Session Affinity for Kubernetes service, can be "None" or "ClientIP"                                                             | `None`                   |
 | `service.sessionAffinityConfig`         | Additional settings for the sessionAffinity                                                                                      | `{}`                     |

--- a/bitnami/haproxy/README.md
+++ b/bitnami/haproxy/README.md
@@ -208,6 +208,7 @@ As an alternative, use one of the preset configurations for pod affinity, pod an
 | `service.clusterIP`                     | haproxy service Cluster IP                                                                                                       | `""`                     |
 | `service.loadBalancerIP`                | haproxy service Load Balancer IP                                                                                                 | `""`                     |
 | `service.loadBalancerSourceRanges`      | haproxy service Load Balancer sources                                                                                            | `[]`                     |
+| `service.externalIPs`                   | External IPs                                                                                                                     | `[]`                     |
 | `service.externalTrafficPolicy`         | haproxy service external traffic policy                                                                                          | `Cluster`                |
 | `service.annotations`                   | Additional custom annotations for haproxy service                                                                                | `{}`                     |
 | `service.sessionAffinity`               | Session Affinity for Kubernetes service, can be "None" or "ClientIP"                                                             | `None`                   |

--- a/bitnami/haproxy/templates/service.yaml
+++ b/bitnami/haproxy/templates/service.yaml
@@ -21,6 +21,9 @@ spec:
   {{- if .Values.service.clusterIP }}
   clusterIP: {{ .Values.service.clusterIP }}
   {{- end }}
+  {{- if .Values.service.externalIPs }}
+  externalIPs: {{- toYaml .Values.service.externalIPs | nindent 4 }}
+  {{- end }}
   {{- if (or (eq .Values.service.type "LoadBalancer") (eq .Values.service.type "NodePort")) }}
   externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy | quote }}
   {{- end }}

--- a/bitnami/haproxy/values.yaml
+++ b/bitnami/haproxy/values.yaml
@@ -101,6 +101,10 @@ service:
   ## @param service.externalTrafficPolicy haproxy service external traffic policy
   ## ref https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
   ##
+  ## @param service.externalIPs [array] External IPs
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#external-ips
+  ##
+  externalIPs: []
   externalTrafficPolicy: Cluster
   ## @param service.annotations Additional custom annotations for haproxy service
   ##


### PR DESCRIPTION
### Description of the change

Allows to set externalIPs on haproxy service.

### Benefits

Allows to expose service with [ExternalIPs](https://kubernetes.io/docs/concepts/services-networking/service/#external-ips) 

Fixes https://github.com/bitnami/charts/issues/25564

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
