### PR TITLE
[bitnami/sonarqube] Use different liveness/readiness probes

### DIFF
--- a/bitnami/sonarqube/Chart.lock
+++ b/bitnami/sonarqube/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: postgresql
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 15.2.4
+  version: 15.3.2
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.19.1
-digest: sha256:34e2965deeb3ba05f59a9bc1e59f2bd0968b1cc223a21e1e7c58b396883a9747
-generated: "2024-04-06T16:57:22.110770819Z"
+  version: 2.19.2
+digest: sha256:b3be00d62395c3cbec87e3ed0b505d68b48a969323d3e4bb14428dca34c75a52
+generated: "2024-05-17T18:14:38.549469+02:00"

--- a/bitnami/sonarqube/Chart.yaml
+++ b/bitnami/sonarqube/Chart.yaml
@@ -37,4 +37,4 @@ maintainers:
 name: sonarqube
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/sonarqube
-version: 5.0.3
+version: 5.0.4

--- a/bitnami/sonarqube/templates/deployment.yaml
+++ b/bitnami/sonarqube/templates/deployment.yaml
@@ -379,8 +379,7 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.livenessProbe "enabled") "context" $) | nindent 12 }}
-            httpGet:
-              path: /
+            tcpSocket:
               port: http
           {{- end }}
           {{- if .Values.customReadinessProbe }}


### PR DESCRIPTION
### Description of the change
This PR aims to use different liveness/readiness probes to improve overall security and avoid unnecessary container restarts. [More info](https://github.com/zegl/kube-score/blob/master/README_PROBES.md).

### Benefits

Increase availability and resilience.

### Possible drawbacks

N/A

### Applicable issues

- fixes #

### Additional information

- Related to #23537

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- ~[X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)~
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
