### PR TITLE
[bitnami/etcd] feat: :sparkles: :lock: Add warning when original images are replaced

### DIFF
--- a/bitnami/etcd/CHANGELOG.md
+++ b/bitnami/etcd/CHANGELOG.md
@@ -1,0 +1,1515 @@
+# Changelog
+
+## 10.1.0 (2024-05-21)
+
+* [bitnami/etcd] feat: :sparkles: :lock: Add warning when original images are replaced ([#26198](https://github.com/bitnami/charts/pulls/26198))
+
+## <small>10.0.11 (2024-05-18)</small>
+
+* [bitnami/etcd] Release 10.0.11 updating components versions (#26011) ([27a7d6c](https://github.com/bitnami/charts/commit/27a7d6c)), closes [#26011](https://github.com/bitnami/charts/issues/26011)
+
+## <small>10.0.10 (2024-05-17)</small>
+
+* [bitnami/etcd] Revert #25896 (#25917) ([8f095b1](https://github.com/bitnami/charts/commit/8f095b1)), closes [#25896](https://github.com/bitnami/charts/issues/25896) [#25917](https://github.com/bitnami/charts/issues/25917)
+* Fix inconsistent readme and values.yaml for etcd (#25941) ([c289f0e](https://github.com/bitnami/charts/commit/c289f0e)), closes [#25941](https://github.com/bitnami/charts/issues/25941)
+
+## <small>10.0.9 (2024-05-15)</small>
+
+* [bitnami/etcd] PDB review (#25896) ([5235139](https://github.com/bitnami/charts/commit/5235139)), closes [#25896](https://github.com/bitnami/charts/issues/25896)
+
+## <small>10.0.8 (2024-05-13)</small>
+
+* [bitnami/*] Change non-root and rolling-tags doc URLs (#25628) ([b067c94](https://github.com/bitnami/charts/commit/b067c94)), closes [#25628](https://github.com/bitnami/charts/issues/25628)
+* [bitnami/etcd] Release 10.0.8 updating components versions (#25751) ([9824a8b](https://github.com/bitnami/charts/commit/9824a8b)), closes [#25751](https://github.com/bitnami/charts/issues/25751)
+
+## <small>10.0.7 (2024-05-08)</small>
+
+* [bitnami/etcd] Release 10.0.7 updating components versions (#25598) ([36b07ca](https://github.com/bitnami/charts/commit/36b07ca)), closes [#25598](https://github.com/bitnami/charts/issues/25598)
+
+## <small>10.0.6 (2024-05-07)</small>
+
+* [bitnami/etcd] Release 10.0.6 updating components versions (#25589) ([cfb62c0](https://github.com/bitnami/charts/commit/cfb62c0)), closes [#25589](https://github.com/bitnami/charts/issues/25589)
+
+## <small>10.0.5 (2024-05-07)</small>
+
+* [bitnami/*] Set new header/owner (#25558) ([8d1dc11](https://github.com/bitnami/charts/commit/8d1dc11)), closes [#25558](https://github.com/bitnami/charts/issues/25558)
+* [bitnami/etcd] Properly get ROOT_PASSWORD when providing an existing secret (#25574) ([ae696c5](https://github.com/bitnami/charts/commit/ae696c5)), closes [#25574](https://github.com/bitnami/charts/issues/25574)
+* Replace VMware by Broadcom copyright text (#25306) ([a5e4bd0](https://github.com/bitnami/charts/commit/a5e4bd0)), closes [#25306](https://github.com/bitnami/charts/issues/25306)
+
+## <small>10.0.4 (2024-04-24)</small>
+
+* [bitnami/etcd] Release 10.0.4 updating components versions (#25354) ([bc549df](https://github.com/bitnami/charts/commit/bc549df)), closes [#25354](https://github.com/bitnami/charts/issues/25354)
+
+## <small>10.0.3 (2024-04-05)</small>
+
+* [bitnami/etcd] Release 10.0.3 updating components versions (#25008) ([45bb657](https://github.com/bitnami/charts/commit/45bb657)), closes [#25008](https://github.com/bitnami/charts/issues/25008)
+
+## <small>10.0.2 (2024-04-04)</small>
+
+* [bitnami/etcd] Release 10.0.2 (#24878) ([c493c44](https://github.com/bitnami/charts/commit/c493c44)), closes [#24878](https://github.com/bitnami/charts/issues/24878)
+* Update resourcesPreset comments (#24467) ([92e3e8a](https://github.com/bitnami/charts/commit/92e3e8a)), closes [#24467](https://github.com/bitnami/charts/issues/24467)
+
+## <small>10.0.1 (2024-03-29)</small>
+
+* [bitnami/etcd] Release 10.0.1 updating components versions (#24753) ([17a3edb](https://github.com/bitnami/charts/commit/17a3edb)), closes [#24753](https://github.com/bitnami/charts/issues/24753)
+* Fix linter issues in markdown ([8991e37](https://github.com/bitnami/charts/commit/8991e37))
+
+## 10.0.0 (2024-03-18)
+
+* [bitnami/*] Reorder Chart sections (#24455) ([0cf4048](https://github.com/bitnami/charts/commit/0cf4048)), closes [#24455](https://github.com/bitnami/charts/issues/24455)
+* [bitnami/etcd] feat!: :lock: :boom: Improve security defaults (#24323) ([ef88229](https://github.com/bitnami/charts/commit/ef88229)), closes [#24323](https://github.com/bitnami/charts/issues/24323)
+
+## <small>9.15.2 (2024-03-07)</small>
+
+* [bitnami/etcd] Release 9.15.2 updating components versions (#24248) ([8f5400d](https://github.com/bitnami/charts/commit/8f5400d)), closes [#24248](https://github.com/bitnami/charts/issues/24248)
+
+## <small>9.15.1 (2024-03-06)</small>
+
+* [bitnami/etcd] Release 9.15.1 updating components versions (#24194) ([c996abd](https://github.com/bitnami/charts/commit/c996abd)), closes [#24194](https://github.com/bitnami/charts/issues/24194)
+
+## 9.15.0 (2024-03-06)
+
+* [bitnami/etcd] feat: :sparkles: :lock: Add automatic adaptation for Openshift restricted-v2 SCC (#24 ([038ebc7](https://github.com/bitnami/charts/commit/038ebc7)), closes [#24079](https://github.com/bitnami/charts/issues/24079)
+
+## <small>9.14.3 (2024-02-29)</small>
+
+* [bitnami/etcd] Release 9.14.3 updating components versions (#23984) ([813259c](https://github.com/bitnami/charts/commit/813259c)), closes [#23984](https://github.com/bitnami/charts/issues/23984)
+
+## <small>9.14.2 (2024-02-21)</small>
+
+* [bitnami/etcd] Release 9.14.2 updating components versions (#23767) ([fc6901e](https://github.com/bitnami/charts/commit/fc6901e)), closes [#23767](https://github.com/bitnami/charts/issues/23767)
+
+## <small>9.14.1 (2024-02-21)</small>
+
+* [bitnami/etcd] Release 9.14.1 updating components versions (#23701) ([277354f](https://github.com/bitnami/charts/commit/277354f)), closes [#23701](https://github.com/bitnami/charts/issues/23701)
+
+## 9.14.0 (2024-02-20)
+
+* [bitnami/etcd] feat: :sparkles: :lock: Add readOnlyRootFilesystem support (#23611) ([045d64e](https://github.com/bitnami/charts/commit/045d64e)), closes [#23611](https://github.com/bitnami/charts/issues/23611)
+
+## 9.13.0 (2024-02-20)
+
+* [bitnami/*] Bump all versions (#23602) ([b70ee2a](https://github.com/bitnami/charts/commit/b70ee2a)), closes [#23602](https://github.com/bitnami/charts/issues/23602)
+
+## 9.12.0 (2024-02-16)
+
+* [bitnami/etcd] feat: :sparkles: :lock: Add resource preset support (#23446) ([c23f6a6](https://github.com/bitnami/charts/commit/c23f6a6)), closes [#23446](https://github.com/bitnami/charts/issues/23446)
+
+## 9.11.0 (2024-02-07)
+
+* [bitnami/etcd] feat: :lock: Enable networkPolicy (#23286) ([7cbf9ec](https://github.com/bitnami/charts/commit/7cbf9ec)), closes [#23286](https://github.com/bitnami/charts/issues/23286)
+
+## <small>9.10.8 (2024-02-07)</small>
+
+* [bitnami/etcd] Release 9.10.8 updating components versions (#23298) ([ec528c3](https://github.com/bitnami/charts/commit/ec528c3)), closes [#23298](https://github.com/bitnami/charts/issues/23298)
+
+## <small>9.10.7 (2024-02-07)</small>
+
+* [bitnami/etcd] Release 9.10.7 updating components versions (#23247) ([2c9e6fb](https://github.com/bitnami/charts/commit/2c9e6fb)), closes [#23247](https://github.com/bitnami/charts/issues/23247)
+
+## <small>9.10.6 (2024-02-02)</small>
+
+* [bitnami/etcd] Release 9.10.6 updating components versions (#23068) ([e4f2d5b](https://github.com/bitnami/charts/commit/e4f2d5b)), closes [#23068](https://github.com/bitnami/charts/issues/23068)
+
+## <small>9.10.5 (2024-02-01)</small>
+
+* [bitnami/etcd] Release 9.10.5 updating components versions (#23001) ([3adf43c](https://github.com/bitnami/charts/commit/3adf43c)), closes [#23001](https://github.com/bitnami/charts/issues/23001)
+
+## <small>9.10.4 (2024-01-30)</small>
+
+* [bitnami/etcd] Release 9.10.4 updating components versions (#22859) ([a016f58](https://github.com/bitnami/charts/commit/a016f58)), closes [#22859](https://github.com/bitnami/charts/issues/22859)
+
+## <small>9.10.3 (2024-01-27)</small>
+
+* [bitnami/*] Move documentation sections from docs.bitnami.com back to the README (#22203) ([7564f36](https://github.com/bitnami/charts/commit/7564f36)), closes [#22203](https://github.com/bitnami/charts/issues/22203)
+* [bitnami/etcd] Release 9.10.3 updating components versions (#22774) ([51dfe9c](https://github.com/bitnami/charts/commit/51dfe9c)), closes [#22774](https://github.com/bitnami/charts/issues/22774)
+
+## <small>9.10.2 (2024-01-24)</small>
+
+* [bitnami/etcd] fix: :bug: Set seLinuxOptions to null for Openshift compatibility (#22584) ([d77f13b](https://github.com/bitnami/charts/commit/d77f13b)), closes [#22584](https://github.com/bitnami/charts/issues/22584)
+
+## <small>9.10.1 (2024-01-22)</small>
+
+* [bitnami/etcd] Release 9.10.1 updating components versions (#22542) ([6303449](https://github.com/bitnami/charts/commit/6303449)), closes [#22542](https://github.com/bitnami/charts/issues/22542)
+
+## 9.10.0 (2024-01-19)
+
+* [bitnami/etcd] fix: :lock: Move service-account token auto-mount to pod declaration (#22397) ([0bd8132](https://github.com/bitnami/charts/commit/0bd8132)), closes [#22397](https://github.com/bitnami/charts/issues/22397)
+
+## <small>9.9.1 (2024-01-18)</small>
+
+* [bitnami/etcd] Release 9.9.1 updating components versions (#22272) ([0fcd1b8](https://github.com/bitnami/charts/commit/0fcd1b8)), closes [#22272](https://github.com/bitnami/charts/issues/22272)
+
+## 9.9.0 (2024-01-16)
+
+* [bitnami/etcd] fix: :lock: Improve podSecurityContext and containerSecurityContext with essential se ([06f7d1b](https://github.com/bitnami/charts/commit/06f7d1b)), closes [#22115](https://github.com/bitnami/charts/issues/22115)
+
+## <small>9.8.2 (2024-01-15)</small>
+
+* [bitnami/*] Fix ref links (in comments) (#21822) ([e4fa296](https://github.com/bitnami/charts/commit/e4fa296)), closes [#21822](https://github.com/bitnami/charts/issues/21822)
+* [bitnami/etcd] fix: :lock: Do not use the default service account (#22008) ([8749ab2](https://github.com/bitnami/charts/commit/8749ab2)), closes [#22008](https://github.com/bitnami/charts/issues/22008)
+
+## <small>9.8.1 (2024-01-10)</small>
+
+* [bitnami/*] Fix docs.bitnami.com broken links (#21901) ([f35506d](https://github.com/bitnami/charts/commit/f35506d)), closes [#21901](https://github.com/bitnami/charts/issues/21901)
+* [bitnami/*] Update copyright: Year and company (#21815) ([6c4bf75](https://github.com/bitnami/charts/commit/6c4bf75)), closes [#21815](https://github.com/bitnami/charts/issues/21815)
+* [bitnami/etcd] Release 9.8.1 updating components versions (#21934) ([a282aa6](https://github.com/bitnami/charts/commit/a282aa6)), closes [#21934](https://github.com/bitnami/charts/issues/21934)
+
+## 9.8.0 (2023-12-21)
+
+* Allow Configuration of ServiceAccount for CronJob Pods (#21512) ([c7962bd](https://github.com/bitnami/charts/commit/c7962bd)), closes [#21512](https://github.com/bitnami/charts/issues/21512)
+
+## <small>9.7.7 (2023-12-19)</small>
+
+* [bitnami/etcd] Release 9.7.7 updating components versions (#21652) ([cf772d4](https://github.com/bitnami/charts/commit/cf772d4)), closes [#21652](https://github.com/bitnami/charts/issues/21652)
+
+## <small>9.7.6 (2023-12-17)</small>
+
+* [bitnami/etcd] Release 9.7.6 updating components versions (#21605) ([71081da](https://github.com/bitnami/charts/commit/71081da)), closes [#21605](https://github.com/bitnami/charts/issues/21605)
+
+## <small>9.7.5 (2023-12-07)</small>
+
+* [bitnami/etcd] Release 9.7.5 updating components versions (#21467) ([a09047c](https://github.com/bitnami/charts/commit/a09047c)), closes [#21467](https://github.com/bitnami/charts/issues/21467)
+
+## <small>9.7.4 (2023-12-06)</small>
+
+* [bitnami/etcd] Release 9.7.4 updating components versions (#21427) ([d972395](https://github.com/bitnami/charts/commit/d972395)), closes [#21427](https://github.com/bitnami/charts/issues/21427)
+
+## <small>9.7.3 (2023-11-24)</small>
+
+* [bitnami/etcd] Fix podLabels for disasterrecovery cronjob (#21199) ([bd928ee](https://github.com/bitnami/charts/commit/bd928ee)), closes [#21199](https://github.com/bitnami/charts/issues/21199)
+
+## <small>9.7.2 (2023-11-21)</small>
+
+* [bitnami/*] Rename solutions to "Bitnami package for ..." (#21038) ([b82f979](https://github.com/bitnami/charts/commit/b82f979)), closes [#21038](https://github.com/bitnami/charts/issues/21038)
+* [bitnami/etcd] Release 9.7.2 updating components versions (#21113) ([78a07dc](https://github.com/bitnami/charts/commit/78a07dc)), closes [#21113](https://github.com/bitnami/charts/issues/21113)
+
+## <small>9.7.1 (2023-11-20)</small>
+
+* [bitnami/etcd] Release 9.7.1 updating components versions (#21061) ([371f22a](https://github.com/bitnami/charts/commit/371f22a)), closes [#21061](https://github.com/bitnami/charts/issues/21061)
+
+## 9.7.0 (2023-11-17)
+
+* [bitnami/*] Remove relative links to non-README sections, add verification for that and update TL;DR ([1103633](https://github.com/bitnami/charts/commit/1103633)), closes [#20967](https://github.com/bitnami/charts/issues/20967)
+* [bitnami/etcd] Add option to add extra labels only for snapshot cronjob (#21025) ([a0a38de](https://github.com/bitnami/charts/commit/a0a38de)), closes [#21025](https://github.com/bitnami/charts/issues/21025)
+
+## <small>9.6.2 (2023-11-08)</small>
+
+* [bitnami/etcd] Release 9.6.2 updating components versions (#20803) ([d9b6734](https://github.com/bitnami/charts/commit/d9b6734)), closes [#20803](https://github.com/bitnami/charts/issues/20803)
+
+## <small>9.6.1 (2023-11-08)</small>
+
+* [bitnami/etcd] Release 9.6.1 updating components versions (#20727) ([b856c6b](https://github.com/bitnami/charts/commit/b856c6b)), closes [#20727](https://github.com/bitnami/charts/issues/20727)
+
+## 9.6.0 (2023-10-31)
+
+* [bitnami/etcd] feat: :sparkles: Add support for PSA restricted policy (#20425) ([fbdc5f1](https://github.com/bitnami/charts/commit/fbdc5f1)), closes [#20425](https://github.com/bitnami/charts/issues/20425)
+
+## <small>9.5.7 (2023-10-27)</small>
+
+* [bitnami/*] Rename VMware Application Catalog (#20361) ([3acc734](https://github.com/bitnami/charts/commit/3acc734)), closes [#20361](https://github.com/bitnami/charts/issues/20361)
+* [bitnami/*] Skip image's tag in the README files of the Bitnami Charts (#19841) ([bb9a01b](https://github.com/bitnami/charts/commit/bb9a01b)), closes [#19841](https://github.com/bitnami/charts/issues/19841)
+* [bitnami/*] Standardize documentation (#19835) ([af5f753](https://github.com/bitnami/charts/commit/af5f753)), closes [#19835](https://github.com/bitnami/charts/issues/19835)
+* [bitnami/etcd] Release 9.5.7 updating components versions (#20487) ([b27292c](https://github.com/bitnami/charts/commit/b27292c)), closes [#20487](https://github.com/bitnami/charts/issues/20487)
+
+## <small>9.5.6 (2023-10-12)</small>
+
+* [bitnami/etcd] Release 9.5.6 (#20130) ([ac7cf62](https://github.com/bitnami/charts/commit/ac7cf62)), closes [#20130](https://github.com/bitnami/charts/issues/20130)
+
+## <small>9.5.5 (2023-10-11)</small>
+
+* [bitnami/etcd] Release 9.5.5 (#20037) ([83505b6](https://github.com/bitnami/charts/commit/83505b6)), closes [#20037](https://github.com/bitnami/charts/issues/20037)
+
+## <small>9.5.4 (2023-10-09)</small>
+
+* [bitnami/etcd] Release 9.5.4 (#19907) ([036b22a](https://github.com/bitnami/charts/commit/036b22a)), closes [#19907](https://github.com/bitnami/charts/issues/19907)
+
+## <small>9.5.3 (2023-10-09)</small>
+
+* [bitnami/etcd] Release 9.5.3 (#19821) ([80c4b3c](https://github.com/bitnami/charts/commit/80c4b3c)), closes [#19821](https://github.com/bitnami/charts/issues/19821)
+
+## <small>9.5.2 (2023-10-09)</small>
+
+* [bitnami/*] Update Helm charts prerequisites (#19745) ([eb755dd](https://github.com/bitnami/charts/commit/eb755dd)), closes [#19745](https://github.com/bitnami/charts/issues/19745)
+* [bitnami/etcd] bump bitnami/common (#19785) ([1d4a5c2](https://github.com/bitnami/charts/commit/1d4a5c2)), closes [#19785](https://github.com/bitnami/charts/issues/19785)
+
+## <small>9.5.1 (2023-10-03)</small>
+
+* [bitnami/etcd] Release 9.5.1 (#19703) ([71914d8](https://github.com/bitnami/charts/commit/71914d8)), closes [#19703](https://github.com/bitnami/charts/issues/19703)
+* Autogenerate schema files (#19194) ([a2c2090](https://github.com/bitnami/charts/commit/a2c2090)), closes [#19194](https://github.com/bitnami/charts/issues/19194)
+* Revert "Autogenerate schema files (#19194)" (#19335) ([73d80be](https://github.com/bitnami/charts/commit/73d80be)), closes [#19194](https://github.com/bitnami/charts/issues/19194) [#19335](https://github.com/bitnami/charts/issues/19335)
+
+## 9.5.0 (2023-09-11)
+
+* [bitnami/etcd] Adding seccompProfile in etcd (#19015) ([2e53be9](https://github.com/bitnami/charts/commit/2e53be9)), closes [#19015](https://github.com/bitnami/charts/issues/19015)
+
+## <small>9.4.3 (2023-09-08)</small>
+
+* [bitnami/etcd: Use merge helper]: (#19035) ([a95e00a](https://github.com/bitnami/charts/commit/a95e00a)), closes [#19035](https://github.com/bitnami/charts/issues/19035)
+
+## <small>9.4.2 (2023-09-06)</small>
+
+* [bitnami/etcd] Release 9.4.2 (#19146) ([ce81ac7](https://github.com/bitnami/charts/commit/ce81ac7)), closes [#19146](https://github.com/bitnami/charts/issues/19146)
+
+## <small>9.4.1 (2023-08-29)</small>
+
+* [bitnami/etcd] test: :recycle: Use ginkgo-utils in persistence test (#18918) ([1f73d2b](https://github.com/bitnami/charts/commit/1f73d2b)), closes [#18918](https://github.com/bitnami/charts/issues/18918)
+
+## 9.4.0 (2023-08-25)
+
+* [bitnami/etcd] Add ETCD_LISTEN_METRICS_URLS (#18452) ([b7889dd](https://github.com/bitnami/charts/commit/b7889dd)), closes [#18452](https://github.com/bitnami/charts/issues/18452)
+
+## 9.3.0 (2023-08-22)
+
+* [bitnami/etcd] Support for customizing standard labels (#18298) ([894eebb](https://github.com/bitnami/charts/commit/894eebb)), closes [#18298](https://github.com/bitnami/charts/issues/18298)
+
+## <small>9.2.2 (2023-08-19)</small>
+
+* [bitnami/etcd] Release 9.2.2 (#18657) ([0ac424c](https://github.com/bitnami/charts/commit/0ac424c)), closes [#18657](https://github.com/bitnami/charts/issues/18657)
+
+## <small>9.2.1 (2023-08-17)</small>
+
+* [bitnami/etcd] Release 9.2.1 (#18513) ([ad89f0f](https://github.com/bitnami/charts/commit/ad89f0f)), closes [#18513](https://github.com/bitnami/charts/issues/18513)
+
+## 9.2.0 (2023-08-09)
+
+* [bitnami/etcd] only add the service to advertised addresses when it is enabled (#18211) ([ece67e0](https://github.com/bitnami/charts/commit/ece67e0)), closes [#18211](https://github.com/bitnami/charts/issues/18211)
+
+## 9.1.0 (2023-08-01)
+
+* [bitnami/etcd] Add initialClusterToken (#17802) ([443e30c](https://github.com/bitnami/charts/commit/443e30c)), closes [#17802](https://github.com/bitnami/charts/issues/17802)
+
+## <small>9.0.7 (2023-07-25)</small>
+
+* [bitnami/etcd] Release 9.0.7 (#17884) ([9378270](https://github.com/bitnami/charts/commit/9378270)), closes [#17884](https://github.com/bitnami/charts/issues/17884)
+
+## <small>9.0.6 (2023-07-19)</small>
+
+* [bitnami/etcd] Add feature extraVolumeClaimTemplate (#17763) ([eaad838](https://github.com/bitnami/charts/commit/eaad838)), closes [#17763](https://github.com/bitnami/charts/issues/17763)
+
+## <small>9.0.5 (2023-07-15)</small>
+
+* [bitnami/etcd] Release 9 (#17591) ([154de6c](https://github.com/bitnami/charts/commit/154de6c)), closes [#17591](https://github.com/bitnami/charts/issues/17591)
+
+## <small>9.0.4 (2023-06-30)</small>
+
+* [bitnami/etcd] Release 9.0.4 (#17437) ([6010dfa](https://github.com/bitnami/charts/commit/6010dfa)), closes [#17437](https://github.com/bitnami/charts/issues/17437)
+
+## <small>9.0.3 (2023-06-30)</small>
+
+* [bitnami/etcd] Release 9.0.3 (#17423) ([78cb8ce](https://github.com/bitnami/charts/commit/78cb8ce)), closes [#17423](https://github.com/bitnami/charts/issues/17423)
+
+## <small>9.0.2 (2023-06-29)</small>
+
+* [bitnami/etcd] Release 9.0.2 (#17405) ([475363d](https://github.com/bitnami/charts/commit/475363d)), closes [#17405](https://github.com/bitnami/charts/issues/17405)
+* Add copyright header (#17300) ([da68be8](https://github.com/bitnami/charts/commit/da68be8)), closes [#17300](https://github.com/bitnami/charts/issues/17300)
+* Update charts readme (#17217) ([31b3c0a](https://github.com/bitnami/charts/commit/31b3c0a)), closes [#17217](https://github.com/bitnami/charts/issues/17217)
+
+## <small>9.0.1 (2023-06-20)</small>
+
+* [bitnami/etcd] Release 9.0.1 (#17204) ([4f9edd0](https://github.com/bitnami/charts/commit/4f9edd0)), closes [#17204](https://github.com/bitnami/charts/issues/17204)
+
+## 9.0.0 (2023-06-16)
+
+* [bitnami/*] Change copyright section in READMEs (#17006) ([ef986a1](https://github.com/bitnami/charts/commit/ef986a1)), closes [#17006](https://github.com/bitnami/charts/issues/17006)
+* [bitnami/etcd] Fix label selector for pdb (#17001) ([6aa39d8](https://github.com/bitnami/charts/commit/6aa39d8)), closes [#17001](https://github.com/bitnami/charts/issues/17001)
+* [bitnami/several] Change copyright section in READMEs (#16989) ([5b6a5cf](https://github.com/bitnami/charts/commit/5b6a5cf)), closes [#16989](https://github.com/bitnami/charts/issues/16989)
+
+## 8.12.0 (2023-06-01)
+
+* [bitnami/etcd] Fix subpath for snapshots (#16714) ([0db19a3](https://github.com/bitnami/charts/commit/0db19a3)), closes [#16714](https://github.com/bitnami/charts/issues/16714)
+
+## <small>8.11.4 (2023-05-21)</small>
+
+* [bitnami/etcd] Release 8.11.4 (#16761) ([d8959dd](https://github.com/bitnami/charts/commit/d8959dd)), closes [#16761](https://github.com/bitnami/charts/issues/16761)
+
+## <small>8.11.3 (2023-05-17)</small>
+
+* [bitnami/etcd] Fix `service.clusterIP` only works when `service.type` is `ClusterIP` (#16390) ([9f2a5a8](https://github.com/bitnami/charts/commit/9f2a5a8)), closes [#16390](https://github.com/bitnami/charts/issues/16390)
+
+## <small>8.11.2 (2023-05-11)</small>
+
+* [bitnami/etcd] Release 8.11.2 (#16592) ([d3340f7](https://github.com/bitnami/charts/commit/d3340f7)), closes [#16592](https://github.com/bitnami/charts/issues/16592)
+* Add wording for enterprise page (#16560) ([8f22774](https://github.com/bitnami/charts/commit/8f22774)), closes [#16560](https://github.com/bitnami/charts/issues/16560)
+
+## <small>8.11.1 (2023-05-10)</small>
+
+* Update with a commnet the values.yaml (#16548) ([ee32086](https://github.com/bitnami/charts/commit/ee32086)), closes [#16548](https://github.com/bitnami/charts/issues/16548)
+
+## 8.11.0 (2023-05-09)
+
+* [bitnami/several] Adapt Chart.yaml to set desired OCI annotations (#16546) ([fc9b18f](https://github.com/bitnami/charts/commit/fc9b18f)), closes [#16546](https://github.com/bitnami/charts/issues/16546)
+
+## <small>8.10.2 (2023-05-09)</small>
+
+* [bitnami/etcd] Release 8.10.2 (#16453) ([157e8be](https://github.com/bitnami/charts/commit/157e8be)), closes [#16453](https://github.com/bitnami/charts/issues/16453)
+
+## <small>8.10.1 (2023-04-24)</small>
+
+* [bitnami/etcd] Release 8.10.1 (#16203) ([f28776d](https://github.com/bitnami/charts/commit/f28776d)), closes [#16203](https://github.com/bitnami/charts/issues/16203)
+
+## 8.10.0 (2023-04-20)
+
+* [bitnami/*] Make Helm charts 100% OCI (#15998) ([8841510](https://github.com/bitnami/charts/commit/8841510)), closes [#15998](https://github.com/bitnami/charts/issues/15998)
+
+## 8.9.0 (2023-04-17)
+
+* [bitnami/etcd] Add support for dynamic snapshot dir in snapshotter cronjob (#16023) ([7726f63](https://github.com/bitnami/charts/commit/7726f63)), closes [#16023](https://github.com/bitnami/charts/issues/16023)
+
+## <small>8.8.3 (2023-04-13)</small>
+
+* [bitnami/etcd] Release 8.8.3 (#16047) ([a522a96](https://github.com/bitnami/charts/commit/a522a96)), closes [#16047](https://github.com/bitnami/charts/issues/16047)
+
+## <small>8.8.2 (2023-04-05)</small>
+
+* Use common.labels.matchLabels instead of common.labels.standard in networkpolicy matchLabels (#15950 ([3874554](https://github.com/bitnami/charts/commit/3874554)), closes [#15950](https://github.com/bitnami/charts/issues/15950)
+
+## <small>8.8.1 (2023-03-31)</small>
+
+* [bitnami/etcd] Release 8.8.1 (#15826) ([180c95c](https://github.com/bitnami/charts/commit/180c95c)), closes [#15826](https://github.com/bitnami/charts/issues/15826)
+
+## 8.8.0 (2023-03-10)
+
+* [bitnami/etcd] Add support for service.headless.annotations (#15427) ([b00169e](https://github.com/bitnami/charts/commit/b00169e)), closes [#15427](https://github.com/bitnami/charts/issues/15427)
+
+## <small>8.7.7 (2023-03-08)</small>
+
+* [bitnami/charts] Apply linter to README files (#15357) ([0e29e60](https://github.com/bitnami/charts/commit/0e29e60)), closes [#15357](https://github.com/bitnami/charts/issues/15357)
+* [bitnami/etcd] add PVC labels (#15350) ([562aee0](https://github.com/bitnami/charts/commit/562aee0)), closes [#15350](https://github.com/bitnami/charts/issues/15350)
+
+## <small>8.7.6 (2023-03-01)</small>
+
+* [bitnami/etcd] Release 8.7.6 (#15196) ([d8f63d4](https://github.com/bitnami/charts/commit/d8f63d4)), closes [#15196](https://github.com/bitnami/charts/issues/15196)
+* Fixes dead links (#15065) ([9e99fd9](https://github.com/bitnami/charts/commit/9e99fd9)), closes [#15065](https://github.com/bitnami/charts/issues/15065)
+
+## <small>8.7.5 (2023-02-17)</small>
+
+* [bitnami/*] Fix markdown linter issues 2 (#14890) ([aa96572](https://github.com/bitnami/charts/commit/aa96572)), closes [#14890](https://github.com/bitnami/charts/issues/14890)
+* [bitnami/etcd] Release 8.7.5 (#14949) ([1f6d3bc](https://github.com/bitnami/charts/commit/1f6d3bc)), closes [#14949](https://github.com/bitnami/charts/issues/14949)
+
+## <small>8.7.4 (2023-02-14)</small>
+
+* [bitnami/*] Change copyright date (#14682) ([add4ec7](https://github.com/bitnami/charts/commit/add4ec7)), closes [#14682](https://github.com/bitnami/charts/issues/14682)
+* [bitnami/*] Fix markdown linter issues (#14874) ([a51e0e8](https://github.com/bitnami/charts/commit/a51e0e8)), closes [#14874](https://github.com/bitnami/charts/issues/14874)
+* [bitnami/*] Unify READMEs (#14472) ([2064fb8](https://github.com/bitnami/charts/commit/2064fb8)), closes [#14472](https://github.com/bitnami/charts/issues/14472)
+* [bitnami/etcd] Release 8.7.4 (#14883) ([e0e5a39](https://github.com/bitnami/charts/commit/e0e5a39)), closes [#14883](https://github.com/bitnami/charts/issues/14883)
+
+## <small>8.7.3 (2023-01-20)</small>
+
+* [bitnami/etcd] Release 8.7.3 (#14476) ([1afa79c](https://github.com/bitnami/charts/commit/1afa79c)), closes [#14476](https://github.com/bitnami/charts/issues/14476)
+
+## <small>8.7.2 (2023-01-18)</small>
+
+* [bitnami/*] Change licenses annotation format (#14377) ([0ab7608](https://github.com/bitnami/charts/commit/0ab7608)), closes [#14377](https://github.com/bitnami/charts/issues/14377)
+* [bitnami/etcd] Release 8.7.2 (#14430) ([1aacd78](https://github.com/bitnami/charts/commit/1aacd78)), closes [#14430](https://github.com/bitnami/charts/issues/14430)
+
+## <small>8.7.1 (2023-01-16)</small>
+
+* Fix an issue where the etcd chart renders the jwt secret when the auth token is disabled (#14364) ([0b18941](https://github.com/bitnami/charts/commit/0b18941)), closes [#14364](https://github.com/bitnami/charts/issues/14364)
+
+## 8.7.0 (2023-01-13)
+
+* [bitnami/*] Add license annotation and remove obsolete engine parameter (#14293) ([da2a794](https://github.com/bitnami/charts/commit/da2a794)), closes [#14293](https://github.com/bitnami/charts/issues/14293)
+* [bitnami/etcd] Add param auth.token.enabled to disable etcd auth (#14273) ([210f917](https://github.com/bitnami/charts/commit/210f917)), closes [#14273](https://github.com/bitnami/charts/issues/14273)
+
+## 8.6.0 (2023-01-09)
+
+* [bitnami/etcd] Add support for shareProcessNamespace (#14018) ([0c4ed33](https://github.com/bitnami/charts/commit/0c4ed33)), closes [#14018](https://github.com/bitnami/charts/issues/14018)
+
+## <small>8.5.11 (2022-12-19)</small>
+
+* [bitnami/etcd] Release 8.5.11 (#14027) ([2ae2f7c](https://github.com/bitnami/charts/commit/2ae2f7c)), closes [#14027](https://github.com/bitnami/charts/issues/14027)
+
+## <small>8.5.10 (2022-11-21)</small>
+
+* [bitnami/etcd] Release 8.5.10 (#13620) ([f014842](https://github.com/bitnami/charts/commit/f014842)), closes [#13620](https://github.com/bitnami/charts/issues/13620)
+
+## <small>8.5.9 (2022-11-20)</small>
+
+* [bitnami/etcd] Release 8.5.9 (#13609) ([52974e4](https://github.com/bitnami/charts/commit/52974e4)), closes [#13609](https://github.com/bitnami/charts/issues/13609)
+
+## <small>8.5.8 (2022-10-21)</small>
+
+* [bitnami/etcd] Release 8.5.8 (#13076) ([1ea11eb](https://github.com/bitnami/charts/commit/1ea11eb)), closes [#13076](https://github.com/bitnami/charts/issues/13076)
+
+## <small>8.5.7 (2022-10-19)</small>
+
+* [bitnami/*] Use new default branch name in links (#12943) ([a529e02](https://github.com/bitnami/charts/commit/a529e02)), closes [#12943](https://github.com/bitnami/charts/issues/12943)
+* [bitnami/etcd] Release 8.5.7 (#13028) ([7f24872](https://github.com/bitnami/charts/commit/7f24872)), closes [#13028](https://github.com/bitnami/charts/issues/13028)
+
+## <small>8.5.6 (2022-10-14)</small>
+
+* adjust the naming style for resources to make them not pass the length limit (#12955) ([523d82d](https://github.com/bitnami/charts/commit/523d82d)), closes [#12955](https://github.com/bitnami/charts/issues/12955)
+* Generic README instructions related to the repo (#12792) ([3cf6b10](https://github.com/bitnami/charts/commit/3cf6b10)), closes [#12792](https://github.com/bitnami/charts/issues/12792)
+
+## <small>8.5.5 (2022-09-22)</small>
+
+* [bitnami/etcd] Use custom probes if given (#12494) ([353c06e](https://github.com/bitnami/charts/commit/353c06e)), closes [#12494](https://github.com/bitnami/charts/issues/12494) [#12354](https://github.com/bitnami/charts/issues/12354)
+
+## <small>8.5.4 (2022-09-20)</small>
+
+* [bitnami/etcd] Make ETCD_LOG_LEVEL a parameter (#12347) ([d775261](https://github.com/bitnami/charts/commit/d775261)), closes [#12347](https://github.com/bitnami/charts/issues/12347)
+
+## <small>8.5.3 (2022-09-19)</small>
+
+* [bitnami/etcd] Fix API Version for CronJob of etcd (#12449) ([fdc4d7d](https://github.com/bitnami/charts/commit/fdc4d7d)), closes [#12449](https://github.com/bitnami/charts/issues/12449)
+* [bitnami/etcd] Release 8.5.3 (#12575) ([ef65a30](https://github.com/bitnami/charts/commit/ef65a30)), closes [#12575](https://github.com/bitnami/charts/issues/12575)
+
+## <small>8.5.2 (2022-09-16)</small>
+
+* [bitnami/etcd] Reuse etcd jwt token while upgrade (#12019) ([b29606f](https://github.com/bitnami/charts/commit/b29606f)), closes [#12019](https://github.com/bitnami/charts/issues/12019)
+
+## <small>8.5.1 (2022-09-15)</small>
+
+* [bitnami/etcd] Release 8.5.1 (#12445) ([4c2d100](https://github.com/bitnami/charts/commit/4c2d100)), closes [#12445](https://github.com/bitnami/charts/issues/12445)
+
+## 8.5.0 (2022-09-14)
+
+* [bitnami/etcd] Disallowing privilege escalation for etcd (#12311) ([a448711](https://github.com/bitnami/charts/commit/a448711)), closes [#12311](https://github.com/bitnami/charts/issues/12311)
+
+## <small>8.4.5 (2022-09-05)</small>
+
+* [bitnami/etcd] Bump chart version ([ae3a7d2](https://github.com/bitnami/charts/commit/ae3a7d2))
+* [bitnami/etcd] Fix pvc deletion when trying to restore from snapshot (#12261) ([ff48cf4](https://github.com/bitnami/charts/commit/ff48cf4)), closes [#12261](https://github.com/bitnami/charts/issues/12261)
+
+## <small>8.4.4 (2022-09-03)</small>
+
+* [bitnami/etcd] Release 8.4.4 (#12269) ([758faa1](https://github.com/bitnami/charts/commit/758faa1)), closes [#12269](https://github.com/bitnami/charts/issues/12269)
+
+## <small>8.4.3 (2022-08-23)</small>
+
+* [bitnami/etcd] Update Chart.lock (#12032) ([36f82a9](https://github.com/bitnami/charts/commit/36f82a9)), closes [#12032](https://github.com/bitnami/charts/issues/12032)
+
+## <small>8.4.2 (2022-08-23)</small>
+
+* [bitnami/etcd] Bump bitnami/common major version (#12010) ([08d9e4f](https://github.com/bitnami/charts/commit/08d9e4f)), closes [#12010](https://github.com/bitnami/charts/issues/12010)
+
+## <small>8.4.1 (2022-08-22)</small>
+
+* [bitnami/etcd] Update Chart.lock (#11993) ([c69a029](https://github.com/bitnami/charts/commit/c69a029)), closes [#11993](https://github.com/bitnami/charts/issues/11993)
+
+## 8.4.0 (2022-08-18)
+
+* [bitnami/etcd] Add support for image digest apart from tag (#11798) ([30a4ec9](https://github.com/bitnami/charts/commit/30a4ec9)), closes [#11798](https://github.com/bitnami/charts/issues/11798)
+
+## <small>8.3.8 (2022-08-09)</small>
+
+* [binami/etcd] Fix command for cronjob when diagnostic and disaster recovery are enabled (#11637) ([a6a7812](https://github.com/bitnami/charts/commit/a6a7812)), closes [#11637](https://github.com/bitnami/charts/issues/11637)
+
+## <small>8.3.7 (2022-08-04)</small>
+
+* [bitnami/etcd] Release 8.3.7 updating components versions ([92e7250](https://github.com/bitnami/charts/commit/92e7250))
+
+## <small>8.3.6 (2022-08-03)</small>
+
+* [bitnami/etcd] Release 8.3.6 updating components versions ([a0eeae1](https://github.com/bitnami/charts/commit/a0eeae1))
+
+## <small>8.3.5 (2022-08-02)</small>
+
+* [bitnami/*] Update URLs to point to the new bitnami/containers monorepo (#11352) ([d665af0](https://github.com/bitnami/charts/commit/d665af0)), closes [#11352](https://github.com/bitnami/charts/issues/11352)
+* [bitnami/etcd] Release 8.3.5 updating components versions ([d29c674](https://github.com/bitnami/charts/commit/d29c674))
+
+## <small>8.3.4 (2022-07-14)</small>
+
+* [bitnami/etcd] Release 8.3.4 updating components versions ([430394a](https://github.com/bitnami/charts/commit/430394a))
+
+## <small>8.3.3 (2022-06-30)</small>
+
+* [bitnami/etcd] Release 8.3.3 updating components versions ([5e3cacb](https://github.com/bitnami/charts/commit/5e3cacb))
+
+## <small>8.3.2 (2022-06-25)</small>
+
+* [bitnami/etcd] Release 8.3.2 updating components versions ([3f7c2c1](https://github.com/bitnami/charts/commit/3f7c2c1))
+
+## <small>8.3.1 (2022-06-24)</small>
+
+* [bitnami/etcd] Release 8.3.1 updating components versions ([b005137](https://github.com/bitnami/charts/commit/b005137))
+
+## 8.3.0 (2022-06-13)
+
+* [bitnami/etcd] add runtime class support (#10709) ([d363117](https://github.com/bitnami/charts/commit/d363117)), closes [#10709](https://github.com/bitnami/charts/issues/10709)
+
+## <small>8.2.6 (2022-06-10)</small>
+
+* [bitnami/*] Replace Kubeapps URL in READMEs (and kubeapps Chart.yaml) and remove BKPR references (#1 ([c6a7914](https://github.com/bitnami/charts/commit/c6a7914)), closes [#10600](https://github.com/bitnami/charts/issues/10600)
+* [bitnami/etcd] Release 8.2.6 updating components versions ([e1639c0](https://github.com/bitnami/charts/commit/e1639c0))
+
+## <small>8.2.5 (2022-06-06)</small>
+
+* [bitnami/etcd] Release 8.2.5 updating components versions ([1faaec1](https://github.com/bitnami/charts/commit/1faaec1))
+
+## <small>8.2.4 (2022-06-01)</small>
+
+* [bitnami/several] Replace maintainers email by url (#10523) ([ff3cf61](https://github.com/bitnami/charts/commit/ff3cf61)), closes [#10523](https://github.com/bitnami/charts/issues/10523)
+
+## <small>8.2.3 (2022-05-30)</small>
+
+* [bitnami/several] Replace base64 --decode with base64 -d (#10495) ([099286a](https://github.com/bitnami/charts/commit/099286a)), closes [#10495](https://github.com/bitnami/charts/issues/10495)
+
+## <small>8.2.2 (2022-05-21)</small>
+
+* [bitnami/etcd] Release 8.2.2 updating components versions ([100a61e](https://github.com/bitnami/charts/commit/100a61e))
+
+## <small>8.2.1 (2022-05-20)</small>
+
+* [bitnami/etcd] Release 8.2.1 updating components versions ([bf89f82](https://github.com/bitnami/charts/commit/bf89f82))
+
+## 8.2.0 (2022-05-19)
+
+* [bitnami/etcd] add prometheus rule (#10299) ([42de0f5](https://github.com/bitnami/charts/commit/42de0f5)), closes [#10299](https://github.com/bitnami/charts/issues/10299)
+
+## <small>8.1.3 (2022-05-19)</small>
+
+* [bitnami/etcd] Release 8.1.3 updating components versions ([ddbf52d](https://github.com/bitnami/charts/commit/ddbf52d))
+
+## <small>8.1.2 (2022-05-18)</small>
+
+* [bitnami/*] Remove old 'ci' files (#10171) ([5df30c4](https://github.com/bitnami/charts/commit/5df30c4)), closes [#10171](https://github.com/bitnami/charts/issues/10171)
+* [bitnami/etcd] Release 8.1.2 updating components versions ([f737e91](https://github.com/bitnami/charts/commit/f737e91))
+
+## <small>8.1.1 (2022-05-11)</small>
+
+* [bitnami/etcd] added persistentVolumeClaimRetentionPolicy control to statefulset spec (#10058) ([a019f12](https://github.com/bitnami/charts/commit/a019f12)), closes [#10058](https://github.com/bitnami/charts/issues/10058)
+
+## 8.1.0 (2022-04-29)
+
+* [bitnami/etcd] PodDisruptionBudget should be enabled by default (#9929) ([a4a0c16](https://github.com/bitnami/charts/commit/a4a0c16)), closes [#9929](https://github.com/bitnami/charts/issues/9929)
+
+## <small>8.0.2 (2022-04-24)</small>
+
+* [bitnami/etcd] Release 8.0.2 updating components versions ([28d94d3](https://github.com/bitnami/charts/commit/28d94d3))
+
+## <small>8.0.1 (2022-04-20)</small>
+
+* [bitnami/etcd] Release 8.0.1 updating components versions ([a792f42](https://github.com/bitnami/charts/commit/a792f42))
+
+## 8.0.0 (2022-04-20)
+
+* [bitnami/etcd] Update etcd version (#9820) ([e2dec6b](https://github.com/bitnami/charts/commit/e2dec6b)), closes [#9820](https://github.com/bitnami/charts/issues/9820)
+
+## <small>7.0.6 (2022-04-20)</small>
+
+* [bitnami/etcd] Release 7.0.6 updating components versions ([c04b33d](https://github.com/bitnami/charts/commit/c04b33d))
+
+## <small>7.0.5 (2022-04-19)</small>
+
+* [bitnami/etcd] Release 7.0.5 updating components versions ([2a662b8](https://github.com/bitnami/charts/commit/2a662b8))
+
+## <small>7.0.4 (2022-04-13)</small>
+
+* [bitnami/etcd] Release 7.0.4 updating components versions ([ac1a499](https://github.com/bitnami/charts/commit/ac1a499))
+
+## <small>7.0.3 (2022-04-13)</small>
+
+* This fixes #9720 (#9735) ([1dc3acd](https://github.com/bitnami/charts/commit/1dc3acd)), closes [#9720](https://github.com/bitnami/charts/issues/9720) [#9735](https://github.com/bitnami/charts/issues/9735)
+
+## <small>7.0.2 (2022-04-06)</small>
+
+* [bitnami/etcd]: fix: :bug: Use StatefulSet to calculate peers (#9708) ([54af93c](https://github.com/bitnami/charts/commit/54af93c)), closes [#9708](https://github.com/bitnami/charts/issues/9708)
+
+## <small>7.0.1 (2022-04-02)</small>
+
+* [bitnami/etcd] Release 7.0.1 updating components versions ([a588d7f](https://github.com/bitnami/charts/commit/a588d7f))
+
+## 7.0.0 (2022-03-30)
+
+* [bitnami/etcd] fix!: :arrow_down: Downgrade default etcd version to 3.4. (#9628) ([522c8f7](https://github.com/bitnami/charts/commit/522c8f7)), closes [#9628](https://github.com/bitnami/charts/issues/9628)
+
+## <small>6.13.9 (2022-03-28)</small>
+
+* [bitnami/etcd] Release 6.13.9 updating components versions ([d6cc5b0](https://github.com/bitnami/charts/commit/d6cc5b0))
+
+## <small>6.13.8 (2022-03-27)</small>
+
+* [bitnami/etcd] Release 6.13.8 updating components versions ([f636c88](https://github.com/bitnami/charts/commit/f636c88))
+
+## <small>6.13.7 (2022-03-17)</small>
+
+* [bitnami/etcd] Release 6.13.7 updating components versions ([586ec34](https://github.com/bitnami/charts/commit/586ec34))
+
+## <small>6.13.6 (2022-03-16)</small>
+
+* [bitnami/etcd] Release 6.13.6 updating components versions ([5445e1a](https://github.com/bitnami/charts/commit/5445e1a))
+
+## <small>6.13.5 (2022-02-27)</small>
+
+* [bitnami/etcd] Release 6.13.5 updating components versions ([aaf7774](https://github.com/bitnami/charts/commit/aaf7774))
+* Update README.md ([d57e505](https://github.com/bitnami/charts/commit/d57e505))
+
+## <small>6.13.4 (2022-02-21)</small>
+
+* [bitnami/etcd] Do not hardcode PDB apiVersion (#9094) ([7f6a195](https://github.com/bitnami/charts/commit/7f6a195)), closes [#9094](https://github.com/bitnami/charts/issues/9094)
+* Non utf8 chars (#8923) ([6ffd18f](https://github.com/bitnami/charts/commit/6ffd18f)), closes [#8923](https://github.com/bitnami/charts/issues/8923)
+
+## <small>6.13.3 (2022-02-01)</small>
+
+* [bitnami/etcd] Release 6.13.3 updating components versions ([f96b19c](https://github.com/bitnami/charts/commit/f96b19c))
+
+## <small>6.13.2 (2022-01-20)</small>
+
+* [bitnami/*] Update READMEs (#8716) ([b9a9533](https://github.com/bitnami/charts/commit/b9a9533)), closes [#8716](https://github.com/bitnami/charts/issues/8716)
+* [bitnami/several] Change prerequisites (#8725) ([8d740c5](https://github.com/bitnami/charts/commit/8d740c5)), closes [#8725](https://github.com/bitnami/charts/issues/8725)
+
+## <small>6.13.1 (2022-01-18)</small>
+
+* [bitnami/etcd] Release 6.13.1 updating components versions ([76351d0](https://github.com/bitnami/charts/commit/76351d0))
+
+## 6.13.0 (2022-01-18)
+
+* [bitnami/*] Readme automation (#8579) ([78d1938](https://github.com/bitnami/charts/commit/78d1938)), closes [#8579](https://github.com/bitnami/charts/issues/8579)
+* [bitnami/etcd] Chart standardised (#7926) ([c3f6f9a](https://github.com/bitnami/charts/commit/c3f6f9a)), closes [#7926](https://github.com/bitnami/charts/issues/7926)
+
+## <small>6.12.2 (2022-01-15)</small>
+
+* [bitnami/etcd] Release 6.12.2 updating components versions ([d0bef1e](https://github.com/bitnami/charts/commit/d0bef1e))
+
+## <small>6.12.1 (2022-01-11)</small>
+
+* [bitnami/etcd] Fix values metadata (#8611) ([1e29708](https://github.com/bitnami/charts/commit/1e29708)), closes [#8611](https://github.com/bitnami/charts/issues/8611)
+
+## 6.12.0 (2022-01-07)
+
+* [bitnami/etcd] Allow to override schedulerName (#8595) ([b116b7e](https://github.com/bitnami/charts/commit/b116b7e)), closes [#8595](https://github.com/bitnami/charts/issues/8595)
+
+## 6.11.0 (2022-01-05)
+
+* [bitnami/several] Adapt templating format (#8562) ([8cad18a](https://github.com/bitnami/charts/commit/8cad18a)), closes [#8562](https://github.com/bitnami/charts/issues/8562)
+
+## <small>6.10.8 (2022-01-04)</small>
+
+* [bitnami/several] Add license to the README ([05f7633](https://github.com/bitnami/charts/commit/05f7633))
+* [bitnami/several] Add license to the README ([32fb238](https://github.com/bitnami/charts/commit/32fb238))
+* [bitnami/several] Add license to the README ([b87c2f7](https://github.com/bitnami/charts/commit/b87c2f7))
+* [bitnami/several] Fix issue with quote when followed by }} (#8561) ([58077af](https://github.com/bitnami/charts/commit/58077af)), closes [#8561](https://github.com/bitnami/charts/issues/8561)
+
+## <small>6.10.7 (2022-01-03)</small>
+
+* [bitnami/etcd] Change hardcoded password key with etcd.secretPasswordKey (#8442) ([d63c26c](https://github.com/bitnami/charts/commit/d63c26c)), closes [#8442](https://github.com/bitnami/charts/issues/8442)
+
+## <small>6.10.6 (2021-12-16)</small>
+
+* [bitnami/etcd] Release 6.10.6 updating components versions ([28c022a](https://github.com/bitnami/charts/commit/28c022a))
+
+## <small>6.10.5 (2021-12-09)</small>
+
+* [bitnami/cassandra,etcd,influxdb,metallb,mysql,postgresql,postgresql-ha,redis] Align networkpolicy   ([0404b1a](https://github.com/bitnami/charts/commit/0404b1a)), closes [#8336](https://github.com/bitnami/charts/issues/8336)
+
+## <small>6.10.4 (2021-11-29)</small>
+
+* [bitnami/several] Fix deadlinks in README.md (#8215) ([99e90d2](https://github.com/bitnami/charts/commit/99e90d2)), closes [#8215](https://github.com/bitnami/charts/issues/8215)
+* [bitnami/several] Regenerate README tables ([7b091c0](https://github.com/bitnami/charts/commit/7b091c0))
+* [bitnami/several] Replace HTTP by HTTPS when possible (#8259) ([eafb5bd](https://github.com/bitnami/charts/commit/eafb5bd)), closes [#8259](https://github.com/bitnami/charts/issues/8259)
+
+## <small>6.10.3 (2021-11-19)</small>
+
+* [bitnami/etcd] Fix etcd when using a custom svc port (#8189) ([7fb8d7e](https://github.com/bitnami/charts/commit/7fb8d7e)), closes [#8189](https://github.com/bitnami/charts/issues/8189)
+
+## <small>6.10.2 (2021-11-18)</small>
+
+* [bitnami/etcd] Release 6.10.2 updating components versions ([e300a10](https://github.com/bitnami/charts/commit/e300a10))
+
+## <small>6.10.1 (2021-11-18)</small>
+
+* [bitnami/etcd] ETCD_LISTEN_* to use container ports instead of svc ports (#8180) ([1ca4cbf](https://github.com/bitnami/charts/commit/1ca4cbf)), closes [#8180](https://github.com/bitnami/charts/issues/8180)
+
+## 6.10.0 (2021-11-04)
+
+* feat: add etcd nodeselctor & toleration on disasterRecovery (#7984) ([93ce746](https://github.com/bitnami/charts/commit/93ce746)), closes [#7984](https://github.com/bitnami/charts/issues/7984)
+* [bitnami/several] Regenerate README tables ([412cf6a](https://github.com/bitnami/charts/commit/412cf6a))
+
+## <small>6.9.4 (2021-10-27)</small>
+
+* [bitnami/etcd] Release 6.9.4 updating components versions ([0e507a7](https://github.com/bitnami/charts/commit/0e507a7))
+
+## <small>6.9.3 (2021-10-22)</small>
+
+* [bitnami/several] Add chart info to NOTES.txt (#7889) ([a6751cd](https://github.com/bitnami/charts/commit/a6751cd)), closes [#7889](https://github.com/bitnami/charts/issues/7889)
+
+## <small>6.9.2 (2021-10-19)</small>
+
+* [bitnami/several] Change pullPolicy for bitnami-shell image (#7852) ([9711a33](https://github.com/bitnami/charts/commit/9711a33)), closes [#7852](https://github.com/bitnami/charts/issues/7852)
+* [bitnami/several] Regenerate README tables ([0a26eaa](https://github.com/bitnami/charts/commit/0a26eaa))
+
+## <small>6.9.1 (2021-10-15)</small>
+
+* [bitnami/etcd] Release 6.9.1 updating components versions ([d3c5418](https://github.com/bitnami/charts/commit/d3c5418))
+
+## 6.9.0 (2021-10-08)
+
+* [bitnami/etcd] Add support for customizing authentication token type (#7735) ([9f9d8aa](https://github.com/bitnami/charts/commit/9f9d8aa)), closes [#7735](https://github.com/bitnami/charts/issues/7735)
+* [bitnami/several] Regenerate README tables ([ff170d1](https://github.com/bitnami/charts/commit/ff170d1))
+
+## <small>6.8.4 (2021-09-24)</small>
+
+* [bitnami/*] Generate READMEs with new generator version (#7614) ([e5ab2e6](https://github.com/bitnami/charts/commit/e5ab2e6)), closes [#7614](https://github.com/bitnami/charts/issues/7614)
+* [bitnami/etcd] feat: allow reuse startFromSnapshot volume in the disasterRecovery (#7511) ([b307202](https://github.com/bitnami/charts/commit/b307202)), closes [#7511](https://github.com/bitnami/charts/issues/7511)
+
+## <small>6.8.3 (2021-09-24)</small>
+
+* [bitnami/etcd] Release 6.8.3 updating components versions ([e5c193e](https://github.com/bitnami/charts/commit/e5c193e))
+
+## <small>6.8.2 (2021-09-17)</small>
+
+* [bitnami/etcd] fix snapshots directory ownership when security context is enabled (#7498) ([831eed7](https://github.com/bitnami/charts/commit/831eed7)), closes [#7498](https://github.com/bitnami/charts/issues/7498)
+
+## <small>6.8.1 (2021-09-15)</small>
+
+* [bitnami/several] Regenerate README tables ([c01cbe5](https://github.com/bitnami/charts/commit/c01cbe5))
+* fix kubectl exec example in chart notes (#7496) ([971c4a4](https://github.com/bitnami/charts/commit/971c4a4)), closes [#7496](https://github.com/bitnami/charts/issues/7496)
+
+## 6.8.0 (2021-09-07)
+
+* [bitnami/etcd] add Prometheus podmonitor relabelings parameter (#7399) ([9e15549](https://github.com/bitnami/charts/commit/9e15549)), closes [#7399](https://github.com/bitnami/charts/issues/7399)
+* [bitnami/several] Regenerate README tables ([8c2dfde](https://github.com/bitnami/charts/commit/8c2dfde))
+
+## 6.7.0 (2021-09-02)
+
+* [bitnami/etcd] Adding the possibility to disable service (#7371) ([91e80b3](https://github.com/bitnami/charts/commit/91e80b3)), closes [#7371](https://github.com/bitnami/charts/issues/7371)
+
+## <small>6.6.2 (2021-09-01)</small>
+
+* [bitnami/etcd] add service.clusterIP parameter (#7356) ([78508eb](https://github.com/bitnami/charts/commit/78508eb)), closes [#7356](https://github.com/bitnami/charts/issues/7356)
+* [bitnami/several] Regenerate README tables ([da2513b](https://github.com/bitnami/charts/commit/da2513b))
+
+## <small>6.6.1 (2021-08-25)</small>
+
+* [bitnami/etcd] Release 6.6.1 updating components versions ([4a34868](https://github.com/bitnami/charts/commit/4a34868))
+
+## 6.6.0 (2021-08-25)
+
+* [bitnami/etcd] Add support for custom terminationGracePeriodSeconds (#7307) ([e880129](https://github.com/bitnami/charts/commit/e880129)), closes [#7307](https://github.com/bitnami/charts/issues/7307)
+
+## 6.5.0 (2021-08-20)
+
+* [bitnami/etcd] add support for network policy (#7205) ([1e24ddb](https://github.com/bitnami/charts/commit/1e24ddb)), closes [#7205](https://github.com/bitnami/charts/issues/7205)
+
+## <small>6.4.1 (2021-08-18)</small>
+
+* [bitnami/etcd] Release 6.4.1 updating components versions ([2e0bfc1](https://github.com/bitnami/charts/commit/2e0bfc1))
+
+## 6.4.0 (2021-08-17)
+
+* [bitnami/etcd] Add existingSecretPasswordKey field in auth.rbac (#7212) ([5baf3cf](https://github.com/bitnami/charts/commit/5baf3cf)), closes [#7212](https://github.com/bitnami/charts/issues/7212)
+
+## <small>6.3.4 (2021-08-17)</small>
+
+* [bitnami/etcd] use existingSecret parameters as a template (#7209) ([2bfeaef](https://github.com/bitnami/charts/commit/2bfeaef)), closes [#7209](https://github.com/bitnami/charts/issues/7209)
+* [bitnami/several] Update READMEs (#7108) ([44961d9](https://github.com/bitnami/charts/commit/44961d9)), closes [#7108](https://github.com/bitnami/charts/issues/7108)
+
+## <small>6.3.3 (2021-07-30)</small>
+
+* [bitnami/etcd] Release 6.3.3 updating components versions ([ba6f835](https://github.com/bitnami/charts/commit/ba6f835))
+
+## <small>6.3.2 (2021-07-30)</small>
+
+* [bitnami/etcd] Release 6.3.2 updating components versions ([c2cf742](https://github.com/bitnami/charts/commit/c2cf742))
+
+## <small>6.3.1 (2021-07-27)</small>
+
+* [bitnami/several] Fix default values and regenerate README (#7024) ([4c86733](https://github.com/bitnami/charts/commit/4c86733)), closes [#7024](https://github.com/bitnami/charts/issues/7024)
+
+## 6.3.0 (2021-07-27)
+
+* [bitnami/several] Add diagnostic mode (#7012) ([f1344b0](https://github.com/bitnami/charts/commit/f1344b0)), closes [#7012](https://github.com/bitnami/charts/issues/7012)
+
+## <small>6.2.11 (2021-07-19)</small>
+
+* [bitnami/*] Adapt values.yaml of Elasticsearch, etcd and external-dns charts (#6822) ([a5d80d6](https://github.com/bitnami/charts/commit/a5d80d6)), closes [#6822](https://github.com/bitnami/charts/issues/6822)
+
+## <small>6.2.10 (2021-07-17)</small>
+
+* [bitnami/etcd] Release 6.2.10 updating components versions ([037d1b9](https://github.com/bitnami/charts/commit/037d1b9))
+
+## <small>6.2.9 (2021-06-17)</small>
+
+* [bitnami/etcd] Release 6.2.9 updating components versions ([8e9ee29](https://github.com/bitnami/charts/commit/8e9ee29))
+
+## <small>6.2.8 (2021-06-15)</small>
+
+* [bitnami/etcd] Release 6.2.8 updating components versions ([324afd9](https://github.com/bitnami/charts/commit/324afd9))
+
+## <small>6.2.7 (2021-06-11)</small>
+
+* [bitnami/etcd] Release 6.2.7 updating components versions ([0c73128](https://github.com/bitnami/charts/commit/0c73128))
+
+## <small>6.2.6 (2021-05-28)</small>
+
+* [bitnami/etcd] Release 6.2.6 updating components versions ([8cdea9d](https://github.com/bitnami/charts/commit/8cdea9d))
+
+## <small>6.2.5 (2021-05-23)</small>
+
+* [bitnami/etcd] Release 6.2.5 updating components versions ([976a204](https://github.com/bitnami/charts/commit/976a204))
+
+## <small>6.2.4 (2021-05-14)</small>
+
+* [bitnami/etcd] Release 6.2.4 updating components versions ([6c2ec2b](https://github.com/bitnami/charts/commit/6c2ec2b))
+
+## <small>6.2.3 (2021-04-16)</small>
+
+* T39353 Updated links (#6128) ([9d5aa6e](https://github.com/bitnami/charts/commit/9d5aa6e)), closes [#6128](https://github.com/bitnami/charts/issues/6128)
+
+## <small>6.2.2 (2021-04-15)</small>
+
+* [bitnami/etcd] Release 6.2.2 updating components versions ([f04d933](https://github.com/bitnami/charts/commit/f04d933))
+
+## <small>6.2.1 (2021-04-12)</small>
+
+* [bitnami/etcd] Add image pull secrets to cronjob (#6071) ([ca6416a](https://github.com/bitnami/charts/commit/ca6416a)), closes [#6071](https://github.com/bitnami/charts/issues/6071)
+
+## 6.2.0 (2021-04-09)
+
+* [bitnami/etcd] Service account specification (#6055) ([c1a4703](https://github.com/bitnami/charts/commit/c1a4703)), closes [#6055](https://github.com/bitnami/charts/issues/6055)
+
+## <small>6.1.5 (2021-04-07)</small>
+
+* [bitnami/etcd] Fix configmap template (#6025) ([2fe5d38](https://github.com/bitnami/charts/commit/2fe5d38)), closes [#6025](https://github.com/bitnami/charts/issues/6025)
+
+## <small>6.1.4 (2021-04-06)</small>
+
+* Etcd init from snapshot (#6013) ([570be78](https://github.com/bitnami/charts/commit/570be78)), closes [#6013](https://github.com/bitnami/charts/issues/6013)
+
+## <small>6.1.3 (2021-03-18)</small>
+
+* Quote retention env variable values (#5831) ([65747e8](https://github.com/bitnami/charts/commit/65747e8)), closes [#5831](https://github.com/bitnami/charts/issues/5831)
+
+## <small>6.1.2 (2021-03-16)</small>
+
+* [bitnami/etcd] Release 6.1.2 updating components versions ([182114e](https://github.com/bitnami/charts/commit/182114e))
+
+## <small>6.1.1 (2021-03-15)</small>
+
+* [bitnami/etcd] Service: Fix clientPortNameOverride and peerPortNameOverride. (#5786) ([4a2f19f](https://github.com/bitnami/charts/commit/4a2f19f)), closes [#5786](https://github.com/bitnami/charts/issues/5786)
+
+## 6.1.0 (2021-03-15)
+
+* [bitnami/chart] Adding parameters to enable and manipulate auto-compaction feature of etcd (#5756) ([43fc0df](https://github.com/bitnami/charts/commit/43fc0df)), closes [#5756](https://github.com/bitnami/charts/issues/5756)
+* Update README.md ([7e84fee](https://github.com/bitnami/charts/commit/7e84fee))
+* Update README.md ([44f1276](https://github.com/bitnami/charts/commit/44f1276))
+
+## 6.0.0 (2021-03-12)
+
+* [bitnami/etcd] Major version: refactoring (#5682) ([5741a6d](https://github.com/bitnami/charts/commit/5741a6d)), closes [#5682](https://github.com/bitnami/charts/issues/5682)
+
+## <small>5.6.2 (2021-03-04)</small>
+
+* [bitnami/*] Remove minideb mentions (#5677) ([870bc4d](https://github.com/bitnami/charts/commit/870bc4d)), closes [#5677](https://github.com/bitnami/charts/issues/5677)
+
+## <small>5.6.1 (2021-02-10)</small>
+
+* [bitnami/*] Add notice regarding parameters immutability after chart installation (#4853) ([5f09573](https://github.com/bitnami/charts/commit/5f09573)), closes [#4853](https://github.com/bitnami/charts/issues/4853)
+* [bitnami/etcd] Release 5.6.1 updating components versions ([aecde05](https://github.com/bitnami/charts/commit/aecde05))
+
+## 5.6.0 (2021-01-28)
+
+* [bitnami/etcd] Add hostAliases (#5238) ([c36935d](https://github.com/bitnami/charts/commit/c36935d)), closes [#5238](https://github.com/bitnami/charts/issues/5238)
+
+## <small>5.5.2 (2021-01-25)</small>
+
+* [bitnami/*] Unify icons in Chart.yaml and add missing fields (#5206) ([0462921](https://github.com/bitnami/charts/commit/0462921)), closes [#5206](https://github.com/bitnami/charts/issues/5206)
+
+## <small>5.5.1 (2021-01-19)</small>
+
+* [bitnami/*] Change helm version in the prerequisites (#5090) ([c5e67a3](https://github.com/bitnami/charts/commit/c5e67a3)), closes [#5090](https://github.com/bitnami/charts/issues/5090)
+* [bitnami/etcd] Drop values-production.yaml support (#5103) ([5cd0f00](https://github.com/bitnami/charts/commit/5cd0f00)), closes [#5103](https://github.com/bitnami/charts/issues/5103)
+
+## 5.5.0 (2021-01-11)
+
+* [bitnami/etcd] Reuse startFromSnapshot volume in the disasterRecovery mode (#4940) ([2e05d2a](https://github.com/bitnami/charts/commit/2e05d2a)), closes [#4940](https://github.com/bitnami/charts/issues/4940)
+
+## <small>5.4.2 (2021-01-04)</small>
+
+* [bitnami/etcd] Fix port in concatenation of endpoints (#4875) ([ffdb62e](https://github.com/bitnami/charts/commit/ffdb62e)), closes [#4875](https://github.com/bitnami/charts/issues/4875)
+
+## <small>5.4.1 (2020-12-26)</small>
+
+* [bitnami/etcd] Release 5.4.1 updating components versions ([18e5e47](https://github.com/bitnami/charts/commit/18e5e47))
+
+## 5.4.0 (2020-12-18)
+
+* [bitnami/etcd] Allow externalIPs in svc (#4770) ([5ee088e](https://github.com/bitnami/charts/commit/5ee088e)), closes [#4770](https://github.com/bitnami/charts/issues/4770)
+
+## <small>5.3.2 (2020-12-17)</small>
+
+* [bitnami/*] fix typos (#4699) ([49adc63](https://github.com/bitnami/charts/commit/49adc63)), closes [#4699](https://github.com/bitnami/charts/issues/4699)
+* [bitnami/etcd] Add publishNotReadyAddresses: true to headless service (#4748) ([bfc6ae7](https://github.com/bitnami/charts/commit/bfc6ae7)), closes [#4748](https://github.com/bitnami/charts/issues/4748)
+
+## <small>5.3.1 (2020-12-11)</small>
+
+* [bitnami/*] Update dependencies (#4694) ([2826c12](https://github.com/bitnami/charts/commit/2826c12)), closes [#4694](https://github.com/bitnami/charts/issues/4694)
+
+## 5.3.0 (2020-12-01)
+
+* [bitnami/etcd] Add `statefulsetLabels` and `podLabels` (#4518) ([6ff4b1d](https://github.com/bitnami/charts/commit/6ff4b1d)), closes [#4518](https://github.com/bitnami/charts/issues/4518)
+
+## <small>5.2.1 (2020-11-26)</small>
+
+* [bitnami/etcd] Release 5.2.1 updating components versions ([9aeb6e0](https://github.com/bitnami/charts/commit/9aeb6e0))
+
+## 5.2.0 (2020-11-25)
+
+* [bitnami/*] Affinity based on common presets (ii) (#4472) ([934259f](https://github.com/bitnami/charts/commit/934259f)), closes [#4472](https://github.com/bitnami/charts/issues/4472)
+
+## 5.1.0 (2020-11-13)
+
+* [bitnami/etcd] Allow client/peer port name overrides for custom SRV domains (#4147) ([039a831](https://github.com/bitnami/charts/commit/039a831)), closes [#4147](https://github.com/bitnami/charts/issues/4147)
+
+## <small>5.0.1 (2020-11-11)</small>
+
+* [bitnami/etcd] Remove unused etcd.dataDir template function (#4254) ([2f9ee67](https://github.com/bitnami/charts/commit/2f9ee67)), closes [#4254](https://github.com/bitnami/charts/issues/4254)
+
+## 5.0.0 (2020-11-10)
+
+* [bitnami/etcd] Major version. Adapt Chart to apiVersion: v2 (#4283) ([7b380b6](https://github.com/bitnami/charts/commit/7b380b6)), closes [#4283](https://github.com/bitnami/charts/issues/4283)
+
+## <small>4.12.2 (2020-11-04)</small>
+
+* [bitnami/*] Include link to Troubleshootin guide on README.md (#4136) ([c08a20e](https://github.com/bitnami/charts/commit/c08a20e)), closes [#4136](https://github.com/bitnami/charts/issues/4136)
+* [bitnami/etcd] Disable metrics even if podAnnotations are provided (#4146) ([91ca0df](https://github.com/bitnami/charts/commit/91ca0df)), closes [#4146](https://github.com/bitnami/charts/issues/4146)
+
+## <small>4.12.1 (2020-10-22)</small>
+
+* [bitnami/etcd] Release 4.12.1 updating components versions ([94e0dd6](https://github.com/bitnami/charts/commit/94e0dd6))
+
+## 4.12.0 (2020-10-14)
+
+* [bitnami/etcd] Allow alternate TLS secret filenames (#3902) ([e901dd8](https://github.com/bitnami/charts/commit/e901dd8)), closes [#3902](https://github.com/bitnami/charts/issues/3902)
+
+## <small>4.11.1 (2020-09-22)</small>
+
+* [bitnami/etcd] Release 4.11.1 updating components versions ([cd8ff11](https://github.com/bitnami/charts/commit/cd8ff11))
+
+## 4.11.0 (2020-09-11)
+
+* [bitnami/etcd] add loadBalancerSourceRanges (#3637) ([975fe17](https://github.com/bitnami/charts/commit/975fe17)), closes [#3637](https://github.com/bitnami/charts/issues/3637)
+* [bitnami/metrics-server] Add source repo (#3577) ([1ed12f9](https://github.com/bitnami/charts/commit/1ed12f9)), closes [#3577](https://github.com/bitnami/charts/issues/3577)
+
+## <small>4.10.1 (2020-08-26)</small>
+
+* [bitnami/etcd] Release 4.10.1 updating components versions ([996649f](https://github.com/bitnami/charts/commit/996649f))
+
+## 4.10.0 (2020-08-21)
+
+* [bitnami/etcd] Add persistent volume claim selector (#3480) ([0e10b5f](https://github.com/bitnami/charts/commit/0e10b5f)), closes [#3480](https://github.com/bitnami/charts/issues/3480)
+
+## <small>4.9.5 (2020-08-20)</small>
+
+* [bitnami/etcd] Release 4.9.5 updating components versions ([ac3ee4a](https://github.com/bitnami/charts/commit/ac3ee4a))
+
+## <small>4.9.4 (2020-08-11)</small>
+
+* [bitnami/etcd] Fix typo in values file (#3378) ([0fdec44](https://github.com/bitnami/charts/commit/0fdec44)), closes [#3378](https://github.com/bitnami/charts/issues/3378)
+
+## <small>4.9.3 (2020-08-05)</small>
+
+* [bitnami/etcd] Release 4.9.3 updating components versions ([8476d54](https://github.com/bitnami/charts/commit/8476d54))
+
+## <small>4.9.2 (2020-07-31)</small>
+
+* [bitnami/*] Fix TL;DR typo in READMEs (#3280) ([3d7ab40](https://github.com/bitnami/charts/commit/3d7ab40)), closes [#3280](https://github.com/bitnami/charts/issues/3280)
+* [bitnami/etcd] Fix etcd deployment when disabling useAutoTLS in client auth configuration (#3279) ([adb3f6b](https://github.com/bitnami/charts/commit/adb3f6b)), closes [#3279](https://github.com/bitnami/charts/issues/3279)
+
+## <small>4.9.1 (2020-07-27)</small>
+
+* [bitnami/etcd] Fix issue when removing pod not being reattatched to the cluster properly (#3212) ([7734c98](https://github.com/bitnami/charts/commit/7734c98)), closes [#3212](https://github.com/bitnami/charts/issues/3212)
+
+## 4.9.0 (2020-07-23)
+
+* [bitnami/etcd] Ensure ETCD_DATA_DIR permissions are set to 700 (#3196) ([b331fa6](https://github.com/bitnami/charts/commit/b331fa6)), closes [#3196](https://github.com/bitnami/charts/issues/3196)
+
+## <small>4.8.14 (2020-07-18)</small>
+
+* [bitnami/etcd] Release 4.8.14 updating components versions ([6d58840](https://github.com/bitnami/charts/commit/6d58840))
+
+## <small>4.8.13 (2020-07-16)</small>
+
+* [bitnami/etcd] Fix issue on snapshooting cronjob (#3134) ([bbe0baa](https://github.com/bitnami/charts/commit/bbe0baa)), closes [#3134](https://github.com/bitnami/charts/issues/3134)
+
+## <small>4.8.12 (2020-07-16)</small>
+
+* [bitnami/etcd] Release 4.8.12 updating components versions ([6d05f38](https://github.com/bitnami/charts/commit/6d05f38))
+
+## <small>4.8.11 (2020-07-15)</small>
+
+* [bitnami/etcd] Fix snapshotter job when there's only one replica (#3119) ([f234cc7](https://github.com/bitnami/charts/commit/f234cc7)), closes [#3119](https://github.com/bitnami/charts/issues/3119)
+
+## <small>4.8.10 (2020-07-10)</small>
+
+* [bitnami/all] Add categories (#3075) ([63bde06](https://github.com/bitnami/charts/commit/63bde06)), closes [#3075](https://github.com/bitnami/charts/issues/3075)
+* [bitnami/etcd] Release 4.8.10 updating components versions ([25540ec](https://github.com/bitnami/charts/commit/25540ec))
+
+## <small>4.8.9 (2020-07-03)</small>
+
+* [bitnami/etcd] Release 4.8.9 updating components versions ([65f0ed6](https://github.com/bitnami/charts/commit/65f0ed6))
+
+## <small>4.8.8 (2020-07-03)</small>
+
+* Fixing grep used to create member_id file (#3013) ([90af20f](https://github.com/bitnami/charts/commit/90af20f)), closes [#3013](https://github.com/bitnami/charts/issues/3013)
+
+## <small>4.8.7 (2020-06-29)</small>
+
+* [bitnami/etcd] Release 4.8.7 updating components versions ([5649a31](https://github.com/bitnami/charts/commit/5649a31))
+
+## <small>4.8.6 (2020-06-29)</small>
+
+* [bitnami/etcd] Don't create hardlink for latest snapshot (#2948) ([28c35be](https://github.com/bitnami/charts/commit/28c35be)), closes [#2948](https://github.com/bitnami/charts/issues/2948)
+
+## <small>4.8.5 (2020-06-24)</small>
+
+* [bitnami/etcd] Release 4.8.5 updating components versions ([dc009cd](https://github.com/bitnami/charts/commit/dc009cd))
+
+## <small>4.8.4 (2020-06-16)</small>
+
+* [bitnami/etcd] make cluster state variable configurable to fix https://github.com/bitnami/charts/iss ([bd7f575](https://github.com/bitnami/charts/commit/bd7f575)), closes [#2837](https://github.com/bitnami/charts/issues/2837)
+
+## <small>4.8.3 (2020-06-15)</small>
+
+* [bitnami/etcd] Release 4.8.3 updating components versions ([ded4ba8](https://github.com/bitnami/charts/commit/ded4ba8))
+
+## <small>4.8.2 (2020-05-21)</small>
+
+* [bitnami/etcd] Release 4.8.2 updating components versions ([c061385](https://github.com/bitnami/charts/commit/c061385))
+* update bitnami/common to be compatible with helm v2.12+ (#2615) ([c7751eb](https://github.com/bitnami/charts/commit/c7751eb)), closes [#2615](https://github.com/bitnami/charts/issues/2615)
+
+## <small>4.8.1 (2020-05-18)</small>
+
+* [bitnami/etcd] Release 4.8.1 updating components versions ([acfd77f](https://github.com/bitnami/charts/commit/acfd77f))
+
+## 4.8.0 (2020-05-08)
+
+* [bitnami/etcd] Add PodDisruptionBudget (#2545) ([78c98d3](https://github.com/bitnami/charts/commit/78c98d3)), closes [#2545](https://github.com/bitnami/charts/issues/2545)
+
+## <small>4.7.5 (2020-04-22)</small>
+
+* [bitnami/etcd] Release 4.7.5 updating components versions ([eab1be2](https://github.com/bitnami/charts/commit/eab1be2))
+
+## <small>4.7.4 (2020-04-16)</small>
+
+* [bitnami/etcd] Release 4.7.4 updating components versions ([3876458](https://github.com/bitnami/charts/commit/3876458))
+
+## <small>4.7.3 (2020-04-02)</small>
+
+* [bitnami/etcd] Release 4.7.3 updating components versions ([dbf0ed2](https://github.com/bitnami/charts/commit/dbf0ed2))
+
+## <small>4.7.2 (2020-03-29)</small>
+
+* [bitnami/etcd] Release 4.7.2 updating components versions ([a3940dd](https://github.com/bitnami/charts/commit/a3940dd))
+
+## <small>4.7.1 (2020-03-26)</small>
+
+* [bitnami/etcd] Release 4.7.1 updating components versions ([4917220](https://github.com/bitnami/charts/commit/4917220))
+
+## 4.7.0 (2020-03-25)
+
+* [bitnami/etcd] add priority class name option to etcd (#2126) ([8d87e6f](https://github.com/bitnami/charts/commit/8d87e6f)), closes [#2126](https://github.com/bitnami/charts/issues/2126)
+
+## <small>4.6.4 (2020-03-20)</small>
+
+* [bitnami/etcd] Release 4.6.4 updating components versions ([bcfc42a](https://github.com/bitnami/charts/commit/bcfc42a))
+
+## <small>4.6.3 (2020-03-19)</small>
+
+* [bitnami/etcd] Release 4.6.3 updating components versions ([8cca14f](https://github.com/bitnami/charts/commit/8cca14f))
+
+## <small>4.6.2 (2020-03-12)</small>
+
+* [bitnami/etcd] Release 4.6.2 updating components versions ([e443986](https://github.com/bitnami/charts/commit/e443986))
+
+## <small>4.6.1 (2020-03-11)</small>
+
+* Move charts from upstreamed folder to bitnami (#2032) ([a0e44f7](https://github.com/bitnami/charts/commit/a0e44f7)), closes [#2032](https://github.com/bitnami/charts/issues/2032)
+
+## 4.6.0 (2020-03-02)
+
+* [bitnami/etcd] keep snapshot history (#1920) ([55bb26b](https://github.com/bitnami/charts/commit/55bb26b)), closes [#1920](https://github.com/bitnami/charts/issues/1920)
+
+## <small>4.5.1 (2020-02-26)</small>
+
+* [bitnami/etcd] Release 4.5.1 updating components versions ([67827b5](https://github.com/bitnami/charts/commit/67827b5))
+
+## 4.5.0 (2020-02-25)
+
+* [bitnami/etcd] fix save-snapshot script (#1958) ([8e451ec](https://github.com/bitnami/charts/commit/8e451ec)), closes [#1958](https://github.com/bitnami/charts/issues/1958)
+* [bitnami/etcd] Fix showing ETCD_ROOT_PASSWORD in the logs (#1909) ([5534f5e](https://github.com/bitnami/charts/commit/5534f5e)), closes [#1909](https://github.com/bitnami/charts/issues/1909)
+
+## <small>4.4.14 (2020-02-11)</small>
+
+* [bitnami/several] Adapt READMEs and helpers to Helm 3 (#1911) ([40ee57c](https://github.com/bitnami/charts/commit/40ee57c)), closes [#1911](https://github.com/bitnami/charts/issues/1911)
+
+## <small>4.4.13 (2020-02-11)</small>
+
+* [bitnami/etcd] Release 4.4.13 updating components versions ([c4f47a0](https://github.com/bitnami/charts/commit/c4f47a0))
+
+## <small>4.4.12 (2020-02-10)</small>
+
+* [bitnami/several] Replace stretch by buster in minideb secondary containers (#1900) ([678febc](https://github.com/bitnami/charts/commit/678febc)), closes [#1900](https://github.com/bitnami/charts/issues/1900)
+
+## <small>4.4.11 (2020-01-23)</small>
+
+* [bitnami/etcd] Release 4.4.11 updating components versions ([eb1cb9f](https://github.com/bitnami/charts/commit/eb1cb9f))
+
+## <small>4.4.10 (2020-01-14)</small>
+
+* [bitnami/etcd] Release 4.4.10 updating components versions ([cf60876](https://github.com/bitnami/charts/commit/cf60876))
+
+## <small>4.4.9 (2020-01-10)</small>
+
+* [bitnami/etcd] Release 4.4.9 updating components versions ([dfe3d5b](https://github.com/bitnami/charts/commit/dfe3d5b))
+
+## <small>4.4.8 (2020-01-02)</small>
+
+* [bitnami/etcd] support snapshot restore on single node deployment ([7d18cf4](https://github.com/bitnami/charts/commit/7d18cf4)), closes [#1784](https://github.com/bitnami/charts/issues/1784)
+
+## <small>4.4.7 (2019-12-18)</small>
+
+* [bitnami/etcd] Use auto-generated TLS certificates when ETCD_AUTO_TLS is true ([550a1d6](https://github.com/bitnami/charts/commit/550a1d6))
+
+## <small>4.4.6 (2019-12-13)</small>
+
+* use BITNAMI_DEBUG te enable bash script debugging ([de6f9bc](https://github.com/bitnami/charts/commit/de6f9bc))
+
+## <small>4.4.5 (2019-11-27)</small>
+
+* [bitnami/*] Remove reference to Cassandra on non-cassandra charts ([8418d32](https://github.com/bitnami/charts/commit/8418d32))
+
+## <small>4.4.4 (2019-11-22)</small>
+
+* [bitnami/etcd] Fix regexp to detect removed members from cluster ([e4d820e](https://github.com/bitnami/charts/commit/e4d820e))
+* [bitnami/etcd] Update components versions ([5ff0985](https://github.com/bitnami/charts/commit/5ff0985))
+* fix updateStrategy in etcd statefulset ([0cf3548](https://github.com/bitnami/charts/commit/0cf3548))
+* Update README.md ([237c982](https://github.com/bitnami/charts/commit/237c982))
+
+## <small>4.4.3 (2019-11-18)</small>
+
+* [bitnami/elasticsearch] Lint chart ([e5776f9](https://github.com/bitnami/charts/commit/e5776f9))
+
+## <small>4.4.2 (2019-11-11)</small>
+
+* [bitnami/etcd] etcd auto-recover cluster ([0877afe](https://github.com/bitnami/charts/commit/0877afe))
+
+## <small>4.4.1 (2019-11-01)</small>
+
+* [bitnami/etcd] Fix issue with restarting pods on single-node clusters ([3f085a7](https://github.com/bitnami/charts/commit/3f085a7))
+
+## 4.4.0 (2019-10-25)
+
+* [bitnami/etcd] adds servicemonitor support ([7c4bc74](https://github.com/bitnami/charts/commit/7c4bc74))
+
+## <small>4.3.13 (2019-10-24)</small>
+
+* Adapt README in charts (I) ([eb80a7e](https://github.com/bitnami/charts/commit/eb80a7e))
+* Fix links because of section renaming ([8e6fa3b](https://github.com/bitnami/charts/commit/8e6fa3b))
+
+## <small>4.3.11 (2019-10-23)</small>
+
+* [bitnami/etcd] Release 4.3.11 updating components versions ([07bf653](https://github.com/bitnami/charts/commit/07bf653))
+
+## <small>4.3.10 (2019-10-15)</small>
+
+* [bitnami/etcd] Update prerequisites ([56bccc4](https://github.com/bitnami/charts/commit/56bccc4))
+
+## <small>4.3.9 (2019-10-11)</small>
+
+* [bitnami/etcd] Release 4.3.9 updating components versions ([7466ea7](https://github.com/bitnami/charts/commit/7466ea7))
+* Fix conflict between ETCDCTL_ENDPOINTS env var and --endpoints cmdline parameter. Add debug output f ([de0ebfa](https://github.com/bitnami/charts/commit/de0ebfa))
+* Remove extra blank lines and remove unnecessary 'exec' command. ([bfb0a28](https://github.com/bitnami/charts/commit/bfb0a28))
+
+## <small>4.3.8 (2019-10-01)</small>
+
+* Remove duplicated section ([93ae67e](https://github.com/bitnami/charts/commit/93ae67e))
+
+## <small>4.3.7 (2019-09-20)</small>
+
+* [bitnami/*] Update apiVersion on sts, deployments, daemonsets and podsecuritypolicies ([4dfac07](https://github.com/bitnami/charts/commit/4dfac07))
+
+## <small>4.3.6 (2019-09-18)</small>
+
+* [bitnami/etcd] Release 4.3.6 updating components versions ([463b475](https://github.com/bitnami/charts/commit/463b475))
+
+## <small>4.3.5 (2019-09-02)</small>
+
+* [bitnami/etcd] Release 4.3.5 updating components versions ([1d306af](https://github.com/bitnami/charts/commit/1d306af))
+* Use stretch instead of buster to be consistent ([decd85f](https://github.com/bitnami/charts/commit/decd85f))
+
+## <small>4.3.4 (2019-08-30)</small>
+
+* [bitnami/*] Use buster instead of latest as minideb tag and adapt sysctl ([921e811](https://github.com/bitnami/charts/commit/921e811))
+
+## <small>4.3.3 (2019-08-22)</small>
+
+* [bitnami/*] Fix 'storageClass' macros ([f41c193](https://github.com/bitnami/charts/commit/f41c193))
+
+## <small>4.3.2 (2019-08-21)</small>
+
+* [bitnami/etcd] Release 4.3.2 updating components versions ([8adc421](https://github.com/bitnami/charts/commit/8adc421))
+
+## <small>4.3.1 (2019-08-21)</small>
+
+* Refactor StorageClass template to support old Helm versions ([1d7f3df](https://github.com/bitnami/charts/commit/1d7f3df))
+* Refactor storageClassTemplate ([1872215](https://github.com/bitnami/charts/commit/1872215))
+
+## 4.3.0 (2019-08-19)
+
+* Add global variable to set the storage class to all of the Hekm Charts ([cdb4bdc](https://github.com/bitnami/charts/commit/cdb4bdc))
+* Update charts versions ([9459dbb](https://github.com/bitnami/charts/commit/9459dbb))
+
+## <small>4.2.3 (2019-08-14)</small>
+
+* bumped chart fix version + added the secret as parameter and added an if statement for the volume an ([c8f8448](https://github.com/bitnami/charts/commit/c8f8448)), closes [#1359](https://github.com/bitnami/charts/issues/1359)
+* fix #1359 ([cb7cef3](https://github.com/bitnami/charts/commit/cb7cef3)), closes [#1359](https://github.com/bitnami/charts/issues/1359)
+
+## <small>4.2.2 (2019-08-13)</small>
+
+* Update README.md ([3ba1dbd](https://github.com/bitnami/charts/commit/3ba1dbd))
+* Updated version numbers ([aa0294b](https://github.com/bitnami/charts/commit/aa0294b))
+
+## <small>4.2.1 (2019-07-31)</small>
+
+* [bitnami/etcd] Release 4.2.1 updating components versions ([d2e3ae1](https://github.com/bitnami/charts/commit/d2e3ae1))
+
+## 4.2.0 (2019-07-29)
+
+* [bitnami/etcd] Bumped version of the chart for my PR ([1c99d45](https://github.com/bitnami/charts/commit/1c99d45))
+* [bitnami/etcd] Debug logging added for pod bash scripts ([c33621b](https://github.com/bitnami/charts/commit/c33621b))
+* [bitnami/etcd] Fix readinessProbe, cluster can only bootstrap when all nodes come up simultaneously  ([fd8e42b](https://github.com/bitnami/charts/commit/fd8e42b))
+* Fix indentation ([c699e9f](https://github.com/bitnami/charts/commit/c699e9f))
+* Fix livenessProbe ([bbe462c](https://github.com/bitnami/charts/commit/bbe462c))
+
+## 4.1.0 (2019-07-22)
+
+* Change etcd ([9d01e0a](https://github.com/bitnami/charts/commit/9d01e0a))
+
+## 4.0.0 (2019-07-17)
+
+* Implement again #1283 changes but bumping the major version ([1ce079c](https://github.com/bitnami/charts/commit/1ce079c)), closes [#1283](https://github.com/bitnami/charts/issues/1283)
+
+## <small>3.1.3 (2019-07-17)</small>
+
+* Revert pull request #1283 ([8e5940a](https://github.com/bitnami/charts/commit/8e5940a)), closes [#1283](https://github.com/bitnami/charts/issues/1283)
+
+## <small>3.1.2 (2019-07-11)</small>
+
+* Standardize component.name & component.fullname functions ([775948e](https://github.com/bitnami/charts/commit/775948e))
+
+## <small>3.1.1 (2019-06-27)</small>
+
+* [bitnami/etcd] Fix 'unbound variable' issue when RBAC is set to false ([e933e91](https://github.com/bitnami/charts/commit/e933e91))
+* Adapt 'is_disastrous_failure' code depending on wether disasterRecovery is enabled or not ([3ea6a19](https://github.com/bitnami/charts/commit/3ea6a19))
+* Add a function to decided whether to add new member or not ([3679c68](https://github.com/bitnami/charts/commit/3679c68))
+* Add message to warn the users about being unable to recover the cluster ([4fe9a1b](https://github.com/bitnami/charts/commit/4fe9a1b))
+* Allow 'member remove' command to fail ([cf65d78](https://github.com/bitnami/charts/commit/cf65d78))
+* Fix pod recovery when disaster recovery is not enabled ([4465239](https://github.com/bitnami/charts/commit/4465239))
+* Improve the comand to calculate ETCDCTL_ENDPOINTS ([d4d8a15](https://github.com/bitnami/charts/commit/d4d8a15))
+* Rebase from master ([2a14ca4](https://github.com/bitnami/charts/commit/2a14ca4))
+* Support 'existing claims' for snapshotter pvc ([2199a18](https://github.com/bitnami/charts/commit/2199a18))
+* Support creating new cluster from existing snapshot ([8d1280b](https://github.com/bitnami/charts/commit/8d1280b))
+* Use a 'cronjob' for snapshooting ([0ba23d1](https://github.com/bitnami/charts/commit/0ba23d1))
+
+## 3.0.0 (2019-06-21)
+
+* [bitnami/etcd] Support auto disaster recovery ([860a00f](https://github.com/bitnami/charts/commit/860a00f))
+
+## 2.4.0 (2019-06-25)
+
+* Add nameOverride and fullnameOverride documentation. ([ff56764](https://github.com/bitnami/charts/commit/ff56764))
+* Add nameOverride/fullnameOverride examples to values*.yaml and update version. ([473aa3c](https://github.com/bitnami/charts/commit/473aa3c))
+* Use the popular 'fullname' template definition. ([bff1e70](https://github.com/bitnami/charts/commit/bff1e70))
+
+## 3.0.0 (2019-06-21)
+
+* [bitnami/etcd] Support auto disaster recovery ([860a00f](https://github.com/bitnami/charts/commit/860a00f))
+* Changes in README ([7ac4ec0](https://github.com/bitnami/charts/commit/7ac4ec0))
+
+## <small>2.3.3 (2019-06-10)</small>
+
+* bitnami/etcd: update to 3.3.13 ([370907e](https://github.com/bitnami/charts/commit/370907e))
+* Bump version ([a672193](https://github.com/bitnami/charts/commit/a672193))
+
+## <small>2.3.2 (2019-06-10)</small>
+
+* Unify sections ([c227027](https://github.com/bitnami/charts/commit/c227027))
+* Use IfNotPresent as imagePullPolicy since we are using immutable tags ([53247da](https://github.com/bitnami/charts/commit/53247da))
+
+## <small>2.3.1 (2019-06-07)</small>
+
+* [bitnami/etcd] Unify and document production values ([22258c9](https://github.com/bitnami/charts/commit/22258c9))
+
+## 2.3.0 (2019-06-06)
+
+* [bitnami/etcd] Provide a way to set 'GOMAXPROCS' ([67dac2f](https://github.com/bitnami/charts/commit/67dac2f))
+* Truncate etcd name to 63 chart instead 24 ([08aa621](https://github.com/bitnami/charts/commit/08aa621))
+
+## <small>2.2.5 (2019-05-29)</small>
+
+* Change syntax because of linter failing ([adfc357](https://github.com/bitnami/charts/commit/adfc357))
+* Fix https://github.com/helm/charts/pull/14199\#issuecomment-496883321 and support _sha256_ as an imm ([95957ea](https://github.com/bitnami/charts/commit/95957ea)), closes [#issuecomment-496883321](https://github.com/bitnami/charts/issues/issuecomment-496883321)
+* Use immutable tags in the main images ([17ca4f5](https://github.com/bitnami/charts/commit/17ca4f5))
+
+## <small>2.2.4 (2019-05-28)</small>
+
+* Prepare immutable tags ([f9093c1](https://github.com/bitnami/charts/commit/f9093c1))
+
+## <small>2.2.3 (2019-05-03)</small>
+
+* bitnami/etcd: update to 3.3.13 ([d684f25](https://github.com/bitnami/charts/commit/d684f25))
+
+## <small>2.2.2 (2019-03-18)</small>
+
+* Set rollingUpdate to null when updateStrategy is Recreate ([1a45bba](https://github.com/bitnami/charts/commit/1a45bba))
+
+## <small>2.2.1 (2019-03-18)</small>
+
+* Remove pullSecrets for metrics without image in the helpers ([195f2ed](https://github.com/bitnami/charts/commit/195f2ed))
+
+## 2.2.0 (2019-03-12)
+
+* Fix typo ([72460d9](https://github.com/bitnami/charts/commit/72460d9))
+* Fix typo in helpers ([d1d60dc](https://github.com/bitnami/charts/commit/d1d60dc))
+* pullSecrets for production and metrics ([22d6e0b](https://github.com/bitnami/charts/commit/22d6e0b))
+
+## 2.1.0 (2019-03-11)
+
+* [bitnami/etcd] Add global imagePullSecrets to overwrite any other existing one ([1009174](https://github.com/bitnami/charts/commit/1009174))
+* Apply requested changes ([9411481](https://github.com/bitnami/charts/commit/9411481))
+* Get rid of useConfigMap missing value ([7cf14c3](https://github.com/bitnami/charts/commit/7cf14c3))
+
+## 2.0.0 (2019-03-04)
+
+* [bitnami/etcd] Allow custom configuration via file or env vars ([ce32b0d](https://github.com/bitnami/charts/commit/ce32b0d))
+* [bitnami/etcd] Fix etcd node 0 recovery from failure ([9368593](https://github.com/bitnami/charts/commit/9368593))
+
+## <small>1.5.6 (2019-02-27)</small>
+
+* Add appiVersion to Chart.yaml ([08704a5](https://github.com/bitnami/charts/commit/08704a5))
+
+## <small>1.5.5 (2019-02-21)</small>
+
+* Update Chart.yaml ([aac1dfc](https://github.com/bitnami/charts/commit/aac1dfc))
+* Update README.md ([ac35126](https://github.com/bitnami/charts/commit/ac35126))
+
+## <small>1.5.4 (2019-02-11)</small>
+
+* chore(bitnami/etcd): version to 1.5.3 ([bae6229](https://github.com/bitnami/charts/commit/bae6229))
+* chore(bitnami/etcd): version to 1.5.4 ([498bdc2](https://github.com/bitnami/charts/commit/498bdc2))
+* fix(bitnami/etcd): Sleep until cluster can respond before setting root ([8f8e731](https://github.com/bitnami/charts/commit/8f8e731))
+
+## <small>1.5.3 (2019-02-07)</small>
+
+* etcd: update to `3.3.12` ([b59b44a](https://github.com/bitnami/charts/commit/b59b44a))
+
+## <small>1.5.2 (2019-02-02)</small>
+
+* chore(bitnami/etcd): version to 1.5.2 ([6380d49](https://github.com/bitnami/charts/commit/6380d49))
+* fix(bitnami/etc): revert PR #1006 ([23610d4](https://github.com/bitnami/charts/commit/23610d4)), closes [#1006](https://github.com/bitnami/charts/issues/1006) [#1006](https://github.com/bitnami/charts/issues/1006) [#1040](https://github.com/bitnami/charts/issues/1040)
+* fix(bitnami/etcd): right path for existingSecret ([e0bd1bd](https://github.com/bitnami/charts/commit/e0bd1bd)), closes [#1041](https://github.com/bitnami/charts/issues/1041)
+* fix(templates/statefulset.yaml): dnsBase path ([3bc9cf1](https://github.com/bitnami/charts/commit/3bc9cf1))
+* Missing substitution of .svc.cluster.local for $dnsBase ([a99457b](https://github.com/bitnami/charts/commit/a99457b))
+
+## <small>1.5.1 (2019-01-25)</small>
+
+* Document the correct format for pullSecrets in READMEs ([9a2cf81](https://github.com/bitnami/charts/commit/9a2cf81))
+
+## 1.5.0 (2019-01-25)
+
+* etcd: Allow non-default service domains ([82f7884](https://github.com/bitnami/charts/commit/82f7884))
+
+## <small>1.4.3 (2019-01-12)</small>
+
+* etcd: update to `3.3.11` ([fce09b2](https://github.com/bitnami/charts/commit/fce09b2))
+
+## <small>1.4.2 (2019-01-10)</small>
+
+* Fix single node etcd cluster with auth ([6e8a04c](https://github.com/bitnami/charts/commit/6e8a04c))
+
+## <small>1.4.1 (2019-01-03)</small>
+
+* [bitnami/etcd] inc chart version ([6f5c477](https://github.com/bitnami/charts/commit/6f5c477))
+* [bitnami/etcd] start temporary etcd single node cluster for root password setting when start cluster ([6987b6c](https://github.com/bitnami/charts/commit/6987b6c))
+* Apply bash style fixes ([a79bbf9](https://github.com/bitnami/charts/commit/a79bbf9))
+
+## 1.4.0 (2019-01-02)
+
+* [bitnami/etcd] Fix etcd after pod restart ([a6b7c15](https://github.com/bitnami/charts/commit/a6b7c15))
+
+## <small>1.3.1 (2018-11-21)</small>
+
+* Bump chart version ([bf25b0f](https://github.com/bitnami/charts/commit/bf25b0f))
+* Fix README ([e574574](https://github.com/bitnami/charts/commit/e574574))
+
+## 1.2.0 (2018-10-12)
+
+* [bitnami/etcd] Enable prometheus metrics ([a829979](https://github.com/bitnami/charts/commit/a829979))
+
+## <small>1.2.1 (2018-10-17)</small>
+
+* Add global registry option to Bitnami charts ([395ba08](https://github.com/bitnami/charts/commit/395ba08))
+* Apply some suggestions ([24706a6](https://github.com/bitnami/charts/commit/24706a6))
+* Bump versions ([0cfd3f4](https://github.com/bitnami/charts/commit/0cfd3f4))
+* Change logic to determine registry ([9ead294](https://github.com/bitnami/charts/commit/9ead294))
+* Check if global is set ([dec26e5](https://github.com/bitnami/charts/commit/dec26e5))
+* Fix typo ([93170ac](https://github.com/bitnami/charts/commit/93170ac))
+* Remove distro tags in charts ([427ac51](https://github.com/bitnami/charts/commit/427ac51))
+* Reword and update kafka dependencies ([be6cbed](https://github.com/bitnami/charts/commit/be6cbed))
+
+## 1.2.0 (2018-10-12)
+
+* [bitnami/etcd] Enable prometheus metrics ([a829979](https://github.com/bitnami/charts/commit/a829979))
+
+## <small>1.1.6 (2018-10-10)</small>
+
+* etcd: bump chart appVersion to `3.3.10` ([8ccb0a7](https://github.com/bitnami/charts/commit/8ccb0a7))
+* etcd: bump chart version to `1.1.6` ([9109fee](https://github.com/bitnami/charts/commit/9109fee))
+* etcd: update to `3.3.10-debian-9` ([29c8250](https://github.com/bitnami/charts/commit/29c8250))
+
+## <small>1.1.5 (2018-10-05)</small>
+
+* Add kubeapps text to charts READMEs ([2f6dc51](https://github.com/bitnami/charts/commit/2f6dc51))
+
+## <small>1.1.4 (2018-10-02)</small>
+
+* Add ) ([728466a](https://github.com/bitnami/charts/commit/728466a))
+* Add affinity rules setting ability to bitnami/etcd. ([8259e61](https://github.com/bitnami/charts/commit/8259e61))
+* Fix go template inside go template ([a140313](https://github.com/bitnami/charts/commit/a140313))
+
+## <small>1.1.3 (2018-09-27)</small>
+
+* Bump etcd version ([21ff639](https://github.com/bitnami/charts/commit/21ff639))
+* Improve getting LoadBalancer address in Bitnami charts NOTES.txt ([a641728](https://github.com/bitnami/charts/commit/a641728))
+
+## <small>1.1.2 (2018-09-27)</small>
+
+* etcd: bump chart appVersion to `3.3.9` ([9bb4db3](https://github.com/bitnami/charts/commit/9bb4db3))
+* etcd: bump chart version to `1.1.2` ([867b3f2](https://github.com/bitnami/charts/commit/867b3f2))
+* etcd: update to `3.3.9-debian-9` ([d41ab85](https://github.com/bitnami/charts/commit/d41ab85))
+
+## <small>1.1.1 (2018-09-26)</small>
+
+* [bitnami/etcd] fix svc template when passing loadBalancerIP property ([f1e4595](https://github.com/bitnami/charts/commit/f1e4595))
+
+## 1.1.0 (2018-09-24)
+
+* Fix scaling etcd nodes ([63fbf10](https://github.com/bitnami/charts/commit/63fbf10))
+
+## 1.0.0 (2018-09-21)
+
+* [bitnami/etcd] FIx chart not upgrading ([fbc436f](https://github.com/bitnami/charts/commit/fbc436f))
+
+## <small>0.0.4 (2018-09-13)</small>
+
+* Allow running etcd on a non-default namespace ([2030f4a](https://github.com/bitnami/charts/commit/2030f4a))
+
+## <small>0.0.3 (2018-09-04)</small>
+
+* Fix issue configuring etcd auth ([73562d8](https://github.com/bitnami/charts/commit/73562d8))
+
+## <small>0.0.2 (2018-08-06)</small>
+
+* Apply several suggestions from juan131 and javsalgar ([5be0e5d](https://github.com/bitnami/charts/commit/5be0e5d))
+* Create helper template to return auth options for etcdctl command line ([9e950c9](https://github.com/bitnami/charts/commit/9e950c9))
+* Enable persistence by default ([6192599](https://github.com/bitnami/charts/commit/6192599))
+* Improve notes to access deployed services ([0071eb5](https://github.com/bitnami/charts/commit/0071eb5))
+* Minor improvements ([a059522](https://github.com/bitnami/charts/commit/a059522))
+* Update README.md ([11705de](https://github.com/bitnami/charts/commit/11705de))
+
+## <small>0.0.1 (2018-06-27)</small>
+
+* Firs version of etcd chart ([cf5869b](https://github.com/bitnami/charts/commit/cf5869b))

--- a/bitnami/etcd/Chart.lock
+++ b/bitnami/etcd/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.19.2
-digest: sha256:e670e1075bfafffe040fae1158f1fa1f592585f394b48704ba137d2d083b1571
-generated: "2024-05-07T22:37:09.513244514Z"
+  version: 2.19.3
+digest: sha256:de997835d9ce9a9deefc2d70d8c62b11aa1d1a76ece9e86a83736ab9f930bf4d
+generated: "2024-05-21T13:38:03.480546625+02:00"

--- a/bitnami/etcd/Chart.yaml
+++ b/bitnami/etcd/Chart.yaml
@@ -32,4 +32,4 @@ maintainers:
 name: etcd
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/etcd
-version: 10.0.11
+version: 10.1.0

--- a/bitnami/etcd/templates/NOTES.txt
+++ b/bitnami/etcd/templates/NOTES.txt
@@ -118,3 +118,4 @@ To connect to your etcd server from outside the cluster execute the following co
 {{- $requiredEtcdPasswordErrors := include "common.validations.values.multiple.empty" (dict "required" $requiredPassword "context" $) -}}
 {{- include "common.errors.upgrade.passwords.empty" (dict "validationErrors" (list $requiredEtcdPasswordErrors) "context" $) -}}
 {{- include "common.warnings.resources" (dict "sections" (list "disasterRecovery.cronjob" "" "volumePermissions") "context" $) }}
+{{- include "common.warnings.modifiedImages" (dict "images" (list .Values.image .Values.volumePermissions.image) "context" $) }}


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Replacing the original images that have been tested and verified when releasing the chart is a dangerous practice in terms of security, performance and available features. This PR updates the `NOTES.txt` file using the `common.warnings.modifiedImages` helper developed in https://github.com/bitnami/charts/pull/25952.


<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

Users are more aware of the risks of changing original images.
<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

n/a
<!-- Describe any known limitations with your change -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
