### PR TITLE
[bitnami/grafana-loki] Network policy review

### DIFF
--- a/bitnami/grafana-loki/Chart.yaml
+++ b/bitnami/grafana-loki/Chart.yaml
@@ -57,4 +57,4 @@ maintainers:
 name: grafana-loki
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/grafana-loki
-version: 4.0.3
+version: 4.1.0

--- a/bitnami/grafana-loki/README.md
+++ b/bitnami/grafana-loki/README.md
@@ -294,27 +294,29 @@ The [Bitnami grafana-loki](https://github.com/bitnami/containers/tree/main/bitna
 
 ### Compactor Traffic Exposure Parameters
 
-| Name                                              | Description                                                      | Value       |
-| ------------------------------------------------- | ---------------------------------------------------------------- | ----------- |
-| `compactor.service.type`                          | Compactor service type                                           | `ClusterIP` |
-| `compactor.service.ports.http`                    | Compactor HTTP service port                                      | `3100`      |
-| `compactor.service.ports.grpc`                    | Compactor gRPC service port                                      | `9095`      |
-| `compactor.service.nodePorts.http`                | Node port for HTTP                                               | `""`        |
-| `compactor.service.sessionAffinityConfig`         | Additional settings for the sessionAffinity                      | `{}`        |
-| `compactor.service.sessionAffinity`               | Control where client requests go, to the same pod or round-robin | `None`      |
-| `compactor.service.clusterIP`                     | Compactor service Cluster IP                                     | `""`        |
-| `compactor.service.loadBalancerIP`                | Compactor service Load Balancer IP                               | `""`        |
-| `compactor.service.loadBalancerSourceRanges`      | Compactor service Load Balancer sources                          | `[]`        |
-| `compactor.service.externalTrafficPolicy`         | Compactor service external traffic policy                        | `Cluster`   |
-| `compactor.service.annotations`                   | Additional custom annotations for Compactor service              | `{}`        |
-| `compactor.service.extraPorts`                    | Extra ports to expose in the Compactor service                   | `[]`        |
-| `compactor.networkPolicy.enabled`                 | Specifies whether a NetworkPolicy should be created              | `true`      |
-| `compactor.networkPolicy.allowExternal`           | Don't require server label for connections                       | `true`      |
-| `compactor.networkPolicy.allowExternalEgress`     | Allow the pod to access any range of port and all destinations.  | `true`      |
-| `compactor.networkPolicy.extraIngress`            | Add extra ingress rules to the NetworkPolicy                     | `[]`        |
-| `compactor.networkPolicy.extraEgress`             | Add extra ingress rules to the NetworkPolicy                     | `[]`        |
-| `compactor.networkPolicy.ingressNSMatchLabels`    | Labels to match to allow traffic from other namespaces           | `{}`        |
-| `compactor.networkPolicy.ingressNSPodMatchLabels` | Pod labels to match to allow traffic from other namespaces       | `{}`        |
+| Name                                              | Description                                                                                                             | Value       |
+| ------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- | ----------- |
+| `compactor.service.type`                          | Compactor service type                                                                                                  | `ClusterIP` |
+| `compactor.service.ports.http`                    | Compactor HTTP service port                                                                                             | `3100`      |
+| `compactor.service.ports.grpc`                    | Compactor gRPC service port                                                                                             | `9095`      |
+| `compactor.service.nodePorts.http`                | Node port for HTTP                                                                                                      | `""`        |
+| `compactor.service.sessionAffinityConfig`         | Additional settings for the sessionAffinity                                                                             | `{}`        |
+| `compactor.service.sessionAffinity`               | Control where client requests go, to the same pod or round-robin                                                        | `None`      |
+| `compactor.service.clusterIP`                     | Compactor service Cluster IP                                                                                            | `""`        |
+| `compactor.service.loadBalancerIP`                | Compactor service Load Balancer IP                                                                                      | `""`        |
+| `compactor.service.loadBalancerSourceRanges`      | Compactor service Load Balancer sources                                                                                 | `[]`        |
+| `compactor.service.externalTrafficPolicy`         | Compactor service external traffic policy                                                                               | `Cluster`   |
+| `compactor.service.annotations`                   | Additional custom annotations for Compactor service                                                                     | `{}`        |
+| `compactor.service.extraPorts`                    | Extra ports to expose in the Compactor service                                                                          | `[]`        |
+| `compactor.networkPolicy.enabled`                 | Specifies whether a NetworkPolicy should be created                                                                     | `true`      |
+| `compactor.networkPolicy.allowExternal`           | Don't require server label for connections                                                                              | `true`      |
+| `compactor.networkPolicy.allowExternalEgress`     | Allow the pod to access any range of port and all destinations.                                                         | `true`      |
+| `compactor.networkPolicy.addExternalClientAccess` | Allow access from pods with client label set to "true". Ignored if `compactor.networkPolicy.allowExternal` is true.     | `true`      |
+| `compactor.networkPolicy.extraIngress`            | Add extra ingress rules to the NetworkPolicy                                                                            | `[]`        |
+| `compactor.networkPolicy.extraEgress`             | Add extra ingress rules to the NetworkPolicy                                                                            | `[]`        |
+| `compactor.networkPolicy.ingressPodMatchLabels`   | Labels to match to allow traffic from other pods. Ignored if `compactor.networkPolicy.allowExternal` is true.           | `{}`        |
+| `compactor.networkPolicy.ingressNSMatchLabels`    | Labels to match to allow traffic from other namespaces. Ignored if `compactor.networkPolicy.allowExternal` is true.     | `{}`        |
+| `compactor.networkPolicy.ingressNSPodMatchLabels` | Pod labels to match to allow traffic from other namespaces. Ignored if `compactor.networkPolicy.allowExternal` is true. | `{}`        |
 
 ### Gateway Deployment Parameters
 
@@ -419,10 +421,12 @@ The [Bitnami grafana-loki](https://github.com/bitnami/containers/tree/main/bitna
 | `gateway.networkPolicy.enabled`                 | Specifies whether a NetworkPolicy should be created                                                                              | `true`                   |
 | `gateway.networkPolicy.allowExternal`           | Don't require server label for connections                                                                                       | `true`                   |
 | `gateway.networkPolicy.allowExternalEgress`     | Allow the pod to access any range of port and all destinations.                                                                  | `true`                   |
+| `gateway.networkPolicy.addExternalClientAccess` | Allow access from pods with client label set to "true". Ignored if `gateway.networkPolicy.allowExternal` is true.                | `true`                   |
 | `gateway.networkPolicy.extraIngress`            | Add extra ingress rules to the NetworkPolicy                                                                                     | `[]`                     |
 | `gateway.networkPolicy.extraEgress`             | Add extra ingress rules to the NetworkPolicy                                                                                     | `[]`                     |
-| `gateway.networkPolicy.ingressNSMatchLabels`    | Labels to match to allow traffic from other namespaces                                                                           | `{}`                     |
-| `gateway.networkPolicy.ingressNSPodMatchLabels` | Pod labels to match to allow traffic from other namespaces                                                                       | `{}`                     |
+| `gateway.networkPolicy.ingressPodMatchLabels`   | Labels to match to allow traffic from other pods. Ignored if `gateway.networkPolicy.allowExternal` is true.                      | `{}`                     |
+| `gateway.networkPolicy.ingressNSMatchLabels`    | Labels to match to allow traffic from other namespaces. Ignored if `gateway.networkPolicy.allowExternal` is true.                | `{}`                     |
+| `gateway.networkPolicy.ingressNSPodMatchLabels` | Pod labels to match to allow traffic from other namespaces. Ignored if `gateway.networkPolicy.allowExternal` is true.            | `{}`                     |
 | `gateway.ingress.enabled`                       | Enable ingress record generation for Loki Gateway                                                                                | `false`                  |
 | `gateway.ingress.pathType`                      | Ingress path type                                                                                                                | `ImplementationSpecific` |
 | `gateway.ingress.apiVersion`                    | Force Ingress API version (automatically detected if not set)                                                                    | `""`                     |
@@ -525,28 +529,30 @@ The [Bitnami grafana-loki](https://github.com/bitnami/containers/tree/main/bitna
 
 ### index-gateway Traffic Exposure Parameters
 
-| Name                                                 | Description                                                      | Value       |
-| ---------------------------------------------------- | ---------------------------------------------------------------- | ----------- |
-| `indexGateway.service.type`                          | index-gateway service type                                       | `ClusterIP` |
-| `indexGateway.service.ports.http`                    | index-gateway HTTP service port                                  | `3100`      |
-| `indexGateway.service.ports.grpc`                    | index-gateway GRPC service port                                  | `9095`      |
-| `indexGateway.service.nodePorts.http`                | Node port for HTTP                                               | `""`        |
-| `indexGateway.service.nodePorts.grpc`                | Node port for GRPC                                               | `""`        |
-| `indexGateway.service.sessionAffinityConfig`         | Additional settings for the sessionAffinity                      | `{}`        |
-| `indexGateway.service.sessionAffinity`               | Control where client requests go, to the same pod or round-robin | `None`      |
-| `indexGateway.service.clusterIP`                     | index-gateway service Cluster IP                                 | `""`        |
-| `indexGateway.service.loadBalancerIP`                | index-gateway service Load Balancer IP                           | `""`        |
-| `indexGateway.service.loadBalancerSourceRanges`      | index-gateway service Load Balancer sources                      | `[]`        |
-| `indexGateway.service.externalTrafficPolicy`         | index-gateway service external traffic policy                    | `Cluster`   |
-| `indexGateway.service.annotations`                   | Additional custom annotations for index-gateway service          | `{}`        |
-| `indexGateway.service.extraPorts`                    | Extra ports to expose in the index-gateway service               | `[]`        |
-| `indexGateway.networkPolicy.enabled`                 | Specifies whether a NetworkPolicy should be created              | `true`      |
-| `indexGateway.networkPolicy.allowExternal`           | Don't require server label for connections                       | `true`      |
-| `indexGateway.networkPolicy.allowExternalEgress`     | Allow the pod to access any range of port and all destinations.  | `true`      |
-| `indexGateway.networkPolicy.extraIngress`            | Add extra ingress rules to the NetworkPolicy                     | `[]`        |
-| `indexGateway.networkPolicy.extraEgress`             | Add extra ingress rules to the NetworkPolicy                     | `[]`        |
-| `indexGateway.networkPolicy.ingressNSMatchLabels`    | Labels to match to allow traffic from other namespaces           | `{}`        |
-| `indexGateway.networkPolicy.ingressNSPodMatchLabels` | Pod labels to match to allow traffic from other namespaces       | `{}`        |
+| Name                                                 | Description                                                                                                                | Value       |
+| ---------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| `indexGateway.service.type`                          | index-gateway service type                                                                                                 | `ClusterIP` |
+| `indexGateway.service.ports.http`                    | index-gateway HTTP service port                                                                                            | `3100`      |
+| `indexGateway.service.ports.grpc`                    | index-gateway GRPC service port                                                                                            | `9095`      |
+| `indexGateway.service.nodePorts.http`                | Node port for HTTP                                                                                                         | `""`        |
+| `indexGateway.service.nodePorts.grpc`                | Node port for GRPC                                                                                                         | `""`        |
+| `indexGateway.service.sessionAffinityConfig`         | Additional settings for the sessionAffinity                                                                                | `{}`        |
+| `indexGateway.service.sessionAffinity`               | Control where client requests go, to the same pod or round-robin                                                           | `None`      |
+| `indexGateway.service.clusterIP`                     | index-gateway service Cluster IP                                                                                           | `""`        |
+| `indexGateway.service.loadBalancerIP`                | index-gateway service Load Balancer IP                                                                                     | `""`        |
+| `indexGateway.service.loadBalancerSourceRanges`      | index-gateway service Load Balancer sources                                                                                | `[]`        |
+| `indexGateway.service.externalTrafficPolicy`         | index-gateway service external traffic policy                                                                              | `Cluster`   |
+| `indexGateway.service.annotations`                   | Additional custom annotations for index-gateway service                                                                    | `{}`        |
+| `indexGateway.service.extraPorts`                    | Extra ports to expose in the index-gateway service                                                                         | `[]`        |
+| `indexGateway.networkPolicy.enabled`                 | Specifies whether a NetworkPolicy should be created                                                                        | `true`      |
+| `indexGateway.networkPolicy.allowExternal`           | Don't require server label for connections                                                                                 | `true`      |
+| `indexGateway.networkPolicy.allowExternalEgress`     | Allow the pod to access any range of port and all destinations.                                                            | `true`      |
+| `indexGateway.networkPolicy.addExternalClientAccess` | Allow access from pods with client label set to "true". Ignored if `indexGateway.networkPolicy.allowExternal` is true.     | `true`      |
+| `indexGateway.networkPolicy.extraIngress`            | Add extra ingress rules to the NetworkPolicy                                                                               | `[]`        |
+| `indexGateway.networkPolicy.extraEgress`             | Add extra ingress rules to the NetworkPolicy                                                                               | `[]`        |
+| `indexGateway.networkPolicy.ingressPodMatchLabels`   | Labels to match to allow traffic from other pods. Ignored if `indexGateway.networkPolicy.allowExternal` is true.           | `{}`        |
+| `indexGateway.networkPolicy.ingressNSMatchLabels`    | Labels to match to allow traffic from other namespaces. Ignored if `indexGateway.networkPolicy.allowExternal` is true.     | `{}`        |
+| `indexGateway.networkPolicy.ingressNSPodMatchLabels` | Pod labels to match to allow traffic from other namespaces. Ignored if `indexGateway.networkPolicy.allowExternal` is true. | `{}`        |
 
 ### Distributor Deployment Parameters
 
@@ -622,28 +628,30 @@ The [Bitnami grafana-loki](https://github.com/bitnami/containers/tree/main/bitna
 
 ### Distributor Traffic Exposure Parameters
 
-| Name                                                | Description                                                      | Value       |
-| --------------------------------------------------- | ---------------------------------------------------------------- | ----------- |
-| `distributor.service.type`                          | Distributor service type                                         | `ClusterIP` |
-| `distributor.service.ports.http`                    | Distributor HTTP service port                                    | `3100`      |
-| `distributor.service.ports.grpc`                    | Distributor GRPC service port                                    | `9095`      |
-| `distributor.service.nodePorts.http`                | Node port for HTTP                                               | `""`        |
-| `distributor.service.nodePorts.grpc`                | Node port for GRPC                                               | `""`        |
-| `distributor.service.sessionAffinityConfig`         | Additional settings for the sessionAffinity                      | `{}`        |
-| `distributor.service.sessionAffinity`               | Control where client requests go, to the same pod or round-robin | `None`      |
-| `distributor.service.clusterIP`                     | Distributor service Cluster IP                                   | `""`        |
-| `distributor.service.loadBalancerIP`                | Distributor service Load Balancer IP                             | `""`        |
-| `distributor.service.loadBalancerSourceRanges`      | Distributor service Load Balancer sources                        | `[]`        |
-| `distributor.service.externalTrafficPolicy`         | Distributor service external traffic policy                      | `Cluster`   |
-| `distributor.service.annotations`                   | Additional custom annotations for Distributor service            | `{}`        |
-| `distributor.service.extraPorts`                    | Extra ports to expose in the Distributor service                 | `[]`        |
-| `distributor.networkPolicy.enabled`                 | Specifies whether a NetworkPolicy should be created              | `true`      |
-| `distributor.networkPolicy.allowExternal`           | Don't require server label for connections                       | `true`      |
-| `distributor.networkPolicy.allowExternalEgress`     | Allow the pod to access any range of port and all destinations.  | `true`      |
-| `distributor.networkPolicy.extraIngress`            | Add extra ingress rules to the NetworkPolicy                     | `[]`        |
-| `distributor.networkPolicy.extraEgress`             | Add extra ingress rules to the NetworkPolicy                     | `[]`        |
-| `distributor.networkPolicy.ingressNSMatchLabels`    | Labels to match to allow traffic from other namespaces           | `{}`        |
-| `distributor.networkPolicy.ingressNSPodMatchLabels` | Pod labels to match to allow traffic from other namespaces       | `{}`        |
+| Name                                                | Description                                                                                                               | Value       |
+| --------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| `distributor.service.type`                          | Distributor service type                                                                                                  | `ClusterIP` |
+| `distributor.service.ports.http`                    | Distributor HTTP service port                                                                                             | `3100`      |
+| `distributor.service.ports.grpc`                    | Distributor GRPC service port                                                                                             | `9095`      |
+| `distributor.service.nodePorts.http`                | Node port for HTTP                                                                                                        | `""`        |
+| `distributor.service.nodePorts.grpc`                | Node port for GRPC                                                                                                        | `""`        |
+| `distributor.service.sessionAffinityConfig`         | Additional settings for the sessionAffinity                                                                               | `{}`        |
+| `distributor.service.sessionAffinity`               | Control where client requests go, to the same pod or round-robin                                                          | `None`      |
+| `distributor.service.clusterIP`                     | Distributor service Cluster IP                                                                                            | `""`        |
+| `distributor.service.loadBalancerIP`                | Distributor service Load Balancer IP                                                                                      | `""`        |
+| `distributor.service.loadBalancerSourceRanges`      | Distributor service Load Balancer sources                                                                                 | `[]`        |
+| `distributor.service.externalTrafficPolicy`         | Distributor service external traffic policy                                                                               | `Cluster`   |
+| `distributor.service.annotations`                   | Additional custom annotations for Distributor service                                                                     | `{}`        |
+| `distributor.service.extraPorts`                    | Extra ports to expose in the Distributor service                                                                          | `[]`        |
+| `distributor.networkPolicy.enabled`                 | Specifies whether a NetworkPolicy should be created                                                                       | `true`      |
+| `distributor.networkPolicy.allowExternal`           | Don't require server label for connections                                                                                | `true`      |
+| `distributor.networkPolicy.allowExternalEgress`     | Allow the pod to access any range of port and all destinations.                                                           | `true`      |
+| `distributor.networkPolicy.addExternalClientAccess` | Allow access from pods with client label set to "true". Ignored if `distributor.networkPolicy.allowExternal` is true.     | `true`      |
+| `distributor.networkPolicy.extraIngress`            | Add extra ingress rules to the NetworkPolicy                                                                              | `[]`        |
+| `distributor.networkPolicy.extraEgress`             | Add extra ingress rules to the NetworkPolicy                                                                              | `[]`        |
+| `distributor.networkPolicy.ingressPodMatchLabels`   | Labels to match to allow traffic from other pods. Ignored if `distributor.networkPolicy.allowExternal` is true.           | `{}`        |
+| `distributor.networkPolicy.ingressNSMatchLabels`    | Labels to match to allow traffic from other namespaces. Ignored if `distributor.networkPolicy.allowExternal` is true.     | `{}`        |
+| `distributor.networkPolicy.ingressNSPodMatchLabels` | Pod labels to match to allow traffic from other namespaces. Ignored if `distributor.networkPolicy.allowExternal` is true. | `{}`        |
 
 ### Ingester Deployment Parameters
 
@@ -732,28 +740,30 @@ The [Bitnami grafana-loki](https://github.com/bitnami/containers/tree/main/bitna
 
 ### Ingester Traffic Exposure Parameters
 
-| Name                                             | Description                                                      | Value       |
-| ------------------------------------------------ | ---------------------------------------------------------------- | ----------- |
-| `ingester.service.type`                          | Ingester service type                                            | `ClusterIP` |
-| `ingester.service.ports.http`                    | Ingester HTTP service port                                       | `3100`      |
-| `ingester.service.ports.grpc`                    | Ingester GRPC service port                                       | `9095`      |
-| `ingester.service.nodePorts.http`                | Node port for HTTP                                               | `""`        |
-| `ingester.service.nodePorts.grpc`                | Node port for GRPC                                               | `""`        |
-| `ingester.service.sessionAffinityConfig`         | Additional settings for the sessionAffinity                      | `{}`        |
-| `ingester.service.sessionAffinity`               | Control where client requests go, to the same pod or round-robin | `None`      |
-| `ingester.service.clusterIP`                     | Ingester service Cluster IP                                      | `""`        |
-| `ingester.service.loadBalancerIP`                | Ingester service Load Balancer IP                                | `""`        |
-| `ingester.service.loadBalancerSourceRanges`      | Ingester service Load Balancer sources                           | `[]`        |
-| `ingester.service.externalTrafficPolicy`         | Ingester service external traffic policy                         | `Cluster`   |
-| `ingester.service.annotations`                   | Additional custom annotations for Ingester service               | `{}`        |
-| `ingester.service.extraPorts`                    | Extra ports to expose in the Ingester service                    | `[]`        |
-| `ingester.networkPolicy.enabled`                 | Specifies whether a NetworkPolicy should be created              | `true`      |
-| `ingester.networkPolicy.allowExternal`           | Don't require server label for connections                       | `true`      |
-| `ingester.networkPolicy.allowExternalEgress`     | Allow the pod to access any range of port and all destinations.  | `true`      |
-| `ingester.networkPolicy.extraIngress`            | Add extra ingress rules to the NetworkPolicy                     | `[]`        |
-| `ingester.networkPolicy.extraEgress`             | Add extra ingress rules to the NetworkPolicy                     | `[]`        |
-| `ingester.networkPolicy.ingressNSMatchLabels`    | Labels to match to allow traffic from other namespaces           | `{}`        |
-| `ingester.networkPolicy.ingressNSPodMatchLabels` | Pod labels to match to allow traffic from other namespaces       | `{}`        |
+| Name                                             | Description                                                                                                            | Value       |
+| ------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------- | ----------- |
+| `ingester.service.type`                          | Ingester service type                                                                                                  | `ClusterIP` |
+| `ingester.service.ports.http`                    | Ingester HTTP service port                                                                                             | `3100`      |
+| `ingester.service.ports.grpc`                    | Ingester GRPC service port                                                                                             | `9095`      |
+| `ingester.service.nodePorts.http`                | Node port for HTTP                                                                                                     | `""`        |
+| `ingester.service.nodePorts.grpc`                | Node port for GRPC                                                                                                     | `""`        |
+| `ingester.service.sessionAffinityConfig`         | Additional settings for the sessionAffinity                                                                            | `{}`        |
+| `ingester.service.sessionAffinity`               | Control where client requests go, to the same pod or round-robin                                                       | `None`      |
+| `ingester.service.clusterIP`                     | Ingester service Cluster IP                                                                                            | `""`        |
+| `ingester.service.loadBalancerIP`                | Ingester service Load Balancer IP                                                                                      | `""`        |
+| `ingester.service.loadBalancerSourceRanges`      | Ingester service Load Balancer sources                                                                                 | `[]`        |
+| `ingester.service.externalTrafficPolicy`         | Ingester service external traffic policy                                                                               | `Cluster`   |
+| `ingester.service.annotations`                   | Additional custom annotations for Ingester service                                                                     | `{}`        |
+| `ingester.service.extraPorts`                    | Extra ports to expose in the Ingester service                                                                          | `[]`        |
+| `ingester.networkPolicy.enabled`                 | Specifies whether a NetworkPolicy should be created                                                                    | `true`      |
+| `ingester.networkPolicy.allowExternal`           | Don't require server label for connections                                                                             | `true`      |
+| `ingester.networkPolicy.allowExternalEgress`     | Allow the pod to access any range of port and all destinations.                                                        | `true`      |
+| `ingester.networkPolicy.addExternalClientAccess` | Allow access from pods with client label set to "true". Ignored if `ingester.networkPolicy.allowExternal` is true.     | `true`      |
+| `ingester.networkPolicy.extraIngress`            | Add extra ingress rules to the NetworkPolicy                                                                           | `[]`        |
+| `ingester.networkPolicy.extraEgress`             | Add extra ingress rules to the NetworkPolicy                                                                           | `[]`        |
+| `ingester.networkPolicy.ingressPodMatchLabels`   | Labels to match to allow traffic from other pods. Ignored if `ingester.networkPolicy.allowExternal` is true.           | `{}`        |
+| `ingester.networkPolicy.ingressNSMatchLabels`    | Labels to match to allow traffic from other namespaces. Ignored if `ingester.networkPolicy.allowExternal` is true.     | `{}`        |
+| `ingester.networkPolicy.ingressNSPodMatchLabels` | Pod labels to match to allow traffic from other namespaces. Ignored if `ingester.networkPolicy.allowExternal` is true. | `{}`        |
 
 ### Querier Deployment Parameters
 
@@ -842,28 +852,30 @@ The [Bitnami grafana-loki](https://github.com/bitnami/containers/tree/main/bitna
 
 ### Querier Traffic Exposure Parameters
 
-| Name                                            | Description                                                      | Value       |
-| ----------------------------------------------- | ---------------------------------------------------------------- | ----------- |
-| `querier.service.type`                          | Querier service type                                             | `ClusterIP` |
-| `querier.service.ports.http`                    | Querier HTTP service port                                        | `3100`      |
-| `querier.service.ports.grpc`                    | Querier GRPC service port                                        | `9095`      |
-| `querier.service.nodePorts.http`                | Node port for HTTP                                               | `""`        |
-| `querier.service.nodePorts.grpc`                | Node port for GRPC                                               | `""`        |
-| `querier.service.sessionAffinityConfig`         | Additional settings for the sessionAffinity                      | `{}`        |
-| `querier.service.sessionAffinity`               | Control where client requests go, to the same pod or round-robin | `None`      |
-| `querier.service.clusterIP`                     | Querier service Cluster IP                                       | `""`        |
-| `querier.service.loadBalancerIP`                | Querier service Load Balancer IP                                 | `""`        |
-| `querier.service.loadBalancerSourceRanges`      | Querier service Load Balancer sources                            | `[]`        |
-| `querier.service.externalTrafficPolicy`         | Querier service external traffic policy                          | `Cluster`   |
-| `querier.service.annotations`                   | Additional custom annotations for Querier service                | `{}`        |
-| `querier.service.extraPorts`                    | Extra ports to expose in the Querier service                     | `[]`        |
-| `querier.networkPolicy.enabled`                 | Specifies whether a NetworkPolicy should be created              | `true`      |
-| `querier.networkPolicy.allowExternal`           | Don't require server label for connections                       | `true`      |
-| `querier.networkPolicy.allowExternalEgress`     | Allow the pod to access any range of port and all destinations.  | `true`      |
-| `querier.networkPolicy.extraIngress`            | Add extra ingress rules to the NetworkPolicy                     | `[]`        |
-| `querier.networkPolicy.extraEgress`             | Add extra ingress rules to the NetworkPolicy                     | `[]`        |
-| `querier.networkPolicy.ingressNSMatchLabels`    | Labels to match to allow traffic from other namespaces           | `{}`        |
-| `querier.networkPolicy.ingressNSPodMatchLabels` | Pod labels to match to allow traffic from other namespaces       | `{}`        |
+| Name                                            | Description                                                                                                           | Value       |
+| ----------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- | ----------- |
+| `querier.service.type`                          | Querier service type                                                                                                  | `ClusterIP` |
+| `querier.service.ports.http`                    | Querier HTTP service port                                                                                             | `3100`      |
+| `querier.service.ports.grpc`                    | Querier GRPC service port                                                                                             | `9095`      |
+| `querier.service.nodePorts.http`                | Node port for HTTP                                                                                                    | `""`        |
+| `querier.service.nodePorts.grpc`                | Node port for GRPC                                                                                                    | `""`        |
+| `querier.service.sessionAffinityConfig`         | Additional settings for the sessionAffinity                                                                           | `{}`        |
+| `querier.service.sessionAffinity`               | Control where client requests go, to the same pod or round-robin                                                      | `None`      |
+| `querier.service.clusterIP`                     | Querier service Cluster IP                                                                                            | `""`        |
+| `querier.service.loadBalancerIP`                | Querier service Load Balancer IP                                                                                      | `""`        |
+| `querier.service.loadBalancerSourceRanges`      | Querier service Load Balancer sources                                                                                 | `[]`        |
+| `querier.service.externalTrafficPolicy`         | Querier service external traffic policy                                                                               | `Cluster`   |
+| `querier.service.annotations`                   | Additional custom annotations for Querier service                                                                     | `{}`        |
+| `querier.service.extraPorts`                    | Extra ports to expose in the Querier service                                                                          | `[]`        |
+| `querier.networkPolicy.enabled`                 | Specifies whether a NetworkPolicy should be created                                                                   | `true`      |
+| `querier.networkPolicy.allowExternal`           | Don't require server label for connections                                                                            | `true`      |
+| `querier.networkPolicy.allowExternalEgress`     | Allow the pod to access any range of port and all destinations.                                                       | `true`      |
+| `querier.networkPolicy.addExternalClientAccess` | Allow access from pods with client label set to "true". Ignored if `querier.networkPolicy.allowExternal` is true.     | `true`      |
+| `querier.networkPolicy.extraIngress`            | Add extra ingress rules to the NetworkPolicy                                                                          | `[]`        |
+| `querier.networkPolicy.extraEgress`             | Add extra ingress rules to the NetworkPolicy                                                                          | `[]`        |
+| `querier.networkPolicy.ingressPodMatchLabels`   | Labels to match to allow traffic from other pods. Ignored if `querier.networkPolicy.allowExternal` is true.           | `{}`        |
+| `querier.networkPolicy.ingressNSMatchLabels`    | Labels to match to allow traffic from other namespaces. Ignored if `querier.networkPolicy.allowExternal` is true.     | `{}`        |
+| `querier.networkPolicy.ingressNSPodMatchLabels` | Pod labels to match to allow traffic from other namespaces. Ignored if `querier.networkPolicy.allowExternal` is true. | `{}`        |
 
 ### Query Frontend Deployment Parameters
 
@@ -939,29 +951,31 @@ The [Bitnami grafana-loki](https://github.com/bitnami/containers/tree/main/bitna
 
 ### Query Frontend Traffic Exposure Parameters
 
-| Name                                                  | Description                                                      | Value       |
-| ----------------------------------------------------- | ---------------------------------------------------------------- | ----------- |
-| `queryFrontend.service.type`                          | queryFrontend service type                                       | `ClusterIP` |
-| `queryFrontend.service.ports.http`                    | queryFrontend HTTP service port                                  | `3100`      |
-| `queryFrontend.service.ports.grpc`                    | queryFrontend GRPC service port                                  | `9095`      |
-| `queryFrontend.service.nodePorts.http`                | Node port for HTTP                                               | `""`        |
-| `queryFrontend.service.nodePorts.grpc`                | Node port for GRPC                                               | `""`        |
-| `queryFrontend.service.sessionAffinityConfig`         | Additional settings for the sessionAffinity                      | `{}`        |
-| `queryFrontend.service.sessionAffinity`               | Control where client requests go, to the same pod or round-robin | `None`      |
-| `queryFrontend.service.clusterIP`                     | queryFrontend service Cluster IP                                 | `""`        |
-| `queryFrontend.service.loadBalancerIP`                | queryFrontend service Load Balancer IP                           | `""`        |
-| `queryFrontend.service.loadBalancerSourceRanges`      | queryFrontend service Load Balancer sources                      | `[]`        |
-| `queryFrontend.service.externalTrafficPolicy`         | queryFrontend service external traffic policy                    | `Cluster`   |
-| `queryFrontend.service.annotations`                   | Additional custom annotations for queryFrontend service          | `{}`        |
-| `queryFrontend.service.extraPorts`                    | Extra ports to expose in the queryFrontend service               | `[]`        |
-| `queryFrontend.service.headless.annotations`          | Annotations for the headless service.                            | `{}`        |
-| `queryFrontend.networkPolicy.enabled`                 | Specifies whether a NetworkPolicy should be created              | `true`      |
-| `queryFrontend.networkPolicy.allowExternal`           | Don't require server label for connections                       | `true`      |
-| `queryFrontend.networkPolicy.allowExternalEgress`     | Allow the pod to access any range of port and all destinations.  | `true`      |
-| `queryFrontend.networkPolicy.extraIngress`            | Add extra ingress rules to the NetworkPolicy                     | `[]`        |
-| `queryFrontend.networkPolicy.extraEgress`             | Add extra ingress rules to the NetworkPolicy                     | `[]`        |
-| `queryFrontend.networkPolicy.ingressNSMatchLabels`    | Labels to match to allow traffic from other namespaces           | `{}`        |
-| `queryFrontend.networkPolicy.ingressNSPodMatchLabels` | Pod labels to match to allow traffic from other namespaces       | `{}`        |
+| Name                                                  | Description                                                                                                                 | Value       |
+| ----------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| `queryFrontend.service.type`                          | queryFrontend service type                                                                                                  | `ClusterIP` |
+| `queryFrontend.service.ports.http`                    | queryFrontend HTTP service port                                                                                             | `3100`      |
+| `queryFrontend.service.ports.grpc`                    | queryFrontend GRPC service port                                                                                             | `9095`      |
+| `queryFrontend.service.nodePorts.http`                | Node port for HTTP                                                                                                          | `""`        |
+| `queryFrontend.service.nodePorts.grpc`                | Node port for GRPC                                                                                                          | `""`        |
+| `queryFrontend.service.sessionAffinityConfig`         | Additional settings for the sessionAffinity                                                                                 | `{}`        |
+| `queryFrontend.service.sessionAffinity`               | Control where client requests go, to the same pod or round-robin                                                            | `None`      |
+| `queryFrontend.service.clusterIP`                     | queryFrontend service Cluster IP                                                                                            | `""`        |
+| `queryFrontend.service.loadBalancerIP`                | queryFrontend service Load Balancer IP                                                                                      | `""`        |
+| `queryFrontend.service.loadBalancerSourceRanges`      | queryFrontend service Load Balancer sources                                                                                 | `[]`        |
+| `queryFrontend.service.externalTrafficPolicy`         | queryFrontend service external traffic policy                                                                               | `Cluster`   |
+| `queryFrontend.service.annotations`                   | Additional custom annotations for queryFrontend service                                                                     | `{}`        |
+| `queryFrontend.service.extraPorts`                    | Extra ports to expose in the queryFrontend service                                                                          | `[]`        |
+| `queryFrontend.service.headless.annotations`          | Annotations for the headless service.                                                                                       | `{}`        |
+| `queryFrontend.networkPolicy.enabled`                 | Specifies whether a NetworkPolicy should be created                                                                         | `true`      |
+| `queryFrontend.networkPolicy.allowExternal`           | Don't require server label for connections                                                                                  | `true`      |
+| `queryFrontend.networkPolicy.allowExternalEgress`     | Allow the pod to access any range of port and all destinations.                                                             | `true`      |
+| `queryFrontend.networkPolicy.addExternalClientAccess` | Allow access from pods with client label set to "true". Ignored if `queryFrontend.networkPolicy.allowExternal` is true.     | `true`      |
+| `queryFrontend.networkPolicy.extraIngress`            | Add extra ingress rules to the NetworkPolicy                                                                                | `[]`        |
+| `queryFrontend.networkPolicy.extraEgress`             | Add extra ingress rules to the NetworkPolicy                                                                                | `[]`        |
+| `queryFrontend.networkPolicy.ingressPodMatchLabels`   | Labels to match to allow traffic from other pods. Ignored if `queryFrontend.networkPolicy.allowExternal` is true.           | `{}`        |
+| `queryFrontend.networkPolicy.ingressNSMatchLabels`    | Labels to match to allow traffic from other namespaces. Ignored if `queryFrontend.networkPolicy.allowExternal` is true.     | `{}`        |
+| `queryFrontend.networkPolicy.ingressNSPodMatchLabels` | Pod labels to match to allow traffic from other namespaces. Ignored if `queryFrontend.networkPolicy.allowExternal` is true. | `{}`        |
 
 ### Query Scheduler Deployment Parameters
 
@@ -1038,28 +1052,30 @@ The [Bitnami grafana-loki](https://github.com/bitnami/containers/tree/main/bitna
 
 ### Query Scheduler Traffic Exposure Parameters
 
-| Name                                                   | Description                                                      | Value       |
-| ------------------------------------------------------ | ---------------------------------------------------------------- | ----------- |
-| `queryScheduler.service.type`                          | queryScheduler service type                                      | `ClusterIP` |
-| `queryScheduler.service.ports.http`                    | queryScheduler HTTP service port                                 | `3100`      |
-| `queryScheduler.service.ports.grpc`                    | queryScheduler GRPC service port                                 | `9095`      |
-| `queryScheduler.service.nodePorts.http`                | Node port for HTTP                                               | `""`        |
-| `queryScheduler.service.nodePorts.grpc`                | Node port for GRPC                                               | `""`        |
-| `queryScheduler.service.sessionAffinityConfig`         | Additional settings for the sessionAffinity                      | `{}`        |
-| `queryScheduler.service.sessionAffinity`               | Control where client requests go, to the same pod or round-robin | `None`      |
-| `queryScheduler.service.clusterIP`                     | queryScheduler service Cluster IP                                | `""`        |
-| `queryScheduler.service.loadBalancerIP`                | queryScheduler service Load Balancer IP                          | `""`        |
-| `queryScheduler.service.loadBalancerSourceRanges`      | queryScheduler service Load Balancer sources                     | `[]`        |
-| `queryScheduler.service.externalTrafficPolicy`         | queryScheduler service external traffic policy                   | `Cluster`   |
-| `queryScheduler.service.annotations`                   | Additional custom annotations for queryScheduler service         | `{}`        |
-| `queryScheduler.service.extraPorts`                    | Extra ports to expose in the queryScheduler service              | `[]`        |
-| `queryScheduler.networkPolicy.enabled`                 | Specifies whether a NetworkPolicy should be created              | `true`      |
-| `queryScheduler.networkPolicy.allowExternal`           | Don't require server label for connections                       | `true`      |
-| `queryScheduler.networkPolicy.allowExternalEgress`     | Allow the pod to access any range of port and all destinations.  | `true`      |
-| `queryScheduler.networkPolicy.extraIngress`            | Add extra ingress rules to the NetworkPolicy                     | `[]`        |
-| `queryScheduler.networkPolicy.extraEgress`             | Add extra ingress rules to the NetworkPolicy                     | `[]`        |
-| `queryScheduler.networkPolicy.ingressNSMatchLabels`    | Labels to match to allow traffic from other namespaces           | `{}`        |
-| `queryScheduler.networkPolicy.ingressNSPodMatchLabels` | Pod labels to match to allow traffic from other namespaces       | `{}`        |
+| Name                                                   | Description                                                                                                                  | Value       |
+| ------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| `queryScheduler.service.type`                          | queryScheduler service type                                                                                                  | `ClusterIP` |
+| `queryScheduler.service.ports.http`                    | queryScheduler HTTP service port                                                                                             | `3100`      |
+| `queryScheduler.service.ports.grpc`                    | queryScheduler GRPC service port                                                                                             | `9095`      |
+| `queryScheduler.service.nodePorts.http`                | Node port for HTTP                                                                                                           | `""`        |
+| `queryScheduler.service.nodePorts.grpc`                | Node port for GRPC                                                                                                           | `""`        |
+| `queryScheduler.service.sessionAffinityConfig`         | Additional settings for the sessionAffinity                                                                                  | `{}`        |
+| `queryScheduler.service.sessionAffinity`               | Control where client requests go, to the same pod or round-robin                                                             | `None`      |
+| `queryScheduler.service.clusterIP`                     | queryScheduler service Cluster IP                                                                                            | `""`        |
+| `queryScheduler.service.loadBalancerIP`                | queryScheduler service Load Balancer IP                                                                                      | `""`        |
+| `queryScheduler.service.loadBalancerSourceRanges`      | queryScheduler service Load Balancer sources                                                                                 | `[]`        |
+| `queryScheduler.service.externalTrafficPolicy`         | queryScheduler service external traffic policy                                                                               | `Cluster`   |
+| `queryScheduler.service.annotations`                   | Additional custom annotations for queryScheduler service                                                                     | `{}`        |
+| `queryScheduler.service.extraPorts`                    | Extra ports to expose in the queryScheduler service                                                                          | `[]`        |
+| `queryScheduler.networkPolicy.enabled`                 | Specifies whether a NetworkPolicy should be created                                                                          | `true`      |
+| `queryScheduler.networkPolicy.allowExternal`           | Don't require server label for connections                                                                                   | `true`      |
+| `queryScheduler.networkPolicy.allowExternalEgress`     | Allow the pod to access any range of port and all destinations.                                                              | `true`      |
+| `queryScheduler.networkPolicy.addExternalClientAccess` | Allow access from pods with client label set to "true". Ignored if `queryScheduler.networkPolicy.allowExternal` is true.     | `true`      |
+| `queryScheduler.networkPolicy.extraIngress`            | Add extra ingress rules to the NetworkPolicy                                                                                 | `[]`        |
+| `queryScheduler.networkPolicy.extraEgress`             | Add extra ingress rules to the NetworkPolicy                                                                                 | `[]`        |
+| `queryScheduler.networkPolicy.ingressPodMatchLabels`   | Labels to match to allow traffic from other pods. Ignored if `queryScheduler.networkPolicy.allowExternal` is true.           | `{}`        |
+| `queryScheduler.networkPolicy.ingressNSMatchLabels`    | Labels to match to allow traffic from other namespaces. Ignored if `queryScheduler.networkPolicy.allowExternal` is true.     | `{}`        |
+| `queryScheduler.networkPolicy.ingressNSPodMatchLabels` | Pod labels to match to allow traffic from other namespaces. Ignored if `queryScheduler.networkPolicy.allowExternal` is true. | `{}`        |
 
 ### Ruler Deployment Parameters
 
@@ -1149,28 +1165,30 @@ The [Bitnami grafana-loki](https://github.com/bitnami/containers/tree/main/bitna
 
 ### Ruler Traffic Exposure Parameters
 
-| Name                                          | Description                                                      | Value       |
-| --------------------------------------------- | ---------------------------------------------------------------- | ----------- |
-| `ruler.service.type`                          | Ruler service type                                               | `ClusterIP` |
-| `ruler.service.ports.http`                    | Ruler HTTP service port                                          | `3100`      |
-| `ruler.service.ports.grpc`                    | Ruler GRPC service port                                          | `9095`      |
-| `ruler.service.nodePorts.http`                | Node port for HTTP                                               | `""`        |
-| `ruler.service.nodePorts.grpc`                | Node port for GRPC                                               | `""`        |
-| `ruler.service.sessionAffinityConfig`         | Additional settings for the sessionAffinity                      | `{}`        |
-| `ruler.service.sessionAffinity`               | Control where client requests go, to the same pod or round-robin | `None`      |
-| `ruler.service.clusterIP`                     | Ruler service Cluster IP                                         | `""`        |
-| `ruler.service.loadBalancerIP`                | Ruler service Load Balancer IP                                   | `""`        |
-| `ruler.service.loadBalancerSourceRanges`      | Ruler service Load Balancer sources                              | `[]`        |
-| `ruler.service.externalTrafficPolicy`         | Ruler service external traffic policy                            | `Cluster`   |
-| `ruler.service.annotations`                   | Additional custom annotations for Ruler service                  | `{}`        |
-| `ruler.service.extraPorts`                    | Extra ports to expose in the Ruler service                       | `[]`        |
-| `ruler.networkPolicy.enabled`                 | Specifies whether a NetworkPolicy should be created              | `true`      |
-| `ruler.networkPolicy.allowExternal`           | Don't require server label for connections                       | `true`      |
-| `ruler.networkPolicy.allowExternalEgress`     | Allow the pod to access any range of port and all destinations.  | `true`      |
-| `ruler.networkPolicy.extraIngress`            | Add extra ingress rules to the NetworkPolicy                     | `[]`        |
-| `ruler.networkPolicy.extraEgress`             | Add extra ingress rules to the NetworkPolicy                     | `[]`        |
-| `ruler.networkPolicy.ingressNSMatchLabels`    | Labels to match to allow traffic from other namespaces           | `{}`        |
-| `ruler.networkPolicy.ingressNSPodMatchLabels` | Pod labels to match to allow traffic from other namespaces       | `{}`        |
+| Name                                          | Description                                                                                                         | Value       |
+| --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- | ----------- |
+| `ruler.service.type`                          | Ruler service type                                                                                                  | `ClusterIP` |
+| `ruler.service.ports.http`                    | Ruler HTTP service port                                                                                             | `3100`      |
+| `ruler.service.ports.grpc`                    | Ruler GRPC service port                                                                                             | `9095`      |
+| `ruler.service.nodePorts.http`                | Node port for HTTP                                                                                                  | `""`        |
+| `ruler.service.nodePorts.grpc`                | Node port for GRPC                                                                                                  | `""`        |
+| `ruler.service.sessionAffinityConfig`         | Additional settings for the sessionAffinity                                                                         | `{}`        |
+| `ruler.service.sessionAffinity`               | Control where client requests go, to the same pod or round-robin                                                    | `None`      |
+| `ruler.service.clusterIP`                     | Ruler service Cluster IP                                                                                            | `""`        |
+| `ruler.service.loadBalancerIP`                | Ruler service Load Balancer IP                                                                                      | `""`        |
+| `ruler.service.loadBalancerSourceRanges`      | Ruler service Load Balancer sources                                                                                 | `[]`        |
+| `ruler.service.externalTrafficPolicy`         | Ruler service external traffic policy                                                                               | `Cluster`   |
+| `ruler.service.annotations`                   | Additional custom annotations for Ruler service                                                                     | `{}`        |
+| `ruler.service.extraPorts`                    | Extra ports to expose in the Ruler service                                                                          | `[]`        |
+| `ruler.networkPolicy.enabled`                 | Specifies whether a NetworkPolicy should be created                                                                 | `true`      |
+| `ruler.networkPolicy.allowExternal`           | Don't require server label for connections                                                                          | `true`      |
+| `ruler.networkPolicy.allowExternalEgress`     | Allow the pod to access any range of port and all destinations.                                                     | `true`      |
+| `ruler.networkPolicy.addExternalClientAccess` | Allow access from pods with client label set to "true". Ignored if `ruler.networkPolicy.allowExternal` is true.     | `true`      |
+| `ruler.networkPolicy.extraIngress`            | Add extra ingress rules to the NetworkPolicy                                                                        | `[]`        |
+| `ruler.networkPolicy.extraEgress`             | Add extra ingress rules to the NetworkPolicy                                                                        | `[]`        |
+| `ruler.networkPolicy.ingressPodMatchLabels`   | Labels to match to allow traffic from other pods. Ignored if `ruler.networkPolicy.allowExternal` is true.           | `{}`        |
+| `ruler.networkPolicy.ingressNSMatchLabels`    | Labels to match to allow traffic from other namespaces. Ignored if `ruler.networkPolicy.allowExternal` is true.     | `{}`        |
+| `ruler.networkPolicy.ingressNSPodMatchLabels` | Pod labels to match to allow traffic from other namespaces. Ignored if `ruler.networkPolicy.allowExternal` is true. | `{}`        |
 
 ### table-manager Deployment Parameters
 
@@ -1247,28 +1265,30 @@ The [Bitnami grafana-loki](https://github.com/bitnami/containers/tree/main/bitna
 
 ### table-manager Traffic Exposure Parameters
 
-| Name                                                 | Description                                                      | Value       |
-| ---------------------------------------------------- | ---------------------------------------------------------------- | ----------- |
-| `tableManager.service.type`                          | table-manager service type                                       | `ClusterIP` |
-| `tableManager.service.ports.http`                    | table-manager HTTP service port                                  | `3100`      |
-| `tableManager.service.ports.grpc`                    | table-manager GRPC service port                                  | `9095`      |
-| `tableManager.service.nodePorts.http`                | Node port for HTTP                                               | `""`        |
-| `tableManager.service.nodePorts.grpc`                | Node port for GRPC                                               | `""`        |
-| `tableManager.service.sessionAffinityConfig`         | Additional settings for the sessionAffinity                      | `{}`        |
-| `tableManager.service.sessionAffinity`               | Control where client requests go, to the same pod or round-robin | `None`      |
-| `tableManager.service.clusterIP`                     | table-manager service Cluster IP                                 | `""`        |
-| `tableManager.service.loadBalancerIP`                | table-manager service Load Balancer IP                           | `""`        |
-| `tableManager.service.loadBalancerSourceRanges`      | table-manager service Load Balancer sources                      | `[]`        |
-| `tableManager.service.externalTrafficPolicy`         | table-manager service external traffic policy                    | `Cluster`   |
-| `tableManager.service.annotations`                   | Additional custom annotations for table-manager service          | `{}`        |
-| `tableManager.service.extraPorts`                    | Extra ports to expose in the table-manager service               | `[]`        |
-| `tableManager.networkPolicy.enabled`                 | Specifies whether a NetworkPolicy should be created              | `true`      |
-| `tableManager.networkPolicy.allowExternal`           | Don't require server label for connections                       | `true`      |
-| `tableManager.networkPolicy.allowExternalEgress`     | Allow the pod to access any range of port and all destinations.  | `true`      |
-| `tableManager.networkPolicy.extraIngress`            | Add extra ingress rules to the NetworkPolicy                     | `[]`        |
-| `tableManager.networkPolicy.extraEgress`             | Add extra ingress rules to the NetworkPolicy                     | `[]`        |
-| `tableManager.networkPolicy.ingressNSMatchLabels`    | Labels to match to allow traffic from other namespaces           | `{}`        |
-| `tableManager.networkPolicy.ingressNSPodMatchLabels` | Pod labels to match to allow traffic from other namespaces       | `{}`        |
+| Name                                                 | Description                                                                                                                | Value       |
+| ---------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| `tableManager.service.type`                          | table-manager service type                                                                                                 | `ClusterIP` |
+| `tableManager.service.ports.http`                    | table-manager HTTP service port                                                                                            | `3100`      |
+| `tableManager.service.ports.grpc`                    | table-manager GRPC service port                                                                                            | `9095`      |
+| `tableManager.service.nodePorts.http`                | Node port for HTTP                                                                                                         | `""`        |
+| `tableManager.service.nodePorts.grpc`                | Node port for GRPC                                                                                                         | `""`        |
+| `tableManager.service.sessionAffinityConfig`         | Additional settings for the sessionAffinity                                                                                | `{}`        |
+| `tableManager.service.sessionAffinity`               | Control where client requests go, to the same pod or round-robin                                                           | `None`      |
+| `tableManager.service.clusterIP`                     | table-manager service Cluster IP                                                                                           | `""`        |
+| `tableManager.service.loadBalancerIP`                | table-manager service Load Balancer IP                                                                                     | `""`        |
+| `tableManager.service.loadBalancerSourceRanges`      | table-manager service Load Balancer sources                                                                                | `[]`        |
+| `tableManager.service.externalTrafficPolicy`         | table-manager service external traffic policy                                                                              | `Cluster`   |
+| `tableManager.service.annotations`                   | Additional custom annotations for table-manager service                                                                    | `{}`        |
+| `tableManager.service.extraPorts`                    | Extra ports to expose in the table-manager service                                                                         | `[]`        |
+| `tableManager.networkPolicy.enabled`                 | Specifies whether a NetworkPolicy should be created                                                                        | `true`      |
+| `tableManager.networkPolicy.allowExternal`           | Don't require server label for connections                                                                                 | `true`      |
+| `tableManager.networkPolicy.allowExternalEgress`     | Allow the pod to access any range of port and all destinations.                                                            | `true`      |
+| `tableManager.networkPolicy.addExternalClientAccess` | Allow access from pods with client label set to "true". Ignored if `tableManager.networkPolicy.allowExternal` is true.     | `true`      |
+| `tableManager.networkPolicy.extraIngress`            | Add extra ingress rules to the NetworkPolicy                                                                               | `[]`        |
+| `tableManager.networkPolicy.extraEgress`             | Add extra ingress rules to the NetworkPolicy                                                                               | `[]`        |
+| `tableManager.networkPolicy.ingressPodMatchLabels`   | Labels to match to allow traffic from other pods. Ignored if `tableManager.networkPolicy.allowExternal` is true.           | `{}`        |
+| `tableManager.networkPolicy.ingressNSMatchLabels`    | Labels to match to allow traffic from other namespaces. Ignored if `tableManager.networkPolicy.allowExternal` is true.     | `{}`        |
+| `tableManager.networkPolicy.ingressNSPodMatchLabels` | Pod labels to match to allow traffic from other namespaces. Ignored if `tableManager.networkPolicy.allowExternal` is true. | `{}`        |
 
 ### Promtail Deployment Parameters
 
@@ -1354,33 +1374,35 @@ The [Bitnami grafana-loki](https://github.com/bitnami/containers/tree/main/bitna
 
 ### Promtail Traffic Exposure Parameters
 
-| Name                                                   | Description                                                                                        | Value       |
-| ------------------------------------------------------ | -------------------------------------------------------------------------------------------------- | ----------- |
-| `promtail.service.type`                                | Promtail service type                                                                              | `ClusterIP` |
-| `promtail.service.ports.http`                          | Promtail HTTP service port                                                                         | `3100`      |
-| `promtail.service.ports.grpc`                          | Promtail gRPC service port                                                                         | `9095`      |
-| `promtail.service.nodePorts.http`                      | Node port for HTTP                                                                                 | `""`        |
-| `promtail.service.sessionAffinityConfig`               | Additional settings for the sessionAffinity                                                        | `{}`        |
-| `promtail.service.sessionAffinity`                     | Control where client requests go, to the same pod or round-robin                                   | `None`      |
-| `promtail.service.clusterIP`                           | Promtail service Cluster IP                                                                        | `""`        |
-| `promtail.service.loadBalancerIP`                      | Promtail service Load Balancer IP                                                                  | `""`        |
-| `promtail.service.loadBalancerSourceRanges`            | Promtail service Load Balancer sources                                                             | `[]`        |
-| `promtail.service.externalTrafficPolicy`               | Promtail service external traffic policy                                                           | `Cluster`   |
-| `promtail.service.annotations`                         | Additional custom annotations for Promtail service                                                 | `{}`        |
-| `promtail.service.extraPorts`                          | Extra ports to expose in the Promtail service                                                      | `[]`        |
-| `promtail.networkPolicy.enabled`                       | Specifies whether a NetworkPolicy should be created                                                | `true`      |
-| `promtail.networkPolicy.allowExternal`                 | Don't require server label for connections                                                         | `true`      |
-| `promtail.networkPolicy.allowExternalEgress`           | Allow the pod to access any range of port and all destinations.                                    | `true`      |
-| `promtail.networkPolicy.kubeAPIServerPorts`            | List of possible endpoints to kube-apiserver (limit to your cluster settings to increase security) | `[]`        |
-| `promtail.networkPolicy.extraIngress`                  | Add extra ingress rules to the NetworkPolicy                                                       | `[]`        |
-| `promtail.networkPolicy.extraEgress`                   | Add extra ingress rules to the NetworkPolicy                                                       | `[]`        |
-| `promtail.networkPolicy.ingressNSMatchLabels`          | Labels to match to allow traffic from other namespaces                                             | `{}`        |
-| `promtail.networkPolicy.ingressNSPodMatchLabels`       | Pod labels to match to allow traffic from other namespaces                                         | `{}`        |
-| `promtail.rbac.create`                                 | Create RBAC rules                                                                                  | `true`      |
-| `promtail.serviceAccount.create`                       | Enable creation of ServiceAccount for Promtail pods                                                | `true`      |
-| `promtail.serviceAccount.name`                         | The name of the ServiceAccount to use                                                              | `""`        |
-| `promtail.serviceAccount.automountServiceAccountToken` | Allows auto mount of ServiceAccountToken on the promtail.serviceAccount.created                    | `false`     |
-| `promtail.serviceAccount.annotations`                  | Additional custom annotations for the ServiceAccount                                               | `{}`        |
+| Name                                                   | Description                                                                                                            | Value       |
+| ------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------- | ----------- |
+| `promtail.service.type`                                | Promtail service type                                                                                                  | `ClusterIP` |
+| `promtail.service.ports.http`                          | Promtail HTTP service port                                                                                             | `3100`      |
+| `promtail.service.ports.grpc`                          | Promtail gRPC service port                                                                                             | `9095`      |
+| `promtail.service.nodePorts.http`                      | Node port for HTTP                                                                                                     | `""`        |
+| `promtail.service.sessionAffinityConfig`               | Additional settings for the sessionAffinity                                                                            | `{}`        |
+| `promtail.service.sessionAffinity`                     | Control where client requests go, to the same pod or round-robin                                                       | `None`      |
+| `promtail.service.clusterIP`                           | Promtail service Cluster IP                                                                                            | `""`        |
+| `promtail.service.loadBalancerIP`                      | Promtail service Load Balancer IP                                                                                      | `""`        |
+| `promtail.service.loadBalancerSourceRanges`            | Promtail service Load Balancer sources                                                                                 | `[]`        |
+| `promtail.service.externalTrafficPolicy`               | Promtail service external traffic policy                                                                               | `Cluster`   |
+| `promtail.service.annotations`                         | Additional custom annotations for Promtail service                                                                     | `{}`        |
+| `promtail.service.extraPorts`                          | Extra ports to expose in the Promtail service                                                                          | `[]`        |
+| `promtail.networkPolicy.enabled`                       | Specifies whether a NetworkPolicy should be created                                                                    | `true`      |
+| `promtail.networkPolicy.allowExternal`                 | Don't require server label for connections                                                                             | `true`      |
+| `promtail.networkPolicy.allowExternalEgress`           | Allow the pod to access any range of port and all destinations.                                                        | `true`      |
+| `promtail.networkPolicy.addExternalClientAccess`       | Allow access from pods with client label set to "true". Ignored if `promtail.networkPolicy.allowExternal` is true.     | `true`      |
+| `promtail.networkPolicy.kubeAPIServerPorts`            | List of possible endpoints to kube-apiserver (limit to your cluster settings to increase security)                     | `[]`        |
+| `promtail.networkPolicy.extraIngress`                  | Add extra ingress rules to the NetworkPolicy                                                                           | `[]`        |
+| `promtail.networkPolicy.extraEgress`                   | Add extra ingress rules to the NetworkPolicy                                                                           | `[]`        |
+| `promtail.networkPolicy.ingressPodMatchLabels`         | Labels to match to allow traffic from other pods. Ignored if `promtail.networkPolicy.allowExternal` is true.           | `{}`        |
+| `promtail.networkPolicy.ingressNSMatchLabels`          | Labels to match to allow traffic from other namespaces. Ignored if `promtail.networkPolicy.allowExternal` is true.     | `{}`        |
+| `promtail.networkPolicy.ingressNSPodMatchLabels`       | Pod labels to match to allow traffic from other namespaces. Ignored if `promtail.networkPolicy.allowExternal` is true. | `{}`        |
+| `promtail.rbac.create`                                 | Create RBAC rules                                                                                                      | `true`      |
+| `promtail.serviceAccount.create`                       | Enable creation of ServiceAccount for Promtail pods                                                                    | `true`      |
+| `promtail.serviceAccount.name`                         | The name of the ServiceAccount to use                                                                                  | `""`        |
+| `promtail.serviceAccount.automountServiceAccountToken` | Allows auto mount of ServiceAccountToken on the promtail.serviceAccount.created                                        | `false`     |
+| `promtail.serviceAccount.annotations`                  | Additional custom annotations for the ServiceAccount                                                                   | `{}`        |
 
 ### Init Container Parameters
 

--- a/bitnami/grafana-loki/templates/compactor/networkpolicy.yaml
+++ b/bitnami/grafana-loki/templates/compactor/networkpolicy.yaml
@@ -133,10 +133,10 @@ spec:
         {{- end }}
         {{- if .Values.compactor.networkPolicy.ingressNSMatchLabels }}
         - namespaceSelector:
-            matchLabels: {{- include "common.tplvalues.render" (dict "value" $ingressNSMatchLabels "context" $ ) | nindent 14 }}
+            matchLabels: {{- include "common.tplvalues.render" (dict "value" .Values.compactor.networkPolicy.ingressNSMatchLabels "context" $ ) | nindent 14 }}
           {{- if .Values.compactor.networkPolicy.ingressNSPodMatchLabels }}
           podSelector:
-            matchLabels: {{- include "common.tplvalues.render" (dict "value" $ingressNSPodMatchLabels "context" $ ) | nindent 14 }}
+            matchLabels: {{- include "common.tplvalues.render" (dict "value" .Values.compactor.networkPolicy.ingressNSPodMatchLabels "context" $ ) | nindent 14 }}
           {{- end }}
         {{- end }}
       {{- end }}

--- a/bitnami/grafana-loki/templates/compactor/networkpolicy.yaml
+++ b/bitnami/grafana-loki/templates/compactor/networkpolicy.yaml
@@ -122,21 +122,21 @@ spec:
         - podSelector:
             matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 14 }}
               app.kubernetes.io/part-of: grafana-loki
+        {{- if .Values.compactor.networkPolicy.addExternalClientAccess }}
         - podSelector:
             matchLabels:
               {{ template "grafana-loki.compactor.fullname" . }}-compactor: "true"
+        {{- end }}
+        {{- if .Values.compactor.networkPolicy.ingressPodMatchLabels }}
+        - podSelector:
+            matchLabels: {{- include "common.tplvalues.render" (dict "value" .Values.compactor.networkPolicy.ingressPodMatchLabels "context" $ ) | nindent 14 }}
+        {{- end }}
         {{- if .Values.compactor.networkPolicy.ingressNSMatchLabels }}
         - namespaceSelector:
-            matchLabels:
-              {{- range $key, $value := .Values.compactor.networkPolicy.ingressNSMatchLabels }}
-              {{ $key | quote }}: {{ $value | quote }}
-              {{- end }}
+            matchLabels: {{- include "common.tplvalues.render" (dict "value" $ingressNSMatchLabels "context" $ ) | nindent 14 }}
           {{- if .Values.compactor.networkPolicy.ingressNSPodMatchLabels }}
           podSelector:
-            matchLabels:
-              {{- range $key, $value := .Values.compactor.networkPolicy.ingressNSPodMatchLabels }}
-              {{ $key | quote }}: {{ $value | quote }}
-              {{- end }}
+            matchLabels: {{- include "common.tplvalues.render" (dict "value" $ingressNSPodMatchLabels "context" $ ) | nindent 14 }}
           {{- end }}
         {{- end }}
       {{- end }}

--- a/bitnami/grafana-loki/templates/distributor/networkpolicy.yaml
+++ b/bitnami/grafana-loki/templates/distributor/networkpolicy.yaml
@@ -125,10 +125,10 @@ spec:
         {{- end }}
         {{- if .Values.distributor.networkPolicy.ingressNSMatchLabels }}
         - namespaceSelector:
-            matchLabels: {{- include "common.tplvalues.render" (dict "value" $ingressNSMatchLabels "context" $ ) | nindent 14 }}
+            matchLabels: {{- include "common.tplvalues.render" (dict "value" .Values.distributor.networkPolicy.ingressNSMatchLabels "context" $ ) | nindent 14 }}
           {{- if .Values.distributor.networkPolicy.ingressNSPodMatchLabels }}
           podSelector:
-            matchLabels: {{- include "common.tplvalues.render" (dict "value" $ingressNSPodMatchLabels "context" $ ) | nindent 14 }}
+            matchLabels: {{- include "common.tplvalues.render" (dict "value" .Values.distributor.networkPolicy.ingressNSPodMatchLabels "context" $ ) | nindent 14 }}
           {{- end }}
         {{- end }}
       {{- end }}

--- a/bitnami/grafana-loki/templates/distributor/networkpolicy.yaml
+++ b/bitnami/grafana-loki/templates/distributor/networkpolicy.yaml
@@ -114,21 +114,21 @@ spec:
         - podSelector:
             matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 14 }}
               app.kubernetes.io/part-of: grafana-loki
+        {{- if .Values.distributor.networkPolicy.addExternalClientAccess }}
         - podSelector:
             matchLabels:
               {{ template "grafana-loki.distributor.fullname" . }}-distributor: "true"
+        {{- end }}
+        {{- if .Values.distributor.networkPolicy.ingressPodMatchLabels }}
+        - podSelector:
+            matchLabels: {{- include "common.tplvalues.render" (dict "value" .Values.distributor.networkPolicy.ingressPodMatchLabels "context" $ ) | nindent 14 }}
+        {{- end }}
         {{- if .Values.distributor.networkPolicy.ingressNSMatchLabels }}
         - namespaceSelector:
-            matchLabels:
-              {{- range $key, $value := .Values.distributor.networkPolicy.ingressNSMatchLabels }}
-              {{ $key | quote }}: {{ $value | quote }}
-              {{- end }}
+            matchLabels: {{- include "common.tplvalues.render" (dict "value" $ingressNSMatchLabels "context" $ ) | nindent 14 }}
           {{- if .Values.distributor.networkPolicy.ingressNSPodMatchLabels }}
           podSelector:
-            matchLabels:
-              {{- range $key, $value := .Values.distributor.networkPolicy.ingressNSPodMatchLabels }}
-              {{ $key | quote }}: {{ $value | quote }}
-              {{- end }}
+            matchLabels: {{- include "common.tplvalues.render" (dict "value" $ingressNSPodMatchLabels "context" $ ) | nindent 14 }}
           {{- end }}
         {{- end }}
       {{- end }}

--- a/bitnami/grafana-loki/templates/gateway/networkpolicy.yaml
+++ b/bitnami/grafana-loki/templates/gateway/networkpolicy.yaml
@@ -124,10 +124,10 @@ spec:
         {{- end }}
         {{- if .Values.gateway.networkPolicy.ingressNSMatchLabels }}
         - namespaceSelector:
-            matchLabels: {{- include "common.tplvalues.render" (dict "value" $ingressNSMatchLabels "context" $ ) | nindent 14 }}
+            matchLabels: {{- include "common.tplvalues.render" (dict "value" .Values.gateway.networkPolicy.ingressNSMatchLabels "context" $ ) | nindent 14 }}
           {{- if .Values.gateway.networkPolicy.ingressNSPodMatchLabels }}
           podSelector:
-            matchLabels: {{- include "common.tplvalues.render" (dict "value" $ingressNSPodMatchLabels "context" $ ) | nindent 14 }}
+            matchLabels: {{- include "common.tplvalues.render" (dict "value" .Values.gateway.networkPolicy.ingressNSPodMatchLabels "context" $ ) | nindent 14 }}
           {{- end }}
         {{- end }}
       {{- end }}

--- a/bitnami/grafana-loki/templates/gateway/networkpolicy.yaml
+++ b/bitnami/grafana-loki/templates/gateway/networkpolicy.yaml
@@ -113,21 +113,21 @@ spec:
         - podSelector:
             matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 14 }}
               app.kubernetes.io/part-of: grafana-loki
+        {{- if .Values.gateway.networkPolicy.addExternalClientAccess }}
         - podSelector:
             matchLabels:
               {{ template "grafana-loki.gateway.fullname" . }}-gateway: "true"
+        {{- end }}
+        {{- if .Values.gateway.networkPolicy.ingressPodMatchLabels }}
+        - podSelector:
+            matchLabels: {{- include "common.tplvalues.render" (dict "value" .Values.gateway.networkPolicy.ingressPodMatchLabels "context" $ ) | nindent 14 }}
+        {{- end }}
         {{- if .Values.gateway.networkPolicy.ingressNSMatchLabels }}
         - namespaceSelector:
-            matchLabels:
-              {{- range $key, $value := .Values.gateway.networkPolicy.ingressNSMatchLabels }}
-              {{ $key | quote }}: {{ $value | quote }}
-              {{- end }}
+            matchLabels: {{- include "common.tplvalues.render" (dict "value" $ingressNSMatchLabels "context" $ ) | nindent 14 }}
           {{- if .Values.gateway.networkPolicy.ingressNSPodMatchLabels }}
           podSelector:
-            matchLabels:
-              {{- range $key, $value := .Values.gateway.networkPolicy.ingressNSPodMatchLabels }}
-              {{ $key | quote }}: {{ $value | quote }}
-              {{- end }}
+            matchLabels: {{- include "common.tplvalues.render" (dict "value" $ingressNSPodMatchLabels "context" $ ) | nindent 14 }}
           {{- end }}
         {{- end }}
       {{- end }}

--- a/bitnami/grafana-loki/templates/index-gateway/networkpolicy.yaml
+++ b/bitnami/grafana-loki/templates/index-gateway/networkpolicy.yaml
@@ -114,21 +114,21 @@ spec:
         - podSelector:
             matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 14 }}
               app.kubernetes.io/part-of: grafana-loki
+        {{- if .Values.indexGateway.networkPolicy.addExternalClientAccess }}
         - podSelector:
             matchLabels:
               {{ template "grafana-loki.index-gateway.fullname" . }}-index-gateway: "true"
+        {{- end }}
+        {{- if .Values.indexGateway.networkPolicy.ingressPodMatchLabels }}
+        - podSelector:
+            matchLabels: {{- include "common.tplvalues.render" (dict "value" .Values.indexGateway.networkPolicy.ingressPodMatchLabels "context" $ ) | nindent 14 }}
+        {{- end }}
         {{- if .Values.indexGateway.networkPolicy.ingressNSMatchLabels }}
         - namespaceSelector:
-            matchLabels:
-              {{- range $key, $value := .Values.indexGateway.networkPolicy.ingressNSMatchLabels }}
-              {{ $key | quote }}: {{ $value | quote }}
-              {{- end }}
+            matchLabels: {{- include "common.tplvalues.render" (dict "value" $ingressNSMatchLabels "context" $ ) | nindent 14 }}
           {{- if .Values.indexGateway.networkPolicy.ingressNSPodMatchLabels }}
           podSelector:
-            matchLabels:
-              {{- range $key, $value := .Values.indexGateway.networkPolicy.ingressNSPodMatchLabels }}
-              {{ $key | quote }}: {{ $value | quote }}
-              {{- end }}
+            matchLabels: {{- include "common.tplvalues.render" (dict "value" $ingressNSPodMatchLabels "context" $ ) | nindent 14 }}
           {{- end }}
         {{- end }}
       {{- end }}

--- a/bitnami/grafana-loki/templates/index-gateway/networkpolicy.yaml
+++ b/bitnami/grafana-loki/templates/index-gateway/networkpolicy.yaml
@@ -125,10 +125,10 @@ spec:
         {{- end }}
         {{- if .Values.indexGateway.networkPolicy.ingressNSMatchLabels }}
         - namespaceSelector:
-            matchLabels: {{- include "common.tplvalues.render" (dict "value" $ingressNSMatchLabels "context" $ ) | nindent 14 }}
+            matchLabels: {{- include "common.tplvalues.render" (dict "value" .Values.indexGateway.networkPolicy.ingressNSMatchLabels "context" $ ) | nindent 14 }}
           {{- if .Values.indexGateway.networkPolicy.ingressNSPodMatchLabels }}
           podSelector:
-            matchLabels: {{- include "common.tplvalues.render" (dict "value" $ingressNSPodMatchLabels "context" $ ) | nindent 14 }}
+            matchLabels: {{- include "common.tplvalues.render" (dict "value" .Values.indexGateway.networkPolicy.ingressNSPodMatchLabels "context" $ ) | nindent 14 }}
           {{- end }}
         {{- end }}
       {{- end }}

--- a/bitnami/grafana-loki/templates/ingester/networkpolicy.yaml
+++ b/bitnami/grafana-loki/templates/ingester/networkpolicy.yaml
@@ -125,10 +125,10 @@ spec:
         {{- end }}
         {{- if .Values.ingester.networkPolicy.ingressNSMatchLabels }}
         - namespaceSelector:
-            matchLabels: {{- include "common.tplvalues.render" (dict "value" $ingressNSMatchLabels "context" $ ) | nindent 14 }}
+            matchLabels: {{- include "common.tplvalues.render" (dict "value" .Values.ingester.networkPolicy.ingressNSMatchLabels "context" $ ) | nindent 14 }}
           {{- if .Values.ingester.networkPolicy.ingressNSPodMatchLabels }}
           podSelector:
-            matchLabels: {{- include "common.tplvalues.render" (dict "value" $ingressNSPodMatchLabels "context" $ ) | nindent 14 }}
+            matchLabels: {{- include "common.tplvalues.render" (dict "value" .Values.ingester.networkPolicy.ingressNSPodMatchLabels "context" $ ) | nindent 14 }}
           {{- end }}
         {{- end }}
       {{- end }}

--- a/bitnami/grafana-loki/templates/ingester/networkpolicy.yaml
+++ b/bitnami/grafana-loki/templates/ingester/networkpolicy.yaml
@@ -114,21 +114,21 @@ spec:
         - podSelector:
             matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 14 }}
               app.kubernetes.io/part-of: grafana-loki
+        {{- if .Values.ingester.networkPolicy.addExternalClientAccess }}
         - podSelector:
             matchLabels:
               {{ template "grafana-loki.ingester.fullname" . }}-ingester: "true"
+        {{- end }}
+        {{- if .Values.ingester.networkPolicy.ingressPodMatchLabels }}
+        - podSelector:
+            matchLabels: {{- include "common.tplvalues.render" (dict "value" .Values.ingester.networkPolicy.ingressPodMatchLabels "context" $ ) | nindent 14 }}
+        {{- end }}
         {{- if .Values.ingester.networkPolicy.ingressNSMatchLabels }}
         - namespaceSelector:
-            matchLabels:
-              {{- range $key, $value := .Values.ingester.networkPolicy.ingressNSMatchLabels }}
-              {{ $key | quote }}: {{ $value | quote }}
-              {{- end }}
+            matchLabels: {{- include "common.tplvalues.render" (dict "value" $ingressNSMatchLabels "context" $ ) | nindent 14 }}
           {{- if .Values.ingester.networkPolicy.ingressNSPodMatchLabels }}
           podSelector:
-            matchLabels:
-              {{- range $key, $value := .Values.ingester.networkPolicy.ingressNSPodMatchLabels }}
-              {{ $key | quote }}: {{ $value | quote }}
-              {{- end }}
+            matchLabels: {{- include "common.tplvalues.render" (dict "value" $ingressNSPodMatchLabels "context" $ ) | nindent 14 }}
           {{- end }}
         {{- end }}
       {{- end }}

--- a/bitnami/grafana-loki/templates/promtail/networkpolicy.yaml
+++ b/bitnami/grafana-loki/templates/promtail/networkpolicy.yaml
@@ -127,10 +127,10 @@ spec:
         {{- end }}
         {{- if .Values.promtail.networkPolicy.ingressNSMatchLabels }}
         - namespaceSelector:
-            matchLabels: {{- include "common.tplvalues.render" (dict "value" $ingressNSMatchLabels "context" $ ) | nindent 14 }}
+            matchLabels: {{- include "common.tplvalues.render" (dict "value" .Values.promtail.networkPolicy.ingressNSMatchLabels "context" $ ) | nindent 14 }}
           {{- if .Values.promtail.networkPolicy.ingressNSPodMatchLabels }}
           podSelector:
-            matchLabels: {{- include "common.tplvalues.render" (dict "value" $ingressNSPodMatchLabels "context" $ ) | nindent 14 }}
+            matchLabels: {{- include "common.tplvalues.render" (dict "value" .Values.promtail.networkPolicy.ingressNSPodMatchLabels "context" $ ) | nindent 14 }}
           {{- end }}
         {{- end }}
       {{- end }}

--- a/bitnami/grafana-loki/templates/promtail/networkpolicy.yaml
+++ b/bitnami/grafana-loki/templates/promtail/networkpolicy.yaml
@@ -116,21 +116,21 @@ spec:
         - podSelector:
             matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 14 }}
               app.kubernetes.io/part-of: grafana-loki
