### PR TITLE
[bitnami/keycloak] Add HPA Behavior when scaling up and down

### DIFF
--- a/bitnami/keycloak/Chart.yaml
+++ b/bitnami/keycloak/Chart.yaml
@@ -33,4 +33,4 @@ maintainers:
 name: keycloak
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/keycloak
-version: 21.1.3
+version: 21.2.0

--- a/bitnami/keycloak/README.md
+++ b/bitnami/keycloak/README.md
@@ -511,16 +511,22 @@ As an alternative, you can use of the preset configurations for pod affinity, po
 
 ### Other parameters
 
-| Name                       | Description                                                    | Value   |
-| -------------------------- | -------------------------------------------------------------- | ------- |
-| `pdb.create`               | Enable/disable a Pod Disruption Budget creation                | `false` |
-| `pdb.minAvailable`         | Minimum number/percentage of pods that should remain scheduled | `1`     |
-| `pdb.maxUnavailable`       | Maximum number/percentage of pods that may be made unavailable | `""`    |
-| `autoscaling.enabled`      | Enable autoscaling for Keycloak                                | `false` |
-| `autoscaling.minReplicas`  | Minimum number of Keycloak replicas                            | `1`     |
-| `autoscaling.maxReplicas`  | Maximum number of Keycloak replicas                            | `11`    |
-| `autoscaling.targetCPU`    | Target CPU utilization percentage                              | `""`    |
-| `autoscaling.targetMemory` | Target Memory utilization percentage                           | `""`    |
+| Name                                                        | Description                                                                                  | Value   |
+| ----------------------------------------------------------- | -------------------------------------------------------------------------------------------- | ------- |
+| `pdb.create`                                                | Enable/disable a Pod Disruption Budget creation                                              | `false` |
+| `pdb.minAvailable`                                          | Minimum number/percentage of pods that should remain scheduled                               | `1`     |
+| `pdb.maxUnavailable`                                        | Maximum number/percentage of pods that may be made unavailable                               | `""`    |
+| `autoscaling.enabled`                                       | Enable autoscaling for Keycloak                                                              | `false` |
+| `autoscaling.minReplicas`                                   | Minimum number of Keycloak replicas                                                          | `1`     |
+| `autoscaling.maxReplicas`                                   | Maximum number of Keycloak replicas                                                          | `11`    |
+| `autoscaling.targetCPU`                                     | Target CPU utilization percentage                                                            | `""`    |
+| `autoscaling.targetMemory`                                  | Target Memory utilization percentage                                                         | `""`    |
+| `autoscaling.behavior.scaleUp.stabilizationWindowSeconds`   | The number of seconds for which past recommendations should be considered while scaling up   | `120`   |
+| `autoscaling.behavior.scaleUp.selectPolicy`                 | The priority of policies that the autoscaler will apply when scaling up                      | `Max`   |
+| `autoscaling.behavior.scaleUp.policies`                     | HPA scaling policies when scaling up                                                         | `[]`    |
+| `autoscaling.behavior.scaleDown.stabilizationWindowSeconds` | The number of seconds for which past recommendations should be considered while scaling down | `300`   |
+| `autoscaling.behavior.scaleDown.selectPolicy`               | The priority of policies that the autoscaler will apply when scaling down                    | `Max`   |
+| `autoscaling.behavior.scaleDown.policies`                   | HPA scaling policies when scaling down                                                       | `[]`    |
 
 ### Metrics parameters
 

--- a/bitnami/keycloak/templates/hpa.yaml
+++ b/bitnami/keycloak/templates/hpa.yaml
@@ -46,4 +46,21 @@ spec:
           averageUtilization: {{ .Values.autoscaling.targetMemory }}
         {{- end }}
     {{- end }}
