### PR TITLE
[bitnami/kube-state-metrics-probes] Use different liveness/readiness probes

### DIFF
--- a/bitnami/kube-state-metrics/CHANGELOG.md
+++ b/bitnami/kube-state-metrics/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
+## 4.1.1 (2024-05-21)
+
+* [bitnami/kube-state-metrics-probes] Use different liveness/readiness probes ([#26174](https://github.com/bitnami/charts/pulls/26174))
+
 ## 4.1.0 (2024-05-21)
 
-* [bitnami/kube-state-metrics] feat: :sparkles: :lock: Add warning when original images are replaced ([#26230](https://github.com/bitnami/charts/pulls/26230))
+* [bitnami/*] ci: :construction_worker: Add tag and changelog support (#25359) ([91c707c](https://github.com/bitnami/charts/commit/91c707c)), closes [#25359](https://github.com/bitnami/charts/issues/25359)
+* [bitnami/kube-state-metrics] feat: :sparkles: :lock: Add warning when original images are replaced ( ([24028d6](https://github.com/bitnami/charts/commit/24028d6)), closes [#26230](https://github.com/bitnami/charts/issues/26230)
 
 ## <small>4.0.7 (2024-05-18)</small>
 

--- a/bitnami/kube-state-metrics/Chart.yaml
+++ b/bitnami/kube-state-metrics/Chart.yaml
@@ -28,4 +28,5 @@ maintainers:
 name: kube-state-metrics
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/kube-state-metrics
-version: 4.1.0
+version: 4.1.1
+

--- a/bitnami/kube-state-metrics/Chart.yaml
+++ b/bitnami/kube-state-metrics/Chart.yaml
@@ -29,4 +29,3 @@ name: kube-state-metrics
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/kube-state-metrics
 version: 4.1.1
-

--- a/bitnami/kube-state-metrics/templates/deployment.yaml
+++ b/bitnami/kube-state-metrics/templates/deployment.yaml
@@ -216,8 +216,7 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.livenessProbe "enabled") "context" $) | nindent 12 }}
-            httpGet:
-              path: /healthz
+            tcpSocket:
               port: http
           {{- end }}
           {{- if .Values.customReadinessProbe }}


### PR DESCRIPTION
### Description of the change
This PR aims to use different liveness/readiness probes to improve overall security and avoid unnecessary container restarts. [More info](https://github.com/zegl/kube-score/blob/master/README_PROBES.md).

### Benefits

Increase availability and resilience.

### Possible drawbacks

N/A

### Applicable issues

- fixes #

### Additional information

- Related to #23537

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- ~[X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)~
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
