### PR TITLE
[bitnami/flux] PDB review

### DIFF
--- a/bitnami/flux/Chart.yaml
+++ b/bitnami/flux/Chart.yaml
@@ -43,4 +43,4 @@ maintainers:
 name: flux
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/flux
-version: 2.1.3
+version: 2.1.4

--- a/bitnami/flux/templates/helm-controller/pdb.yaml
+++ b/bitnami/flux/templates/helm-controller/pdb.yaml
@@ -3,7 +3,7 @@ Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- if .Values.helmController.pdb.create }}
+{{- if and .Values.helmController.enabled .Values.helmController.pdb.create }}
 apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:

--- a/bitnami/flux/templates/image-automation-controller/pdb.yaml
+++ b/bitnami/flux/templates/image-automation-controller/pdb.yaml
@@ -3,7 +3,7 @@ Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- if .Values.imageAutomationController.pdb.create }}
+{{- if and .Values.imageAutomationController.enabled .Values.imageAutomationController.pdb.create }}
 apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:

--- a/bitnami/flux/templates/image-reflector-controller/pdb.yaml
+++ b/bitnami/flux/templates/image-reflector-controller/pdb.yaml
@@ -3,7 +3,7 @@ Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- if .Values.imageReflectorController.pdb.create }}
+{{- if and .Values.imageReflectorController.enabled .Values.imageReflectorController.pdb.create }}
 apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:

--- a/bitnami/flux/templates/kustomize-controller/pdb.yaml
+++ b/bitnami/flux/templates/kustomize-controller/pdb.yaml
@@ -3,7 +3,7 @@ Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- if .Values.kustomizeController.pdb.create }}
+{{- if and .Values.kustomizeController.enabled .Values.kustomizeController.pdb.create }}
 apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:

--- a/bitnami/flux/templates/notification-controller/pdb.yaml
+++ b/bitnami/flux/templates/notification-controller/pdb.yaml
@@ -3,7 +3,7 @@ Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- if .Values.notificationController.pdb.create }}
+{{- if and .Values.notificationController.enabled .Values.notificationController.pdb.create }}
 apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:

--- a/bitnami/flux/templates/source-controller/pdb.yaml
+++ b/bitnami/flux/templates/source-controller/pdb.yaml
@@ -3,7 +3,7 @@ Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- if .Values.sourceController.pdb.create }}
+{{- if and .Values.sourceController.enabled .Values.sourceController.pdb.create }}
 apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:


### PR DESCRIPTION
### Description of the change

Little fixes in PodDisruptionBudget configuration to keep it aligned with current templates.

### Benefits

Keep our charts up to date according to our templates

### Possible drawbacks

None

### Adition information

* [Pod disruption budgets](https://kubernetes.io/docs/concepts/workloads/pods/disruptions/#pod-disruption-budgets)
* [Specifying a Disruption Budget for your Application](https://kubernetes.io/docs/tasks/run-application/configure-pdb/)

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
