### PR TITLE
[bitnami/deepspeed] Use different liveness/readiness probes

### DIFF
--- a/bitnami/deepspeed/Chart.yaml
+++ b/bitnami/deepspeed/Chart.yaml
@@ -35,4 +35,4 @@ name: deepspeed
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/deepspeed
 - https://github.com/bitnami/charts/tree/main/bitnami/pytorch
-version: 2.0.5
+version: 2.0.6

--- a/bitnami/deepspeed/templates/client/client-dep-job.yaml
+++ b/bitnami/deepspeed/templates/client/client-dep-job.yaml
@@ -160,7 +160,7 @@ spec:
               command:
                 - python
                 - -c
-                - import deepspeed; deepspeed.__version__
+                - import torch; torch.__version__
           {{- end }}
           {{- if .Values.client.customReadinessProbe }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.client.customReadinessProbe "context" $) | nindent 12 }}

--- a/bitnami/deepspeed/templates/worker/worker-statefulset.yaml
+++ b/bitnami/deepspeed/templates/worker/worker-statefulset.yaml
@@ -154,8 +154,11 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.worker.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.worker.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.worker.livenessProbe "enabled") "context" $) | nindent 12 }}
-            tcpSocket:
-              port: tcp-ssh
+            exec:
+              command:
+                - pgrep
+                - -f
+                - sshd
           {{- end }}
           {{- if .Values.worker.customReadinessProbe }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.worker.customReadinessProbe "context" $) | nindent 12 }}


### PR DESCRIPTION
### Description of the change
This PR aims to use different liveness/readiness probes to improve overall security and avoid unnecessary container restarts. [More info](https://github.com/zegl/kube-score/blob/master/README_PROBES.md).

### Benefits

Increase availability and resilience.

### Possible drawbacks

N/A

### Applicable issues

- fixes #

### Additional information

- Related to #23537

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- ~[X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)~
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
