### PR TITLE
[bitnami/janusgraph] feat: :sparkles: :lock: Add warning when original images are replaced

### DIFF
--- a/bitnami/janusgraph/CHANGELOG.md
+++ b/bitnami/janusgraph/CHANGELOG.md
@@ -1,0 +1,44 @@
+# Changelog
+
+## 0.3.0 (2024-05-21)
+
+* [bitnami/janusgraph] feat: :sparkles: :lock: Add warning when original images are replaced ([#26219](https://github.com/bitnami/charts/pulls/26219))
+
+## 0.2.0 (2024-05-20)
+
+* [bitnami/janusgraph] PDB review (#25936) ([15ee760](https://github.com/bitnami/charts/commit/15ee760)), closes [#25936](https://github.com/bitnami/charts/issues/25936)
+
+## <small>0.1.7 (2024-05-18)</small>
+
+* [bitnami/janusgraph] Release 0.1.7 updating components versions (#26026) ([0e800dc](https://github.com/bitnami/charts/commit/0e800dc)), closes [#26026](https://github.com/bitnami/charts/issues/26026)
+
+## <small>0.1.6 (2024-05-14)</small>
+
+* [bitnami/*] Change non-root and rolling-tags doc URLs (#25628) ([b067c94](https://github.com/bitnami/charts/commit/b067c94)), closes [#25628](https://github.com/bitnami/charts/issues/25628)
+* [bitnami/*] Set new header/owner (#25558) ([8d1dc11](https://github.com/bitnami/charts/commit/8d1dc11)), closes [#25558](https://github.com/bitnami/charts/issues/25558)
+* [bitnami/janusgraph] Release 0.1.6 updating components versions (#25770) ([20c76cb](https://github.com/bitnami/charts/commit/20c76cb)), closes [#25770](https://github.com/bitnami/charts/issues/25770)
+
+## <small>0.1.5 (2024-05-02)</small>
+
+* [bitnami/janusgraph] Add metrics port in networkPolicy ingress (#25498) ([1b280b8](https://github.com/bitnami/charts/commit/1b280b8)), closes [#25498](https://github.com/bitnami/charts/issues/25498)
+* [bitnami/janusgraph] Release 0.1.5 updating components versions (#25502) ([76d2a3e](https://github.com/bitnami/charts/commit/76d2a3e)), closes [#25502](https://github.com/bitnami/charts/issues/25502)
+
+## <small>0.1.4 (2024-05-02)</small>
+
+* [bitnami/janusgraph] Release 0.1.4 updating components versions (#25495) ([b8e7d16](https://github.com/bitnami/charts/commit/b8e7d16)), closes [#25495](https://github.com/bitnami/charts/issues/25495)
+
+## <small>0.1.3 (2024-04-30)</small>
+
+* [bitnami/janusgraph] Add vib-publish role (#25465) ([81bd3f0](https://github.com/bitnami/charts/commit/81bd3f0)), closes [#25465](https://github.com/bitnami/charts/issues/25465)
+
+## <small>0.1.2 (2024-04-30)</small>
+
+* [bitnami/janusgraph] Release 0.1.2 updating components versions (#25461) ([0de0beb](https://github.com/bitnami/charts/commit/0de0beb)), closes [#25461](https://github.com/bitnami/charts/issues/25461)
+
+## <small>0.1.1 (2024-04-30)</small>
+
+* [bitnami/janusgraph] Release 0.1.1 updating components versions (#25458) ([352b0c3](https://github.com/bitnami/charts/commit/352b0c3)), closes [#25458](https://github.com/bitnami/charts/issues/25458)
+
+## 0.1.0 (2024-04-30)
+
+* [bitnami/janusgraph] Add chart (#24621) ([c225e73](https://github.com/bitnami/charts/commit/c225e73)), closes [#24621](https://github.com/bitnami/charts/issues/24621)

--- a/bitnami/janusgraph/Chart.lock
+++ b/bitnami/janusgraph/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: cassandra
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 11.1.7
+  version: 11.1.8
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.19.2
-digest: sha256:ced9381cea9fd6c9a01a176200be0171748ebf3c0c2004b31a12c9bf81e6a706
-generated: "2024-05-18T01:15:49.251069125Z"
+  version: 2.19.3
+digest: sha256:5b2e8ae135cfbb1a67d985cbf84a1823295e4de782fc78969c97e115903efbdc
+generated: "2024-05-21T13:51:34.330952837+02:00"

--- a/bitnami/janusgraph/Chart.yaml
+++ b/bitnami/janusgraph/Chart.yaml
@@ -37,4 +37,4 @@ name: janusgraph
 sources:
 - https://github.com/bitnami/containers/tree/main/bitnami/janusgraph
 - https://github.com/janusgraph/janusgraph
-version: 0.2.0
+version: 0.3.0

--- a/bitnami/janusgraph/templates/NOTES.txt
+++ b/bitnami/janusgraph/templates/NOTES.txt
@@ -67,3 +67,4 @@ To access Janusgraph from outside the cluster follow the steps below:
 
 {{- include "common.warnings.rollingTag" .Values.image }}
 {{- include "janusgraph.validateValues" . }}
+{{- include "common.warnings.modifiedImages" (dict "images" (list .Values.image .Values.metrics.image .Values.volumePermissions.image) "context" $) }}


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Replacing the original images that have been tested and verified when releasing the chart is a dangerous practice in terms of security, performance and available features. This PR updates the `NOTES.txt` file using the `common.warnings.modifiedImages` helper developed in https://github.com/bitnami/charts/pull/25952.


<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

Users are more aware of the risks of changing original images.
<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

n/a
<!-- Describe any known limitations with your change -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
