### PR TITLE
[bitnami/node-exporter] Use different liveness/readiness probes

### DIFF
--- a/bitnami/node-exporter/CHANGELOG.md
+++ b/bitnami/node-exporter/CHANGELOG.md
@@ -1,0 +1,746 @@
+# Changelog
+
+## 4.2.4 (2024-05-21)
+
+* [bitnami/node-exporter] Use different liveness/readiness probes ([#26178](https://github.com/bitnami/charts/pulls/26178))
+
+## <small>4.2.3 (2024-05-18)</small>
+
+* [bitnami/node-exporter] Release 4.2.3 updating components versions (#26056) ([1e0821d](https://github.com/bitnami/charts/commit/1e0821d)), closes [#26056](https://github.com/bitnami/charts/issues/26056)
+
+## <small>4.2.2 (2024-05-14)</small>
+
+* [bitnami/*] Change non-root and rolling-tags doc URLs (#25628) ([b067c94](https://github.com/bitnami/charts/commit/b067c94)), closes [#25628](https://github.com/bitnami/charts/issues/25628)
+* [bitnami/node-exporter] Release 4.2.2 updating components versions (#25803) ([0a8a4bd](https://github.com/bitnami/charts/commit/0a8a4bd)), closes [#25803](https://github.com/bitnami/charts/issues/25803)
+
+## <small>4.2.1 (2024-05-08)</small>
+
+* [bitnami/*] Set new header/owner (#25558) ([8d1dc11](https://github.com/bitnami/charts/commit/8d1dc11)), closes [#25558](https://github.com/bitnami/charts/issues/25558)
+* [bitnami/node-exporter] Release 4.2.1 updating components versions (#25614) ([d72779d](https://github.com/bitnami/charts/commit/d72779d)), closes [#25614](https://github.com/bitnami/charts/issues/25614)
+
+## 4.2.0 (2024-05-03)
+
+* [bitnami/multiple charts] Fix typo: "NetworkPolice" vs "NetworkPolicy" (#25348) ([6970c1b](https://github.com/bitnami/charts/commit/6970c1b)), closes [#25348](https://github.com/bitnami/charts/issues/25348)
+* [bitnami/node-exporter] Update PSP annotation to dynamic value (#25430) ([5bbe0fa](https://github.com/bitnami/charts/commit/5bbe0fa)), closes [#25430](https://github.com/bitnami/charts/issues/25430)
+* Replace VMware by Broadcom copyright text (#25306) ([a5e4bd0](https://github.com/bitnami/charts/commit/a5e4bd0)), closes [#25306](https://github.com/bitnami/charts/issues/25306)
+
+## <small>4.1.1 (2024-04-24)</small>
+
+* [bitnami/node-exporter] Release 4.1.1 updating components versions (#25368) ([e31a16c](https://github.com/bitnami/charts/commit/e31a16c)), closes [#25368](https://github.com/bitnami/charts/issues/25368)
+
+## 4.1.0 (2024-04-22)
+
+* add deployment support (#25079) ([ef92f8a](https://github.com/bitnami/charts/commit/ef92f8a)), closes [#25079](https://github.com/bitnami/charts/issues/25079)
+
+## <small>4.0.3 (2024-04-05)</small>
+
+* [bitnami/node-exporter] Release 4.0.3 updating components versions (#24966) ([4c884d2](https://github.com/bitnami/charts/commit/4c884d2)), closes [#24966](https://github.com/bitnami/charts/issues/24966)
+
+## <small>4.0.2 (2024-04-04)</small>
+
+* [bitnami/node-exporter] Release 4.0.2 (#24910) ([a53b61d](https://github.com/bitnami/charts/commit/a53b61d)), closes [#24910](https://github.com/bitnami/charts/issues/24910)
+* Update resourcesPreset comments (#24467) ([92e3e8a](https://github.com/bitnami/charts/commit/92e3e8a)), closes [#24467](https://github.com/bitnami/charts/issues/24467)
+
+## <small>4.0.1 (2024-04-01)</small>
+
+* [bitnami/*] Reorder Chart sections (#24455) ([0cf4048](https://github.com/bitnami/charts/commit/0cf4048)), closes [#24455](https://github.com/bitnami/charts/issues/24455)
+* [bitnami/node-exporter] fix: :bug: Set seLinuxOptions to {} (#24675) ([7b5618a](https://github.com/bitnami/charts/commit/7b5618a)), closes [#24675](https://github.com/bitnami/charts/issues/24675)
+
+## 4.0.0 (2024-03-15)
+
+* [bitnami/node-exporter] feat!: 🔒 💥 Improve security defaults (#24367) ([92eefcd](https://github.com/bitnami/charts/commit/92eefcd)), closes [#24367](https://github.com/bitnami/charts/issues/24367)
+
+## <small>3.16.1 (2024-03-07)</small>
+
+* [bitnami/node-exporter] Release 3.16.1 updating components versions (#24228) ([8ee86c5](https://github.com/bitnami/charts/commit/8ee86c5)), closes [#24228](https://github.com/bitnami/charts/issues/24228)
+
+## 3.16.0 (2024-03-06)
+
+* [bitnami/node-exporter] feat: :sparkles: :lock: Add automatic adaptation for Openshift restricted-v2 ([e6fd18e](https://github.com/bitnami/charts/commit/e6fd18e)), closes [#24132](https://github.com/bitnami/charts/issues/24132)
+
+## 3.15.0 (2024-02-29)
+
+* [bitnami/node-exporter] feat: :sparkles: :lock: Add readOnlyRootFilesystem support (#23988) ([5b680f2](https://github.com/bitnami/charts/commit/5b680f2)), closes [#23988](https://github.com/bitnami/charts/issues/23988)
+
+## <small>3.14.2 (2024-02-22)</small>
+
+* [bitnami/node-exporter] Release 3.14.2 updating components versions (#23813) ([9b022d5](https://github.com/bitnami/charts/commit/9b022d5)), closes [#23813](https://github.com/bitnami/charts/issues/23813)
+
+## <small>3.14.1 (2024-02-21)</small>
+
+* [bitnami/node-exporter] Release 3.14.1 updating components versions (#23681) ([5bfe332](https://github.com/bitnami/charts/commit/5bfe332)), closes [#23681](https://github.com/bitnami/charts/issues/23681)
+
+## 3.14.0 (2024-02-20)
+
+* [bitnami/*] Bump all versions (#23602) ([b70ee2a](https://github.com/bitnami/charts/commit/b70ee2a)), closes [#23602](https://github.com/bitnami/charts/issues/23602)
+
+## 3.13.0 (2024-02-16)
+
+* [bitnami/node-exporter] feat: :sparkles: :lock: Add resource preset support (#23499) ([62a0dfa](https://github.com/bitnami/charts/commit/62a0dfa)), closes [#23499](https://github.com/bitnami/charts/issues/23499)
+
+## <small>3.12.4 (2024-02-08)</small>
+
+* [bitnami/node-exporter] Release 3.12.4 updating components versions (#23313) ([a90e16c](https://github.com/bitnami/charts/commit/a90e16c)), closes [#23313](https://github.com/bitnami/charts/issues/23313)
+
+## <small>3.12.3 (2024-02-07)</small>
+
+* [bitnami/node-exporter] Release 3.12.3 updating components versions (#23248) ([8c85b8f](https://github.com/bitnami/charts/commit/8c85b8f)), closes [#23248](https://github.com/bitnami/charts/issues/23248)
+
+## <small>3.12.2 (2024-02-03)</small>
+
+* [bitnami/node-exporter] Release 3.12.2 updating components versions (#23118) ([4ddb468](https://github.com/bitnami/charts/commit/4ddb468)), closes [#23118](https://github.com/bitnami/charts/issues/23118)
+
+## <small>3.12.1 (2024-02-02)</small>
+
+* [bitnami/node-exporter] fix: :bug: Remove unnecessary label ([b9a4825](https://github.com/bitnami/charts/commit/b9a4825))
+
+## 3.12.0 (2024-02-01)
+
+* [bitnami/node-exporter] feat: :lock: Enable networkPolicy (#22873) ([653f7ca](https://github.com/bitnami/charts/commit/653f7ca)), closes [#22873](https://github.com/bitnami/charts/issues/22873)
+
+## <small>3.11.2 (2024-01-30)</small>
+
+* [bitnami/*] Move documentation sections from docs.bitnami.com back to the README (#22203) ([7564f36](https://github.com/bitnami/charts/commit/7564f36)), closes [#22203](https://github.com/bitnami/charts/issues/22203)
+* [bitnami/node-exporter] Release 3.11.2 updating components versions (#22914) ([5db80f4](https://github.com/bitnami/charts/commit/5db80f4)), closes [#22914](https://github.com/bitnami/charts/issues/22914)
+
+## <small>3.11.1 (2024-01-24)</small>
+
+* [bitnami/node-exporter] fix: :bug: Set seLinuxOptions to null for Openshift compatibility (#22636) ([f8b3bd1](https://github.com/bitnami/charts/commit/f8b3bd1)), closes [#22636](https://github.com/bitnami/charts/issues/22636)
+
+## 3.11.0 (2024-01-19)
+
+* [bitnami/node-exporter] fix: :lock: Move service-account token auto-mount to pod declaration (#22443 ([17c4bba](https://github.com/bitnami/charts/commit/17c4bba)), closes [#22443](https://github.com/bitnami/charts/issues/22443)
+
+## <small>3.10.1 (2024-01-18)</small>
+
+* [bitnami/node-exporter] Release 3.10.1 updating components versions (#22309) ([19d8a07](https://github.com/bitnami/charts/commit/19d8a07)), closes [#22309](https://github.com/bitnami/charts/issues/22309)
+
+## 3.10.0 (2024-01-16)
+
+* [bitnami/node-exporter] fix: :lock: Improve podSecurityContext and containerSecurityContext with ess ([bcfd87b](https://github.com/bitnami/charts/commit/bcfd87b)), closes [#22167](https://github.com/bitnami/charts/issues/22167)
+
+## <small>3.9.8 (2024-01-15)</small>
+
+* [bitnami/*] Fix ref links (in comments) (#21822) ([e4fa296](https://github.com/bitnami/charts/commit/e4fa296)), closes [#21822](https://github.com/bitnami/charts/issues/21822)
+* [bitnami/node-exporter] fix: :lock: Do not automount the service account token unless necessary (#22 ([412a4ae](https://github.com/bitnami/charts/commit/412a4ae)), closes [#22056](https://github.com/bitnami/charts/issues/22056)
+
+## <small>3.9.7 (2024-01-10)</small>
+
+* [bitnami/*] Fix docs.bitnami.com broken links (#21901) ([f35506d](https://github.com/bitnami/charts/commit/f35506d)), closes [#21901](https://github.com/bitnami/charts/issues/21901)
+* [bitnami/*] Update copyright: Year and company (#21815) ([6c4bf75](https://github.com/bitnami/charts/commit/6c4bf75)), closes [#21815](https://github.com/bitnami/charts/issues/21815)
+* [bitnami/node-exporter] Release 3.9.7 updating components versions (#21967) ([1cb042b](https://github.com/bitnami/charts/commit/1cb042b)), closes [#21967](https://github.com/bitnami/charts/issues/21967)
+
+## <small>3.9.6 (2023-12-07)</small>
+
+* [bitnami/node-exporter] Release 3.9.6 updating components versions (#21438) ([22bab14](https://github.com/bitnami/charts/commit/22bab14)), closes [#21438](https://github.com/bitnami/charts/issues/21438)
+
+## <small>3.9.5 (2023-12-05)</small>
+
+* [bitnami/node-exporter] Replace deprecated pull secret partial (#21391) ([de67b33](https://github.com/bitnami/charts/commit/de67b33)), closes [#21391](https://github.com/bitnami/charts/issues/21391)
+
+## <small>3.9.4 (2023-11-21)</small>
+
+* [bitnami/*] Remove relative links to non-README sections, add verification for that and update TL;DR ([1103633](https://github.com/bitnami/charts/commit/1103633)), closes [#20967](https://github.com/bitnami/charts/issues/20967)
+* [bitnami/*] Rename solutions to "Bitnami package for ..." (#21038) ([b82f979](https://github.com/bitnami/charts/commit/b82f979)), closes [#21038](https://github.com/bitnami/charts/issues/21038)
+* [bitnami/node-exporter] Release 3.9.4 updating components versions (#21146) ([80ba4ff](https://github.com/bitnami/charts/commit/80ba4ff)), closes [#21146](https://github.com/bitnami/charts/issues/21146)
+
+## <small>3.9.3 (2023-11-13)</small>
+
+* [bitnami/node-exporter] Release 3.9.3 updating components versions (#20911) ([3e1b21a](https://github.com/bitnami/charts/commit/3e1b21a)), closes [#20911](https://github.com/bitnami/charts/issues/20911)
+
+## <small>3.9.2 (2023-11-09)</small>
+
+* [bitnami/node-exporter] Release 3.9.2 updating components versions (#20825) ([1076321](https://github.com/bitnami/charts/commit/1076321)), closes [#20825](https://github.com/bitnami/charts/issues/20825)
+
+## <small>3.9.1 (2023-11-08)</small>
+
+* [bitnami/node-exporter] Release 3.9.1 updating components versions (#20761) ([62bf409](https://github.com/bitnami/charts/commit/62bf409)), closes [#20761](https://github.com/bitnami/charts/issues/20761)
+
+## 3.9.0 (2023-10-31)
+
+* [bitnami/*] Rename VMware Application Catalog (#20361) ([3acc734](https://github.com/bitnami/charts/commit/3acc734)), closes [#20361](https://github.com/bitnami/charts/issues/20361)
+* [bitnami/*] Skip image's tag in the README files of the Bitnami Charts (#19841) ([bb9a01b](https://github.com/bitnami/charts/commit/bb9a01b)), closes [#19841](https://github.com/bitnami/charts/issues/19841)
+* [bitnami/*] Standardize documentation (#19835) ([af5f753](https://github.com/bitnami/charts/commit/af5f753)), closes [#19835](https://github.com/bitnami/charts/issues/19835)
+* [bitnami/node-exporter] feat: :sparkles: Add partial support for PSA restricted policy (#20514) ([7119224](https://github.com/bitnami/charts/commit/7119224)), closes [#20514](https://github.com/bitnami/charts/issues/20514)
+
+## <small>3.8.5 (2023-10-12)</small>
+
+* [bitnami/node-exporter] Release 3.8.5 updating components versions (#20160) ([36932cd](https://github.com/bitnami/charts/commit/36932cd)), closes [#20160](https://github.com/bitnami/charts/issues/20160)
+
+## <small>3.8.4 (2023-10-11)</small>
+
+* [bitnami/node-exporter] Release 3.8.4 (#20057) ([3243e54](https://github.com/bitnami/charts/commit/3243e54)), closes [#20057](https://github.com/bitnami/charts/issues/20057)
+
+## <small>3.8.3 (2023-10-10)</small>
+
+* [bitnami/node-exporter] Use common capabilities for PSP (#19635) ([21f1f90](https://github.com/bitnami/charts/commit/21f1f90)), closes [#19635](https://github.com/bitnami/charts/issues/19635)
+
+## <small>3.8.2 (2023-10-09)</small>
+
+* [bitnami/*] Update Helm charts prerequisites (#19745) ([eb755dd](https://github.com/bitnami/charts/commit/eb755dd)), closes [#19745](https://github.com/bitnami/charts/issues/19745)
+* [bitnami/node-exporter] Release 3.8.2 (#19879) ([636aca1](https://github.com/bitnami/charts/commit/636aca1)), closes [#19879](https://github.com/bitnami/charts/issues/19879)
+
+## <small>3.8.1 (2023-10-04)</small>
+
+* [bitnami/node-exporter] Release 3.8.1 (#19730) ([d793e89](https://github.com/bitnami/charts/commit/d793e89)), closes [#19730](https://github.com/bitnami/charts/issues/19730)
+
+## 3.8.0 (2023-09-19)
+
+* [bitnami/node-exporter] Allow setting ServiceMonitor's sampleLimit (#19322) ([86669a5](https://github.com/bitnami/charts/commit/86669a5)), closes [#19322](https://github.com/bitnami/charts/issues/19322)
+
+## <small>3.7.2 (2023-09-19)</small>
+
+* [bitnami/node-exporter] Release 3.7.2 (#19385) ([385c07f](https://github.com/bitnami/charts/commit/385c07f)), closes [#19385](https://github.com/bitnami/charts/issues/19385)
+* Autogenerate schema files (#19194) ([a2c2090](https://github.com/bitnami/charts/commit/a2c2090)), closes [#19194](https://github.com/bitnami/charts/issues/19194)
+* Revert "Autogenerate schema files (#19194)" (#19335) ([73d80be](https://github.com/bitnami/charts/commit/73d80be)), closes [#19194](https://github.com/bitnami/charts/issues/19194) [#19335](https://github.com/bitnami/charts/issues/19335)
+
+## <small>3.7.1 (2023-09-08)</small>
+
+* [bitnami/node-exporter: Use merge helper]: (#19170) ([79fcbf1](https://github.com/bitnami/charts/commit/79fcbf1)), closes [#19170](https://github.com/bitnami/charts/issues/19170)
+
+## 3.7.0 (2023-08-22)
+
+* [bitnami/node-exporter] Support for customizing standard labels (#18398) ([5d92426](https://github.com/bitnami/charts/commit/5d92426)), closes [#18398](https://github.com/bitnami/charts/issues/18398)
+
+## <small>3.6.6 (2023-08-20)</small>
+
+* [bitnami/node-exporter] Release 3.6.6 (#18695) ([fa5e331](https://github.com/bitnami/charts/commit/fa5e331)), closes [#18695](https://github.com/bitnami/charts/issues/18695)
+
+## <small>3.6.5 (2023-08-17)</small>
+
+* [bitnami/node-exporter] Release 3.6.5 (#18565) ([895476d](https://github.com/bitnami/charts/commit/895476d)), closes [#18565](https://github.com/bitnami/charts/issues/18565)
+
+## <small>3.6.4 (2023-07-26)</small>
+
+* [bitnami/node-exporter] Release 3.6.4 (#17926) ([0e67109](https://github.com/bitnami/charts/commit/0e67109)), closes [#17926](https://github.com/bitnami/charts/issues/17926)
+
+## <small>3.6.3 (2023-07-22)</small>
+
+* [bitnami/node-exporter] Release 3.6.3 (#17823) ([bb0630e](https://github.com/bitnami/charts/commit/bb0630e)), closes [#17823](https://github.com/bitnami/charts/issues/17823)
+
+## <small>3.6.2 (2023-07-17)</small>
+
+* [bitnami/node-exporter] Release 3.6.2 (#17750) ([b5a2eda](https://github.com/bitnami/charts/commit/b5a2eda)), closes [#17750](https://github.com/bitnami/charts/issues/17750)
+
+## <small>3.6.1 (2023-07-15)</small>
+
+* [bitnami/node-exporter] Release 3 (#17623) ([43bded6](https://github.com/bitnami/charts/commit/43bded6)), closes [#17623](https://github.com/bitnami/charts/issues/17623)
+
+## 3.6.0 (2023-06-28)
+
+* add attachMetadata option support for node_exporter's serviceMonitor (#17281) ([e1b669a](https://github.com/bitnami/charts/commit/e1b669a)), closes [#17281](https://github.com/bitnami/charts/issues/17281)
+
+## <small>3.5.5 (2023-06-28)</small>
+
+* [bitnami/node-exporter] Release 3.5.5 (#17351) ([439d626](https://github.com/bitnami/charts/commit/439d626)), closes [#17351](https://github.com/bitnami/charts/issues/17351)
+* Add copyright header (#17300) ([da68be8](https://github.com/bitnami/charts/commit/da68be8)), closes [#17300](https://github.com/bitnami/charts/issues/17300)
+* Update charts readme (#17217) ([31b3c0a](https://github.com/bitnami/charts/commit/31b3c0a)), closes [#17217](https://github.com/bitnami/charts/issues/17217)
+
+## <small>3.5.4 (2023-06-21)</small>
+
+* [bitnami/*] Change copyright section in READMEs (#17006) ([ef986a1](https://github.com/bitnami/charts/commit/ef986a1)), closes [#17006](https://github.com/bitnami/charts/issues/17006)
+* [bitnami/node-exporter] Remove namespace field for cluster wide resources (#17263) ([78123d3](https://github.com/bitnami/charts/commit/78123d3)), closes [#17263](https://github.com/bitnami/charts/issues/17263)
+* [bitnami/several] Change copyright section in READMEs (#16989) ([5b6a5cf](https://github.com/bitnami/charts/commit/5b6a5cf)), closes [#16989](https://github.com/bitnami/charts/issues/16989)
+
+## <small>3.5.3 (2023-05-28)</small>
+
+* [bitnami/node-exporter] Release 3.5.3 (#16939) ([725ed9e](https://github.com/bitnami/charts/commit/725ed9e)), closes [#16939](https://github.com/bitnami/charts/issues/16939)
+
+## <small>3.5.2 (2023-05-21)</small>
+
+* [bitnami/node-exporter] Release 3.5.2 (#16794) ([0643c3a](https://github.com/bitnami/charts/commit/0643c3a)), closes [#16794](https://github.com/bitnami/charts/issues/16794)
+
+## <small>3.5.1 (2023-05-16)</small>
+
+* [bitnami/node-exporter] Release 3.5.1 (#16691) ([1ea1f5a](https://github.com/bitnami/charts/commit/1ea1f5a)), closes [#16691](https://github.com/bitnami/charts/issues/16691)
+* Add wording for enterprise page (#16560) ([8f22774](https://github.com/bitnami/charts/commit/8f22774)), closes [#16560](https://github.com/bitnami/charts/issues/16560)
+
+## 3.5.0 (2023-05-09)
+
+* [bitnami/several] Adapt Chart.yaml to set desired OCI annotations (#16546) ([fc9b18f](https://github.com/bitnami/charts/commit/fc9b18f)), closes [#16546](https://github.com/bitnami/charts/issues/16546)
+
+## <small>3.4.2 (2023-05-09)</small>
+
+* [bitnami/node-exporter] Release 3.4.2 (#16482) ([df4b33c](https://github.com/bitnami/charts/commit/df4b33c)), closes [#16482](https://github.com/bitnami/charts/issues/16482)
+
+## <small>3.4.1 (2023-05-01)</small>
+
+* [bitnami/node-exporter] Release 3.4.1 (#16318) ([22b929b](https://github.com/bitnami/charts/commit/22b929b)), closes [#16318](https://github.com/bitnami/charts/issues/16318)
+
+## 3.4.0 (2023-04-20)
+
+* [bitnami/*] Make Helm charts 100% OCI (#15998) ([8841510](https://github.com/bitnami/charts/commit/8841510)), closes [#15998](https://github.com/bitnami/charts/issues/15998)
+
+## <small>3.3.4 (2023-04-01)</small>
+
+* [bitnami/node-exporter] Release 3.3.4 (#15911) ([22bba8d](https://github.com/bitnami/charts/commit/22bba8d)), closes [#15911](https://github.com/bitnami/charts/issues/15911)
+
+## <small>3.3.3 (2023-03-18)</small>
+
+* [bitnami/charts] Apply linter to README files (#15357) ([0e29e60](https://github.com/bitnami/charts/commit/0e29e60)), closes [#15357](https://github.com/bitnami/charts/issues/15357)
+* [bitnami/node-exporter] Release 3.3.3 (#15586) ([c019d29](https://github.com/bitnami/charts/commit/c019d29)), closes [#15586](https://github.com/bitnami/charts/issues/15586)
+
+## <small>3.3.2 (2023-03-01)</small>
+
+* [bitnami/node-exporter] Release 3.3.2 (#15242) ([7a88da8](https://github.com/bitnami/charts/commit/7a88da8)), closes [#15242](https://github.com/bitnami/charts/issues/15242)
+
+## <small>3.3.1 (2023-02-17)</small>
+
+* [bitnami/*] Fix markdown linter issues (#14874) ([a51e0e8](https://github.com/bitnami/charts/commit/a51e0e8)), closes [#14874](https://github.com/bitnami/charts/issues/14874)
+* [bitnami/*] Remove unexpected extra spaces (#14873) ([c97c714](https://github.com/bitnami/charts/commit/c97c714)), closes [#14873](https://github.com/bitnami/charts/issues/14873)
+* [bitnami/node-exporter] Release 3.3.1 (#14996) ([52c1e82](https://github.com/bitnami/charts/commit/52c1e82)), closes [#14996](https://github.com/bitnami/charts/issues/14996)
+
+## 3.3.0 (2023-02-09)
+
+* [bitnami/*] Change copyright date (#14682) ([add4ec7](https://github.com/bitnami/charts/commit/add4ec7)), closes [#14682](https://github.com/bitnami/charts/issues/14682)
+* [bitnami/node-exporter] Add BasicAuth to Node Exporter ServiceMonitor (#14777) ([070e30c](https://github.com/bitnami/charts/commit/070e30c)), closes [#14777](https://github.com/bitnami/charts/issues/14777)
+
+## <small>3.2.8 (2023-01-28)</small>
+
+* [bitnami/*] Unify READMEs (#14472) ([2064fb8](https://github.com/bitnami/charts/commit/2064fb8)), closes [#14472](https://github.com/bitnami/charts/issues/14472)
+* [bitnami/node-exporter] Release 3.2.8 (#14584) ([29103a9](https://github.com/bitnami/charts/commit/29103a9)), closes [#14584](https://github.com/bitnami/charts/issues/14584)
+
+## <small>3.2.7 (2023-01-17)</small>
+
+* [bitnami/*] Add license annotation and remove obsolete engine parameter (#14293) ([da2a794](https://github.com/bitnami/charts/commit/da2a794)), closes [#14293](https://github.com/bitnami/charts/issues/14293)
+* [bitnami/*] Change licenses annotation format (#14377) ([0ab7608](https://github.com/bitnami/charts/commit/0ab7608)), closes [#14377](https://github.com/bitnami/charts/issues/14377)
+* [bitnami/node-exporter] Upgrade values.yaml for hostPID (#14331) ([5cee328](https://github.com/bitnami/charts/commit/5cee328)), closes [#14331](https://github.com/bitnami/charts/issues/14331)
+
+## <small>3.2.6 (2022-12-29)</small>
+
+* [bitnami/node-exporter] Release 3.2.6 (#14135) ([522ee8a](https://github.com/bitnami/charts/commit/522ee8a)), closes [#14135](https://github.com/bitnami/charts/issues/14135)
+
+## <small>3.2.5 (2022-11-29)</small>
+
+* [bitnami/node-exporter] Release 3.2.5 (#13751) ([ea86b97](https://github.com/bitnami/charts/commit/ea86b97)), closes [#13751](https://github.com/bitnami/charts/issues/13751)
+
+## <small>3.2.4 (2022-11-29)</small>
+
+* [bitnami/node-exporter] Release 3.2.4 (#13735) ([0d042ef](https://github.com/bitnami/charts/commit/0d042ef)), closes [#13735](https://github.com/bitnami/charts/issues/13735)
+
+## <small>3.2.3 (2022-10-30)</small>
+
+* [bitnami/node-exporter] Release 3.2.3 (#13251) ([97ab344](https://github.com/bitnami/charts/commit/97ab344)), closes [#13251](https://github.com/bitnami/charts/issues/13251)
+
+## <small>3.2.2 (2022-10-26)</small>
+
+* [bitnami/*] Use new default branch name in links (#12943) ([a529e02](https://github.com/bitnami/charts/commit/a529e02)), closes [#12943](https://github.com/bitnami/charts/issues/12943)
+* Generic README instructions related to the repo (#12792) ([3cf6b10](https://github.com/bitnami/charts/commit/3cf6b10)), closes [#12792](https://github.com/bitnami/charts/issues/12792)
+* optimize annos (#13125) ([82803be](https://github.com/bitnami/charts/commit/82803be)), closes [#13125](https://github.com/bitnami/charts/issues/13125)
+
+## <small>3.2.1 (2022-09-30)</small>
+
+* [bitnami/node-exporter] Release 3.2.1 (#12761) ([abf5a4a](https://github.com/bitnami/charts/commit/abf5a4a)), closes [#12761](https://github.com/bitnami/charts/issues/12761)
+
+## 3.2.0 (2022-09-29)
+
+* [bitnami/node-exporter] Add tests and publishing using VIB (#12727) ([5175656](https://github.com/bitnami/charts/commit/5175656)), closes [#12727](https://github.com/bitnami/charts/issues/12727)
+
+## <small>3.1.4 (2022-09-26)</small>
+
+* [bitnami/node-exporter] Release 3.1.4 updating components versions ([b62b545](https://github.com/bitnami/charts/commit/b62b545))
+
+## <small>3.1.3 (2022-09-23)</small>
+
+* [bitnami/node-exporter] Use custom probes if given (#12538) ([bd4a113](https://github.com/bitnami/charts/commit/bd4a113)), closes [#12538](https://github.com/bitnami/charts/issues/12538) [#12354](https://github.com/bitnami/charts/issues/12354)
+
+## <small>3.1.2 (2022-09-03)</small>
+
+* [bitnami/node-exporter] Release 3.1.2 updating components versions ([14193da](https://github.com/bitnami/charts/commit/14193da))
+
+## <small>3.1.1 (2022-08-23)</small>
+
+* [bitnami/node-exporter] Update Chart.lock (#12076) ([6d54044](https://github.com/bitnami/charts/commit/6d54044)), closes [#12076](https://github.com/bitnami/charts/issues/12076)
+
+## 3.1.0 (2022-08-22)
+
+* [bitnami/node-exporter] Add support for image digest apart from tag (#11930) ([7d620d7](https://github.com/bitnami/charts/commit/7d620d7)), closes [#11930](https://github.com/bitnami/charts/issues/11930)
+
+## <small>3.0.8 (2022-08-04)</small>
+
+* [bitnami/node-exporter] Release 3.0.8 updating components versions ([cb84e6c](https://github.com/bitnami/charts/commit/cb84e6c))
+
+## <small>3.0.7 (2022-08-03)</small>
+
+* [bitnami/node-exporter] Release 3.0.7 updating components versions ([08db847](https://github.com/bitnami/charts/commit/08db847))
+
+## <small>3.0.6 (2022-08-02)</small>
+
+* [bitnami/node-exporter] Release 3.0.6 updating components versions ([b69fc57](https://github.com/bitnami/charts/commit/b69fc57))
+
+## <small>3.0.5 (2022-07-30)</small>
+
+* [bitnami/*] Update URLs to point to the new bitnami/containers monorepo (#11352) ([d665af0](https://github.com/bitnami/charts/commit/d665af0)), closes [#11352](https://github.com/bitnami/charts/issues/11352)
+* [bitnami/node-exporter] Release 3.0.5 updating components versions ([e27aafb](https://github.com/bitnami/charts/commit/e27aafb))
+
+## <small>3.0.4 (2022-06-30)</small>
+
+* [bitnami/node-exporter] Release 3.0.4 updating components versions ([9f1c371](https://github.com/bitnami/charts/commit/9f1c371))
+
+## <small>3.0.3 (2022-06-10)</small>
+
+* [bitnami/*] Replace Kubeapps URL in READMEs (and kubeapps Chart.yaml) and remove BKPR references (#1 ([c6a7914](https://github.com/bitnami/charts/commit/c6a7914)), closes [#10600](https://github.com/bitnami/charts/issues/10600)
+* [bitnami/node-exporter] Release 3.0.3 updating components versions ([a0b8034](https://github.com/bitnami/charts/commit/a0b8034))
+
+## <small>3.0.2 (2022-06-06)</small>
+
+* [bitnami/node-exporter] Release 3.0.2 updating components versions ([3e49025](https://github.com/bitnami/charts/commit/3e49025))
+
+## <small>3.0.1 (2022-06-01)</small>
+
+* [bitnami/several] Replace maintainers email by url (#10523) ([ff3cf61](https://github.com/bitnami/charts/commit/ff3cf61)), closes [#10523](https://github.com/bitnami/charts/issues/10523)
+
+## 3.0.0 (2022-05-26)
+
+* [bitnami/node-exporter] Chart standardised (#10250) ([307bf77](https://github.com/bitnami/charts/commit/307bf77)), closes [#10250](https://github.com/bitnami/charts/issues/10250)
+
+## <small>2.4.16 (2022-05-21)</small>
+
+* [bitnami/node-exporter] Release 2.4.16 updating components versions ([8c73f8d](https://github.com/bitnami/charts/commit/8c73f8d))
+
+## <small>2.4.15 (2022-05-20)</small>
+
+* [bitnami/node-exporter] Release 2.4.15 updating components versions ([1db6355](https://github.com/bitnami/charts/commit/1db6355))
+
+## <small>2.4.14 (2022-05-19)</small>
+
+* [bitnami/node-exporter] Release 2.4.14 updating components versions ([c08092b](https://github.com/bitnami/charts/commit/c08092b))
+
+## <small>2.4.13 (2022-05-18)</small>
+
+* [bitnami/node-exporter] Release 2.4.13 updating components versions ([1f13605](https://github.com/bitnami/charts/commit/1f13605))
+
+## <small>2.4.12 (2022-05-11)</small>
+
+* [bitnami/node-exporter] Add missing namespace metadata (#10146) ([74b3d60](https://github.com/bitnami/charts/commit/74b3d60)), closes [#10146](https://github.com/bitnami/charts/issues/10146)
+
+## <small>2.4.11 (2022-04-19)</small>
+
+* [bitnami/node-exporter] Release 2.4.11 updating components versions ([1985429](https://github.com/bitnami/charts/commit/1985429))
+
+## <small>2.4.10 (2022-04-12)</small>
+
+* quote all namespace (#9732) ([0412782](https://github.com/bitnami/charts/commit/0412782)), closes [#9732](https://github.com/bitnami/charts/issues/9732)
+
+## <small>2.4.9 (2022-04-07)</small>
+
+* [bitnami/node-exporter] Release 2.4.9 updating components versions ([10ceb05](https://github.com/bitnami/charts/commit/10ceb05))
+
+## <small>2.4.8 (2022-04-05)</small>
+
+* [bitnami/node-exporter] Release 2.4.8 updating components versions ([962b781](https://github.com/bitnami/charts/commit/962b781))
+
+## <small>2.4.7 (2022-04-02)</small>
+
+* [bitnami/node-exporter] Release 2.4.7 updating components versions ([d62072d](https://github.com/bitnami/charts/commit/d62072d))
+
+## <small>2.4.6 (2022-03-27)</small>
+
+* [bitnami/node-exporter] Release 2.4.6 updating components versions ([4d4ccde](https://github.com/bitnami/charts/commit/4d4ccde))
+
+## <small>2.4.5 (2022-03-16)</small>
+
+* [bitnami/node-exporter] Release 2.4.5 updating components versions ([c6257ec](https://github.com/bitnami/charts/commit/c6257ec))
+
+## <small>2.4.4 (2022-02-27)</small>
+
+* [bitnami/node-exporter] Release 2.4.4 updating components versions ([8345518](https://github.com/bitnami/charts/commit/8345518))
+
+## <small>2.4.3 (2022-02-21)</small>
+
+* [bitnami/node-exporter] Release 2.4.3 updating components versions ([954798a](https://github.com/bitnami/charts/commit/954798a))
+
+## <small>2.4.2 (2022-02-19)</small>
+
+* [bitnami/node-exporter] Release 2.4.2 updating components versions ([ac13774](https://github.com/bitnami/charts/commit/ac13774))
+* [bitnami/several] Change prerequisites (#8725) ([8d740c5](https://github.com/bitnami/charts/commit/8d740c5)), closes [#8725](https://github.com/bitnami/charts/issues/8725)
+* Non utf8 chars (#8923) ([6ffd18f](https://github.com/bitnami/charts/commit/6ffd18f)), closes [#8923](https://github.com/bitnami/charts/issues/8923)
+
+## <small>2.4.1 (2022-01-20)</small>
+
+* [bitnami/*] Readme automation (#8579) ([78d1938](https://github.com/bitnami/charts/commit/78d1938)), closes [#8579](https://github.com/bitnami/charts/issues/8579)
+* [bitnami/*] Update READMEs (#8716) ([b9a9533](https://github.com/bitnami/charts/commit/b9a9533)), closes [#8716](https://github.com/bitnami/charts/issues/8716)
+* [bitnami/node-exporter] Release 2.4.1 updating components versions ([0c3d264](https://github.com/bitnami/charts/commit/0c3d264))
+
+## 2.4.0 (2022-01-05)
+
+* [bitnami/several] Adapt templating format (#8562) ([8cad18a](https://github.com/bitnami/charts/commit/8cad18a)), closes [#8562](https://github.com/bitnami/charts/issues/8562)
+
+## <small>2.3.18 (2022-01-04)</small>
+
+* [bitnami/node-exporter] Release 2.3.18 updating components versions ([67ea28e](https://github.com/bitnami/charts/commit/67ea28e))
+* [bitnami/several] Add license to the README ([05f7633](https://github.com/bitnami/charts/commit/05f7633))
+* [bitnami/several] Add license to the README ([32fb238](https://github.com/bitnami/charts/commit/32fb238))
+* [bitnami/several] Add license to the README ([b87c2f7](https://github.com/bitnami/charts/commit/b87c2f7))
+
+## <small>2.3.17 (2021-12-05)</small>
+
+* [bitnami/node-exporter] Release 2.3.17 updating components versions ([a3c8340](https://github.com/bitnami/charts/commit/a3c8340))
+
+## <small>2.3.16 (2021-11-29)</small>
+
+* [bitnami/several] Regenerate README tables ([7b091c0](https://github.com/bitnami/charts/commit/7b091c0))
+* [bitnami/several] Replace HTTP by HTTPS when possible (#8259) ([eafb5bd](https://github.com/bitnami/charts/commit/eafb5bd)), closes [#8259](https://github.com/bitnami/charts/issues/8259)
+
+## <small>2.3.15 (2021-11-18)</small>
+
+* [bitnami/node-exporter] Release 2.3.15 updating components versions ([7371116](https://github.com/bitnami/charts/commit/7371116))
+
+## <small>2.3.14 (2021-11-17)</small>
+
+* [bitnami/several] Add extraDeploy feature to the pending charts (#8164) ([d812a24](https://github.com/bitnami/charts/commit/d812a24)), closes [#8164](https://github.com/bitnami/charts/issues/8164)
+
+## <small>2.3.13 (2021-10-28)</small>
+
+* [bitnami/*] Mark PodSecurityPolicy resources as deprecated (#7950) ([30e6946](https://github.com/bitnami/charts/commit/30e6946)), closes [#7950](https://github.com/bitnami/charts/issues/7950)
+* [bitnami/several] Regenerate README tables ([412cf6a](https://github.com/bitnami/charts/commit/412cf6a))
+
+## <small>2.3.12 (2021-10-26)</small>
+
+* [bitnami/node-exporter] Release 2.3.12 updating components versions ([9b90924](https://github.com/bitnami/charts/commit/9b90924))
+* [bitnami/several] Regenerate README tables ([c82619f](https://github.com/bitnami/charts/commit/c82619f))
+
+## <small>2.3.11 (2021-10-24)</small>
+
+* [bitnami/node-exporter] Release 2.3.11 updating components versions ([b506491](https://github.com/bitnami/charts/commit/b506491))
+
+## <small>2.3.10 (2021-10-22)</small>
+
+* [bitnami/several] Add chart info to NOTES.txt (#7889) ([a6751cd](https://github.com/bitnami/charts/commit/a6751cd)), closes [#7889](https://github.com/bitnami/charts/issues/7889)
+* [bitnami/several] Regenerate README tables ([ff170d1](https://github.com/bitnami/charts/commit/ff170d1))
+
+## <small>2.3.9 (2021-09-24)</small>
+
+* [bitnami/node-exporter] Release 2.3.9 updating components versions ([b37a6d2](https://github.com/bitnami/charts/commit/b37a6d2))
+* [bitnami/several] Regenerate README tables ([da2513b](https://github.com/bitnami/charts/commit/da2513b))
+
+## <small>2.3.8 (2021-08-25)</small>
+
+* [bitnami/node-exporter] Release 2.3.8 updating components versions ([bb5d5ee](https://github.com/bitnami/charts/commit/bb5d5ee))
+* [bitnami/several] Regenerate README tables ([6c107e8](https://github.com/bitnami/charts/commit/6c107e8))
+
+## <small>2.3.7 (2021-08-06)</small>
+
+* [bitnami/node-exporter] Release 2.3.7 updating components versions ([9194af6](https://github.com/bitnami/charts/commit/9194af6))
+
+## <small>2.3.6 (2021-08-05)</small>
+
+* [bitnami/node-exporter] Release 2.3.6 updating components versions ([752614b](https://github.com/bitnami/charts/commit/752614b))
+
+## <small>2.3.5 (2021-08-04)</small>
+
+* [bitnami/node-exporter] Release 2.3.5 updating components versions ([a8dfec6](https://github.com/bitnami/charts/commit/a8dfec6))
+* [bitnami/several] Upadte READMEs ([eb3c291](https://github.com/bitnami/charts/commit/eb3c291))
+
+## <small>2.3.4 (2021-07-20)</small>
+
+* [bitnami/several] Fix default values and regenerate README (I) (#6991) ([d4fd5eb](https://github.com/bitnami/charts/commit/d4fd5eb)), closes [#6991](https://github.com/bitnami/charts/issues/6991)
+
+## <small>2.3.3 (2021-07-19)</small>
+
+* [bitnami/node-exporter] Release 2.3.3 updating components versions ([1ea2ec3](https://github.com/bitnami/charts/commit/1ea2ec3))
+
+## <small>2.3.2 (2021-07-13)</small>
+
+* [bitnami/node-exporter] Release 2.3.2 updating components versions ([4966a00](https://github.com/bitnami/charts/commit/4966a00))
+* T40806 Updated README (#6927) ([2ea884e](https://github.com/bitnami/charts/commit/2ea884e)), closes [#6927](https://github.com/bitnami/charts/issues/6927)
+
+## <small>2.3.1 (2021-07-12)</small>
+
+* [bitnami/*] Adapt values.yaml of Nginx Ingress Controller, Node and Node Exporter charts (#6920) ([7b2b45a](https://github.com/bitnami/charts/commit/7b2b45a)), closes [#6920](https://github.com/bitnami/charts/issues/6920)
+
+## 2.3.0 (2021-07-08)
+
+* [bitnami/node-exporter] Common labels node exporter (#6886) ([8be55ea](https://github.com/bitnami/charts/commit/8be55ea)), closes [#6886](https://github.com/bitnami/charts/issues/6886)
+
+## <small>2.2.7 (2021-06-13)</small>
+
+* [bitnami/node-exporter] Release 2.2.7 updating components versions ([8433fe1](https://github.com/bitnami/charts/commit/8433fe1))
+
+## <small>2.2.6 (2021-05-14)</small>
+
+* [bitnami/node-exporter] Release 2.2.6 updating components versions ([204088d](https://github.com/bitnami/charts/commit/204088d))
+
+## <small>2.2.5 (2021-04-14)</small>
+
+* [bitnami/node-exporter] Release 2.2.5 updating components versions ([d8e117a](https://github.com/bitnami/charts/commit/d8e117a))
+
+## <small>2.2.4 (2021-03-15)</small>
+
+* [bitnami/node-exporter] Release 2.2.4 updating components versions ([ea8d116](https://github.com/bitnami/charts/commit/ea8d116))
+
+## <small>2.2.3 (2021-02-22)</small>
+
+* [bitnami/*] Use common macro to define RBAC apiVersion (#5585) ([71fb99f](https://github.com/bitnami/charts/commit/71fb99f)), closes [#5585](https://github.com/bitnami/charts/issues/5585)
+
+## <small>2.2.2 (2021-02-13)</small>
+
+* [bitnami/node-exporter] Release 2.2.2 updating components versions ([2a52b46](https://github.com/bitnami/charts/commit/2a52b46))
+
+## <small>2.2.1 (2021-02-06)</small>
+
+* [bitnami/node-exporter] Release 2.2.1 updating components versions ([55bf724](https://github.com/bitnami/charts/commit/55bf724))
+
+## 2.2.0 (2021-01-28)
+
+* [bitnami/*] Change helm version in the prerequisites (#5090) ([c5e67a3](https://github.com/bitnami/charts/commit/c5e67a3)), closes [#5090](https://github.com/bitnami/charts/issues/5090)
+* [bitnami/node-exporter] Add hostAliases (#5283) ([8d01caa](https://github.com/bitnami/charts/commit/8d01caa)), closes [#5283](https://github.com/bitnami/charts/issues/5283)
+
+## <small>2.1.3 (2021-01-10)</small>
+
+* [bitnami/*] fix typos (#4699) ([49adc63](https://github.com/bitnami/charts/commit/49adc63)), closes [#4699](https://github.com/bitnami/charts/issues/4699)
+* [bitnami/node-exporter] Release 2.1.3 updating components versions ([1c978f5](https://github.com/bitnami/charts/commit/1c978f5))
+
+## <small>2.1.2 (2020-12-11)</small>
+
+* [bitnami/*] Update dependencies (#4694) ([2826c12](https://github.com/bitnami/charts/commit/2826c12)), closes [#4694](https://github.com/bitnami/charts/issues/4694)
+
+## <small>2.1.1 (2020-12-11)</small>
+
+* [bitnami/node-exporter] Release 2.1.1 updating components versions ([bbe157e](https://github.com/bitnami/charts/commit/bbe157e))
+
+## 2.1.0 (2020-12-09)
+
+* [bitnami/*] Affinity based on common presets (vi) (#4517) ([5594e66](https://github.com/bitnami/charts/commit/5594e66)), closes [#4517](https://github.com/bitnami/charts/issues/4517)
+
+## 2.0.0 (2020-11-11)
+
+* [bitnami/*] Include link to Troubleshootin guide on README.md (#4136) ([c08a20e](https://github.com/bitnami/charts/commit/c08a20e)), closes [#4136](https://github.com/bitnami/charts/issues/4136)
+* [bitnami/node-exporter] Major version. Adapt Chart to apiVersion: v2 (#4267) ([ab664ee](https://github.com/bitnami/charts/commit/ab664ee)), closes [#4267](https://github.com/bitnami/charts/issues/4267)
+
+## <small>1.1.6 (2020-10-19)</small>
+
+* [bitnami/node-exporter] Release 1.1.6 updating components versions ([d87292e](https://github.com/bitnami/charts/commit/d87292e))
+
+## <small>1.1.5 (2020-10-19)</small>
+
+* [bitnami/node-exporter] Release 1.1.5 updating components versions ([ae274fc](https://github.com/bitnami/charts/commit/ae274fc))
+
+## <small>1.1.4 (2020-10-14)</small>
+
+* [bitnami/node-exporter] Release 1.1.4 updating components versions ([8e243d2](https://github.com/bitnami/charts/commit/8e243d2))
+
+## <small>1.1.3 (2020-10-02)</small>
+
+* [bitnami/node-exporter] Fix service annotations indentation (#3824) ([4fab1ec](https://github.com/bitnami/charts/commit/4fab1ec)), closes [#3824](https://github.com/bitnami/charts/issues/3824)
+
+## <small>1.1.2 (2020-09-22)</small>
+
+* [bitnami/node-exporter] Release 1.1.2 updating components versions ([1d307f0](https://github.com/bitnami/charts/commit/1d307f0))
+
+## <small>1.1.1 (2020-09-04)</small>
+
+* [bitnami/metrics-server] Add source repo (#3577) ([1ed12f9](https://github.com/bitnami/charts/commit/1ed12f9)), closes [#3577](https://github.com/bitnami/charts/issues/3577)
+* [bitnami/node-exporter] Release 1.1.1 updating components versions ([bfb17dc](https://github.com/bitnami/charts/commit/bfb17dc))
+
+## 1.1.0 (2020-08-18)
+
+* [bitnami/node-exporter] Introduce .Release.Namespace in meta (#3418) ([133d6b7](https://github.com/bitnami/charts/commit/133d6b7)), closes [#3418](https://github.com/bitnami/charts/issues/3418)
+
+## <small>1.0.3 (2020-08-05)</small>
+
+* [bitnami/*] Fix TL;DR typo in READMEs (#3280) ([3d7ab40](https://github.com/bitnami/charts/commit/3d7ab40)), closes [#3280](https://github.com/bitnami/charts/issues/3280)
+* [bitnami/node-exporter] Release 1.0.3 updating components versions ([097e43d](https://github.com/bitnami/charts/commit/097e43d))
+
+## <small>1.0.2 (2020-07-24)</small>
+
+* [bitnami/all] Add categories (#3075) ([63bde06](https://github.com/bitnami/charts/commit/63bde06)), closes [#3075](https://github.com/bitnami/charts/issues/3075)
+* [bitnami/node-exporter] Release 1.0.2 updating components versions ([602b32a](https://github.com/bitnami/charts/commit/602b32a))
+
+## <small>1.0.1 (2020-06-24)</small>
+
+* [bitnami/node-exporter] Release 1.0.1 updating components versions ([5b4cd25](https://github.com/bitnami/charts/commit/5b4cd25))
+
+## 1.0.0 (2020-06-17)
+
+* [bitnami/node-exporter] Update chart to Node Exporter 1 (#2858) ([149c919](https://github.com/bitnami/charts/commit/149c919)), closes [#2858](https://github.com/bitnami/charts/issues/2858)
+
+## <small>0.2.14 (2020-05-22)</small>
+
+* [bitnami/node-exporter] Release 0.2.14 updating components versions ([2b2a522](https://github.com/bitnami/charts/commit/2b2a522))
+* update bitnami/common to be compatible with helm v2.12+ (#2615) ([c7751eb](https://github.com/bitnami/charts/commit/c7751eb)), closes [#2615](https://github.com/bitnami/charts/issues/2615)
+
+## <small>0.2.13 (2020-04-22)</small>
+
+* [bitnami/node-exporter] Release 0.2.13 updating components versions ([c58068e](https://github.com/bitnami/charts/commit/c58068e))
+
+## <small>0.2.12 (2020-04-22)</small>
+
+* [bitnami/node-exporter] Release 0.2.12 updating components versions ([abd4f54](https://github.com/bitnami/charts/commit/abd4f54))
+
+## <small>0.2.11 (2020-04-16)</small>
+
+* [bitnami/node-exporter] Let the prometheus scrape annotation be optional (#2242) ([afdcb84](https://github.com/bitnami/charts/commit/afdcb84)), closes [#2242](https://github.com/bitnami/charts/issues/2242)
+* [bitnami/node-exporter] Release 0.2.11 updating components versions ([a971bfb](https://github.com/bitnami/charts/commit/a971bfb))
+
+## <small>0.2.10 (2020-04-06)</small>
+
+* [bitnami/node-exporter] Release 0.2.10 updating components versions ([27cddb8](https://github.com/bitnami/charts/commit/27cddb8))
+
+## <small>0.2.9 (2020-04-06)</small>
+
+* [bitnami/node-exporter] Add the ability to specify the ServiceMonitor relabelings (#2222) ([edfe72b](https://github.com/bitnami/charts/commit/edfe72b)), closes [#2222](https://github.com/bitnami/charts/issues/2222)
+
+## <small>0.2.8 (2020-03-26)</small>
+
+* [bitnami/node-exporter] Release 0.2.8 updating components versions ([2bf9c55](https://github.com/bitnami/charts/commit/2bf9c55))
+
+## <small>0.2.7 (2020-03-20)</small>
+
+* [bitnami/node-exporter] Release 0.2.7 updating components versions ([3011a9c](https://github.com/bitnami/charts/commit/3011a9c))
+
+## <small>0.2.6 (2020-03-11)</small>
+
+* [bitnami/node-exporter] Release 0.2.6 updating components versions ([8838618](https://github.com/bitnami/charts/commit/8838618))
+
+## <small>0.2.5 (2020-03-11)</small>
+
+* Move charts from upstreamed folder to bitnami (#2032) ([a0e44f7](https://github.com/bitnami/charts/commit/a0e44f7)), closes [#2032](https://github.com/bitnami/charts/issues/2032)
+
+## <small>0.2.4 (2020-02-26)</small>
+
+* [bitnami/node-exporter] Release 0.2.4 updating components versions ([1a08003](https://github.com/bitnami/charts/commit/1a08003))
+
+## <small>0.2.3 (2020-02-18)</small>
+
+* [bitnami/node-exporter] Release 0.2.3 updating components versions ([4837534](https://github.com/bitnami/charts/commit/4837534))
+
+## <small>0.2.2 (2020-02-11)</small>
+
+* [bitnami/several] Adapt READMEs and helpers to Helm 3 (#1911) ([40ee57c](https://github.com/bitnami/charts/commit/40ee57c)), closes [#1911](https://github.com/bitnami/charts/issues/1911)
+
+## <small>0.2.1 (2020-01-23)</small>
+
+* [bitnami/node-exporter] Release 0.2.1 updating components versions ([8a8ecf1](https://github.com/bitnami/charts/commit/8a8ecf1))
+
+## 0.2.0 (2020-01-22)
+
+* [bitnami/node-exporter] adds `service.targetPort` chart parameter ([cea868b](https://github.com/bitnami/charts/commit/cea868b))
+
+## <small>0.1.4 (2020-01-14)</small>
+
+* [bitnami/node-exporter] Release 0.1.4 updating components versions ([a680023](https://github.com/bitnami/charts/commit/a680023))
+
+## <small>0.1.3 (2020-01-10)</small>
+
+* [bitnami/node-exporter] Release 0.1.3 updating components versions ([06cb3fc](https://github.com/bitnami/charts/commit/06cb3fc))
+
+## <small>0.1.2 (2019-12-22)</small>
+
+* [bitnami/node-exporter]: Add metricRelabelings to ServiceMonitor ([dd0e754](https://github.com/bitnami/charts/commit/dd0e754))
+
+## <small>0.1.1 (2019-12-11)</small>
+
+* [bitnami/node-exporter] minor updates ([bc1ef46](https://github.com/bitnami/charts/commit/bc1ef46))
+* fix linter errors ([56faaaf](https://github.com/bitnami/charts/commit/56faaaf))
+* fix more linter errors ([6670b05](https://github.com/bitnami/charts/commit/6670b05))
+* fix yaml list indentation ([421a52b](https://github.com/bitnami/charts/commit/421a52b))
+* move `serviceAccount` config closer to `rbac` config as their related ([ca5575c](https://github.com/bitnami/charts/commit/ca5575c))
+* removed values-production.yaml ([d9f25d1](https://github.com/bitnami/charts/commit/d9f25d1))
+* simplify `affinity` configuration ([43ba551](https://github.com/bitnami/charts/commit/43ba551))
+* update `resources` formatting ([016d40f](https://github.com/bitnami/charts/commit/016d40f))
+* use `tplValue` helper for podAnnotations ([608d7fe](https://github.com/bitnami/charts/commit/608d7fe))
+
+## 0.1.0 (2019-11-26)
+
+* [bitnami/node-exporter] new chart ([7c27166](https://github.com/bitnami/charts/commit/7c27166))

--- a/bitnami/node-exporter/Chart.lock
+++ b/bitnami/node-exporter/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.19.2
-digest: sha256:e670e1075bfafffe040fae1158f1fa1f592585f394b48704ba137d2d083b1571
-generated: "2024-05-08T02:48:07.870009568Z"
+  version: 2.19.3
+digest: sha256:de997835d9ce9a9deefc2d70d8c62b11aa1d1a76ece9e86a83736ab9f930bf4d
+generated: "2024-05-21T13:22:20.488573+02:00"

--- a/bitnami/node-exporter/Chart.yaml
+++ b/bitnami/node-exporter/Chart.yaml
@@ -28,4 +28,4 @@ maintainers:
 name: node-exporter
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/node-exporter
-version: 4.2.3
+version: 4.2.4

--- a/bitnami/node-exporter/templates/daemonset.yaml
+++ b/bitnami/node-exporter/templates/daemonset.yaml
@@ -111,8 +111,7 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.livenessProbe "enabled") "context" $) | nindent 12 }}
-            httpGet:
-              path: /
+            tcpSocket:
               port: metrics
           {{- end }}
           {{- if .Values.customReadinessProbe }}

--- a/bitnami/node-exporter/templates/deployment.yaml
+++ b/bitnami/node-exporter/templates/deployment.yaml
@@ -114,8 +114,7 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.livenessProbe "enabled") "context" $) | nindent 12 }}
-            httpGet:
-              path: /
+            tcpSocket:
               port: metrics
           {{- end }}
           {{- if .Values.customReadinessProbe }}


### PR DESCRIPTION
### Description of the change
This PR aims to use different liveness/readiness probes to improve overall security and avoid unnecessary container restarts. [More info](https://github.com/zegl/kube-score/blob/master/README_PROBES.md).

### Benefits

Increase availability and resilience.

### Possible drawbacks

N/A

### Applicable issues

- fixes #

### Additional information

- Related to #23537

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- ~[X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)~
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
