### PR TITLE
[bitnami/common] feat: :sparkles: Show warning when original images are replaced

### DIFF
--- a/bitnami/common/Chart.yaml
+++ b/bitnami/common/Chart.yaml
@@ -6,7 +6,7 @@ annotations:
   licenses: Apache-2.0
 apiVersion: v2
 # Please make sure that version and appVersion are always the same.
-appVersion: 2.19.2
+appVersion: 2.19.3
 description: A Library Helm Chart for grouping common logic between bitnami charts. This chart is not deployable by itself.
 home: https://bitnami.com
 icon: https://bitnami.com/downloads/logos/bitnami-mark.png
@@ -23,4 +23,4 @@ name: common
 sources:
   - https://github.com/bitnami/charts
 type: library
-version: 2.19.2
+version: 2.19.3

--- a/bitnami/common/templates/_warnings.tpl
+++ b/bitnami/common/templates/_warnings.tpl
@@ -20,15 +20,16 @@ WARNING: Rolling tag detected ({{ .repository }}:{{ .tag }}), please note that i
 {{/*
 Warning about replaced images from the original.
 Usage:
-{{ include "common.warnings.modifiedImages" (list .Values.path.to.the.imageRoot) }}
+{{ include "common.warnings.modifiedImages" (dict "images" (list .Values.path.to.the.imageRoot) "context" $) }}
 */}}
 {{- define "common.warnings.modifiedImages" -}}
-{{- $images := . -}}
 {{- $affectedImages := list -}}
 {{- $printMessage := false -}}
-{{- range $images -}}
-  {{- if not (regexMatch "^bitnami/" .repository) }}
-    {{- $affectedImages = append $affectedImages (printf "%s:%s" .repository .tag) -}}
+{{- $originalImages := .context.Chart.Annotations.images -}}
+{{- range .images -}}
+  {{- $fullImageName := printf (printf "%s/%s:%s" .registry .repository .tag) -}}
+  {{- if not (contains $fullImageName $originalImages) }}
+    {{- $affectedImages = append $affectedImages (printf "%s/%s:%s" .registry .repository .tag) -}}
     {{- $printMessage = true -}}
   {{- end -}}
 {{- end -}}

--- a/bitnami/common/templates/_warnings.tpl
+++ b/bitnami/common/templates/_warnings.tpl
@@ -35,7 +35,7 @@ Usage:
 {{- end -}}
 {{- if $printMessage }}
 
-SECURITY WARNING: Original containers have been substituted. This Helm chart was designed, tested, and validated on multiple platforms using a specific set of Bitnami and Tanzu Application Catalog containers. Substituting other containers is likely to cause degraded security and performance, broken chart features, and missing environment variables.
+⚠ SECURITY WARNING: Original containers have been substituted. This Helm chart was designed, tested, and validated on multiple platforms using a specific set of Bitnami and Tanzu Application Catalog containers. Substituting other containers is likely to cause degraded security and performance, broken chart features, and missing environment variables.
 
 Substituted images detected:
 {{- range $affectedImages }}

--- a/bitnami/common/templates/_warnings.tpl
+++ b/bitnami/common/templates/_warnings.tpl
@@ -18,6 +18,32 @@ WARNING: Rolling tag detected ({{ .repository }}:{{ .tag }}), please note that i
 {{- end -}}
 
 {{/*
+Warning about replaced images from the original.
+Usage:
+{{ include "common.warnings.modifiedImages" (list .Values.path.to.the.imageRoot) }}
+*/}}
+{{- define "common.warnings.modifiedImages" -}}
+{{- $images := . -}}
+{{- $affectedImages := list -}}
+{{- $printMessage := false -}}
+{{- range $images -}}
+  {{- if not (regexMatch "^bitnami/" .repository) }}
+    {{- $affectedImages = append $affectedImages (printf "%s:%s" .repository .tag) -}}
+    {{- $printMessage = true -}}
+  {{- end -}}
+{{- end -}}
+{{- if $printMessage }}
+
+SECURITY WARNING: Original containers have been substituted. This Helm chart was designed, tested, and validated on multiple platforms using a specific set of Bitnami and Tanzu Application Catalog containers. Substituting other containers is likely to cause degraded security and performance, broken chart features, and missing environment variables.
+
+Substituted images detected:
+{{- range $affectedImages }}
+  - {{ . }}
+{{- end }}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Warning about not setting the resource object in all deployments.
 Usage:
 {{ include "common.warnings.resources" (dict "sections" (list "path1" "path2") context $) }}


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

This PR adds a common warning function to be used in NOTES.txt: `common.warnings.modifiedImages`. This one checks if the Bitnami shipped images are being replaced by images different from the ones set in Chart.Annotations (the ones that have been verified and tested). We want to warn users of the potential risks of this action.

Example of usage in the matomo chart:

```
{{- include "common.warnings.modifiedImages" (dict "images" (list .Values.image .Values.metrics.image .Values.volumePermissions.image .Values.certificates.image) "context" $) }}
```

If we change one of the images, we see the following warning:

```
SECURITY WARNING: Original containers have been substituted. This Helm chart was designed, tested, and validated on multiple platforms using a specific set of Bitnami and Tanzu Application Catalog containers. Substituting other containers is likely to cause degraded security and performance, broken chart features, and missing environment variables.

Substituted images detected:
  - docker.io/fakebitmame:5.0.3-debian-12-r8
```

### Benefits

Users are more aware of the risks of changing the original images

### Possible drawbacks

Potential false negatives/positives. This can be further improved in the future.

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