+  {{- if or .Values.autoscaling.behavior.scaleDown.policies .Values.autoscaling.behavior.scaleUp.policies }}
+  behavior:
+    {{- if .Values.autoscaling.behavior.scaleDown.policies }}
+    scaleDown:
+      stabilizationWindowSeconds: {{ .Values.autoscaling.behavior.scaleDown.stabilizationWindowSeconds }}
+      selectPolicy: {{ .Values.autoscaling.behavior.scaleDown.selectPolicy }}
+      policies:
+        {{- toYaml .Values.autoscaling.behavior.scaleDown.policies | nindent 8 }}
+    {{- end }}
+    {{- if .Values.autoscaling.behavior.scaleUp.policies }}
+    scaleUp:
+      stabilizationWindowSeconds: {{ .Values.autoscaling.behavior.scaleUp.stabilizationWindowSeconds }}
+      selectPolicy: {{ .Values.autoscaling.behavior.scaleUp.selectPolicy }}
+      policies:
+       {{- toYaml .Values.autoscaling.behavior.scaleUp.policies | nindent 8 }}
+    {{- end }}
+  {{- end }}
 {{- end }}

--- a/bitnami/keycloak/values.yaml
+++ b/bitnami/keycloak/values.yaml
@@ -912,6 +912,7 @@ pdb:
   ##
   maxUnavailable: ""
 ## Keycloak Autoscaling configuration
+## ref: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
 ## @param autoscaling.enabled Enable autoscaling for Keycloak
 ## @param autoscaling.minReplicas Minimum number of Keycloak replicas
 ## @param autoscaling.maxReplicas Maximum number of Keycloak replicas
@@ -924,6 +925,41 @@ autoscaling:
   maxReplicas: 11
   targetCPU: ""
   targetMemory: ""
+  ## HPA Scaling Behavior
+  ## ref: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#configurable-scaling-behavior
+  ##
+  behavior:
+    ## HPA behavior when scaling up
+    ## @param autoscaling.behavior.scaleUp.stabilizationWindowSeconds The number of seconds for which past recommendations should be considered while scaling up
+    ## @param autoscaling.behavior.scaleUp.selectPolicy The priority of policies that the autoscaler will apply when scaling up
+    ## @param autoscaling.behavior.scaleUp.policies [array] HPA scaling policies when scaling up
+    ## e.g:
+    ## Policy to scale 20% of the pod in 60s
+    ## - type: Percent
+    ##   value: 20
+    ##   periodSeconds: 60
+    ##
+    scaleUp:
+      stabilizationWindowSeconds: 120
+      selectPolicy: Max
+      policies: []
+    ## HPA behavior when scaling down
+    ## @param autoscaling.behavior.scaleDown.stabilizationWindowSeconds The number of seconds for which past recommendations should be considered while scaling down
+    ## @param autoscaling.behavior.scaleDown.selectPolicy The priority of policies that the autoscaler will apply when scaling down
+    ## @param autoscaling.behavior.scaleDown.policies [array] HPA scaling policies when scaling down
+    ## e.g:
+    ## Policy to scale one pod in 300s
+    ## - type: Pods
+    ##   value: 1
+    ##   periodSeconds: 300
+    ##
+    scaleDown:
+      stabilizationWindowSeconds: 300
+      selectPolicy: Max
+      policies:
+        - type: Pods
+          value: 1
+          periodSeconds: 300
 ## @section Metrics parameters
 ##
 


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

This PR adds the ability to configure the `behavior` of the `HorizontalPodAutoscaler` of the Keycloak StatefulSet with new parameter block `autoscaling.behavior` 
ref: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#configurable-scaling-behavior

This allows us to set policies that control how the autoscaler scales up/down the pods e.g., the keycloak pods can be scaled by X units or percent of current pods during a `periodSeconds` window. 
`stabilizationWindowSeconds` can be set to set the duration which past recommendations should be considered while scaling
`selectPolicy` - The priority of policies that the autoscaler will apply when scaling up/down. Can be `Max`, `Min`, `Disabled`

<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

<!-- What benefits will be realized by the code change? -->

Keycloak pods are stateful due to the embedded Infinispan cache that requires cache key rebalancing across all live nodes when a pod joins or leaves the cluster. (This process happens on pod startup and shutdown).

