### PR TITLE
[bitnami/elasticsearch] PDB review

### DIFF
--- a/bitnami/elasticsearch/Chart.yaml
+++ b/bitnami/elasticsearch/Chart.yaml
@@ -34,4 +34,4 @@ maintainers:
 name: elasticsearch
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/elasticsearch
-version: 21.0.4
+version: 21.0.5

--- a/bitnami/elasticsearch/templates/coordinating/pdb.yaml
+++ b/bitnami/elasticsearch/templates/coordinating/pdb.yaml
@@ -3,7 +3,8 @@ Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- if and ( include "elasticsearch.coordinating.enabled" . ) .Values.coordinating.pdb.create }}
+{{- $replicaCount := int .Values.coordinating.replicaCount }}
+{{- if and ( include "elasticsearch.coordinating.enabled" . ) .Values.coordinating.pdb.create (or (gt $replicaCount 1) .Values.coordinating.autoscaling.enabled) }}
 apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:

--- a/bitnami/elasticsearch/templates/data/pdb.yaml
+++ b/bitnami/elasticsearch/templates/data/pdb.yaml
@@ -3,7 +3,8 @@ Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- if and ( include "elasticsearch.data.enabled" . ) .Values.data.pdb.create }}
+{{- $replicaCount := int .Values.data.replicaCount }}
+{{- if and ( include "elasticsearch.data.enabled" . ) .Values.data.pdb.create (or (gt $replicaCount 1) .Values.data.autoscaling.enabled) }}
 apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:

--- a/bitnami/elasticsearch/templates/ingest/pdb.yaml
+++ b/bitnami/elasticsearch/templates/ingest/pdb.yaml
@@ -3,7 +3,8 @@ Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- if and ( include "elasticsearch.ingest.enabled" . ) .Values.ingest.pdb.create }}
+{{- $replicaCount := int .Values.ingest.replicaCount }}
+{{- if and ( include "elasticsearch.ingest.enabled" . ) .Values.ingest.pdb.create (or (gt $replicaCount 1) .Values.ingest.autoscaling.enabled) }}
 apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:

--- a/bitnami/elasticsearch/templates/master/pdb.yaml
+++ b/bitnami/elasticsearch/templates/master/pdb.yaml
@@ -3,7 +3,8 @@ Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- if and ( include "elasticsearch.master.enabled" . ) .Values.master.pdb.create }}
+{{- $replicaCount := int .Values.master.replicaCount }}
+{{- if and ( include "elasticsearch.master.enabled" . ) .Values.master.pdb.create (or (gt $replicaCount 1) .Values.master.autoscaling.enabled) }}
 apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:


### PR DESCRIPTION
### Description of the change

Little fixes in PodDisruptionBudget configuration to keep it aligned with current templates.

### Benefits

Keep our charts up to date according to our templates

### Possible drawbacks

None

### Adition information

* [Pod disruption budgets](https://kubernetes.io/docs/concepts/workloads/pods/disruptions/#pod-disruption-budgets)
* [Specifying a Disruption Budget for your Application](https://kubernetes.io/docs/tasks/run-application/configure-pdb/)

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