+        {{- if .Values.promtail.networkPolicy.addExternalClientAccess }}
         - podSelector:
             matchLabels:
               {{ template "grafana-loki.promtail.fullname" . }}-promtail: "true"
+        {{- end }}
+        {{- if .Values.promtail.networkPolicy.ingressPodMatchLabels }}
+        - podSelector:
+            matchLabels: {{- include "common.tplvalues.render" (dict "value" .Values.promtail.networkPolicy.ingressPodMatchLabels "context" $ ) | nindent 14 }}
+        {{- end }}
         {{- if .Values.promtail.networkPolicy.ingressNSMatchLabels }}
         - namespaceSelector:
-            matchLabels:
-              {{- range $key, $value := .Values.promtail.networkPolicy.ingressNSMatchLabels }}
-              {{ $key | quote }}: {{ $value | quote }}
-              {{- end }}
+            matchLabels: {{- include "common.tplvalues.render" (dict "value" $ingressNSMatchLabels "context" $ ) | nindent 14 }}
           {{- if .Values.promtail.networkPolicy.ingressNSPodMatchLabels }}
           podSelector:
-            matchLabels:
-              {{- range $key, $value := .Values.promtail.networkPolicy.ingressNSPodMatchLabels }}
-              {{ $key | quote }}: {{ $value | quote }}
-              {{- end }}
+            matchLabels: {{- include "common.tplvalues.render" (dict "value" $ingressNSPodMatchLabels "context" $ ) | nindent 14 }}
           {{- end }}
         {{- end }}
       {{- end }}

