### PR TITLE
[bitnami/mysql] Add a warning on running older versions of MySQL

### DIFF
--- a/bitnami/mysql/README.md
+++ b/bitnami/mysql/README.md
@@ -56,9 +56,11 @@ It is strongly recommended to use immutable tags in a production environment. Th
 
 Bitnami will release a new chart updating its containers if a new version of the main container, significant changes, or critical vulnerabilities exist.
 
-### Use a different MySQL version
+### Use a different MySQL 8.x version
 
 To modify the application version used in this chart, specify a different version of the image using the `image.tag` parameter and/or a different repository using the `image.repository` parameter.
+
+> **Warning**: This chart is tested with MySQL version 8.x. Older versions most likely won't work if you merely switch the tag.
 
 ### Customize a new MySQL instance
 


### PR DESCRIPTION
### Description of the change

Add a warning on the README section that explains that the chart is only tested with MySQL 8.x and will most likely not work with older versions.

### Benefits

People will not waste time trying to run with older images or at least be aware that there is some additional research to be made on the differences and potential other changes required.

### Possible drawbacks

None

### Applicable issues

- fixes #14827

### Checklist

- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
