### PR TITLE
[bitnami/vault] Use different liveness/readiness probes

### DIFF
--- a/bitnami/vault/Chart.lock
+++ b/bitnami/vault/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.19.2
-digest: sha256:e670e1075bfafffe040fae1158f1fa1f592585f394b48704ba137d2d083b1571
-generated: "2024-05-08T04:08:28.851234424Z"
+  version: 2.19.3
+digest: sha256:de997835d9ce9a9deefc2d70d8c62b11aa1d1a76ece9e86a83736ab9f930bf4d
+generated: "2024-05-21T11:12:17.107981+02:00"

--- a/bitnami/vault/Chart.yaml
+++ b/bitnami/vault/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: vault
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/vault
-version: 1.2.2
+version: 1.2.3

--- a/bitnami/vault/templates/csi-provider/daemonset.yaml
+++ b/bitnami/vault/templates/csi-provider/daemonset.yaml
@@ -124,8 +124,7 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.csiProvider.provider.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.csiProvider.provider.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.csiProvider.provider.livenessProbe "enabled") "context" $) | nindent 12 }}
-            httpGet:
-              path: /health/ready
+            tcpSocket:
               port: http-health
           {{- end }}
           {{- if .Values.csiProvider.provider.customReadinessProbe }}

--- a/bitnami/vault/templates/injector/deployment.yaml
+++ b/bitnami/vault/templates/injector/deployment.yaml
@@ -145,10 +145,8 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.injector.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.injector.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.injector.livenessProbe "enabled") "context" $) | nindent 12 }}
-            httpGet:
-              path: /health/ready
+            tcpSocket:
               port: https
-              scheme: HTTPS
           {{- end }}
           {{- if .Values.injector.customReadinessProbe }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.injector.customReadinessProbe "context" $) | nindent 12 }}


### PR DESCRIPTION
### Description of the change
This PR aims to use different liveness/readiness probes to improve overall security and avoid unnecessary container restarts. [More info](https://github.com/zegl/kube-score/blob/master/README_PROBES.md).

### Benefits

Increase availability and resilience.

### Possible drawbacks

N/A

### Applicable issues

- fixes #

### Additional information

- Related to #23537

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
