### PR TITLE
[bitnami/nginx-ingress-controller] Enable PodDisruptionBudgets

### DIFF
--- a/bitnami/nginx-ingress-controller/Chart.yaml
+++ b/bitnami/nginx-ingress-controller/Chart.yaml
@@ -34,4 +34,4 @@ maintainers:
 name: nginx-ingress-controller
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/nginx-ingress-controller
-version: 11.1.5
+version: 11.2.0

--- a/bitnami/nginx-ingress-controller/README.md
+++ b/bitnami/nginx-ingress-controller/README.md
@@ -327,7 +327,7 @@ As an alternative, you can use of the preset configurations for pod affinity, po
 | `defaultBackend.networkPolicy.extraEgress`                         | Add extra ingress rules to the NetworkPolicy                                                                                                                                                                                                    | `[]`                    |
 | `defaultBackend.networkPolicy.ingressNSMatchLabels`                | Labels to match to allow traffic from other namespaces                                                                                                                                                                                          | `{}`                    |
 | `defaultBackend.networkPolicy.ingressNSPodMatchLabels`             | Pod labels to match to allow traffic from other namespaces                                                                                                                                                                                      | `{}`                    |
-| `defaultBackend.pdb.create`                                        | Enable/disable a Pod Disruption Budget creation for Default backend                                                                                                                                                                             | `false`                 |
+| `defaultBackend.pdb.create`                                        | Enable/disable a Pod Disruption Budget creation for Default backend                                                                                                                                                                             | `true`                  |
 | `defaultBackend.pdb.minAvailable`                                  | Minimum number/percentage of Default backend pods that should remain scheduled                                                                                                                                                                  | `1`                     |
 | `defaultBackend.pdb.maxUnavailable`                                | Maximum number/percentage of Default backend pods that may be made unavailable                                                                                                                                                                  | `""`                    |
 
@@ -376,7 +376,7 @@ As an alternative, you can use of the preset configurations for pod affinity, po
 
 | Name                       | Description                                                               | Value   |
 | -------------------------- | ------------------------------------------------------------------------- | ------- |
-| `pdb.create`               | Enable/disable a Pod Disruption Budget creation for Controller            | `false` |
+| `pdb.create`               | Enable/disable a Pod Disruption Budget creation for Controller            | `true`  |
 | `pdb.minAvailable`         | Minimum number/percentage of Controller pods that should remain scheduled | `1`     |
 | `pdb.maxUnavailable`       | Maximum number/percentage of Controller pods that may be made unavailable | `""`    |
 | `autoscaling.enabled`      | Enable autoscaling for Controller                                         | `false` |

--- a/bitnami/nginx-ingress-controller/values.yaml
+++ b/bitnami/nginx-ingress-controller/values.yaml
@@ -868,7 +868,7 @@ defaultBackend:
   pdb:
     ## @param defaultBackend.pdb.create Enable/disable a Pod Disruption Budget creation for Default backend
     ##
-    create: false
+    create: true
     ## @param defaultBackend.pdb.minAvailable Minimum number/percentage of Default backend pods that should remain scheduled
     ##
     minAvailable: 1
@@ -1060,7 +1060,7 @@ rbac:
 pdb:
   ## @param pdb.create Enable/disable a Pod Disruption Budget creation for Controller
   ##
-  create: false
+  create: true
   ## @param pdb.minAvailable Minimum number/percentage of Controller pods that should remain scheduled
   ##
   minAvailable: 1


### PR DESCRIPTION
### Description of the change

Enabled PodDisruptionBudget by default and little fixes in PDB configuration to keep it aligned with current templates.

### Benefits

PDB protects our applications from voluntary disruption initiated by cluster administrators.
Keep our charts up to date according to our templates.

### Possible drawbacks

None

### Adition information

* [Pod disruption budgets](https://kubernetes.io/docs/concepts/workloads/pods/disruptions/#pod-disruption-budgets)
* [Specifying a Disruption Budget for your Application](https://kubernetes.io/docs/tasks/run-application/configure-pdb/)

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
