### PR TITLE
[bitnami/joomla] feat: :sparkles: :lock: Add warning when original images are replaced

### DIFF
--- a/bitnami/joomla/CHANGELOG.md
+++ b/bitnami/joomla/CHANGELOG.md
@@ -1,0 +1,814 @@
+# Changelog
+
+## 19.1.0 (2024-05-21)
+
+* [bitnami/joomla] feat: :sparkles: :lock: Add warning when original images are replaced ([#26221](https://github.com/bitnami/charts/pulls/26221))
+
+## <small>19.0.5 (2024-05-18)</small>
+
+* [bitnami/joomla] Release 19.0.5 updating components versions (#26028) ([5e5faa9](https://github.com/bitnami/charts/commit/5e5faa9)), closes [#26028](https://github.com/bitnami/charts/issues/26028)
+
+## <small>19.0.4 (2024-05-16)</small>
+
+* [bitnami/joomla] Use different liveness/readiness probes (#25922) ([1cbe463](https://github.com/bitnami/charts/commit/1cbe463)), closes [#25922](https://github.com/bitnami/charts/issues/25922)
+
+## <small>19.0.3 (2024-05-14)</small>
+
+* [bitnami/*] Change non-root and rolling-tags doc URLs (#25628) ([b067c94](https://github.com/bitnami/charts/commit/b067c94)), closes [#25628](https://github.com/bitnami/charts/issues/25628)
+* [bitnami/*] Set new header/owner (#25558) ([8d1dc11](https://github.com/bitnami/charts/commit/8d1dc11)), closes [#25558](https://github.com/bitnami/charts/issues/25558)
+* [bitnami/joomla] Release 19.0.3 updating components versions (#25773) ([2edf467](https://github.com/bitnami/charts/commit/2edf467)), closes [#25773](https://github.com/bitnami/charts/issues/25773)
+* [bitnami/multiple charts] Fix typo: "NetworkPolice" vs "NetworkPolicy" (#25348) ([6970c1b](https://github.com/bitnami/charts/commit/6970c1b)), closes [#25348](https://github.com/bitnami/charts/issues/25348)
+* Replace VMware by Broadcom copyright text (#25306) ([a5e4bd0](https://github.com/bitnami/charts/commit/a5e4bd0)), closes [#25306](https://github.com/bitnami/charts/issues/25306)
+
+## <small>19.0.2 (2024-04-19)</small>
+
+* [bitnami/joomla] Release 19.0.2 (#25195) ([f5e74bc](https://github.com/bitnami/charts/commit/f5e74bc)), closes [#25195](https://github.com/bitnami/charts/issues/25195)
+
+## <small>19.0.1 (2024-04-08)</small>
+
+* [bitnami/joomla] Release 19.0.1 updating components versions (#25052) ([8149933](https://github.com/bitnami/charts/commit/8149933)), closes [#25052](https://github.com/bitnami/charts/issues/25052)
+
+## 19.0.0 (2024-04-03)
+
+* [bitnami/joomla] feat!: :lock: :boom: Improve security defaults (#24821) ([4b34ce6](https://github.com/bitnami/charts/commit/4b34ce6)), closes [#24821](https://github.com/bitnami/charts/issues/24821)
+* Update resourcesPreset comments (#24467) ([92e3e8a](https://github.com/bitnami/charts/commit/92e3e8a)), closes [#24467](https://github.com/bitnami/charts/issues/24467)
+
+## <small>18.5.2 (2024-04-02)</small>
+
+* [bitnami/joomla] Release 18.5.2 updating components versions (#24791) ([c1b19c5](https://github.com/bitnami/charts/commit/c1b19c5)), closes [#24791](https://github.com/bitnami/charts/issues/24791)
+
+## <small>18.5.1 (2024-04-01)</small>
+
+* [bitnami/*] Reorder Chart sections (#24455) ([0cf4048](https://github.com/bitnami/charts/commit/0cf4048)), closes [#24455](https://github.com/bitnami/charts/issues/24455)
+* [bitnami/joomla] Release 18.5.1 updating components versions (#24779) ([5f73a91](https://github.com/bitnami/charts/commit/5f73a91)), closes [#24779](https://github.com/bitnami/charts/issues/24779)
+
+## 18.5.0 (2024-03-06)
+
+* [bitnami/joomla] feat: :sparkles: :lock: Add automatic adaptation for Openshift restricted-v2 SCC (# ([463e9f5](https://github.com/bitnami/charts/commit/463e9f5)), closes [#24098](https://github.com/bitnami/charts/issues/24098)
+
+## <small>18.4.2 (2024-02-21)</small>
+
+* [bitnami/joomla] Release 18.4.2 updating components versions (#23771) ([dbc5169](https://github.com/bitnami/charts/commit/dbc5169)), closes [#23771](https://github.com/bitnami/charts/issues/23771)
+
+## <small>18.4.1 (2024-02-21)</small>
+
+* [bitnami/joomla] Release 18.4.1 updating components versions (#23664) ([08be73d](https://github.com/bitnami/charts/commit/08be73d)), closes [#23664](https://github.com/bitnami/charts/issues/23664)
+
+## 18.4.0 (2024-02-20)
+
+* [bitnami/*] Bump all versions (#23602) ([b70ee2a](https://github.com/bitnami/charts/commit/b70ee2a)), closes [#23602](https://github.com/bitnami/charts/issues/23602)
+
+## 18.3.0 (2024-02-16)
+
+* [bitnami/joomla] feat: :sparkles: :lock: Add resource preset support (#23466) ([005d90f](https://github.com/bitnami/charts/commit/005d90f)), closes [#23466](https://github.com/bitnami/charts/issues/23466)
+
+## <small>18.2.3 (2024-02-02)</small>
+
+* [bitnami/joomla] Release 18.2.3 updating components versions (#23084) ([f1a0a9c](https://github.com/bitnami/charts/commit/f1a0a9c)), closes [#23084](https://github.com/bitnami/charts/issues/23084)
+
+## <small>18.2.2 (2024-01-30)</small>
+
+* [bitnami/joomla] Release 18.2.2 updating components versions (#22898) ([3471248](https://github.com/bitnami/charts/commit/3471248)), closes [#22898](https://github.com/bitnami/charts/issues/22898)
+
+## <small>18.2.1 (2024-01-26)</small>
+
+* [bitnami/*] Move documentation sections from docs.bitnami.com back to the README (#22203) ([7564f36](https://github.com/bitnami/charts/commit/7564f36)), closes [#22203](https://github.com/bitnami/charts/issues/22203)
+* [bitnami/joomla] fix: :bug: Set seLinuxOptions to null for Openshift compatibility (#22603) ([ec28b79](https://github.com/bitnami/charts/commit/ec28b79)), closes [#22603](https://github.com/bitnami/charts/issues/22603)
+
+## 18.2.0 (2024-01-22)
+
+* [bitnami/joomla] fix: :lock: Move service-account token auto-mount to pod declaration (#22487) ([194627b](https://github.com/bitnami/charts/commit/194627b)), closes [#22487](https://github.com/bitnami/charts/issues/22487)
+
+## <small>18.1.1 (2024-01-18)</small>
+
+* [bitnami/joomla] Release 18.1.1 updating components versions (#22284) ([9f4db69](https://github.com/bitnami/charts/commit/9f4db69)), closes [#22284](https://github.com/bitnami/charts/issues/22284)
+
+## 18.1.0 (2024-01-17)
+
+* [bitnami/*] Fix ref links (in comments) (#21822) ([e4fa296](https://github.com/bitnami/charts/commit/e4fa296)), closes [#21822](https://github.com/bitnami/charts/issues/21822)
+* [bitnami/joomla] fix: :lock: Improve podSecurityContext and containerSecurityContext with essential  ([91571bb](https://github.com/bitnami/charts/commit/91571bb)), closes [#22134](https://github.com/bitnami/charts/issues/22134)
+
+## <small>18.0.1 (2024-01-09)</small>
+
+* [bitnami/*] Fix docs.bitnami.com broken links (#21901) ([f35506d](https://github.com/bitnami/charts/commit/f35506d)), closes [#21901](https://github.com/bitnami/charts/issues/21901)
+* [bitnami/*] Update copyright: Year and company (#21815) ([6c4bf75](https://github.com/bitnami/charts/commit/6c4bf75)), closes [#21815](https://github.com/bitnami/charts/issues/21815)
+* [bitnami/joomla] Release 18.0.1 updating components versions (#21926) ([7ed90d8](https://github.com/bitnami/charts/commit/7ed90d8)), closes [#21926](https://github.com/bitnami/charts/issues/21926)
+
+## 18.0.0 (2023-12-20)
+
+* [bitnami/joomla] Upgrade MariaDB 11.2 (#21683) ([520c290](https://github.com/bitnami/charts/commit/520c290)), closes [#21683](https://github.com/bitnami/charts/issues/21683)
+
+## <small>17.1.4 (2023-12-20)</small>
+
+* [bitnami/joomla] Release 17.1.4 updating components versions (#21667) ([8e752ea](https://github.com/bitnami/charts/commit/8e752ea)), closes [#21667](https://github.com/bitnami/charts/issues/21667)
+
+## <small>17.1.3 (2023-11-28)</small>
+
+* [bitnami/joomla] Release 17.1.3 updating components versions (#21295) ([2088915](https://github.com/bitnami/charts/commit/2088915)), closes [#21295](https://github.com/bitnami/charts/issues/21295)
+
+## <small>17.1.2 (2023-11-21)</small>
+
+* [bitnami/*] Remove relative links to non-README sections, add verification for that and update TL;DR ([1103633](https://github.com/bitnami/charts/commit/1103633)), closes [#20967](https://github.com/bitnami/charts/issues/20967)
+* [bitnami/*] Rename solutions to "Bitnami package for ..." (#21038) ([b82f979](https://github.com/bitnami/charts/commit/b82f979)), closes [#21038](https://github.com/bitnami/charts/issues/21038)
+* [bitnami/joomla] Release 17.1.2 updating components versions (#21125) ([44bb1c2](https://github.com/bitnami/charts/commit/44bb1c2)), closes [#21125](https://github.com/bitnami/charts/issues/21125)
+
+## <small>17.1.1 (2023-11-08)</small>
+
+* [bitnami/joomla] Release 17.1.1 updating components versions (#20741) ([194f5ae](https://github.com/bitnami/charts/commit/194f5ae)), closes [#20741](https://github.com/bitnami/charts/issues/20741)
+
+## 17.1.0 (2023-10-31)
+
+* [bitnami/*] Rename VMware Application Catalog (#20361) ([3acc734](https://github.com/bitnami/charts/commit/3acc734)), closes [#20361](https://github.com/bitnami/charts/issues/20361)
+* [bitnami/joomla] feat: :sparkles: Add support for PSA restricted policy (#20457) ([00364f8](https://github.com/bitnami/charts/commit/00364f8)), closes [#20457](https://github.com/bitnami/charts/issues/20457)
+
+## 17.0.0 (2023-10-23)
+
+* [bitnami/*] Skip image's tag in the README files of the Bitnami Charts (#19841) ([bb9a01b](https://github.com/bitnami/charts/commit/bb9a01b)), closes [#19841](https://github.com/bitnami/charts/issues/19841)
+* [bitnami/*] Standardize documentation (#19835) ([af5f753](https://github.com/bitnami/charts/commit/af5f753)), closes [#19835](https://github.com/bitnami/charts/issues/19835)
+* [bitnami/joomla] Release 17.0.0 updating components versions (#20362) ([f14faf8](https://github.com/bitnami/charts/commit/f14faf8)), closes [#20362](https://github.com/bitnami/charts/issues/20362)
+
+## <small>16.0.1 (2023-10-17)</small>
+
+* [bitnami/joomla] Release 16.0.1 (#20292) ([dc93c3b](https://github.com/bitnami/charts/commit/dc93c3b)), closes [#20292](https://github.com/bitnami/charts/issues/20292)
+
+## 16.0.0 (2023-10-11)
+
+* [bitnami/joomla] Update MariaDB to 14.x.x (#20015) ([4457fa3](https://github.com/bitnami/charts/commit/4457fa3)), closes [#20015](https://github.com/bitnami/charts/issues/20015)
+
+## <small>15.1.5 (2023-10-10)</small>
+
+* [bitnami/*] Update Helm charts prerequisites (#19745) ([eb755dd](https://github.com/bitnami/charts/commit/eb755dd)), closes [#19745](https://github.com/bitnami/charts/issues/19745)
+* [bitnami/joomla] Release 15.1.5 (#19994) ([456491f](https://github.com/bitnami/charts/commit/456491f)), closes [#19994](https://github.com/bitnami/charts/issues/19994)
+
+## <small>15.1.4 (2023-10-06)</small>
+
+* [bitnami/joomla] Release 15.1.4 (#19788) ([39d71ee](https://github.com/bitnami/charts/commit/39d71ee)), closes [#19788](https://github.com/bitnami/charts/issues/19788)
+
+## <small>15.1.3 (2023-09-30)</small>
+
+* [bitnami/joomla] Release 15.1.3 (#19665) ([433be63](https://github.com/bitnami/charts/commit/433be63)), closes [#19665](https://github.com/bitnami/charts/issues/19665)
+* Autogenerate schema files (#19194) ([a2c2090](https://github.com/bitnami/charts/commit/a2c2090)), closes [#19194](https://github.com/bitnami/charts/issues/19194)
+* Revert "Autogenerate schema files (#19194)" (#19335) ([73d80be](https://github.com/bitnami/charts/commit/73d80be)), closes [#19194](https://github.com/bitnami/charts/issues/19194) [#19335](https://github.com/bitnami/charts/issues/19335)
+
+## <small>15.1.2 (2023-09-08)</small>
+
+* [bitnami/joomla]: Use merge helper (#19054) ([f2dc2df](https://github.com/bitnami/charts/commit/f2dc2df)), closes [#19054](https://github.com/bitnami/charts/issues/19054)
+
+## <small>15.1.1 (2023-08-31)</small>
+
+* [bitnami/joomla] Release 15.1.1 (#18965) ([aedb216](https://github.com/bitnami/charts/commit/aedb216)), closes [#18965](https://github.com/bitnami/charts/issues/18965)
+
+## 15.1.0 (2023-08-24)
+
+* [bitnami/joomla] Support for customizing standard labels (#18550) ([c5f2e77](https://github.com/bitnami/charts/commit/c5f2e77)), closes [#18550](https://github.com/bitnami/charts/issues/18550)
+
+## <small>15.0.2 (2023-08-17)</small>
+
+* [bitnami/joomla] Release 15.0.2 (#18530) ([8b1ac38](https://github.com/bitnami/charts/commit/8b1ac38)), closes [#18530](https://github.com/bitnami/charts/issues/18530)
+
+## <small>15.0.1 (2023-08-03)</small>
+
+* [bitnami/joomla] Release 15.0.1 (#18163) ([9a8479b](https://github.com/bitnami/charts/commit/9a8479b)), closes [#18163](https://github.com/bitnami/charts/issues/18163)
+
+## 15.0.0 (2023-08-01)
+
+* [bitnami/joomla] Update MariaDB chart to 13.0 (#18106) ([4eb113b](https://github.com/bitnami/charts/commit/4eb113b)), closes [#18106](https://github.com/bitnami/charts/issues/18106)
+
+## <small>14.1.8 (2023-08-01)</small>
+
+* [bitnami/joomla] Release 14.1.8 (#18082) ([d7b3653](https://github.com/bitnami/charts/commit/d7b3653)), closes [#18082](https://github.com/bitnami/charts/issues/18082)
+
+## <small>14.1.7 (2023-07-25)</small>
+
+* [bitnami/joomla] Release 14.1.7 (#17890) ([bd1266e](https://github.com/bitnami/charts/commit/bd1266e)), closes [#17890](https://github.com/bitnami/charts/issues/17890)
+
+## <small>14.1.6 (2023-07-15)</small>
+
+* [bitnami/joomla] Release 14.1.6 updating components versions (#17638) ([28419bd](https://github.com/bitnami/charts/commit/28419bd)), closes [#17638](https://github.com/bitnami/charts/issues/17638)
+
+## <small>14.1.5 (2023-07-12)</small>
+
+* [bitnami/joomla] Release 14.1.5 (#17573) ([4c7ed7c](https://github.com/bitnami/charts/commit/4c7ed7c)), closes [#17573](https://github.com/bitnami/charts/issues/17573)
+
+## <small>14.1.4 (2023-06-29)</small>
+
+* [bitnami/*] Change copyright section in READMEs (#17006) ([ef986a1](https://github.com/bitnami/charts/commit/ef986a1)), closes [#17006](https://github.com/bitnami/charts/issues/17006)
+* [bitnami/joomla] Release 14.1.4 (#17407) ([aa3b300](https://github.com/bitnami/charts/commit/aa3b300)), closes [#17407](https://github.com/bitnami/charts/issues/17407)
+* [bitnami/several] Change copyright section in READMEs (#16989) ([5b6a5cf](https://github.com/bitnami/charts/commit/5b6a5cf)), closes [#16989](https://github.com/bitnami/charts/issues/16989)
+* [bitnami/several] Remove 'Community supported solution' section from READMEs (#17119) ([4531d57](https://github.com/bitnami/charts/commit/4531d57)), closes [#17119](https://github.com/bitnami/charts/issues/17119)
+* Add copyright header (#17300) ([da68be8](https://github.com/bitnami/charts/commit/da68be8)), closes [#17300](https://github.com/bitnami/charts/issues/17300)
+* Update charts readme (#17217) ([31b3c0a](https://github.com/bitnami/charts/commit/31b3c0a)), closes [#17217](https://github.com/bitnami/charts/issues/17217)
+
+## <small>14.1.3 (2023-05-30)</small>
+
+* [bitnami/joomla] Release 14.1.3 (#16969) ([f30016f](https://github.com/bitnami/charts/commit/f30016f)), closes [#16969](https://github.com/bitnami/charts/issues/16969)
+
+## <small>14.1.2 (2023-05-21)</small>
+
+* [bitnami/joomla] Release 14.1.2 (#16843) ([c797234](https://github.com/bitnami/charts/commit/c797234)), closes [#16843](https://github.com/bitnami/charts/issues/16843)
+
+## <small>14.1.1 (2023-05-11)</small>
+
+* [bitnami/joomla] Release 14.0.2 (#16463) ([af3ede5](https://github.com/bitnami/charts/commit/af3ede5)), closes [#16463](https://github.com/bitnami/charts/issues/16463)
+* Add wording for enterprise page (#16560) ([8f22774](https://github.com/bitnami/charts/commit/8f22774)), closes [#16560](https://github.com/bitnami/charts/issues/16560)
+
+## 14.1.0 (2023-05-09)
+
+* [bitnami/several] Adapt Chart.yaml to set desired OCI annotations (#16546) ([fc9b18f](https://github.com/bitnami/charts/commit/fc9b18f)), closes [#16546](https://github.com/bitnami/charts/issues/16546)
+
+## <small>14.0.1 (2023-05-02)</small>
+
+* [bitnami/joomla] Release 14.0.1 (#16347) ([69fb01f](https://github.com/bitnami/charts/commit/69fb01f)), closes [#16347](https://github.com/bitnami/charts/issues/16347)
+
+## 14.0.0 (2023-04-21)
+
+* [bitnami/joomla] Upgrade MariaDB to version 10.11 (#16171) ([899f8f5](https://github.com/bitnami/charts/commit/899f8f5)), closes [#16171](https://github.com/bitnami/charts/issues/16171)
+
+## 13.4.0 (2023-04-20)
+
+* [bitnami/*] Make Helm charts 100% OCI (#15998) ([8841510](https://github.com/bitnami/charts/commit/8841510)), closes [#15998](https://github.com/bitnami/charts/issues/15998)
+
+## <small>13.3.20 (2023-04-18)</small>
+
+* [bitnami/joomla] Release 13.3.20 (#16120) ([89cd6a8](https://github.com/bitnami/charts/commit/89cd6a8)), closes [#16120](https://github.com/bitnami/charts/issues/16120)
+
+## <small>13.3.19 (2023-04-01)</small>
+
+* [bitnami/joomla] Release 13.3.19 (#15859) ([8a3dcab](https://github.com/bitnami/charts/commit/8a3dcab)), closes [#15859](https://github.com/bitnami/charts/issues/15859)
+
+## <small>13.3.18 (2023-03-22)</small>
+
+* [bitnami/joomla] Release 13.3.18 (#15663) ([abe03c9](https://github.com/bitnami/charts/commit/abe03c9)), closes [#15663](https://github.com/bitnami/charts/issues/15663)
+
+## <small>13.3.17 (2023-03-14)</small>
+
+* [bitnami/charts] Apply linter to README files (#15357) ([0e29e60](https://github.com/bitnami/charts/commit/0e29e60)), closes [#15357](https://github.com/bitnami/charts/issues/15357)
+* [bitnami/joomla] Release 13.3.17 (#15500) ([98f1e1e](https://github.com/bitnami/charts/commit/98f1e1e)), closes [#15500](https://github.com/bitnami/charts/issues/15500)
+
+## <small>13.3.16 (2023-03-01)</small>
+
+* [bitnami/joomla] Release 13.3.16 (#15211) ([c8d372b](https://github.com/bitnami/charts/commit/c8d372b)), closes [#15211](https://github.com/bitnami/charts/issues/15211)
+
+## <small>13.3.15 (2023-02-17)</small>
+
+* [bitnami/*] Fix markdown linter issues (#14874) ([a51e0e8](https://github.com/bitnami/charts/commit/a51e0e8)), closes [#14874](https://github.com/bitnami/charts/issues/14874)
+* [bitnami/*] Fix markdown linter issues 2 (#14890) ([aa96572](https://github.com/bitnami/charts/commit/aa96572)), closes [#14890](https://github.com/bitnami/charts/issues/14890)
+* [bitnami/*] Remove unexpected extra spaces (#14873) ([c97c714](https://github.com/bitnami/charts/commit/c97c714)), closes [#14873](https://github.com/bitnami/charts/issues/14873)
+* [bitnami/joomla] Release 13.3.15 (#14976) ([6561002](https://github.com/bitnami/charts/commit/6561002)), closes [#14976](https://github.com/bitnami/charts/issues/14976)
+
+## <small>13.3.14 (2023-02-01)</small>
+
+* [bitnami/*] Change copyright date (#14682) ([add4ec7](https://github.com/bitnami/charts/commit/add4ec7)), closes [#14682](https://github.com/bitnami/charts/issues/14682)
+* [bitnami/*] Change licenses annotation format (#14377) ([0ab7608](https://github.com/bitnami/charts/commit/0ab7608)), closes [#14377](https://github.com/bitnami/charts/issues/14377)
+* [bitnami/*] Unify READMEs (#14472) ([2064fb8](https://github.com/bitnami/charts/commit/2064fb8)), closes [#14472](https://github.com/bitnami/charts/issues/14472)
+* [bitnami/joomla] Release 13.3.14 (#14710) ([9466a67](https://github.com/bitnami/charts/commit/9466a67)), closes [#14710](https://github.com/bitnami/charts/issues/14710)
+
+## <small>13.3.13 (2023-01-12)</small>
+
+* [bitnami/*] Add license annotation and remove obsolete engine parameter (#14293) ([da2a794](https://github.com/bitnami/charts/commit/da2a794)), closes [#14293](https://github.com/bitnami/charts/issues/14293)
+* [bitnami/joomla] Release 13.3.13 (#14316) ([175a7ff](https://github.com/bitnami/charts/commit/175a7ff)), closes [#14316](https://github.com/bitnami/charts/issues/14316)
+
+## <small>13.3.12 (2022-12-13)</small>
+
+* [bitnami/joomla] Release 13.3.12 (#13943) ([ca17b57](https://github.com/bitnami/charts/commit/ca17b57)), closes [#13943](https://github.com/bitnami/charts/issues/13943)
+
+## <small>13.3.11 (2022-12-09)</small>
+
+* [bitnami/joomla] Release 13.3.11 (#13877) ([7ccef5a](https://github.com/bitnami/charts/commit/7ccef5a)), closes [#13877](https://github.com/bitnami/charts/issues/13877)
+
+## <small>13.3.10 (2022-11-09)</small>
+
+* [bitnami/joomla] Release 13.3.10 (#13418) ([52a7b33](https://github.com/bitnami/charts/commit/52a7b33)), closes [#13418](https://github.com/bitnami/charts/issues/13418)
+
+## <small>13.3.9 (2022-10-31)</small>
+
+* optimize annos (#13126) ([f63c306](https://github.com/bitnami/charts/commit/f63c306)), closes [#13126](https://github.com/bitnami/charts/issues/13126)
+
+## <small>13.3.8 (2022-10-26)</small>
+
+* [bitnami/*] Use new default branch name in links (#12943) ([a529e02](https://github.com/bitnami/charts/commit/a529e02)), closes [#12943](https://github.com/bitnami/charts/issues/12943)
+* [bitnami/joomla] Release 13.3.8 (#13154) ([1c73d8b](https://github.com/bitnami/charts/commit/1c73d8b)), closes [#13154](https://github.com/bitnami/charts/issues/13154)
+* Generic README instructions related to the repo (#12792) ([3cf6b10](https://github.com/bitnami/charts/commit/3cf6b10)), closes [#12792](https://github.com/bitnami/charts/issues/12792)
+
+## <small>13.3.7 (2022-09-27)</small>
+
+* [bitnami/joomla] Release 13.3.7 (#12708) ([2669449](https://github.com/bitnami/charts/commit/2669449)), closes [#12708](https://github.com/bitnami/charts/issues/12708)
+
+## <small>13.3.6 (2022-09-21)</small>
+
+* [bitnami/joomla] Use custom probes if given (#12508) ([87f08f7](https://github.com/bitnami/charts/commit/87f08f7)), closes [#12508](https://github.com/bitnami/charts/issues/12508) [#12354](https://github.com/bitnami/charts/issues/12354)
+
+## <small>13.3.5 (2022-09-03)</small>
+
+* [bitnami/joomla] Release 13.3.5 (#12265) ([6190dd7](https://github.com/bitnami/charts/commit/6190dd7)), closes [#12265](https://github.com/bitnami/charts/issues/12265)
+
+## <small>13.3.4 (2022-08-30)</small>
+
+* [bitnami/joomla] Release 13.3.4 (#12218) ([83b140e](https://github.com/bitnami/charts/commit/83b140e)), closes [#12218](https://github.com/bitnami/charts/issues/12218)
+
+## <small>13.3.3 (2022-08-23)</small>
+
+* [bitnami/joomla] Update Chart.lock (#12095) ([a542075](https://github.com/bitnami/charts/commit/a542075)), closes [#12095](https://github.com/bitnami/charts/issues/12095)
+
+## <small>13.3.2 (2022-08-23)</small>
+
+* [bitnami/joomla] Release 13.3.2 (#12018) ([03ace1e](https://github.com/bitnami/charts/commit/03ace1e)), closes [#12018](https://github.com/bitnami/charts/issues/12018)
+
+## <small>13.3.1 (2022-08-22)</small>
+
+* [bitnami/joomla] Update Chart.lock (#11988) ([960df97](https://github.com/bitnami/charts/commit/960df97)), closes [#11988](https://github.com/bitnami/charts/issues/11988)
+
+## 13.3.0 (2022-08-22)
+
+* [bitnami/joomla] Add support for image digest apart from tag (#11889) ([a3d07ee](https://github.com/bitnami/charts/commit/a3d07ee)), closes [#11889](https://github.com/bitnami/charts/issues/11889)
+
+## <small>13.2.18 (2022-08-09)</small>
+
+* [bitnami/joomla] Release 13.2.18 updating components versions ([a6cd323](https://github.com/bitnami/charts/commit/a6cd323))
+
+## <small>13.2.17 (2022-08-04)</small>
+
+* [bitnami/joomla] Release 13.2.17 updating components versions ([52000d1](https://github.com/bitnami/charts/commit/52000d1))
+
+## <small>13.2.16 (2022-08-03)</small>
+
+* [bitnami/joomla] Release 13.2.16 updating components versions ([26767cc](https://github.com/bitnami/charts/commit/26767cc))
+
+## <small>13.2.15 (2022-08-02)</small>
+
+* [bitnami/*] Update URLs to point to the new bitnami/containers monorepo (#11352) ([d665af0](https://github.com/bitnami/charts/commit/d665af0)), closes [#11352](https://github.com/bitnami/charts/issues/11352)
+* [bitnami/joomla] Release 13.2.15 updating components versions ([2f8bba0](https://github.com/bitnami/charts/commit/2f8bba0))
+
+## <small>13.2.14 (2022-07-12)</small>
+
+* [bitnami/joomla] Release 13.2.14 updating components versions ([f6950a2](https://github.com/bitnami/charts/commit/f6950a2))
+
+## <small>13.2.13 (2022-07-09)</small>
+
+* [bitnami/joomla] Release 13.2.13 updating components versions ([2825a47](https://github.com/bitnami/charts/commit/2825a47))
+
+## <small>13.2.12 (2022-06-30)</small>
+
+* [bitnami/joomla] Release 13.2.12 updating components versions ([0cc6268](https://github.com/bitnami/charts/commit/0cc6268))
+
+## <small>13.2.11 (2022-06-21)</small>
+
+* [bitnami/joomla] Release 13.2.11 updating components versions ([0faf82b](https://github.com/bitnami/charts/commit/0faf82b))
+
+## <small>13.2.10 (2022-06-10)</small>
+
+* [bitnami/*] Replace Kubeapps URL in READMEs (and kubeapps Chart.yaml) and remove BKPR references (#1 ([c6a7914](https://github.com/bitnami/charts/commit/c6a7914)), closes [#10600](https://github.com/bitnami/charts/issues/10600)
+* [bitnami/joomla] Release 13.2.10 updating components versions ([65c3d14](https://github.com/bitnami/charts/commit/65c3d14))
+
+## <small>13.2.9 (2022-06-07)</small>
+
+* [bitnami/joomla] Release 13.2.9 updating components versions ([700dffb](https://github.com/bitnami/charts/commit/700dffb))
+
+## <small>13.2.8 (2022-06-01)</small>
+
+* [bitnami/several] Replace maintainers email by url (#10523) ([ff3cf61](https://github.com/bitnami/charts/commit/ff3cf61)), closes [#10523](https://github.com/bitnami/charts/issues/10523)
+
+## <small>13.2.7 (2022-05-30)</small>
+
+* [bitnami/several] Replace base64 --decode with base64 -d (#10495) ([099286a](https://github.com/bitnami/charts/commit/099286a)), closes [#10495](https://github.com/bitnami/charts/issues/10495)
+
+## <small>13.2.6 (2022-05-25)</small>
+
+* [bitnami/joomla] Release 13.2.6 updating components versions ([f837d9e](https://github.com/bitnami/charts/commit/f837d9e))
+
+## <small>13.2.5 (2022-05-24)</small>
+
+* [bitnami/joomla] Release 13.2.5 updating components versions ([2732cab](https://github.com/bitnami/charts/commit/2732cab))
+
+## <small>13.2.4 (2022-05-21)</small>
+
+* [bitnami/joomla] Release 13.2.4 updating components versions ([fad6d96](https://github.com/bitnami/charts/commit/fad6d96))
+
+## <small>13.2.3 (2022-05-20)</small>
+
+* [bitnami/joomla] Release 13.2.3 updating components versions ([09736d4](https://github.com/bitnami/charts/commit/09736d4))
+
+## <small>13.2.2 (2022-05-19)</small>
+
+* [bitnami/joomla] Release 13.2.2 updating components versions ([5d885d1](https://github.com/bitnami/charts/commit/5d885d1))
+
+## <small>13.2.1 (2022-05-18)</small>
+
+* [bitnami/joomla] Release 13.2.1 updating components versions ([8667dc1](https://github.com/bitnami/charts/commit/8667dc1))
+
+## 13.2.0 (2022-05-16)
+
+* [bitnami/*] add ingress extraRules feature (#10253) ([0f6cbb9](https://github.com/bitnami/charts/commit/0f6cbb9)), closes [#10253](https://github.com/bitnami/charts/issues/10253)
+
+## <small>13.1.1 (2022-05-15)</small>
+
+* [bitnami/*] Remove old 'ci' files (#10171) ([5df30c4](https://github.com/bitnami/charts/commit/5df30c4)), closes [#10171](https://github.com/bitnami/charts/issues/10171)
+* [bitnami/joomla] Release 13.1.1 updating components versions ([9e1a9f2](https://github.com/bitnami/charts/commit/9e1a9f2))
+
+## 13.1.0 (2022-05-11)
+
+* [bitnami/joomla] Add missing namespace metadata (#10128) ([e3cbaeb](https://github.com/bitnami/charts/commit/e3cbaeb)), closes [#10128](https://github.com/bitnami/charts/issues/10128)
+
+## <small>13.0.2 (2022-05-10)</small>
+
+* [bitnami/joomla] Release 13.0.2 updating components versions ([d16b406](https://github.com/bitnami/charts/commit/d16b406))
+
+## <small>13.0.1 (2022-04-21)</small>
+
+* [bitnami/joomla] Release 13.0.1 updating components versions ([1db695c](https://github.com/bitnami/charts/commit/1db695c))
+
+## 13.0.0 (2022-04-21)
+
+* [bitnami/joomla] feat!: :arrow_up: Bump MariaDB version to 10.6 (#9849) ([b3db0f4](https://github.com/bitnami/charts/commit/b3db0f4)), closes [#9849](https://github.com/bitnami/charts/issues/9849)
+
+## <small>12.0.21 (2022-04-20)</small>
+
+* [bitnami/joomla] Release 12.0.21 updating components versions ([9947d3a](https://github.com/bitnami/charts/commit/9947d3a))
+
+## <small>12.0.20 (2022-04-19)</small>
+
+* [bitnami/joomla] Release 12.0.20 updating components versions ([11e4867](https://github.com/bitnami/charts/commit/11e4867))
+
+## <small>12.0.19 (2022-04-08)</small>
+
+* [bitnami/joomla] Release 12.0.19 updating components versions ([17247b0](https://github.com/bitnami/charts/commit/17247b0))
+
+## <small>12.0.18 (2022-04-06)</small>
+
+* [bitnami/joomla] Release 12.0.18 updating components versions ([84bc583](https://github.com/bitnami/charts/commit/84bc583))
+
+## <small>12.0.17 (2022-04-03)</small>
+
+* [bitnami/joomla] Release 12.0.17 updating components versions ([77750a3](https://github.com/bitnami/charts/commit/77750a3))
+
+## <small>12.0.16 (2022-04-02)</small>
+
+* [bitnami/joomla] Release 12.0.16 updating components versions ([4241c20](https://github.com/bitnami/charts/commit/4241c20))
+
+## <small>12.0.15 (2022-03-30)</small>
+
+* [bitnami/joomla] Release 12.0.15 updating components versions ([291c2f1](https://github.com/bitnami/charts/commit/291c2f1))
+
+## <small>12.0.14 (2022-03-29)</small>
+
+* [bitnami/joomla] Release 12.0.14 updating components versions ([7e3ea28](https://github.com/bitnami/charts/commit/7e3ea28))
+
+## <small>12.0.13 (2022-03-29)</small>
+
+* [bitnami/joomla] Release 12.0.13 updating components versions ([f00593e](https://github.com/bitnami/charts/commit/f00593e))
+
+## <small>12.0.12 (2022-03-27)</small>
+
+* [bitnami/joomla] Release 12.0.12 updating components versions ([e027265](https://github.com/bitnami/charts/commit/e027265))
+
+## <small>12.0.11 (2022-03-25)</small>
+
+* [bitnami/joomla] Release 12.0.11 updating components versions ([d32eaa5](https://github.com/bitnami/charts/commit/d32eaa5))
+
+## <small>12.0.10 (2022-03-18)</small>
+
+* [bitnami/joomla] Release 12.0.10 updating components versions ([afc38fe](https://github.com/bitnami/charts/commit/afc38fe))
+
+## <small>12.0.9 (2022-03-16)</small>
+
+* [bitnami/joomla] Release 12.0.9 updating components versions ([1c821bd](https://github.com/bitnami/charts/commit/1c821bd))
+
+## <small>12.0.8 (2022-03-01)</small>
+
+* [bitnami/joomla] Release 12.0.8 updating components versions ([ae4cc4c](https://github.com/bitnami/charts/commit/ae4cc4c))
+
+## <small>12.0.7 (2022-02-27)</small>
+
+* [bitnami/joomla] Release 12.0.7 updating components versions ([c5133a2](https://github.com/bitnami/charts/commit/c5133a2))
+
+## <small>12.0.6 (2022-02-23)</small>
+
+* [bitnami/joomla] Release 12.0.6 updating components versions ([c4d2660](https://github.com/bitnami/charts/commit/c4d2660))
+
+## <small>12.0.5 (2022-02-22)</small>
+
+* [bitnami/joomla] Release 12.0.5 updating components versions ([21a66b4](https://github.com/bitnami/charts/commit/21a66b4))
+
+## <small>12.0.4 (2022-02-13)</small>
+
+* [bitnami/joomla] Release 12.0.4 updating components versions ([48cbdf8](https://github.com/bitnami/charts/commit/48cbdf8))
+* Fix non utf-8 character (#8741) ([60efb0d](https://github.com/bitnami/charts/commit/60efb0d)), closes [#8741](https://github.com/bitnami/charts/issues/8741)
+
+## <small>12.0.3 (2022-01-20)</small>
+
+* [bitnami/joomla] Release 12.0.3 updating components versions ([3d48fbf](https://github.com/bitnami/charts/commit/3d48fbf))
+
+## <small>12.0.2 (2022-01-20)</small>
+
+* [bitnami/*] Readme automation (#8579) ([78d1938](https://github.com/bitnami/charts/commit/78d1938)), closes [#8579](https://github.com/bitnami/charts/issues/8579)
+* [bitnami/*] Update READMEs (#8716) ([b9a9533](https://github.com/bitnami/charts/commit/b9a9533)), closes [#8716](https://github.com/bitnami/charts/issues/8716)
+* [bitnami/several] Change prerequisites (#8725) ([8d740c5](https://github.com/bitnami/charts/commit/8d740c5)), closes [#8725](https://github.com/bitnami/charts/issues/8725)
+
+## <small>12.0.1 (2022-01-05)</small>
+
+* [bitnami/several] Adapt templating format (#8562) ([8cad18a](https://github.com/bitnami/charts/commit/8cad18a)), closes [#8562](https://github.com/bitnami/charts/issues/8562)
+
+## 12.0.0 (2022-01-05)
+
+* [bitnami/joomla] Chart standardized (#7583) ([0f8f19d](https://github.com/bitnami/charts/commit/0f8f19d)), closes [#7583](https://github.com/bitnami/charts/issues/7583)
+* [bitnami/several] Add license to the README ([05f7633](https://github.com/bitnami/charts/commit/05f7633))
+* [bitnami/several] Add license to the README ([32fb238](https://github.com/bitnami/charts/commit/32fb238))
+* [bitnami/several] Add license to the README ([b87c2f7](https://github.com/bitnami/charts/commit/b87c2f7))
+
+## 11.0.0 (2021-12-28)
+
+* [bitnami/joomla] feat!: :boom: Bump to Joomla 4 (#8514) ([bcf081e](https://github.com/bitnami/charts/commit/bcf081e)), closes [#8514](https://github.com/bitnami/charts/issues/8514)
+
+## <small>10.2.3 (2021-12-14)</small>
+
+* [bitnami/joomla] Release 10.2.3 updating components versions ([d68a082](https://github.com/bitnami/charts/commit/d68a082))
+
+## <small>10.2.2 (2021-11-29)</small>
+
+* [bitnami/several] Add 'community support' note to some Helm chart READMEs (#8148) ([ce6b838](https://github.com/bitnami/charts/commit/ce6b838)), closes [#8148](https://github.com/bitnami/charts/issues/8148)
+* [bitnami/several] Fix deadlinks in README.md (#8215) ([99e90d2](https://github.com/bitnami/charts/commit/99e90d2)), closes [#8215](https://github.com/bitnami/charts/issues/8215)
+* [bitnami/several] Regenerate README tables ([1cde837](https://github.com/bitnami/charts/commit/1cde837))
+* [bitnami/several] Replace HTTP by HTTPS when possible (#8259) ([eafb5bd](https://github.com/bitnami/charts/commit/eafb5bd)), closes [#8259](https://github.com/bitnami/charts/issues/8259)
+
+## <small>10.2.1 (2021-11-16)</small>
+
+* [bitnami/joomla] Release 10.2.1 updating components versions ([ae6305b](https://github.com/bitnami/charts/commit/ae6305b))
+
+## 10.2.0 (2021-11-16)
+
+* [bitnami/*] Add network policies - second batch (#8100) ([ec0efae](https://github.com/bitnami/charts/commit/ec0efae)), closes [#8100](https://github.com/bitnami/charts/issues/8100)
+
+## <small>10.1.29 (2021-11-15)</small>
+
+* Fixing a typo in the post-deploy notes for bitnami/joomla (#8117) ([a3459d5](https://github.com/bitnami/charts/commit/a3459d5)), closes [#8117](https://github.com/bitnami/charts/issues/8117)
+
+## <small>10.1.28 (2021-11-04)</small>
+
+* [bitnami/joomla ] Update deployment.yaml to fix issue 8004 (#8013) ([f362976](https://github.com/bitnami/charts/commit/f362976)), closes [#8013](https://github.com/bitnami/charts/issues/8013)
+* [bitnami/several] Regenerate README tables ([6e3fb95](https://github.com/bitnami/charts/commit/6e3fb95))
+
+## <small>10.1.27 (2021-10-27)</small>
+
+* [bitnami/joomla] Release 10.1.27 updating components versions ([5df1c8e](https://github.com/bitnami/charts/commit/5df1c8e))
+* [bitnami/several] Regenerate README tables ([412cf6a](https://github.com/bitnami/charts/commit/412cf6a))
+
+## <small>10.1.26 (2021-10-26)</small>
+
+* [bitnami/joomla] Release 10.1.26 updating components versions ([e62f94e](https://github.com/bitnami/charts/commit/e62f94e))
+
+## <small>10.1.25 (2021-10-22)</small>
+
+* [bitnami/several] Add chart info to NOTES.txt (#7889) ([a6751cd](https://github.com/bitnami/charts/commit/a6751cd)), closes [#7889](https://github.com/bitnami/charts/issues/7889)
+* [bitnami/several] Regenerate README tables ([9bead53](https://github.com/bitnami/charts/commit/9bead53))
+
+## <small>10.1.24 (2021-10-07)</small>
+
+* [bitnami/joomla] Release 10.1.24 updating components versions ([53c7504](https://github.com/bitnami/charts/commit/53c7504))
+* [bitnami/prestashop] Fix default value for `ingress. ingressClassName` (and regenerate READMEs) (#77 ([c3fbb73](https://github.com/bitnami/charts/commit/c3fbb73)), closes [#7732](https://github.com/bitnami/charts/issues/7732)
+
+## <small>10.1.23 (2021-10-07)</small>
+
+* [bitnami/joomla] Release 10.1.23 updating components versions ([c9bde37](https://github.com/bitnami/charts/commit/c9bde37))
+
+## <small>10.1.22 (2021-10-01)</small>
+
+* [bitnami/*] Drop support for deprecated cert-manager annotation (#7582) ([a081792](https://github.com/bitnami/charts/commit/a081792)), closes [#7582](https://github.com/bitnami/charts/issues/7582)
+* [bitnami/several] Regenerate README tables ([5c79422](https://github.com/bitnami/charts/commit/5c79422))
+
+## <small>10.1.21 (2021-09-14)</small>
+
+* [bitnami/joomla] Release 10.1.21 updating components versions ([1dca97f](https://github.com/bitnami/charts/commit/1dca97f))
+* [bitnami/several] Regenerate README tables ([da2513b](https://github.com/bitnami/charts/commit/da2513b))
+
+## <small>10.1.20 (2021-08-25)</small>
+
+* [bitnami/joomla] Release 10.1.20 updating components versions ([0536310](https://github.com/bitnami/charts/commit/0536310))
+* [bitnami/several] Regenerate README tables ([04e7724](https://github.com/bitnami/charts/commit/04e7724))
+
+## <small>10.1.19 (2021-08-24)</small>
+
+* [bitnami/joomla] Release 10.1.19 updating components versions ([c64ea73](https://github.com/bitnami/charts/commit/c64ea73))
+* [bitnami/several] Regenerate README tables ([6c9124f](https://github.com/bitnami/charts/commit/6c9124f))
+
+## <small>10.1.18 (2021-08-17)</small>
+
+* [bitnami/joomla] Release 10.1.18 updating components versions ([b24d3ce](https://github.com/bitnami/charts/commit/b24d3ce))
+* [bitnami/several] Regenerate README tables ([6c107e8](https://github.com/bitnami/charts/commit/6c107e8))
+
+## <small>10.1.17 (2021-08-04)</small>
+
+* [bitnami/joomla] Release 10.1.17 updating components versions ([1010764](https://github.com/bitnami/charts/commit/1010764))
+
+## <small>10.1.16 (2021-07-27)</small>
+
+* [bitnami/several] Fix default values and regenerate README (#7024) ([4c86733](https://github.com/bitnami/charts/commit/4c86733)), closes [#7024](https://github.com/bitnami/charts/issues/7024)
+
+## <small>10.1.15 (2021-07-09)</small>
+
+* [bitnami/*] Adapt values.yaml of Joomla, Jupyterhub and Kafka charts (#6850) ([8ebbf6e](https://github.com/bitnami/charts/commit/8ebbf6e)), closes [#6850](https://github.com/bitnami/charts/issues/6850)
+
+## <small>10.1.14 (2021-07-06)</small>
+
+* [bitnami/joomla] Release 10.1.14 updating components versions ([3e885e6](https://github.com/bitnami/charts/commit/3e885e6))
+
+## <small>10.1.13 (2021-06-26)</small>
+
+* [bitnami/joomla] Release 10.1.13 updating components versions ([8bd7348](https://github.com/bitnami/charts/commit/8bd7348))
+
+## <small>10.1.12 (2021-06-21)</small>
+
+* [bitnami/joomla] Release 10.1.12 updating components versions ([5839abb](https://github.com/bitnami/charts/commit/5839abb))
+
+## <small>10.1.11 (2021-06-19)</small>
+
+* [bitnami/joomla] Release 10.1.11 updating components versions ([4383997](https://github.com/bitnami/charts/commit/4383997))
+
+## <small>10.1.10 (2021-05-25)</small>
+
+* [bitnami/joomla] Release 10.1.10 updating components versions ([8cfbbaa](https://github.com/bitnami/charts/commit/8cfbbaa))
+
+## <small>10.1.9 (2021-05-25)</small>
+
+* [bitnami/joomla] Release 10.1.9 updating components versions ([144225d](https://github.com/bitnami/charts/commit/144225d))
+
+## <small>10.1.8 (2021-05-23)</small>
+
+* [bitnami/joomla] Release 10.1.8 updating components versions ([85ac8c3](https://github.com/bitnami/charts/commit/85ac8c3))
+
+## <small>10.1.7 (2021-05-07)</small>
+
+* [bitnami/joomla] Release 10.1.7 updating components versions ([2805f6c](https://github.com/bitnami/charts/commit/2805f6c))
+
+## <small>10.1.6 (2021-05-05)</small>
+
+* Update NOTES.txt (#6292) ([ee5597c](https://github.com/bitnami/charts/commit/ee5597c)), closes [#6292](https://github.com/bitnami/charts/issues/6292)
+
+## <small>10.1.5 (2021-04-13)</small>
+
+* [bitnami/joomla] Release 10.1.5 updating components versions ([a2ff780](https://github.com/bitnami/charts/commit/a2ff780))
+
+## <small>10.1.4 (2021-04-02)</small>
+
+* [bitnami/joomla] Release 10.1.4 updating components versions ([6ed3a79](https://github.com/bitnami/charts/commit/6ed3a79))
+
+## <small>10.1.3 (2021-03-04)</small>
+
+* [bitnami/*] Remove minideb mentions (#5677) ([870bc4d](https://github.com/bitnami/charts/commit/870bc4d)), closes [#5677](https://github.com/bitnami/charts/issues/5677)
+
+## <small>10.1.2 (2021-03-03)</small>
+
+* [bitnami/joomla] Release 10.1.2 updating components versions ([fc729e4](https://github.com/bitnami/charts/commit/fc729e4))
+
+## <small>10.1.1 (2021-02-13)</small>
+
+* [bitnami/*] Add notice regarding parameters immutability after chart installation (#4853) ([5f09573](https://github.com/bitnami/charts/commit/5f09573)), closes [#4853](https://github.com/bitnami/charts/issues/4853)
+* [bitnami/joomla] Release 10.1.1 updating components versions ([28e9618](https://github.com/bitnami/charts/commit/28e9618))
+
+## 10.1.0 (2021-01-28)
+
+* [bitnami/*] Change helm version in the prerequisites (#5090) ([c5e67a3](https://github.com/bitnami/charts/commit/c5e67a3)), closes [#5090](https://github.com/bitnami/charts/issues/5090)
+* [bitnami/joomla] Add hostAliases (#5247) ([085b3ce](https://github.com/bitnami/charts/commit/085b3ce)), closes [#5247](https://github.com/bitnami/charts/issues/5247)
+
+## <small>10.0.1 (2021-01-14)</small>
+
+* [bitnami/joomla] Release 10.0.1 updating components versions ([5c5e3e6](https://github.com/bitnami/charts/commit/5c5e3e6))
+
+## 10.0.0 (2021-01-14)
+
+* [bitnami/joomla] Major change: adapt ingress (#4973) ([deb6d3c](https://github.com/bitnami/charts/commit/deb6d3c)), closes [#4973](https://github.com/bitnami/charts/issues/4973)
+
+## <small>9.0.5 (2020-12-24)</small>
+
+* [bitnami/*] fix typos (#4699) ([49adc63](https://github.com/bitnami/charts/commit/49adc63)), closes [#4699](https://github.com/bitnami/charts/issues/4699)
+* [bitnami/joomla] Release 9.0.5 updating components versions ([b9474d0](https://github.com/bitnami/charts/commit/b9474d0))
+
+## <small>9.0.4 (2020-12-11)</small>
+
+* [bitnami/*] Update dependencies (#4694) ([2826c12](https://github.com/bitnami/charts/commit/2826c12)), closes [#4694](https://github.com/bitnami/charts/issues/4694)
+
+## <small>9.0.3 (2020-11-25)</small>
+
+* [bitnami/*] Affinity based on common presets (ii) (#4472) ([934259f](https://github.com/bitnami/charts/commit/934259f)), closes [#4472](https://github.com/bitnami/charts/issues/4472)
+
+## <small>9.0.2 (2020-11-24)</small>
+
+* [bitnami/joomla] Release 9.0.2 updating components versions ([1825be9](https://github.com/bitnami/charts/commit/1825be9))
+
+## <small>9.0.1 (2020-11-20)</small>
+
+* [bitnami/*] Expose the "service type" in the basic form for Kubeapps (#4445) ([cf3b3d3](https://github.com/bitnami/charts/commit/cf3b3d3)), closes [#4445](https://github.com/bitnami/charts/issues/4445)
+
+## 9.0.0 (2020-11-19)
+
+* [bitnami/Joomla] Major version. Adapt Chart to apiVersion: v2 and Update MariaDB Dependency (#4348) ([3f58e53](https://github.com/bitnami/charts/commit/3f58e53)), closes [#4348](https://github.com/bitnami/charts/issues/4348)
+
+## <small>8.1.10 (2020-11-12)</small>
+
+* [bitnami/joomla] Release 8.1.10 updating components versions ([88c984c](https://github.com/bitnami/charts/commit/88c984c))
+
+## <small>8.1.9 (2020-10-30)</small>
+
+* [bitnami/*] Extra manifests should be top-level (#4161) ([b3a95b7](https://github.com/bitnami/charts/commit/b3a95b7)), closes [#4161](https://github.com/bitnami/charts/issues/4161)
+* [bitnami/*] Include link to Troubleshootin guide on README.md (#4136) ([c08a20e](https://github.com/bitnami/charts/commit/c08a20e)), closes [#4136](https://github.com/bitnami/charts/issues/4136)
+
+## <small>8.1.8 (2020-10-13)</small>
+
+* [bitnami/joomla] Release 8.1.8 updating components versions ([4acc9f2](https://github.com/bitnami/charts/commit/4acc9f2))
+
+## <small>8.1.7 (2020-10-13)</small>
+
+* [bitnami/joomla] fix: version mismatch between mariadb and common ([ccd7644](https://github.com/bitnami/charts/commit/ccd7644))
+
+## <small>8.1.6 (2020-09-21)</small>
+
+* [bitnami/joomla] Release 8.1.6 updating components versions ([96de6e5](https://github.com/bitnami/charts/commit/96de6e5))
+
+## <small>8.1.5 (2020-09-11)</small>
+
+* illegal number syntax: "-" in NOTES.txt (#3654) ([6572fc2](https://github.com/bitnami/charts/commit/6572fc2)), closes [#3654](https://github.com/bitnami/charts/issues/3654)
+
+## <small>8.1.4 (2020-09-04)</small>
+
+* [bitnami/joomla] Release 8.1.4 updating components versions ([7aef5b2](https://github.com/bitnami/charts/commit/7aef5b2))
+
+## <small>8.1.3 (2020-09-03)</small>
+
+* [bitnami/joomla] Release 8.1.3 updating components versions ([ab812c8](https://github.com/bitnami/charts/commit/ab812c8))
+* [bitnami/metrics-server] Add source repo (#3577) ([1ed12f9](https://github.com/bitnami/charts/commit/1ed12f9)), closes [#3577](https://github.com/bitnami/charts/issues/3577)
+
+## <small>8.1.2 (2020-08-26)</small>
+
+* [bitnami/joomla] Release 8.1.2 updating components versions ([ffd8514](https://github.com/bitnami/charts/commit/ffd8514))
+
+## <small>8.1.1 (2020-08-14)</small>
+
+* [bitnami/joomla] Remove drupal references and fix ingress renderization (#3410) ([1f25b4f](https://github.com/bitnami/charts/commit/1f25b4f)), closes [#3410](https://github.com/bitnami/charts/issues/3410)
+
+## 8.1.0 (2020-08-13)
+
+* [bitnami/*] Use common helps for upgrade password errors (#3335) ([079f5bd](https://github.com/bitnami/charts/commit/079f5bd)), closes [#3335](https://github.com/bitnami/charts/issues/3335)
+
+## <small>8.0.4 (2020-08-06)</small>
+
+* [bitnami/joomla] Release 8.0.4 updating components versions ([c2af157](https://github.com/bitnami/charts/commit/c2af157))
+
+## <small>8.0.3 (2020-08-04)</small>
+
+* [bitnami/joomla] Release 8.0.3 updating components versions ([2459615](https://github.com/bitnami/charts/commit/2459615))
+
+## <small>8.0.2 (2020-07-31)</small>
+
+* [bitnami/*] Fix TL;DR typo in READMEs (#3280) ([3d7ab40](https://github.com/bitnami/charts/commit/3d7ab40)), closes [#3280](https://github.com/bitnami/charts/issues/3280)
+* [bitnami/joomla] Release 8.0.2 updating components versions ([e4e0302](https://github.com/bitnami/charts/commit/e4e0302))
+
+## <small>8.0.1 (2020-07-15)</small>
+
+* [bitnami/joomla] Release 8.0.1 updating components versions ([aad7aad](https://github.com/bitnami/charts/commit/aad7aad))
+
+## 8.0.0 (2020-07-14)
+
+* [bitnami/all] Add categories (#3075) ([63bde06](https://github.com/bitnami/charts/commit/63bde06)), closes [#3075](https://github.com/bitnami/charts/issues/3075)
+* [bitnami/joomla] Move to non-root and adapt to Bitnami standards. (#3085) ([7b9c400](https://github.com/bitnami/charts/commit/7b9c400)), closes [#3085](https://github.com/bitnami/charts/issues/3085)
+
+## <small>7.1.19 (2020-06-19)</small>
+
+* [bitnami/joomla] Release 7.1.19 updating components versions ([e84a85a](https://github.com/bitnami/charts/commit/e84a85a))
+* [multiple charts] Update hidden properties in the different JSON schemas (#2871) ([4cff6ba](https://github.com/bitnami/charts/commit/4cff6ba)), closes [#2871](https://github.com/bitnami/charts/issues/2871)
+
+## <small>7.1.18 (2020-06-03)</small>
+
+* [bitnami/joomla] Release 7.1.18 updating components versions ([6e61403](https://github.com/bitnami/charts/commit/6e61403))
+* Add support for helm lint and helm install in PRs via GH Actions (#2721) ([5ed97f0](https://github.com/bitnami/charts/commit/5ed97f0)), closes [#2721](https://github.com/bitnami/charts/issues/2721)
+
+## <small>7.1.17 (2020-05-22)</small>
+
+* [bitnami/joomla] Release 7.1.17 updating components versions ([3d2cef9](https://github.com/bitnami/charts/commit/3d2cef9))
+* update bitnami/common to be compatible with helm v2.12+ (#2615) ([c7751eb](https://github.com/bitnami/charts/commit/c7751eb)), closes [#2615](https://github.com/bitnami/charts/issues/2615)
+
+## <small>7.1.16 (2020-04-22)</small>
+
+* [bitnami/joomla] Release 7.1.16 updating components versions ([337264d](https://github.com/bitnami/charts/commit/337264d))
+
+## <small>7.1.15 (2020-04-21)</small>
+
+* [bitnami/joomla] Release 7.1.15 updating components versions ([0d1c4a6](https://github.com/bitnami/charts/commit/0d1c4a6))
+
+## <small>7.1.14 (2020-04-16)</small>
+
+* [bitnami/joomla] Release 7.1.14 updating components versions ([b8f8056](https://github.com/bitnami/charts/commit/b8f8056))
+
+## <small>7.1.13 (2020-04-10)</small>
+
+* [bitnami/joomla] Change in the command of apache-exporter (#2283) ([dedd949](https://github.com/bitnami/charts/commit/dedd949)), closes [#2283](https://github.com/bitnami/charts/issues/2283)
+
+## <small>7.1.12 (2020-03-26)</small>
+
+* [bitnami/joomla] Release 7.1.12 updating components versions ([2ed0e67](https://github.com/bitnami/charts/commit/2ed0e67))
+
+## <small>7.1.11 (2020-03-11)</small>
+
+* [bitnami/joomla] Release 7.1.11 updating components versions ([f6066dd](https://github.com/bitnami/charts/commit/f6066dd))
+
+## <small>7.1.10 (2020-03-11)</small>
+
+* Move charts from upstreamed folder to bitnami (#2032) ([a0e44f7](https://github.com/bitnami/charts/commit/a0e44f7)), closes [#2032](https://github.com/bitnami/charts/issues/2032)

--- a/bitnami/joomla/Chart.lock
+++ b/bitnami/joomla/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: mariadb
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 18.0.5
+  version: 18.0.6
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.19.2
-digest: sha256:c5470e186b8c675df045d2df334629fb8a47a53f87044bd4348c80105ca25eaf
-generated: "2024-05-15T16:56:09.988817+02:00"
+  version: 2.19.3
+digest: sha256:b301b80e916d0e948742e5fd94df9700a7be160a173ef39f11b54fac32887216
+generated: "2024-05-21T13:54:12.35160875+02:00"

--- a/bitnami/joomla/Chart.yaml
+++ b/bitnami/joomla/Chart.yaml
@@ -36,4 +36,4 @@ maintainers:
 name: joomla
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/joomla
-version: 19.0.5
+version: 19.1.0

--- a/bitnami/joomla/templates/NOTES.txt
+++ b/bitnami/joomla/templates/NOTES.txt
@@ -88,3 +88,4 @@ WARNING: Review values for the following password in the command, if they are co
   {{- include "common.validations.values.multiple.empty" (dict "required" (list $requiredExternalPassword) "context" $) -}}
 {{- end -}}
 {{- include "common.warnings.resources" (dict "sections" (list "metrics" "") "context" $) }}
+{{- include "common.warnings.modifiedImages" (dict "images" (list .Values.image .Values.metrics.image) "context" $) }}


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Replacing the original images that have been tested and verified when releasing the chart is a dangerous practice in terms of security, performance and available features. This PR updates the `NOTES.txt` file using the `common.warnings.modifiedImages` helper developed in https://github.com/bitnami/charts/pull/25952.


<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

Users are more aware of the risks of changing original images.
<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

n/a
<!-- Describe any known limitations with your change -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
