### PR TITLE
[bitnami/kubeapps] Use different liveness/readiness probes

### DIFF
--- a/bitnami/kubeapps/CHANGELOG.md
+++ b/bitnami/kubeapps/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
+## 15.1.1 (2024-05-21)
+
+* [bitnami/kubeapps] Use different liveness/readiness probes ([#26171](https://github.com/bitnami/charts/pulls/26171))
+
 ## 15.1.0 (2024-05-21)
 
-* [bitnami/kubeapps] feat: :sparkles: :lock: Add warning when original images are replaced ([#26231](https://github.com/bitnami/charts/pulls/26231))
+* [bitnami/*] ci: :construction_worker: Add tag and changelog support (#25359) ([91c707c](https://github.com/bitnami/charts/commit/91c707c)), closes [#25359](https://github.com/bitnami/charts/issues/25359)
+* [bitnami/kubeapps] feat: :sparkles: :lock: Add warning when original images are replaced (#26231) ([8be3e8b](https://github.com/bitnami/charts/commit/8be3e8b)), closes [#26231](https://github.com/bitnami/charts/issues/26231)
 
 ## <small>15.0.5 (2024-05-20)</small>
 

--- a/bitnami/kubeapps/Chart.lock
+++ b/bitnami/kubeapps/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: redis
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 19.3.4
+  version: 19.4.0
 - name: postgresql
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 15.3.5
+  version: 15.4.0
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 2.19.3
-digest: sha256:421922ce652958558ed4b16c9dfb556eac3adbc0e50bee3d2b888b1e046ef74a
-generated: "2024-05-21T14:01:57.176502977+02:00"
+digest: sha256:e21817b7aa0ee15ab290176e6dd5b77fafd184098f1e4c222a708adaf39a59dd
+generated: "2024-05-21T17:33:02.758471+02:00"

--- a/bitnami/kubeapps/Chart.yaml
+++ b/bitnami/kubeapps/Chart.yaml
@@ -52,4 +52,5 @@ maintainers:
 name: kubeapps
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/kubeapps
-version: 15.1.0
+version: 15.1.1
+

--- a/bitnami/kubeapps/templates/dashboard/deployment.yaml
+++ b/bitnami/kubeapps/templates/dashboard/deployment.yaml
@@ -112,8 +112,7 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.dashboard.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.dashboard.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.dashboard.livenessProbe "enabled") "context" $) | nindent 12 }}
-            httpGet:
-              path: /
+            tcpSocket:
               port: http
           {{- end }}
           {{- if .Values.dashboard.customReadinessProbe }}

--- a/bitnami/kubeapps/templates/frontend/deployment.yaml
+++ b/bitnami/kubeapps/templates/frontend/deployment.yaml
@@ -111,8 +111,7 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.frontend.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.frontend.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.frontend.livenessProbe "enabled") "context" $) | nindent 12 }}
-            httpGet:
-              path: /healthz
+            tcpSocket:
               port: http
           {{- end }}
           {{- if .Values.frontend.customReadinessProbe }}

--- a/bitnami/kubeapps/templates/kubeappsapis/deployment.yaml
+++ b/bitnami/kubeapps/templates/kubeappsapis/deployment.yaml
@@ -189,8 +189,8 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.kubeappsapis.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.kubeappsapis.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.kubeappsapis.livenessProbe "enabled") "context" $) | nindent 12 }}
-            exec:
-              command: ["grpc_health_probe", "-addr=:{{ .Values.kubeappsapis.containerPorts.http }}"]
+            tcpSocket:
+              port: grpc-http
           {{- end }}
           {{- if .Values.kubeappsapis.customReadinessProbe }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.kubeappsapis.customReadinessProbe "context" $) | nindent 12 }}
@@ -289,8 +289,8 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.ociCatalog.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.ociCatalog.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.kubeappsapis.livenessProbe "enabled") "context" $) | nindent 12 }}
-            exec:
-              command: ["grpc_health_probe", "-addr=:{{ .Values.ociCatalog.containerPorts.grpc }}"]
+            tcpSocket:
+              port: grpc-http
           {{- end }}
           {{- if .Values.ociCatalog.customReadinessProbe }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.ociCatalog.customReadinessProbe "context" $) | nindent 12 }}


### PR DESCRIPTION
### Description of the change
This PR aims to use different liveness/readiness probes to improve overall security and avoid unnecessary container restarts. [More info](https://github.com/zegl/kube-score/blob/master/README_PROBES.md).

### Benefits

Increase availability and resilience.

### Possible drawbacks

N/A

### Applicable issues

- fixes #

### Additional information

- Related to #23537

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- ~[X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)~
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