--- a/bitnami/grafana-loki/templates/querier/networkpolicy.yaml
+++ b/bitnami/grafana-loki/templates/querier/networkpolicy.yaml
@@ -125,10 +125,10 @@ spec:
         {{- end }}
         {{- if .Values.querier.networkPolicy.ingressNSMatchLabels }}
         - namespaceSelector:
-            matchLabels: {{- include "common.tplvalues.render" (dict "value" $ingressNSMatchLabels "context" $ ) | nindent 14 }}
+            matchLabels: {{- include "common.tplvalues.render" (dict "value" .Values.querier.networkPolicy.ingressNSMatchLabels "context" $ ) | nindent 14 }}
           {{- if .Values.querier.networkPolicy.ingressNSPodMatchLabels }}
           podSelector:
-            matchLabels: {{- include "common.tplvalues.render" (dict "value" $ingressNSPodMatchLabels "context" $ ) | nindent 14 }}
+            matchLabels: {{- include "common.tplvalues.render" (dict "value" .Values.querier.networkPolicy.ingressNSPodMatchLabels "context" $ ) | nindent 14 }}
           {{- end }}
         {{- end }}
       {{- end }}

--- a/bitnami/grafana-loki/templates/querier/networkpolicy.yaml
+++ b/bitnami/grafana-loki/templates/querier/networkpolicy.yaml
@@ -114,21 +114,21 @@ spec:
         - podSelector:
             matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 14 }}
               app.kubernetes.io/part-of: grafana-loki
