### PR TITLE
[bitnami/milvus] feat: :sparkles: :lock: Add warning when original images are replaced

### DIFF
--- a/bitnami/milvus/CHANGELOG.md
+++ b/bitnami/milvus/CHANGELOG.md
@@ -1,0 +1,238 @@
+# Changelog
+
+## 7.1.0 (2024-05-21)
+
+* [bitnami/milvus] feat: :sparkles: :lock: Add warning when original images are replaced ([#26244](https://github.com/bitnami/charts/pulls/26244))
+
+## <small>7.0.5 (2024-05-18)</small>
+
+* [bitnami/milvus] Release 7.0.5 updating components versions (#26096) ([cda9801](https://github.com/bitnami/charts/commit/cda9801)), closes [#26096](https://github.com/bitnami/charts/issues/26096)
+
+## <small>7.0.4 (2024-05-15)</small>
+
+* [bitnami/milvus] Release 7.0.4 updating components versions (#25937) ([79fbe7a](https://github.com/bitnami/charts/commit/79fbe7a)), closes [#25937](https://github.com/bitnami/charts/issues/25937)
+
+## <small>7.0.3 (2024-05-15)</small>
+
+* [bitnami/milvus] Release 7.0.3 updating components versions (#25892) ([b011954](https://github.com/bitnami/charts/commit/b011954)), closes [#25892](https://github.com/bitnami/charts/issues/25892)
+
+## <small>7.0.2 (2024-05-14)</small>
+
+* [bitnami/milvus] Release 7.0.2 updating components versions (#25792) ([da37fe8](https://github.com/bitnami/charts/commit/da37fe8)), closes [#25792](https://github.com/bitnami/charts/issues/25792)
+
+## <small>7.0.1 (2024-05-08)</small>
+
+* [bitnami/*] Change non-root and rolling-tags doc URLs (#25628) ([b067c94](https://github.com/bitnami/charts/commit/b067c94)), closes [#25628](https://github.com/bitnami/charts/issues/25628)
+* [bitnami/*] Set new header/owner (#25558) ([8d1dc11](https://github.com/bitnami/charts/commit/8d1dc11)), closes [#25558](https://github.com/bitnami/charts/issues/25558)
+* [bitnami/milvus] Release 7.0.1 (#25627) ([ba55c4b](https://github.com/bitnami/charts/commit/ba55c4b)), closes [#25627](https://github.com/bitnami/charts/issues/25627)
+* Replace VMware by Broadcom copyright text (#25306) ([a5e4bd0](https://github.com/bitnami/charts/commit/a5e4bd0)), closes [#25306](https://github.com/bitnami/charts/issues/25306)
+* Update resourcesPreset comments (#24467) ([92e3e8a](https://github.com/bitnami/charts/commit/92e3e8a)), closes [#24467](https://github.com/bitnami/charts/issues/24467)
+
+## 7.0.0 (2024-03-27)
+
+* [bitnami/*] Reorder Chart sections (#24455) ([0cf4048](https://github.com/bitnami/charts/commit/0cf4048)), closes [#24455](https://github.com/bitnami/charts/issues/24455)
+* [bitnami/milvus] feat!: :lock: :boom: Improve security defaults (#24683) ([1b97e66](https://github.com/bitnami/charts/commit/1b97e66)), closes [#24683](https://github.com/bitnami/charts/issues/24683)
+* [bitnami/several] Fix comment mentioning Keycloak (#24661) ([641c546](https://github.com/bitnami/charts/commit/641c546)), closes [#24661](https://github.com/bitnami/charts/issues/24661)
+
+## <small>6.1.2 (2024-03-15)</small>
+
+* [bitnami/milvus] Release 6.1.2 updating components versions (#24470) ([09d30b2](https://github.com/bitnami/charts/commit/09d30b2)), closes [#24470](https://github.com/bitnami/charts/issues/24470)
+
+## <small>6.1.1 (2024-03-12)</small>
+
+* [bitnami/milvus] Release 6.1.1 updating components versions (#24378) ([55e4ffc](https://github.com/bitnami/charts/commit/55e4ffc)), closes [#24378](https://github.com/bitnami/charts/issues/24378)
+
+## 6.1.0 (2024-03-06)
+
+* [bitnami/milvus] feat: :sparkles: :lock: Add automatic adaptation for Openshift restricted-v2 SCC (# ([0e8ab78](https://github.com/bitnami/charts/commit/0e8ab78)), closes [#24121](https://github.com/bitnami/charts/issues/24121)
+
+## <small>6.0.1 (2024-03-04)</small>
+
+* [bitnami/milvus] Release 6.0.1 updating components versions (#24045) ([f89ed9c](https://github.com/bitnami/charts/commit/f89ed9c)), closes [#24045](https://github.com/bitnami/charts/issues/24045)
+
+## 6.0.0 (2024-03-04)
+
+* [bitnami/milvus] Update bundled MinIO (#24031) ([cce046b](https://github.com/bitnami/charts/commit/cce046b)), closes [#24031](https://github.com/bitnami/charts/issues/24031)
+
+## <small>5.6.3 (2024-02-23)</small>
+
+* [bitnami/milvus] Release 5.6.3 updating components versions (#23883) ([2d30d91](https://github.com/bitnami/charts/commit/2d30d91)), closes [#23883](https://github.com/bitnami/charts/issues/23883)
+
+## <small>5.6.2 (2024-02-22)</small>
+
+* [bitnami/milvus] Release 5.6.2 updating components versions (#23805) ([86b746e](https://github.com/bitnami/charts/commit/86b746e)), closes [#23805](https://github.com/bitnami/charts/issues/23805)
+
+## <small>5.6.1 (2024-02-21)</small>
+
+* [bitnami/milvus] Release 5.6.1 updating components versions (#23728) ([e22a5f0](https://github.com/bitnami/charts/commit/e22a5f0)), closes [#23728](https://github.com/bitnami/charts/issues/23728)
+
+## 5.6.0 (2024-02-20)
+
+* [bitnami/*] Bump all versions (#23602) ([b70ee2a](https://github.com/bitnami/charts/commit/b70ee2a)), closes [#23602](https://github.com/bitnami/charts/issues/23602)
+
+## 5.5.0 (2024-02-16)
+
+* [bitnami/milvus] feat: :sparkles: :lock: Add resource preset support (#23488) ([f264963](https://github.com/bitnami/charts/commit/f264963)), closes [#23488](https://github.com/bitnami/charts/issues/23488)
+
+## <small>5.4.2 (2024-02-08)</small>
+
+* [bitnami/milvus] Release 5.4.2 updating components versions (#23322) ([7250931](https://github.com/bitnami/charts/commit/7250931)), closes [#23322](https://github.com/bitnami/charts/issues/23322)
+
+## <small>5.4.1 (2024-02-07)</small>
+
+* [bitnami/milvus] Release 5.4.1 updating components versions (#23278) ([3e0a447](https://github.com/bitnami/charts/commit/3e0a447)), closes [#23278](https://github.com/bitnami/charts/issues/23278)
+
+## 5.4.0 (2024-02-07)
+
+* [bitnami/milvus] feat: :lock: Enable networkPolicy (#22923) ([965c6be](https://github.com/bitnami/charts/commit/965c6be)), closes [#22923](https://github.com/bitnami/charts/issues/22923)
+
+## <small>5.3.2 (2024-02-06)</small>
+
+* [bitnami/milvus] Release 5.3.2 (#23166) ([c1a15db](https://github.com/bitnami/charts/commit/c1a15db)), closes [#23166](https://github.com/bitnami/charts/issues/23166)
+
+## <small>5.3.1 (2024-01-26)</small>
+
+* [bitnami/*] Move documentation sections from docs.bitnami.com back to the README (#22203) ([7564f36](https://github.com/bitnami/charts/commit/7564f36)), closes [#22203](https://github.com/bitnami/charts/issues/22203)
+* [bitnami/milvus] fix: :bug: Set seLinuxOptions to null for Openshift compatibility (#22625) ([101930a](https://github.com/bitnami/charts/commit/101930a)), closes [#22625](https://github.com/bitnami/charts/issues/22625)
+
+## 5.3.0 (2024-01-19)
+
+* [bitnami/milvus] fix: :lock: Move service-account token auto-mount to pod declaration (#22434) ([0ff9aeb](https://github.com/bitnami/charts/commit/0ff9aeb)), closes [#22434](https://github.com/bitnami/charts/issues/22434)
+
+## 5.2.0 (2024-01-16)
+
+* [bitnami/milvus] fix: :lock: Improve podSecurityContext and containerSecurityContext with essential  ([51dbf7e](https://github.com/bitnami/charts/commit/51dbf7e)), closes [#22156](https://github.com/bitnami/charts/issues/22156)
+
+## <small>5.1.6 (2024-01-15)</small>
+
+* [bitnami/*] Fix docs.bitnami.com broken links (#21901) ([f35506d](https://github.com/bitnami/charts/commit/f35506d)), closes [#21901](https://github.com/bitnami/charts/issues/21901)
+* [bitnami/*] Fix ref links (in comments) (#21822) ([e4fa296](https://github.com/bitnami/charts/commit/e4fa296)), closes [#21822](https://github.com/bitnami/charts/issues/21822)
+* [bitnami/*] Update copyright: Year and company (#21815) ([6c4bf75](https://github.com/bitnami/charts/commit/6c4bf75)), closes [#21815](https://github.com/bitnami/charts/issues/21815)
+* [bitnami/milvus] fix: :lock: Do not use the default service account (#22021) ([7aee921](https://github.com/bitnami/charts/commit/7aee921)), closes [#22021](https://github.com/bitnami/charts/issues/22021)
+
+## <small>5.1.5 (2023-12-15)</small>
+
+* [bitnami/milvus] Fix helm not being submitted when using commonAnnotations in indexNode (#21543) (#2 ([f267a4a](https://github.com/bitnami/charts/commit/f267a4a)), closes [#21543](https://github.com/bitnami/charts/issues/21543) [#21544](https://github.com/bitnami/charts/issues/21544)
+
+## <small>5.1.4 (2023-12-14)</small>
+
+* [bitnami/milvus] Fix milvus server cannot startup with SSL (#19838) (#21516) ([0fa3d41](https://github.com/bitnami/charts/commit/0fa3d41)), closes [#19838](https://github.com/bitnami/charts/issues/19838) [#21516](https://github.com/bitnami/charts/issues/21516) [#19838](https://github.com/bitnami/charts/issues/19838)
+
+## <small>5.1.3 (2023-11-24)</small>
+
+* [bitnami/milvus] Fix initJob.extraVolumes (#21231) ([3ef45c7](https://github.com/bitnami/charts/commit/3ef45c7)), closes [#21231](https://github.com/bitnami/charts/issues/21231)
+
+## <small>5.1.2 (2023-11-22)</small>
+
+* [bitnami/*] Rename solutions to "Bitnami package for ..." (#21038) ([b82f979](https://github.com/bitnami/charts/commit/b82f979)), closes [#21038](https://github.com/bitnami/charts/issues/21038)
+* [bitnami/milvus] Fix Milvus notes (#21200) ([14a0a4a](https://github.com/bitnami/charts/commit/14a0a4a)), closes [#21200](https://github.com/bitnami/charts/issues/21200)
+
+## <small>5.1.1 (2023-11-20)</small>
+
+* [bitnami/milvus] Fixup waitForS3InitContainer missing s3 port (bitnami#20398) (#20502) ([dd40a2a](https://github.com/bitnami/charts/commit/dd40a2a)), closes [bitnami#20398](https://github.com/bitnami/issues/20398) [#20502](https://github.com/bitnami/charts/issues/20502)
+* Update readme-generator links (#21043) ([1581eba](https://github.com/bitnami/charts/commit/1581eba)), closes [#21043](https://github.com/bitnami/charts/issues/21043)
+
+## 5.1.0 (2023-11-17)
+
+* [bitnami/*] Remove relative links to non-README sections, add verification for that and update TL;DR ([1103633](https://github.com/bitnami/charts/commit/1103633)), closes [#20967](https://github.com/bitnami/charts/issues/20967)
+* [bitnami/milvus] Fixup milvus & externalS3 couldn't be deployed in the same namespace (bitnami#20396 ([15910c2](https://github.com/bitnami/charts/commit/15910c2)), closes [bitnami#20396](https://github.com/bitnami/issues/20396) [#20500](https://github.com/bitnami/charts/issues/20500) [bitnami#20396](https://github.com/bitnami/issues/20396)
+
+## 5.0.0 (2023-11-09)
+
+* [bitnami/milvus] Fix externalEtcd settings with ssl (bitnami#19983) (#20498) ([75d4661](https://github.com/bitnami/charts/commit/75d4661)), closes [bitnami#19983](https://github.com/bitnami/issues/19983) [#20498](https://github.com/bitnami/charts/issues/20498)
+
+## <small>4.2.1 (2023-11-08)</small>
+
+* [bitnami/milvus] Release 4.2.1 updating components versions (#20770) ([f553b73](https://github.com/bitnami/charts/commit/f553b73)), closes [#20770](https://github.com/bitnami/charts/issues/20770)
+
+## 4.2.0 (2023-10-31)
+
+* [bitnami/milvus] feat: :sparkles: Add support for PSA restricted policy (#20486) ([f36e834](https://github.com/bitnami/charts/commit/f36e834)), closes [#20486](https://github.com/bitnami/charts/issues/20486)
+
+## 4.1.0 (2023-10-25)
+
+* [bitnami/*] Rename VMware Application Catalog (#20361) ([3acc734](https://github.com/bitnami/charts/commit/3acc734)), closes [#20361](https://github.com/bitnami/charts/issues/20361)
+* [bitnami/*] Skip image's tag in the README files of the Bitnami Charts (#19841) ([bb9a01b](https://github.com/bitnami/charts/commit/bb9a01b)), closes [#19841](https://github.com/bitnami/charts/issues/19841)
+* [bitnami/*] Standardize documentation (#19835) ([af5f753](https://github.com/bitnami/charts/commit/af5f753)), closes [#19835](https://github.com/bitnami/charts/issues/19835)
+* [bitnami/milvus] Fix externalEtcd settings (#20405) ([3542124](https://github.com/bitnami/charts/commit/3542124)), closes [#20405](https://github.com/bitnami/charts/issues/20405)
+
+## 4.0.0 (2023-10-17)
+
+* [bitnami/milvus] Update Kafka 26.x.x (#20277) ([8fb91a0](https://github.com/bitnami/charts/commit/8fb91a0)), closes [#20277](https://github.com/bitnami/charts/issues/20277)
+
+## <small>3.1.8 (2023-10-16)</small>
+
+* [bitnami/milvus] Release 3.1.8 updating components versions (#20261) ([d83be05](https://github.com/bitnami/charts/commit/d83be05)), closes [#20261](https://github.com/bitnami/charts/issues/20261)
+
+## <small>3.1.7 (2023-10-12)</small>
+
+* [bitnami/milvus] Release 3.1.7 (#20204) ([9792064](https://github.com/bitnami/charts/commit/9792064)), closes [#20204](https://github.com/bitnami/charts/issues/20204)
+
+## <small>3.1.6 (2023-10-09)</small>
+
+* [bitnami/*] Update Helm charts prerequisites (#19745) ([eb755dd](https://github.com/bitnami/charts/commit/eb755dd)), closes [#19745](https://github.com/bitnami/charts/issues/19745)
+* [bitnami/milvus] Release 3.1.6 (#19922) ([51d3f73](https://github.com/bitnami/charts/commit/51d3f73)), closes [#19922](https://github.com/bitnami/charts/issues/19922)
+
+## <small>3.1.5 (2023-09-25)</small>
+
+* [bitnami/*] Update readme files (#19277) ([e56aeb2](https://github.com/bitnami/charts/commit/e56aeb2)), closes [#19277](https://github.com/bitnami/charts/issues/19277)
+* [bitnami/milvus] Release 3.1.5 (#19502) ([2154023](https://github.com/bitnami/charts/commit/2154023)), closes [#19502](https://github.com/bitnami/charts/issues/19502)
+
+## <small>3.1.4 (2023-09-18)</small>
+
+* [bitnami/milvus] Use different app.kubernetes.io/version label on subcomponents (#19348) ([c389e81](https://github.com/bitnami/charts/commit/c389e81)), closes [#19348](https://github.com/bitnami/charts/issues/19348)
+* Autogenerate schema files (#19194) ([a2c2090](https://github.com/bitnami/charts/commit/a2c2090)), closes [#19194](https://github.com/bitnami/charts/issues/19194)
+* Revert "Autogenerate schema files (#19194)" (#19335) ([73d80be](https://github.com/bitnami/charts/commit/73d80be)), closes [#19194](https://github.com/bitnami/charts/issues/19194) [#19335](https://github.com/bitnami/charts/issues/19335)
+
+## <small>3.1.3 (2023-09-07)</small>
+
+* [bitnami/milvus]: Use merge helper (#19073) ([29c2b5d](https://github.com/bitnami/charts/commit/29c2b5d)), closes [#19073](https://github.com/bitnami/charts/issues/19073)
+
+## <small>3.1.2 (2023-09-06)</small>
+
+* [bitnami/milvus] Release 3.1.2 (#19138) ([3b2bf8d](https://github.com/bitnami/charts/commit/3b2bf8d)), closes [#19138](https://github.com/bitnami/charts/issues/19138)
+
+## <small>3.1.1 (2023-09-06)</small>
+
+* [bitnami/milvus] Release 3.1.1 (#18916) ([b3bebec](https://github.com/bitnami/charts/commit/b3bebec)), closes [#18916](https://github.com/bitnami/charts/issues/18916)
+
+## 3.1.0 (2023-08-25)
+
+* [bitnami/milvus] Support for customizing standard labels (#18627) ([a8d8eb9](https://github.com/bitnami/charts/commit/a8d8eb9)), closes [#18627](https://github.com/bitnami/charts/issues/18627)
+
+## 3.0.0 (2023-08-24)
+
+* [bitnami/milvus] Update Kafka subchart 25.0.0 (#18838) ([a91e8a4](https://github.com/bitnami/charts/commit/a91e8a4)), closes [#18838](https://github.com/bitnami/charts/issues/18838)
+
+## <small>2.0.1 (2023-08-09)</small>
+
+* [bitnami/milvus] Release 2.0.1 (#18334) ([b93517a](https://github.com/bitnami/charts/commit/b93517a)), closes [#18334](https://github.com/bitnami/charts/issues/18334)
+
+## 2.0.0 (2023-08-07)
+
+* [bitnami/milvus] Update Kafka subchart 24.0.0 (#18186) ([85a66a2](https://github.com/bitnami/charts/commit/85a66a2)), closes [#18186](https://github.com/bitnami/charts/issues/18186)
+
+## <small>1.0.4 (2023-07-26)</small>
+
+* [bitnami/milvus] Release 1.0.4 (#17923) ([ba3b8fa](https://github.com/bitnami/charts/commit/ba3b8fa)), closes [#17923](https://github.com/bitnami/charts/issues/17923)
+
+## <small>1.0.3 (2023-07-15)</small>
+
+* [bitnami/milvus] Release 1 (#17619) ([fbc2f0c](https://github.com/bitnami/charts/commit/fbc2f0c)), closes [#17619](https://github.com/bitnami/charts/issues/17619)
+
+## <small>1.0.2 (2023-07-13)</small>
+
+* [bitnami/milvus] Release 1.0.1 (#17544) ([16097c4](https://github.com/bitnami/charts/commit/16097c4)), closes [#17544](https://github.com/bitnami/charts/issues/17544)
+
+## <small>1.0.1 (2023-07-12)</small>
+
+* [bitnami/milvus] fix: :bug: Add emptyDir to init job /tmp (#17578) ([8aeecfa](https://github.com/bitnami/charts/commit/8aeecfa)), closes [#17578](https://github.com/bitnami/charts/issues/17578)
+* Use os-shell in tempate and Jaeger runtime params (#17557) ([91a49eb](https://github.com/bitnami/charts/commit/91a49eb)), closes [#17557](https://github.com/bitnami/charts/issues/17557)
+
+## 1.0.0 (2023-07-10)
+
+* [bitnami/milvus] Bump kafka major version and update license header (#17538) ([ba40e46](https://github.com/bitnami/charts/commit/ba40e46)), closes [#17538](https://github.com/bitnami/charts/issues/17538)
+
+## 0.1.0 (2023-07-07)
+
+* [bitnami/milvus] feat: 🎉 Add chart (#17425) ([ed35062](https://github.com/bitnami/charts/commit/ed35062)), closes [#17425](https://github.com/bitnami/charts/issues/17425)

--- a/bitnami/milvus/Chart.lock
+++ b/bitnami/milvus/Chart.lock
@@ -4,12 +4,12 @@ dependencies:
   version: 10.0.11
 - name: kafka
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 28.2.5
+  version: 28.2.6
 - name: minio
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 14.4.3
+  version: 14.5.0
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.19.2
-digest: sha256:1a1407e4ea9facd4660e2bc348badab022e0d0a56b8c811bf0c46f3aa5028305
-generated: "2024-05-18T03:58:03.188355049Z"
+  version: 2.19.3
+digest: sha256:448dc3f00f8e79a56c21b227728698a5aae292a854b141391ea776a742d3cc60
+generated: "2024-05-21T14:13:10.126618783+02:00"

--- a/bitnami/milvus/Chart.yaml
+++ b/bitnami/milvus/Chart.yaml
@@ -48,4 +48,4 @@ maintainers:
 name: milvus
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/milvus
-version: 7.0.5
+version: 7.1.0

--- a/bitnami/milvus/templates/NOTES.txt
+++ b/bitnami/milvus/templates/NOTES.txt
@@ -117,3 +117,4 @@ Check the upstream Milvus documentation: https://milvus.io/docs
 
 {{- end }}
 {{- include "common.warnings.resources" (dict "sections" (list "attu" "dataCoord" "dataNode" "indexCoord" "indexNode" "initJob" "proxy" "queryCoord" "queryNode" "rootCoord" "waitContainer") "context" $) }}
+{{- include "common.warnings.modifiedImages" (dict "images" (list .Values.milvus.image .Values.initJob.image .Values.attu.image .Values.waitContainer.image) "context" $) }}


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Replacing the original images that have been tested and verified when releasing the chart is a dangerous practice in terms of security, performance and available features. This PR updates the `NOTES.txt` file using the `common.warnings.modifiedImages` helper developed in https://github.com/bitnami/charts/pull/25952.


<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

Users are more aware of the risks of changing original images.
<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

n/a
<!-- Describe any known limitations with your change -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
