### PR TITLE
[bitnami/metallb] feat: :sparkles: :lock: Add warning when original images are replaced

### DIFF
--- a/bitnami/metallb/CHANGELOG.md
+++ b/bitnami/metallb/CHANGELOG.md
@@ -1,0 +1,845 @@
+# Changelog
+
+## 6.2.0 (2024-05-21)
+
+* [bitnami/metallb] feat: :sparkles: :lock: Add warning when original images are replaced ([#26242](https://github.com/bitnami/charts/pulls/26242))
+
+## <small>6.1.7 (2024-05-18)</small>
+
+* [bitnami/metallb] Release 6.1.7 updating components versions (#26044) ([7e86d34](https://github.com/bitnami/charts/commit/7e86d34)), closes [#26044](https://github.com/bitnami/charts/issues/26044)
+
+## <small>6.1.6 (2024-05-14)</small>
+
+* [bitnami/metallb] Release 6.1.6 updating components versions (#25791) ([19af641](https://github.com/bitnami/charts/commit/19af641)), closes [#25791](https://github.com/bitnami/charts/issues/25791)
+
+## <small>6.1.5 (2024-05-13)</small>
+
+* [bitnami/metallb] Typo fix in speaker RBAC (#25699) ([c3eef09](https://github.com/bitnami/charts/commit/c3eef09)), closes [#25699](https://github.com/bitnami/charts/issues/25699)
+
+## <small>6.1.4 (2024-05-08)</small>
+
+* [bitnami/*] Change non-root and rolling-tags doc URLs (#25628) ([b067c94](https://github.com/bitnami/charts/commit/b067c94)), closes [#25628](https://github.com/bitnami/charts/issues/25628)
+* [bitnami/*] Set new header/owner (#25558) ([8d1dc11](https://github.com/bitnami/charts/commit/8d1dc11)), closes [#25558](https://github.com/bitnami/charts/issues/25558)
+* [bitnami/metallb] Release 6.1.4 updating components versions (#25630) ([86744ff](https://github.com/bitnami/charts/commit/86744ff)), closes [#25630](https://github.com/bitnami/charts/issues/25630)
+
+## <small>6.1.3 (2024-05-02)</small>
+
+* [bitnami/*] Fix license headers (#25447) ([2d7dca6](https://github.com/bitnami/charts/commit/2d7dca6)), closes [#25447](https://github.com/bitnami/charts/issues/25447)
+* [bitnami/metallb] Fixes for FRR mode (#25501) ([19f1cb5](https://github.com/bitnami/charts/commit/19f1cb5)), closes [#25501](https://github.com/bitnami/charts/issues/25501)
+* Replace VMware by Broadcom copyright text (#25306) ([a5e4bd0](https://github.com/bitnami/charts/commit/a5e4bd0)), closes [#25306](https://github.com/bitnami/charts/issues/25306)
+
+## <small>6.1.2 (2024-04-23)</small>
+
+* [bitnami/metallb] Release 6.1.2 updating components versions (#25331) ([e28f84b](https://github.com/bitnami/charts/commit/e28f84b)), closes [#25331](https://github.com/bitnami/charts/issues/25331)
+
+## <small>6.1.1 (2024-04-23)</small>
+
+* [bitnami/metallb] Release 6.1.1 updating components versions (#25327) ([23baab3](https://github.com/bitnami/charts/commit/23baab3)), closes [#25327](https://github.com/bitnami/charts/issues/25327)
+
+## 6.1.0 (2024-04-23)
+
+* [bitnami/metallb] Add support for FRR in speaker (#25282) ([9d36bbd](https://github.com/bitnami/charts/commit/9d36bbd)), closes [#25282](https://github.com/bitnami/charts/issues/25282)
+
+## <small>6.0.1 (2024-04-22)</small>
+
+* [bitnami/metallb] Release 6.0.1 (#25313) ([a855aa1](https://github.com/bitnami/charts/commit/a855aa1)), closes [#25313](https://github.com/bitnami/charts/issues/25313)
+
+## 6.0.0 (2024-04-22)
+
+* [bitnami/metallb] Upgrade to version 0.14.5 (#25310) ([4d1c45a](https://github.com/bitnami/charts/commit/4d1c45a)), closes [#25310](https://github.com/bitnami/charts/issues/25310)
+
+## <small>5.0.3 (2024-04-11)</small>
+
+* [bitnami/metallb] fix: :bug: Set proper webhook service name in CRD (#24930) ([625ad4b](https://github.com/bitnami/charts/commit/625ad4b)), closes [#24930](https://github.com/bitnami/charts/issues/24930)
+* [bitnami/several] Fix comment mentioning Keycloak (#24661) ([641c546](https://github.com/bitnami/charts/commit/641c546)), closes [#24661](https://github.com/bitnami/charts/issues/24661)
+* Update resourcesPreset comments (#24467) ([92e3e8a](https://github.com/bitnami/charts/commit/92e3e8a)), closes [#24467](https://github.com/bitnami/charts/issues/24467)
+
+## <small>5.0.2 (2024-03-21)</small>
+
+* [bitnami/metallb] Release 5.0.2 updating components versions (#24604) ([46825f4](https://github.com/bitnami/charts/commit/46825f4)), closes [#24604](https://github.com/bitnami/charts/issues/24604)
+
+## <small>5.0.1 (2024-03-21)</small>
+
+* [bitnami/*] Reorder Chart sections (#24455) ([0cf4048](https://github.com/bitnami/charts/commit/0cf4048)), closes [#24455](https://github.com/bitnami/charts/issues/24455)
+* [bitnami/metallb] Update speaker image that includes tcpdump (#24595) ([da6677c](https://github.com/bitnami/charts/commit/da6677c)), closes [#24595](https://github.com/bitnami/charts/issues/24595)
+
+## 5.0.0 (2024-03-12)
+
+* [bitnami/metallb] feat!: :lock: :boom: Improve security defaults (#24355) ([2c13c64](https://github.com/bitnami/charts/commit/2c13c64)), closes [#24355](https://github.com/bitnami/charts/issues/24355)
+
+## <small>4.16.1 (2024-03-06)</small>
+
+* [bitnami/metallb] Release 4.16.1 updating components versions (#24213) ([96e0ee9](https://github.com/bitnami/charts/commit/96e0ee9)), closes [#24213](https://github.com/bitnami/charts/issues/24213)
+
+## 4.16.0 (2024-03-06)
+
+* [bitnami/metallb] feat: :sparkles: :lock: Add automatic adaptation for Openshift restricted-v2 SCC ( ([2ab80b9](https://github.com/bitnami/charts/commit/2ab80b9)), closes [#24119](https://github.com/bitnami/charts/issues/24119)
+
+## 4.15.0 (2024-02-29)
+
+* [bitnami/metallb] feat: :sparkles: :lock: Add runAsGroup (#23969) ([0fd8baa](https://github.com/bitnami/charts/commit/0fd8baa)), closes [#23969](https://github.com/bitnami/charts/issues/23969)
+
+## <small>4.14.2 (2024-02-22)</small>
+
+* [bitnami/metallb] Release 4.14.2 updating components versions (#23802) ([9070ca2](https://github.com/bitnami/charts/commit/9070ca2)), closes [#23802](https://github.com/bitnami/charts/issues/23802)
+
+## <small>4.14.1 (2024-02-21)</small>
+
+* [bitnami/metallb] Release 4.14.1 updating components versions (#23724) ([0fdb81c](https://github.com/bitnami/charts/commit/0fdb81c)), closes [#23724](https://github.com/bitnami/charts/issues/23724)
+
+## 4.14.0 (2024-02-20)
+
+* [bitnami/*] Bump all versions (#23602) ([b70ee2a](https://github.com/bitnami/charts/commit/b70ee2a)), closes [#23602](https://github.com/bitnami/charts/issues/23602)
+
+## 4.13.0 (2024-02-15)
+
+* [bitnami/metallb] feat: :sparkles: :lock: Add resource preset support (#23486) ([5647129](https://github.com/bitnami/charts/commit/5647129)), closes [#23486](https://github.com/bitnami/charts/issues/23486)
+
+## <small>4.12.2 (2024-02-08)</small>
+
+* [bitnami/metallb] Release 4.12.2 updating components versions (#23304) ([b7e34bb](https://github.com/bitnami/charts/commit/b7e34bb)), closes [#23304](https://github.com/bitnami/charts/issues/23304)
+
+## <small>4.12.1 (2024-02-07)</small>
+
+* [bitnami/metallb] Release 4.12.1 updating components versions (#23256) ([fa4cd20](https://github.com/bitnami/charts/commit/fa4cd20)), closes [#23256](https://github.com/bitnami/charts/issues/23256)
+
+## 4.12.0 (2024-02-07)
+
+* [bitnami/metallb] feat: :lock: Enable networkPolicy (#23024) ([a88e104](https://github.com/bitnami/charts/commit/a88e104)), closes [#23024](https://github.com/bitnami/charts/issues/23024)
+
+## <small>4.11.5 (2024-02-03)</small>
+
+* [bitnami/metallb] Release 4.11.5 updating components versions (#23107) ([05e7260](https://github.com/bitnami/charts/commit/05e7260)), closes [#23107](https://github.com/bitnami/charts/issues/23107)
+
+## <small>4.11.4 (2024-02-01)</small>
+
+* [bitnami/metallb] Release 4.11.4 (#23012) ([7b133c1](https://github.com/bitnami/charts/commit/7b133c1)), closes [#23012](https://github.com/bitnami/charts/issues/23012)
+
+## <small>4.11.3 (2024-01-31)</small>
+
+* [bitnami/metallb] Update CRDs and add headers for automatic update (#22890) ([8e1fc16](https://github.com/bitnami/charts/commit/8e1fc16)), closes [#22890](https://github.com/bitnami/charts/issues/22890)
+
+## <small>4.11.2 (2024-01-30)</small>
+
+* [bitnami/metallb] Release 4.11.2 updating components versions (#22904) ([bb30b9b](https://github.com/bitnami/charts/commit/bb30b9b)), closes [#22904](https://github.com/bitnami/charts/issues/22904)
+
+## <small>4.11.1 (2024-01-26)</small>
+
+* [bitnami/*] Move documentation sections from docs.bitnami.com back to the README (#22203) ([7564f36](https://github.com/bitnami/charts/commit/7564f36)), closes [#22203](https://github.com/bitnami/charts/issues/22203)
+* [bitnami/metallb] fix: :bug: Set seLinuxOptions to null for Openshift compatibility (#22623) ([c874b7b](https://github.com/bitnami/charts/commit/c874b7b)), closes [#22623](https://github.com/bitnami/charts/issues/22623)
+
+## 4.11.0 (2024-01-22)
+
+* [bitnami/metallb] fix: :lock: Move service-account token auto-mount to pod declaration (#22432) ([41fb370](https://github.com/bitnami/charts/commit/41fb370)), closes [#22432](https://github.com/bitnami/charts/issues/22432)
+* [bitnami/metallb] Update CRDs and add source header (#22377) ([5b16a6c](https://github.com/bitnami/charts/commit/5b16a6c)), closes [#22377](https://github.com/bitnami/charts/issues/22377)
+
+## <small>4.10.1 (2024-01-18)</small>
+
+* [bitnami/metallb] Release 4.10.1 updating components versions (#22302) ([3292e1e](https://github.com/bitnami/charts/commit/3292e1e)), closes [#22302](https://github.com/bitnami/charts/issues/22302)
+
+## 4.10.0 (2024-01-16)
+
+* [bitnami/*] Fix ref links (in comments) (#21822) ([e4fa296](https://github.com/bitnami/charts/commit/e4fa296)), closes [#21822](https://github.com/bitnami/charts/issues/21822)
+* [bitnami/metallb] fix: :lock: Improve podSecurityContext and containerSecurityContext with essential ([1c42540](https://github.com/bitnami/charts/commit/1c42540)), closes [#22154](https://github.com/bitnami/charts/issues/22154)
+
+## <small>4.9.1 (2024-01-10)</small>
+
+* [bitnami/metallb] Release 4.9.1 updating components versions (#21959) ([e65b9a1](https://github.com/bitnami/charts/commit/e65b9a1)), closes [#21959](https://github.com/bitnami/charts/issues/21959)
+
+## 4.9.0 (2024-01-10)
+
+* [bitnami/*] Fix docs.bitnami.com broken links (#21901) ([f35506d](https://github.com/bitnami/charts/commit/f35506d)), closes [#21901](https://github.com/bitnami/charts/issues/21901)
+* [bitnami/*] Update copyright: Year and company (#21815) ([6c4bf75](https://github.com/bitnami/charts/commit/6c4bf75)), closes [#21815](https://github.com/bitnami/charts/issues/21815)
+* [bitnami/metallb] feat: :sparkles: Add seccompProfile to containerSecurityContext (#21916) ([f743427](https://github.com/bitnami/charts/commit/f743427)), closes [#21916](https://github.com/bitnami/charts/issues/21916)
+
+## 4.8.0 (2023-12-13)
+
+* [bitnami/metallb] Missing features (#21534) ([ceffc1f](https://github.com/bitnami/charts/commit/ceffc1f)), closes [#21534](https://github.com/bitnami/charts/issues/21534)
+
+## <small>4.7.16 (2023-12-07)</small>
+
+* [bitnami/metallb] Release 4.7.16 updating components versions (#21444) ([04c087f](https://github.com/bitnami/charts/commit/04c087f)), closes [#21444](https://github.com/bitnami/charts/issues/21444)
+
+## <small>4.7.15 (2023-11-21)</small>
+
+* [bitnami/*] Remove relative links to non-README sections, add verification for that and update TL;DR ([1103633](https://github.com/bitnami/charts/commit/1103633)), closes [#20967](https://github.com/bitnami/charts/issues/20967)
+* [bitnami/*] Rename solutions to "Bitnami package for ..." (#21038) ([b82f979](https://github.com/bitnami/charts/commit/b82f979)), closes [#21038](https://github.com/bitnami/charts/issues/21038)
+* [bitnami/metallb] Release 4.7.15 updating components versions (#21138) ([f835427](https://github.com/bitnami/charts/commit/f835427)), closes [#21138](https://github.com/bitnami/charts/issues/21138)
+
+## <small>4.7.14 (2023-11-10)</small>
+
+* [bitnami/metallb] Replace deprecated pull secret partial (#20661) ([7e2d8b5](https://github.com/bitnami/charts/commit/7e2d8b5)), closes [#20661](https://github.com/bitnami/charts/issues/20661)
+
+## <small>4.7.13 (2023-11-09)</small>
+
+* [bitnami/metallb] Release 4.7.13 updating components versions (#20843) ([75a1690](https://github.com/bitnami/charts/commit/75a1690)), closes [#20843](https://github.com/bitnami/charts/issues/20843)
+
+## <small>4.7.12 (2023-11-09)</small>
+
+* [bitnami/*] Rename VMware Application Catalog (#20361) ([3acc734](https://github.com/bitnami/charts/commit/3acc734)), closes [#20361](https://github.com/bitnami/charts/issues/20361)
+* [bitnami/metallb] Release 4.7.12 updating components versions (#20753) ([e4c3c51](https://github.com/bitnami/charts/commit/e4c3c51)), closes [#20753](https://github.com/bitnami/charts/issues/20753)
+
+## <small>4.7.11 (2023-10-20)</small>
+
+* [bitnami/*] Skip image's tag in the README files of the Bitnami Charts (#19841) ([bb9a01b](https://github.com/bitnami/charts/commit/bb9a01b)), closes [#19841](https://github.com/bitnami/charts/issues/19841)
+* [bitnami/*] Standardize documentation (#19835) ([af5f753](https://github.com/bitnami/charts/commit/af5f753)), closes [#19835](https://github.com/bitnami/charts/issues/19835)
+* [bitnami/metallb] Release 4.7.11 updating components versions (#20337) ([a037790](https://github.com/bitnami/charts/commit/a037790)), closes [#20337](https://github.com/bitnami/charts/issues/20337)
+
+## <small>4.7.10 (2023-10-16)</small>
+
+* [bitnami/metallb] Fix memberlist secret key configuration (#19836) ([521f941](https://github.com/bitnami/charts/commit/521f941)), closes [#19836](https://github.com/bitnami/charts/issues/19836)
+
+## <small>4.7.9 (2023-10-11)</small>
+
+* [bitnami/metallb] Release 4.7.9 (#20054) ([412709c](https://github.com/bitnami/charts/commit/412709c)), closes [#20054](https://github.com/bitnami/charts/issues/20054)
+
+## <small>4.7.8 (2023-10-09)</small>
+
+* [bitnami/metallb] Release 4.7.8 (#19878) ([cc99e10](https://github.com/bitnami/charts/commit/cc99e10)), closes [#19878](https://github.com/bitnami/charts/issues/19878)
+
+## <small>4.7.7 (2023-10-09)</small>
+
+* [bitnami/*] Update Helm charts prerequisites (#19745) ([eb755dd](https://github.com/bitnami/charts/commit/eb755dd)), closes [#19745](https://github.com/bitnami/charts/issues/19745)
+* [bitnami/metallb] Release 4.7.7 (#19866) ([9427f69](https://github.com/bitnami/charts/commit/9427f69)), closes [#19866](https://github.com/bitnami/charts/issues/19866)
+
+## <small>4.7.6 (2023-10-04)</small>
+
+* [bitnami/metallb] Release 4.7.6 (#19727) ([309c509](https://github.com/bitnami/charts/commit/309c509)), closes [#19727](https://github.com/bitnami/charts/issues/19727)
+
+## <small>4.7.5 (2023-10-04)</small>
+
+* [bitnami/metallb] Release 4.7.5 (#19723) ([e78e6f7](https://github.com/bitnami/charts/commit/e78e6f7)), closes [#19723](https://github.com/bitnami/charts/issues/19723)
+
+## <small>4.7.4 (2023-10-02)</small>
+
+* [bitnami/metallb] Use common capabilities for PSP (#19632) ([07fc7c7](https://github.com/bitnami/charts/commit/07fc7c7)), closes [#19632](https://github.com/bitnami/charts/issues/19632)
+
+## <small>4.7.3 (2023-09-18)</small>
+
+* [bitnami/metallb] Use different app.kubernetes.io/version label on subcomponents (#19344) ([8937f8a](https://github.com/bitnami/charts/commit/8937f8a)), closes [#19344](https://github.com/bitnami/charts/issues/19344)
+* Autogenerate schema files (#19194) ([a2c2090](https://github.com/bitnami/charts/commit/a2c2090)), closes [#19194](https://github.com/bitnami/charts/issues/19194)
+* Revert "Autogenerate schema files (#19194)" (#19335) ([73d80be](https://github.com/bitnami/charts/commit/73d80be)), closes [#19194](https://github.com/bitnami/charts/issues/19194) [#19335](https://github.com/bitnami/charts/issues/19335)
+
+## <small>4.7.2 (2023-09-06)</small>
+
+* [bitnami/metallb: Use merge helper]: (#19071) ([6accc10](https://github.com/bitnami/charts/commit/6accc10)), closes [#19071](https://github.com/bitnami/charts/issues/19071)
+
+## <small>4.7.1 (2023-09-05)</small>
+
+* [bitnami/metallb] Release 4.7.1 (#19124) ([702757c](https://github.com/bitnami/charts/commit/702757c)), closes [#19124](https://github.com/bitnami/charts/issues/19124)
+
+## 4.7.0 (2023-08-22)
+
+* [bitnami/metallb] Support for customizing standard labels (#18333) ([3af35f9](https://github.com/bitnami/charts/commit/3af35f9)), closes [#18333](https://github.com/bitnami/charts/issues/18333)
+
+## <small>4.6.5 (2023-08-20)</small>
+
+* [bitnami/metallb] Release 4.6.5 (#18684) ([dd92c82](https://github.com/bitnami/charts/commit/dd92c82)), closes [#18684](https://github.com/bitnami/charts/issues/18684)
+
+## <small>4.6.4 (2023-08-17)</small>
+
+* [bitnami/metallb] Release 4.6.4 (#18551) ([c658e27](https://github.com/bitnami/charts/commit/c658e27)), closes [#18551](https://github.com/bitnami/charts/issues/18551)
+
+## <small>4.6.3 (2023-08-08)</small>
+
+* [bitnami/metallb] chore: :page_facing_up: Remove license in CRDs (#18279) ([80509b9](https://github.com/bitnami/charts/commit/80509b9)), closes [#18279](https://github.com/bitnami/charts/issues/18279)
+
+## <small>4.6.2 (2023-08-08)</small>
+
+* [bitnami/metallb] chore: :truck: Move crds to crds/ folder (#18251) ([19d1176](https://github.com/bitnami/charts/commit/19d1176)), closes [#18251](https://github.com/bitnami/charts/issues/18251)
+
+## <small>4.6.1 (2023-08-07)</small>
+
+* Adds namespaces for the webhook service and webhook secret. (#18221) ([53832c2](https://github.com/bitnami/charts/commit/53832c2)), closes [#18221](https://github.com/bitnami/charts/issues/18221)
+
+## 4.6.0 (2023-08-02)
+
+* [bitnami/metallb] Allow overriding speaker log level from values (#17996) ([fefbd62](https://github.com/bitnami/charts/commit/fefbd62)), closes [#17996](https://github.com/bitnami/charts/issues/17996)
+
+## <small>4.5.7 (2023-07-26)</small>
+
+* [bitnami/metallb] Release 4.5.7 (#17913) ([74e8306](https://github.com/bitnami/charts/commit/74e8306)), closes [#17913](https://github.com/bitnami/charts/issues/17913)
+
+## <small>4.5.6 (2023-07-15)</small>
+
+* [bitnami/metallb] Release 4 (#17625) ([f034ef5](https://github.com/bitnami/charts/commit/f034ef5)), closes [#17625](https://github.com/bitnami/charts/issues/17625)
+
+## <small>4.5.5 (2023-06-30)</small>
+
+* [bitnami/metallb] Release 4.5.5 (#17430) ([0aa683d](https://github.com/bitnami/charts/commit/0aa683d)), closes [#17430](https://github.com/bitnami/charts/issues/17430)
+* Add copyright header (#17300) ([da68be8](https://github.com/bitnami/charts/commit/da68be8)), closes [#17300](https://github.com/bitnami/charts/issues/17300)
+* Update charts readme (#17217) ([31b3c0a](https://github.com/bitnami/charts/commit/31b3c0a)), closes [#17217](https://github.com/bitnami/charts/issues/17217)
+
+## <small>4.5.4 (2023-06-21)</small>
+
+* [bitnami/metallb] Remove namespace field for cluster wide resources (#17278) ([c2bb96e](https://github.com/bitnami/charts/commit/c2bb96e)), closes [#17278](https://github.com/bitnami/charts/issues/17278)
+* [bitnami/several] Remove 'Community supported solution' section from READMEs (#17119) ([4531d57](https://github.com/bitnami/charts/commit/4531d57)), closes [#17119](https://github.com/bitnami/charts/issues/17119)
+
+## <small>4.5.3 (2023-06-07)</small>
+
+* [bitnami/*] Change copyright section in READMEs (#17006) ([ef986a1](https://github.com/bitnami/charts/commit/ef986a1)), closes [#17006](https://github.com/bitnami/charts/issues/17006)
+* [bitnami/metallb] Add missing rule to controller role (#16992) ([bbc3a6d](https://github.com/bitnami/charts/commit/bbc3a6d)), closes [#16992](https://github.com/bitnami/charts/issues/16992) [/github.com/metallb/metallb/blob/e708fc9010afb80c379bdfadd5d543931164ca5e/config/rbac/role.yaml#L17-L22](https://github.com//github.com/metallb/metallb/blob/e708fc9010afb80c379bdfadd5d543931164ca5e/config/rbac/role.yaml/issues/L17-L22)
+* [bitnami/several] Change copyright section in READMEs (#16989) ([5b6a5cf](https://github.com/bitnami/charts/commit/5b6a5cf)), closes [#16989](https://github.com/bitnami/charts/issues/16989)
+
+## <small>4.5.2 (2023-05-31)</small>
+
+* [bitnami/metallb] Release 4.5.2 (#16981) ([8bbbc28](https://github.com/bitnami/charts/commit/8bbbc28)), closes [#16981](https://github.com/bitnami/charts/issues/16981)
+
+## <small>4.5.1 (2023-05-21)</small>
+
+* [bitnami/metallb] Release 4.5.1 (#16820) ([b6233c3](https://github.com/bitnami/charts/commit/b6233c3)), closes [#16820](https://github.com/bitnami/charts/issues/16820)
+* Add wording for enterprise page (#16560) ([8f22774](https://github.com/bitnami/charts/commit/8f22774)), closes [#16560](https://github.com/bitnami/charts/issues/16560)
+
+## 4.5.0 (2023-05-09)
+
+* [bitnami/several] Adapt Chart.yaml to set desired OCI annotations (#16546) ([fc9b18f](https://github.com/bitnami/charts/commit/fc9b18f)), closes [#16546](https://github.com/bitnami/charts/issues/16546)
+
+## <small>4.4.2 (2023-05-09)</small>
+
+* [bitnami/metallb] Release 4.4.2 (#16478) ([8aa8bb0](https://github.com/bitnami/charts/commit/8aa8bb0)), closes [#16478](https://github.com/bitnami/charts/issues/16478)
+
+## <small>4.4.1 (2023-05-01)</small>
+
+* [bitnami/metallb] Release 4.4.1 (#16300) ([6b85ee2](https://github.com/bitnami/charts/commit/6b85ee2)), closes [#16300](https://github.com/bitnami/charts/issues/16300)
+
+## 4.4.0 (2023-04-20)
+
+* [bitnami/*] Make Helm charts 100% OCI (#15998) ([8841510](https://github.com/bitnami/charts/commit/8841510)), closes [#15998](https://github.com/bitnami/charts/issues/15998)
+
+## 4.3.0 (2023-04-12)
+
+* [bitnami/metallb] Provide a flag for disabling BGP speakers (#15981) ([aa48954](https://github.com/bitnami/charts/commit/aa48954)), closes [#15981](https://github.com/bitnami/charts/issues/15981) [#8742](https://github.com/bitnami/charts/issues/8742)
+
+## 4.2.0 (2023-04-05)
+
+* add option to skip CRD install (#15939) ([ea3a30d](https://github.com/bitnami/charts/commit/ea3a30d)), closes [#15939](https://github.com/bitnami/charts/issues/15939)
+
+## <small>4.1.23 (2023-04-01)</small>
+
+* [bitnami/metallb] Release 4.1.23 (#15870) ([f98363a](https://github.com/bitnami/charts/commit/f98363a)), closes [#15870](https://github.com/bitnami/charts/issues/15870)
+
+## <small>4.1.22 (2023-03-30)</small>
+
+* [bitnami/metallb] crds.yaml update to 0.13.9 (#15745 fix) (#15781) ([94021f7](https://github.com/bitnami/charts/commit/94021f7)), closes [#15745](https://github.com/bitnami/charts/issues/15745) [#15781](https://github.com/bitnami/charts/issues/15781) [#15745](https://github.com/bitnami/charts/issues/15745) [#15745](https://github.com/bitnami/charts/issues/15745)
+
+## <small>4.1.21 (2023-03-18)</small>
+
+* [bitnami/charts] Apply linter to README files (#15357) ([0e29e60](https://github.com/bitnami/charts/commit/0e29e60)), closes [#15357](https://github.com/bitnami/charts/issues/15357)
+* [bitnami/metallb] Release 4.1.21 (#15577) ([e939485](https://github.com/bitnami/charts/commit/e939485)), closes [#15577](https://github.com/bitnami/charts/issues/15577)
+
+## <small>4.1.20 (2023-03-01)</small>
+
+* [bitnami/metallb] fix failed-to-call-webhook issue (#15134) ([f27f0f3](https://github.com/bitnami/charts/commit/f27f0f3)), closes [#15134](https://github.com/bitnami/charts/issues/15134)
+
+## <small>4.1.19 (2023-03-01)</small>
+
+* [bitnami/metallb] Release 4.1.19 (#15283) ([bbd2711](https://github.com/bitnami/charts/commit/bbd2711)), closes [#15283](https://github.com/bitnami/charts/issues/15283)
+
+## <small>4.1.18 (2023-03-01)</small>
+
+* [bitnami/metallb] Bump chart release to trigger publishing (#15202) ([aa2b71d](https://github.com/bitnami/charts/commit/aa2b71d)), closes [#15202](https://github.com/bitnami/charts/issues/15202)
+* [bitnami/metallb] Release 4.1.17 (#15083) ([9c908c0](https://github.com/bitnami/charts/commit/9c908c0)), closes [#15083](https://github.com/bitnami/charts/issues/15083)
+
+## <small>4.1.17 (2023-03-01)</small>
+
+* [bitnami/metallb] fix failed-to-list-namespaces issue (#15130) ([94d9bd4](https://github.com/bitnami/charts/commit/94d9bd4)), closes [#15130](https://github.com/bitnami/charts/issues/15130)
+
+## <small>4.1.16 (2023-02-17)</small>
+
+* [bitnami/*] Fix markdown linter issues 2 (#14890) ([aa96572](https://github.com/bitnami/charts/commit/aa96572)), closes [#14890](https://github.com/bitnami/charts/issues/14890)
+* [bitnami/metallb] Release 4.1.16 (#14984) ([67df406](https://github.com/bitnami/charts/commit/67df406)), closes [#14984](https://github.com/bitnami/charts/issues/14984)
+
+## <small>4.1.15 (2023-02-14)</small>
+
+* [bitnami/*] Change copyright date (#14682) ([add4ec7](https://github.com/bitnami/charts/commit/add4ec7)), closes [#14682](https://github.com/bitnami/charts/issues/14682)
+* [bitnami/*] Change licenses annotation format (#14377) ([0ab7608](https://github.com/bitnami/charts/commit/0ab7608)), closes [#14377](https://github.com/bitnami/charts/issues/14377)
+* [bitnami/*] Fix markdown linter issues (#14874) ([a51e0e8](https://github.com/bitnami/charts/commit/a51e0e8)), closes [#14874](https://github.com/bitnami/charts/issues/14874)
+* [bitnami/*] Unify READMEs (#14472) ([2064fb8](https://github.com/bitnami/charts/commit/2064fb8)), closes [#14472](https://github.com/bitnami/charts/issues/14472)
+* [bitnami/metallb] Release 4.1.15 (#14881) ([7ddac58](https://github.com/bitnami/charts/commit/7ddac58)), closes [#14881](https://github.com/bitnami/charts/issues/14881)
+
+## <small>4.1.14 (2023-01-15)</small>
+
+* [bitnami/*] Add license annotation and remove obsolete engine parameter (#14293) ([da2a794](https://github.com/bitnami/charts/commit/da2a794)), closes [#14293](https://github.com/bitnami/charts/issues/14293)
+* [bitnami/metallb] Release 4.1.14 (#14368) ([5884c8e](https://github.com/bitnami/charts/commit/5884c8e)), closes [#14368](https://github.com/bitnami/charts/issues/14368)
+
+## <small>4.1.13 (2022-12-16)</small>
+
+* [bitnami/metallb] Release 4.1.13 (#13999) ([196f2e6](https://github.com/bitnami/charts/commit/196f2e6)), closes [#13999](https://github.com/bitnami/charts/issues/13999)
+
+## <small>4.1.12 (2022-11-17)</small>
+
+* [bitnami/metallb] Release 4.1.12 (#13553) ([c095098](https://github.com/bitnami/charts/commit/c095098)), closes [#13553](https://github.com/bitnami/charts/issues/13553)
+
+## <small>4.1.11 (2022-11-10)</small>
+
+* [bitnami/metallb] kube version support (#13254) ([74bcbf6](https://github.com/bitnami/charts/commit/74bcbf6)), closes [#13254](https://github.com/bitnami/charts/issues/13254)
+
+## <small>4.1.10 (2022-10-25)</small>
+
+* [bitnami/metallb] Fix serviceaccount names (#13135) ([cde9331](https://github.com/bitnami/charts/commit/cde9331)), closes [#13135](https://github.com/bitnami/charts/issues/13135)
+* adjust the naming style for resources to make them not pass the length (#13072) ([d0bf4ba](https://github.com/bitnami/charts/commit/d0bf4ba)), closes [#13072](https://github.com/bitnami/charts/issues/13072)
+
+## <small>4.1.9 (2022-10-21)</small>
+
+* [bitnami/metallb] Fix service account name handling (#13070) ([9238f42](https://github.com/bitnami/charts/commit/9238f42)), closes [#13070](https://github.com/bitnami/charts/issues/13070)
+
+## <small>4.1.8 (2022-10-17)</small>
+
+* [bitnami/*] Use new default branch name in links (#12943) ([a529e02](https://github.com/bitnami/charts/commit/a529e02)), closes [#12943](https://github.com/bitnami/charts/issues/12943)
+* [bitnami/metallb] Release 4.1.8 updating components versions ([3f02c22](https://github.com/bitnami/charts/commit/3f02c22))
+
+## <small>4.1.7 (2022-10-13)</small>
+
+* [bitnami/metallb] Release 4.1.7 updating components versions ([4b44727](https://github.com/bitnami/charts/commit/4b44727))
+
+## <small>4.1.6 (2022-10-11)</small>
+
+* [bitnami/metallb] Release 4.1.6 updating components versions ([8c7d497](https://github.com/bitnami/charts/commit/8c7d497))
+
+## <small>4.1.5 (2022-10-05)</small>
+
+* [bitnami/metallb] Update maintainers (#12816) ([a6c408a](https://github.com/bitnami/charts/commit/a6c408a)), closes [#12816](https://github.com/bitnami/charts/issues/12816)
+* Generic README instructions related to the repo (#12792) ([3cf6b10](https://github.com/bitnami/charts/commit/3cf6b10)), closes [#12792](https://github.com/bitnami/charts/issues/12792)
+
+## <small>4.1.4 (2022-10-03)</small>
+
+* [bitnami/metallb] Release 4.1.4 updating components versions ([5146ecc](https://github.com/bitnami/charts/commit/5146ecc))
+
+## <small>4.1.3 (2022-09-21)</small>
+
+* [bitnami/metallb] Use custom probes if given (#12525) ([fd91af7](https://github.com/bitnami/charts/commit/fd91af7)), closes [#12525](https://github.com/bitnami/charts/issues/12525) [#12354](https://github.com/bitnami/charts/issues/12354)
+
+## <small>4.1.2 (2022-09-03)</small>
+
+* [bitnami/metallb] Release 4.1.2 updating components versions ([f030f6a](https://github.com/bitnami/charts/commit/f030f6a))
+
+## <small>4.1.1 (2022-08-23)</small>
+
+* [bitnami/metallb] Update Chart.lock (#12047) ([aa4e38a](https://github.com/bitnami/charts/commit/aa4e38a)), closes [#12047](https://github.com/bitnami/charts/issues/12047)
+
+## 4.1.0 (2022-08-22)
+
+* [bitnami/metallb] Add support for image digest apart from tag (#11917) ([1c57d87](https://github.com/bitnami/charts/commit/1c57d87)), closes [#11917](https://github.com/bitnami/charts/issues/11917)
+
+## <small>4.0.2 (2022-08-09)</small>
+
+* [bitnami/metallb] Release 4.0.2 updating components versions ([1d4b008](https://github.com/bitnami/charts/commit/1d4b008))
+
+## <small>4.0.1 (2022-08-04)</small>
+
+* [bitnami/metallb] Release 4.0.1 updating components versions ([e6c9e75](https://github.com/bitnami/charts/commit/e6c9e75))
+
+## 4.0.0 (2022-08-03)
+
+* [bitnami/metallb] Adapt chart to app version 0.13 (#11503) ([5a40ef9](https://github.com/bitnami/charts/commit/5a40ef9)), closes [#11503](https://github.com/bitnami/charts/issues/11503)
+
+## <small>3.0.12 (2022-07-30)</small>
+
+* [bitnami/*] Update URLs to point to the new bitnami/containers monorepo (#11352) ([d665af0](https://github.com/bitnami/charts/commit/d665af0)), closes [#11352](https://github.com/bitnami/charts/issues/11352)
+* [bitnami/metallb] Release 3.0.12 updating components versions ([bdbbd7c](https://github.com/bitnami/charts/commit/bdbbd7c))
+
+## <small>3.0.11 (2022-07-18)</small>
+
+* [bitnami/metallb] Prettify and unify Chart.yaml (#11216) ([2fac752](https://github.com/bitnami/charts/commit/2fac752)), closes [#11216](https://github.com/bitnami/charts/issues/11216)
+
+## <small>3.0.10 (2022-06-30)</small>
+
+* [bitnami/metallb] Release 3.0.10 updating components versions ([9f2eaf3](https://github.com/bitnami/charts/commit/9f2eaf3))
+
+## <small>3.0.9 (2022-06-10)</small>
+
+* [bitnami/*] Replace Kubeapps URL in READMEs (and kubeapps Chart.yaml) and remove BKPR references (#1 ([c6a7914](https://github.com/bitnami/charts/commit/c6a7914)), closes [#10600](https://github.com/bitnami/charts/issues/10600)
+* [bitnami/metallb] Release 3.0.9 updating components versions ([e6d1feb](https://github.com/bitnami/charts/commit/e6d1feb))
+
+## <small>3.0.8 (2022-06-07)</small>
+
+* [bitnami/metallb] Release 3.0.8 updating components versions ([66530a6](https://github.com/bitnami/charts/commit/66530a6))
+
+## <small>3.0.7 (2022-06-01)</small>
+
+* [bitnami/several] Replace maintainers email by url (#10523) ([ff3cf61](https://github.com/bitnami/charts/commit/ff3cf61)), closes [#10523](https://github.com/bitnami/charts/issues/10523)
+
+## <small>3.0.6 (2022-05-21)</small>
+
+* [bitnami/metallb] Release 3.0.6 updating components versions ([55b8e34](https://github.com/bitnami/charts/commit/55b8e34))
+
+## <small>3.0.5 (2022-05-20)</small>
+
+* [bitnami/metallb] Release 3.0.5 updating components versions ([3d1fb9d](https://github.com/bitnami/charts/commit/3d1fb9d))
+
+## <small>3.0.4 (2022-05-19)</small>
+
+* [bitnami/metallb] Release 3.0.4 updating components versions ([324c274](https://github.com/bitnami/charts/commit/324c274))
+
+## <small>3.0.3 (2022-05-18)</small>
+
+* [bitnami/metallb] Release 3.0.3 updating components versions ([3c8a7b2](https://github.com/bitnami/charts/commit/3c8a7b2))
+
+## <small>3.0.2 (2022-05-13)</small>
+
+* [bitnami/*] Unify k8s directives separators (#10185) ([2650214](https://github.com/bitnami/charts/commit/2650214)), closes [#10185](https://github.com/bitnami/charts/issues/10185)
+
+## <small>3.0.1 (2022-04-26)</small>
+
+* missing "context" (#9904) ([4eaf8a7](https://github.com/bitnami/charts/commit/4eaf8a7)), closes [#9904](https://github.com/bitnami/charts/issues/9904)
+
+## 3.0.0 (2022-04-21)
+
+* [bitnami/metallb] Chart standardised (#9787) ([e65da33](https://github.com/bitnami/charts/commit/e65da33)), closes [#9787](https://github.com/bitnami/charts/issues/9787)
+
+## <small>2.6.14 (2022-04-20)</small>
+
+* [bitnami/metallb] Release 2.6.14 updating components versions ([2a5de49](https://github.com/bitnami/charts/commit/2a5de49))
+
+## <small>2.6.13 (2022-04-19)</small>
+
+* [bitnami/metallb] Release 2.6.13 updating components versions ([16c8a76](https://github.com/bitnami/charts/commit/16c8a76))
+
+## <small>2.6.12 (2022-04-07)</small>
+
+* [bitnami/metallb] Release 2.6.12 updating components versions ([cb46c09](https://github.com/bitnami/charts/commit/cb46c09))
+
+## <small>2.6.11 (2022-04-02)</small>
+
+* [bitnami/metallb] Release 2.6.11 updating components versions ([80d4157](https://github.com/bitnami/charts/commit/80d4157))
+
+## <small>2.6.10 (2022-03-27)</small>
+
+* [bitnami/metallb] Release 2.6.10 updating components versions ([20311db](https://github.com/bitnami/charts/commit/20311db))
+
+## <small>2.6.9 (2022-03-16)</small>
+
+* [bitnami/metallb] Release 2.6.9 updating components versions ([be781c4](https://github.com/bitnami/charts/commit/be781c4))
+
+## <small>2.6.8 (2022-03-07)</small>
+
+* [bitnami/metallb] fix: use podLabels values (#9310) ([e8ae276](https://github.com/bitnami/charts/commit/e8ae276)), closes [#9310](https://github.com/bitnami/charts/issues/9310)
+
+## <small>2.6.7 (2022-03-01)</small>
+
+* [bitnami/several] Prettify Chart.yaml ([a056e06](https://github.com/bitnami/charts/commit/a056e06))
+
+## <small>2.6.6 (2022-02-27)</small>
+
+* [bitnami/metallb] Release 2.6.6 updating components versions ([37916a7](https://github.com/bitnami/charts/commit/37916a7))
+
+## <small>2.6.5 (2022-02-20)</small>
+
+* [bitnami/metallb] Release 2.6.5 updating components versions ([b37d10a](https://github.com/bitnami/charts/commit/b37d10a))
+
+## <small>2.6.4 (2022-02-17)</small>
+
+* [bitnami/metallb] Release 2.6.4 updating components versions ([d6ab39d](https://github.com/bitnami/charts/commit/d6ab39d))
+
+## <small>2.6.3 (2022-02-16)</small>
+
+* [bitnami/metallb] Release 2.6.3 updating components versions ([356cfc2](https://github.com/bitnami/charts/commit/356cfc2))
+* Non utf8 chars (#8923) ([6ffd18f](https://github.com/bitnami/charts/commit/6ffd18f)), closes [#8923](https://github.com/bitnami/charts/issues/8923)
+
+## <small>2.6.2 (2022-01-20)</small>
+
+* [bitnami/*] Readme automation (#8579) ([78d1938](https://github.com/bitnami/charts/commit/78d1938)), closes [#8579](https://github.com/bitnami/charts/issues/8579)
+* [bitnami/*] Update READMEs (#8716) ([b9a9533](https://github.com/bitnami/charts/commit/b9a9533)), closes [#8716](https://github.com/bitnami/charts/issues/8716)
+* [bitnami/several] Change prerequisites (#8725) ([8d740c5](https://github.com/bitnami/charts/commit/8d740c5)), closes [#8725](https://github.com/bitnami/charts/issues/8725)
+
+## <small>2.6.1 (2022-01-16)</small>
+
+* [bitnami/metallb] Release 2.6.1 updating components versions ([fac49d7](https://github.com/bitnami/charts/commit/fac49d7))
+
+## 2.6.0 (2022-01-05)
+
+* [bitnami/several] Adapt templating format (#8562) ([8cad18a](https://github.com/bitnami/charts/commit/8cad18a)), closes [#8562](https://github.com/bitnami/charts/issues/8562)
+* [bitnami/several] Add license to the README ([05f7633](https://github.com/bitnami/charts/commit/05f7633))
+* [bitnami/several] Add license to the README ([32fb238](https://github.com/bitnami/charts/commit/32fb238))
+* [bitnami/several] Add license to the README ([b87c2f7](https://github.com/bitnami/charts/commit/b87c2f7))
+
+## <small>2.5.16 (2021-12-17)</small>
+
+* [bitnami/metallb] Release 2.5.16 updating components versions ([fa7563e](https://github.com/bitnami/charts/commit/fa7563e))
+
+## <small>2.5.15 (2021-12-16)</small>
+
+* [bitnami/metallb] Release 2.5.15 updating components versions ([63fe87d](https://github.com/bitnami/charts/commit/63fe87d))
+
+## <small>2.5.14 (2021-12-09)</small>
+
+* [bitnami/cassandra,etcd,influxdb,metallb,mysql,postgresql,postgresql-ha,redis] Align networkpolicy   ([0404b1a](https://github.com/bitnami/charts/commit/0404b1a)), closes [#8336](https://github.com/bitnami/charts/issues/8336)
+* [bitnami/several] Regenerate README tables ([8150149](https://github.com/bitnami/charts/commit/8150149))
+
+## <small>2.5.13 (2021-11-29)</small>
+
+* [bitnami/several] Replace HTTP by HTTPS when possible (#8259) ([eafb5bd](https://github.com/bitnami/charts/commit/eafb5bd)), closes [#8259](https://github.com/bitnami/charts/issues/8259)
+
+## <small>2.5.12 (2021-11-29)</small>
+
+* [bitnami/metallb] Release 2.5.12 updating components versions ([c0a16d6](https://github.com/bitnami/charts/commit/c0a16d6))
+* [bitnami/several] Add 'community support' note to some Helm chart READMEs (#8148) ([ce6b838](https://github.com/bitnami/charts/commit/ce6b838)), closes [#8148](https://github.com/bitnami/charts/issues/8148)
+
+## <small>2.5.11 (2021-11-17)</small>
+
+* [bitnami/several] Add extraDeploy feature to the pending charts (#8164) ([d812a24](https://github.com/bitnami/charts/commit/d812a24)), closes [#8164](https://github.com/bitnami/charts/issues/8164)
+* [bitnami/several] Regenerate README tables ([3cefed3](https://github.com/bitnami/charts/commit/3cefed3))
+
+## <small>2.5.10 (2021-10-30)</small>
+
+* [bitnami/metallb] Release 2.5.10 updating components versions ([cf7c21d](https://github.com/bitnami/charts/commit/cf7c21d))
+
+## <small>2.5.9 (2021-10-28)</small>
+
+* [bitnami/*] Mark PodSecurityPolicy resources as deprecated (#7950) ([30e6946](https://github.com/bitnami/charts/commit/30e6946)), closes [#7950](https://github.com/bitnami/charts/issues/7950)
+* [bitnami/several] Regenerate README tables ([bb0eee1](https://github.com/bitnami/charts/commit/bb0eee1))
+
+## <small>2.5.8 (2021-10-27)</small>
+
+* [bitnami/metallb] Release 2.5.8 updating components versions ([68d23cb](https://github.com/bitnami/charts/commit/68d23cb))
+
+## <small>2.5.7 (2021-10-22)</small>
+
+* [bitnami/several] Add chart info to NOTES.txt (#7889) ([a6751cd](https://github.com/bitnami/charts/commit/a6751cd)), closes [#7889](https://github.com/bitnami/charts/issues/7889)
+* [bitnami/several] Regenerate README tables ([9bead53](https://github.com/bitnami/charts/commit/9bead53))
+
+## <small>2.5.6 (2021-10-07)</small>
+
+* [bitnami/metallb] Release 2.5.6 updating components versions ([9f73bc4](https://github.com/bitnami/charts/commit/9f73bc4))
+* [bitnami/several] Regenerate README tables ([ff170d1](https://github.com/bitnami/charts/commit/ff170d1))
+
+## <small>2.5.5 (2021-09-25)</small>
+
+* [bitnami/metallb] Release 2.5.5 updating components versions ([b969cc5](https://github.com/bitnami/charts/commit/b969cc5))
+* [bitnami/several] Regenerate README tables ([da2513b](https://github.com/bitnami/charts/commit/da2513b))
+
+## <small>2.5.4 (2021-08-26)</small>
+
+* [bitnami/metallb] Release 2.5.4 updating components versions ([c7ba218](https://github.com/bitnami/charts/commit/c7ba218))
+
+## <small>2.5.3 (2021-08-25)</small>
+
+* [bitnami/metallb] Release 2.5.3 updating components versions ([5d5bc1f](https://github.com/bitnami/charts/commit/5d5bc1f))
+* [bitnami/several] Regenerate README tables ([6c107e8](https://github.com/bitnami/charts/commit/6c107e8))
+
+## <small>2.5.2 (2021-08-04)</small>
+
+* [bitnami/metallb] Release 2.5.2 updating components versions ([3d905e1](https://github.com/bitnami/charts/commit/3d905e1))
+
+## <small>2.5.1 (2021-07-28)</small>
+
+* [bitnami/several] Fix default values and regenerate README (III) (#7000) ([4d4fe83](https://github.com/bitnami/charts/commit/4d4fe83)), closes [#7000](https://github.com/bitnami/charts/issues/7000)
+
+## 2.5.0 (2021-07-26)
+
+* [bitnami/metallb] Hotfix double tolerations in speaker daemonset. (#7044) ([b8a1e06](https://github.com/bitnami/charts/commit/b8a1e06)), closes [#7044](https://github.com/bitnami/charts/issues/7044)
+
+## <small>2.4.5 (2021-07-19)</small>
+
+* [bitnami/*] Adapt values.yaml of MediaWiki, memcached and MetalLB charts (#6887) ([d0cb2fc](https://github.com/bitnami/charts/commit/d0cb2fc)), closes [#6887](https://github.com/bitnami/charts/issues/6887)
+
+## <small>2.4.4 (2021-07-12)</small>
+
+* [bitnami/metallb] Release 2.4.4 updating components versions ([d84c39c](https://github.com/bitnami/charts/commit/d84c39c))
+
+## <small>2.4.3 (2021-06-12)</small>
+
+* [bitnami/metallb] Release 2.4.3 updating components versions ([26de7be](https://github.com/bitnami/charts/commit/26de7be))
+
+## <small>2.4.2 (2021-06-09)</small>
+
+* [bitnami/metallb] Release 2.4.2 updating components versions ([554dca1](https://github.com/bitnami/charts/commit/554dca1))
+
+## <small>2.4.1 (2021-06-08)</small>
+
+* [bitnami/metallb] Release 2.4.1 updating components versions ([b6966e4](https://github.com/bitnami/charts/commit/b6966e4))
+
+## 2.4.0 (2021-05-26)
+
+* [bitnami/metallb] Add priorityClassName support. (#6464) ([7e39ebe](https://github.com/bitnami/charts/commit/7e39ebe)), closes [#6464](https://github.com/bitnami/charts/issues/6464)
+
+## <small>2.3.7 (2021-05-21)</small>
+
+* [bitnami/metallb] Release 2.3.7 updating components versions ([632bb0d](https://github.com/bitnami/charts/commit/632bb0d))
+
+## <small>2.3.6 (2021-04-21)</small>
+
+* [bitnami/metallb] Release 2.3.6 updating components versions ([cbfed08](https://github.com/bitnami/charts/commit/cbfed08))
+
+## <small>2.3.5 (2021-03-29)</small>
+
+* [bitnami/metallb] Modify fullname and matchLabels variable in NetworkPolicy (#5947) ([3e80ce2](https://github.com/bitnami/charts/commit/3e80ce2)), closes [#5947](https://github.com/bitnami/charts/issues/5947)
+
+## <small>2.3.4 (2021-03-22)</small>
+
+* [bitnami/metallb] Release 2.3.4 updating components versions ([5f90e27](https://github.com/bitnami/charts/commit/5f90e27))
+
+## <small>2.3.3 (2021-03-21)</small>
+
+* [bitnami/metallb] Release 2.3.3 updating components versions ([ffc5d82](https://github.com/bitnami/charts/commit/ffc5d82))
+
+## <small>2.3.2 (2021-02-22)</small>
+
+* [bitnami/*] Use common macro to define RBAC apiVersion (#5585) ([71fb99f](https://github.com/bitnami/charts/commit/71fb99f)), closes [#5585](https://github.com/bitnami/charts/issues/5585)
+
+## <small>2.3.1 (2021-02-19)</small>
+
+* [bitnami/metallb] Fix successThreshold reference in README (#5547) ([56c62a4](https://github.com/bitnami/charts/commit/56c62a4)), closes [#5547](https://github.com/bitnami/charts/issues/5547)
+* [bitnami/metallb] Release 2.3.1 updating components versions ([9a15c80](https://github.com/bitnami/charts/commit/9a15c80))
+
+## 2.3.0 (2021-02-09)
+
+* [bitnami/metallb] Add initcontainer support to the speaker (#5365) ([7822823](https://github.com/bitnami/charts/commit/7822823)), closes [#5365](https://github.com/bitnami/charts/issues/5365)
+
+## <small>2.2.2 (2021-02-03)</small>
+
+* [bitnami/metallb] revert: fix: remove unnecessary hooks (#5383) ([ffc447c](https://github.com/bitnami/charts/commit/ffc447c)), closes [#5383](https://github.com/bitnami/charts/issues/5383) [#5322](https://github.com/bitnami/charts/issues/5322)
+
+## <small>2.2.1 (2021-02-02)</small>
+
+* [bitnami/metallb] fix: remove unnecessary hooks (#5322) ([e3d18ea](https://github.com/bitnami/charts/commit/e3d18ea)), closes [#5322](https://github.com/bitnami/charts/issues/5322)
+
+## 2.2.0 (2021-01-28)
+
+* [bitnami/metallb] Add hostAlias and lint (#5268) ([70869aa](https://github.com/bitnami/charts/commit/70869aa)), closes [#5268](https://github.com/bitnami/charts/issues/5268)
+
+## <small>2.1.2 (2021-01-20)</small>
+
+* [bitnami/*] Change helm version in the prerequisites (#5090) ([c5e67a3](https://github.com/bitnami/charts/commit/c5e67a3)), closes [#5090](https://github.com/bitnami/charts/issues/5090)
+* [bitnami/metallb] Fix hooks for speaker secret (#5153) ([8429583](https://github.com/bitnami/charts/commit/8429583)), closes [#5153](https://github.com/bitnami/charts/issues/5153)
+
+## <small>2.1.1 (2021-01-13)</small>
+
+* [bitnami/metallb] Release 2.1.1 updating components versions ([a21b7c2](https://github.com/bitnami/charts/commit/a21b7c2))
+
+## 2.1.0 (2021-01-13)
+
+* [bitnami/*] POC Lookup function implementation (#4831) ([240dc1b](https://github.com/bitnami/charts/commit/240dc1b)), closes [#4831](https://github.com/bitnami/charts/issues/4831)
+
+## <small>2.0.5 (2021-01-12)</small>
+
+* [bitnami/several] Prettify Chart.yaml following bitnami standards (#4954) ([cd897df](https://github.com/bitnami/charts/commit/cd897df)), closes [#4954](https://github.com/bitnami/charts/issues/4954)
+
+## <small>2.0.4 (2021-01-10)</small>
+
+* [bitnami/metallb] Release 2.0.4 updating components versions ([de90456](https://github.com/bitnami/charts/commit/de90456))
+
+## <small>2.0.3 (2021-01-05)</small>
+
+* [bitnami/metallb] update tplValue references (#4886) ([e5ad2d8](https://github.com/bitnami/charts/commit/e5ad2d8)), closes [#4886](https://github.com/bitnami/charts/issues/4886)
+
+## <small>2.0.2 (2020-12-29)</small>
+
+* [bitnami/metallb] fix: take speaker tolertation value into account (#4842) ([4185af9](https://github.com/bitnami/charts/commit/4185af9)), closes [#4842](https://github.com/bitnami/charts/issues/4842)
+
+## <small>2.0.1 (2020-12-22)</small>
+
+* [bitnami/metallb] Fix metallb service type from None to ClusterIP (#4808) ([7abded0](https://github.com/bitnami/charts/commit/7abded0)), closes [#4808](https://github.com/bitnami/charts/issues/4808)
+
+## 2.0.0 (2020-12-18)
+
+* [bitnami/metallb] Migrate to common lib and restructure the directory layout. (#3889) ([00fde0b](https://github.com/bitnami/charts/commit/00fde0b)), closes [#3889](https://github.com/bitnami/charts/issues/3889)
+
+## 1.1.0 (2020-12-16)
+
+* [bitnami/*] fix typos (#4699) ([49adc63](https://github.com/bitnami/charts/commit/49adc63)), closes [#4699](https://github.com/bitnami/charts/issues/4699)
+* [bitnami/metallb] Metallb networkpolicy (#4703) ([86e8067](https://github.com/bitnami/charts/commit/86e8067)), closes [#4703](https://github.com/bitnami/charts/issues/4703)
+
+## <small>1.0.2 (2020-12-11)</small>
+
+* [bitnami/metallb] Release 1.0.2 updating components versions ([e9d3905](https://github.com/bitnami/charts/commit/e9d3905))
+
+## <small>1.0.1 (2020-11-11)</small>
+
+* [bitnami/metallb] Release 1.0.1 updating components versions ([2268480](https://github.com/bitnami/charts/commit/2268480))
+
+## 1.0.0 (2020-11-10)
+
+* [bitnami/metallb] Major version. Adapt Chart to apiVersion: v2 (#4271) ([854f143](https://github.com/bitnami/charts/commit/854f143)), closes [#4271](https://github.com/bitnami/charts/issues/4271)
+
+## <small>0.1.30 (2020-11-10)</small>
+
+* [bitnami/metallb] fix rbac metadata naming (#4250) ([d7b137b](https://github.com/bitnami/charts/commit/d7b137b)), closes [#4250](https://github.com/bitnami/charts/issues/4250)
+
+## <small>0.1.29 (2020-11-07)</small>
+
+* [bitnami/*] Include link to Troubleshootin guide on README.md (#4136) ([c08a20e](https://github.com/bitnami/charts/commit/c08a20e)), closes [#4136](https://github.com/bitnami/charts/issues/4136)
+* [bitnami/metallb] Release 0.1.29 updating components versions ([25c1a97](https://github.com/bitnami/charts/commit/25c1a97))
+
+## <small>0.1.28 (2020-10-23)</small>
+
+* [bitnami/metallb] Release 0.1.28 updating components versions ([d2ebf58](https://github.com/bitnami/charts/commit/d2ebf58))
+
+## <small>0.1.27 (2020-10-17)</small>
+
+* [bitnami/metallb] Release 0.1.27 updating components versions ([3352159](https://github.com/bitnami/charts/commit/3352159))
+
+## <small>0.1.26 (2020-10-16)</small>
+
+* [bitnami/metallb] Release 0.1.26 updating components versions ([110f4b6](https://github.com/bitnami/charts/commit/110f4b6))
+
+## <small>0.1.25 (2020-10-16)</small>
+
+* [bitnami/metallb] Release 0.1.25 updating components versions ([28ba27e](https://github.com/bitnami/charts/commit/28ba27e))
+
+## <small>0.1.24 (2020-09-21)</small>
+
+* [bitnami/metallb] Release 0.1.24 updating components versions ([8fff7f4](https://github.com/bitnami/charts/commit/8fff7f4))
+
+## <small>0.1.23 (2020-09-09)</small>
+
+* [bitnami/metallb] Fixed the PrometheusRule creation issue (#3609) ([3b436a5](https://github.com/bitnami/charts/commit/3b436a5)), closes [#3609](https://github.com/bitnami/charts/issues/3609)
+
+## <small>0.1.22 (2020-09-07)</small>
+
+* [bitnami/metallb] Release 0.1.22 updating components versions ([d9eac29](https://github.com/bitnami/charts/commit/d9eac29))
+* [bitnami/metrics-server] Add source repo (#3577) ([1ed12f9](https://github.com/bitnami/charts/commit/1ed12f9)), closes [#3577](https://github.com/bitnami/charts/issues/3577)
+
+## <small>0.1.21 (2020-08-08)</small>
+
+* [bitnami/metallb] Release 0.1.21 updating components versions ([13dc12b](https://github.com/bitnami/charts/commit/13dc12b))
+
+## <small>0.1.20 (2020-08-05)</small>
+
+* [bitnami/metallb] Fixed missing `.image` in documentation. (#3288) ([1ff708b](https://github.com/bitnami/charts/commit/1ff708b)), closes [#3288](https://github.com/bitnami/charts/issues/3288)
+* [bitnami/metallb] Release 0.1.20 updating components versions ([f8dd40d](https://github.com/bitnami/charts/commit/f8dd40d))
+
+## <small>0.1.19 (2020-08-01)</small>
+
+* [bitnami/*] Fix TL;DR typo in READMEs (#3280) ([3d7ab40](https://github.com/bitnami/charts/commit/3d7ab40)), closes [#3280](https://github.com/bitnami/charts/issues/3280)
+* [bitnami/metallb] Release 0.1.19 updating components versions ([f170313](https://github.com/bitnami/charts/commit/f170313))
+
+## <small>0.1.18 (2020-07-28)</small>
+
+* [bitnami/all] Add categories (#3075) ([63bde06](https://github.com/bitnami/charts/commit/63bde06)), closes [#3075](https://github.com/bitnami/charts/issues/3075)
+* [bitnami/metallb] Fix speaker daemonSet nodeSelector path (#3223) ([b077656](https://github.com/bitnami/charts/commit/b077656)), closes [#3223](https://github.com/bitnami/charts/issues/3223)
+
+## <small>0.1.17 (2020-07-07)</small>
+
+* [bitnami/metallb] Release 0.1.17 updating components versions ([a9fde76](https://github.com/bitnami/charts/commit/a9fde76))
+
+## <small>0.1.16 (2020-07-07)</small>
+
+* [bitnami/contour, metallb] Fix incorrect icons (#3034) ([fc8c3a7](https://github.com/bitnami/charts/commit/fc8c3a7)), closes [#3034](https://github.com/bitnami/charts/issues/3034)
+* [bitnami/metallb][bitnami/contour] Revert appVersion change (#3046) ([726ad74](https://github.com/bitnami/charts/commit/726ad74)), closes [#3046](https://github.com/bitnami/charts/issues/3046)
+
+## <small>0.1.15 (2020-06-25)</small>
+
+* [bitnami/metallb] Release 0.1.15 updating components versions ([700fa70](https://github.com/bitnami/charts/commit/700fa70))
+
+## <small>0.1.14 (2020-06-10)</small>
+
+* [bitnami/metallb] Bugfix/#2782 (#2783) ([628ffb6](https://github.com/bitnami/charts/commit/628ffb6)), closes [Bugfix/#2782](https://github.com/bitnami/charts/issues/2782) [#2783](https://github.com/bitnami/charts/issues/2783)
+* [bitnami/several] Fix trailing spaces to make helm lint work on all of them (#2705) ([bafba3f](https://github.com/bitnami/charts/commit/bafba3f)), closes [#2705](https://github.com/bitnami/charts/issues/2705)
+
+## <small>0.1.13 (2020-05-25)</small>
+
+* [bitnami/metallb] Use a proper jobLabel for the serviceMonitor. (#2616) ([db0b159](https://github.com/bitnami/charts/commit/db0b159)), closes [#2616](https://github.com/bitnami/charts/issues/2616)
+* update bitnami/common to be compatible with helm v2.12+ (#2615) ([c7751eb](https://github.com/bitnami/charts/commit/c7751eb)), closes [#2615](https://github.com/bitnami/charts/issues/2615)
+
+## <small>0.1.12 (2020-05-06)</small>
+
+* [bitnami/metallb] Change container names (#2530) ([480ef0a](https://github.com/bitnami/charts/commit/480ef0a)), closes [#2530](https://github.com/bitnami/charts/issues/2530)
+
+## <small>0.1.11 (2020-04-30)</small>
+
+* [bitnami/metallb] Release 0.1.11 updating components versions ([60e228b](https://github.com/bitnami/charts/commit/60e228b))
+
+## <small>0.1.10 (2020-04-29)</small>
+
+* [bitnami/metallb] Adding the MetalLB Helm Chart. (#2068) ([31d6a86](https://github.com/bitnami/charts/commit/31d6a86)), closes [#2068](https://github.com/bitnami/charts/issues/2068)

--- a/bitnami/metallb/Chart.lock
+++ b/bitnami/metallb/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.19.2
-digest: sha256:e670e1075bfafffe040fae1158f1fa1f592585f394b48704ba137d2d083b1571
-generated: "2024-05-08T07:46:30.052530853Z"
+  version: 2.19.3
+digest: sha256:de997835d9ce9a9deefc2d70d8c62b11aa1d1a76ece9e86a83736ab9f930bf4d
+generated: "2024-05-21T14:11:40.819394606+02:00"

--- a/bitnami/metallb/Chart.yaml
+++ b/bitnami/metallb/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: metallb
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/metallb
-version: 6.1.7
+version: 6.2.0

--- a/bitnami/metallb/templates/NOTES.txt
+++ b/bitnami/metallb/templates/NOTES.txt
@@ -50,3 +50,4 @@ If it is missing create it with:
 {{- end }}
 {{- end }}
 {{- include "common.warnings.resources" (dict "sections" (list "controller" "speaker") "context" $) }}
+{{- include "common.warnings.modifiedImages" (dict "images" (list .Values.controller.image .Values.speaker.image .Values.speaker.frr.image) "context" $) }}


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Replacing the original images that have been tested and verified when releasing the chart is a dangerous practice in terms of security, performance and available features. This PR updates the `NOTES.txt` file using the `common.warnings.modifiedImages` helper developed in https://github.com/bitnami/charts/pull/25952.


<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

Users are more aware of the risks of changing original images.
<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

n/a
<!-- Describe any known limitations with your change -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
