### PR TITLE
[bitnami/template] Correct image tag in template

### DIFF
--- a/template/CHART_NAME/values.yaml
+++ b/template/CHART_NAME/values.yaml
@@ -700,7 +700,7 @@ volumePermissions:
   image:
     registry: docker.io
     repository: bitnami/os-shell
-    tag: 11-debian-12-r%%IMAGE_REVISION%%
+    tag: 12-debian-12-r%%IMAGE_REVISION%%
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
Correcting the tag in `/templates/CHART_NAME/values.yaml` to match the image tags on Docker Hub. Looks like it was missed in #23658 