### PR TITLE
[bitnami/template] PodDisruptionBudget template more permissive

### DIFF
--- a/template/CHART_NAME/templates/pdb.yaml
+++ b/template/CHART_NAME/templates/pdb.yaml
@@ -3,8 +3,7 @@ Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- $replicaCount := int .Values.%%MAIN_OBJECT_BLOCK%%.replicaCount }}
-{{- if and .Values.%%MAIN_OBJECT_BLOCK%%.pdb.create (or (gt $replicaCount 1) .Values.%%MAIN_OBJECT_BLOCK%%.autoscaling.enabled) }}
+{{- if and .Values.%%MAIN_OBJECT_BLOCK%%.pdb.create }}
 apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Remove replicaCount and autoscaling conditions from the PodDisruptionBudget template.

### Benefits

Users with just one pod in their deployments or replicasets can enable Pod disruption budget feature. There is no real restriction to enforce users to create a deployment or replicasets with two or more pods if they want to enable the PDBs.

### Possible drawbacks

None

### Additional information

* [Pod disruption budgets](https://kubernetes.io/docs/concepts/workloads/pods/disruptions/#pod-disruption-budgets)
* [Specifying a Disruption Budget for your Application](https://kubernetes.io/docs/tasks/run-application/configure-pdb/)
* https://github.com/bitnami/charts/pull/14433

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
