### PR TITLE
[bitnami/jaeger] feat: :sparkles: :lock: Add warning when original images are replaced

### DIFF
--- a/bitnami/jaeger/CHANGELOG.md
+++ b/bitnami/jaeger/CHANGELOG.md
@@ -1,0 +1,327 @@
+# Changelog
+
+## 2.2.0 (2024-05-21)
+
+* [bitnami/jaeger] feat: :sparkles: :lock: Add warning when original images are replaced ([#26218](https://github.com/bitnami/charts/pulls/26218))
+
+## <small>2.1.5 (2024-05-18)</small>
+
+* [bitnami/jaeger] Release 2.1.5 updating components versions (#26025) ([498e990](https://github.com/bitnami/charts/commit/498e990)), closes [#26025](https://github.com/bitnami/charts/issues/26025)
+
+## <small>2.1.4 (2024-05-14)</small>
+
+* [bitnami/jaeger] Release 2.1.4 updating components versions (#25768) ([40990d9](https://github.com/bitnami/charts/commit/40990d9)), closes [#25768](https://github.com/bitnami/charts/issues/25768)
+
+## <small>2.1.3 (2024-05-08)</small>
+
+* [bitnami/*] Change non-root and rolling-tags doc URLs (#25628) ([b067c94](https://github.com/bitnami/charts/commit/b067c94)), closes [#25628](https://github.com/bitnami/charts/issues/25628)
+* [bitnami/jaeger] Release 2.1.3 updating components versions (#25634) ([9338486](https://github.com/bitnami/charts/commit/9338486)), closes [#25634](https://github.com/bitnami/charts/issues/25634)
+
+## <small>2.1.2 (2024-05-08)</small>
+
+* [bitnami/*] Set new header/owner (#25558) ([8d1dc11](https://github.com/bitnami/charts/commit/8d1dc11)), closes [#25558](https://github.com/bitnami/charts/issues/25558)
+* [bitnami/jaeger] Release 2.1.2 updating components versions (#25604) ([a550fd7](https://github.com/bitnami/charts/commit/a550fd7)), closes [#25604](https://github.com/bitnami/charts/issues/25604)
+
+## <small>2.1.1 (2024-05-02)</small>
+
+* [bitnami/jaeger] Release 2.1.1 updating components versions (#25504) ([e85a5c8](https://github.com/bitnami/charts/commit/e85a5c8)), closes [#25504](https://github.com/bitnami/charts/issues/25504)
+* [bitnami/multiple charts] Fix typo: "NetworkPolice" vs "NetworkPolicy" (#25348) ([6970c1b](https://github.com/bitnami/charts/commit/6970c1b)), closes [#25348](https://github.com/bitnami/charts/issues/25348)
+* Replace VMware by Broadcom copyright text (#25306) ([a5e4bd0](https://github.com/bitnami/charts/commit/a5e4bd0)), closes [#25306](https://github.com/bitnami/charts/issues/25306)
+
+## 2.1.0 (2024-04-18)
+
+* [bitnami/jaeger] fix: :bug: :lock: Expose missing ports in deployment spec (#25156) ([ac69ddd](https://github.com/bitnami/charts/commit/ac69ddd)), closes [#25156](https://github.com/bitnami/charts/issues/25156)
+
+## <small>2.0.1 (2024-04-05)</small>
+
+* [bitnami/jaeger] Release 2.0.1 updating components versions (#24991) ([7e16109](https://github.com/bitnami/charts/commit/7e16109)), closes [#24991](https://github.com/bitnami/charts/issues/24991)
+
+## 2.0.0 (2024-04-05)
+
+* [bitnami/jaeger] feat!: :lock: :boom: Improve security defaults (#24649) ([69a3cbd](https://github.com/bitnami/charts/commit/69a3cbd)), closes [#24649](https://github.com/bitnami/charts/issues/24649)
+
+## <small>1.11.3 (2024-04-04)</small>
+
+* [bitnami/*] Reorder Chart sections (#24455) ([0cf4048](https://github.com/bitnami/charts/commit/0cf4048)), closes [#24455](https://github.com/bitnami/charts/issues/24455)
+* [bitnami/jaeger] Release 1.11.3 (#24888) ([455377a](https://github.com/bitnami/charts/commit/455377a)), closes [#24888](https://github.com/bitnami/charts/issues/24888)
+* Update resourcesPreset comments (#24467) ([92e3e8a](https://github.com/bitnami/charts/commit/92e3e8a)), closes [#24467](https://github.com/bitnami/charts/issues/24467)
+
+## <small>1.11.2 (2024-03-07)</small>
+
+* [bitnami/jaeger] Release 1.11.2 updating components versions (#24240) ([6990419](https://github.com/bitnami/charts/commit/6990419)), closes [#24240](https://github.com/bitnami/charts/issues/24240)
+
+## <small>1.11.1 (2024-03-06)</small>
+
+* [bitnami/jaeger] Release 1.11.1 updating components versions (#24208) ([af69082](https://github.com/bitnami/charts/commit/af69082)), closes [#24208](https://github.com/bitnami/charts/issues/24208)
+
+## 1.11.0 (2024-03-06)
+
+* [bitnami/jaeger] feat: :sparkles: :lock: Add automatic adaptation for Openshift restricted-v2 SCC (# ([cb47717](https://github.com/bitnami/charts/commit/cb47717)), closes [#24095](https://github.com/bitnami/charts/issues/24095)
+
+## <small>1.10.2 (2024-02-21)</small>
+
+* [bitnami/jaeger] Release 1.10.2 updating components versions (#23769) ([eea8169](https://github.com/bitnami/charts/commit/eea8169)), closes [#23769](https://github.com/bitnami/charts/issues/23769)
+
+## <small>1.10.1 (2024-02-21)</small>
+
+* [bitnami/jaeger] Release 1.10.1 updating components versions (#23662) ([fa8bbb6](https://github.com/bitnami/charts/commit/fa8bbb6)), closes [#23662](https://github.com/bitnami/charts/issues/23662)
+
+## 1.10.0 (2024-02-20)
+
+* [bitnami/jaeger] feat: :sparkles: :lock: Add resource preset support (#23463) ([d5e62ae](https://github.com/bitnami/charts/commit/d5e62ae)), closes [#23463](https://github.com/bitnami/charts/issues/23463)
+
+## 1.9.0 (2024-02-20)
+
+* [bitnami/*] Bump all versions (#23602) ([b70ee2a](https://github.com/bitnami/charts/commit/b70ee2a)), closes [#23602](https://github.com/bitnami/charts/issues/23602)
+
+## <small>1.8.4 (2024-02-09)</small>
+
+* [bitnami/jaeger] Release 1.8.4 updating components versions (#23373) ([36e7847](https://github.com/bitnami/charts/commit/36e7847)), closes [#23373](https://github.com/bitnami/charts/issues/23373)
+
+## <small>1.8.3 (2024-02-07)</small>
+
+* [bitnami/jaeger] Release 1.8.3 updating components versions (#23294) ([ffca9e9](https://github.com/bitnami/charts/commit/ffca9e9)), closes [#23294](https://github.com/bitnami/charts/issues/23294)
+
+## <small>1.8.2 (2024-02-07)</small>
+
+* [bitnami/jaeger] Release 1.8.2 updating components versions (#23275) ([1c2b989](https://github.com/bitnami/charts/commit/1c2b989)), closes [#23275](https://github.com/bitnami/charts/issues/23275)
+
+## <small>1.8.1 (2024-02-07)</small>
+
+* [bitnami/jaeger] Release 1.8.1 updating components versions (#23232) ([1dfe4db](https://github.com/bitnami/charts/commit/1dfe4db)), closes [#23232](https://github.com/bitnami/charts/issues/23232)
+
+## 1.8.0 (2024-02-06)
+
+* [bitnami/jaeger] feat: :lock: Enable networkPolicy (#23202) ([e809554](https://github.com/bitnami/charts/commit/e809554)), closes [#23202](https://github.com/bitnami/charts/issues/23202)
+
+## <small>1.7.5 (2024-02-02)</small>
+
+* [bitnami/jaeger] Release 1.7.5 updating components versions (#23082) ([3dc39cd](https://github.com/bitnami/charts/commit/3dc39cd)), closes [#23082](https://github.com/bitnami/charts/issues/23082)
+
+## <small>1.7.4 (2024-01-30)</small>
+
+* [bitnami/jaeger] Release 1.7.4 updating components versions (#22931) ([06f9d0a](https://github.com/bitnami/charts/commit/06f9d0a)), closes [#22931](https://github.com/bitnami/charts/issues/22931)
+
+## <small>1.7.3 (2024-01-30)</small>
+
+* [bitnami/jaeger] Release 1.7.3 updating components versions (#22917) ([01d5212](https://github.com/bitnami/charts/commit/01d5212)), closes [#22917](https://github.com/bitnami/charts/issues/22917)
+
+## <small>1.7.2 (2024-01-30)</small>
+
+* [bitnami/jaeger] Release 1.7.2 updating components versions (#22850) ([3a2efeb](https://github.com/bitnami/charts/commit/3a2efeb)), closes [#22850](https://github.com/bitnami/charts/issues/22850)
+
+## <small>1.7.1 (2024-01-26)</small>
+
+* [bitnami/*] Move documentation sections from docs.bitnami.com back to the README (#22203) ([7564f36](https://github.com/bitnami/charts/commit/7564f36)), closes [#22203](https://github.com/bitnami/charts/issues/22203)
+* [bitnami/jaeger] fix: :bug: Set seLinuxOptions to null for Openshift compatibility (#22600) ([ebe83b4](https://github.com/bitnami/charts/commit/ebe83b4)), closes [#22600](https://github.com/bitnami/charts/issues/22600)
+
+## 1.7.0 (2024-01-22)
+
+* [bitnami/jaeger] fix: :lock: Move service-account token auto-mount to pod declaration (#22484) ([61e0af7](https://github.com/bitnami/charts/commit/61e0af7)), closes [#22484](https://github.com/bitnami/charts/issues/22484)
+
+## <small>1.6.2 (2024-01-19)</small>
+
+* [bitnami/jaeger] Enable readinessProbe by default (#22516) ([3af2fca](https://github.com/bitnami/charts/commit/3af2fca)), closes [#22516](https://github.com/bitnami/charts/issues/22516)
+
+## <small>1.6.1 (2024-01-18)</small>
+
+* [bitnami/jaeger] Release 1.6.1 updating components versions (#22287) ([bea4638](https://github.com/bitnami/charts/commit/bea4638)), closes [#22287](https://github.com/bitnami/charts/issues/22287)
+
+## 1.6.0 (2024-01-17)
+
+* [bitnami/jaeger] fix: :lock: Improve podSecurityContext and containerSecurityContext with essential  ([7348c92](https://github.com/bitnami/charts/commit/7348c92)), closes [#22131](https://github.com/bitnami/charts/issues/22131)
+
+## <small>1.5.8 (2024-01-12)</small>
+
+* [bitnami/jaeger] fix: :lock: Do not automount the service account token unless necessary (#22046) ([e4f3f1a](https://github.com/bitnami/charts/commit/e4f3f1a)), closes [#22046](https://github.com/bitnami/charts/issues/22046)
+
+## <small>1.5.7 (2024-01-12)</small>
+
+* [bitnami/jaeger] Release 1.5.7 updating components versions (#22033) ([ac8624c](https://github.com/bitnami/charts/commit/ac8624c)), closes [#22033](https://github.com/bitnami/charts/issues/22033)
+
+## <small>1.5.6 (2024-01-11)</small>
+
+* [bitnami/jaeger] Release 1.5.6 updating components versions (#21997) ([ea051d1](https://github.com/bitnami/charts/commit/ea051d1)), closes [#21997](https://github.com/bitnami/charts/issues/21997)
+
+## <small>1.5.5 (2024-01-11)</small>
+
+* [bitnami/*] Fix docs.bitnami.com broken links (#21901) ([f35506d](https://github.com/bitnami/charts/commit/f35506d)), closes [#21901](https://github.com/bitnami/charts/issues/21901)
+* [bitnami/*] Fix ref links (in comments) (#21822) ([e4fa296](https://github.com/bitnami/charts/commit/e4fa296)), closes [#21822](https://github.com/bitnami/charts/issues/21822)
+* [bitnami/*] Update copyright: Year and company (#21815) ([6c4bf75](https://github.com/bitnami/charts/commit/6c4bf75)), closes [#21815](https://github.com/bitnami/charts/issues/21815)
+* [bitnami/jaeger] Release 1.5.5 (#21894) ([030f7bb](https://github.com/bitnami/charts/commit/030f7bb)), closes [#21894](https://github.com/bitnami/charts/issues/21894)
+
+## <small>1.5.4 (2023-12-12)</small>
+
+* [bitnami/jaeger] Release 1.5.4 updating components versions (#21525) ([fc04205](https://github.com/bitnami/charts/commit/fc04205)), closes [#21525](https://github.com/bitnami/charts/issues/21525)
+
+## <small>1.5.3 (2023-12-07)</small>
+
+* [bitnami/jaeger] Release 1.5.3 updating components versions (#21439) ([460af63](https://github.com/bitnami/charts/commit/460af63)), closes [#21439](https://github.com/bitnami/charts/issues/21439)
+
+## <small>1.5.2 (2023-12-05)</small>
+
+* [bitnami/jaeger] Replace deprecated pull secret partial (#21375) ([f4b4aec](https://github.com/bitnami/charts/commit/f4b4aec)), closes [#21375](https://github.com/bitnami/charts/issues/21375)
+
+## <small>1.5.1 (2023-11-21)</small>
+
+* [bitnami/*] Rename solutions to "Bitnami package for ..." (#21038) ([b82f979](https://github.com/bitnami/charts/commit/b82f979)), closes [#21038](https://github.com/bitnami/charts/issues/21038)
+* [bitnami/jaeger] Release 1.5.1 updating components versions (#21121) ([1a10756](https://github.com/bitnami/charts/commit/1a10756)), closes [#21121](https://github.com/bitnami/charts/issues/21121)
+
+## 1.5.0 (2023-11-17)
+
+* [bitnami/*] Remove relative links to non-README sections, add verification for that and update TL;DR ([1103633](https://github.com/bitnami/charts/commit/1103633)), closes [#20967](https://github.com/bitnami/charts/issues/20967)
+* [bitnami/jaeger] Chart missing imagePullSecrets and otlp ports (#20544) ([a8ebf5d](https://github.com/bitnami/charts/commit/a8ebf5d)), closes [#20544](https://github.com/bitnami/charts/issues/20544)
+
+## <small>1.4.3 (2023-11-08)</small>
+
+* [bitnami/jaeger] Release 1.4.3 updating components versions (#20808) ([c217bf4](https://github.com/bitnami/charts/commit/c217bf4)), closes [#20808](https://github.com/bitnami/charts/issues/20808)
+
+## <small>1.4.2 (2023-11-08)</small>
+
+* [bitnami/jaeger] Release 1.4.2 updating components versions (#20734) ([59e61be](https://github.com/bitnami/charts/commit/59e61be)), closes [#20734](https://github.com/bitnami/charts/issues/20734)
+
+## <small>1.4.1 (2023-11-06)</small>
+
+* [bitnami/jaeger] Release 1.4.1 updating components versions (#20637) ([16b9d8c](https://github.com/bitnami/charts/commit/16b9d8c)), closes [#20637](https://github.com/bitnami/charts/issues/20637)
+
+## 1.4.0 (2023-10-31)
+
+* [bitnami/*] Rename VMware Application Catalog (#20361) ([3acc734](https://github.com/bitnami/charts/commit/3acc734)), closes [#20361](https://github.com/bitnami/charts/issues/20361)
+* [bitnami/*] Skip image's tag in the README files of the Bitnami Charts (#19841) ([bb9a01b](https://github.com/bitnami/charts/commit/bb9a01b)), closes [#19841](https://github.com/bitnami/charts/issues/19841)
+* [bitnami/*] Standardize documentation (#19835) ([af5f753](https://github.com/bitnami/charts/commit/af5f753)), closes [#19835](https://github.com/bitnami/charts/issues/19835)
+* [bitnami/jaeger] feat: :sparkles: Add support for PSA restricted policy (#20453) ([52b2d9a](https://github.com/bitnami/charts/commit/52b2d9a)), closes [#20453](https://github.com/bitnami/charts/issues/20453)
+
+## <small>1.3.5 (2023-10-11)</small>
+
+* [bitnami/jaeger] Release 1.3.5 (#20045) ([9ccd7de](https://github.com/bitnami/charts/commit/9ccd7de)), closes [#20045](https://github.com/bitnami/charts/issues/20045)
+
+## <small>1.3.4 (2023-10-09)</small>
+
+* [bitnami/*] Update Helm charts prerequisites (#19745) ([eb755dd](https://github.com/bitnami/charts/commit/eb755dd)), closes [#19745](https://github.com/bitnami/charts/issues/19745)
+* [bitnami/jaeger] Release 1.3.4 (#19849) ([a6995e7](https://github.com/bitnami/charts/commit/a6995e7)), closes [#19849](https://github.com/bitnami/charts/issues/19849)
+
+## <small>1.3.3 (2023-10-04)</small>
+
+* [bitnami/jaeger] Release 1.3.3 (#19717) ([cd18bfd](https://github.com/bitnami/charts/commit/cd18bfd)), closes [#19717](https://github.com/bitnami/charts/issues/19717)
+* Autogenerate schema files (#19194) ([a2c2090](https://github.com/bitnami/charts/commit/a2c2090)), closes [#19194](https://github.com/bitnami/charts/issues/19194)
+* Revert "Autogenerate schema files (#19194)" (#19335) ([73d80be](https://github.com/bitnami/charts/commit/73d80be)), closes [#19194](https://github.com/bitnami/charts/issues/19194) [#19335](https://github.com/bitnami/charts/issues/19335)
+
+## <small>1.3.2 (2023-09-08)</small>
+
+* [bitnami/jaeger: Use merge helper]: (#19051) ([9d76922](https://github.com/bitnami/charts/commit/9d76922)), closes [#19051](https://github.com/bitnami/charts/issues/19051)
+
+## <small>1.3.1 (2023-09-07)</small>
+
+* [bitnami/jaeger] Release 1.3.1 (#19180) ([4183435](https://github.com/bitnami/charts/commit/4183435)), closes [#19180](https://github.com/bitnami/charts/issues/19180)
+
+## 1.3.0 (2023-08-25)
+
+* [bitnami/jaeger] Support for customizing standard labels (#18542) ([ea8e3e9](https://github.com/bitnami/charts/commit/ea8e3e9)), closes [#18542](https://github.com/bitnami/charts/issues/18542)
+
+## <small>1.2.10 (2023-08-23)</small>
+
+* [bitnami/jaeger] Release 1.2.10 (#18818) ([34baae2](https://github.com/bitnami/charts/commit/34baae2)), closes [#18818](https://github.com/bitnami/charts/issues/18818)
+
+## <small>1.2.9 (2023-08-17)</small>
+
+* [bitnami/jaeger] Release 1.2.9 (#18526) ([fbce91f](https://github.com/bitnami/charts/commit/fbce91f)), closes [#18526](https://github.com/bitnami/charts/issues/18526)
+
+## <small>1.2.8 (2023-07-25)</small>
+
+* [bitnami/jaeger] Release 1.2.8 (#17883) ([145ca92](https://github.com/bitnami/charts/commit/145ca92)), closes [#17883](https://github.com/bitnami/charts/issues/17883)
+
+## <small>1.2.7 (2023-07-15)</small>
+
+* [bitnami/jaeger] Release 1.2.7 (#17653) ([98e600a](https://github.com/bitnami/charts/commit/98e600a)), closes [#17653](https://github.com/bitnami/charts/issues/17653)
+
+## <small>1.2.6 (2023-07-07)</small>
+
+* [bitnami/jaeger] Release 1.2.6 (#17526) ([742d494](https://github.com/bitnami/charts/commit/742d494)), closes [#17526](https://github.com/bitnami/charts/issues/17526)
+
+## <small>1.2.5 (2023-07-05)</small>
+
+* [bitnami/jaeger] Release 1.2.5 updating components versions (#17484) ([5a257c6](https://github.com/bitnami/charts/commit/5a257c6)), closes [#17484](https://github.com/bitnami/charts/issues/17484)
+* Add copyright header (#17300) ([da68be8](https://github.com/bitnami/charts/commit/da68be8)), closes [#17300](https://github.com/bitnami/charts/issues/17300)
+* Update charts readme (#17217) ([31b3c0a](https://github.com/bitnami/charts/commit/31b3c0a)), closes [#17217](https://github.com/bitnami/charts/issues/17217)
+
+## <small>1.2.4 (2023-06-05)</small>
+
+* [bitnami/*] Change copyright section in READMEs (#17006) ([ef986a1](https://github.com/bitnami/charts/commit/ef986a1)), closes [#17006](https://github.com/bitnami/charts/issues/17006)
+* [bitnami/jaeger] Release 1.2.4 (#17018) ([16a9116](https://github.com/bitnami/charts/commit/16a9116)), closes [#17018](https://github.com/bitnami/charts/issues/17018)
+* [bitnami/several] Change copyright section in READMEs (#16989) ([5b6a5cf](https://github.com/bitnami/charts/commit/5b6a5cf)), closes [#16989](https://github.com/bitnami/charts/issues/16989)
+
+## <small>1.2.3 (2023-05-21)</small>
+
+* [bitnami/jaeger] Release 1.2.3 (#16771) ([fdb188c](https://github.com/bitnami/charts/commit/fdb188c)), closes [#16771](https://github.com/bitnami/charts/issues/16771)
+
+## <small>1.2.2 (2023-05-16)</small>
+
+* [bitnami/jaeger] Release 1.2.2 (#16688) ([a4b45e1](https://github.com/bitnami/charts/commit/a4b45e1)), closes [#16688](https://github.com/bitnami/charts/issues/16688)
+* Add wording for enterprise page (#16560) ([8f22774](https://github.com/bitnami/charts/commit/8f22774)), closes [#16560](https://github.com/bitnami/charts/issues/16560)
+
+## <small>1.2.1 (2023-05-10)</small>
+
+* [bitnami/jaeger] Release 1.2.1 (#16553) ([b9aa4b6](https://github.com/bitnami/charts/commit/b9aa4b6)), closes [#16553](https://github.com/bitnami/charts/issues/16553)
+
+## 1.2.0 (2023-05-09)
+
+* [bitnami/several] Adapt Chart.yaml to set desired OCI annotations (#16546) ([fc9b18f](https://github.com/bitnami/charts/commit/fc9b18f)), closes [#16546](https://github.com/bitnami/charts/issues/16546)
+
+## 1.1.0 (2023-04-20)
+
+* [bitnami/*] Make Helm charts 100% OCI (#15998) ([8841510](https://github.com/bitnami/charts/commit/8841510)), closes [#15998](https://github.com/bitnami/charts/issues/15998)
+
+## <small>1.0.7 (2023-04-11)</small>
+
+* [bitnami/jaeger] Release 1.0.7 (#16007) ([eab4e39](https://github.com/bitnami/charts/commit/eab4e39)), closes [#16007](https://github.com/bitnami/charts/issues/16007)
+
+## <small>1.0.6 (2023-04-01)</small>
+
+* [bitnami/jaeger] Release 1.0.6 (#15852) ([767d67c](https://github.com/bitnami/charts/commit/767d67c)), closes [#15852](https://github.com/bitnami/charts/issues/15852)
+
+## <small>1.0.5 (2023-03-19)</small>
+
+* [bitnami/charts] Apply linter to README files (#15357) ([0e29e60](https://github.com/bitnami/charts/commit/0e29e60)), closes [#15357](https://github.com/bitnami/charts/issues/15357)
+* [bitnami/jaeger] Release 1.0.5 (#15606) ([c042ddf](https://github.com/bitnami/charts/commit/c042ddf)), closes [#15606](https://github.com/bitnami/charts/issues/15606)
+
+## <small>1.0.4 (2023-03-01)</small>
+
+* [bitnami/jaeger] Release 1.0.4 (#15238) ([01c9192](https://github.com/bitnami/charts/commit/01c9192)), closes [#15238](https://github.com/bitnami/charts/issues/15238)
+
+## <small>1.0.3 (2023-02-17)</small>
+
+* [bitnami/*] Fix markdown linter issues (#14874) ([a51e0e8](https://github.com/bitnami/charts/commit/a51e0e8)), closes [#14874](https://github.com/bitnami/charts/issues/14874)
+* [bitnami/*] Remove unexpected extra spaces (#14873) ([c97c714](https://github.com/bitnami/charts/commit/c97c714)), closes [#14873](https://github.com/bitnami/charts/issues/14873)
+* [bitnami/jaeger] Release 1.0.3 (#15017) ([27e319d](https://github.com/bitnami/charts/commit/27e319d)), closes [#15017](https://github.com/bitnami/charts/issues/15017)
+
+## <small>1.0.2 (2023-02-06)</small>
+
+* [bitnami/*] Change copyright date (#14682) ([add4ec7](https://github.com/bitnami/charts/commit/add4ec7)), closes [#14682](https://github.com/bitnami/charts/issues/14682)
+* [bitnami/*] Unify READMEs (#14472) ([2064fb8](https://github.com/bitnami/charts/commit/2064fb8)), closes [#14472](https://github.com/bitnami/charts/issues/14472)
+* [bitnami/jaeger] Release 1.0.2 (#14759) ([647dbcf](https://github.com/bitnami/charts/commit/647dbcf)), closes [#14759](https://github.com/bitnami/charts/issues/14759)
+
+## <small>1.0.1 (2023-01-19)</small>
+
+* [bitnami/*] Change licenses annotation format (#14377) ([0ab7608](https://github.com/bitnami/charts/commit/0ab7608)), closes [#14377](https://github.com/bitnami/charts/issues/14377)
+* [bitnami/jaeger] Release 1.0.1 (#14452) ([348ac92](https://github.com/bitnami/charts/commit/348ac92)), closes [#14452](https://github.com/bitnami/charts/issues/14452)
+
+## 1.0.0 (2023-01-13)
+
+* [bitnami/*] Add license annotation and remove obsolete engine parameter (#14293) ([da2a794](https://github.com/bitnami/charts/commit/da2a794)), closes [#14293](https://github.com/bitnami/charts/issues/14293)
+* [bitnami/jaeger] Update dependencies (#14315) ([187dd71](https://github.com/bitnami/charts/commit/187dd71)), closes [#14315](https://github.com/bitnami/charts/issues/14315)
+
+## <small>0.1.3 (2023-01-04)</small>
+
+* [bitnami/jaeger] Release 0.1.3 (#14179) ([0c860ae](https://github.com/bitnami/charts/commit/0c860ae)), closes [#14179](https://github.com/bitnami/charts/issues/14179)
+
+## <small>0.1.2 (2022-12-21)</small>
+
+* [bitnami/jaeger] Reorder chart dependencies (#14063) ([73a262c](https://github.com/bitnami/charts/commit/73a262c)), closes [#14063](https://github.com/bitnami/charts/issues/14063)
+
+## <small>0.1.1 (2022-12-20)</small>
+
+* [bitnami/jaeger] Release 0.1.1 (#14042) ([516374a](https://github.com/bitnami/charts/commit/516374a)), closes [#14042](https://github.com/bitnami/charts/issues/14042)
+
+## 0.1.0 (2022-12-20)
+
+* [bitnami/jaeger] Add Jaeger chart (#13480) ([73307cd](https://github.com/bitnami/charts/commit/73307cd)), closes [#13480](https://github.com/bitnami/charts/issues/13480)

--- a/bitnami/jaeger/Chart.lock
+++ b/bitnami/jaeger/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.19.2
+  version: 2.19.3
 - name: cassandra
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 11.1.7
-digest: sha256:78bee9075e1c9eacaeb8943fadfb2b907f3007220df3dca339f692e1b9d851fd
-generated: "2024-05-18T01:15:45.586358019Z"
+  version: 11.1.8
+digest: sha256:123d8cb5c93612a3ed37efad416ff9d527a8282ff4a48fcb76ee99926f0535b3
+generated: "2024-05-21T13:50:37.577123443+02:00"

--- a/bitnami/jaeger/Chart.yaml
+++ b/bitnami/jaeger/Chart.yaml
@@ -34,4 +34,4 @@ maintainers:
 name: jaeger
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/jaeger
-version: 2.1.5
+version: 2.2.0

--- a/bitnami/jaeger/templates/NOTES.txt
+++ b/bitnami/jaeger/templates/NOTES.txt
@@ -22,3 +22,4 @@ APP VERSION: {{ .Chart.AppVersion }}
 
 {{- include "common.warnings.rollingTag" .Values.image }}
 {{- include "common.warnings.resources" (dict "sections" (list "agent" "collector" "migration" "query") "context" $) }}
+{{- include "common.warnings.modifiedImages" (dict "images" (list .Values.image .Values.cqlshImage) "context" $) }}


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Replacing the original images that have been tested and verified when releasing the chart is a dangerous practice in terms of security, performance and available features. This PR updates the `NOTES.txt` file using the `common.warnings.modifiedImages` helper developed in https://github.com/bitnami/charts/pull/25952.


<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

Users are more aware of the risks of changing original images.
<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

n/a
<!-- Describe any known limitations with your change -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
