### PR TITLE
[bitnami/postgresql-ha] Fix typo in postgresql-ha/templates/NOTES.txt preventing deployments

### DIFF
--- a/bitnami/postgresql-ha/Chart.yaml
+++ b/bitnami/postgresql-ha/Chart.yaml
@@ -40,4 +40,4 @@ maintainers:
 name: postgresql-ha
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/postgresql-ha
-version: 14.0.13
+version: 14.0.14

--- a/bitnami/postgresql-ha/templates/NOTES.txt
+++ b/bitnami/postgresql-ha/templates/NOTES.txt
@@ -57,7 +57,7 @@ Note: Since NetworkPolicy is enabled, only pods with label "{{ include "postgres
 
 {{- if and (.Values.pgpool.networkPolicy.enabled) (not .Values.pgpool.networkPolicy.allowExternal) }}
 
-Note: Since NetworkPolicy is enabled, only pods with label "{{ include "postgresql-ha.pgppol" . }}-client=true" can access postgresql will be able to connect PgPool.
+Note: Since NetworkPolicy is enabled, only pods with label "{{ include "postgresql-ha.pgpool" . }}-client=true" can access postgresql will be able to connect PgPool.
 
 {{- end }}
 


### PR DESCRIPTION
### Description of the change

Fixes a type preventing the deployment of the postgresql-ha chart through FluxCD and increments the chart version

### Benefits

Starting with postgresql-ha version 13.0.0, deployments don't work with FluxCD

### Possible drawbacks

None that I can think of.

### Applicable issues

- fixes #25993 

### Additional information


### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
