### PR TITLE
[bitnami/wordpress] Use different liveness/readiness probes

### DIFF
--- a/bitnami/wordpress/Chart.lock
+++ b/bitnami/wordpress/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: memcached
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 7.0.5
+  version: 7.0.6
 - name: mariadb
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 18.0.3
+  version: 18.0.5
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 2.19.2
-digest: sha256:63f6cf875b4e640d1d88c477122588399eebb6c512d40a8649d4e78b57c943e8
-generated: "2024-05-14T05:18:08.298870653Z"
+digest: sha256:88f139bdbfc47912743cec19b9ae0dccb73703e9df39b18a6797915702078ce9
+generated: "2024-05-15T12:57:13.430837+02:00"

--- a/bitnami/wordpress/Chart.yaml
+++ b/bitnami/wordpress/Chart.yaml
@@ -44,4 +44,4 @@ maintainers:
 name: wordpress
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/wordpress
-version: 22.2.8
+version: 22.2.9

--- a/bitnami/wordpress/values.yaml
+++ b/bitnami/wordpress/values.yaml
@@ -453,7 +453,7 @@ containerSecurityContext:
 ## Configure extra options for WordPress containers' liveness, readiness and startup probes
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes
 ## @param livenessProbe.enabled Enable livenessProbe on WordPress containers
-## @skip livenessProbe.httpGet
+## @skip livenessProbe.tcpSocket
 ## @param livenessProbe.initialDelaySeconds Initial delay seconds for livenessProbe
 ## @param livenessProbe.periodSeconds Period seconds for livenessProbe
 ## @param livenessProbe.timeoutSeconds Timeout seconds for livenessProbe
@@ -462,20 +462,8 @@ containerSecurityContext:
 ##
 livenessProbe:
   enabled: true
-  httpGet:
-    path: /wp-admin/install.php
-    port: '{{ .Values.wordpressScheme }}'
-    scheme: '{{ .Values.wordpressScheme | upper }}'
-    ## If using an HTTPS-terminating load-balancer, the probes may need to behave
-    ## like the balancer to prevent HTTP 302 responses. According to the Kubernetes
-    ## docs, 302 should be considered "successful", but this issue on GitHub
-    ## (https://github.com/kubernetes/kubernetes/issues/47893) shows that it isn't.
-    ## E.g.
-    ## httpHeaders:
-    ## - name: X-Forwarded-Proto
-    ##   value: https
-    ##
-    httpHeaders: []
+  tcpSocket:
+    port: http
   initialDelaySeconds: 120
   periodSeconds: 10
   timeoutSeconds: 5


### PR DESCRIPTION
### Description of the change
This PR aims to use different liveness/readiness probes to improve overall security and avoid unnecessary container restarts. [More info](https://github.com/zegl/kube-score/blob/master/README_PROBES.md).

### Benefits

Increase availability and resilience.

### Possible drawbacks

N/A

### Applicable issues

- fixes #

### Additional information

- Related to #23537

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- ~[X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)~
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