+        {{- if .Values.querier.networkPolicy.addExternalClientAccess }}
         - podSelector:
             matchLabels:
               {{ template "grafana-loki.querier.fullname" . }}-querier: "true"
+        {{- end }}
+        {{- if .Values.querier.networkPolicy.ingressPodMatchLabels }}
+        - podSelector:
+            matchLabels: {{- include "common.tplvalues.render" (dict "value" .Values.querier.networkPolicy.ingressPodMatchLabels "context" $ ) | nindent 14 }}
+        {{- end }}
         {{- if .Values.querier.networkPolicy.ingressNSMatchLabels }}
         - namespaceSelector:
-            matchLabels:
-              {{- range $key, $value := .Values.querier.networkPolicy.ingressNSMatchLabels }}
-              {{ $key | quote }}: {{ $value | quote }}
-              {{- end }}
+            matchLabels: {{- include "common.tplvalues.render" (dict "value" $ingressNSMatchLabels "context" $ ) | nindent 14 }}
           {{- if .Values.querier.networkPolicy.ingressNSPodMatchLabels }}
           podSelector:
-            matchLabels:
-              {{- range $key, $value := .Values.querier.networkPolicy.ingressNSPodMatchLabels }}
-              {{ $key | quote }}: {{ $value | quote }}
-              {{- end }}
+            matchLabels: {{- include "common.tplvalues.render" (dict "value" $ingressNSPodMatchLabels "context" $ ) | nindent 14 }}
           {{- end }}
         {{- end }}
       {{- end }}

