### PR TITLE
[bitnami/grafana-mimir] PDB review

### DIFF
--- a/bitnami/grafana-mimir/Chart.yaml
+++ b/bitnami/grafana-mimir/Chart.yaml
@@ -59,4 +59,4 @@ maintainers:
 name: grafana-mimir
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/grafana-mimir
-version: 1.0.6
+version: 1.0.7

--- a/bitnami/grafana-mimir/templates/alertmanager/pdb.yaml
+++ b/bitnami/grafana-mimir/templates/alertmanager/pdb.yaml
@@ -3,8 +3,7 @@ Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- $replicaCount := int .Values.alertmanager.replicaCount }}
-{{- if and .Values.alertmanager.enabled .Values.alertmanager.pdb.create (gt $replicaCount 1) }}
+{{- if and .Values.alertmanager.enabled .Values.alertmanager.pdb.create }}
 apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:

--- a/bitnami/grafana-mimir/templates/compactor/pdb.yaml
+++ b/bitnami/grafana-mimir/templates/compactor/pdb.yaml
@@ -3,8 +3,7 @@ Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- $replicaCount := int .Values.compactor.replicaCount }}
-{{- if and .Values.compactor.pdb.create (gt $replicaCount 1) }}
+{{- if .Values.compactor.pdb.create }}
 apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:

--- a/bitnami/grafana-mimir/templates/distributor/pdb.yaml
+++ b/bitnami/grafana-mimir/templates/distributor/pdb.yaml
@@ -3,8 +3,7 @@ Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- $replicaCount := int .Values.distributor.replicaCount }}
-{{- if and .Values.distributor.pdb.create (gt $replicaCount 1) }}
+{{- if .Values.distributor.pdb.create }}
 apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:

--- a/bitnami/grafana-mimir/templates/gateway/pdb.yaml
+++ b/bitnami/grafana-mimir/templates/gateway/pdb.yaml
@@ -3,8 +3,7 @@ Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- $replicaCount := int .Values.gateway.replicaCount }}
-{{- if and .Values.gateway.pdb.create (gt $replicaCount 1) }}
+{{- if and .Values.gateway.enabled .Values.gateway.pdb.create }}
 apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:

--- a/bitnami/grafana-mimir/templates/ingester/pdb.yaml
+++ b/bitnami/grafana-mimir/templates/ingester/pdb.yaml
@@ -3,8 +3,7 @@ Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- $replicaCount := int .Values.ingester.replicaCount }}
-{{- if and .Values.ingester.pdb.create (gt $replicaCount 1) }}
+{{- if .Values.ingester.pdb.create }}
 apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:

--- a/bitnami/grafana-mimir/templates/overrides-exporter/pdb.yaml
+++ b/bitnami/grafana-mimir/templates/overrides-exporter/pdb.yaml
@@ -3,8 +3,7 @@ Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- $replicaCount := int .Values.overridesExporter.replicaCount }}
-{{- if and .Values.overridesExporter.enabled .Values.overridesExporter.pdb.create (gt $replicaCount 1) }}
+{{- if and .Values.overridesExporter.enabled .Values.overridesExporter.pdb.create }}
 apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:

--- a/bitnami/grafana-mimir/templates/querier/pdb.yaml
+++ b/bitnami/grafana-mimir/templates/querier/pdb.yaml
@@ -3,8 +3,7 @@ Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- $replicaCount := int .Values.querier.replicaCount }}
-{{- if and .Values.querier.pdb.create (gt $replicaCount 1) }}
+{{- if .Values.querier.pdb.create }}
 apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:

--- a/bitnami/grafana-mimir/templates/query-frontend/pdb.yaml
+++ b/bitnami/grafana-mimir/templates/query-frontend/pdb.yaml
@@ -3,8 +3,7 @@ Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- $replicaCount := int .Values.queryFrontend.replicaCount }}
-{{- if and .Values.queryFrontend.pdb.create (gt $replicaCount 1) }}
+{{- if .Values.queryFrontend.pdb.create }}
 apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:

--- a/bitnami/grafana-mimir/templates/query-scheduler/pdb.yaml
+++ b/bitnami/grafana-mimir/templates/query-scheduler/pdb.yaml
@@ -3,8 +3,7 @@ Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- $replicaCount := int .Values.queryScheduler.replicaCount }}
-{{- if and .Values.queryScheduler.enabled .Values.queryScheduler.pdb.create (gt $replicaCount 1) }}
+{{- if and .Values.queryScheduler.enabled .Values.queryScheduler.pdb.create }}
 apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:

--- a/bitnami/grafana-mimir/templates/ruler/pdb.yaml
+++ b/bitnami/grafana-mimir/templates/ruler/pdb.yaml
@@ -3,8 +3,7 @@ Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- $replicaCount := int .Values.ruler.replicaCount }}
-{{- if and .Values.ruler.pdb.create (gt $replicaCount 1) }}
+{{- if and .Values.ruler.enabled .Values.ruler.pdb.create }}
 apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:

--- a/bitnami/grafana-mimir/templates/store-gateway/pdb.yaml
+++ b/bitnami/grafana-mimir/templates/store-gateway/pdb.yaml
@@ -3,8 +3,7 @@ Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- $replicaCount := int .Values.storeGateway.replicaCount }}
-{{- if and .Values.storeGateway.pdb.create (gt $replicaCount 1) }}
+{{- if .Values.storeGateway.pdb.create }}
 apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:


### PR DESCRIPTION
### Description of the change

Little fixes in PodDisruptionBudget configuration to keep it aligned with current templates.

### Benefits

Keep our charts up to date according to our templates

### Possible drawbacks

None

### Adition information

* [Pod disruption budgets](https://kubernetes.io/docs/concepts/workloads/pods/disruptions/#pod-disruption-budgets)
* [Specifying a Disruption Budget for your Application](https://kubernetes.io/docs/tasks/run-application/configure-pdb/)

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
