### PR TITLE
[bitnami/prometheus] Updated prometheus server local cluster address

### DIFF
--- a/bitnami/prometheus/Chart.yaml
+++ b/bitnami/prometheus/Chart.yaml
@@ -35,4 +35,4 @@ sources:
 - https://github.com/bitnami/containers/tree/main/bitnami/prometheus
 - https://github.com/prometheus/prometheus
 - https://github.com/prometheus-community/helm-charts
-version: 1.0.11
+version: 1.0.12

--- a/bitnami/prometheus/templates/NOTES.txt
+++ b/bitnami/prometheus/templates/NOTES.txt
@@ -26,7 +26,7 @@ In order to replicate the container startup scripts execute this command:
 
 Prometheus can be accessed via port "{{ .Values.server.service.ports.http }}" on the following DNS name from within your cluster:
 
-    {{ template "common.names.fullname" . }}.{{ include "common.names.namespace" . }}.svc.cluster.local
+    {{ template "prometheus.server.fullname" . }}.{{ include "common.names.namespace" . }}.svc.cluster.local
 
 To access Prometheus from outside the cluster execute the following commands:
 


### PR DESCRIPTION
Updated prometheus server local cluster address, as it pointed to the wrong service name.

### Description of the change

The post install message generates this cluster url: prometheus.prometheus.svc.cluster.local
However, the url is wrong, as it uses the `common.names.fullname` template instead of the `prometheus.server.fullname`.
Using the correct template, the generated cluster url is: **prometheus-server.prometheus.svc.cluster.local**.

For reference, also the alert manager and thanos internal url are generated in a similar way:
- template "prometheus.alertmanager.fullname"
- template "prometheus.thanos-sidecar.fullname"

### Benefits

The cluster url for the prometheus-server service is now correct.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