--- a/bitnami/grafana-loki/templates/query-frontend/networkpolicy.yaml
+++ b/bitnami/grafana-loki/templates/query-frontend/networkpolicy.yaml
@@ -125,10 +125,10 @@ spec:
         {{- end }}
         {{- if .Values.queryFrontend.networkPolicy.ingressNSMatchLabels }}
         - namespaceSelector:
-            matchLabels: {{- include "common.tplvalues.render" (dict "value" $ingressNSMatchLabels "context" $ ) | nindent 14 }}
+            matchLabels: {{- include "common.tplvalues.render" (dict "value" .Values.queryFrontend.networkPolicy.ingressNSMatchLabels "context" $ ) | nindent 14 }}
           {{- if .Values.queryFrontend.networkPolicy.ingressNSPodMatchLabels }}
           podSelector:
-            matchLabels: {{- include "common.tplvalues.render" (dict "value" $ingressNSPodMatchLabels "context" $ ) | nindent 14 }}
+            matchLabels: {{- include "common.tplvalues.render" (dict "value" .Values.queryFrontend.networkPolicy.ingressNSPodMatchLabels "context" $ ) | nindent 14 }}
           {{- end }}
         {{- end }}
       {{- end }}

--- a/bitnami/grafana-loki/templates/query-frontend/networkpolicy.yaml
+++ b/bitnami/grafana-loki/templates/query-frontend/networkpolicy.yaml
@@ -114,21 +114,21 @@ spec:
         - podSelector:
             matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 14 }}
               app.kubernetes.io/part-of: grafana-loki
