### PR TITLE
[bitnami/solr] Use different liveness/readiness probes

### DIFF
--- a/bitnami/solr/CHANGELOG.md
+++ b/bitnami/solr/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
+## 9.2.1 (2024-05-21)
+
+* [bitnami/solr] Use different liveness/readiness probes ([#26125](https://github.com/bitnami/charts/pulls/26125))
+
 ## 9.2.0 (2024-05-21)
 
-* [bitnami/solr] feat: :sparkles: :lock: Add warning when original images are replaced ([#26277](https://github.com/bitnami/charts/pulls/26277))
+* [bitnami/*] ci: :construction_worker: Add tag and changelog support (#25359) ([91c707c](https://github.com/bitnami/charts/commit/91c707c)), closes [#25359](https://github.com/bitnami/charts/issues/25359)
+* [bitnami/solr] feat: :sparkles: :lock: Add warning when original images are replaced (#26277) ([816155e](https://github.com/bitnami/charts/commit/816155e)), closes [#26277](https://github.com/bitnami/charts/issues/26277)
 
 ## <small>9.1.6 (2024-05-18)</small>
 

--- a/bitnami/solr/Chart.lock
+++ b/bitnami/solr/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: zookeeper
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 13.2.3
+  version: 13.3.0
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 2.19.3
-digest: sha256:5ec074d1704d0eaf798aa3d0c8a6ef4a9459a94ee3029b0e1621b790cf44e310
-generated: "2024-05-21T14:39:50.625630213+02:00"
+digest: sha256:344b1f77eb0e4dddc6962899b8cc2892c652be5b8a96c88d9ad57708f9e61b93
+generated: "2024-05-21T18:02:59.596153+02:00"

--- a/bitnami/solr/Chart.yaml
+++ b/bitnami/solr/Chart.yaml
@@ -34,4 +34,5 @@ maintainers:
 name: solr
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/solr
-version: 9.2.0
+version: 9.2.1
+

--- a/bitnami/solr/templates/metrics-deployment.yaml
+++ b/bitnami/solr/templates/metrics-deployment.yaml
@@ -162,8 +162,7 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.metrics.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.metrics.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.metrics.livenessProbe "enabled") "context" $) | nindent 12 }}
-            httpGet:
-              path: "/metrics"
+            tcpSocket:
               port: {{ .Values.metrics.containerPorts.http }}
           {{- end }}
           {{- if .Values.metrics.customReadinessProbe }}

--- a/bitnami/solr/templates/statefulset.yaml
+++ b/bitnami/solr/templates/statefulset.yaml
@@ -295,7 +295,7 @@ spec:
               - /bin/bash
               - -ec
               - |
-                curl --silent --connect-timeout 15000 {{ ternary "--user ${SOLR_ADMIN_USERNAME}:${SOLR_ADMIN_PASSWORD}" "" .Values.auth.enabled }} http://localhost:${SOLR_PORT_NUMBER}/api/node/health | grep --quiet  '\"status\":\"OK\"'
+                curl --silent --connect-timeout 15000 {{ ternary "--user ${SOLR_ADMIN_USERNAME}:${SOLR_ADMIN_PASSWORD}" "" .Values.auth.enabled }} http://localhost:${SOLR_PORT_NUMBER}/solr/admin/info/system | grep --quiet  '\"status\":0'
           {{- end }}
           {{- if .Values.customReadinessProbe }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customReadinessProbe "context" $) | nindent 12 }}


### PR DESCRIPTION
### Description of the change
This PR aims to use different liveness/readiness probes to improve overall security and avoid unnecessary container restarts. [More info](https://github.com/zegl/kube-score/blob/master/README_PROBES.md).

### Benefits

Increase availability and resilience.

### Possible drawbacks

N/A

### Applicable issues

- fixes #

### Additional information

- Related to #23537

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
