### PR TITLE
[bitnami/memcached] Network policy review

### DIFF
--- a/bitnami/memcached/Chart.yaml
+++ b/bitnami/memcached/Chart.yaml
@@ -31,4 +31,4 @@ maintainers:
 name: memcached
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/memcached
-version: 7.0.6
+version: 7.1.0

--- a/bitnami/memcached/README.md
+++ b/bitnami/memcached/README.md
@@ -237,26 +237,28 @@ If you encounter errors when working with persistent volumes, refer to our [trou
 
 ### Traffic Exposure parameters
 
-| Name                                    | Description                                                                             | Value       |
-| --------------------------------------- | --------------------------------------------------------------------------------------- | ----------- |
-| `service.type`                          | Kubernetes Service type                                                                 | `ClusterIP` |
-| `service.ports.memcached`               | Memcached service port                                                                  | `11211`     |
-| `service.nodePorts.memcached`           | Node port for Memcached                                                                 | `""`        |
-| `service.sessionAffinity`               | Control where client requests go, to the same pod or round-robin                        | `""`        |
-| `service.sessionAffinityConfig`         | Additional settings for the sessionAffinity                                             | `{}`        |
-| `service.clusterIP`                     | Memcached service Cluster IP                                                            | `""`        |
-| `service.loadBalancerIP`                | Memcached service Load Balancer IP                                                      | `""`        |
-| `service.loadBalancerSourceRanges`      | Memcached service Load Balancer sources                                                 | `[]`        |
-| `service.externalTrafficPolicy`         | Memcached service external traffic policy                                               | `Cluster`   |
-| `service.annotations`                   | Additional custom annotations for Memcached service                                     | `{}`        |
-| `service.extraPorts`                    | Extra ports to expose in the Memcached service (normally used with the `sidecar` value) | `[]`        |
-| `networkPolicy.enabled`                 | Enable creation of NetworkPolicy resources                                              | `true`      |
-| `networkPolicy.allowExternal`           | The Policy model to apply                                                               | `true`      |
-| `networkPolicy.allowExternalEgress`     | Allow the pod to access any range of port and all destinations.                         | `true`      |
-| `networkPolicy.extraIngress`            | Add extra ingress rules to the NetworkPolicy                                            | `[]`        |
-| `networkPolicy.extraEgress`             | Add extra ingress rules to the NetworkPolicy                                            | `[]`        |
-| `networkPolicy.ingressNSMatchLabels`    | Labels to match to allow traffic from other namespaces                                  | `{}`        |
-| `networkPolicy.ingressNSPodMatchLabels` | Pod labels to match to allow traffic from other namespaces                              | `{}`        |
+| Name                                    | Description                                                                                                   | Value       |
+| --------------------------------------- | ------------------------------------------------------------------------------------------------------------- | ----------- |
+| `service.type`                          | Kubernetes Service type                                                                                       | `ClusterIP` |
+| `service.ports.memcached`               | Memcached service port                                                                                        | `11211`     |
+| `service.nodePorts.memcached`           | Node port for Memcached                                                                                       | `""`        |
+| `service.sessionAffinity`               | Control where client requests go, to the same pod or round-robin                                              | `""`        |
+| `service.sessionAffinityConfig`         | Additional settings for the sessionAffinity                                                                   | `{}`        |
+| `service.clusterIP`                     | Memcached service Cluster IP                                                                                  | `""`        |
+| `service.loadBalancerIP`                | Memcached service Load Balancer IP                                                                            | `""`        |
+| `service.loadBalancerSourceRanges`      | Memcached service Load Balancer sources                                                                       | `[]`        |
+| `service.externalTrafficPolicy`         | Memcached service external traffic policy                                                                     | `Cluster`   |
+| `service.annotations`                   | Additional custom annotations for Memcached service                                                           | `{}`        |
+| `service.extraPorts`                    | Extra ports to expose in the Memcached service (normally used with the `sidecar` value)                       | `[]`        |
+| `networkPolicy.enabled`                 | Enable creation of NetworkPolicy resources                                                                    | `true`      |
+| `networkPolicy.allowExternal`           | The Policy model to apply                                                                                     | `true`      |
+| `networkPolicy.allowExternalEgress`     | Allow the pod to access any range of port and all destinations.                                               | `true`      |
+| `networkPolicy.addExternalClientAccess` | Allow access from pods with client label set to "true". Ignored if `networkPolicy.allowExternal` is true.     | `true`      |
+| `networkPolicy.extraIngress`            | Add extra ingress rules to the NetworkPolicy                                                                  | `[]`        |
+| `networkPolicy.extraEgress`             | Add extra ingress rules to the NetworkPolicy                                                                  | `[]`        |
+| `networkPolicy.ingressPodMatchLabels`   | Labels to match to allow traffic from other pods. Ignored if `networkPolicy.allowExternal` is true.           | `{}`        |
+| `networkPolicy.ingressNSMatchLabels`    | Labels to match to allow traffic from other namespaces. Ignored if `networkPolicy.allowExternal` is true.     | `{}`        |
+| `networkPolicy.ingressNSPodMatchLabels` | Pod labels to match to allow traffic from other namespaces. Ignored if `networkPolicy.allowExternal` is true. | `{}`        |
 
 ### Other Parameters
 

--- a/bitnami/memcached/templates/networkpolicy.yaml
+++ b/bitnami/memcached/templates/networkpolicy.yaml
@@ -49,22 +49,22 @@ spec:
       {{- if not .Values.networkPolicy.allowExternal }}
       from:
         - podSelector:
-            matchLabels:
-              {{ template "common.names.fullname" . }}-client: "true"
-        - podSelector:
             matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 14 }}
