### PR TITLE
[bitnami/schema-registry] Use different liveness/readiness probes

### DIFF
--- a/bitnami/schema-registry/CHANGELOG.md
+++ b/bitnami/schema-registry/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
+## 18.1.1 (2024-05-21)
+
+* [bitnami/schema-registry] Use different liveness/readiness probes ([#26202](https://github.com/bitnami/charts/pulls/26202))
+
 ## 18.1.0 (2024-05-21)
 
-* [bitnami/schema-registry] feat: :sparkles: :lock: Add warning when original images are replaced ([#26274](https://github.com/bitnami/charts/pulls/26274))
+* [bitnami/*] ci: :construction_worker: Add tag and changelog support (#25359) ([91c707c](https://github.com/bitnami/charts/commit/91c707c)), closes [#25359](https://github.com/bitnami/charts/issues/25359)
+* [bitnami/schema-registry] feat: :sparkles: :lock: Add warning when original images are replaced (#26 ([91ed758](https://github.com/bitnami/charts/commit/91ed758)), closes [#26274](https://github.com/bitnami/charts/issues/26274)
 
 ## <small>18.0.6 (2024-05-18)</small>
 

--- a/bitnami/schema-registry/Chart.lock
+++ b/bitnami/schema-registry/Chart.lock
@@ -7,3 +7,4 @@ dependencies:
   version: 2.19.3
 digest: sha256:a9f471f7ecd7361bcb645e81dd6dbffb31090c945c187a2a8da8697d312164fd
 generated: "2024-05-21T14:36:54.462283256+02:00"
+

--- a/bitnami/schema-registry/Chart.yaml
+++ b/bitnami/schema-registry/Chart.yaml
@@ -34,4 +34,5 @@ maintainers:
 name: schema-registry
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/schema-registry
-version: 18.1.0
+version: 18.1.1
+

--- a/bitnami/schema-registry/templates/statefulset.yaml
+++ b/bitnami/schema-registry/templates/statefulset.yaml
@@ -224,15 +224,17 @@ spec:
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customReadinessProbe "context" $) | nindent 12 }}
           {{- else if .Values.readinessProbe.enabled }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.readinessProbe "enabled") "context" $) | nindent 12 }}
-            tcpSocket:
+            httpGet:
               port: http
+              path: /
           {{- end }}
           {{- if .Values.customStartupProbe }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customStartupProbe "context" $) | nindent 12 }}
           {{- else if .Values.startupProbe.enabled }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.startupProbe "enabled") "context" $) | nindent 12 }}
-            tcpSocket:
+            httpGet:
               port: http
+              path: /
           {{- end }}
           {{- end }}
           {{- if .Values.resources }}


### PR DESCRIPTION
### Description of the change
This PR aims to use different liveness/readiness probes to improve overall security and avoid unnecessary container restarts. [More info](https://github.com/zegl/kube-score/blob/master/README_PROBES.md).

### Benefits

Increase availability and resilience.

### Possible drawbacks

N/A

### Applicable issues

- fixes #

### Additional information

- Related to #23537

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- ~[X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)~
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
