### PR TITLE
[bitnami/kafka] feat: :sparkles: :lock: Add warning when original images are replaced

### DIFF
--- a/bitnami/kafka/CHANGELOG.md
+++ b/bitnami/kafka/CHANGELOG.md
@@ -1,0 +1,2356 @@
+# Changelog
+
+## 28.3.0 (2024-05-21)
+
+* [bitnami/kafka] feat: :sparkles: :lock: Add warning when original images are replaced ([#26224](https://github.com/bitnami/charts/pulls/26224))
+
+## <small>28.2.6 (2024-05-21)</small>
+
+* [bitnami/kafka] Use different liveness/readiness probes (#26134) ([814bef1](https://github.com/bitnami/charts/commit/814bef1)), closes [#26134](https://github.com/bitnami/charts/issues/26134)
+
+## <small>28.2.5 (2024-05-18)</small>
+
+* [bitnami/kafka] Release 28.2.5 updating components versions (#26030) ([4806aac](https://github.com/bitnami/charts/commit/4806aac)), closes [#26030](https://github.com/bitnami/charts/issues/26030)
+
+## <small>28.2.4 (2024-05-15)</small>
+
+* bitnami/kafka Fix for sed in kafka-init.sh (#25856) ([d0a9edd](https://github.com/bitnami/charts/commit/d0a9edd)), closes [#25856](https://github.com/bitnami/charts/issues/25856)
+
+## <small>28.2.3 (2024-05-14)</small>
+
+* [bitnami/kafka] Release 28.2.3 updating components versions (#25772) ([f6337eb](https://github.com/bitnami/charts/commit/f6337eb)), closes [#25772](https://github.com/bitnami/charts/issues/25772)
+
+## <small>28.2.2 (2024-05-13)</small>
+
+* [bitnami/*] Change non-root and rolling-tags doc URLs (#25628) ([b067c94](https://github.com/bitnami/charts/commit/b067c94)), closes [#25628](https://github.com/bitnami/charts/issues/25628)
+* [bitnami/kafka] Release 28.2.2 updating components versions (#25735) ([1c78c32](https://github.com/bitnami/charts/commit/1c78c32)), closes [#25735](https://github.com/bitnami/charts/issues/25735)
+
+## <small>28.2.1 (2024-05-07)</small>
+
+* [bitnami/*] Set new header/owner (#25558) ([8d1dc11](https://github.com/bitnami/charts/commit/8d1dc11)), closes [#25558](https://github.com/bitnami/charts/issues/25558)
+* [bitnami/kafka] change probe path for kafka-exporter to /healthz (#25559) ([533146d](https://github.com/bitnami/charts/commit/533146d)), closes [#25559](https://github.com/bitnami/charts/issues/25559)
+
+## 28.2.0 (2024-05-06)
+
+* [bitnami/*] Fix license headers (#25447) ([2d7dca6](https://github.com/bitnami/charts/commit/2d7dca6)), closes [#25447](https://github.com/bitnami/charts/issues/25447)
+* [bitnami/kafka] Allow loadBalancerClass to be customized for the kafka chart (#25538) ([600eae9](https://github.com/bitnami/charts/commit/600eae9)), closes [#25538](https://github.com/bitnami/charts/issues/25538)
+
+## <small>28.1.1 (2024-04-26)</small>
+
+* [bitnami/kafka] Release 28.1.1 updating components versions (#25417) ([db7ee33](https://github.com/bitnami/charts/commit/db7ee33)), closes [#25417](https://github.com/bitnami/charts/issues/25417)
+
+## 28.1.0 (2024-04-25)
+
+* [bitnami/kafka] feat: :sparkles: Add autoscaling support (experimental) (#24929) ([e0c0d63](https://github.com/bitnami/charts/commit/e0c0d63)), closes [#24929](https://github.com/bitnami/charts/issues/24929)
+* [bitnami/multiple charts] Fix typo: "NetworkPolice" vs "NetworkPolicy" (#25348) ([6970c1b](https://github.com/bitnami/charts/commit/6970c1b)), closes [#25348](https://github.com/bitnami/charts/issues/25348)
+* Replace VMware by Broadcom copyright text (#25306) ([a5e4bd0](https://github.com/bitnami/charts/commit/a5e4bd0)), closes [#25306](https://github.com/bitnami/charts/issues/25306)
+
+## <small>28.0.4 (2024-04-11)</small>
+
+* [bitnami/kafka] :lady_beetle: Fix password replace for >10 users (#25133) ([5fd4980](https://github.com/bitnami/charts/commit/5fd4980)), closes [#25133](https://github.com/bitnami/charts/issues/25133)
+
+## <small>28.0.3 (2024-04-05)</small>
+
+* [bitnami/kafka] Release 28.0.3 (#24985) ([f30afb2](https://github.com/bitnami/charts/commit/f30afb2)), closes [#24985](https://github.com/bitnami/charts/issues/24985)
+
+## <small>28.0.2 (2024-04-05)</small>
+
+* [bitnami/kafka] fix: :bug: Add missing controller port in networkpolicy (#24937) ([e91090b](https://github.com/bitnami/charts/commit/e91090b)), closes [#24937](https://github.com/bitnami/charts/issues/24937)
+* Update resourcesPreset comments (#24467) ([92e3e8a](https://github.com/bitnami/charts/commit/92e3e8a)), closes [#24467](https://github.com/bitnami/charts/issues/24467)
+
+## <small>28.0.1 (2024-04-01)</small>
+
+* [bitnami/kafka] Register targetPod in global context (#24391) ([7c2aed4](https://github.com/bitnami/charts/commit/7c2aed4)), closes [#24391](https://github.com/bitnami/charts/issues/24391)
+
+## 28.0.0 (2024-03-26)
+
+* [bitnami/*] Reorder Chart sections (#24455) ([0cf4048](https://github.com/bitnami/charts/commit/0cf4048)), closes [#24455](https://github.com/bitnami/charts/issues/24455)
+* [bitnami/kafka] feat!: :lock: :boom: Improve security defaults (#24659) ([ba3b159](https://github.com/bitnami/charts/commit/ba3b159)), closes [#24659](https://github.com/bitnami/charts/issues/24659)
+
+## <small>27.1.2 (2024-03-14)</small>
+
+* bitnami/kafka pass jmx exporter metrics port as args (#24401) ([6202965](https://github.com/bitnami/charts/commit/6202965)), closes [#24401](https://github.com/bitnami/charts/issues/24401)
+
+## <small>27.1.1 (2024-03-11)</small>
+
+* [bitnami/kafka] fix: Setup of sasl authentication to external zookeeper (#23550) ([ac9dca4](https://github.com/bitnami/charts/commit/ac9dca4)), closes [#23550](https://github.com/bitnami/charts/issues/23550)
+
+## 27.1.0 (2024-03-06)
+
+* [bitnami/kafka] feat: :sparkles: :lock: Add automatic adaptation for Openshift restricted-v2 SCC (#2 ([a839f68](https://github.com/bitnami/charts/commit/a839f68)), closes [#24100](https://github.com/bitnami/charts/issues/24100)
+
+## 27.0.0 (2024-03-04)
+
+* [bitnami/kafka] Release 27.0.0 updating components versions (#24048) ([6fd6ed0](https://github.com/bitnami/charts/commit/6fd6ed0)), closes [#24048](https://github.com/bitnami/charts/issues/24048)
+
+## <small>26.11.4 (2024-02-28)</small>
+
+* [bitnami/kafka] Fix installation issue when serviceBindings.enabled is true - part 2 (#23898) ([97df6fc](https://github.com/bitnami/charts/commit/97df6fc)), closes [#23898](https://github.com/bitnami/charts/issues/23898)
+
+## <small>26.11.3 (2024-02-23)</small>
+
+* [bitnami/kafka] fix: use root context for Values in range (#23604) ([2e8d666](https://github.com/bitnami/charts/commit/2e8d666)), closes [#23604](https://github.com/bitnami/charts/issues/23604)
+
+## <small>26.11.2 (2024-02-22)</small>
+
+* [bitnami/kafka] Release 26.11.2 updating components versions (#23789) ([8b3d4bf](https://github.com/bitnami/charts/commit/8b3d4bf)), closes [#23789](https://github.com/bitnami/charts/issues/23789)
+
+## <small>26.11.1 (2024-02-21)</small>
+
+* [bitnami/kafka] Release 26.11.1 updating components versions (#23629) ([ff5ed8c](https://github.com/bitnami/charts/commit/ff5ed8c)), closes [#23629](https://github.com/bitnami/charts/issues/23629)
+
+## 26.11.0 (2024-02-20)
+
+* [bitnami/*] Bump all versions (#23602) ([b70ee2a](https://github.com/bitnami/charts/commit/b70ee2a)), closes [#23602](https://github.com/bitnami/charts/issues/23602)
+
+## 26.10.0 (2024-02-20)
+
+* [bitnami/kafka] feat: :sparkles: :lock: Add resource preset support (#23468) ([f267103](https://github.com/bitnami/charts/commit/f267103)), closes [#23468](https://github.com/bitnami/charts/issues/23468)
+
+## 26.9.0 (2024-02-15)
+
+* feat: add useHelmHooks value to allow install with --wait (#23460) ([a5b06d4](https://github.com/bitnami/charts/commit/a5b06d4)), closes [#23460](https://github.com/bitnami/charts/issues/23460)
+
+## <small>26.8.5 (2024-02-02)</small>
+
+* [bitnami/kafka] Release 26.8.5 updating components versions (#23087) ([171cf03](https://github.com/bitnami/charts/commit/171cf03)), closes [#23087](https://github.com/bitnami/charts/issues/23087)
+
+## <small>26.8.4 (2024-02-02)</small>
+
+* [bitnami/kafka] fix: Migrate existing broker.id to node.id only when kraft mode enabled (#21940) (#2 ([80e31e8](https://github.com/bitnami/charts/commit/80e31e8)), closes [#21940](https://github.com/bitnami/charts/issues/21940) [#22721](https://github.com/bitnami/charts/issues/22721)
+
+## <small>26.8.3 (2024-01-27)</small>
+
+* [bitnami/kafka] Release 26.8.3 updating components versions (#22804) ([49133b7](https://github.com/bitnami/charts/commit/49133b7)), closes [#22804](https://github.com/bitnami/charts/issues/22804)
+
+## <small>26.8.2 (2024-01-26)</small>
+
+* [bitnami/kafka] fix: :bug: Set seLinuxOptions to null for Openshift compatibility (#22605) ([c444150](https://github.com/bitnami/charts/commit/c444150)), closes [#22605](https://github.com/bitnami/charts/issues/22605)
+* Add missing version, kind to kafka volumeClaimTemplates (#22728) ([7b5f425](https://github.com/bitnami/charts/commit/7b5f425)), closes [#22728](https://github.com/bitnami/charts/issues/22728)
+
+## <small>26.8.1 (2024-01-24)</small>
+
+* [bitnami/*] Move documentation sections from docs.bitnami.com back to the README (#22203) ([7564f36](https://github.com/bitnami/charts/commit/7564f36)), closes [#22203](https://github.com/bitnami/charts/issues/22203)
+* [bitnami/kafka] fix: :lock: Move service-account token auto-mount to pod declaration (#22415) ([76a5880](https://github.com/bitnami/charts/commit/76a5880)), closes [#22415](https://github.com/bitnami/charts/issues/22415)
+* [bitnami/kafka] Release 26.8.1 updating components versions (#22704) ([48afa1a](https://github.com/bitnami/charts/commit/48afa1a)), closes [#22704](https://github.com/bitnami/charts/issues/22704)
+
+## 26.8.0 (2024-01-19)
+
+* [bitnami/kafka] Added option 'allocateLoadBalancerNodePorts' for services of type 'LoadBalancer' (#2 ([230d6a3](https://github.com/bitnami/charts/commit/230d6a3)), closes [#21919](https://github.com/bitnami/charts/issues/21919)
+
+## <small>26.7.1 (2024-01-18)</small>
+
+* [bitnami/kafka] Release 26.7.1 updating components versions (#22295) ([87f887c](https://github.com/bitnami/charts/commit/87f887c)), closes [#22295](https://github.com/bitnami/charts/issues/22295)
+
+## 26.7.0 (2024-01-17)
+
+* [bitnami/kafka] fix: :lock: Improve podSecurityContext and containerSecurityContext with essential s ([5c3feae](https://github.com/bitnami/charts/commit/5c3feae)), closes [#22136](https://github.com/bitnami/charts/issues/22136)
+
+## <small>26.6.3 (2024-01-12)</small>
+
+* [bitnami/*] Fix docs.bitnami.com broken links (#21901) ([f35506d](https://github.com/bitnami/charts/commit/f35506d)), closes [#21901](https://github.com/bitnami/charts/issues/21901)
+* [bitnami/*] Fix ref links (in comments) (#21822) ([e4fa296](https://github.com/bitnami/charts/commit/e4fa296)), closes [#21822](https://github.com/bitnami/charts/issues/21822)
+* [bitnami/*] Update copyright: Year and company (#21815) ([6c4bf75](https://github.com/bitnami/charts/commit/6c4bf75)), closes [#21815](https://github.com/bitnami/charts/issues/21815)
+* [bitnami/kafka] fix: :lock: Do not use the default service account (#22018) ([b3b9432](https://github.com/bitnami/charts/commit/b3b9432)), closes [#22018](https://github.com/bitnami/charts/issues/22018)
+
+## <small>26.6.2 (2023-12-22)</small>
+
+* [bitnami/kafka] Release 26.6.2 updating components versions (#21738) ([9ac23fb](https://github.com/bitnami/charts/commit/9ac23fb)), closes [#21738](https://github.com/bitnami/charts/issues/21738)
+
+## <small>26.6.1 (2023-12-20)</small>
+
+* [bitnami/kafka] Fix Kafka log/logs dir config (#20476) ([a36243d](https://github.com/bitnami/charts/commit/a36243d)), closes [#20476](https://github.com/bitnami/charts/issues/20476)
+
+## 26.6.0 (2023-12-20)
+
+* [bitnami/kafka] feat: :sparkles: Add missing probes (#21650) ([039ce09](https://github.com/bitnami/charts/commit/039ce09)), closes [#21650](https://github.com/bitnami/charts/issues/21650)
+
+## <small>26.5.1 (2023-12-19)</small>
+
+* [bitnami/kafka] Allowing for customize dnsPolicy and dnsConfig for Kafka (#21402) ([0287ecf](https://github.com/bitnami/charts/commit/0287ecf)), closes [#21402](https://github.com/bitnami/charts/issues/21402)
+
+## 26.5.0 (2023-12-13)
+
+* [bitnami/kafka] fix: :bug: Make auto-discovery compatible with PSA restrictedSigned-off-by: Javier S ([1f3bfc8](https://github.com/bitnami/charts/commit/1f3bfc8))
+
+## <small>26.4.5 (2023-12-12)</small>
+
+* [bitnami/kafka] Fix condition for secret mounting (#21358) ([cbff765](https://github.com/bitnami/charts/commit/cbff765)), closes [#21358](https://github.com/bitnami/charts/issues/21358)
+* Make Kafka DefaultMode YAML 1.2 Compliant (#21086) ([b51288a](https://github.com/bitnami/charts/commit/b51288a)), closes [#21086](https://github.com/bitnami/charts/issues/21086) [dtolnay/serde-yaml#225](https://github.com/dtolnay/serde-yaml/issues/225)
+
+## <small>26.4.4 (2023-12-09)</small>
+
+* [bitnami/kafka] Release 26.4.4 updating components versions (#21486) ([75b9ae3](https://github.com/bitnami/charts/commit/75b9ae3)), closes [#21486](https://github.com/bitnami/charts/issues/21486)
+
+## <small>26.4.3 (2023-11-29)</small>
+
+* [bitnami/kafka] Fix controller component validation for external access (#20941) ([d05f605](https://github.com/bitnami/charts/commit/d05f605)), closes [#20941](https://github.com/bitnami/charts/issues/20941)
+
+## <small>26.4.2 (2023-11-21)</small>
+
+* [bitnami/*] Remove relative links to non-README sections, add verification for that and update TL;DR ([1103633](https://github.com/bitnami/charts/commit/1103633)), closes [#20967](https://github.com/bitnami/charts/issues/20967)
+* [bitnami/*] Rename solutions to "Bitnami package for ..." (#21038) ([b82f979](https://github.com/bitnami/charts/commit/b82f979)), closes [#21038](https://github.com/bitnami/charts/issues/21038)
+* [bitnami/kafka] Release 26.4.2 updating components versions (#21127) ([c75c019](https://github.com/bitnami/charts/commit/c75c019)), closes [#21127](https://github.com/bitnami/charts/issues/21127)
+
+## <small>26.4.1 (2023-11-15)</small>
+
+* [bitnami/kafka] Update 'Upgrading notes' section with missing TLS secret breaking change (#20632) ([a46f0ed](https://github.com/bitnami/charts/commit/a46f0ed)), closes [#20632](https://github.com/bitnami/charts/issues/20632)
+
+## 26.4.0 (2023-11-09)
+
+* Add kafka init container custom resource function according to issue #20641 (#20652) ([e4ad6e4](https://github.com/bitnami/charts/commit/e4ad6e4)), closes [#20641](https://github.com/bitnami/charts/issues/20641) [#20652](https://github.com/bitnami/charts/issues/20652) [#20641](https://github.com/bitnami/charts/issues/20641)
+
+## <small>26.3.2 (2023-11-08)</small>
+
+* [bitnami/kafka] Release 26.3.2 updating components versions (#20748) ([02e2724](https://github.com/bitnami/charts/commit/02e2724)), closes [#20748](https://github.com/bitnami/charts/issues/20748)
+
+## <small>26.3.1 (2023-11-07)</small>
+
+* [bitnami/kafka] Release 26.3.1 updating components versions (#20655) ([619011b](https://github.com/bitnami/charts/commit/619011b)), closes [#20655](https://github.com/bitnami/charts/issues/20655)
+
+## 26.3.0 (2023-11-06)
+
+* [bitnami/kafka] Add minReadySeconds configuration (#20571) ([c626d5d](https://github.com/bitnami/charts/commit/c626d5d)), closes [#20571](https://github.com/bitnami/charts/issues/20571)
+
+## <small>26.2.1 (2023-11-03)</small>
+
+* [bitnami/*] Rename VMware Application Catalog (#20361) ([3acc734](https://github.com/bitnami/charts/commit/3acc734)), closes [#20361](https://github.com/bitnami/charts/issues/20361)
+* [bitnami/kafka] Update README (#17029) (#20489) ([72e3761](https://github.com/bitnami/charts/commit/72e3761)), closes [#17029](https://github.com/bitnami/charts/issues/17029) [#20489](https://github.com/bitnami/charts/issues/20489)
+* [bitnami/kafka]: clarify docs (#20484) ([d852a8f](https://github.com/bitnami/charts/commit/d852a8f)), closes [#20484](https://github.com/bitnami/charts/issues/20484)
+
+## 26.2.0 (2023-10-20)
+
+* [bitnami/*] Skip image's tag in the README files of the Bitnami Charts (#19841) ([bb9a01b](https://github.com/bitnami/charts/commit/bb9a01b)), closes [#19841](https://github.com/bitnami/charts/issues/19841)
+* [bitnami/kafka] replicate variable logic for keystore (#19789) ([1f37786](https://github.com/bitnami/charts/commit/1f37786)), closes [#19789](https://github.com/bitnami/charts/issues/19789)
+
+## 26.1.0 (2023-10-20)
+
+* [bitnami/*] Standardize documentation (#19835) ([af5f753](https://github.com/bitnami/charts/commit/af5f753)), closes [#19835](https://github.com/bitnami/charts/issues/19835)
+* [bitnami/kafka] init-script: Remove PEM certificates before start  (#19427) ([86ddf46](https://github.com/bitnami/charts/commit/86ddf46)), closes [#19427](https://github.com/bitnami/charts/issues/19427)
+
+## <small>26.0.1 (2023-10-19)</small>
+
+* [bitnami/kafka] Amend service name for broker external services (#20226) ([ce6806c](https://github.com/bitnami/charts/commit/ce6806c)), closes [#20226](https://github.com/bitnami/charts/issues/20226)
+* [bitnami/kafka] Update README.md (#20272) ([4923e3d](https://github.com/bitnami/charts/commit/4923e3d)), closes [#20272](https://github.com/bitnami/charts/issues/20272)
+
+## 26.0.0 (2023-10-16)
+
+* [bitnami/kafka] Release 26.0.0 (#20262) ([70f1219](https://github.com/bitnami/charts/commit/70f1219)), closes [#20262](https://github.com/bitnami/charts/issues/20262)
+
+## <small>25.3.5 (2023-10-12)</small>
+
+* [bitnami/kafka] Release 25.3.5 updating components versions (#20144) ([767cdb7](https://github.com/bitnami/charts/commit/767cdb7)), closes [#20144](https://github.com/bitnami/charts/issues/20144)
+
+## <small>25.3.4 (2023-10-12)</small>
+
+* [bitnami/kafka] Release 25.3.4 (#20120) ([717032e](https://github.com/bitnami/charts/commit/717032e)), closes [#20120](https://github.com/bitnami/charts/issues/20120)
+
+## <small>25.3.3 (2023-10-09)</small>
+
+* [bitnami/kafka] Release 25.3.3 (#19917) ([bb02298](https://github.com/bitnami/charts/commit/bb02298)), closes [#19917](https://github.com/bitnami/charts/issues/19917)
+
+## <small>25.3.2 (2023-10-09)</small>
+
+* [bitnami/*] Update Helm charts prerequisites (#19745) ([eb755dd](https://github.com/bitnami/charts/commit/eb755dd)), closes [#19745](https://github.com/bitnami/charts/issues/19745)
+* [bitnami/kafka] Release 25.3.2 (#19857) ([4d13755](https://github.com/bitnami/charts/commit/4d13755)), closes [#19857](https://github.com/bitnami/charts/issues/19857)
+* [bitnami/kafka] Update Readme.md (#19767) ([ce42530](https://github.com/bitnami/charts/commit/ce42530)), closes [#19767](https://github.com/bitnami/charts/issues/19767)
+
+## <small>25.3.1 (2023-10-05)</small>
+
+* [bitnami/kafka] log4j configmap metadata (#19682) ([80e25e3](https://github.com/bitnami/charts/commit/80e25e3)), closes [#19682](https://github.com/bitnami/charts/issues/19682)
+
+## 25.3.0 (2023-10-03)
+
+* [bitnami/kafka] Adding support for the sasl mechanism, oauthbearer (#19224) ([f7896ec](https://github.com/bitnami/charts/commit/f7896ec)), closes [#19224](https://github.com/bitnami/charts/issues/19224)
+
+## 25.2.0 (2023-09-29)
+
+* bitnami/kafka add the ability to reference an existing cluster id secret (#19518) ([d3844a7](https://github.com/bitnami/charts/commit/d3844a7)), closes [#19518](https://github.com/bitnami/charts/issues/19518)
+
+## <small>25.1.12 (2023-09-25)</small>
+
+* [bitnami/kafka] Release 25.1.12 (#19499) ([cde5d7c](https://github.com/bitnami/charts/commit/cde5d7c)), closes [#19499](https://github.com/bitnami/charts/issues/19499)
+
+## <small>25.1.11 (2023-09-20)</small>
+
+* [bitnami/kafka] Use different app.kubernetes.io/version label on subcomponents (#19340) ([e0c6df2](https://github.com/bitnami/charts/commit/e0c6df2)), closes [#19340](https://github.com/bitnami/charts/issues/19340)
+* Autogenerate schema files (#19194) ([a2c2090](https://github.com/bitnami/charts/commit/a2c2090)), closes [#19194](https://github.com/bitnami/charts/issues/19194)
+* Revert "Autogenerate schema files (#19194)" (#19335) ([73d80be](https://github.com/bitnami/charts/commit/73d80be)), closes [#19194](https://github.com/bitnami/charts/issues/19194) [#19335](https://github.com/bitnami/charts/issues/19335)
+
+## <small>25.1.10 (2023-09-09)</small>
+
+* [bitnami/kafka] Release 25.1.8 (#19164) ([a3b3966](https://github.com/bitnami/charts/commit/a3b3966)), closes [#19164](https://github.com/bitnami/charts/issues/19164)
+
+## <small>25.1.9 (2023-09-08)</small>
+
+* [bitnami/kafka] Bugfix LogPersistence storageclass (#18957) ([9b54e3d](https://github.com/bitnami/charts/commit/9b54e3d)), closes [#18957](https://github.com/bitnami/charts/issues/18957)
+
+## <small>25.1.8 (2023-09-07)</small>
+
+* [bitnami/kafka]: Use merge helper (#19063) ([5c7ed77](https://github.com/bitnami/charts/commit/5c7ed77)), closes [#19063](https://github.com/bitnami/charts/issues/19063)
+
+## <small>25.1.7 (2023-09-07)</small>
+
+* [bitnami/kafka] Release 25.1.7 (#19160) ([98e95ff](https://github.com/bitnami/charts/commit/98e95ff)), closes [#19160](https://github.com/bitnami/charts/issues/19160)
+
+## <small>25.1.6 (2023-09-05)</small>
+
+* [bitnami/kafka] Added values for supplying additional configuration as a secret object (#18978) ([3e75157](https://github.com/bitnami/charts/commit/3e75157)), closes [#18978](https://github.com/bitnami/charts/issues/18978)
+* [bitnami/kafka] Release 25.1.6 (#19121) ([3e0abdf](https://github.com/bitnami/charts/commit/3e0abdf)), closes [#19121](https://github.com/bitnami/charts/issues/19121)
+* Some fixes for PDB: (#18966) ([8a42abf](https://github.com/bitnami/charts/commit/8a42abf)), closes [#18966](https://github.com/bitnami/charts/issues/18966)
+
+## <small>25.1.5 (2023-09-01)</small>
+
+* [#14600] Support using keys provided by cert-manager (#18887) ([59e1480](https://github.com/bitnami/charts/commit/59e1480)), closes [#14600](https://github.com/bitnami/charts/issues/14600) [#18887](https://github.com/bitnami/charts/issues/18887)
+
+## <small>25.1.4 (2023-08-30)</small>
+
+* [bitnami/kafka] Release 25.1.4 (#18950) ([ba5f8e5](https://github.com/bitnami/charts/commit/ba5f8e5)), closes [#18950](https://github.com/bitnami/charts/issues/18950)
+
+## <small>25.1.3 (2023-08-29)</small>
+
+* [bitnami/kafka] Fix pod affinity labels (#18927) ([9b87f4f](https://github.com/bitnami/charts/commit/9b87f4f)), closes [#18927](https://github.com/bitnami/charts/issues/18927)
+* [bitnami/kafka] Fix typo (#18902) ([de01ec0](https://github.com/bitnami/charts/commit/de01ec0)), closes [#18902](https://github.com/bitnami/charts/issues/18902)
+* [bitnami/kafka] Use the container port instead of the service port in kafka metrics exporter (#18319 ([499c5c5](https://github.com/bitnami/charts/commit/499c5c5)), closes [#18319](https://github.com/bitnami/charts/issues/18319)
+
+## <small>25.1.2 (2023-08-28)</small>
+
+* [bitnami/kafka] Delete a tab in bitnami/kafka/templates/broker/svc-headless.yaml,line 36,which cause ([57328e7](https://github.com/bitnami/charts/commit/57328e7)), closes [#18886](https://github.com/bitnami/charts/issues/18886)
+
+## <small>25.1.1 (2023-08-25)</small>
+
+* [bitnami/kafka] broker pod labels (#18852) ([7a2a0dc](https://github.com/bitnami/charts/commit/7a2a0dc)), closes [#18852](https://github.com/bitnami/charts/issues/18852)
+
+## 25.1.0 (2023-08-24)
+
+* [bitnami/kafka] Support for customizing standard labels (#18609) ([5b306c5](https://github.com/bitnami/charts/commit/5b306c5)), closes [#18609](https://github.com/bitnami/charts/issues/18609)
+
+## <small>25.0.1 (2023-08-24)</small>
+
+* [bitnami/kafka] Change selector labels of kafka JMX metrics exporter (#18815) ([44442b9](https://github.com/bitnami/charts/commit/44442b9)), closes [#18815](https://github.com/bitnami/charts/issues/18815)
+
+## 25.0.0 (2023-08-23)
+
+* [bitnami/kafka] Zookeeper chart update (#18805) ([c051054](https://github.com/bitnami/charts/commit/c051054)), closes [#18805](https://github.com/bitnami/charts/issues/18805)
+
+## <small>24.0.14 (2023-08-19)</small>
+
+* [bitnami/kafka] Release 24.0.14 (#18670) ([511dad2](https://github.com/bitnami/charts/commit/511dad2)), closes [#18670](https://github.com/bitnami/charts/issues/18670)
+
+## <small>24.0.13 (2023-08-18)</small>
+
+* [bitnami/kafka] Release 24.0.13 (#18635) ([d30282d](https://github.com/bitnami/charts/commit/d30282d)), closes [#18635](https://github.com/bitnami/charts/issues/18635)
+
+## <small>24.0.12 (2023-08-18)</small>
+
+* [bitnami/kafka] Release 24.0.12 (#18630) ([5c27d23](https://github.com/bitnami/charts/commit/5c27d23)), closes [#18630](https://github.com/bitnami/charts/issues/18630)
+
+## <small>24.0.11 (2023-08-17)</small>
+
+* [bitnami/kafka] Release 24.0.11 (#18532) ([0fe34db](https://github.com/bitnami/charts/commit/0fe34db)), closes [#18532](https://github.com/bitnami/charts/issues/18532)
+
+## <small>24.0.10 (2023-08-11)</small>
+
+* ! provisioning job to use a writable tmp folder for client.properties; (#18369) ([729161a](https://github.com/bitnami/charts/commit/729161a)), closes [#18369](https://github.com/bitnami/charts/issues/18369)
+
+## <small>24.0.9 (2023-08-10)</small>
+
+* [bitnami/kafka] Add enableServiceLinks (#18324) ([66eb9d7](https://github.com/bitnami/charts/commit/66eb9d7)), closes [#18324](https://github.com/bitnami/charts/issues/18324)
+
+## <small>24.0.8 (2023-08-09)</small>
+
+* [bitnami/kafka] Release 24.0.8 (#18328) ([2382a55](https://github.com/bitnami/charts/commit/2382a55)), closes [#18328](https://github.com/bitnami/charts/issues/18328)
+
+## <small>24.0.7 (2023-08-09)</small>
+
+* [bitnami/kafka] Mount /tmp for kafka-init (#18323) ([d3a850b](https://github.com/bitnami/charts/commit/d3a850b)), closes [#18323](https://github.com/bitnami/charts/issues/18323)
+
+## <small>24.0.6 (2023-08-09)</small>
+
+* [bitnami/kafka] Fix issue with Kafka port in NOTES.txt and restore default service ports (#18274) ([995b868](https://github.com/bitnami/charts/commit/995b868)), closes [#18274](https://github.com/bitnami/charts/issues/18274)
+
+## <small>24.0.5 (2023-08-07)</small>
+
+* [bitnami/kafka] Fix Kafka provisoning (#18242) ([76926cb](https://github.com/bitnami/charts/commit/76926cb)), closes [#18242](https://github.com/bitnami/charts/issues/18242)
+
+## <small>24.0.4 (2023-08-07)</small>
+
+* [bitnami/kafka] Release 24.0.4 (#18234) ([db054a7](https://github.com/bitnami/charts/commit/db054a7)), closes [#18234](https://github.com/bitnami/charts/issues/18234)
+
+## <small>24.0.3 (2023-08-04)</small>
+
+* [bitnami/kafka] Mount /tmp as an emptyDir volume (#18212) ([d6572e4](https://github.com/bitnami/charts/commit/d6572e4)), closes [#18212](https://github.com/bitnami/charts/issues/18212)
+* [bitnami/kafka] Release 24.0.3 (#18217) ([de5c79d](https://github.com/bitnami/charts/commit/de5c79d)), closes [#18217](https://github.com/bitnami/charts/issues/18217)
+
+## <small>24.0.2 (2023-08-04)</small>
+
+* changes from RegexFind to RegexMatch as boolean is expected (#18202) ([bfc6ab7](https://github.com/bitnami/charts/commit/bfc6ab7)), closes [#18202](https://github.com/bitnami/charts/issues/18202)
+
+## <small>24.0.1 (2023-08-04)</small>
+
+* [bitnami/kafka] Always create system-user if client SASL enabled (#18197) ([2e9bbbd](https://github.com/bitnami/charts/commit/2e9bbbd)), closes [#18197](https://github.com/bitnami/charts/issues/18197)
+
+## 24.0.0 (2023-08-03)
+
+* [bitnami/kafka] Chart refactor (#17507) ([fb96509](https://github.com/bitnami/charts/commit/fb96509)), closes [#17507](https://github.com/bitnami/charts/issues/17507)
+
+## <small>23.0.7 (2023-07-25)</small>
+
+* [bitnami/kafka] Release 23.0.7 (#17904) ([4fd78cd](https://github.com/bitnami/charts/commit/4fd78cd)), closes [#17904](https://github.com/bitnami/charts/issues/17904)
+
+## <small>23.0.6 (2023-07-24)</small>
+
+* [bitnami/kafka] Release 23.0.6 (#17843) ([f985538](https://github.com/bitnami/charts/commit/f985538)), closes [#17843](https://github.com/bitnami/charts/issues/17843)
+
+## <small>23.0.5 (2023-07-17)</small>
+
+* [bitnami/kafka] Release 23.0.5 (#17735) ([18b28f5](https://github.com/bitnami/charts/commit/18b28f5)), closes [#17735](https://github.com/bitnami/charts/issues/17735)
+
+## <small>23.0.4 (2023-07-13)</small>
+
+* [bitnami/kafka] Release 23.0.4 (#17695) ([1a65f84](https://github.com/bitnami/charts/commit/1a65f84)), closes [#17695](https://github.com/bitnami/charts/issues/17695)
+
+## <small>23.0.3 (2023-07-13)</small>
+
+* [bitnami/kafka] Release 23.0.3 (#17642) ([e1bc746](https://github.com/bitnami/charts/commit/e1bc746)), closes [#17642](https://github.com/bitnami/charts/issues/17642)
+
+## <small>23.0.2 (2023-07-05)</small>
+
+* [bitnami/kafka] Release 23.0.2 (#17495) ([5213407](https://github.com/bitnami/charts/commit/5213407)), closes [#17495](https://github.com/bitnami/charts/issues/17495)
+
+## <small>23.0.1 (2023-06-27)</small>
+
+* [bitnami/kafka] Release 23.0.1 (#17368) ([235d8c3](https://github.com/bitnami/charts/commit/235d8c3)), closes [#17368](https://github.com/bitnami/charts/issues/17368)
+
+## 23.0.0 (2023-06-26)
+
+* [bitnami/kafka] Release 23.0.0 (#17354) ([ce20f41](https://github.com/bitnami/charts/commit/ce20f41)), closes [#17354](https://github.com/bitnami/charts/issues/17354)
+* Add copyright header (#17300) ([da68be8](https://github.com/bitnami/charts/commit/da68be8)), closes [#17300](https://github.com/bitnami/charts/issues/17300)
+* Update charts readme (#17217) ([31b3c0a](https://github.com/bitnami/charts/commit/31b3c0a)), closes [#17217](https://github.com/bitnami/charts/issues/17217)
+
+## <small>22.1.6 (2023-06-19)</small>
+
+* [bitnami/kafka] Remove KAFKA_ENABLE_KRAFT duplicated keys (#17148) ([ec08951](https://github.com/bitnami/charts/commit/ec08951)), closes [#17148](https://github.com/bitnami/charts/issues/17148)
+
+## <small>22.1.5 (2023-06-07)</small>
+
+* [bitnami/kafka] Release 22.1.5 (#17055) ([8d8d074](https://github.com/bitnami/charts/commit/8d8d074)), closes [#17055](https://github.com/bitnami/charts/issues/17055)
+
+## <small>22.1.4 (2023-06-05)</small>
+
+* [bitnami/*] Change copyright section in READMEs (#17006) ([ef986a1](https://github.com/bitnami/charts/commit/ef986a1)), closes [#17006](https://github.com/bitnami/charts/issues/17006)
+* [bitnami/kafka]Fix kafka.validateValues.tlsPasswords gives an error for provisioning even when provi ([45b550b](https://github.com/bitnami/charts/commit/45b550b)), closes [#16948](https://github.com/bitnami/charts/issues/16948)
+* [bitnami/several] Change copyright section in READMEs (#16989) ([5b6a5cf](https://github.com/bitnami/charts/commit/5b6a5cf)), closes [#16989](https://github.com/bitnami/charts/issues/16989)
+
+## <small>22.1.3 (2023-05-21)</small>
+
+* [bitnami/kafka] Release 22.1.3 (#16778) ([d204faa](https://github.com/bitnami/charts/commit/d204faa)), closes [#16778](https://github.com/bitnami/charts/issues/16778)
+
+## <small>22.1.2 (2023-05-17)</small>
+
+* [bitnami/kafka] Fix issue with Kafka where Zookeeper mode could not be used + minor fixes (#16558) ([3a97a52](https://github.com/bitnami/charts/commit/3a97a52)), closes [#16558](https://github.com/bitnami/charts/issues/16558)
+* [bitnami/kafka] fix:  set domain is ineffective when autoDiscovery #16237 (#16392) ([a2ab641](https://github.com/bitnami/charts/commit/a2ab641)), closes [#16237](https://github.com/bitnami/charts/issues/16237) [#16392](https://github.com/bitnami/charts/issues/16392)
+* Add wording for enterprise page (#16560) ([8f22774](https://github.com/bitnami/charts/commit/8f22774)), closes [#16560](https://github.com/bitnami/charts/issues/16560)
+
+## <small>22.1.1 (2023-05-10)</small>
+
+* [bitnami/kafka] set KAFKA_ENABLE_KRAFT=false if we don't use kraft (#16276) ([33178ed](https://github.com/bitnami/charts/commit/33178ed)), closes [#16276](https://github.com/bitnami/charts/issues/16276)
+
+## 22.1.0 (2023-05-09)
+
+* [bitnami/several] Adapt Chart.yaml to set desired OCI annotations (#16546) ([fc9b18f](https://github.com/bitnami/charts/commit/fc9b18f)), closes [#16546](https://github.com/bitnami/charts/issues/16546)
+
+## <small>22.0.3 (2023-05-09)</small>
+
+* [bitnami/kafka] Release 22.0.3 (#16466) ([6b56379](https://github.com/bitnami/charts/commit/6b56379)), closes [#16466](https://github.com/bitnami/charts/issues/16466)
+
+## <small>22.0.2 (2023-05-04)</small>
+
+* [bitnami/kafka] Fix logic to prevent overwriting voter variable (#16263) ([1f31f8e](https://github.com/bitnami/charts/commit/1f31f8e)), closes [#16263](https://github.com/bitnami/charts/issues/16263)
+
+## <small>22.0.1 (2023-04-27)</small>
+
+* [bitnami/kafka] Use username as key in the Service Binding secret (#16252) ([bdf46e5](https://github.com/bitnami/charts/commit/bdf46e5)), closes [#16252](https://github.com/bitnami/charts/issues/16252)
+
+## 22.0.0 (2023-04-24)
+
+* [bitnami/kafka] Configure Kraft mode by default (#15768) ([f1aec56](https://github.com/bitnami/charts/commit/f1aec56)), closes [#15768](https://github.com/bitnami/charts/issues/15768)
+
+## 21.5.0 (2023-04-20)
+
+* [bitnami/*] Make Helm charts 100% OCI (#15998) ([8841510](https://github.com/bitnami/charts/commit/8841510)), closes [#15998](https://github.com/bitnami/charts/issues/15998)
+
+## <small>21.4.6 (2023-04-20)</small>
+
+* Fix provisioning with bundle CA (#16032) ([31eb383](https://github.com/bitnami/charts/commit/31eb383)), closes [#16032](https://github.com/bitnami/charts/issues/16032)
+
+## <small>21.4.5 (2023-04-19)</small>
+
+* [bitnami/kafka] fix reversed certs in provisioning job when using PEM certs; (#16057) ([c12bc0a](https://github.com/bitnami/charts/commit/c12bc0a)), closes [#16057](https://github.com/bitnami/charts/issues/16057)
+
+## <small>21.4.4 (2023-04-01)</small>
+
+* [bitnami/kafka] Release 21.4.4 (#15857) ([dfc0dde](https://github.com/bitnami/charts/commit/dfc0dde)), closes [#15857](https://github.com/bitnami/charts/issues/15857)
+
+## <small>21.4.3 (2023-03-31)</small>
+
+* [bitnami/kafka] Release 21.4.3 (#15823) ([2dd5f76](https://github.com/bitnami/charts/commit/2dd5f76)), closes [#15823](https://github.com/bitnami/charts/issues/15823)
+
+## <small>21.4.2 (2023-03-28)</small>
+
+* [bitnami/kafka] Release 21.4.2 (#15752) ([728c37d](https://github.com/bitnami/charts/commit/728c37d)), closes [#15752](https://github.com/bitnami/charts/issues/15752)
+
+## <small>21.4.1 (2023-03-22)</small>
+
+* [bitnami/kafka] Add upgrading notes to version 21.0.0 (#15537) ([ee223d9](https://github.com/bitnami/charts/commit/ee223d9)), closes [#15537](https://github.com/bitnami/charts/issues/15537)
+* [bitnami/kafka] kraft.clusterId format docs (#15519) ([43b10fc](https://github.com/bitnami/charts/commit/43b10fc)), closes [#15519](https://github.com/bitnami/charts/issues/15519)
+* [bitnami/kafka] Release 21.4.1 (#15667) ([62b6143](https://github.com/bitnami/charts/commit/62b6143)), closes [#15667](https://github.com/bitnami/charts/issues/15667)
+
+## 21.4.0 (2023-03-13)
+
+* [bitnami/kafka] Allow externalIPs for external access. (#15364) ([a7b0323](https://github.com/bitnami/charts/commit/a7b0323)), closes [#15364](https://github.com/bitnami/charts/issues/15364) [#14222](https://github.com/bitnami/charts/issues/14222)
+
+## <small>21.3.1 (2023-03-09)</small>
+
+* [bitnami/charts] Apply linter to README files (#15357) ([0e29e60](https://github.com/bitnami/charts/commit/0e29e60)), closes [#15357](https://github.com/bitnami/charts/issues/15357)
+* [bitnami/kafka] fix no security protocol defined for listener CONTROLLER (#15409) ([93b4eb1](https://github.com/bitnami/charts/commit/93b4eb1)), closes [#15409](https://github.com/bitnami/charts/issues/15409)
+
+## 21.3.0 (2023-03-07)
+
+* [bitnami/kafka] Kafka Kraft implementation (#14850) ([956de76](https://github.com/bitnami/charts/commit/956de76)), closes [#14850](https://github.com/bitnami/charts/issues/14850)
+
+## 21.2.0 (2023-03-02)
+
+* [bitnami/kafka] Add kafka network metrics (#15295) ([06c5a98](https://github.com/bitnami/charts/commit/06c5a98)), closes [#15295](https://github.com/bitnami/charts/issues/15295)
+
+## <small>21.1.1 (2023-03-01)</small>
+
+* [bitnami/kafka] Release 21.1.1 (#15237) ([5349a74](https://github.com/bitnami/charts/commit/5349a74)), closes [#15237](https://github.com/bitnami/charts/issues/15237)
+
+## 21.1.0 (2023-03-01)
+
+* [kafka] bump to 21.x (#15161) ([7ef7725](https://github.com/bitnami/charts/commit/7ef7725)), closes [#15161](https://github.com/bitnami/charts/issues/15161)
+
+## <small>20.1.1 (2023-02-22)</small>
+
+* [bitnami/kafka] Release 20.1.1 (#15102) ([d952db5](https://github.com/bitnami/charts/commit/d952db5)), closes [#15102](https://github.com/bitnami/charts/issues/15102)
+
+## 20.1.0 (2023-02-21)
+
+* [bitnami/kafka] feat: :sparkles: Add ServiceBinding-compatible secrets (#14938) ([e64ae76](https://github.com/bitnami/charts/commit/e64ae76)), closes [#14938](https://github.com/bitnami/charts/issues/14938)
+
+## <small>21.0.1 (2023-02-17)</small>
+
+* [bitnami/kafka] Release 21.0.1 (#14986) ([e390275](https://github.com/bitnami/charts/commit/e390275)), closes [#14986](https://github.com/bitnami/charts/issues/14986)
+
+## 21.0.0 (2023-02-17)
+
+* [bitnami/*] Change copyright date (#14682) ([add4ec7](https://github.com/bitnami/charts/commit/add4ec7)), closes [#14682](https://github.com/bitnami/charts/issues/14682)
+* [bitnami/*] Fix markdown linter issues (#14874) ([a51e0e8](https://github.com/bitnami/charts/commit/a51e0e8)), closes [#14874](https://github.com/bitnami/charts/issues/14874)
+* [bitnami/*] Fix markdown linter issues 2 (#14890) ([aa96572](https://github.com/bitnami/charts/commit/aa96572)), closes [#14890](https://github.com/bitnami/charts/issues/14890)
+* [bitnami/*] Remove unexpected extra spaces (#14873) ([c97c714](https://github.com/bitnami/charts/commit/c97c714)), closes [#14873](https://github.com/bitnami/charts/issues/14873)
+* [bitnami/kafka] Release 21.0.0 (#14943) ([4d0c758](https://github.com/bitnami/charts/commit/4d0c758)), closes [#14943](https://github.com/bitnami/charts/issues/14943)
+
+## <small>20.0.6 (2023-01-31)</small>
+
+* [bitnami/kafka] Don't regenerate self-signed certs on upgrade (#14629) ([7a5cef7](https://github.com/bitnami/charts/commit/7a5cef7)), closes [#14629](https://github.com/bitnami/charts/issues/14629)
+
+## <small>20.0.5 (2023-01-24)</small>
+
+* [bitnami/*] Change licenses annotation format (#14377) ([0ab7608](https://github.com/bitnami/charts/commit/0ab7608)), closes [#14377](https://github.com/bitnami/charts/issues/14377)
+* [bitnami/*] Unify READMEs (#14472) ([2064fb8](https://github.com/bitnami/charts/commit/2064fb8)), closes [#14472](https://github.com/bitnami/charts/issues/14472)
+* [bitnami/kafka] Release 20.0.5 (#14509) ([bfbb05f](https://github.com/bitnami/charts/commit/bfbb05f)), closes [#14509](https://github.com/bitnami/charts/issues/14509)
+
+## <small>20.0.4 (2023-01-13)</small>
+
+* [bitnami/kafka] Release 20.0.4 (#14337) ([40bf90e](https://github.com/bitnami/charts/commit/40bf90e)), closes [#14337](https://github.com/bitnami/charts/issues/14337)
+
+## <small>20.0.3 (2023-01-12)</small>
+
+* [bitnami/*] Add license annotation and remove obsolete engine parameter (#14293) ([da2a794](https://github.com/bitnami/charts/commit/da2a794)), closes [#14293](https://github.com/bitnami/charts/issues/14293)
+* [bitnami/kafka] Remove hardcoded ports from listeners (#14251) ([13dc244](https://github.com/bitnami/charts/commit/13dc244)), closes [#14251](https://github.com/bitnami/charts/issues/14251)
+
+## <small>20.0.2 (2022-12-19)</small>
+
+* [bitnami/kafka] Release 20.0.2 (#14014) ([95c7f7c](https://github.com/bitnami/charts/commit/95c7f7c)), closes [#14014](https://github.com/bitnami/charts/issues/14014)
+* Expose external port in svc for ClusterIP (#13869) ([d878de3](https://github.com/bitnami/charts/commit/d878de3)), closes [#13869](https://github.com/bitnami/charts/issues/13869)
+
+## <small>20.0.1 (2022-12-10)</small>
+
+* [bitnami/kafka] Release 20.0.1 (#13889) ([8199a23](https://github.com/bitnami/charts/commit/8199a23)), closes [#13889](https://github.com/bitnami/charts/issues/13889)
+
+## 20.0.0 (2022-12-06)
+
+* [bitnami/kafka] Zookeeper chart update (#13839) ([06de679](https://github.com/bitnami/charts/commit/06de679)), closes [#13839](https://github.com/bitnami/charts/issues/13839)
+
+## <small>19.1.5 (2022-12-02)</small>
+
+* [bitnami/kafka] Adding publishNotReadyAddresses to kafka services headless and external. (#13672) ([11576cf](https://github.com/bitnami/charts/commit/11576cf)), closes [#13672](https://github.com/bitnami/charts/issues/13672)
+* [bitnami/kafka] Release 19.1.5 (#13802) ([47c8dc4](https://github.com/bitnami/charts/commit/47c8dc4)), closes [#13802](https://github.com/bitnami/charts/issues/13802)
+
+## <small>19.1.4 (2022-11-29)</small>
+
+* [bitnami/kafka] adding back rollingUpdate default setting (#13592) ([5b09f7a](https://github.com/bitnami/charts/commit/5b09f7a)), closes [#13592](https://github.com/bitnami/charts/issues/13592)
+
+## <small>19.1.3 (2022-11-11)</small>
+
+* [bitnami/kafka] use new memory opts for jmx-exporter (#13445) ([2814eed](https://github.com/bitnami/charts/commit/2814eed)), closes [#13445](https://github.com/bitnami/charts/issues/13445)
+
+## <small>19.1.2 (2022-11-08)</small>
+
+* [bitnami/kafka] Create rolebindings always (#13403) ([49a0598](https://github.com/bitnami/charts/commit/49a0598)), closes [#13403](https://github.com/bitnami/charts/issues/13403)
+* [bitnami/kafka] Force new version publishing (#13411) ([289822e](https://github.com/bitnami/charts/commit/289822e)), closes [#13411](https://github.com/bitnami/charts/issues/13411)
+
+## <small>19.1.1 (2022-11-08)</small>
+
+* [bitnami/kafka] Allow Kafka provisioning to be assigned a service account (#13091) ([841d781](https://github.com/bitnami/charts/commit/841d781)), closes [#13091](https://github.com/bitnami/charts/issues/13091)
+* [bitnami/kafka] Release 19.1.1 (#13401) ([fa439b2](https://github.com/bitnami/charts/commit/fa439b2)), closes [#13401](https://github.com/bitnami/charts/issues/13401)
+
+## 19.1.0 (2022-11-04)
+
+* [bitnami/kafka] Add support set config broker.rack with AWS availability zone info (#13308) ([cbd65c9](https://github.com/bitnami/charts/commit/cbd65c9)), closes [#13308](https://github.com/bitnami/charts/issues/13308)
+
+## <small>19.0.2 (2022-11-02)</small>
+
+* [bitnami/kafka] removing default value updateStrategy.rollingUpdate (#13271) ([5b80521](https://github.com/bitnami/charts/commit/5b80521)), closes [#13271](https://github.com/bitnami/charts/issues/13271)
+
+## <small>19.0.1 (2022-10-21)</small>
+
+* [bitnami/*] Use new default branch name in links (#12943) ([a529e02](https://github.com/bitnami/charts/commit/a529e02)), closes [#12943](https://github.com/bitnami/charts/issues/12943)
+* [bitnami/kafka] Add nodeSelector to Kafka provisioning (#12913) ([92a77bd](https://github.com/bitnami/charts/commit/92a77bd)), closes [#12913](https://github.com/bitnami/charts/issues/12913)
+* [bitnami/kafka] Added description on how to set ssl.client.auth=required in Kafka configuration (#12 ([3620d8c](https://github.com/bitnami/charts/commit/3620d8c)), closes [#12650](https://github.com/bitnami/charts/issues/12650)
+* [bitnami/kafka] Upgrade README after releasing version 19.0.0 (#12898) ([d8cb4aa](https://github.com/bitnami/charts/commit/d8cb4aa)), closes [#12898](https://github.com/bitnami/charts/issues/12898)
+
+## 19.0.0 (2022-10-10)
+
+* [bitnami/kafka] Release 19.0.0 (#12892) ([5fca92c](https://github.com/bitnami/charts/commit/5fca92c)), closes [#12892](https://github.com/bitnami/charts/issues/12892)
+* Generic README instructions related to the repo (#12792) ([3cf6b10](https://github.com/bitnami/charts/commit/3cf6b10)), closes [#12792](https://github.com/bitnami/charts/issues/12792)
+
+## 18.5.0 (2022-10-04)
+
+* [bitnami/kafka] Add labels to volume claim template (#12641) ([ec3aa60](https://github.com/bitnami/charts/commit/ec3aa60)), closes [#12641](https://github.com/bitnami/charts/issues/12641)
+
+## <small>18.4.4 (2022-09-21)</small>
+
+* [bitnami/kafka] Release 18.4.4 (#12618) ([f3197b4](https://github.com/bitnami/charts/commit/f3197b4)), closes [#12618](https://github.com/bitnami/charts/issues/12618)
+* [bitnami/kafka] Use custom probes if given (#12510) ([ff0c2a0](https://github.com/bitnami/charts/commit/ff0c2a0)), closes [#12510](https://github.com/bitnami/charts/issues/12510) [#12354](https://github.com/bitnami/charts/issues/12354)
+
+## <small>18.4.3 (2022-09-20)</small>
+
+* [bitnami/kafka] Release 18.4.3 (#12587) ([74e522b](https://github.com/bitnami/charts/commit/74e522b)), closes [#12587](https://github.com/bitnami/charts/issues/12587)
+
+## <small>18.4.2 (2022-09-15)</small>
+
+* [bitnami/kafka] Release 18.4.2 (#12441) ([b28a288](https://github.com/bitnami/charts/commit/b28a288)), closes [#12441](https://github.com/bitnami/charts/issues/12441)
+
+## <small>18.4.1 (2022-09-15)</small>
+
+* [bitnami/kafka] Disallowing privilege escalation for kafka (#12313) ([c2cf11a](https://github.com/bitnami/charts/commit/c2cf11a)), closes [#12313](https://github.com/bitnami/charts/issues/12313)
+* [bitnami/kafka] Fix KAFKA_CFG_LOG_RETENTION_CHECK_INTERVALS_MS typo (#12169) ([1ea8e40](https://github.com/bitnami/charts/commit/1ea8e40)), closes [#12169](https://github.com/bitnami/charts/issues/12169) [#12164](https://github.com/bitnami/charts/issues/12164)
+* [bitnami/kafka] implement prometheusrule (#12377) ([b1e051e](https://github.com/bitnami/charts/commit/b1e051e)), closes [#12377](https://github.com/bitnami/charts/issues/12377)
+
+## 18.4.0 (2022-09-14)
+
+* [bitnami/kafka] Enable external access via cluster IP (#11853) ([909819b](https://github.com/bitnami/charts/commit/909819b)), closes [#11853](https://github.com/bitnami/charts/issues/11853)
+
+## <small>18.3.1 (2022-08-30)</small>
+
+* [bitnami/kafka] Release 18.3.1 (#12201) ([d08cd2d](https://github.com/bitnami/charts/commit/d08cd2d)), closes [#12201](https://github.com/bitnami/charts/issues/12201)
+
+## 18.3.0 (2022-08-25)
+
+* [bitnami/kafka] adding extra rules to jmx template (#11996) ([e65cd43](https://github.com/bitnami/charts/commit/e65cd43)), closes [#11996](https://github.com/bitnami/charts/issues/11996)
+
+## 18.2.0 (2022-08-24)
+
+* bitnami/kafka Adding external service labels (#11780) ([f213c37](https://github.com/bitnami/charts/commit/f213c37)), closes [#11780](https://github.com/bitnami/charts/issues/11780)
+
+## <small>18.1.3 (2022-08-23)</small>
+
+* [bitnami/kafka] Update Chart.lock (#12122) ([7338d25](https://github.com/bitnami/charts/commit/7338d25)), closes [#12122](https://github.com/bitnami/charts/issues/12122)
+
+## <small>18.1.2 (2022-08-23)</small>
+
+* revert logsDir log /opt/bitnami/data by default (#11788) ([a7673f7](https://github.com/bitnami/charts/commit/a7673f7)), closes [#11788](https://github.com/bitnami/charts/issues/11788)
+
+## <small>18.1.1 (2022-08-22)</small>
+
+* [bitnami/kafka] Update Chart.lock (#11987) ([5b65a36](https://github.com/bitnami/charts/commit/5b65a36)), closes [#11987](https://github.com/bitnami/charts/issues/11987)
+
+## 18.1.0 (2022-08-22)
+
+* [bitnami/kafka] Add support for image digest apart from tag (#11908) ([f870b04](https://github.com/bitnami/charts/commit/f870b04)), closes [#11908](https://github.com/bitnami/charts/issues/11908)
+
+## <small>18.0.8 (2022-08-09)</small>
+
+* [bitnami/kafka] Release 18.0.8 (#11682) ([37deddd](https://github.com/bitnami/charts/commit/37deddd)), closes [#11682](https://github.com/bitnami/charts/issues/11682)
+
+## <small>18.0.7 (2022-08-05)</small>
+
+* [bitnami/kafka] Fix typo introduced in 11569 (#11612) ([4f11de9](https://github.com/bitnami/charts/commit/4f11de9)), closes [#11612](https://github.com/bitnami/charts/issues/11612)
+* [bitnami/kafka] Modify logsDir to use persistence.mountPath (#11569) ([98a4d64](https://github.com/bitnami/charts/commit/98a4d64)), closes [#11569](https://github.com/bitnami/charts/issues/11569)
+
+## <small>18.0.6 (2022-08-04)</small>
+
+* [bitnami/kafka] Release 18.0.6 (#11604) ([2ae853c](https://github.com/bitnami/charts/commit/2ae853c)), closes [#11604](https://github.com/bitnami/charts/issues/11604)
+
+## <small>18.0.5 (2022-08-04)</small>
+
+* [bitnami/kafka] Release 18.0.5 (#11560) ([e7ae7a7](https://github.com/bitnami/charts/commit/e7ae7a7)), closes [#11560](https://github.com/bitnami/charts/issues/11560)
+
+## <small>18.0.4 (2022-08-03)</small>
+
+* [bitnami/*] Update URLs to point to the new bitnami/containers monorepo (#11352) ([d665af0](https://github.com/bitnami/charts/commit/d665af0)), closes [#11352](https://github.com/bitnami/charts/issues/11352)
+* [bitnami/kafka] Release 18.0.4 (#11511) ([40f31ce](https://github.com/bitnami/charts/commit/40f31ce)), closes [#11511](https://github.com/bitnami/charts/issues/11511)
+
+## <small>18.0.3 (2022-07-06)</small>
+
+* [bitnami/kafka] Release 18.0.3 (#11056) ([5360260](https://github.com/bitnami/charts/commit/5360260)), closes [#11056](https://github.com/bitnami/charts/issues/11056)
+
+## <small>18.0.2 (2022-07-05)</small>
+
+* [bitnami/kafka] Release 18.0.2 (#11026) ([a5606d0](https://github.com/bitnami/charts/commit/a5606d0)), closes [#11026](https://github.com/bitnami/charts/issues/11026)
+
+## <small>18.0.1 (2022-06-30)</small>
+
+* [bitnami/kafka] Release 18.0.1 (#10952) ([0e21deb](https://github.com/bitnami/charts/commit/0e21deb)), closes [#10952](https://github.com/bitnami/charts/issues/10952)
+
+## 18.0.0 (2022-06-15)
+
+* [bitnami/kafka] #10470: component labels for jmx & kafka exporter (#10551) ([22b2a67](https://github.com/bitnami/charts/commit/22b2a67)), closes [#10470](https://github.com/bitnami/charts/issues/10470) [#10551](https://github.com/bitnami/charts/issues/10551)
+* [bitnami/kafka] Update Zookeeper major and subchart values (#10760) ([d2ecf9a](https://github.com/bitnami/charts/commit/d2ecf9a)), closes [#10760](https://github.com/bitnami/charts/issues/10760)
+
+## <small>17.2.6 (2022-06-11)</small>
+
+* [bitnami/kafka] Release 17.2.6 updating components versions ([148773c](https://github.com/bitnami/charts/commit/148773c))
+
+## <small>17.2.5 (2022-06-07)</small>
+
+* [bitnami/*] Replace Kubeapps URL in READMEs (and kubeapps Chart.yaml) and remove BKPR references (#1 ([c6a7914](https://github.com/bitnami/charts/commit/c6a7914)), closes [#10600](https://github.com/bitnami/charts/issues/10600)
+* Fix tolerations and topologySpreadConstraints default values (#10629) ([f7a7d04](https://github.com/bitnami/charts/commit/f7a7d04)), closes [#10629](https://github.com/bitnami/charts/issues/10629)
+
+## <small>17.2.4 (2022-06-06)</small>
+
+* [bitnami/kafka] Release 17.2.4 updating components versions ([d6d4840](https://github.com/bitnami/charts/commit/d6d4840))
+
+## <small>17.2.3 (2022-06-01)</small>
+
+* [bitnami/kafka] Fix link in README (#10526) ([3f28032](https://github.com/bitnami/charts/commit/3f28032)), closes [#10526](https://github.com/bitnami/charts/issues/10526)
+
+## <small>17.2.2 (2022-06-01)</small>
+
+* [bitnami/several] Replace maintainers email by url (#10523) ([ff3cf61](https://github.com/bitnami/charts/commit/ff3cf61)), closes [#10523](https://github.com/bitnami/charts/issues/10523)
+
+## <small>17.2.1 (2022-05-30)</small>
+
+* [bitnami/several] Replace base64 --decode with base64 -d (#10495) ([099286a](https://github.com/bitnami/charts/commit/099286a)), closes [#10495](https://github.com/bitnami/charts/issues/10495)
+
+## 17.2.0 (2022-05-30)
+
+* [bitnami/kafka] Allow to configure headless svc labels and annotations (#9873) ([82915ee](https://github.com/bitnami/charts/commit/82915ee)), closes [#9873](https://github.com/bitnami/charts/issues/9873)
+
+## 17.1.0 (2022-05-26)
+
+* [bitnami/kafka] Add missing service parameter (#10417) ([cb61bcb](https://github.com/bitnami/charts/commit/cb61bcb)), closes [#10417](https://github.com/bitnami/charts/issues/10417)
+
+## <small>17.0.1 (2022-05-25)</small>
+
+* [bitnami/kafka] Release 17.0.1 updating components versions ([c73b1c3](https://github.com/bitnami/charts/commit/c73b1c3))
+
+## 17.0.0 (2022-05-23)
+
+* [bitnami/kafka] Release 17.0.0 updating components versions ([1ea3e29](https://github.com/bitnami/charts/commit/1ea3e29))
+
+## 16.4.0 (2022-05-23)
+
+* [bitnami/kafka] Add provisioning job tolerations (#10330) ([43f87f1](https://github.com/bitnami/charts/commit/43f87f1)), closes [#10330](https://github.com/bitnami/charts/issues/10330)
+
+## <small>16.3.2 (2022-05-21)</small>
+
+* [bitnami/kafka] Release 16.3.2 updating components versions ([149ee61](https://github.com/bitnami/charts/commit/149ee61))
+
+## <small>16.3.1 (2022-05-20)</small>
+
+* [bitnami/kafka] Release 16.3.1 updating components versions ([a94e8ca](https://github.com/bitnami/charts/commit/a94e8ca))
+
+## 16.3.0 (2022-05-19)
+
+* [bitnami/kafka] Add parameters to configure SSL for Zookeeper client connections (#9915) ([a34396e](https://github.com/bitnami/charts/commit/a34396e)), closes [#9915](https://github.com/bitnami/charts/issues/9915)
+
+## <small>16.2.15 (2022-05-19)</small>
+
+* [bitnami/kafka] Release 16.2.15 updating components versions ([9b716a8](https://github.com/bitnami/charts/commit/9b716a8))
+
+## <small>16.2.14 (2022-05-18)</small>
+
+* [bitnami/kafka] Release 16.2.14 updating components versions ([2b284ac](https://github.com/bitnami/charts/commit/2b284ac))
+
+## <small>16.2.13 (2022-05-13)</small>
+
+* [bitnami/kafka] Release 16.2.13 updating components versions ([51836a3](https://github.com/bitnami/charts/commit/51836a3))
+
+## <small>16.2.12 (2022-05-13)</small>
+
+* [bitnami/*] Remove old 'ci' files (#10171) ([5df30c4](https://github.com/bitnami/charts/commit/5df30c4)), closes [#10171](https://github.com/bitnami/charts/issues/10171)
+* [bitnami/*] Unify k8s directives separators (#10185) ([2650214](https://github.com/bitnami/charts/commit/2650214)), closes [#10185](https://github.com/bitnami/charts/issues/10185)
+
+## <small>16.2.11 (2022-05-11)</small>
+
+* [bitnami/kafka] Add missing namespace metadata (#10129) ([990eb85](https://github.com/bitnami/charts/commit/990eb85)), closes [#10129](https://github.com/bitnami/charts/issues/10129)
+* [bitnami/kafka] Fix label selector in jmx service monitor (#9995) ([648e5f3](https://github.com/bitnami/charts/commit/648e5f3)), closes [#9995](https://github.com/bitnami/charts/issues/9995)
+
+## <small>16.2.10 (2022-05-04)</small>
+
+* [bitnami/kafka] Append zookeeperChrootPath when using external zookeeper. (#9990) ([13eaa3f](https://github.com/bitnami/charts/commit/13eaa3f)), closes [#9990](https://github.com/bitnami/charts/issues/9990)
+
+## <small>16.2.9 (2022-04-26)</small>
+
+* [bitnami/kafka] Add chown for data dir, not only children (#9690) (#9823) ([d13421d](https://github.com/bitnami/charts/commit/d13421d)), closes [#9690](https://github.com/bitnami/charts/issues/9690) [#9823](https://github.com/bitnami/charts/issues/9823) [#9690](https://github.com/bitnami/charts/issues/9690)
+
+## <small>16.2.8 (2022-04-25)</small>
+
+* [bitnami/kafka] Release 16.2.8 updating components versions ([58f7748](https://github.com/bitnami/charts/commit/58f7748))
+
+## <small>16.2.7 (2022-04-21)</small>
+
+* [bitnami/kafka] Release 16.2.7 updating components versions ([1054315](https://github.com/bitnami/charts/commit/1054315))
+
+## <small>16.2.6 (2022-04-20)</small>
+
+* [bitnami/kafka] Release 16.2.6 updating components versions ([a40de81](https://github.com/bitnami/charts/commit/a40de81))
+
+## <small>16.2.5 (2022-04-19)</small>
+
+* [bitnami/kafka] Release 16.2.5 updating components versions ([c3d5344](https://github.com/bitnami/charts/commit/c3d5344))
+
+## <small>16.2.4 (2022-04-18)</small>
+
+* [bitnami/kafka] Release 16.2.4 updating components versions ([123d19a](https://github.com/bitnami/charts/commit/123d19a))
+
+## <small>16.2.3 (2022-04-05)</small>
+
+* [bitnami/kafka] Release 16.2.3 updating components versions ([701f434](https://github.com/bitnami/charts/commit/701f434))
+
+## <small>16.2.2 (2022-04-03)</small>
+
+* [bitnami/kafka] Release 16.2.2 updating components versions ([e168391](https://github.com/bitnami/charts/commit/e168391))
+
+## <small>16.2.1 (2022-04-02)</small>
+
+* [bitnami/kafka] Release 16.2.1 updating components versions ([8abde33](https://github.com/bitnami/charts/commit/8abde33))
+
+## 16.2.0 (2022-03-30)
+
+* [bitnami/kafka] Improve SASL handling and support for service mesh (#9242) ([5f0728d](https://github.com/bitnami/charts/commit/5f0728d)), closes [#9242](https://github.com/bitnami/charts/issues/9242)
+
+## <small>16.1.3 (2022-03-29)</small>
+
+* [bitnami/kafka] Release 16.1.3 updating components versions ([ce63b28](https://github.com/bitnami/charts/commit/ce63b28))
+
+## <small>16.1.2 (2022-03-28)</small>
+
+* [bitnami/kafka] Release 16.1.2 updating components versions ([7f5b5e7](https://github.com/bitnami/charts/commit/7f5b5e7))
+
+## <small>16.1.1 (2022-03-27)</small>
+
+* [bitnami/kafka] Release 16.1.1 updating components versions ([16a191a](https://github.com/bitnami/charts/commit/16a191a))
+
+## 16.1.0 (2022-03-25)
+
+* chore: add the possibility to provision kafka topics in parallel (#9520) ([7fdd75e](https://github.com/bitnami/charts/commit/7fdd75e)), closes [#9520](https://github.com/bitnami/charts/issues/9520)
+
+## 16.0.0 (2022-03-24)
+
+* [bitnami/kakfa] Update zookeeper version for kafka (#9549) ([5fa146a](https://github.com/bitnami/charts/commit/5fa146a)), closes [#9549](https://github.com/bitnami/charts/issues/9549)
+
+## <small>15.5.1 (2022-03-21)</small>
+
+* [bitnami/kafka] Release 15.5.1 updating components versions ([1fdd228](https://github.com/bitnami/charts/commit/1fdd228))
+
+## 15.5.0 (2022-03-18)
+
+* [bitnami/kafka] Allow PEM chain to be used for TLS (#9422) ([801091d](https://github.com/bitnami/charts/commit/801091d)), closes [#9422](https://github.com/bitnami/charts/issues/9422)
+
+## <small>15.4.3 (2022-03-18)</small>
+
+* [bitnami/kafka] Release 15.4.3 updating components versions ([cb64d46](https://github.com/bitnami/charts/commit/cb64d46))
+
+## <small>15.4.2 (2022-03-17)</small>
+
+* [bitnami/kafka] Release 15.4.2 updating components versions ([4adf8d6](https://github.com/bitnami/charts/commit/4adf8d6))
+
+## <small>15.4.1 (2022-03-16)</small>
+
+* [bitnami/kafka] Release 15.4.1 updating components versions ([8ca4706](https://github.com/bitnami/charts/commit/8ca4706))
+
+## 15.4.0 (2022-03-10)
+
+* [bitnami/kafka] Enable SSL for kafka privisioning job (#9072) ([a7aa286](https://github.com/bitnami/charts/commit/a7aa286)), closes [#9072](https://github.com/bitnami/charts/issues/9072)
+
+## <small>15.3.8 (2022-03-09)</small>
+
+* [bitnami/kafka] Release 15.3.8 updating components versions ([8639cf9](https://github.com/bitnami/charts/commit/8639cf9))
+
+## <small>15.3.7 (2022-03-09)</small>
+
+* [bitnami/kafka] Fix typo in comment (#9341) ([b9eb6e0](https://github.com/bitnami/charts/commit/b9eb6e0)), closes [#9341](https://github.com/bitnami/charts/issues/9341)
+
+## <small>15.3.6 (2022-03-07)</small>
+
+* Fix rendering of topologySpreadConstraints (#9149) ([caae35a](https://github.com/bitnami/charts/commit/caae35a)), closes [#9149](https://github.com/bitnami/charts/issues/9149)
+
+## <small>15.3.5 (2022-03-04)</small>
+
+* [bitnami/several] Reorder subcharts (#9299) ([a041f6b](https://github.com/bitnami/charts/commit/a041f6b)), closes [#9299](https://github.com/bitnami/charts/issues/9299)
+
+## <small>15.3.4 (2022-03-01)</small>
+
+* [bitnami/kafka] Release 15.3.4 updating components versions ([95b5329](https://github.com/bitnami/charts/commit/95b5329))
+
+## <small>15.3.3 (2022-02-27)</small>
+
+* [bitnami/kafka] Release 15.3.3 updating components versions ([f752d88](https://github.com/bitnami/charts/commit/f752d88))
+
+## <small>15.3.2 (2022-02-22)</small>
+
+* Add hostIPC option for Kafka StatefulSet (#9156) ([5662ba9](https://github.com/bitnami/charts/commit/5662ba9)), closes [#9156](https://github.com/bitnami/charts/issues/9156)
+* Add hostNetwork option for Kafka StatefulSet (#9081) ([e511753](https://github.com/bitnami/charts/commit/e511753)), closes [#9081](https://github.com/bitnami/charts/issues/9081)
+
+## <small>15.3.1 (2022-02-21)</small>
+
+* [bitnami/kafka] Add flag '-r' to xargs in volumePermissions init-container (#9134) ([e928476](https://github.com/bitnami/charts/commit/e928476)), closes [#9134](https://github.com/bitnami/charts/issues/9134)
+
+## 15.3.0 (2022-02-17)
+
+* [bitnami/kafka] Add passwordSecret parameter (#8936) ([b192405](https://github.com/bitnami/charts/commit/b192405)), closes [#8936](https://github.com/bitnami/charts/issues/8936)
+
+## <small>15.2.3 (2022-02-17)</small>
+
+* [btinami/kafka] Fixes kafka_exporter with TLS (#9042) ([be26f17](https://github.com/bitnami/charts/commit/be26f17)), closes [#9042](https://github.com/bitnami/charts/issues/9042)
+
+## <small>15.2.1 (2022-02-15)</small>
+
+* [bitnami/kafka] Release 15.2.1 updating components versions ([cf80444](https://github.com/bitnami/charts/commit/cf80444))
+
+## 15.2.0 (2022-02-15)
+
+* [bitnami/kafka] Include new parameter to allow setting external names for load balanced external lis ([a8028de](https://github.com/bitnami/charts/commit/a8028de)), closes [#8983](https://github.com/bitnami/charts/issues/8983) [bitnami/charts#8983](https://github.com/bitnami/charts/issues/8983) [bitnami/charts#8875](https://github.com/bitnami/charts/issues/8875)
+
+## <small>15.1.1 (2022-02-11)</small>
+
+* [bitnami/kafka] Fix SASL mechanisms in Kafka exporter (#8980) ([0dc3f89](https://github.com/bitnami/charts/commit/0dc3f89)), closes [#8980](https://github.com/bitnami/charts/issues/8980)
+
+## 15.1.0 (2022-02-08)
+
+* [bitnami/kafka] Add external clients setting (#8902) ([f5e8d0b](https://github.com/bitnami/charts/commit/f5e8d0b)), closes [#8902](https://github.com/bitnami/charts/issues/8902) [#8856](https://github.com/bitnami/charts/issues/8856) [#8660](https://github.com/bitnami/charts/issues/8660)
+
+## <small>15.0.5 (2022-02-07)</small>
+
+* [bitnami/kafka] Fix volumeMounts error for kafka-provisioning (#8910) ([119656c](https://github.com/bitnami/charts/commit/119656c)), closes [#8910](https://github.com/bitnami/charts/issues/8910)
+
+## <small>15.0.4 (2022-02-03)</small>
+
+* Changed CRLF to LF (#8886) ([994bcd2](https://github.com/bitnami/charts/commit/994bcd2)), closes [#8886](https://github.com/bitnami/charts/issues/8886)
+
+## <small>15.0.3 (2022-02-02)</small>
+
+* [bitnami/kafka] Release 15.0.3 updating components versions ([62a53a8](https://github.com/bitnami/charts/commit/62a53a8))
+
+## <small>15.0.2 (2022-02-02)</small>
+
+* [bitnami/*] Fix non-utf8 characters (#8826) ([aebe0ed](https://github.com/bitnami/charts/commit/aebe0ed)), closes [#8826](https://github.com/bitnami/charts/issues/8826)
+* [bitnami/kafka] Provisioning hook lifecycle (#8870) ([4d0be3e](https://github.com/bitnami/charts/commit/4d0be3e)), closes [#8870](https://github.com/bitnami/charts/issues/8870)
+
+## <small>15.0.1 (2022-01-25)</small>
+
+* [bitnami/kafka] Release 15.0.1 updating components versions ([2783625](https://github.com/bitnami/charts/commit/2783625))
+
+## 15.0.0 (2022-01-24)
+
+* [bitnami/kafka] Kafka 3 + Chart standardized (#8666) ([a0732d7](https://github.com/bitnami/charts/commit/a0732d7)), closes [#8666](https://github.com/bitnami/charts/issues/8666)
+
+## <small>14.9.3 (2022-01-20)</small>
+
+* fix resource-name for kafka-egress-netpol (#8727) ([aec00b4](https://github.com/bitnami/charts/commit/aec00b4)), closes [#8727](https://github.com/bitnami/charts/issues/8727)
+
+## <small>14.9.2 (2022-01-20)</small>
+
+* [bitnami/*] Readme automation (#8579) ([78d1938](https://github.com/bitnami/charts/commit/78d1938)), closes [#8579](https://github.com/bitnami/charts/issues/8579)
+* [bitnami/*] Update READMEs (#8716) ([b9a9533](https://github.com/bitnami/charts/commit/b9a9533)), closes [#8716](https://github.com/bitnami/charts/issues/8716)
+* [bitnami/several] Change prerequisites (#8725) ([8d740c5](https://github.com/bitnami/charts/commit/8d740c5)), closes [#8725](https://github.com/bitnami/charts/issues/8725)
+
+## <small>14.9.1 (2022-01-14)</small>
+
+* [bitnami/kafka] Release 14.9.1 updating components versions ([109571b](https://github.com/bitnami/charts/commit/109571b))
+
+## 14.9.0 (2022-01-05)
+
+* [bitnami/several] Adapt templating format (#8562) ([8cad18a](https://github.com/bitnami/charts/commit/8cad18a)), closes [#8562](https://github.com/bitnami/charts/issues/8562)
+* [bitnami/several] Add license to the README ([05f7633](https://github.com/bitnami/charts/commit/05f7633))
+* [bitnami/several] Add license to the README ([32fb238](https://github.com/bitnami/charts/commit/32fb238))
+* [bitnami/several] Add license to the README ([b87c2f7](https://github.com/bitnami/charts/commit/b87c2f7))
+
+## <small>14.8.1 (2021-12-22)</small>
+
+* [bitnami/kafka] Improved compatibility with Kubernetes 1.21+ and Openshift (#8458) ([94bc49b](https://github.com/bitnami/charts/commit/94bc49b)), closes [#8458](https://github.com/bitnami/charts/issues/8458)
+
+## 14.8.0 (2021-12-22)
+
+* [bitnami/kafka] Add egress custom rules (#8445) ([c30197d](https://github.com/bitnami/charts/commit/c30197d)), closes [#8445](https://github.com/bitnami/charts/issues/8445)
+
+## <small>14.7.1 (2021-12-15)</small>
+
+* [bitnami/kafka] Release 14.7.1 updating components versions ([697e832](https://github.com/bitnami/charts/commit/697e832))
+
+## 14.7.0 (2021-12-14)
+
+* [bitnami/kafka] Add networkpolicy support (#8356) ([cffa866](https://github.com/bitnami/charts/commit/cffa866)), closes [#8356](https://github.com/bitnami/charts/issues/8356)
+
+## 14.6.0 (2021-12-13)
+
+* [bitnami/kafka] Add value zookeeperChrootPath (#8285) ([7965edb](https://github.com/bitnami/charts/commit/7965edb)), closes [#8285](https://github.com/bitnami/charts/issues/8285)
+
+## <small>14.5.1 (2021-12-10)</small>
+
+* [bitnami/kafka] use resources for provisioning initContainer (#8276) ([13aa12b](https://github.com/bitnami/charts/commit/13aa12b)), closes [#8276](https://github.com/bitnami/charts/issues/8276)
+
+## 14.5.0 (2021-12-09)
+
+* [bitnami/kafka] Make it possible to customize the securityContext in all containers (#8319) ([ae92f76](https://github.com/bitnami/charts/commit/ae92f76)), closes [#8319](https://github.com/bitnami/charts/issues/8319)
+* [bitnami/several] Regenerate README tables ([8150149](https://github.com/bitnami/charts/commit/8150149))
+
+## <small>14.4.3 (2021-11-29)</small>
+
+* [bitnami/several] Replace HTTP by HTTPS when possible (#8259) ([eafb5bd](https://github.com/bitnami/charts/commit/eafb5bd)), closes [#8259](https://github.com/bitnami/charts/issues/8259)
+
+## <small>14.4.2 (2021-11-28)</small>
+
+* [bitnami/kafka] Release 14.4.2 updating components versions ([adfdfa8](https://github.com/bitnami/charts/commit/adfdfa8))
+* [bitnami/several] Fix deadlinks in README.md (#8215) ([99e90d2](https://github.com/bitnami/charts/commit/99e90d2)), closes [#8215](https://github.com/bitnami/charts/issues/8215)
+* [bitnami/several] Regenerate README tables ([3d7ca74](https://github.com/bitnami/charts/commit/3d7ca74))
+
+## <small>14.4.1 (2021-11-15)</small>
+
+* [bitnami/kafka] Add values to set pod labels and annotations for kafka exporter (#8114) ([eea9cf2](https://github.com/bitnami/charts/commit/eea9cf2)), closes [#8114](https://github.com/bitnami/charts/issues/8114)
+* [bitnami/several] Regenerate README tables ([e6f742c](https://github.com/bitnami/charts/commit/e6f742c))
+
+## 14.4.0 (2021-11-11)
+
+* [bitnami/kafka] Add separate service account for kafka exporter (#8045) ([39f1adb](https://github.com/bitnami/charts/commit/39f1adb)), closes [#8045](https://github.com/bitnami/charts/issues/8045)
+
+## 14.3.0 (2021-11-09)
+
+* [bitnami/kafka] Use an array for existing secrets containing TLS certs (#8060) ([c4e5c94](https://github.com/bitnami/charts/commit/c4e5c94)), closes [#8060](https://github.com/bitnami/charts/issues/8060)
+
+## <small>14.2.6 (2021-11-09)</small>
+
+* [bitnami/kafka] evaluate extraVolumes and extraVolumeMounts as a template (#8066) ([1f4027e](https://github.com/bitnami/charts/commit/1f4027e)), closes [#8066](https://github.com/bitnami/charts/issues/8066)
+* [bitnami/several] Regenerate README tables ([6e3fb95](https://github.com/bitnami/charts/commit/6e3fb95))
+
+## <small>14.2.5 (2021-10-27)</small>
+
+* [bitnami/kafka] Release 14.2.5 updating components versions ([c8f657f](https://github.com/bitnami/charts/commit/c8f657f))
+
+## <small>14.2.4 (2021-10-22)</small>
+
+* [bitnami/several] Add chart info to NOTES.txt (#7889) ([a6751cd](https://github.com/bitnami/charts/commit/a6751cd)), closes [#7889](https://github.com/bitnami/charts/issues/7889)
+* [bitnami/several] Regenerate README tables ([70da75e](https://github.com/bitnami/charts/commit/70da75e))
+
+## <small>14.2.3 (2021-10-21)</small>
+
+* [bitnami/kafka] Release 14.2.3 updating components versions ([d629a32](https://github.com/bitnami/charts/commit/d629a32))
+
+## <small>14.2.2 (2021-10-19)</small>
+
+* [bitnami/kafka] Update README.md on using default service from the outside (#7793) ([fe7b30d](https://github.com/bitnami/charts/commit/fe7b30d)), closes [#7793](https://github.com/bitnami/charts/issues/7793) [#7661](https://github.com/bitnami/charts/issues/7661)
+* [bitnami/several] Change pullPolicy for bitnami-shell image (#7852) ([9711a33](https://github.com/bitnami/charts/commit/9711a33)), closes [#7852](https://github.com/bitnami/charts/issues/7852)
+* [bitnami/several] Regenerate README tables ([194a909](https://github.com/bitnami/charts/commit/194a909))
+* [Kafka] Support Using MY_POD_IP address for Kafka External Access (#7700) ([ef9156e](https://github.com/bitnami/charts/commit/ef9156e)), closes [#7700](https://github.com/bitnami/charts/issues/7700)
+
+## <small>14.2.1 (2021-10-07)</small>
+
+* [bitnami/*] Fix service monitors selectors (#7720) ([1279593](https://github.com/bitnami/charts/commit/1279593)), closes [#7720](https://github.com/bitnami/charts/issues/7720)
+* [bitnami/*] Generate READMEs with new generator version (#7614) ([e5ab2e6](https://github.com/bitnami/charts/commit/e5ab2e6)), closes [#7614](https://github.com/bitnami/charts/issues/7614)
+
+## 14.2.0 (2021-09-24)
+
+* [bitnami/several] Regenerate README tables ([bd0f8f2](https://github.com/bitnami/charts/commit/bd0f8f2))
+* add kafka acl config param (#7576) ([1f4a2da](https://github.com/bitnami/charts/commit/1f4a2da)), closes [#7576](https://github.com/bitnami/charts/issues/7576)
+
+## <small>14.1.1 (2021-09-21)</small>
+
+* [bitnami/kafka] Release 14.1.1 updating components versions ([ad605b4](https://github.com/bitnami/charts/commit/ad605b4))
+* [bitnami/several] Regenerate README tables ([c01cbe5](https://github.com/bitnami/charts/commit/c01cbe5))
+
+## 14.1.0 (2021-09-07)
+
+* [bitnami/several] Regenerate README tables ([64d5d74](https://github.com/bitnami/charts/commit/64d5d74))
+* Added topology spread constraints to Kafka chart. (#7406) ([b2a1fb8](https://github.com/bitnami/charts/commit/b2a1fb8)), closes [#7406](https://github.com/bitnami/charts/issues/7406)
+
+## <small>14.0.5 (2021-08-26)</small>
+
+* [bitnami/kafka] Release 14.0.5 updating components versions ([3d44c6b](https://github.com/bitnami/charts/commit/3d44c6b))
+* [bitnami/several] Regenerate README tables ([da2513b](https://github.com/bitnami/charts/commit/da2513b))
+
+## <small>14.0.4 (2021-08-25)</small>
+
+* [bitnami/kafka] Release 14.0.4 updating components versions ([1af0f0d](https://github.com/bitnami/charts/commit/1af0f0d))
+* [bitnami/several] Regenerate README tables ([6c9124f](https://github.com/bitnami/charts/commit/6c9124f))
+
+## <small>14.0.3 (2021-08-20)</small>
+
+* [bitnami/kafka] Fix missing "component" "%COMPONENT_NAME%" (#7271) ([fc25fc5](https://github.com/bitnami/charts/commit/fc25fc5)), closes [#7271](https://github.com/bitnami/charts/issues/7271)
+
+## <small>14.0.2 (2021-08-17)</small>
+
+* [bitnami/kafka] Release 14.0.2 updating components versions ([9023ccf](https://github.com/bitnami/charts/commit/9023ccf))
+* [bitnami/several] Regenerate README tables ([6c107e8](https://github.com/bitnami/charts/commit/6c107e8))
+
+## <small>14.0.1 (2021-08-02)</small>
+
+* [bitnami/kafka] Release 14.0.1 updating components versions ([5f528e8](https://github.com/bitnami/charts/commit/5f528e8))
+
+## 14.0.0 (2021-08-02)
+
+* [bitnami/several] Simplify image definition logic removing duplications (#7114) ([43e4eee](https://github.com/bitnami/charts/commit/43e4eee)), closes [#7114](https://github.com/bitnami/charts/issues/7114)
+* [bitnami/several] Update READMEs (#7108) ([44961d9](https://github.com/bitnami/charts/commit/44961d9)), closes [#7108](https://github.com/bitnami/charts/issues/7108)
+
+## <small>13.1.5 (2021-07-30)</small>
+
+* [bitnami/kafka] Add missing flag to Kafka exporter to use SASL as authentication (#7104) ([d313965](https://github.com/bitnami/charts/commit/d313965)), closes [#7104](https://github.com/bitnami/charts/issues/7104)
+
+## <small>13.1.4 (2021-07-30)</small>
+
+* [bitnami/several] Fix default values when using `foo: |` (#7092) ([fe91297](https://github.com/bitnami/charts/commit/fe91297)), closes [#7092](https://github.com/bitnami/charts/issues/7092)
+
+## <small>13.1.3 (2021-07-30)</small>
+
+* [bitnami/kafka] Adapt env. variables to new format (#7098) ([390f9fb](https://github.com/bitnami/charts/commit/390f9fb)), closes [#7098](https://github.com/bitnami/charts/issues/7098)
+
+## <small>13.1.2 (2021-07-29)</small>
+
+* [bitnami/kafka] Fix missing environment variable for SSL (#7095) ([cd031e4](https://github.com/bitnami/charts/commit/cd031e4)), closes [#7095](https://github.com/bitnami/charts/issues/7095)
+
+## <small>13.1.1 (2021-07-27)</small>
+
+* [bitnami/several] Fix default values and regenerate README (#7024) ([4c86733](https://github.com/bitnami/charts/commit/4c86733)), closes [#7024](https://github.com/bitnami/charts/issues/7024)
+
+## 13.1.0 (2021-07-27)
+
+* [bitnami/several] Add diagnostic mode (#7012) ([f1344b0](https://github.com/bitnami/charts/commit/f1344b0)), closes [#7012](https://github.com/bitnami/charts/issues/7012)
+
+## <small>13.0.4 (2021-07-25)</small>
+
+* [bitnami/kafka] Release 13.0.4 updating components versions ([9791b49](https://github.com/bitnami/charts/commit/9791b49))
+
+## <small>13.0.3 (2021-07-09)</small>
+
+* [bitnami/*] Adapt values.yaml of Joomla, Jupyterhub and Kafka charts (#6850) ([8ebbf6e](https://github.com/bitnami/charts/commit/8ebbf6e)), closes [#6850](https://github.com/bitnami/charts/issues/6850)
+
+## <small>13.0.2 (2021-06-25)</small>
+
+* [bitnami/kafka] Release 13.0.2 updating components versions ([b7bcf26](https://github.com/bitnami/charts/commit/b7bcf26))
+
+## <small>13.0.1 (2021-06-23)</small>
+
+* [bitnami/kafka] Release 13.0.1 updating components versions ([62a0ebe](https://github.com/bitnami/charts/commit/62a0ebe))
+
+## 13.0.0 (2021-06-22)
+
+* [bitnami/*] Update zookeeper deps (#6730) ([b6f75f4](https://github.com/bitnami/charts/commit/b6f75f4)), closes [#6730](https://github.com/bitnami/charts/issues/6730)
+
+## 12.20.0 (2021-06-08)
+
+* [bitnami/kafka] adding a way to pass annotations to provisioning Pods (#6585) ([d2c2576](https://github.com/bitnami/charts/commit/d2c2576)), closes [#6585](https://github.com/bitnami/charts/issues/6585)
+
+## <small>12.19.2 (2021-06-03)</small>
+
+* [bitnami/kafka] Release 12.19.2 updating components versions ([f3c73a4](https://github.com/bitnami/charts/commit/f3c73a4))
+
+## <small>12.19.1 (2021-06-02)</small>
+
+* [bitnami/kafka] Added params `relabelings` and `metricRelabelings` into ServiceMonitor resource (#65 ([6c78705](https://github.com/bitnami/charts/commit/6c78705)), closes [#6511](https://github.com/bitnami/charts/issues/6511)
+* [bitnami/kafka] Fixed duplicate for `reabelings` condition in servicemonitor templates (#6534) ([a8dca07](https://github.com/bitnami/charts/commit/a8dca07)), closes [#6534](https://github.com/bitnami/charts/issues/6534)
+
+## 12.19.0 (2021-06-01)
+
+* [bitnami/kafka] Add selector to pvc (#6503) ([0cd3467](https://github.com/bitnami/charts/commit/0cd3467)), closes [#6503](https://github.com/bitnami/charts/issues/6503)
+
+## <small>12.18.3 (2021-05-24)</small>
+
+* [bitnami/kafka] Release 12.18.3 updating components versions ([df20fda](https://github.com/bitnami/charts/commit/df20fda))
+
+## <small>12.18.2 (2021-05-24)</small>
+
+* [bitnami/kafka] Release 12.18.2 updating components versions ([3bc0244](https://github.com/bitnami/charts/commit/3bc0244))
+
+## <small>12.18.1 (2021-05-20)</small>
+
+* [bitnami/kafka] Release 12.18.1 updating components versions ([4e40b8a](https://github.com/bitnami/charts/commit/4e40b8a))
+
+## 12.18.0 (2021-05-20)
+
+* [bitnami/*] Update Kubectl container version (#6420) ([dad6d38](https://github.com/bitnami/charts/commit/dad6d38)), closes [#6420](https://github.com/bitnami/charts/issues/6420)
+
+## <small>12.17.6 (2021-05-05)</small>
+
+* [bitnami/kafka] SASL parameters updated (#6204) ([93c583a](https://github.com/bitnami/charts/commit/93c583a)), closes [#6204](https://github.com/bitnami/charts/issues/6204)
+* Update NOTES.txt (#6292) ([ee5597c](https://github.com/bitnami/charts/commit/ee5597c)), closes [#6292](https://github.com/bitnami/charts/issues/6292)
+
+## <small>12.17.5 (2021-04-26)</small>
+
+* [bitnami/kafka] Allow empty value for 'auth.tlsEndpointIdentificationAlgorithm' (#6214) ([4768491](https://github.com/bitnami/charts/commit/4768491)), closes [#6214](https://github.com/bitnami/charts/issues/6214)
+
+## <small>12.17.4 (2021-04-20)</small>
+
+* [bitnami/kafka] Release 12.17.4 updating components versions ([bc6d4e8](https://github.com/bitnami/charts/commit/bc6d4e8))
+
+## <small>12.17.3 (2021-04-15)</small>
+
+* [bitnami/kafka] Release 12.17.3 updating components versions ([f789fc3](https://github.com/bitnami/charts/commit/f789fc3))
+
+## <small>12.17.2 (2021-04-14)</small>
+
+* [bitnami/kafka] Do not use zookeeperUser if zookeeper auth is not enabled (#6103) ([7937b20](https://github.com/bitnami/charts/commit/7937b20)), closes [#6103](https://github.com/bitnami/charts/issues/6103)
+
+## <small>12.17.1 (2021-04-14)</small>
+
+* [bitnami/kafka] Fix wrong type for listeners and advertisedListeners vars (#6069) ([6b26c46](https://github.com/bitnami/charts/commit/6b26c46)), closes [#6069](https://github.com/bitnami/charts/issues/6069)
+
+## 12.17.0 (2021-04-14)
+
+* [bitnami/kafka] Add init containers to the Kafka exporter pods (#6084) ([f07241e](https://github.com/bitnami/charts/commit/f07241e)), closes [#6084](https://github.com/bitnami/charts/issues/6084)
+
+## <small>12.16.2 (2021-04-08)</small>
+
+* [bitnami/kafka] Allow provisioned topics to define default partitions and replication (#6051) ([bc0df93](https://github.com/bitnami/charts/commit/bc0df93)), closes [#6051](https://github.com/bitnami/charts/issues/6051)
+
+## <small>12.16.1 (2021-04-07)</small>
+
+* [bitnami/kafka] Release 12.16.1 updating components versions ([7359c59](https://github.com/bitnami/charts/commit/7359c59))
+
+## 12.16.0 (2021-04-02)
+
+* Add serviceAccount to Kafka metrics deployment and add automountServiceAccountToken on SA (#5988) ([3596309](https://github.com/bitnami/charts/commit/3596309)), closes [#5988](https://github.com/bitnami/charts/issues/5988)
+
+## <small>12.15.1 (2021-04-01)</small>
+
+* [bitnami/kafka] exporter templating error (#5985) ([3c28601](https://github.com/bitnami/charts/commit/3c28601)), closes [#5985](https://github.com/bitnami/charts/issues/5985)
+
+## 12.15.0 (2021-03-31)
+
+* [bitnami/kafka] Usage of Host IPs for external service without autodiscovery (#5963) ([7fdb7d1](https://github.com/bitnami/charts/commit/7fdb7d1)), closes [#5963](https://github.com/bitnami/charts/issues/5963)
+
+## <small>12.14.1 (2021-03-29)</small>
+
+* [bitnami/kafka] Kafka-Exporter can start with read only rootfs (#5932) ([49c71a3](https://github.com/bitnami/charts/commit/49c71a3)), closes [#5932](https://github.com/bitnami/charts/issues/5932)
+
+## 12.14.0 (2021-03-29)
+
+* [bitnami/kafka] Ability to configure terminationGracePeriodSeconds (#5919) ([2ce5c75](https://github.com/bitnami/charts/commit/2ce5c75)), closes [#5919](https://github.com/bitnami/charts/issues/5919)
+
+## <small>12.13.3 (2021-03-29)</small>
+
+* [bitnami/kafka] Release 12.13.3 updating components versions ([467cf6f](https://github.com/bitnami/charts/commit/467cf6f))
+
+## <small>12.13.2 (2021-03-25)</small>
+
+* [bitnami/kafka] Fix typo in Kafka connect example (#5901) ([e105226](https://github.com/bitnami/charts/commit/e105226)), closes [#5901](https://github.com/bitnami/charts/issues/5901)
+
+## <small>12.13.1 (2021-03-24)</small>
+
+* [bitnami/kafka] Release 12.13.1 updating components versions ([ecc608a](https://github.com/bitnami/charts/commit/ecc608a))
+
+## 12.13.0 (2021-03-24)
+
+* [bitnami/kafka] Add support for custom command/args on provisioning job (#5890) ([882de69](https://github.com/bitnami/charts/commit/882de69)), closes [#5890](https://github.com/bitnami/charts/issues/5890)
+
+## <small>12.12.2 (2021-03-24)</small>
+
+* [bitnami/kafka] Fix provisioning template (#5895) ([3d496c4](https://github.com/bitnami/charts/commit/3d496c4)), closes [#5895](https://github.com/bitnami/charts/issues/5895)
+
+## <small>12.12.1 (2021-03-23)</small>
+
+* [bitnami/kafka] Fix issue on secrets (#5883) ([8a760ec](https://github.com/bitnami/charts/commit/8a760ec)), closes [#5883](https://github.com/bitnami/charts/issues/5883)
+* Update README.md - Fixed #5649 (#5872) ([f5f4951](https://github.com/bitnami/charts/commit/f5f4951)), closes [#5649](https://github.com/bitnami/charts/issues/5649) [#5872](https://github.com/bitnami/charts/issues/5872) [#5649](https://github.com/bitnami/charts/issues/5649)
+
+## 12.12.0 (2021-03-19)
+
+* [bitnami/kafka] Add support for PEM certificates (#5825) ([b437fef](https://github.com/bitnami/charts/commit/b437fef)), closes [#5825](https://github.com/bitnami/charts/issues/5825)
+
+## <small>12.11.1 (2021-03-15)</small>
+
+* [bitnami/kafka] Always include serviceAccountName on statefulset (#5769) ([92d67eb](https://github.com/bitnami/charts/commit/92d67eb)), closes [#5769](https://github.com/bitnami/charts/issues/5769)
+
+## 12.11.0 (2021-03-11)
+
+* [bitnami/kafka]: Add affinity, tolerations, nodeSelector for kafka-exporter deployment (#5704) ([0d8b400](https://github.com/bitnami/charts/commit/0d8b400)), closes [#5704](https://github.com/bitnami/charts/issues/5704)
+
+## 12.10.0 (2021-03-05)
+
+* [bitnami/kafka] add schedulerName for all resources (#5669) ([5ba7a1d](https://github.com/bitnami/charts/commit/5ba7a1d)), closes [#5669](https://github.com/bitnami/charts/issues/5669)
+
+## <small>12.9.6 (2021-03-04)</small>
+
+* [bitnami/*] Remove minideb mentions (#5677) ([870bc4d](https://github.com/bitnami/charts/commit/870bc4d)), closes [#5677](https://github.com/bitnami/charts/issues/5677)
+
+## <small>12.9.5 (2021-02-26)</small>
+
+* [bitnami/kafka] Release 12.9.5 updating components versions ([5b7694c](https://github.com/bitnami/charts/commit/5b7694c))
+
+## <small>12.9.4 (2021-02-23)</small>
+
+* [bitnami/kafka] Fix `long` value for `log.flush.scheduler.interval.ms` (#5579) ([5e60062](https://github.com/bitnami/charts/commit/5e60062)), closes [#5579](https://github.com/bitnami/charts/issues/5579)
+
+## <small>12.9.3 (2021-02-22)</small>
+
+* [bitnami/*] Use common macro to define RBAC apiVersion (#5585) ([71fb99f](https://github.com/bitnami/charts/commit/71fb99f)), closes [#5585](https://github.com/bitnami/charts/issues/5585)
+
+## <small>12.9.2 (2021-02-22)</small>
+
+* [bitnami/kafka] Only set ssl.client.auth to required when mTLS is used (#5581) ([297bbcb](https://github.com/bitnami/charts/commit/297bbcb)), closes [#5581](https://github.com/bitnami/charts/issues/5581)
+
+## <small>12.9.1 (2021-02-19)</small>
+
+* [bitnami/kafka] Fix Zookeeper with SASL-auth in combination with client and broker mTLS (#5524) ([8e80963](https://github.com/bitnami/charts/commit/8e80963)), closes [#5524](https://github.com/bitnami/charts/issues/5524)
+
+## 12.9.0 (2021-02-17)
+
+* [bitnami/kafka] Flexible tls config for metrics exporter (#5520) ([ec76369](https://github.com/bitnami/charts/commit/ec76369)), closes [#5520](https://github.com/bitnami/charts/issues/5520)
+
+## 12.8.0 (2021-02-15)
+
+* feature(kafka) Flexible tls config (#5473) ([936702f](https://github.com/bitnami/charts/commit/936702f)), closes [#5473](https://github.com/bitnami/charts/issues/5473)
+
+## <small>12.7.6 (2021-02-12)</small>
+
+* [bitnami/kafka] Fix incorrect helpers (#5456) ([5f1d51b](https://github.com/bitnami/charts/commit/5f1d51b)), closes [#5456](https://github.com/bitnami/charts/issues/5456)
+* [bitnami/kafka] Separate tls encryption helpers (#5403) ([c5066aa](https://github.com/bitnami/charts/commit/c5066aa)), closes [#5403](https://github.com/bitnami/charts/issues/5403)
+
+## <small>12.7.5 (2021-02-09)</small>
+
+* Add registered icon to all the MongoDB references (#5426) ([56f2088](https://github.com/bitnami/charts/commit/56f2088)), closes [#5426](https://github.com/bitnami/charts/issues/5426)
+
+## <small>12.7.4 (2021-02-02)</small>
+
+* [bitnami/kafka] Add posibility to templatize externalZookeepers (#5374) ([a4b3ba9](https://github.com/bitnami/charts/commit/a4b3ba9)), closes [#5374](https://github.com/bitnami/charts/issues/5374)
+
+## <small>12.7.3 (2021-01-27)</small>
+
+* [bitnami/kafka] Release 12.7.3 updating components versions ([7dd4eec](https://github.com/bitnami/charts/commit/7dd4eec))
+
+## <small>12.7.2 (2021-01-27)</small>
+
+* [bitnami/kafka] Release 12.7.2 updating components versions ([4276aaa](https://github.com/bitnami/charts/commit/4276aaa))
+
+## <small>12.7.1 (2021-01-27)</small>
+
+* [bitnami/kafka] Add hostAliases (#5248) ([deaafe8](https://github.com/bitnami/charts/commit/deaafe8)), closes [#5248](https://github.com/bitnami/charts/issues/5248)
+* [bitnami/kafka] Advertisedlisteners should use any worker node IP for EXTERNAL, if external service, ([5aae6fa](https://github.com/bitnami/charts/commit/5aae6fa)), closes [#5218](https://github.com/bitnami/charts/issues/5218)
+
+## 12.7.0 (2021-01-27)
+
+* [bitnami/kafka] expose pod management policy (#5229) ([e94bd27](https://github.com/bitnami/charts/commit/e94bd27)), closes [#5229](https://github.com/bitnami/charts/issues/5229)
+
+## <small>12.6.5 (2021-01-26)</small>
+
+* [bitnami/kafka] Use different component name for kafka-provisioning job (#5209) ([b13319b](https://github.com/bitnami/charts/commit/b13319b)), closes [#5209](https://github.com/bitnami/charts/issues/5209)
+
+## <small>12.6.4 (2021-01-25)</small>
+
+* [bitnami/*] Unify icons in Chart.yaml and add missing fields (#5206) ([0462921](https://github.com/bitnami/charts/commit/0462921)), closes [#5206](https://github.com/bitnami/charts/issues/5206)
+
+## <small>12.6.3 (2021-01-21)</small>
+
+* [bitnami/kafka] Add provisioning values to readme (#5086) ([4dc2315](https://github.com/bitnami/charts/commit/4dc2315)), closes [#5086](https://github.com/bitnami/charts/issues/5086)
+* [bitnami/kafka] Release 12.6.3 updating components versions ([d7a8d33](https://github.com/bitnami/charts/commit/d7a8d33))
+
+## <small>12.6.2 (2021-01-19)</small>
+
+* [bitnami/*] Change helm version in the prerequisites (#5090) ([c5e67a3](https://github.com/bitnami/charts/commit/c5e67a3)), closes [#5090](https://github.com/bitnami/charts/issues/5090)
+* [bitnami/kafka] Drop values-production.yaml support (#5109) ([6152d30](https://github.com/bitnami/charts/commit/6152d30)), closes [#5109](https://github.com/bitnami/charts/issues/5109)
+
+## <small>12.6.1 (2021-01-19)</small>
+
+* bitnami/kafka Fix Upgrade regression from PR #4683 (#5073) ([7baeea1](https://github.com/bitnami/charts/commit/7baeea1)), closes [#4683](https://github.com/bitnami/charts/issues/4683) [#5073](https://github.com/bitnami/charts/issues/5073)
+
+## 12.6.0 (2021-01-18)
+
+* [bitnami/kafka] Add topics provisioning job (#4783) ([971ed6d](https://github.com/bitnami/charts/commit/971ed6d)), closes [#4783](https://github.com/bitnami/charts/issues/4783)
+* [bitnami/kafka] fix client.properties usage in NOTES ([de6e0cd](https://github.com/bitnami/charts/commit/de6e0cd))
+
+## 12.5.0 (2020-12-28)
+
+* [bitnami/kafka] Bring Kafka chart more in line with other charts with volumePermissions (#4728) ([4f6966c](https://github.com/bitnami/charts/commit/4f6966c)), closes [#4728](https://github.com/bitnami/charts/issues/4728)
+
+## <small>12.4.3 (2020-12-24)</small>
+
+* [bitnami/kafka] Register targetPod in global context (#4832) ([86b9816](https://github.com/bitnami/charts/commit/86b9816)), closes [#4832](https://github.com/bitnami/charts/issues/4832)
+
+## <small>12.4.2 (2020-12-22)</small>
+
+* [bitnami/kafka] Fix initContainers support (#4798) ([d013f37](https://github.com/bitnami/charts/commit/d013f37)), closes [#4798](https://github.com/bitnami/charts/issues/4798)
+* [bitnami/kafka] Release 12.4.2 updating components versions ([c264ac7](https://github.com/bitnami/charts/commit/c264ac7))
+
+## <small>12.4.1 (2020-12-22)</small>
+
+* [bitnami/kafka] Release 12.4.1 updating components versions ([de794fe](https://github.com/bitnami/charts/commit/de794fe))
+
+## 12.4.0 (2020-12-14)
+
+* [bitnami/*] fix typos (#4699) ([49adc63](https://github.com/bitnami/charts/commit/49adc63)), closes [#4699](https://github.com/bitnami/charts/issues/4699)
+* bitnami/kafka add minBrokerId variable (#4683) ([f4eb717](https://github.com/bitnami/charts/commit/f4eb717)), closes [#4683](https://github.com/bitnami/charts/issues/4683)
+
+## <small>12.3.2 (2020-12-12)</small>
+
+* [bitnami/kafka] Release 12.3.2 updating components versions ([ce525ba](https://github.com/bitnami/charts/commit/ce525ba))
+
+## <small>12.3.1 (2020-12-11)</small>
+
+* [bitnami/*] Update dependencies (#4694) ([2826c12](https://github.com/bitnami/charts/commit/2826c12)), closes [#4694](https://github.com/bitnami/charts/issues/4694)
+
+## 12.3.0 (2020-12-10)
+
+* [bitnami/kafka] Add extra initContainers parameter (#4658) ([4e1edc8](https://github.com/bitnami/charts/commit/4e1edc8)), closes [#4658](https://github.com/bitnami/charts/issues/4658)
+
+## <small>12.2.4 (2020-12-03)</small>
+
+* [bitnami/kafka,kube-prometheus,kubernetes-event-exporter] Replace K8s List (#4575) ([b363798](https://github.com/bitnami/charts/commit/b363798)), closes [#4575](https://github.com/bitnami/charts/issues/4575) [#4559](https://github.com/bitnami/charts/issues/4559)
+
+## <small>12.2.3 (2020-12-03)</small>
+
+* [bitnami/kafka] Fix Kafka website url (#4588) ([e284668](https://github.com/bitnami/charts/commit/e284668)), closes [#4588](https://github.com/bitnami/charts/issues/4588)
+
+## <small>12.2.2 (2020-12-02)</small>
+
+* [bitnami/kafka] Use autoDiscovery values for NodePort external access (#4545) ([ce1bb73](https://github.com/bitnami/charts/commit/ce1bb73)), closes [#4545](https://github.com/bitnami/charts/issues/4545)
+
+## <small>12.2.1 (2020-11-25)</small>
+
+* [bitnami/kafka] Fix typo in custom liveness and readiness probes (#4491) ([17d7250](https://github.com/bitnami/charts/commit/17d7250)), closes [#4491](https://github.com/bitnami/charts/issues/4491)
+
+## 12.2.0 (2020-11-25)
+
+* [bitnami/*] Affinity based on common presets (ii) (#4472) ([934259f](https://github.com/bitnami/charts/commit/934259f)), closes [#4472](https://github.com/bitnami/charts/issues/4472)
+* [bitnami/kafka] Update README.md (#4441) ([be46cb1](https://github.com/bitnami/charts/commit/be46cb1)), closes [#4441](https://github.com/bitnami/charts/issues/4441)
+
+## 12.1.0 (2020-11-16)
+
+* [bitnami/kafka] Move kafka's logs to the persistence storage (#4234) ([fb83c60](https://github.com/bitnami/charts/commit/fb83c60)), closes [#4234](https://github.com/bitnami/charts/issues/4234)
+
+## 12.0.0 (2020-11-11)
+
+* [bitnami/kafka] Major version. Adapt Chart to apiVersion: v2 (#4329) ([32625a9](https://github.com/bitnami/charts/commit/32625a9)), closes [#4329](https://github.com/bitnami/charts/issues/4329)
+
+## <small>11.8.9 (2020-11-06)</small>
+
+* [bitnami/*] Include link to Troubleshootin guide on README.md (#4136) ([c08a20e](https://github.com/bitnami/charts/commit/c08a20e)), closes [#4136](https://github.com/bitnami/charts/issues/4136)
+* [bitnami/kafka]Use template for log4j configuration (#4181) ([ae10687](https://github.com/bitnami/charts/commit/ae10687)), closes [#4181](https://github.com/bitnami/charts/issues/4181)
+
+## <small>11.8.8 (2020-10-21)</small>
+
+* [bitnami/kafka] Release 11.8.8 updating components versions ([42a9bd5](https://github.com/bitnami/charts/commit/42a9bd5))
+
+## <small>11.8.7 (2020-10-14)</small>
+
+* [bitnami/kafka] Add docs clarity on interaction of config, existingConfigmap and environment variabl ([d6b3ff9](https://github.com/bitnami/charts/commit/d6b3ff9)), closes [#3971](https://github.com/bitnami/charts/issues/3971)
+
+## <small>11.8.6 (2020-09-29)</small>
+
+* [bitnami/kafka] Sync README.md with values (#3802) ([ed8cbba](https://github.com/bitnami/charts/commit/ed8cbba)), closes [#3802](https://github.com/bitnami/charts/issues/3802)
+
+## <small>11.8.5 (2020-09-21)</small>
+
+* [bitnami/kafka] Release 11.8.5 updating components versions ([34ed2fb](https://github.com/bitnami/charts/commit/34ed2fb))
+
+## <small>11.8.4 (2020-09-06)</small>
+
+* [bitnami/kafka] Release 11.8.4 updating components versions ([591c458](https://github.com/bitnami/charts/commit/591c458))
+* [bitnami/metrics-server] Add source repo (#3577) ([1ed12f9](https://github.com/bitnami/charts/commit/1ed12f9)), closes [#3577](https://github.com/bitnami/charts/issues/3577)
+
+## <small>11.8.3 (2020-09-02)</small>
+
+* [bitnami/kafka] Improves NOTES.txt for users (#3534) ([553783f](https://github.com/bitnami/charts/commit/553783f)), closes [#3534](https://github.com/bitnami/charts/issues/3534)
+
+## <small>11.8.2 (2020-08-24)</small>
+
+* fix kafka_jaas.conf filepath in KAFKA_OPTS (#3492) ([6b861b1](https://github.com/bitnami/charts/commit/6b861b1)), closes [#3492](https://github.com/bitnami/charts/issues/3492)
+
+## <small>11.8.1 (2020-08-18)</small>
+
+* [bitnami/kafka] fix: use the proper loadBalancerSourceRanges (#3453) ([bb9c09e](https://github.com/bitnami/charts/commit/bb9c09e)), closes [#3453](https://github.com/bitnami/charts/issues/3453)
+
+## 11.8.0 (2020-08-07)
+
+* [bitnami/kafka] Add external connection to cluster LB (#3343) ([5e38c48](https://github.com/bitnami/charts/commit/5e38c48)), closes [#3343](https://github.com/bitnami/charts/issues/3343)
+
+## <small>11.7.3 (2020-08-07)</small>
+
+* [bitnami/kafka] Release 11.7.3 updating components versions ([ab0d4c0](https://github.com/bitnami/charts/commit/ab0d4c0))
+
+## <small>11.7.2 (2020-08-06)</small>
+
+* [bitnami/kafka] Fix typo in helpers (#3344) ([19759aa](https://github.com/bitnami/charts/commit/19759aa)), closes [#3344](https://github.com/bitnami/charts/issues/3344)
+
+## <small>11.7.1 (2020-08-05)</small>
+
+* [bitnami/kafka] Fix typo in kafka.tplValue (#3327) ([84fe78e](https://github.com/bitnami/charts/commit/84fe78e)), closes [#3327](https://github.com/bitnami/charts/issues/3327)
+
+## 11.7.0 (2020-08-03)
+
+* [bitnami/kafka] Add paramters to configure SASL_SCRAM (#3270) ([c033cbd](https://github.com/bitnami/charts/commit/c033cbd)), closes [#3270](https://github.com/bitnami/charts/issues/3270)
+
+## <small>11.6.6 (2020-07-31)</small>
+
+* [bitnami/*] Fix TL;DR typo in READMEs (#3280) ([3d7ab40](https://github.com/bitnami/charts/commit/3d7ab40)), closes [#3280](https://github.com/bitnami/charts/issues/3280)
+* [bitnami/kafka] Allow externalZookeepers.servers to specified both as array and string (#3286) ([de7c077](https://github.com/bitnami/charts/commit/de7c077)), closes [#3286](https://github.com/bitnami/charts/issues/3286)
+
+## <small>11.6.5 (2020-07-30)</small>
+
+* [bitnami/kafka] Release 11.6.5 updating components versions ([5de4d92](https://github.com/bitnami/charts/commit/5de4d92))
+
+## <small>11.6.4 (2020-07-28)</small>
+
+* [bitnami/kafka] Fix metrics annotations (#3252) ([c004e42](https://github.com/bitnami/charts/commit/c004e42)), closes [#3252](https://github.com/bitnami/charts/issues/3252)
+
+## <small>11.6.3 (2020-07-28)</small>
+
+* [bitnami/kafka] Fix typo in NOTES.txt (#3249) ([8cc2cea](https://github.com/bitnami/charts/commit/8cc2cea)), closes [#3249](https://github.com/bitnami/charts/issues/3249)
+
+## <small>11.6.2 (2020-07-27)</small>
+
+* [bitnami/kafka] Fix instructions to use a producer (#3236) ([6b94839](https://github.com/bitnami/charts/commit/6b94839)), closes [#3236](https://github.com/bitnami/charts/issues/3236)
+
+## <small>11.6.1 (2020-07-27)</small>
+
+* [bitnami/kafka] External Access: use the same target port regardless the svc type (#3209) ([37b355b](https://github.com/bitnami/charts/commit/37b355b)), closes [#3209](https://github.com/bitnami/charts/issues/3209)
+
+## 11.6.0 (2020-07-23)
+
+* [bitnami/kafka] Add custom labels/annotations parameters (#3193) ([8ea744a](https://github.com/bitnami/charts/commit/8ea744a)), closes [#3193](https://github.com/bitnami/charts/issues/3193)
+
+## <small>11.5.1 (2020-07-17)</small>
+
+* [bitnami/kafka] Release 11.5.1 updating components versions ([940a617](https://github.com/bitnami/charts/commit/940a617))
+
+## 11.5.0 (2020-07-16)
+
+* [bitnami/kafka] Add parameters to configure command and args for Kafka pod (#3128) ([f357326](https://github.com/bitnami/charts/commit/f357326)), closes [#3128](https://github.com/bitnami/charts/issues/3128)
+
+## <small>11.4.1 (2020-07-16)</small>
+
+* [bitnami/kafka] Release 11.4.1 updating components versions ([0bbfff9](https://github.com/bitnami/charts/commit/0bbfff9))
+
+## 11.4.0 (2020-07-13)
+
+* [bitnami/all] Add categories (#3075) ([63bde06](https://github.com/bitnami/charts/commit/63bde06)), closes [#3075](https://github.com/bitnami/charts/issues/3075)
+* [bitnami/kafka] Add support for deploying extra resources (#3101) ([07a0dad](https://github.com/bitnami/charts/commit/07a0dad)), closes [#3101](https://github.com/bitnami/charts/issues/3101)
+
+## <small>11.3.4 (2020-07-08)</small>
+
+* [bitnami/kafka] Release 11.3.4 updating components versions ([635a514](https://github.com/bitnami/charts/commit/635a514))
+
+## <small>11.3.3 (2020-07-08)</small>
+
+* [bitnami/kafka] Avoid confusion around Kafka broker ID (#3062) ([b834cc9](https://github.com/bitnami/charts/commit/b834cc9)), closes [#3062](https://github.com/bitnami/charts/issues/3062)
+
+## <small>11.3.2 (2020-07-02)</small>
+
+* [bitnami/kafka] Release 11.3.2 updating components versions ([bade53e](https://github.com/bitnami/charts/commit/bade53e))
+
+## <small>11.3.1 (2020-06-25)</small>
+
+* [bitnami/kafka] Release 11.3.1 updating components versions ([39e0316](https://github.com/bitnami/charts/commit/39e0316))
+
+## 11.3.0 (2020-06-25)
+
+* [bitnami/kafka] Provide a way to create JKS secret from local directory (#2923) ([e750b87](https://github.com/bitnami/charts/commit/e750b87)), closes [#2923](https://github.com/bitnami/charts/issues/2923)
+
+## <small>11.2.4 (2020-06-24)</small>
+
+* [bitnami/kafka] Release 11.2.4 updating components versions ([30a9d12](https://github.com/bitnami/charts/commit/30a9d12))
+
+## <small>11.2.3 (2020-06-23)</small>
+
+* [bitnami/kafka] Remove line used for debugging purposes (#2903) ([e7d5d76](https://github.com/bitnami/charts/commit/e7d5d76)), closes [#2903](https://github.com/bitnami/charts/issues/2903)
+
+## <small>11.2.2 (2020-06-19)</small>
+
+* [bitnami/kafka] Fix conflict when mounting custom configuration, and JKS files from a secret (#2886) ([1e8738c](https://github.com/bitnami/charts/commit/1e8738c)), closes [#2886](https://github.com/bitnami/charts/issues/2886)
+
+## <small>11.2.1 (2020-06-17)</small>
+
+* [bitnami/kafka] docs: "Upgrading" typo & formatting (#2835) ([068efd9](https://github.com/bitnami/charts/commit/068efd9)), closes [#2835](https://github.com/bitnami/charts/issues/2835)
+
+## 11.2.0 (2020-06-12)
+
+* [bitnami/kafka] Add custom liveness/readiness probe support (#2809) ([5152ee7](https://github.com/bitnami/charts/commit/5152ee7)), closes [#2809](https://github.com/bitnami/charts/issues/2809)
+
+## <small>11.1.2 (2020-06-09)</small>
+
+* [bitnami/kafka] kafka-exporter-certificates chmod (#2764) ([a413699](https://github.com/bitnami/charts/commit/a413699)), closes [#2764](https://github.com/bitnami/charts/issues/2764)
+
+## <small>11.1.1 (2020-06-08)</small>
+
+* [bitnami/kafka] Fix exporter when authentication is disabled (#2779) ([06abd2b](https://github.com/bitnami/charts/commit/06abd2b)), closes [#2779](https://github.com/bitnami/charts/issues/2779)
+
+## 11.1.0 (2020-06-05)
+
+* [bitnami/kafka] add k8s priorityclass in statefulset (#2754) ([34a3d8d](https://github.com/bitnami/charts/commit/34a3d8d)), closes [#2754](https://github.com/bitnami/charts/issues/2754)
+
+## <small>11.0.2 (2020-06-05)</small>
+
+* [bitnami/kafka] Fix issue with custom ports for inter-broker communications (#2756) ([d310b3a](https://github.com/bitnami/charts/commit/d310b3a)), closes [#2756](https://github.com/bitnami/charts/issues/2756)
+
+## <small>11.0.1 (2020-06-04)</small>
+
+* [bitnami/kafka] fix kafka-exporter-certificates secret volume definition (#2752) ([49ec1e1](https://github.com/bitnami/charts/commit/49ec1e1)), closes [#2752](https://github.com/bitnami/charts/issues/2752)
+
+## 11.0.0 (2020-06-02)
+
+* [bitnami/kafka] Refactor listeners and authentication configuration (#2708) ([ca74711](https://github.com/bitnami/charts/commit/ca74711)), closes [#2708](https://github.com/bitnami/charts/issues/2708)
+* update bitnami/common to be compatible with helm v2.12+ (#2615) ([c7751eb](https://github.com/bitnami/charts/commit/c7751eb)), closes [#2615](https://github.com/bitnami/charts/issues/2615)
+
+## <small>10.3.3 (2020-05-11)</small>
+
+* [bitnami/kafka] Check if existingLog4jConfigMap exists instead of existingConfigmap (#2562) ([f45f622](https://github.com/bitnami/charts/commit/f45f622)), closes [#2562](https://github.com/bitnami/charts/issues/2562)
+
+## <small>10.3.2 (2020-04-28)</small>
+
+* [bitnami/kafka] Improve "Security for Kafka and Zookeeper" README (#2450) ([a9adf15](https://github.com/bitnami/charts/commit/a9adf15)), closes [#2450](https://github.com/bitnami/charts/issues/2450)
+
+## <small>10.3.1 (2020-04-28)</small>
+
+* [bitnami/kafka] Fix Kafka notes after bitnami-docker-kafka/pull/91 (#2444) ([7e08a5a](https://github.com/bitnami/charts/commit/7e08a5a)), closes [#2444](https://github.com/bitnami/charts/issues/2444)
+
+## 10.3.0 (2020-04-24)
+
+* [bitnami/kafka] Add parameters to define extra volume/volumeMount(s) (#2416) ([593112f](https://github.com/bitnami/charts/commit/593112f)), closes [#2416](https://github.com/bitnami/charts/issues/2416)
+
+## <small>10.2.6 (2020-04-22)</small>
+
+* [bitnami/kafka & nginx] Manually update git and kubectl tags (#2385) ([941a647](https://github.com/bitnami/charts/commit/941a647)), closes [#2385](https://github.com/bitnami/charts/issues/2385)
+
+## <small>10.2.5 (2020-04-22)</small>
+
+* [bitnami/kafka] Release 10.2.5 updating components versions ([a1f46a8](https://github.com/bitnami/charts/commit/a1f46a8))
+
+## <small>10.2.4 (2020-04-22)</small>
+
+* [bitnami/kafka] Release 10.2.4 updating components versions ([550110f](https://github.com/bitnami/charts/commit/550110f))
+
+## <small>10.2.3 (2020-04-16)</small>
+
+* [bitnami/kafka] Release 10.2.3 updating components versions ([5e14618](https://github.com/bitnami/charts/commit/5e14618))
+
+## <small>10.2.2 (2020-04-15)</small>
+
+* [bitnami/kafka] Release 10.2.2 updating components versions ([040d3b6](https://github.com/bitnami/charts/commit/040d3b6))
+
+## <small>10.2.1 (2020-04-15)</small>
+
+* [bitnami/kafka] Broaden jsonpath query (#2291) ([e1b9c80](https://github.com/bitnami/charts/commit/e1b9c80)), closes [#2291](https://github.com/bitnami/charts/issues/2291)
+
+## 10.2.0 (2020-04-09)
+
+* [bitnami/kafka] Add templated pod labels to statefulset (#2269) ([b36a601](https://github.com/bitnami/charts/commit/b36a601)), closes [#2269](https://github.com/bitnami/charts/issues/2269)
+
+## <small>10.1.1 (2020-04-09)</small>
+
+* [bitnami/kafka] Release 10.1.1 updating components versions ([0b1b9e3](https://github.com/bitnami/charts/commit/0b1b9e3))
+
+## 10.1.0 (2020-04-07)
+
+* [bitnami/kafka] Added variable to enable/disable auto creation of topics. (#2230) ([42a6a73](https://github.com/bitnami/charts/commit/42a6a73)), closes [#2230](https://github.com/bitnami/charts/issues/2230)
+
+## 10.0.0 (2020-04-06)
+
+* [bitnami/kafka] Add optional log4j config to overwrite log4j.properties. (#2121) ([33455f9](https://github.com/bitnami/charts/commit/33455f9)), closes [#2121](https://github.com/bitnami/charts/issues/2121)
+
+## <small>9.0.6 (2020-04-03)</small>
+
+* [bitnami/kafka] Fix autodiscovery when using NodePort svc type (#2214) ([6fa1d09](https://github.com/bitnami/charts/commit/6fa1d09)), closes [#2214](https://github.com/bitnami/charts/issues/2214)
+
+## <small>9.0.5 (2020-04-02)</small>
+
+* [bitnami/kafka] Use emptyDir when persistence is disabled (#2195) ([8dde59c](https://github.com/bitnami/charts/commit/8dde59c)), closes [#2195](https://github.com/bitnami/charts/issues/2195)
+
+## <small>9.0.4 (2020-03-27)</small>
+
+* [bitnami/kafka] Fix metrics ports on servicemonitor (#2145) ([59b48d3](https://github.com/bitnami/charts/commit/59b48d3)), closes [#2145](https://github.com/bitnami/charts/issues/2145)
+
+## <small>9.0.3 (2020-03-26)</small>
+
+* [bitnami/kafka] Release 9.0.3 updating components versions ([5026d5d](https://github.com/bitnami/charts/commit/5026d5d))
+
+## <small>9.0.2 (2020-03-24)</small>
+
+* [bitnami/kafka] Update README.md (#2125) ([524b338](https://github.com/bitnami/charts/commit/524b338)), closes [#2125](https://github.com/bitnami/charts/issues/2125)
+
+## <small>9.0.1 (2020-03-24)</small>
+
+* [bitnami/kafka] Fix SSL nodeport on external-access svc (#2124) ([a384700](https://github.com/bitnami/charts/commit/a384700)), closes [#2124](https://github.com/bitnami/charts/issues/2124)
+
+## 9.0.0 (2020-03-23)
+
+* [bitnami/kafka] Support external access to every broker auto-discovering external ips/ports (#2098) ([e85995f](https://github.com/bitnami/charts/commit/e85995f)), closes [#2098](https://github.com/bitnami/charts/issues/2098)
+
+## <small>8.0.1 (2020-03-20)</small>
+
+* [bitnami/kafka] Release 8.0.1 updating components versions ([cf70e8b](https://github.com/bitnami/charts/commit/cf70e8b))
+
+## 8.0.0 (2020-03-17)
+
+* [bitnami/kafka] Update major version (#2070) ([d160623](https://github.com/bitnami/charts/commit/d160623)), closes [#2070](https://github.com/bitnami/charts/issues/2070)
+
+## 7.4.0 (2020-03-17)
+
+* [bitnami/kafka] Achieve consistent broker ids during cluster restart/rebuild (#2028) ([5622f31](https://github.com/bitnami/charts/commit/5622f31)), closes [#2028](https://github.com/bitnami/charts/issues/2028)
+* add podannotations to kafka-exporter (#2062) ([e039d22](https://github.com/bitnami/charts/commit/e039d22)), closes [#2062](https://github.com/bitnami/charts/issues/2062)
+
+## <small>7.3.5 (2020-03-13)</small>
+
+* [bitnami/kafka] Release 7.3.5 updating components versions ([cae9024](https://github.com/bitnami/charts/commit/cae9024))
+
+## <small>7.3.4 (2020-03-12)</small>
+
+* Fix typo in truststore file name (#2040) ([2528fed](https://github.com/bitnami/charts/commit/2528fed)), closes [#2040](https://github.com/bitnami/charts/issues/2040)
+
+## <small>7.3.3 (2020-03-12)</small>
+
+* [bitnami/kafka] Release 7.3.3 updating components versions ([e1a260f](https://github.com/bitnami/charts/commit/e1a260f))
+
+## <small>7.3.2 (2020-03-11)</small>
+
+* Move charts from upstreamed folder to bitnami (#2032) ([a0e44f7](https://github.com/bitnami/charts/commit/a0e44f7)), closes [#2032](https://github.com/bitnami/charts/issues/2032)
+
+## <small>7.3.1 (2020-03-05)</small>
+
+* [bitnami/kafka] Release 7.3.1 updating components versions ([9cfee5c](https://github.com/bitnami/charts/commit/9cfee5c))
+
+## 7.3.0 (2020-03-04)
+
+* [bitnami/kafka] add chart param to configure annotations from kafka metrics deployment (#1990) ([a4a1783](https://github.com/bitnami/charts/commit/a4a1783)), closes [#1990](https://github.com/bitnami/charts/issues/1990)
+
+## <small>7.2.9 (2020-02-26)</small>
+
+* [bitnami/kafka] Release 7.2.9 updating components versions ([d23d0b9](https://github.com/bitnami/charts/commit/d23d0b9))
+
+## <small>7.2.8 (2020-02-24)</small>
+
+* Fix svc-external-access template ([94f836f](https://github.com/bitnami/charts/commit/94f836f))
+
+## <small>7.2.7 (2020-02-24)</small>
+
+* [bitnami/kafka] add missed service annotations for external access service (#1965) ([50650fa](https://github.com/bitnami/charts/commit/50650fa)), closes [#1965](https://github.com/bitnami/charts/issues/1965)
+
+## <small>7.2.6 (2020-02-20)</small>
+
+* [bitnami/kafka] Release 7.2.6 updating components versions ([95b5741](https://github.com/bitnami/charts/commit/95b5741))
+
+## <small>7.2.5 (2020-02-19)</small>
+
+* [bitnami/*] Fix requirements.lock (#1950) ([1fa6eb9](https://github.com/bitnami/charts/commit/1fa6eb9)), closes [#1950](https://github.com/bitnami/charts/issues/1950)
+
+## <small>7.2.4 (2020-02-18)</small>
+
+* [bitnami/kafka] Release 7.2.4 updating components versions ([76c5b63](https://github.com/bitnami/charts/commit/76c5b63))
+* [bitnami/several] Adapt READMEs and helpers to Helm 3 (#1911) ([40ee57c](https://github.com/bitnami/charts/commit/40ee57c)), closes [#1911](https://github.com/bitnami/charts/issues/1911)
+
+## <small>7.2.3 (2020-02-10)</small>
+
+* [bitnami/several] Replace stretch by buster in minideb secondary containers (#1900) ([678febc](https://github.com/bitnami/charts/commit/678febc)), closes [#1900](https://github.com/bitnami/charts/issues/1900)
+
+## <small>7.2.2 (2020-02-07)</small>
+
+* [bitnami/kafka] Fix dependencies (#1891) ([bd035aa](https://github.com/bitnami/charts/commit/bd035aa)), closes [#1891](https://github.com/bitnami/charts/issues/1891)
+
+## <small>7.2.1 (2020-02-03)</small>
+
+* Add Juan feedback ([32d9f63](https://github.com/bitnami/charts/commit/32d9f63))
+* Add missing colon ([02782c6](https://github.com/bitnami/charts/commit/02782c6))
+* bumping zookeeper version ([bf80f45](https://github.com/bitnami/charts/commit/bf80f45))
+* Fix linter issues ([b887560](https://github.com/bitnami/charts/commit/b887560))
+* Set external port for listeners ([136776b](https://github.com/bitnami/charts/commit/136776b))
+
+## 7.2.0 (2020-01-27)
+
+* [stable/bitnami] Allow to access Kafka brokers from outside K8s cluster ([8dba9d1](https://github.com/bitnami/charts/commit/8dba9d1))
+
+## <small>7.1.3 (2020-01-24)</small>
+
+* [bitnami/kafka] Release 7.1.3 updating components versions ([964afe4](https://github.com/bitnami/charts/commit/964afe4))
+
+## <small>7.1.2 (2020-01-14)</small>
+
+* [bitnami/kafka] Release 7.1.2 updating components versions ([f516a01](https://github.com/bitnami/charts/commit/f516a01))
+* building requirements.lock to latest zookeeper version ([653ce1d](https://github.com/bitnami/charts/commit/653ce1d))
+* Readd requirements.yaml dependency file ([23fa845](https://github.com/bitnami/charts/commit/23fa845))
+* Remove dependency from Chart.yaml ([43d44d1](https://github.com/bitnami/charts/commit/43d44d1))
+* remove requirements files as no longer needed in helm 3 ([94e6c6b](https://github.com/bitnami/charts/commit/94e6c6b))
+
+## <small>7.1.1 (2020-01-02)</small>
+
+* adding creating serviceAccount name to template ([8d67a6e](https://github.com/bitnami/charts/commit/8d67a6e))
+* fix kafka dependency to latest (zookeeper) ([7b1d0a1](https://github.com/bitnami/charts/commit/7b1d0a1))
+* Fix typo ([57435f6](https://github.com/bitnami/charts/commit/57435f6))
+* Fix typo ([2f6c486](https://github.com/bitnami/charts/commit/2f6c486))
+* fixing indentation ([b335a87](https://github.com/bitnami/charts/commit/b335a87))
+* Unify comments ([e59513b](https://github.com/bitnami/charts/commit/e59513b))
+* Unify comments 2 ([6871f82](https://github.com/bitnami/charts/commit/6871f82))
+* Update bitnami/kafka/README.md ([a19825a](https://github.com/bitnami/charts/commit/a19825a))
+* Update bitnami/kafka/templates/serviceaccount.yaml ([eb71120](https://github.com/bitnami/charts/commit/eb71120))
+* Update bitnami/kafka/templates/statefulset.yaml ([3bf5182](https://github.com/bitnami/charts/commit/3bf5182))
+
+## 7.1.0 (2019-12-29)
+
+* add an option to create a service account for the kafka node ([3a92f97](https://github.com/bitnami/charts/commit/3a92f97))
+* bump version and update README.md ([ed35631](https://github.com/bitnami/charts/commit/ed35631))
+
+## <small>7.0.5 (2019-12-17)</small>
+
+* [bitnami/kafka] Release 7.0.5 updating components versions ([783300a](https://github.com/bitnami/charts/commit/783300a))
+
+## <small>7.0.4 (2019-12-04)</small>
+
+* Bump patch version ([7994c7c](https://github.com/bitnami/charts/commit/7994c7c))
+* Update typo in kafka statefulset ([69dcd96](https://github.com/bitnami/charts/commit/69dcd96))
+
+## <small>7.0.3 (2019-11-24)</small>
+
+* [bitnami/kafka] Release 7.0.3 updating components versions ([efd4ead](https://github.com/bitnami/charts/commit/efd4ead))
+
+## <small>7.0.2 (2019-11-12)</small>
+
+* [bitnami/kafka] Fix values.yaml ([f5e626f](https://github.com/bitnami/charts/commit/f5e626f))
+
+## <small>7.0.1 (2019-11-12)</small>
+
+* [bitnami/kafka] Lint chart ([da33411](https://github.com/bitnami/charts/commit/da33411))
+* Add workaround for upgrading ([7cec7c7](https://github.com/bitnami/charts/commit/7cec7c7))
+* Fix 'upgrade' command ([379b2a9](https://github.com/bitnami/charts/commit/379b2a9))
+
+## 7.0.0 (2019-11-12)
+
+* [bitnami/kafka] Fix labels on kafka exporter & add metric services ([413daa1](https://github.com/bitnami/charts/commit/413daa1))
+* Update kafka-exporter.yaml ([ee6bd44](https://github.com/bitnami/charts/commit/ee6bd44))
+* Update servicemonitor.yaml ([d53c26a](https://github.com/bitnami/charts/commit/d53c26a))
+* Update statefulset.yaml ([137fb43](https://github.com/bitnami/charts/commit/137fb43))
+
+## <small>6.1.8 (2019-11-11)</small>
+
+* Use port name instead of the value ([872e01e](https://github.com/bitnami/charts/commit/872e01e))
+
+## <small>6.1.7 (2019-11-11)</small>
+
+* Add SSL enable value ([9dd0286](https://github.com/bitnami/charts/commit/9dd0286))
+* Fix default values for SSL enabled ([a9500d7](https://github.com/bitnami/charts/commit/a9500d7))
+* Fix port in serviceMonitor ([e5af275](https://github.com/bitnami/charts/commit/e5af275))
+
+## <small>6.1.6 (2019-10-27)</small>
+
+* Add SSL Support for Kafka with Listeners & Container port set ([8251aec](https://github.com/bitnami/charts/commit/8251aec))
+* Update chart version ([0a82edc](https://github.com/bitnami/charts/commit/0a82edc))
+
+## <small>6.1.5 (2019-10-25)</small>
+
+* [bitnami/kafka] Release 6.1.5 updating components versions ([4356fff](https://github.com/bitnami/charts/commit/4356fff))
+
+## <small>6.1.4 (2019-10-24)</small>
+
+* [bitnami/kafka] Specify LOG_MESSAGE_FORMAT_VERSION env-var if not empty (#1515) ([47d948d](https://github.com/bitnami/charts/commit/47d948d)), closes [#1515](https://github.com/bitnami/charts/issues/1515)
+* Fix links because of section renaming ([8e6fa3b](https://github.com/bitnami/charts/commit/8e6fa3b))
+
+## <small>6.1.3 (2019-10-23)</small>
+
+* Adapt README in charts (II) ([4705a98](https://github.com/bitnami/charts/commit/4705a98))
+
+## <small>6.1.2 (2019-10-23)</small>
+
+* [bitnami/kafka] Release 6.1.2 updating components versions ([363224b](https://github.com/bitnami/charts/commit/363224b))
+
+## <small>6.1.1 (2019-10-23)</small>
+
+* [bitnami/kafka] Fixes error when using `externalZookeeper.servers` in a subchart (#1507) ([e747047](https://github.com/bitnami/charts/commit/e747047)), closes [#1507](https://github.com/bitnami/charts/issues/1507)
+
+## 6.1.0 (2019-10-16)
+
+* [bitnami/kafka] Add Metrics Servicemonitor ([8ab7211](https://github.com/bitnami/charts/commit/8ab7211))
+
+## <small>6.0.2 (2019-10-08)</small>
+
+* [bitnami/kafka] Standardize README.md ([d19e748](https://github.com/bitnami/charts/commit/d19e748))
+* Change default value of logsDirs in README and values files. ([ab2b774](https://github.com/bitnami/charts/commit/ab2b774))
+
+## <small>6.0.1 (2019-09-23)</small>
+
+* [bitnami/kafka] Update components versions ([3a6d392](https://github.com/bitnami/charts/commit/3a6d392))
+* Bump Kafka chart version. ([8bb9e2b](https://github.com/bitnami/charts/commit/8bb9e2b))
+* Change logsDirs to correctly use persistent disk as per README. ([bf127f0](https://github.com/bitnami/charts/commit/bf127f0))
+
+## 6.0.0 (2019-09-23)
+
+* Bump major version ([4743d1c](https://github.com/bitnami/charts/commit/4743d1c))
+
+## <small>5.3.2 (2019-09-23)</small>
+
+* [bitnami/kafka] Update dependencies ([dfd15af](https://github.com/bitnami/charts/commit/dfd15af))
+
+## <small>5.3.1 (2019-09-20)</small>
+
+* [bitnami/*] Update apiVersion on sts, deployments, daemonsets and podsecuritypolicies ([4dfac07](https://github.com/bitnami/charts/commit/4dfac07))
+
+## 5.3.0 (2019-09-05)
+
+* fix minor version ([0fb2f2b](https://github.com/bitnami/charts/commit/0fb2f2b))
+
+## 5.4.0 (2019-09-05)
+
+* [bitnami/kafka] Fix name of environment variables set in chart ([b026a5a](https://github.com/bitnami/charts/commit/b026a5a))
+* Major version for chart ([d930547](https://github.com/bitnami/charts/commit/d930547))
+* use minor version instead ([ca634fe](https://github.com/bitnami/charts/commit/ca634fe))
+
+## <small>5.2.4 (2019-09-02)</small>
+
+* [bitnami/kafka] Release 5.2.4 updating components versions ([ba75409](https://github.com/bitnami/charts/commit/ba75409))
+* Use stretch instead of buster to be consistent ([decd85f](https://github.com/bitnami/charts/commit/decd85f))
+
+## <small>5.2.3 (2019-08-30)</small>
+
+* [bitnami/*] Use buster instead of latest as minideb tag and adapt sysctl ([921e811](https://github.com/bitnami/charts/commit/921e811))
+
+## <small>5.2.2 (2019-08-22)</small>
+
+* [bitnami/*] Fix 'storageClass' macros ([f41c193](https://github.com/bitnami/charts/commit/f41c193))
+
+## <small>5.2.1 (2019-08-21)</small>
+
+* Refactor StorageClass template to support old Helm versions ([1d7f3df](https://github.com/bitnami/charts/commit/1d7f3df))
+* Refactor storageClassTemplate ([1872215](https://github.com/bitnami/charts/commit/1872215))
+
+## 5.2.0 (2019-08-19)
+
+* Add global variable to set the storage class to all of the Hekm Charts ([cdb4bdc](https://github.com/bitnami/charts/commit/cdb4bdc))
+* Update charts versions ([9459dbb](https://github.com/bitnami/charts/commit/9459dbb))
+
+## <small>5.1.1 (2019-08-13)</small>
+
+* Update README.md ([c2a0d8e](https://github.com/bitnami/charts/commit/c2a0d8e))
+* Updated version numbers ([aa0294b](https://github.com/bitnami/charts/commit/aa0294b))
+
+## 5.1.0 (2019-08-12)
+
+* [bitnami/kafka] Use bitnami/kafka-exporter ([8d44d7d](https://github.com/bitnami/charts/commit/8d44d7d))
+
+## <small>5.0.3 (2019-08-07)</small>
+
+* Bump chart version ([6d065ff](https://github.com/bitnami/charts/commit/6d065ff))
+* Fix Service port hardcoded ([7ddc1af](https://github.com/bitnami/charts/commit/7ddc1af))
+
+## <small>5.0.2 (2019-08-07)</small>
+
+* [bitnami/kafka] Service port should not be hardcoded ([0e8ffc2](https://github.com/bitnami/charts/commit/0e8ffc2))
+
+## <small>5.0.1 (2019-07-30)</small>
+
+* fix(kafka): Truncate the fullname of zookeeper in a regular way. Should not be too small. ([9c8252e](https://github.com/bitnami/charts/commit/9c8252e))
+
+## 5.0.0 (2019-07-25)
+
+* Fix indentation ([c699e9f](https://github.com/bitnami/charts/commit/c699e9f))
+* Update dependencies for some bitnami charts ([ff54f7f](https://github.com/bitnami/charts/commit/ff54f7f))
+
+## 4.1.0 (2019-07-22)
+
+* Change kafka ([494405f](https://github.com/bitnami/charts/commit/494405f))
+* Long namespace flag instead of -n ([92a50cc](https://github.com/bitnami/charts/commit/92a50cc))
+
+## <small>4.0.2 (2019-07-19)</small>
+
+* added namespace to 'kubectl exec' commands ([e309e35](https://github.com/bitnami/charts/commit/e309e35))
+* updated kafka helm chart version ([72b7f57](https://github.com/bitnami/charts/commit/72b7f57))
+
+## <small>4.0.1 (2019-07-18)</small>
+
+* fix(kafka): Fix mapping value for resources. ([aede4d0](https://github.com/bitnami/charts/commit/aede4d0))
+
+## 4.0.0 (2019-07-17)
+
+* Implement again #1283 changes but bumping the major version ([1ce079c](https://github.com/bitnami/charts/commit/1ce079c)), closes [#1283](https://github.com/bitnami/charts/issues/1283)
+
+## <small>3.0.16 (2019-07-17)</small>
+
+* Revert pull request #1283 ([8e5940a](https://github.com/bitnami/charts/commit/8e5940a)), closes [#1283](https://github.com/bitnami/charts/issues/1283)
+
+## <small>3.0.15 (2019-07-16)</small>
+
+* [bitnami/kafka] Fix zookeeper name helper ([86872ab](https://github.com/bitnami/charts/commit/86872ab))
+* Use name of the solution for the main container included in the pod ([d031dee](https://github.com/bitnami/charts/commit/d031dee))
+
+## <small>3.0.14 (2019-07-11)</small>
+
+* [bitnami/kafka] bump chart version to 3.0.13 ([6586ec3](https://github.com/bitnami/charts/commit/6586ec3))
+* [bitnami/kafka] fix JMX when auth disabled ([175cc9c](https://github.com/bitnami/charts/commit/175cc9c))
+* Change domain by clusterDomain ([4effe5c](https://github.com/bitnami/charts/commit/4effe5c))
+* Standardize component.name & component.fullname functions ([775948e](https://github.com/bitnami/charts/commit/775948e))
+
+## <small>3.0.13 (2019-07-01)</small>
+
+* Create template for cluster domain on Kafka ([e211aa7](https://github.com/bitnami/charts/commit/e211aa7))
+
+## <small>3.0.12 (2019-06-28)</small>
+
+* [bitnami/kafka] Release 3.0.12 updating components versions ([6b0b69c](https://github.com/bitnami/charts/commit/6b0b69c))
+
+## <small>3.0.11 (2019-06-25)</small>
+
+* [bitnami/kafka] Release 3.0.11 updating components versions ([e04395c](https://github.com/bitnami/charts/commit/e04395c))
+
+## <small>3.0.10 (2019-06-25)</small>
+
+* [bitnami/kafka] Release 3.0.10 updating components versions ([e06a248](https://github.com/bitnami/charts/commit/e06a248))
+
+## <small>3.0.9 (2019-06-14)</small>
+
+* Fix extraEnvVars example ([2ff5240](https://github.com/bitnami/charts/commit/2ff5240))
+
+## <small>3.0.8 (2019-06-10)</small>
+
+* bitnami/kafka: update to 2.2.1 ([a46f564](https://github.com/bitnami/charts/commit/a46f564))
+* Bump kafka version ([1cd024b](https://github.com/bitnami/charts/commit/1cd024b))
+* Changes in README ([7ac4ec0](https://github.com/bitnami/charts/commit/7ac4ec0))
+
+## <small>3.0.7 (2019-06-10)</small>
+
+* bitnami/kafka: update to 2.2.1 ([e57ffd9](https://github.com/bitnami/charts/commit/e57ffd9))
+* Bump version ([a672193](https://github.com/bitnami/charts/commit/a672193))
+
+## <small>3.0.6 (2019-06-10)</small>
+
+* Add command ([9e3b8ce](https://github.com/bitnami/charts/commit/9e3b8ce))
+* Unify sections ([99c7d58](https://github.com/bitnami/charts/commit/99c7d58))
+* Use IfNotPresent as imagePullPolicy since we are using immutable tags ([53247da](https://github.com/bitnami/charts/commit/53247da))
+
+## <small>3.0.5 (2019-06-07)</small>
+
+* [bitnami/kafka] Unify and document production values ([9cabcc9](https://github.com/bitnami/charts/commit/9cabcc9))
+
+## <small>3.0.4 (2019-06-03)</small>
+
+* kafka: add protocol map and broker listener options ([a2397d2](https://github.com/bitnami/charts/commit/a2397d2))
+* Update Chart.yaml ([126979e](https://github.com/bitnami/charts/commit/126979e))
+* Update Kafka readme regarding persistency ([e2c3a08](https://github.com/bitnami/charts/commit/e2c3a08))
+* Update README.md ([18786ad](https://github.com/bitnami/charts/commit/18786ad))
+* Update README.md ([471ddf4](https://github.com/bitnami/charts/commit/471ddf4))
+
+## <small>3.0.2 (2019-06-03)</small>
+
+* [bitnami/kakfa] Add option to use existingClaim ([865f218](https://github.com/bitnami/charts/commit/865f218))
+* bitnami/kafka: update to 2.2.1 ([8041c44](https://github.com/bitnami/charts/commit/8041c44))
+* Fix typo ([09eab0f](https://github.com/bitnami/charts/commit/09eab0f))
+* Simplify logic ([03297a3](https://github.com/bitnami/charts/commit/03297a3))
+
+## 3.0.0 (2019-05-30)
+
+* [bitnami/kafka] Allow passing custom env vars with direct mapping to config properties ([9a034ad](https://github.com/bitnami/charts/commit/9a034ad))
+
+## <small>2.2.4 (2019-05-30)</small>
+
+* Bumping chart version from 2.2.3 to 2.2.4 ([774b390](https://github.com/bitnami/charts/commit/774b390))
+* Update Chart.yaml ([94618e9](https://github.com/bitnami/charts/commit/94618e9))
+
+## <small>2.2.3 (2019-05-29)</small>
+
+* Change syntax because of linter failing ([adfc357](https://github.com/bitnami/charts/commit/adfc357))
+* Fix https://github.com/helm/charts/pull/14199\#issuecomment-496883321 and support _sha256_ as an imm ([95957ea](https://github.com/bitnami/charts/commit/95957ea)), closes [#issuecomment-496883321](https://github.com/bitnami/charts/issues/issuecomment-496883321)
+* Use immutable tags in the main images ([17ca4f5](https://github.com/bitnami/charts/commit/17ca4f5))
+
+## <small>2.2.2 (2019-05-28)</small>
+
+* Prepare immutable tags ([f9093c1](https://github.com/bitnami/charts/commit/f9093c1))
+
+## <small>2.2.1 (2019-05-24)</small>
+
+* [bitnami/kafka] Fix values*.yaml syntax ([e7f25ce](https://github.com/bitnami/charts/commit/e7f25ce))
+
+## 2.1.0 (2019-05-14)
+
+* Create a pod distruption budget when replicas is bigger than 1 ([6a0e5d9](https://github.com/bitnami/charts/commit/6a0e5d9))
+
+## <small>1.10.2 (2019-04-29)</small>
+
+* [bitnami/kafka] Add fullnameOverride to the readme ([0ffa56d](https://github.com/bitnami/charts/commit/0ffa56d))
+
+## <small>2.0.3 (2019-05-29)</small>
+
+* enabling prometheus scraping for jmx exporter ([6d80a04](https://github.com/bitnami/charts/commit/6d80a04))
+* Update Chart.yaml ([90d7b64](https://github.com/bitnami/charts/commit/90d7b64))
+
+## <small>2.2.3 (2019-05-29)</small>
+
+* Change syntax because of linter failing ([adfc357](https://github.com/bitnami/charts/commit/adfc357))
+* Fix https://github.com/helm/charts/pull/14199\#issuecomment-496883321 and support _sha256_ as an imm ([95957ea](https://github.com/bitnami/charts/commit/95957ea)), closes [#issuecomment-496883321](https://github.com/bitnami/charts/issues/issuecomment-496883321)
+* Use immutable tags in the main images ([17ca4f5](https://github.com/bitnami/charts/commit/17ca4f5))
+
+## <small>2.2.2 (2019-05-28)</small>
+
+* Prepare immutable tags ([f9093c1](https://github.com/bitnami/charts/commit/f9093c1))
+
+## <small>2.2.1 (2019-05-24)</small>
+
+* [bitnami/kafka] Fix values*.yaml syntax ([e7f25ce](https://github.com/bitnami/charts/commit/e7f25ce))
+
+## <small>1.10.2 (2019-04-29)</small>
+
+* [bitnami/kafka] Add fullnameOverride to the readme ([0ffa56d](https://github.com/bitnami/charts/commit/0ffa56d))
+
+## 2.1.0 (2019-05-14)
+
+* Create a pod distruption budget when replicas is bigger than 1 ([6a0e5d9](https://github.com/bitnami/charts/commit/6a0e5d9))
+* Fix indenting of data volume when not using persistent storage ([1f2bbea](https://github.com/bitnami/charts/commit/1f2bbea))
+
+## <small>2.0.1 (2019-05-07)</small>
+
+* [bitnami/kafka] Adapt kafka to new labels format ([2a95103](https://github.com/bitnami/charts/commit/2a95103))
+
+## 2.0.0 (2019-05-07)
+
+* Bump major version ([f5b13c3](https://github.com/bitnami/charts/commit/f5b13c3))
+
+## 1.11.0 (2019-05-07)
+
+* [bitnami/kafka] Update dependencies ([e13115d](https://github.com/bitnami/charts/commit/e13115d))
+* Bump chart version ([905369d](https://github.com/bitnami/charts/commit/905369d))
+
+## <small>1.10.2 (2019-04-29)</small>
+
+* [bitnami/kafka] Add fullnameOverride to the readme ([0ffa56d](https://github.com/bitnami/charts/commit/0ffa56d))
+* Update chart version ([0f533b7](https://github.com/bitnami/charts/commit/0f533b7))
+
+## 1.10.0 (2019-04-08)
+
+* Add new kafka option. Add affinity for kafka and zookeeper ([10f0e71](https://github.com/bitnami/charts/commit/10f0e71))
+
+## <small>1.9.1 (2019-04-16)</small>
+
+* specify cluster domain ([43ccb4f](https://github.com/bitnami/charts/commit/43ccb4f))
+* Update chart version ([7db6a64](https://github.com/bitnami/charts/commit/7db6a64))
+* update enabling auth docs ([f0ec6ff](https://github.com/bitnami/charts/commit/f0ec6ff))
+* Update zookeeper version ([da526a7](https://github.com/bitnami/charts/commit/da526a7))
+
+## 1.10.0 (2019-04-08)
+
+* Add new kafka option. Add affinity for kafka and zookeeper ([10f0e71](https://github.com/bitnami/charts/commit/10f0e71))
+
+## 1.9.0 (2019-03-29)
+
+* [bitnami/kafka] Add options to configure internal topics ([de1a384](https://github.com/bitnami/charts/commit/de1a384))
+
+## <small>1.8.2 (2019-03-27)</small>
+
+* bitnami/kafka: update to 2.2.0 ([f3b72a2](https://github.com/bitnami/charts/commit/f3b72a2))
+
+## <small>1.8.1 (2019-03-27)</small>
+
+* [bitnami/kafka] Fix issue when zookeeper password is specified but authentication is disabled ([634e5db](https://github.com/bitnami/charts/commit/634e5db))
+
+## 1.8.0 (2019-03-21)
+
+* [bitnami/kafka] Add parameters to specify 'NodePort' and 'loadBalancerIP' ([358e2d2](https://github.com/bitnami/charts/commit/358e2d2))
+
+## <small>1.7.2 (2019-03-18)</small>
+
+* Set rollingUpdate to null when updateStrategy is Recreate ([1a45bba](https://github.com/bitnami/charts/commit/1a45bba))
+
+## <small>1.7.1 (2019-03-14)</small>
+
+* Use global registry in secondary, metrics and other non-default images ([5d216bf](https://github.com/bitnami/charts/commit/5d216bf))
+
+## 1.7.0 (2019-03-12)
+
+* Fix typo ([e11a2a3](https://github.com/bitnami/charts/commit/e11a2a3))
+* Fix typo in helpers ([d0b6f76](https://github.com/bitnami/charts/commit/d0b6f76))
+* pullSecrets for production and metrics ([22d6e0b](https://github.com/bitnami/charts/commit/22d6e0b))
+* Use kafka and jmx values for metrics ([50021c0](https://github.com/bitnami/charts/commit/50021c0))
+
+## 1.6.0 (2019-03-11)
+
+* [bitnami/kafka] Add global imagePullSecrets to overwrite any other existing one ([d61508d](https://github.com/bitnami/charts/commit/d61508d))
+* Add appiVersion to Chart.yaml ([08704a5](https://github.com/bitnami/charts/commit/08704a5))
+* Apply requsted changes ([fdab5e3](https://github.com/bitnami/charts/commit/fdab5e3))
+
+## <small>1.4.1 (2019-02-27)</small>
+
+* [bitnami/kafka] Expose KAFKA_LOG_MESSAGE_FORMAT_VERSION ([7a20589](https://github.com/bitnami/charts/commit/7a20589))
+
+## 1.4.0 (2019-02-26)
+
+* [bitnami/kafka] Add option to configure default replication factor ([0e00bf8](https://github.com/bitnami/charts/commit/0e00bf8))
+
+## <small>1.3.2 (2019-02-20)</small>
+
+* bitnami/kafka: update to 2.1.1 ([b7d4708](https://github.com/bitnami/charts/commit/b7d4708))
+* Update Chart.yaml ([321fe04](https://github.com/bitnami/charts/commit/321fe04))
+
+## <small>1.2.6 (2019-01-30)</small>
+
+* Update Chart.yaml ([5265f54](https://github.com/bitnami/charts/commit/5265f54))
+* Update statefulset.yaml ([e8112e3](https://github.com/bitnami/charts/commit/e8112e3))
+* Update values-production.yaml ([328af8a](https://github.com/bitnami/charts/commit/328af8a))
+* Update values.yaml ([3310c95](https://github.com/bitnami/charts/commit/3310c95))
+
+## <small>1.3.1 (2019-02-21)</small>
+
+* Update Chart.yaml ([4412763](https://github.com/bitnami/charts/commit/4412763))
+* Update README.md ([69a201c](https://github.com/bitnami/charts/commit/69a201c))
+
+## <small>1.3.2 (2019-02-20)</small>
+
+* Add service annotations in values-productions.yaml ([5c8517c](https://github.com/bitnami/charts/commit/5c8517c))
+* bitnami/kafka: update to 2.1.1 ([b7d4708](https://github.com/bitnami/charts/commit/b7d4708))
+* Document the correct format for pullSecrets in READMEs ([9a2cf81](https://github.com/bitnami/charts/commit/9a2cf81))
+* Update Chart.yaml ([321fe04](https://github.com/bitnami/charts/commit/321fe04))
+
+## 1.3.0 (2019-01-21)
+
+* [bitnami/kafka] Add annotations to service ([5191e48](https://github.com/bitnami/charts/commit/5191e48))
+* [bitnami/kafka] Fix kafka advertised name ([04b7484](https://github.com/bitnami/charts/commit/04b7484))
+
+## <small>1.2.6 (2019-01-30)</small>
+
+* Update Chart.yaml ([5265f54](https://github.com/bitnami/charts/commit/5265f54))
+* Update statefulset.yaml ([e8112e3](https://github.com/bitnami/charts/commit/e8112e3))
+* Update values-production.yaml ([328af8a](https://github.com/bitnami/charts/commit/328af8a))
+* Update values.yaml ([3310c95](https://github.com/bitnami/charts/commit/3310c95))
+
+## 1.3.0 (2019-01-21)
+
+* [bitnami/kafka] Add annotations to service ([5191e48](https://github.com/bitnami/charts/commit/5191e48))
+
+## <small>1.2.5 (2019-01-02)</small>
+
+* Change the default advertised listeners to point to the headless service name instead of IP ([db633c6](https://github.com/bitnami/charts/commit/db633c6))
+* Update kafka Chart.yaml ([e68b59c](https://github.com/bitnami/charts/commit/e68b59c))
+
+## <small>1.2.4 (2018-12-20)</small>
+
+* [bitnami/kafka] Add fullnameOverride to kafka chart ([eb12d81](https://github.com/bitnami/charts/commit/eb12d81))
+
+## <small>1.2.3 (2018-12-18)</small>
+
+* [bitnami/kafka] Fix confusing help from NOTES.txt ([d88146d](https://github.com/bitnami/charts/commit/d88146d))
+
+## <small>1.2.2 (2018-12-17)</small>
+
+* [bitnami/kafka] Update zookeeper dependency ([f964514](https://github.com/bitnami/charts/commit/f964514))
+
+## <small>1.2.1 (2018-11-21)</small>
+
+* kafka: bump chart appVersion to `2.1.0` ([aeb53f1](https://github.com/bitnami/charts/commit/aeb53f1))
+* kafka: bump chart version to `1.2.1` ([b41a739](https://github.com/bitnami/charts/commit/b41a739))
+* kafka: update to `2.1.0` ([5412d88](https://github.com/bitnami/charts/commit/5412d88))
+* [bitnami/kafka] Enable metrics by default in values-production.yaml ([3176311](https://github.com/bitnami/charts/commit/3176311))
+* Bump chart version ([0f28135](https://github.com/bitnami/charts/commit/0f28135))
+* Enable jmx metrics ([f62c4f6](https://github.com/bitnami/charts/commit/f62c4f6))
+
+## <small>1.0.3 (2018-10-15)</small>
+
+* [bitnami/zookeeper] Enable Zookeeper exporter ([ce3acad](https://github.com/bitnami/charts/commit/ce3acad))
+
+## <small>1.1.3 (2018-11-13)</small>
+
+* [bitnami/zookeeper] Make trunc consistent between charts ([fbab11d](https://github.com/bitnami/charts/commit/fbab11d))
+
+## <small>1.1.2 (2018-11-09)</small>
+
+* kafka: bump chart appVersion to `2.0.1` ([65becb5](https://github.com/bitnami/charts/commit/65becb5))
+* kafka: bump chart version to `1.1.2` ([42acb1a](https://github.com/bitnami/charts/commit/42acb1a))
+* kafka: update to `2.0.1` ([67fbfc9](https://github.com/bitnami/charts/commit/67fbfc9))
+
+## <small>1.1.1 (2018-10-17)</small>
+
+* Apply some suggestions ([24706a6](https://github.com/bitnami/charts/commit/24706a6))
+* Bump versions ([0cfd3f4](https://github.com/bitnami/charts/commit/0cfd3f4))
+* Change logic to determine registry ([9ead294](https://github.com/bitnami/charts/commit/9ead294))
+* Check if global is set ([dec26e5](https://github.com/bitnami/charts/commit/dec26e5))
+* Fix typo ([93170ac](https://github.com/bitnami/charts/commit/93170ac))
+* Remove distro tags in charts ([427ac51](https://github.com/bitnami/charts/commit/427ac51))
+* Reword and update kafka dependencies ([be6cbed](https://github.com/bitnami/charts/commit/be6cbed))
+* Update kafka deps (zookeeper) ([78a98b6](https://github.com/bitnami/charts/commit/78a98b6))
+
+## 1.1.0 (2018-10-11)
+
+* Add global registry option to Bitnami charts ([395ba08](https://github.com/bitnami/charts/commit/395ba08))
+
+## <small>1.0.3 (2018-10-15)</small>
+
+* [bitnami/zookeeper] Enable Zookeeper exporter ([ce3acad](https://github.com/bitnami/charts/commit/ce3acad))
+
+## 1.1.0 (2018-10-11)
+
+* Add global registry option to Bitnami charts ([395ba08](https://github.com/bitnami/charts/commit/395ba08))
+
+## <small>1.0.2 (2018-10-05)</small>
+
+* Add ) ([728466a](https://github.com/bitnami/charts/commit/728466a))
+* Add kubeapps text to charts READMEs ([2f6dc51](https://github.com/bitnami/charts/commit/2f6dc51))
+* Fix go template inside go template ([a140313](https://github.com/bitnami/charts/commit/a140313))
+* Updated github repo URL for upstreamed charts ([c22b640](https://github.com/bitnami/charts/commit/c22b640))
+
+## <small>1.0.1 (2018-09-27)</small>
+
+* Improve getting LoadBalancer address in Bitnami charts NOTES.txt ([a641728](https://github.com/bitnami/charts/commit/a641728))
+* Update README.md ([6fd90d0](https://github.com/bitnami/charts/commit/6fd90d0))
+
+## 1.0.0 (2018-09-21)
+
+* [bitnami/kafka] Fix chart not being upgradable ([e9dd41e](https://github.com/bitnami/charts/commit/e9dd41e))
+* Update README.md ([bd1ad05](https://github.com/bitnami/charts/commit/bd1ad05)), closes [#794](https://github.com/bitnami/charts/issues/794)
+
+## <small>0.0.9 (2018-08-14)</small>
+
+* kafka: bump chart appVersion to `2.0.0` ([34afefe](https://github.com/bitnami/charts/commit/34afefe))
+* kafka: bump chart version to `0.0.9` ([0db5066](https://github.com/bitnami/charts/commit/0db5066))
+* kafka: update to `2.0.0-debian-9` ([d209240](https://github.com/bitnami/charts/commit/d209240))
+
+## <small>0.0.8 (2018-08-14)</small>
+
+* Fix issue with maxMessageBytes default value ([ae72588](https://github.com/bitnami/charts/commit/ae72588))
+
+## <small>0.0.7 (2018-08-06)</small>
+
+* Add max.message.bytes support to kafka ([0aa5f72](https://github.com/bitnami/charts/commit/0aa5f72))
+* Improve notes to access deployed services ([0071eb5](https://github.com/bitnami/charts/commit/0071eb5))
+* Update readme ([551c250](https://github.com/bitnami/charts/commit/551c250))
+
+## <small>0.0.6 (2018-07-20)</small>
+
+* kafka: bump chart appVersion to `1.1.1` ([e0a2c35](https://github.com/bitnami/charts/commit/e0a2c35))
+* kafka: bump chart version to `0.0.6` ([e0cf56d](https://github.com/bitnami/charts/commit/e0cf56d))
+* kafka: update to `1.1.1-debian-9` ([8d823c2](https://github.com/bitnami/charts/commit/8d823c2))
+
+## <small>0.0.5 (2018-07-06)</small>
+
+* kafka: bump chart appVersion to `1.1.0-debian-9` ([edd533a](https://github.com/bitnami/charts/commit/edd533a))
+* kafka: bump chart version to `0.0.5` ([7e4ddad](https://github.com/bitnami/charts/commit/7e4ddad))
+* kafka: update to `1.1.0-debian-9` ([125ac00](https://github.com/bitnami/charts/commit/125ac00))
+
+## <small>0.0.4 (2018-06-14)</small>
+
+* Fix capitalization of clusterIP parameter ([e8153d8](https://github.com/bitnami/charts/commit/e8153d8))
+* Update requirements.lock file ([386a592](https://github.com/bitnami/charts/commit/386a592))
+
+## <small>0.0.3 (2018-06-14)</small>
+
+* Add missing dependency file ([dd6ca24](https://github.com/bitnami/charts/commit/dd6ca24))
+
+## <small>0.0.2 (2018-06-14)</small>
+
+* Add javsalgar's feedback ([0b28054](https://github.com/bitnami/charts/commit/0b28054))
+* Fix kafka-chart. certificatesSecret is not always needed ([473e2b2](https://github.com/bitnami/charts/commit/473e2b2))
+* not include dummy certificates. now it is mandatory mount them ([ace6973](https://github.com/bitnami/charts/commit/ace6973))
+* Update jmx values yaml path ([98c0b7d](https://github.com/bitnami/charts/commit/98c0b7d))
+
+## <small>0.0.1 (2018-06-13)</small>
+
+* Add kafka chart ([d20173a](https://github.com/bitnami/charts/commit/d20173a))

--- a/bitnami/kafka/Chart.lock
+++ b/bitnami/kafka/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: zookeeper
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 13.2.2
+  version: 13.2.3
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.19.2
-digest: sha256:27ef124d0a7c4c11c04450cfed5a6fa683e8f2a06da7cfc36f3a8d6f8d319f17
-generated: "2024-05-20T17:52:51.140652+02:00"
+  version: 2.19.3
+digest: sha256:5ec074d1704d0eaf798aa3d0c8a6ef4a9459a94ee3029b0e1621b790cf44e310
+generated: "2024-05-21T13:55:47.048573097+02:00"

--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -42,4 +42,4 @@ maintainers:
 name: kafka
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/kafka
-version: 28.2.6
+version: 28.3.0

--- a/bitnami/kafka/templates/NOTES.txt
+++ b/bitnami/kafka/templates/NOTES.txt
@@ -332,3 +332,4 @@ ssl.endpoint.identification.algorithm=
 {{- include "kafka.checkRollingTags" . }}
 {{- include "kafka.validateValues" . }}
 {{- include "common.warnings.resources" (dict "sections" (list "broker" "controller" "externalAccess.autoDiscovery" "metrics.jmx" "metrics.kafka" "provisioning" "volumePermissions") "context" $) }}
+{{- include "common.warnings.modifiedImages" (dict "images" (list .Values.image .Values.externalAccess.autoDiscovery.image .Values.volumePermissions.image .Values.metrics.kafka.image .Values.metrics.jmx.image) "context" $) }}


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Replacing the original images that have been tested and verified when releasing the chart is a dangerous practice in terms of security, performance and available features. This PR updates the `NOTES.txt` file using the `common.warnings.modifiedImages` helper developed in https://github.com/bitnami/charts/pull/25952.


<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

Users are more aware of the risks of changing original images.
<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

n/a
<!-- Describe any known limitations with your change -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
