### PR TITLE
[bitnami/deepspeed] Use different liveness/readiness probes (part 2)

### DIFF
--- a/bitnami/deepspeed/CHANGELOG.md
+++ b/bitnami/deepspeed/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
+## 2.1.1 (2024-05-21)
+
+* [bitnami/deepspeed] Use different liveness/readiness probes (part 2) ([#26168](https://github.com/bitnami/charts/pulls/26168))
+
 ## 2.1.0 (2024-05-21)
 
-* [bitnami/deepspeed] feat: :sparkles: :lock: Add warning when original images are replaced ([#26192](https://github.com/bitnami/charts/pulls/26192))
+* [bitnami/*] ci: :construction_worker: Add tag and changelog support (#25359) ([91c707c](https://github.com/bitnami/charts/commit/91c707c)), closes [#25359](https://github.com/bitnami/charts/issues/25359)
+* [bitnami/deepspeed] feat: :sparkles: :lock: Add warning when original images are replaced (#26192) ([309aec1](https://github.com/bitnami/charts/commit/309aec1)), closes [#26192](https://github.com/bitnami/charts/issues/26192)
 
 ## <small>2.0.6 (2024-05-21)</small>
 

--- a/bitnami/deepspeed/Chart.lock
+++ b/bitnami/deepspeed/Chart.lock
@@ -4,3 +4,4 @@ dependencies:
   version: 2.19.3
 digest: sha256:de997835d9ce9a9deefc2d70d8c62b11aa1d1a76ece9e86a83736ab9f930bf4d
 generated: "2024-05-21T13:33:30.620842827+02:00"
+

--- a/bitnami/deepspeed/Chart.yaml
+++ b/bitnami/deepspeed/Chart.yaml
@@ -35,4 +35,5 @@ name: deepspeed
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/deepspeed
 - https://github.com/bitnami/charts/tree/main/bitnami/pytorch
-version: 2.1.0
+version: 2.1.1
+

--- a/bitnami/deepspeed/templates/client/client-dep-job.yaml
+++ b/bitnami/deepspeed/templates/client/client-dep-job.yaml
@@ -158,9 +158,8 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.client.livenessProbe "enabled") "context" $) | nindent 12 }}
             exec:
               command:
-                - python
-                - -c
-                - import torch; torch.__version__
+                - deepspeed
+                - --help
           {{- end }}
           {{- if .Values.client.customReadinessProbe }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.client.customReadinessProbe "context" $) | nindent 12 }}


### PR DESCRIPTION
### Description of the change
This PR aims to use different liveness/readiness probes to improve overall security and avoid unnecessary container restarts. [More info](https://github.com/zegl/kube-score/blob/master/README_PROBES.md).

### Benefits

Increase availability and resilience.

### Possible drawbacks

N/A

### Applicable issues

- fixes #

### Additional information

- Related to #23537

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