+        {{- if .Values.queryFrontend.networkPolicy.addExternalClientAccess }}
         - podSelector:
             matchLabels:
               {{ template "grafana-loki.query-frontend.fullname" . }}-query-frontend: "true"
+        {{- end }}
+        {{- if .Values.queryFrontend.networkPolicy.ingressPodMatchLabels }}
+        - podSelector:
+            matchLabels: {{- include "common.tplvalues.render" (dict "value" .Values.queryFrontend.networkPolicy.ingressPodMatchLabels "context" $ ) | nindent 14 }}
+        {{- end }}
         {{- if .Values.queryFrontend.networkPolicy.ingressNSMatchLabels }}
         - namespaceSelector:
-            matchLabels:
-              {{- range $key, $value := .Values.queryFrontend.networkPolicy.ingressNSMatchLabels }}
-              {{ $key | quote }}: {{ $value | quote }}
-              {{- end }}
+            matchLabels: {{- include "common.tplvalues.render" (dict "value" $ingressNSMatchLabels "context" $ ) | nindent 14 }}
           {{- if .Values.queryFrontend.networkPolicy.ingressNSPodMatchLabels }}
           podSelector:
-            matchLabels:
-              {{- range $key, $value := .Values.queryFrontend.networkPolicy.ingressNSPodMatchLabels }}
-              {{ $key | quote }}: {{ $value | quote }}
-              {{- end }}
+            matchLabels: {{- include "common.tplvalues.render" (dict "value" $ingressNSPodMatchLabels "context" $ ) | nindent 14 }}
           {{- end }}
         {{- end }}
       {{- end }}

--- a/bitnami/grafana-loki/templates/query-scheduler/networkpolicy.yaml
+++ b/bitnami/grafana-loki/templates/query-scheduler/networkpolicy.yaml
@@ -114,21 +114,21 @@ spec:
         - podSelector:
             matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 14 }}
               app.kubernetes.io/part-of: grafana-loki
+        {{- if .Values.queryScheduler.networkPolicy.addExternalClientAccess }}
         - podSelector:
             matchLabels:
               {{ template "grafana-loki.query-scheduler.fullname" . }}-query-scheduler: "true"
