### PR TITLE
[bitnami/dokuwiki] Fix php session mgmt

### DIFF
--- a/bitnami/dokuwiki/Chart.yaml
+++ b/bitnami/dokuwiki/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: dokuwiki
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/dokuwiki
-version: 16.0.4
+version: 16.0.5

--- a/bitnami/dokuwiki/templates/deployment.yaml
+++ b/bitnami/dokuwiki/templates/deployment.yaml
@@ -99,6 +99,10 @@ spec:
               if ! is_dir_empty /opt/bitnami/apache/logs; then
                 cp -r /opt/bitnami/apache/logs /emptydir/apache-logs-dir
               fi
+              info "Copying php var directory"
+              if ! is_dir_empty /opt/bitnami/php/var; then
+                cp -r /opt/bitnami/php/var /emptydir/php-var-dir
+              fi
               info "Copy operation completed"
           volumeMounts:
             - name: empty-dir


### PR DESCRIPTION
### Description of the change

The php-var-dir needs to be pre-populated in the emptyDir volume to avoid issues in PHP session management.

### Applicable issues

- fixes #25540

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] n/a ~Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)~
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
