### PR TITLE
[bitnami/spark] Use different liveness/readiness probes

### DIFF
--- a/bitnami/spark/Chart.yaml
+++ b/bitnami/spark/Chart.yaml
@@ -27,4 +27,4 @@ maintainers:
 name: spark
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/spark
-version: 9.0.3
+version: 9.0.4

--- a/bitnami/spark/templates/statefulset-master.yaml
+++ b/bitnami/spark/templates/statefulset-master.yaml
@@ -303,8 +303,7 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.master.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.master.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.master.livenessProbe "enabled") "context" $) | nindent 12 }}
-            httpGet:
-              path: /
+            tcpSocket:
               port: {{ .Values.master.containerPorts.http }}
           {{- end }}
           {{- if .Values.master.customReadinessProbe }}

--- a/bitnami/spark/templates/statefulset-worker.yaml
+++ b/bitnami/spark/templates/statefulset-worker.yaml
@@ -327,8 +327,7 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.worker.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.worker.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.worker.livenessProbe "enabled") "context" $) | nindent 12 }}
-            httpGet:
-              path: /
+            tcpSocket:
               port: {{ .Values.worker.containerPorts.http }}
           {{- end }}
           {{- if .Values.worker.customReadinessProbe }}


### PR DESCRIPTION
### Description of the change
This PR aims to use different liveness/readiness probes to improve overall security and avoid unnecessary container restarts. [More info](https://github.com/zegl/kube-score/blob/master/README_PROBES.md).

### Benefits

Increase availability and resilience.

### Possible drawbacks

N/A

### Applicable issues

- fixes #

### Additional information

- Related to #23537

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- ~[X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)~
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
