### PR TITLE
bitnami/kafka Fix for sed in kafka-init.sh

### DIFF
--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -42,4 +42,4 @@ maintainers:
 name: kafka
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/kafka
-version: 28.2.3
+version: 28.2.4

--- a/bitnami/kafka/templates/scripts-configmap.yaml
+++ b/bitnami/kafka/templates/scripts-configmap.yaml
@@ -137,7 +137,8 @@ data:
     replace_placeholder() {
       local placeholder="${1:?missing placeholder value}"
       local password="${2:?missing password value}"
-      sed -i "s/$placeholder/$password/g" "$KAFKA_CONFIG_FILE"
+      local -r del=$'\001' # Use a non-printable character as a 'sed' delimiter to avoid issues with delimiter symbols in sed string
+      sed -i "s${del}$placeholder${del}$password${del}g" "$KAFKA_CONFIG_FILE"
     }
 
     append_file_to_kafka_conf() {


### PR DESCRIPTION
Use non-printable delimiter to avoid sed errors with delimiter symbols in passwords

### Description of the change

Fixes sed string to be correct with passwords that use / symbols (standard sed delimiter symbol)

### Benefits

No sed errors in case of using / symbols in passwords

### Applicable issues

- fixes #25500

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