+        {{- end }}
+        {{- if .Values.queryScheduler.networkPolicy.ingressPodMatchLabels }}
+        - podSelector:
+            matchLabels: {{- include "common.tplvalues.render" (dict "value" .Values.queryScheduler.networkPolicy.ingressPodMatchLabels "context" $ ) | nindent 14 }}
+        {{- end }}
         {{- if .Values.queryScheduler.networkPolicy.ingressNSMatchLabels }}
         - namespaceSelector:
-            matchLabels:
-              {{- range $key, $value := .Values.queryScheduler.networkPolicy.ingressNSMatchLabels }}
-              {{ $key | quote }}: {{ $value | quote }}
-              {{- end }}
+            matchLabels: {{- include "common.tplvalues.render" (dict "value" $ingressNSMatchLabels "context" $ ) | nindent 14 }}
           {{- if .Values.queryScheduler.networkPolicy.ingressNSPodMatchLabels }}
           podSelector:
-            matchLabels:
-              {{- range $key, $value := .Values.queryScheduler.networkPolicy.ingressNSPodMatchLabels }}
-              {{ $key | quote }}: {{ $value | quote }}
-              {{- end }}
+            matchLabels: {{- include "common.tplvalues.render" (dict "value" $ingressNSPodMatchLabels "context" $ ) | nindent 14 }}
           {{- end }}
         {{- end }}
       {{- end }}

--- a/bitnami/grafana-loki/templates/query-scheduler/networkpolicy.yaml
+++ b/bitnami/grafana-loki/templates/query-scheduler/networkpolicy.yaml
@@ -125,10 +125,10 @@ spec:
         {{- end }}
         {{- if .Values.queryScheduler.networkPolicy.ingressNSMatchLabels }}
         - namespaceSelector:
-            matchLabels: {{- include "common.tplvalues.render" (dict "value" $ingressNSMatchLabels "context" $ ) | nindent 14 }}
+            matchLabels: {{- include "common.tplvalues.render" (dict "value" .Values.queryScheduler.networkPolicy.ingressNSMatchLabels "context" $ ) | nindent 14 }}
           {{- if .Values.queryScheduler.networkPolicy.ingressNSPodMatchLabels }}
           podSelector:
-            matchLabels: {{- include "common.tplvalues.render" (dict "value" $ingressNSPodMatchLabels "context" $ ) | nindent 14 }}
+            matchLabels: {{- include "common.tplvalues.render" (dict "value" .Values.queryScheduler.networkPolicy.ingressNSPodMatchLabels "context" $ ) | nindent 14 }}
           {{- end }}
         {{- end }}
       {{- end }}

--- a/bitnami/grafana-loki/templates/ruler/networkpolicy.yaml
+++ b/bitnami/grafana-loki/templates/ruler/networkpolicy.yaml
@@ -125,10 +125,10 @@ spec:
         {{- end }}
         {{- if .Values.ruler.networkPolicy.ingressNSMatchLabels }}
         - namespaceSelector:
-            matchLabels: {{- include "common.tplvalues.render" (dict "value" $ingressNSMatchLabels "context" $ ) | nindent 14 }}
+            matchLabels: {{- include "common.tplvalues.render" (dict "value" .Values.ruler.networkPolicy.ingressNSMatchLabels "context" $ ) | nindent 14 }}
           {{- if .Values.ruler.networkPolicy.ingressNSPodMatchLabels }}
           podSelector:
-            matchLabels: {{- include "common.tplvalues.render" (dict "value" $ingressNSPodMatchLabels "context" $ ) | nindent 14 }}
+            matchLabels: {{- include "common.tplvalues.render" (dict "value" .Values.ruler.networkPolicy.ingressNSPodMatchLabels "context" $ ) | nindent 14 }}
           {{- end }}
         {{- end }}
       {{- end }}

--- a/bitnami/grafana-loki/templates/ruler/networkpolicy.yaml
+++ b/bitnami/grafana-loki/templates/ruler/networkpolicy.yaml
@@ -114,21 +114,21 @@ spec:
         - podSelector:
             matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 14 }}
               app.kubernetes.io/part-of: grafana-loki
+        {{- if .Values.ruler.networkPolicy.addExternalClientAccess }}
         - podSelector:
             matchLabels:
               {{ template "grafana-loki.ruler.fullname" . }}-ruler: "true"
+        {{- end }}
+        {{- if .Values.ruler.networkPolicy.ingressPodMatchLabels }}
+        - podSelector:
+            matchLabels: {{- include "common.tplvalues.render" (dict "value" .Values.ruler.networkPolicy.ingressPodMatchLabels "context" $ ) | nindent 14 }}
+        {{- end }}
         {{- if .Values.ruler.networkPolicy.ingressNSMatchLabels }}
         - namespaceSelector:
-            matchLabels:
-              {{- range $key, $value := .Values.ruler.networkPolicy.ingressNSMatchLabels }}
-              {{ $key | quote }}: {{ $value | quote }}
-              {{- end }}
+            matchLabels: {{- include "common.tplvalues.render" (dict "value" $ingressNSMatchLabels "context" $ ) | nindent 14 }}
           {{- if .Values.ruler.networkPolicy.ingressNSPodMatchLabels }}
           podSelector:
-            matchLabels:
-              {{- range $key, $value := .Values.ruler.networkPolicy.ingressNSPodMatchLabels }}
-              {{ $key | quote }}: {{ $value | quote }}
-              {{- end }}
+            matchLabels: {{- include "common.tplvalues.render" (dict "value" $ingressNSPodMatchLabels "context" $ ) | nindent 14 }}
           {{- end }}
         {{- end }}
       {{- end }}

--- a/bitnami/grafana-loki/templates/table-manager/networkpolicy.yaml
+++ b/bitnami/grafana-loki/templates/table-manager/networkpolicy.yaml
@@ -114,21 +114,21 @@ spec:
         - podSelector:
             matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 14 }}
               app.kubernetes.io/part-of: grafana-loki
+        {{- if .Values.tableManager.networkPolicy.addExternalClientAccess }}
         - podSelector:
             matchLabels:
               {{ template "grafana-loki.table-manager.fullname" . }}-table-manager: "true"
+        {{- end }}
+        {{- if .Values.tableManager.networkPolicy.ingressPodMatchLabels }}
+        - podSelector:
+            matchLabels: {{- include "common.tplvalues.render" (dict "value" .Values.tableManager.networkPolicy.ingressPodMatchLabels "context" $ ) | nindent 14 }}
+        {{- end }}
         {{- if .Values.tableManager.networkPolicy.ingressNSMatchLabels }}
         - namespaceSelector:
-            matchLabels:
-              {{- range $key, $value := .Values.tableManager.networkPolicy.ingressNSMatchLabels }}
-              {{ $key | quote }}: {{ $value | quote }}
-              {{- end }}
+            matchLabels: {{- include "common.tplvalues.render" (dict "value" $ingressNSMatchLabels "context" $ ) | nindent 14 }}
           {{- if .Values.tableManager.networkPolicy.ingressNSPodMatchLabels }}
           podSelector:
-            matchLabels:
-              {{- range $key, $value := .Values.tableManager.networkPolicy.ingressNSPodMatchLabels }}
-              {{ $key | quote }}: {{ $value | quote }}
-              {{- end }}
+            matchLabels: {{- include "common.tplvalues.render" (dict "value" $ingressNSPodMatchLabels "context" $ ) | nindent 14 }}
           {{- end }}
         {{- end }}
       {{- end }}

--- a/bitnami/grafana-loki/templates/table-manager/networkpolicy.yaml
+++ b/bitnami/grafana-loki/templates/table-manager/networkpolicy.yaml
@@ -125,10 +125,10 @@ spec:
         {{- end }}
         {{- if .Values.tableManager.networkPolicy.ingressNSMatchLabels }}
         - namespaceSelector:
-            matchLabels: {{- include "common.tplvalues.render" (dict "value" $ingressNSMatchLabels "context" $ ) | nindent 14 }}
+            matchLabels: {{- include "common.tplvalues.render" (dict "value" .Values.tableManager.networkPolicy.ingressNSMatchLabels "context" $ ) | nindent 14 }}
           {{- if .Values.tableManager.networkPolicy.ingressNSPodMatchLabels }}
           podSelector:
-            matchLabels: {{- include "common.tplvalues.render" (dict "value" $ingressNSPodMatchLabels "context" $ ) | nindent 14 }}
+            matchLabels: {{- include "common.tplvalues.render" (dict "value" .Values.tableManager.networkPolicy.ingressNSPodMatchLabels "context" $ ) | nindent 14 }}
           {{- end }}
         {{- end }}
       {{- end }}

--- a/bitnami/grafana-loki/values.yaml
+++ b/bitnami/grafana-loki/values.yaml
@@ -657,6 +657,9 @@ compactor:
     ## @param compactor.networkPolicy.allowExternalEgress Allow the pod to access any range of port and all destinations.
     ##
     allowExternalEgress: true
+    ## @param compactor.networkPolicy.addExternalClientAccess Allow access from pods with client label set to "true". Ignored if `compactor.networkPolicy.allowExternal` is true.
+    ##
+    addExternalClientAccess: true
     ## @param compactor.networkPolicy.extraIngress [array] Add extra ingress rules to the NetworkPolicy
     ## e.g:
     ## extraIngress:
@@ -690,8 +693,14 @@ compactor:
     ##                   - frontend
     ##
     extraEgress: []
-    ## @param compactor.networkPolicy.ingressNSMatchLabels [object] Labels to match to allow traffic from other namespaces
-    ## @param compactor.networkPolicy.ingressNSPodMatchLabels [object] Pod labels to match to allow traffic from other namespaces
+    ## @param compactor.networkPolicy.ingressPodMatchLabels [object] Labels to match to allow traffic from other pods. Ignored if `compactor.networkPolicy.allowExternal` is true.
+    ## e.g:
+    ## ingressPodMatchLabels:
+    ##   my-client: "true"
+    #
+    ingressPodMatchLabels: {}
+    ## @param compactor.networkPolicy.ingressNSMatchLabels [object] Labels to match to allow traffic from other namespaces. Ignored if `compactor.networkPolicy.allowExternal` is true.
+    ## @param compactor.networkPolicy.ingressNSPodMatchLabels [object] Pod labels to match to allow traffic from other namespaces. Ignored if `compactor.networkPolicy.allowExternal` is true.
     ##
     ingressNSMatchLabels: {}
     ingressNSPodMatchLabels: {}
@@ -1056,6 +1065,9 @@ gateway:
     ## @param gateway.networkPolicy.allowExternalEgress Allow the pod to access any range of port and all destinations.
     ##
     allowExternalEgress: true
+    ## @param gateway.networkPolicy.addExternalClientAccess Allow access from pods with client label set to "true". Ignored if `gateway.networkPolicy.allowExternal` is true.
+    ##
+    addExternalClientAccess: true
     ## @param gateway.networkPolicy.extraIngress [array] Add extra ingress rules to the NetworkPolicy
     ## e.g:
     ## extraIngress:
@@ -1089,8 +1101,14 @@ gateway:
     ##                   - frontend
     ##
     extraEgress: []
-    ## @param gateway.networkPolicy.ingressNSMatchLabels [object] Labels to match to allow traffic from other namespaces
-    ## @param gateway.networkPolicy.ingressNSPodMatchLabels [object] Pod labels to match to allow traffic from other namespaces
+    ## @param gateway.networkPolicy.ingressPodMatchLabels [object] Labels to match to allow traffic from other pods. Ignored if `gateway.networkPolicy.allowExternal` is true.
+    ## e.g:
+    ## ingressPodMatchLabels:
+    ##   my-client: "true"
+    #
+    ingressPodMatchLabels: {}
+    ## @param gateway.networkPolicy.ingressNSMatchLabels [object] Labels to match to allow traffic from other namespaces. Ignored if `gateway.networkPolicy.allowExternal` is true.
+    ## @param gateway.networkPolicy.ingressNSPodMatchLabels [object] Pod labels to match to allow traffic from other namespaces. Ignored if `gateway.networkPolicy.allowExternal` is true.
     ##
     ingressNSMatchLabels: {}
     ingressNSPodMatchLabels: {}
@@ -1549,6 +1567,9 @@ indexGateway:
     ## @param indexGateway.networkPolicy.allowExternalEgress Allow the pod to access any range of port and all destinations.
     ##
     allowExternalEgress: true
+    ## @param indexGateway.networkPolicy.addExternalClientAccess Allow access from pods with client label set to "true". Ignored if `indexGateway.networkPolicy.allowExternal` is true.
+    ##
+    addExternalClientAccess: true
     ## @param indexGateway.networkPolicy.extraIngress [array] Add extra ingress rules to the NetworkPolicy
     ## e.g:
     ## extraIngress:
@@ -1582,8 +1603,14 @@ indexGateway:
     ##                   - frontend
     ##
     extraEgress: []
-    ## @param indexGateway.networkPolicy.ingressNSMatchLabels [object] Labels to match to allow traffic from other namespaces
-    ## @param indexGateway.networkPolicy.ingressNSPodMatchLabels [object] Pod labels to match to allow traffic from other namespaces
+    ## @param indexGateway.networkPolicy.ingressPodMatchLabels [object] Labels to match to allow traffic from other pods. Ignored if `indexGateway.networkPolicy.allowExternal` is true.
+    ## e.g:
+    ## ingressPodMatchLabels:
+    ##   my-client: "true"
+    #
+    ingressPodMatchLabels: {}
+    ## @param indexGateway.networkPolicy.ingressNSMatchLabels [object] Labels to match to allow traffic from other namespaces. Ignored if `indexGateway.networkPolicy.allowExternal` is true.
+    ## @param indexGateway.networkPolicy.ingressNSPodMatchLabels [object] Pod labels to match to allow traffic from other namespaces. Ignored if `indexGateway.networkPolicy.allowExternal` is true.
     ##
     ingressNSMatchLabels: {}
     ingressNSPodMatchLabels: {}
@@ -1903,6 +1930,9 @@ distributor:
     ## @param distributor.networkPolicy.allowExternalEgress Allow the pod to access any range of port and all destinations.
     ##
     allowExternalEgress: true