The cache keys have a set number of owners (pods) that can survive one node failure with its default config (https://www.keycloak.org/server/caching#_configuring_caches). 

Adding the HPA behavior when scaling down to 1 pod every 300s allows the cache keys to be rebalanced across other pods before terminating, hence avoiding potential data loss if too many pods were to be terminated at the same time by the autoscaler's default behaviour.

### Possible drawbacks

<!-- Describe any known limitations with your change -->
The default values set in `values.yaml` slows down the scaleDown of pods.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #25651 

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

The default HPA scaleDown behaviour is now one pod every 300s.

If anybody wishes to go back to the previous behaviour, they can set the values as follows:

```yaml
  behavior:
    scaleDown:
      policies: []
```

@javsalgar - I'm happy to set the default value to the above so that this release doesn't change the default behaviour. But i figured the default value I'm proposing are reasonable for an HA deployment of Keycloak.
These are also the default values set in the [Codecentric Keycloak Helm Chart](https://github.com/codecentric/helm-charts/blob/master/charts/keycloak/values.yaml#L486-L494)

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)

#### Tests
pods start fine using default values

![image](https://github.com/bitnami/charts/assets/6723913/5552362a-1b20-40cf-90da-bc84caccaf20)


```yaml
# HPA Enabled but no behavior set

# values.yaml
autoscaling:
  enabled: true
  minReplicas: 2
  maxReplicas: 10
  targetCPU: 70

---
# applied yaml
apiVersion: autoscaling/v2
kind: HorizontalPodAutoscaler
metadata:
  labels:
    app.kubernetes.io/component: keycloak
    app.kubernetes.io/instance: keycloak
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: keycloak
    app.kubernetes.io/version: 24.0.4
    helm.sh/chart: keycloak-21.1.3
  name: keycloak
  namespace: default
spec:
  behavior:
    scaleDown:
      policies:
      - periodSeconds: 300
        type: Pods
        value: 1
      selectPolicy: Max
      stabilizationWindowSeconds: 300
  maxReplicas: 10
  metrics:
  - resource:
      name: cpu
      target:
        averageUtilization: 70
        type: Utilization
    type: Resource
  minReplicas: 2
  scaleTargetRef:
    apiVersion: apps/v1
    kind: StatefulSet
    name: keycloak
```
---

```yaml
Autoscaling enabled - scaleDown policies set to empty to remove the default scaleDown policy

# values.yaml
autoscaling:
  enabled: true
  minReplicas: 2
  maxReplicas: 10
  targetCPU: 70
  behavior:
    scaleDown:
      policies: []

--- 
# applied yaml
apiVersion: autoscaling/v2
kind: HorizontalPodAutoscaler
metadata:
  labels:
    app.kubernetes.io/component: keycloak
    app.kubernetes.io/instance: keycloak
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: keycloak
    app.kubernetes.io/version: 24.0.4
    helm.sh/chart: keycloak-21.1.3
  name: keycloak
  namespace: default
spec:
  maxReplicas: 10
  metrics:
  - resource:
      name: cpu
      target:
        averageUtilization: 70
        type: Utilization
    type: Resource
  minReplicas: 2
  scaleTargetRef:
    apiVersion: apps/v1
    kind: StatefulSet
    name: keycloak
```


---
Autoscaling enabled - scaleUp policy added and some values changes from default
# values.yaml
```yaml
autoscaling:
  enabled: true
  minReplicas: 2
  maxReplicas: 10
  targetCPU: 70
  behavior:
    scaleUp:
      stabilizationWindowSeconds: 1337
      selectPolicy: Min
      policies:
        - type: Percent
          value: 30
          periodSeconds: 123
    scaleDown:
      stabilizationWindowSeconds: 60

--- 
# applied yaml
apiVersion: autoscaling/v2
kind: HorizontalPodAutoscaler
metadata:
  labels:
    app.kubernetes.io/component: keycloak
    app.kubernetes.io/instance: keycloak
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: keycloak
    app.kubernetes.io/version: 24.0.4
    helm.sh/chart: keycloak-21.1.3
  name: keycloak
  namespace: default
spec:
  behavior:
    scaleDown:
      policies:
      - periodSeconds: 300
        type: Pods
        value: 1
      selectPolicy: Max
      stabilizationWindowSeconds: 60
    scaleUp:
      policies:
      - periodSeconds: 123
        type: Percent
        value: 30
      selectPolicy: Min
      stabilizationWindowSeconds: 1337
  maxReplicas: 10
  metrics:
  - resource:
      name: cpu
      target:
        averageUtilization: 70
        type: Utilization
    type: Resource
  minReplicas: 2
  scaleTargetRef:
    apiVersion: apps/v1
    kind: StatefulSet
    name: keycloak
```
