### PR TITLE
[bitnami/template] Remove unneeded `{{- end }}`

### DIFF
--- a/template/CHART_NAME/templates/statefulset.yaml
+++ b/template/CHART_NAME/templates/statefulset.yaml
@@ -215,4 +215,3 @@ spec:
         {{- end }}
         {{- include "common.storage.class" (dict "persistence" .Values.persistence "global" .Values.global) | nindent 8 }}
   {{- end }}
-{{- end }}


### PR DESCRIPTION
### Description of the change

Fixing error in template. This last `{{- end }}` doesn't have anything to close

### Benefits

Make the template more usable (I'm trying to automate generating charts from the template).

### Possible drawbacks

None

### Applicable issues

None

### Additional information

None

### Checklist

- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
