### PR TITLE
[bitnami/haproxy] Add enableServiceLinks (#25851)

### DIFF
--- a/bitnami/haproxy/Chart.yaml
+++ b/bitnami/haproxy/Chart.yaml
@@ -28,4 +28,4 @@ maintainers:
 name: haproxy
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/haproxy
-version: 1.1.2
+version: 1.2.0

--- a/bitnami/haproxy/README.md
+++ b/bitnami/haproxy/README.md
@@ -333,6 +333,7 @@ As an alternative, use one of the preset configurations for pod affinity, pod an
 | `serviceAccount.annotations`                  | Annotations for service account. Evaluated as a template. Only used if `create` is `true`.                          | `{}`    |
 | `serviceAccount.create`                       | Specifies whether a ServiceAccount should be created                                                                | `true`  |
 | `serviceAccount.name`                         | The name of the ServiceAccount to use.                                                                              | `""`    |
+| `enableServiceLinks`                          | If set to false, disable Kubernetes service links in the pod spec                                                   | `true`  |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/bitnami/haproxy/templates/deployment.yaml
+++ b/bitnami/haproxy/templates/deployment.yaml
@@ -71,6 +71,7 @@ spec:
       {{- if .Values.podSecurityContext.enabled }}
       securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.podSecurityContext "context" $) | nindent 8 }}
       {{- end }}
+      enableServiceLinks: {{ .Values.enableServiceLinks }}
       {{- if .Values.initContainers }}
       initContainers: {{- include "common.tplvalues.render" (dict "value" .Values.initContainers "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/haproxy/values.yaml
+++ b/bitnami/haproxy/values.yaml
@@ -623,3 +623,8 @@ serviceAccount:
   name: ""
   automountServiceAccountToken: false
   annotations: {}
+
+## @param enableServiceLinks If set to false, disable Kubernetes service links in the pod spec
+## Ref: https://kubernetes.io/docs/tutorials/services/connect-applications-service/#accessing-the-service
+##
+enableServiceLinks: true


### PR DESCRIPTION
### Description of the change

Allow to set enableServiceLinks on haproxy, true by default.

### Benefits

Some users need to set enableServiceLinks=false

### Possible drawbacks

### Applicable issues

- fixes #25851

### Additional information


### Checklist


- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
