### PR TITLE
[bitnami/thanos] Use different liveness/readiness probes

### DIFF
--- a/bitnami/thanos/CHANGELOG.md
+++ b/bitnami/thanos/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
+## 15.5.1 (2024-05-21)
+
+* [bitnami/thanos] Use different liveness/readiness probes ([#26165](https://github.com/bitnami/charts/pulls/26165))
+
 ## 15.5.0 (2024-05-21)
 
-* [bitnami/thanos] feat: :sparkles: :lock: Add warning when original images are replaced ([#26283](https://github.com/bitnami/charts/pulls/26283))
+* [bitnami/*] ci: :construction_worker: Add tag and changelog support (#25359) ([91c707c](https://github.com/bitnami/charts/commit/91c707c)), closes [#25359](https://github.com/bitnami/charts/issues/25359)
+* [bitnami/thanos] feat: :sparkles: :lock: Add warning when original images are replaced (#26283) ([2a39de8](https://github.com/bitnami/charts/commit/2a39de8)), closes [#26283](https://github.com/bitnami/charts/issues/26283)
 
 ## <small>15.4.7 (2024-05-18)</small>
 

--- a/bitnami/thanos/Chart.lock
+++ b/bitnami/thanos/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: minio
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 14.5.0
+  version: 14.6.0
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 2.19.3
-digest: sha256:914e5fd99e81f33b87e7716e370c4fb91f202f0e590d96306bbcc34d1f17ddd9
-generated: "2024-05-21T14:45:02.122673789+02:00"
+digest: sha256:cac50605caf3b1189d65e70543b5b083a9fca076e3403fc11c92c68437b6d25e
+generated: "2024-05-21T17:17:49.906796+02:00"

--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -35,4 +35,5 @@ maintainers:
 name: thanos
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/thanos
-version: 15.5.0
+version: 15.5.1
+

--- a/bitnami/thanos/templates/bucketweb/deployment.yaml
+++ b/bitnami/thanos/templates/bucketweb/deployment.yaml
@@ -140,15 +140,8 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.bucketweb.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.bucketweb.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.bucketweb.livenessProbe "enabled") "context" $) | nindent 12 }}
-            {{- if not .Values.auth.basicAuthUsers }}
-            httpGet:
-              path: /-/healthy
-              port: http
-              scheme: {{ ternary "HTTPS" "HTTP" .Values.https.enabled }}
-            {{- else }}
             tcpSocket:
               port: http
-            {{- end }}
           {{- end }}
           {{- if .Values.bucketweb.customReadinessProbe }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.bucketweb.customReadinessProbe "context" $) | nindent 12 }}

--- a/bitnami/thanos/templates/compactor/_pod-template.tpl
+++ b/bitnami/thanos/templates/compactor/_pod-template.tpl
@@ -147,15 +147,8 @@ spec:
       livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.compactor.customLivenessProbe "context" $) | nindent 8 }}
       {{- else if .Values.compactor.livenessProbe.enabled }}
       livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.compactor.livenessProbe "enabled") "context" $) | nindent 8 }}
-        {{- if not .Values.auth.basicAuthUsers }}
-        httpGet:
-          path: /-/healthy
-          port: http
-          scheme: {{ ternary "HTTPS" "HTTP" .Values.https.enabled }}
-        {{- else }}
         tcpSocket:
           port: http
-        {{- end }}
       {{- end }}
       {{- if .Values.compactor.customReadinessProbe }}
       readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.compactor.customReadinessProbe "context" $) | nindent 8 }}

--- a/bitnami/thanos/templates/query-frontend/deployment.yaml
+++ b/bitnami/thanos/templates/query-frontend/deployment.yaml
@@ -135,15 +135,8 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.queryFrontend.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.queryFrontend.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.queryFrontend.livenessProbe "enabled") "context" $) | nindent 12 }}
-            {{- if not .Values.auth.basicAuthUsers }}
-            httpGet:
-              path: /-/healthy
-              port: http
-              scheme: {{ ternary "HTTPS" "HTTP" .Values.https.enabled }}
-            {{- else }}
             tcpSocket:
               port: http
-            {{- end }}
           {{- end }}
           {{- if .Values.queryFrontend.customReadinessProbe }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.queryFrontend.customReadinessProbe "context" $) | nindent 12 }}

--- a/bitnami/thanos/templates/query/deployment.yaml
+++ b/bitnami/thanos/templates/query/deployment.yaml
@@ -199,15 +199,8 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.query.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.query.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.query.livenessProbe "enabled") "context" $) | nindent 12 }}
-            {{- if not .Values.auth.basicAuthUsers }}
-            httpGet:
-              path: /-/healthy
-              port: http
-              scheme: {{ ternary "HTTPS" "HTTP" .Values.https.enabled }}
-            {{- else }}
             tcpSocket:
               port: http
-            {{- end }}
           {{- end }}
           {{- if .Values.query.customReadinessProbe }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.query.customReadinessProbe "context" $) | nindent 12 }}

--- a/bitnami/thanos/templates/receive-distributor/deployment.yaml
+++ b/bitnami/thanos/templates/receive-distributor/deployment.yaml
@@ -160,15 +160,8 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.receiveDistributor.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.receiveDistributor.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.receiveDistributor.livenessProbe "enabled") "context" $) | nindent 12 }}
-            {{- if not .Values.auth.basicAuthUsers }}
-            httpGet:
-              path: /-/healthy
-              port: http
-              scheme: {{ ternary "HTTPS" "HTTP" .Values.https.enabled }}
-            {{- else }}
             tcpSocket:
               port: http
-            {{- end }}
           {{- end }}
           {{- if .Values.receiveDistributor.customReadinessProbe }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.receiveDistributor.customReadinessProbe "context" $) | nindent 12 }}

--- a/bitnami/thanos/templates/receive/statefulset.yaml
+++ b/bitnami/thanos/templates/receive/statefulset.yaml
@@ -213,15 +213,8 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.receive.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.receive.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.receive.livenessProbe "enabled") "context" $) | nindent 12 }}
-            {{- if not .Values.auth.basicAuthUsers }}
-            httpGet:
-              path: /-/healthy
-              port: http
-              scheme: {{ ternary "HTTPS" "HTTP" .Values.https.enabled }}
-            {{- else }}
             tcpSocket:
               port: http
-            {{- end }}
           {{- end }}
           {{- if .Values.receive.customReadinessProbe }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.receive.customReadinessProbe "context" $) | nindent 12 }}

--- a/bitnami/thanos/templates/ruler/statefulset.yaml
+++ b/bitnami/thanos/templates/ruler/statefulset.yaml
@@ -184,15 +184,8 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.ruler.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.ruler.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.ruler.livenessProbe "enabled") "context" $) | nindent 12 }}
-            {{- if not .Values.auth.basicAuthUsers }}
-            httpGet:
-              path: /-/healthy
-              port: http
-              scheme: {{ ternary "HTTPS" "HTTP" .Values.https.enabled }}
-            {{- else }}
             tcpSocket:
               port: http
-            {{- end }}
           {{- end }}
           {{- if .Values.ruler.customReadinessProbe }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.ruler.customReadinessProbe "context" $) | nindent 12 }}

--- a/bitnami/thanos/templates/storegateway/statefulset.yaml
+++ b/bitnami/thanos/templates/storegateway/statefulset.yaml
@@ -177,15 +177,8 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.storegateway.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.storegateway.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.storegateway.livenessProbe "enabled") "context" $) | nindent 12 }}
-            {{- if not .Values.auth.basicAuthUsers }}
-            httpGet:
-              path: /-/healthy
-              port: http
-              scheme: {{ ternary "HTTPS" "HTTP" .Values.https.enabled }}
-            {{- else }}
             tcpSocket:
               port: http
-            {{- end }}
           {{- end }}
           {{- if .Values.storegateway.customReadinessProbe }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.storegateway.customReadinessProbe "context" $) | nindent 12 }}


### PR DESCRIPTION
### Description of the change
This PR aims to use different liveness/readiness probes to improve overall security and avoid unnecessary container restarts. [More info](https://github.com/zegl/kube-score/blob/master/README_PROBES.md).

### Benefits

Increase availability and resilience.

### Possible drawbacks

N/A

### Applicable issues

- fixes #

### Additional information

- Related to #23537

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- ~[X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)~
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)