### PR TITLE
[bitnami/apache] feat: :sparkles: :lock: Add warning when original images are replaced

### DIFF
--- a/bitnami/airflow/Chart.lock
+++ b/bitnami/airflow/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: redis
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 19.3.2
+  version: 19.3.4
 - name: postgresql
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 15.3.2
+  version: 15.3.5
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.19.2
-digest: sha256:141d5a1d20c29e9489a7681a919419731608135a9fc5af912c304ff1a7bed64f
-generated: "2024-05-17T13:20:55.345544+02:00"
+  version: 2.19.3
+digest: sha256:633b7efcc7d7cfc2a74f8072a0857b604a8acd3a65837e8ac1d791ac8e2b68b4
+generated: "2024-05-21T13:05:44.799030153+02:00"

--- a/bitnami/airflow/Chart.yaml
+++ b/bitnami/airflow/Chart.yaml
@@ -47,4 +47,4 @@ maintainers:
 name: airflow
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/airflow
-version: 18.1.1
+version: 18.2.0

--- a/bitnami/airflow/templates/NOTES.txt
+++ b/bitnami/airflow/templates/NOTES.txt
@@ -125,3 +125,4 @@ To connect to Airflow from outside the cluster, perform the following steps:
 {{ include "airflow.validateValues" . }}
 {{ include "airflow.checkRollingTags" . }}
 {{- include "common.warnings.resources" (dict "sections" (list "git.clone" "git.sync" "metrics" "scheduler" "web" "worker") "context" $) }}
+{{- include "common.warnings.modifiedImages" (dict "images" (list .Values.dags.image .Values.web.image .Values.scheduler.image .Values.worker.image .Values.git.image .Values.metrics.image) "context" $) }}

--- a/bitnami/apache/Chart.lock
+++ b/bitnami/apache/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.19.2
-digest: sha256:e670e1075bfafffe040fae1158f1fa1f592585f394b48704ba137d2d083b1571
-generated: "2024-05-13T19:47:36.677660849Z"
+  version: 2.19.3
+digest: sha256:de997835d9ce9a9deefc2d70d8c62b11aa1d1a76ece9e86a83736ab9f930bf4d
+generated: "2024-05-21T13:23:34.746069169+02:00"

--- a/bitnami/apache/Chart.yaml
+++ b/bitnami/apache/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: apache
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/apache
-version: 11.0.6
+version: 11.1.0

--- a/bitnami/apache/templates/NOTES.txt
+++ b/bitnami/apache/templates/NOTES.txt
@@ -44,3 +44,4 @@ WARNING: Rolling tag detected ({{ .Values.image.repository }}:{{ .Values.image.t
 
 {{ include "apache.validateValues" . }}
 {{- include "common.warnings.resources" (dict "sections" (list "cloneHtdocsFromGit" "metrics" "") "context" $) }}
+{{- include "common.warnings.modifiedImages" (dict "images" (list .Values.image .Values.git .Values.cloneHtdocsFromGit .Values.metrics.image) "context" $) }}


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Replacing the original images that have been tested and verified when releasing the chart is a dangerous practice in terms of security, performance and available features. This PR updates the `NOTES.txt` file using the `common.warnings.modifiedImages` helper developed in https://github.com/bitnami/charts/pull/25952.


<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

Users are more aware of the risks of changing original images.
<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

n/a
<!-- Describe any known limitations with your change -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