+        {{- if .Values.networkPolicy.addExternalClientAccess }}
+        - podSelector:
+            matchLabels: 
+              {{ template "common.names.fullname" . }}-client: "true"
+        {{- end }}
+        {{- if .Values.networkPolicy.ingressPodMatchLabels }}
+        - podSelector:
+            matchLabels: {{- include "common.tplvalues.render" (dict "value" .Values.networkPolicy.ingressPodMatchLabels "context" $ ) | nindent 14 }}
+        {{- end }}
         {{- if .Values.networkPolicy.ingressNSMatchLabels }}
         - namespaceSelector:
-            matchLabels:
-              {{- range $key, $value := .Values.networkPolicy.ingressNSMatchLabels }}
-              {{ $key | quote }}: {{ $value | quote }}
-              {{- end }}
+            matchLabels: {{- include "common.tplvalues.render" (dict "value" .Values.networkPolicy.ingressNSMatchLabels "context" $ ) | nindent 14 }}
           {{- if .Values.networkPolicy.ingressNSPodMatchLabels }}
           podSelector:
-            matchLabels:
-              {{- range $key, $value := .Values.networkPolicy.ingressNSPodMatchLabels }}
-              {{ $key | quote }}: {{ $value | quote }}
-              {{- end }}
+            matchLabels: {{- include "common.tplvalues.render" (dict "value" .Values.networkPolicy.ingressNSPodMatchLabels "context" $ ) | nindent 14 }}
           {{- end }}
         {{- end }}
       {{- end }}

--- a/bitnami/memcached/values.yaml
+++ b/bitnami/memcached/values.yaml
@@ -483,6 +483,9 @@ networkPolicy:
   ## @param networkPolicy.allowExternalEgress Allow the pod to access any range of port and all destinations.
   ##
   allowExternalEgress: true
+  ## @param networkPolicy.addExternalClientAccess Allow access from pods with client label set to "true". Ignored if `networkPolicy.allowExternal` is true.
+  ##
+  addExternalClientAccess: true
   ## @param networkPolicy.extraIngress [array] Add extra ingress rules to the NetworkPolicy
   ## e.g:
   ## extraIngress:
@@ -517,8 +520,14 @@ networkPolicy:
   ##                   - frontend
   ##
   extraEgress: []
-  ## @param networkPolicy.ingressNSMatchLabels [object] Labels to match to allow traffic from other namespaces
-  ## @param networkPolicy.ingressNSPodMatchLabels [object] Pod labels to match to allow traffic from other namespaces
+  ## @param networkPolicy.ingressPodMatchLabels [object] Labels to match to allow traffic from other pods. Ignored if `networkPolicy.allowExternal` is true.
+  ## e.g:
+  ## ingressPodMatchLabels:
+  ##   my-client: "true"
+  #
+  ingressPodMatchLabels: {}
+  ## @param networkPolicy.ingressNSMatchLabels [object] Labels to match to allow traffic from other namespaces. Ignored if `networkPolicy.allowExternal` is true.
+  ## @param networkPolicy.ingressNSPodMatchLabels [object] Pod labels to match to allow traffic from other namespaces. Ignored if `networkPolicy.allowExternal` is true.
   ##
   ingressNSMatchLabels: {}
   ingressNSPodMatchLabels: {}


### PR DESCRIPTION
### Description of the change

Apply the same changes made in PR #25519 to the Memcached chart

Review network policy features to allow users cover their needs without forcing specific labels.

### Benefits

Users can restrict access to their deployments in a cleaner way, without leaving open doors to specific labeled pods.

### Possible drawbacks

None

### Applicable issues

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
