### PR TITLE
[bitnami/kuberay] Use different liveness/readiness probes

### DIFF
--- a/bitnami/kuberay/CHANGELOG.md
+++ b/bitnami/kuberay/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
+## 1.1.1 (2024-05-21)
+
+* [bitnami/kuberay] Use different liveness/readiness probes ([#26170](https://github.com/bitnami/charts/pulls/26170))
+
 ## 1.1.0 (2024-05-21)
 
-* [bitnami/kuberay] feat: :sparkles: :lock: Add warning when original images are replaced ([#26232](https://github.com/bitnami/charts/pulls/26232))
+* [bitnami/*] ci: :construction_worker: Add tag and changelog support (#25359) ([91c707c](https://github.com/bitnami/charts/commit/91c707c)), closes [#25359](https://github.com/bitnami/charts/issues/25359)
+* [bitnami/kuberay] feat: :sparkles: :lock: Add warning when original images are replaced (#26232) ([ca2bc25](https://github.com/bitnami/charts/commit/ca2bc25)), closes [#26232](https://github.com/bitnami/charts/issues/26232)
 
 ## <small>1.0.4 (2024-05-18)</small>
 

--- a/bitnami/kuberay/Chart.lock
+++ b/bitnami/kuberay/Chart.lock
@@ -4,3 +4,4 @@ dependencies:
   version: 2.19.3
 digest: sha256:de997835d9ce9a9deefc2d70d8c62b11aa1d1a76ece9e86a83736ab9f930bf4d
 generated: "2024-05-21T14:02:42.537417716+02:00"
+

--- a/bitnami/kuberay/Chart.yaml
+++ b/bitnami/kuberay/Chart.yaml
@@ -32,4 +32,5 @@ maintainers:
 name: kuberay
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/kuberay
-version: 1.1.0
+version: 1.1.1
+

--- a/bitnami/kuberay/templates/apiserver/deployment.yaml
+++ b/bitnami/kuberay/templates/apiserver/deployment.yaml
@@ -125,8 +125,7 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.apiserver.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.apiserver.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.apiserver.livenessProbe "enabled") "context" $) | nindent 12 }}
-            httpGet:
-              path: /healthz
+            tcpSocket:
               port: http
           {{- end }}
           {{- if .Values.apiserver.customReadinessProbe }}

--- a/bitnami/kuberay/templates/operator/deployment.yaml
+++ b/bitnami/kuberay/templates/operator/deployment.yaml
@@ -129,8 +129,7 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.operator.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.operator.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.operator.livenessProbe "enabled") "context" $) | nindent 12 }}
-            httpGet:
-              path: /healthz
+            tcpSocket:
               port: http-health
           {{- end }}
           {{- if .Values.operator.customReadinessProbe }}


### PR DESCRIPTION
### Description of the change
This PR aims to use different liveness/readiness probes to improve overall security and avoid unnecessary container restarts. [More info](https://github.com/zegl/kube-score/blob/master/README_PROBES.md).

### Benefits

Increase availability and resilience.

### Possible drawbacks

N/A

### Applicable issues

- fixes #

### Additional information

- Related to #23537

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- ~[X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)~
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
