### PR TITLE
[bitnami/mastodon] Use different liveness/readiness probes

### DIFF
--- a/bitnami/mastodon/CHANGELOG.md
+++ b/bitnami/mastodon/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
+## 6.1.1 (2024-05-21)
+
+* [bitnami/mastodon] Use different liveness/readiness probes ([#26126](https://github.com/bitnami/charts/pulls/26126))
+
 ## 6.1.0 (2024-05-21)
 
-* [bitnami/mastodon] feat: :sparkles: :lock: Add warning when original images are replaced ([#26238](https://github.com/bitnami/charts/pulls/26238))
+* [bitnami/*] ci: :construction_worker: Add tag and changelog support (#25359) ([91c707c](https://github.com/bitnami/charts/commit/91c707c)), closes [#25359](https://github.com/bitnami/charts/issues/25359)
+* [bitnami/mastodon] feat: :sparkles: :lock: Add warning when original images are replaced (#26238) ([d8f42ab](https://github.com/bitnami/charts/commit/d8f42ab)), closes [#26238](https://github.com/bitnami/charts/issues/26238)
 
 ## <small>6.0.3 (2024-05-18)</small>
 

--- a/bitnami/mastodon/Chart.lock
+++ b/bitnami/mastodon/Chart.lock
@@ -1,21 +1,21 @@
 dependencies:
 - name: redis
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 19.3.4
+  version: 19.4.0
 - name: postgresql
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 15.3.5
+  version: 15.4.0
 - name: elasticsearch
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 21.0.7
+  version: 21.1.0
 - name: minio
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 14.5.0
+  version: 14.6.0
 - name: apache
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 11.0.6
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 2.19.3
-digest: sha256:2ecbf0a2110d5173cfe9d86abc54a97654b0b7930f6dd55ed3bb94d802365bef
-generated: "2024-05-21T14:07:19.245850871+02:00"
+digest: sha256:f00a135fd3b56a3341d191aa5351648e5d58656e527fefec41ec0807ca166ed8
+generated: "2024-05-21T18:04:37.879578+02:00"

--- a/bitnami/mastodon/Chart.yaml
+++ b/bitnami/mastodon/Chart.yaml
@@ -49,4 +49,4 @@ maintainers:
 name: mastodon
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/mastodon
-version: 6.1.0
+version: 6.1.1

--- a/bitnami/mastodon/README.md
+++ b/bitnami/mastodon/README.md
@@ -783,7 +783,6 @@ The [Bitnami mastodon](https://github.com/bitnami/containers/tree/main/bitnami/m
 | `apache.service.loadBalancerIP` | Apache service LoadBalancer IP                                  | `""`                       |
 | `apache.service.ports.http`     | Apache service port                                             | `80`                       |
 | `apache.vhostsConfigMap`        | Name of the ConfigMap containing the Apache vhost configuration | `""`                       |
-| `apache.livenessProbe.path`     | Apache liveness probe path                                      | `/api/v1/streaming/health` |
 | `apache.readinessProbe.path`    | Apache readiness probe path                                     | `/api/v1/streaming/health` |
 | `apache.startupProbe.path`      | Apache startup probe path                                       | `/api/v1/streaming/health` |
 | `apache.ingress.enabled`        | Enable ingress                                                  | `false`                    |

--- a/bitnami/mastodon/templates/sidekiq/deployment.yaml
+++ b/bitnami/mastodon/templates/sidekiq/deployment.yaml
@@ -181,9 +181,9 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.sidekiq.livenessProbe "enabled") "context" $) | nindent 12 }}
             exec:
               command:
-                - /bin/sh
-                - -c
-                - pgrep -f ^sidekiq
+                - pgrep
+                - -f
+                - sidekiq
           {{- end }}
           {{- if .Values.sidekiq.customReadinessProbe }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.sidekiq.customReadinessProbe "context" $) | nindent 12 }}

--- a/bitnami/mastodon/templates/streaming/deployment.yaml
+++ b/bitnami/mastodon/templates/streaming/deployment.yaml
@@ -182,8 +182,7 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.streaming.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.streaming.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.streaming.livenessProbe "enabled") "context" $) | nindent 12 }}
-            httpGet:
-              path: /api/v1/streaming/health
+            tcpSocket:
               port: http
           {{- end }}
           {{- if .Values.streaming.customReadinessProbe }}

--- a/bitnami/mastodon/templates/web/deployment.yaml
+++ b/bitnami/mastodon/templates/web/deployment.yaml
@@ -238,8 +238,7 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.web.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.web.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.web.livenessProbe "enabled") "context" $) | nindent 12 }}
-            httpGet:
-              path: /health
+            tcpSocket:
               port: http
           {{- end }}
           {{- if .Values.web.customReadinessProbe }}

--- a/bitnami/mastodon/values.yaml
+++ b/bitnami/mastodon/values.yaml
@@ -1845,10 +1845,6 @@ apache:
   # We need to change the liveness probe to use the Mastodon streaming health checkpoint
   # We use the streaming because it is the last service to be initialized together with
   # sidekiq
-  ## @param apache.livenessProbe.path Apache liveness probe path
-  ##
-  livenessProbe:
-    path: "/api/v1/streaming/health"
   ## @param apache.readinessProbe.path Apache readiness probe path
   ##
   readinessProbe:


### PR DESCRIPTION
### Description of the change
This PR aims to use different liveness/readiness probes to improve overall security and avoid unnecessary container restarts. [More info](https://github.com/zegl/kube-score/blob/master/README_PROBES.md).

### Benefits

Increase availability and resilience.

### Possible drawbacks

N/A

### Applicable issues

- fixes #

### Additional information

- Related to #23537

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