+    ## @param distributor.networkPolicy.addExternalClientAccess Allow access from pods with client label set to "true". Ignored if `distributor.networkPolicy.allowExternal` is true.
+    ##
+    addExternalClientAccess: true
     ## @param distributor.networkPolicy.extraIngress [array] Add extra ingress rules to the NetworkPolicy
     ## e.g:
     ## extraIngress:
@@ -1936,8 +1966,14 @@ distributor:
     ##                   - frontend
     ##
     extraEgress: []
-    ## @param distributor.networkPolicy.ingressNSMatchLabels [object] Labels to match to allow traffic from other namespaces
-    ## @param distributor.networkPolicy.ingressNSPodMatchLabels [object] Pod labels to match to allow traffic from other namespaces
+    ## @param distributor.networkPolicy.ingressPodMatchLabels [object] Labels to match to allow traffic from other pods. Ignored if `distributor.networkPolicy.allowExternal` is true.
+    ## e.g:
+    ## ingressPodMatchLabels:
+    ##   my-client: "true"
+    #
+    ingressPodMatchLabels: {}
+    ## @param distributor.networkPolicy.ingressNSMatchLabels [object] Labels to match to allow traffic from other namespaces. Ignored if `distributor.networkPolicy.allowExternal` is true.
+    ## @param distributor.networkPolicy.ingressNSPodMatchLabels [object] Pod labels to match to allow traffic from other namespaces. Ignored if `distributor.networkPolicy.allowExternal` is true.
     ##
     ingressNSMatchLabels: {}
     ingressNSPodMatchLabels: {}
@@ -2300,6 +2336,9 @@ ingester:
     ## @param ingester.networkPolicy.allowExternalEgress Allow the pod to access any range of port and all destinations.
     ##
     allowExternalEgress: true
+    ## @param ingester.networkPolicy.addExternalClientAccess Allow access from pods with client label set to "true". Ignored if `ingester.networkPolicy.allowExternal` is true.
+    ##
+    addExternalClientAccess: true
     ## @param ingester.networkPolicy.extraIngress [array] Add extra ingress rules to the NetworkPolicy
     ## e.g:
     ## extraIngress:
@@ -2333,8 +2372,14 @@ ingester:
     ##                   - frontend
     ##
     extraEgress: []
-    ## @param ingester.networkPolicy.ingressNSMatchLabels [object] Labels to match to allow traffic from other namespaces
-    ## @param ingester.networkPolicy.ingressNSPodMatchLabels [object] Pod labels to match to allow traffic from other namespaces
+    ## @param ingester.networkPolicy.ingressPodMatchLabels [object] Labels to match to allow traffic from other pods. Ignored if `ingester.networkPolicy.allowExternal` is true.
+    ## e.g:
+    ## ingressPodMatchLabels:
+    ##   my-client: "true"
+    #
+    ingressPodMatchLabels: {}
+    ## @param ingester.networkPolicy.ingressNSMatchLabels [object] Labels to match to allow traffic from other namespaces. Ignored if `ingester.networkPolicy.allowExternal` is true.
+    ## @param ingester.networkPolicy.ingressNSPodMatchLabels [object] Pod labels to match to allow traffic from other namespaces. Ignored if `ingester.networkPolicy.allowExternal` is true.
     ##
     ingressNSMatchLabels: {}
     ingressNSPodMatchLabels: {}
@@ -2697,6 +2742,9 @@ querier:
     ## @param querier.networkPolicy.allowExternalEgress Allow the pod to access any range of port and all destinations.
     ##
     allowExternalEgress: true
+    ## @param querier.networkPolicy.addExternalClientAccess Allow access from pods with client label set to "true". Ignored if `querier.networkPolicy.allowExternal` is true.
+    ##
+    addExternalClientAccess: true
     ## @param querier.networkPolicy.extraIngress [array] Add extra ingress rules to the NetworkPolicy
     ## e.g:
     ## extraIngress:
@@ -2730,8 +2778,14 @@ querier:
     ##                   - frontend
     ##
     extraEgress: []
-    ## @param querier.networkPolicy.ingressNSMatchLabels [object] Labels to match to allow traffic from other namespaces
-    ## @param querier.networkPolicy.ingressNSPodMatchLabels [object] Pod labels to match to allow traffic from other namespaces
+    ## @param querier.networkPolicy.ingressPodMatchLabels [object] Labels to match to allow traffic from other pods. Ignored if `querier.networkPolicy.allowExternal` is true.
+    ## e.g:
+    ## ingressPodMatchLabels:
+    ##   my-client: "true"
+    #
+    ingressPodMatchLabels: {}
+    ## @param querier.networkPolicy.ingressNSMatchLabels [object] Labels to match to allow traffic from other namespaces. Ignored if `querier.networkPolicy.allowExternal` is true.
+    ## @param querier.networkPolicy.ingressNSPodMatchLabels [object] Pod labels to match to allow traffic from other namespaces. Ignored if `querier.networkPolicy.allowExternal` is true.
     ##
     ingressNSMatchLabels: {}
     ingressNSPodMatchLabels: {}
@@ -3057,6 +3111,9 @@ queryFrontend:
     ## @param queryFrontend.networkPolicy.allowExternalEgress Allow the pod to access any range of port and all destinations.
     ##
     allowExternalEgress: true
+    ## @param queryFrontend.networkPolicy.addExternalClientAccess Allow access from pods with client label set to "true". Ignored if `queryFrontend.networkPolicy.allowExternal` is true.
+    ##
+    addExternalClientAccess: true
     ## @param queryFrontend.networkPolicy.extraIngress [array] Add extra ingress rules to the NetworkPolicy
     ## e.g:
     ## extraIngress:
@@ -3090,8 +3147,14 @@ queryFrontend:
     ##                   - frontend
     ##
     extraEgress: []
-    ## @param queryFrontend.networkPolicy.ingressNSMatchLabels [object] Labels to match to allow traffic from other namespaces
-    ## @param queryFrontend.networkPolicy.ingressNSPodMatchLabels [object] Pod labels to match to allow traffic from other namespaces
+    ## @param queryFrontend.networkPolicy.ingressPodMatchLabels [object] Labels to match to allow traffic from other pods. Ignored if `queryFrontend.networkPolicy.allowExternal` is true.
+    ## e.g:
+    ## ingressPodMatchLabels:
+    ##   my-client: "true"
+    #
+    ingressPodMatchLabels: {}
+    ## @param queryFrontend.networkPolicy.ingressNSMatchLabels [object] Labels to match to allow traffic from other namespaces. Ignored if `queryFrontend.networkPolicy.allowExternal` is true.
+    ## @param queryFrontend.networkPolicy.ingressNSPodMatchLabels [object] Pod labels to match to allow traffic from other namespaces. Ignored if `queryFrontend.networkPolicy.allowExternal` is true.
     ##
     ingressNSMatchLabels: {}
     ingressNSPodMatchLabels: {}
@@ -3414,6 +3477,9 @@ queryScheduler:
     ## @param queryScheduler.networkPolicy.allowExternalEgress Allow the pod to access any range of port and all destinations.
     ##
     allowExternalEgress: true
+    ## @param queryScheduler.networkPolicy.addExternalClientAccess Allow access from pods with client label set to "true". Ignored if `queryScheduler.networkPolicy.allowExternal` is true.
+    ##
+    addExternalClientAccess: true
     ## @param queryScheduler.networkPolicy.extraIngress [array] Add extra ingress rules to the NetworkPolicy
     ## e.g:
     ## extraIngress:
@@ -3447,8 +3513,14 @@ queryScheduler:
     ##                   - frontend
     ##
     extraEgress: []
-    ## @param queryScheduler.networkPolicy.ingressNSMatchLabels [object] Labels to match to allow traffic from other namespaces
-    ## @param queryScheduler.networkPolicy.ingressNSPodMatchLabels [object] Pod labels to match to allow traffic from other namespaces
+    ## @param queryScheduler.networkPolicy.ingressPodMatchLabels [object] Labels to match to allow traffic from other pods. Ignored if `queryScheduler.networkPolicy.allowExternal` is true.
+    ## e.g:
+    ## ingressPodMatchLabels:
+    ##   my-client: "true"
+    #
+    ingressPodMatchLabels: {}
+    ## @param queryScheduler.networkPolicy.ingressNSMatchLabels [object] Labels to match to allow traffic from other namespaces. Ignored if `queryScheduler.networkPolicy.allowExternal` is true.
+    ## @param queryScheduler.networkPolicy.ingressNSPodMatchLabels [object] Pod labels to match to allow traffic from other namespaces. Ignored if `queryScheduler.networkPolicy.allowExternal` is true.
     ##
     ingressNSMatchLabels: {}
     ingressNSPodMatchLabels: {}
@@ -3814,6 +3886,9 @@ ruler:
     ## @param ruler.networkPolicy.allowExternalEgress Allow the pod to access any range of port and all destinations.
     ##
     allowExternalEgress: true
+    ## @param ruler.networkPolicy.addExternalClientAccess Allow access from pods with client label set to "true". Ignored if `ruler.networkPolicy.allowExternal` is true.
+    ##
+    addExternalClientAccess: true
     ## @param ruler.networkPolicy.extraIngress [array] Add extra ingress rules to the NetworkPolicy
     ## e.g:
     ## extraIngress:
@@ -3847,8 +3922,14 @@ ruler:
     ##                   - frontend
     ##
     extraEgress: []
-    ## @param ruler.networkPolicy.ingressNSMatchLabels [object] Labels to match to allow traffic from other namespaces
-    ## @param ruler.networkPolicy.ingressNSPodMatchLabels [object] Pod labels to match to allow traffic from other namespaces
+    ## @param ruler.networkPolicy.ingressPodMatchLabels [object] Labels to match to allow traffic from other pods. Ignored if `ruler.networkPolicy.allowExternal` is true.
+    ## e.g:
+    ## ingressPodMatchLabels:
+    ##   my-client: "true"
+    #
+    ingressPodMatchLabels: {}
+    ## @param ruler.networkPolicy.ingressNSMatchLabels [object] Labels to match to allow traffic from other namespaces. Ignored if `ruler.networkPolicy.allowExternal` is true.
+    ## @param ruler.networkPolicy.ingressNSPodMatchLabels [object] Pod labels to match to allow traffic from other namespaces. Ignored if `ruler.networkPolicy.allowExternal` is true.
     ##
     ingressNSMatchLabels: {}
     ingressNSPodMatchLabels: {}
@@ -4171,6 +4252,9 @@ tableManager:
     ## @param tableManager.networkPolicy.allowExternalEgress Allow the pod to access any range of port and all destinations.
     ##
     allowExternalEgress: true
+    ## @param tableManager.networkPolicy.addExternalClientAccess Allow access from pods with client label set to "true". Ignored if `tableManager.networkPolicy.allowExternal` is true.
+    ##
+    addExternalClientAccess: true
     ## @param tableManager.networkPolicy.extraIngress [array] Add extra ingress rules to the NetworkPolicy
     ## e.g:
     ## extraIngress:
@@ -4204,8 +4288,14 @@ tableManager:
     ##                   - frontend
     ##
     extraEgress: []
-    ## @param tableManager.networkPolicy.ingressNSMatchLabels [object] Labels to match to allow traffic from other namespaces
-    ## @param tableManager.networkPolicy.ingressNSPodMatchLabels [object] Pod labels to match to allow traffic from other namespaces
+    ## @param tableManager.networkPolicy.ingressPodMatchLabels [object] Labels to match to allow traffic from other pods. Ignored if `tableManager.networkPolicy.allowExternal` is true.
+    ## e.g:
+    ## ingressPodMatchLabels:
+    ##   my-client: "true"
+    #
+    ingressPodMatchLabels: {}
+    ## @param tableManager.networkPolicy.ingressNSMatchLabels [object] Labels to match to allow traffic from other namespaces. Ignored if `tableManager.networkPolicy.allowExternal` is true.
+    ## @param tableManager.networkPolicy.ingressNSPodMatchLabels [object] Pod labels to match to allow traffic from other namespaces. Ignored if `tableManager.networkPolicy.allowExternal` is true.
     ##
     ingressNSMatchLabels: {}
     ingressNSPodMatchLabels: {}
@@ -4647,6 +4737,9 @@ promtail:
     ## @param promtail.networkPolicy.allowExternalEgress Allow the pod to access any range of port and all destinations.
     ##
     allowExternalEgress: true
+    ## @param promtail.networkPolicy.addExternalClientAccess Allow access from pods with client label set to "true". Ignored if `promtail.networkPolicy.allowExternal` is true.
+    ##
+    addExternalClientAccess: true
     ## @param promtail.networkPolicy.kubeAPIServerPorts [array] List of possible endpoints to kube-apiserver (limit to your cluster settings to increase security)
     ##
     kubeAPIServerPorts: [443, 6443, 8443]
@@ -4683,8 +4776,14 @@ promtail:
     ##                   - frontend
     ##
     extraEgress: []
-    ## @param promtail.networkPolicy.ingressNSMatchLabels [object] Labels to match to allow traffic from other namespaces
-    ## @param promtail.networkPolicy.ingressNSPodMatchLabels [object] Pod labels to match to allow traffic from other namespaces
+    ## @param promtail.networkPolicy.ingressPodMatchLabels [object] Labels to match to allow traffic from other pods. Ignored if `promtail.networkPolicy.allowExternal` is true.
+    ## e.g:
+    ## ingressPodMatchLabels:
+    ##   my-client: "true"
+    #
+    ingressPodMatchLabels: {}
+    ## @param promtail.networkPolicy.ingressNSMatchLabels [object] Labels to match to allow traffic from other namespaces. Ignored if `promtail.networkPolicy.allowExternal` is true.
+    ## @param promtail.networkPolicy.ingressNSPodMatchLabels [object] Pod labels to match to allow traffic from other namespaces. Ignored if `promtail.networkPolicy.allowExternal` is true.
     ##
     ingressNSMatchLabels: {}
     ingressNSPodMatchLabels: {}


### PR DESCRIPTION
### Description of the change

Apply the same changes made in PR #25519 to the Loki chart

Review network policy features to allow users cover their needs without forcing specific labels.

### Benefits

Users can restrict access to their deployments in a cleaner way, without leaving open doors to specific labeled pods.

### Possible drawbacks

None

### Applicable issues

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
