### PR TITLE
[bitnami/apisix] feat: :sparkles: :lock: Add warning when original images are replaced

### DIFF
--- a/bitnami/apisix/CHANGELOG.md
+++ b/bitnami/apisix/CHANGELOG.md
@@ -1,0 +1,261 @@
+# Changelog
+
+## 3.1.0 (2024-05-21)
+
+* [bitnami/apisix] feat: :sparkles: :lock: Add warning when original images are replaced ([#26180](https://github.com/bitnami/charts/pulls/26180))
+
+## <small>3.0.6 (2024-05-17)</small>
+
+* [bitnami/apisix] Release 3.0.6 updating components versions (#25998) ([8277ffb](https://github.com/bitnami/charts/commit/8277ffb)), closes [#25998](https://github.com/bitnami/charts/issues/25998)
+
+## <small>3.0.5 (2024-05-13)</small>
+
+* [bitnami/apisix] Release 3.0.5 updating components versions (#25738) ([cbe8f03](https://github.com/bitnami/charts/commit/cbe8f03)), closes [#25738](https://github.com/bitnami/charts/issues/25738)
+
+## <small>3.0.4 (2024-05-13)</small>
+
+* [bitnami/*] Change non-root and rolling-tags doc URLs (#25628) ([b067c94](https://github.com/bitnami/charts/commit/b067c94)), closes [#25628](https://github.com/bitnami/charts/issues/25628)
+* [bitnami/*] Set new header/owner (#25558) ([8d1dc11](https://github.com/bitnami/charts/commit/8d1dc11)), closes [#25558](https://github.com/bitnami/charts/issues/25558)
+* [bitnami/apisix] Release 3.0.4 (#25695) ([7ee0ee7](https://github.com/bitnami/charts/commit/7ee0ee7)), closes [#25695](https://github.com/bitnami/charts/issues/25695)
+* [bitnami/multiple charts] Fix typo: "NetworkPolice" vs "NetworkPolicy" (#25348) ([6970c1b](https://github.com/bitnami/charts/commit/6970c1b)), closes [#25348](https://github.com/bitnami/charts/issues/25348)
+* Replace VMware by Broadcom copyright text (#25306) ([a5e4bd0](https://github.com/bitnami/charts/commit/a5e4bd0)), closes [#25306](https://github.com/bitnami/charts/issues/25306)
+
+## <small>3.0.3 (2024-04-24)</small>
+
+* [bitnami/apisix] Release 3.0.3 (#25355) ([933cba1](https://github.com/bitnami/charts/commit/933cba1)), closes [#25355](https://github.com/bitnami/charts/issues/25355)
+
+## <small>3.0.2 (2024-04-09)</small>
+
+* [bitnami/apisix] fix: :bug: :lock: Do not expose http-metrics unless metrics.enabled=true (#25041) ([e35f1d6](https://github.com/bitnami/charts/commit/e35f1d6)), closes [#25041](https://github.com/bitnami/charts/issues/25041)
+* Update resourcesPreset comments (#24467) ([92e3e8a](https://github.com/bitnami/charts/commit/92e3e8a)), closes [#24467](https://github.com/bitnami/charts/issues/24467)
+
+## <small>3.0.1 (2024-03-22)</small>
+
+* [bitnami/apisix] Fix disable tls on controlPlane and dataPlane (#24600) ([0a85409](https://github.com/bitnami/charts/commit/0a85409)), closes [#24600](https://github.com/bitnami/charts/issues/24600)
+
+## 3.0.0 (2024-03-19)
+
+* [bitnami/*] Reorder Chart sections (#24455) ([0cf4048](https://github.com/bitnami/charts/commit/0cf4048)), closes [#24455](https://github.com/bitnami/charts/issues/24455)
+* [bitnami/apisix] feat!: :lock: :boom: Improve security defaults (#24509) ([25ba86e](https://github.com/bitnami/charts/commit/25ba86e)), closes [#24509](https://github.com/bitnami/charts/issues/24509)
+
+## 2.10.0 (2024-03-06)
+
+* [bitnami/apisix] feat: :sparkles: :lock: Add automatic adaptation for Openshift restricted-v2 SCC (# ([6e5bd3e](https://github.com/bitnami/charts/commit/6e5bd3e)), closes [#24061](https://github.com/bitnami/charts/issues/24061)
+
+## 2.9.0 (2024-02-27)
+
+* [bitnami/apisix] feat: :sparkles: :lock: Add runAsGroup (#23874) ([166932f](https://github.com/bitnami/charts/commit/166932f)), closes [#23874](https://github.com/bitnami/charts/issues/23874)
+
+## <small>2.8.2 (2024-02-21)</small>
+
+* [bitnami/apisix] Release 2.8.2 updating components versions (#23733) ([7946235](https://github.com/bitnami/charts/commit/7946235)), closes [#23733](https://github.com/bitnami/charts/issues/23733)
+
+## <small>2.8.1 (2024-02-21)</small>
+
+* [bitnami/apisix] Release 2.8.1 updating components versions (#23628) ([a5a7f2f](https://github.com/bitnami/charts/commit/a5a7f2f)), closes [#23628](https://github.com/bitnami/charts/issues/23628)
+
+## 2.8.0 (2024-02-20)
+
+* [bitnami/*] Bump all versions (#23602) ([b70ee2a](https://github.com/bitnami/charts/commit/b70ee2a)), closes [#23602](https://github.com/bitnami/charts/issues/23602)
+
+## 2.7.0 (2024-02-16)
+
+* [bitnami/apisix] feat: :sparkles: :lock: Add resource preset support (#23429) ([98bc8f0](https://github.com/bitnami/charts/commit/98bc8f0)), closes [#23429](https://github.com/bitnami/charts/issues/23429)
+
+## <small>2.6.1 (2024-02-14)</small>
+
+* fix: allow disabling tls for dashboard and ingressController properly (#23389) ([633d712](https://github.com/bitnami/charts/commit/633d712)), closes [#23389](https://github.com/bitnami/charts/issues/23389)
+
+## 2.6.0 (2024-02-13)
+
+* [bitnami/apisix] feat: :lock: Enable networkPolicy (#23365) ([98d94a8](https://github.com/bitnami/charts/commit/98d94a8)), closes [#23365](https://github.com/bitnami/charts/issues/23365)
+
+## <small>2.5.8 (2024-02-09)</small>
+
+* [bitnami/apisix] Release 2.5.8 updating components versions (#23367) ([0ab18bd](https://github.com/bitnami/charts/commit/0ab18bd)), closes [#23367](https://github.com/bitnami/charts/issues/23367)
+
+## <small>2.5.7 (2024-02-09)</small>
+
+* [bitnami/apisix] Release 2.5.7 updating components versions (#23366) ([20003a3](https://github.com/bitnami/charts/commit/20003a3)), closes [#23366](https://github.com/bitnami/charts/issues/23366)
+
+## <small>2.5.6 (2024-02-05)</small>
+
+* [bitnami/apisix] Release 2.5.6 updating components versions (#23154) ([9b5de30](https://github.com/bitnami/charts/commit/9b5de30)), closes [#23154](https://github.com/bitnami/charts/issues/23154)
+
+## <small>2.5.5 (2024-02-01)</small>
+
+* [bitnami/apisix] Release 2.5.5 updating components versions (#23011) ([a3944a2](https://github.com/bitnami/charts/commit/a3944a2)), closes [#23011](https://github.com/bitnami/charts/issues/23011)
+
+## <small>2.5.4 (2024-01-31)</small>
+
+* [bitnami/apisix] Update CRDs and add headers for automatic update (#22883) ([f827a92](https://github.com/bitnami/charts/commit/f827a92)), closes [#22883](https://github.com/bitnami/charts/issues/22883)
+
+## <small>2.5.3 (2024-01-30)</small>
+
+* [bitnami/apisix] Release 2.5.3 updating components versions (#22845) ([f9819d9](https://github.com/bitnami/charts/commit/f9819d9)), closes [#22845](https://github.com/bitnami/charts/issues/22845)
+
+## <small>2.5.2 (2024-01-25)</small>
+
+* [bitnami/*] Move documentation sections from docs.bitnami.com back to the README (#22203) ([7564f36](https://github.com/bitnami/charts/commit/7564f36)), closes [#22203](https://github.com/bitnami/charts/issues/22203)
+* [bitnami/apisix] fix: :bug: Set seLinuxOptions to null for Openshift compatibility (#22567) ([6829af8](https://github.com/bitnami/charts/commit/6829af8)), closes [#22567](https://github.com/bitnami/charts/issues/22567)
+
+## <small>2.5.1 (2024-01-22)</small>
+
+* [bitnami/apisix] fix: :bug: Enable liveness probe (#22520) ([37434b9](https://github.com/bitnami/charts/commit/37434b9)), closes [#22520](https://github.com/bitnami/charts/issues/22520)
+
+## 2.5.0 (2024-01-19)
+
+* [bitnami/apisix] fix: :lock: Move service-account token auto-mount to pod declaration (#22383) ([b0d9555](https://github.com/bitnami/charts/commit/b0d9555)), closes [#22383](https://github.com/bitnami/charts/issues/22383)
+
+## <small>2.4.3 (2024-01-18)</small>
+
+* [bitnami/apisix] Release 2.4.3 updating components versions (#22342) ([a86706d](https://github.com/bitnami/charts/commit/a86706d)), closes [#22342](https://github.com/bitnami/charts/issues/22342)
+
+## <small>2.4.2 (2024-01-17)</small>
+
+* Revert "[bitnami/apisix] feat: :lock: Allow limit access to secrets by namespace (#22224)" ([85fc083](https://github.com/bitnami/charts/commit/85fc083)), closes [#22224](https://github.com/bitnami/charts/issues/22224)
+
+## <small>2.4.1 (2024-01-17)</small>
+
+* [bitnami/apisix] Fixed the bug of disabling control-plane TLS (#22240) ([8dea304](https://github.com/bitnami/charts/commit/8dea304)), closes [#22240](https://github.com/bitnami/charts/issues/22240)
+
+## 2.4.0 (2024-01-16)
+
+* [bitnami/apisix] feat: :lock: Allow limit access to secrets by namespace (#22224) ([1866370](https://github.com/bitnami/charts/commit/1866370)), closes [#22224](https://github.com/bitnami/charts/issues/22224)
+
+## 2.3.0 (2024-01-16)
+
+* [bitnami/apisix] fix: :lock: Improve podSecurityContext and containerSecurityContext with essential  ([cb687e3](https://github.com/bitnami/charts/commit/cb687e3)), closes [#22098](https://github.com/bitnami/charts/issues/22098)
+
+## <small>2.2.9 (2024-01-15)</small>
+
+* [bitnami/*] Fix docs.bitnami.com broken links (#21901) ([f35506d](https://github.com/bitnami/charts/commit/f35506d)), closes [#21901](https://github.com/bitnami/charts/issues/21901)
+* [bitnami/*] Fix ref links (in comments) (#21822) ([e4fa296](https://github.com/bitnami/charts/commit/e4fa296)), closes [#21822](https://github.com/bitnami/charts/issues/21822)
+* [bitnami/*] Update copyright: Year and company (#21815) ([6c4bf75](https://github.com/bitnami/charts/commit/6c4bf75)), closes [#21815](https://github.com/bitnami/charts/issues/21815)
+* [bitnami/apisix] fix: :lock: Do not mount service account token unless necessary (#21986) ([c6414aa](https://github.com/bitnami/charts/commit/c6414aa)), closes [#21986](https://github.com/bitnami/charts/issues/21986)
+
+## <small>2.2.8 (2023-12-31)</small>
+
+* [bitnami/apisix] Release 2.2.8 updating components versions (#21798) ([56a7592](https://github.com/bitnami/charts/commit/56a7592)), closes [#21798](https://github.com/bitnami/charts/issues/21798)
+
+## <small>2.2.7 (2023-11-21)</small>
+
+* [bitnami/*] Rename solutions to "Bitnami package for ..." (#21038) ([b82f979](https://github.com/bitnami/charts/commit/b82f979)), closes [#21038](https://github.com/bitnami/charts/issues/21038)
+* [bitnami/apisix] Release 2.2.7 updating components versions (#21098) ([45ac9e1](https://github.com/bitnami/charts/commit/45ac9e1)), closes [#21098](https://github.com/bitnami/charts/issues/21098)
+
+## <small>2.2.6 (2023-11-21)</small>
+
+* [bitnami/*] Remove relative links to non-README sections, add verification for that and update TL;DR ([1103633](https://github.com/bitnami/charts/commit/1103633)), closes [#20967](https://github.com/bitnami/charts/issues/20967)
+* [bitnami/apisix] Release 2.2.6 updating components versions (#21077) ([99be4bf](https://github.com/bitnami/charts/commit/99be4bf)), closes [#21077](https://github.com/bitnami/charts/issues/21077)
+
+## <small>2.2.5 (2023-11-10)</small>
+
+* [bitnami/apisix] fix: add missing etcd config for data-plane (#20576) ([301d9da](https://github.com/bitnami/charts/commit/301d9da)), closes [#20576](https://github.com/bitnami/charts/issues/20576)
+
+## <small>2.2.4 (2023-11-08)</small>
+
+* [bitnami/apisix] Release 2.2.4 updating components versions (#20720) ([fd561e1](https://github.com/bitnami/charts/commit/fd561e1)), closes [#20720](https://github.com/bitnami/charts/issues/20720)
+
+## <small>2.2.3 (2023-11-06)</small>
+
+* [bitnami/apisix] Fix ingress template (#18255) ([41bc0e3](https://github.com/bitnami/charts/commit/41bc0e3)), closes [#18255](https://github.com/bitnami/charts/issues/18255)
+
+## <small>2.2.2 (2023-11-04)</small>
+
+* [bitnami/apisix] Release 2.2.2 updating components versions (#20620) ([20f8a17](https://github.com/bitnami/charts/commit/20f8a17)), closes [#20620](https://github.com/bitnami/charts/issues/20620)
+
+## <small>2.2.1 (2023-11-04)</small>
+
+* [bitnami/apisix] Release 2.2.1 updating components versions (#20619) ([a433454](https://github.com/bitnami/charts/commit/a433454)), closes [#20619](https://github.com/bitnami/charts/issues/20619)
+
+## 2.2.0 (2023-10-31)
+
+* [bitnami/*] Rename VMware Application Catalog (#20361) ([3acc734](https://github.com/bitnami/charts/commit/3acc734)), closes [#20361](https://github.com/bitnami/charts/issues/20361)
+* [bitnami/*] Skip image's tag in the README files of the Bitnami Charts (#19841) ([bb9a01b](https://github.com/bitnami/charts/commit/bb9a01b)), closes [#19841](https://github.com/bitnami/charts/issues/19841)
+* [bitnami/*] Standardize documentation (#19835) ([af5f753](https://github.com/bitnami/charts/commit/af5f753)), closes [#19835](https://github.com/bitnami/charts/issues/19835)
+* [bitnami/apisix] feat: :sparkles: Add support for PSA restricted policy (#20419) ([a82dad6](https://github.com/bitnami/charts/commit/a82dad6)), closes [#20419](https://github.com/bitnami/charts/issues/20419)
+
+## <small>2.1.4 (2023-10-15)</small>
+
+* [bitnami/*] Update Helm charts prerequisites (#19745) ([eb755dd](https://github.com/bitnami/charts/commit/eb755dd)), closes [#19745](https://github.com/bitnami/charts/issues/19745)
+* [bitnami/apisix] Release 2.1.4 (#20178) ([f645841](https://github.com/bitnami/charts/commit/f645841)), closes [#20178](https://github.com/bitnami/charts/issues/20178)
+
+## <small>2.1.3 (2023-09-19)</small>
+
+* [bitnami/*] Update readme files (#19277) ([e56aeb2](https://github.com/bitnami/charts/commit/e56aeb2)), closes [#19277](https://github.com/bitnami/charts/issues/19277)
+* [bitnami/apisix] Use different app.kubernetes.io/version label on subcomponents (#19325) ([61653c9](https://github.com/bitnami/charts/commit/61653c9)), closes [#19325](https://github.com/bitnami/charts/issues/19325)
+* Autogenerate schema files (#19194) ([a2c2090](https://github.com/bitnami/charts/commit/a2c2090)), closes [#19194](https://github.com/bitnami/charts/issues/19194)
+* Revert "Autogenerate schema files (#19194)" (#19335) ([73d80be](https://github.com/bitnami/charts/commit/73d80be)), closes [#19194](https://github.com/bitnami/charts/issues/19194) [#19335](https://github.com/bitnami/charts/issues/19335)
+
+## <small>2.1.2 (2023-09-08)</small>
+
+* [bitnami/apisix]: Use merge helper (#19020) ([3fa3cb4](https://github.com/bitnami/charts/commit/3fa3cb4)), closes [#19020](https://github.com/bitnami/charts/issues/19020)
+
+## <small>2.1.1 (2023-09-01)</small>
+
+* [bitnami/apisix] Release 2.1.1 (#18986) ([6d142f7](https://github.com/bitnami/charts/commit/6d142f7)), closes [#18986](https://github.com/bitnami/charts/issues/18986)
+
+## 2.1.0 (2023-08-29)
+
+* [bitnami/apisix] Support for customizing standard labels (#18456) ([8f45915](https://github.com/bitnami/charts/commit/8f45915)), closes [#18456](https://github.com/bitnami/charts/issues/18456)
+
+## <small>2.0.10 (2023-08-19)</small>
+
+* [bitnami/apisix] Release 2.0.10 (#18644) ([f0494e8](https://github.com/bitnami/charts/commit/f0494e8)), closes [#18644](https://github.com/bitnami/charts/issues/18644)
+
+## <small>2.0.9 (2023-08-17)</small>
+
+* [bitnami/apisix] Release 2.0.9 (#18497) ([ab7de5c](https://github.com/bitnami/charts/commit/ab7de5c)), closes [#18497](https://github.com/bitnami/charts/issues/18497)
+
+## <small>2.0.8 (2023-08-08)</small>
+
+* [bitnami/apisix] chore: :page_facing_up: Remove license in CRDs (#18257) ([ca830ba](https://github.com/bitnami/charts/commit/ca830ba)), closes [#18257](https://github.com/bitnami/charts/issues/18257)
+
+## <small>2.0.7 (2023-07-25)</small>
+
+* [bitnami/apisix] Release 2.0.7 (#17856) ([1db0ec6](https://github.com/bitnami/charts/commit/1db0ec6)), closes [#17856](https://github.com/bitnami/charts/issues/17856)
+
+## <small>2.0.6 (2023-07-20)</small>
+
+* [bitnami/apisix] Release 2.0.6 (#17801) ([9660e28](https://github.com/bitnami/charts/commit/9660e28)), closes [#17801](https://github.com/bitnami/charts/issues/17801)
+
+## <small>2.0.5 (2023-07-20)</small>
+
+* [bitnami/apisix] Release 2.0.5 (#17792) ([7ea0ee3](https://github.com/bitnami/charts/commit/7ea0ee3)), closes [#17792](https://github.com/bitnami/charts/issues/17792)
+
+## <small>2.0.4 (2023-07-15)</small>
+
+* [bitnami/apisix] Release 2 (#17599) ([d76f9b7](https://github.com/bitnami/charts/commit/d76f9b7)), closes [#17599](https://github.com/bitnami/charts/issues/17599)
+
+## <small>2.0.3 (2023-07-12)</small>
+
+* [bitnami/apisix] Reorder chart dependencies (#17583) ([31e5bc6](https://github.com/bitnami/charts/commit/31e5bc6)), closes [#17583](https://github.com/bitnami/charts/issues/17583)
+* Use os-shell in tempate and Jaeger runtime params (#17557) ([91a49eb](https://github.com/bitnami/charts/commit/91a49eb)), closes [#17557](https://github.com/bitnami/charts/issues/17557)
+
+## <small>2.0.2 (2023-06-29)</small>
+
+* [bitnami/apisix] Add the plugins list to the dashboard default config (#17289) ([45a6c7d](https://github.com/bitnami/charts/commit/45a6c7d)), closes [#17289](https://github.com/bitnami/charts/issues/17289)
+* Add copyright header (#17300) ([da68be8](https://github.com/bitnami/charts/commit/da68be8)), closes [#17300](https://github.com/bitnami/charts/issues/17300)
+
+## <small>2.0.1 (2023-06-22)</small>
+
+* [bitnami/apisix] Release 2.0.1 (#17316) ([eba8256](https://github.com/bitnami/charts/commit/eba8256)), closes [#17316](https://github.com/bitnami/charts/issues/17316)
+* Update charts readme (#17217) ([31b3c0a](https://github.com/bitnami/charts/commit/31b3c0a)), closes [#17217](https://github.com/bitnami/charts/issues/17217)
+
+## 2.0.0 (2023-06-19)
+
+* [bitnami/*] Change copyright section in READMEs (#17006) ([ef986a1](https://github.com/bitnami/charts/commit/ef986a1)), closes [#17006](https://github.com/bitnami/charts/issues/17006)
+* [bitnami/apisix] Upgrade etcd dependency (#17185) ([d3f1c61](https://github.com/bitnami/charts/commit/d3f1c61)), closes [#17185](https://github.com/bitnami/charts/issues/17185)
+* [bitnami/several] Change copyright section in READMEs (#16989) ([5b6a5cf](https://github.com/bitnami/charts/commit/5b6a5cf)), closes [#16989](https://github.com/bitnami/charts/issues/16989)
+
+## <small>1.0.1 (2023-05-23)</small>
+
+* [bitnami/apisix] Release 1.0.1 (#16886) ([2369235](https://github.com/bitnami/charts/commit/2369235)), closes [#16886](https://github.com/bitnami/charts/issues/16886)
+
+## 1.0.0 (2023-05-23)
+
+* [bitnami/apisix] Release 1.0.0 (#16884) ([3e55063](https://github.com/bitnami/charts/commit/3e55063)), closes [#16884](https://github.com/bitnami/charts/issues/16884)
+
+## 0.1.0 (2023-05-23)
+
+* [bitnami/apisix] feat: :tada: Add chart (#16851) ([a289c26](https://github.com/bitnami/charts/commit/a289c26)), closes [#16851](https://github.com/bitnami/charts/issues/16851)

--- a/bitnami/apisix/Chart.lock
+++ b/bitnami/apisix/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: etcd
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 10.0.10
+  version: 10.0.11
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.19.2
-digest: sha256:67be2c85795448f2ebc9c3fa18cf7a9c29910072878b114b7d1a59c87a7968b3
-generated: "2024-05-17T23:34:18.905404117Z"
+  version: 2.19.3
+digest: sha256:c2b31b3e695a08549b2ea3c0caf353d2dfc55241491497fd1161ae2928aa7f47
+generated: "2024-05-21T13:24:18.473939474+02:00"

--- a/bitnami/apisix/Chart.yaml
+++ b/bitnami/apisix/Chart.yaml
@@ -45,4 +45,4 @@ sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/apisix
 - https://github.com/bitnami/charts/tree/main/bitnami/apisix-dashboard
 - https://github.com/bitnami/charts/tree/main/bitnami/apisix-ingress-controller
-version: 3.0.6
+version: 3.1.0

--- a/bitnami/apisix/templates/NOTES.txt
+++ b/bitnami/apisix/templates/NOTES.txt
@@ -197,3 +197,4 @@ APISIX Data Plane:
 {{- include "common.warnings.rollingTag" .Values.ingressController.image }}
 {{- include "apisix.validateValues" . }}
 {{- include "common.warnings.resources" (dict "sections" (list "controlPlane" "dashboard" "dataPlane" "ingressController") "context" $) }}
+{{- include "common.warnings.modifiedImages" (dict "images" (list .Values.image .Values.dashboard.image .Values.ingressController.image .Values.waitContainer.image) "context" $) }}


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Replacing the original images that have been tested and verified when releasing the chart is a dangerous practice in terms of security, performance and available features. This PR updates the `NOTES.txt` file using the `common.warnings.modifiedImages` helper developed in https://github.com/bitnami/charts/pull/25952.


<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

Users are more aware of the risks of changing original images.
<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

n/a
<!-- Describe any known limitations with your change -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
