### PR TITLE
[bitnami/mysql] feat: :sparkles: :lock: Add warning when original images are replaced

### DIFF
--- a/bitnami/mysql/CHANGELOG.md
+++ b/bitnami/mysql/CHANGELOG.md
@@ -1,0 +1,1364 @@
+# Changelog
+
+## 10.3.0 (2024-05-21)
+
+* [bitnami/mysql] feat: :sparkles: :lock: Add warning when original images are replaced ([#26251](https://github.com/bitnami/charts/pulls/26251))
+
+## <small>10.2.4 (2024-05-15)</small>
+
+* [bitnami/mysql] Use different liveness/readiness probes (#25893) ([1ee381b](https://github.com/bitnami/charts/commit/1ee381b)), closes [#25893](https://github.com/bitnami/charts/issues/25893)
+
+## <small>10.2.3 (2024-05-14)</small>
+
+* [bitnami/*] Change non-root and rolling-tags doc URLs (#25628) ([b067c94](https://github.com/bitnami/charts/commit/b067c94)), closes [#25628](https://github.com/bitnami/charts/issues/25628)
+* [bitnami/*] Set new header/owner (#25558) ([8d1dc11](https://github.com/bitnami/charts/commit/8d1dc11)), closes [#25558](https://github.com/bitnami/charts/issues/25558)
+* [bitnami/mysql] Release 10.2.3 updating components versions (#25797) ([d04e22b](https://github.com/bitnami/charts/commit/d04e22b)), closes [#25797](https://github.com/bitnami/charts/issues/25797)
+
+## <small>10.2.2 (2024-05-02)</small>
+
+* [bitnami/mysql] Release 10.2.2 updating components versions (#25510) ([74b8f70](https://github.com/bitnami/charts/commit/74b8f70)), closes [#25510](https://github.com/bitnami/charts/issues/25510)
+
+## <small>10.2.1 (2024-04-30)</small>
+
+* [bitnami/mysql] Release 10.2.1 updating components versions (#25468) ([445abb9](https://github.com/bitnami/charts/commit/445abb9)), closes [#25468](https://github.com/bitnami/charts/issues/25468)
+* Replace VMware by Broadcom copyright text (#25306) ([a5e4bd0](https://github.com/bitnami/charts/commit/a5e4bd0)), closes [#25306](https://github.com/bitnami/charts/issues/25306)
+
+## 10.2.0 (2024-04-11)
+
+* chore: :bookmark: Bump chart version ([49b0641](https://github.com/bitnami/charts/commit/49b0641))
+* [bitnami/mysql] fix: :bug: :lock: Add support for mysqlx port ([8b27436](https://github.com/bitnami/charts/commit/8b27436))
+* Update resourcesPreset comments (#24467) ([92e3e8a](https://github.com/bitnami/charts/commit/92e3e8a)), closes [#24467](https://github.com/bitnami/charts/issues/24467)
+
+## <small>10.1.1 (2024-04-02)</small>
+
+* [bitnami/mysql] Release 10.1.1 updating components versions (#24802) ([72c09f5](https://github.com/bitnami/charts/commit/72c09f5)), closes [#24802](https://github.com/bitnami/charts/issues/24802)
+* [bitnami/several] Fix comment mentioning Keycloak (#24661) ([641c546](https://github.com/bitnami/charts/commit/641c546)), closes [#24661](https://github.com/bitnami/charts/issues/24661)
+
+## 10.1.0 (2024-03-19)
+
+* [bitnami/mysql] feat: adds any extraPorts entries into the NetworkPolicy's ingress config (#23927) ([4aafee0](https://github.com/bitnami/charts/commit/4aafee0)), closes [#23927](https://github.com/bitnami/charts/issues/23927)
+
+## 10.0.0 (2024-03-18)
+
+* [bitnami/*] Reorder Chart sections (#24455) ([0cf4048](https://github.com/bitnami/charts/commit/0cf4048)), closes [#24455](https://github.com/bitnami/charts/issues/24455)
+* [bitnami/mysql] feat!: :lock: :boom: Improve security defaults (#24242) ([2994fd2](https://github.com/bitnami/charts/commit/2994fd2)), closes [#24242](https://github.com/bitnami/charts/issues/24242)
+
+## 9.23.0 (2024-03-06)
+
+* [bitnami/mysql] feat: :sparkles: :lock: Add automatic adaptation for Openshift restricted-v2 SCC (#2 ([51beaf0](https://github.com/bitnami/charts/commit/51beaf0)), closes [#24128](https://github.com/bitnami/charts/issues/24128)
+
+## 9.22.0 (2024-02-27)
+
+* [bitnami/mysql] feat: :sparkles: :lock: Add readOnlyRootFilesystem support (#23595) ([6abe07f](https://github.com/bitnami/charts/commit/6abe07f)), closes [#23595](https://github.com/bitnami/charts/issues/23595)
+
+## <small>9.21.2 (2024-02-22)</small>
+
+* [bitnami/mysql] Release 9.21.2 updating components versions (#23809) ([753510e](https://github.com/bitnami/charts/commit/753510e)), closes [#23809](https://github.com/bitnami/charts/issues/23809)
+
+## <small>9.21.1 (2024-02-21)</small>
+
+* [bitnami/mysql] Release 9.21.1 updating components versions (#23672) ([9f18b01](https://github.com/bitnami/charts/commit/9f18b01)), closes [#23672](https://github.com/bitnami/charts/issues/23672)
+
+## 9.21.0 (2024-02-20)
+
+* [bitnami/*] Bump all versions (#23602) ([b70ee2a](https://github.com/bitnami/charts/commit/b70ee2a)), closes [#23602](https://github.com/bitnami/charts/issues/23602)
+
+## 9.20.0 (2024-02-16)
+
+* [bitnami/mysql] feat: :sparkles: :lock: Add resource preset support (#23495) ([fafb388](https://github.com/bitnami/charts/commit/fafb388)), closes [#23495](https://github.com/bitnami/charts/issues/23495)
+
+## <small>9.19.1 (2024-02-03)</small>
+
+* [bitnami/mysql] Release 9.19.1 updating components versions (#23114) ([74d1550](https://github.com/bitnami/charts/commit/74d1550)), closes [#23114](https://github.com/bitnami/charts/issues/23114)
+
+## 9.19.0 (2024-02-01)
+
+* [bitnami/mysql] feat: :lock: Enable networkPolicy (#23019) ([394cd12](https://github.com/bitnami/charts/commit/394cd12)), closes [#23019](https://github.com/bitnami/charts/issues/23019)
+
+## <small>9.18.2 (2024-01-31)</small>
+
+* [bitnami/mysql] Release 9.18.2 updating components versions (#22944) ([d7d6d51](https://github.com/bitnami/charts/commit/d7d6d51)), closes [#22944](https://github.com/bitnami/charts/issues/22944)
+
+## <small>9.18.1 (2024-01-25)</small>
+
+* [bitnami/*] Move documentation sections from docs.bitnami.com back to the README (#22203) ([7564f36](https://github.com/bitnami/charts/commit/7564f36)), closes [#22203](https://github.com/bitnami/charts/issues/22203)
+* [bitnami/mysql] fix: :bug: Set seLinuxOptions to null for Openshift compatibility (#22632) ([fb330b0](https://github.com/bitnami/charts/commit/fb330b0)), closes [#22632](https://github.com/bitnami/charts/issues/22632)
+
+## 9.18.0 (2024-01-19)
+
+* [bitnami/mysql] fix: :lock: Move service-account token auto-mount to pod declaration (#22440) ([bede78a](https://github.com/bitnami/charts/commit/bede78a)), closes [#22440](https://github.com/bitnami/charts/issues/22440)
+
+## <small>9.17.1 (2024-01-18)</small>
+
+* [bitnami/mysql] Release 9.17.1 updating components versions (#22313) ([3f6b397](https://github.com/bitnami/charts/commit/3f6b397)), closes [#22313](https://github.com/bitnami/charts/issues/22313)
+
+## 9.17.0 (2024-01-17)
+
+* [bitnami/mysql] fix: :lock: Improve podSecurityContext and containerSecurityContext with essential s ([4bf551a](https://github.com/bitnami/charts/commit/4bf551a)), closes [#22163](https://github.com/bitnami/charts/issues/22163)
+
+## <small>9.16.4 (2024-01-16)</small>
+
+* [bitnami/mysql] Release 9.16.4 updating components versions (#22239) ([876a1b4](https://github.com/bitnami/charts/commit/876a1b4)), closes [#22239](https://github.com/bitnami/charts/issues/22239)
+
+## <small>9.16.3 (2024-01-16)</small>
+
+* [bitnami/mysql] Release 9.16.3 updating components versions (#22227) ([dc63386](https://github.com/bitnami/charts/commit/dc63386)), closes [#22227](https://github.com/bitnami/charts/issues/22227)
+
+## <small>9.16.2 (2024-01-14)</small>
+
+* [bitnami/*] Fix docs.bitnami.com broken links (#21901) ([f35506d](https://github.com/bitnami/charts/commit/f35506d)), closes [#21901](https://github.com/bitnami/charts/issues/21901)
+* [bitnami/*] Fix ref links (in comments) (#21822) ([e4fa296](https://github.com/bitnami/charts/commit/e4fa296)), closes [#21822](https://github.com/bitnami/charts/issues/21822)
+* [bitnami/*] Update copyright: Year and company (#21815) ([6c4bf75](https://github.com/bitnami/charts/commit/6c4bf75)), closes [#21815](https://github.com/bitnami/charts/issues/21815)
+* [bitnami/mysql] fix: :lock: Do not automount the service account token unless necessary (#22055) ([fc8b74d](https://github.com/bitnami/charts/commit/fc8b74d)), closes [#22055](https://github.com/bitnami/charts/issues/22055)
+
+## <small>9.16.1 (2023-12-31)</small>
+
+* [bitnami/mysql] Release 9.16.1 updating components versions (#21805) ([160d73f](https://github.com/bitnami/charts/commit/160d73f)), closes [#21805](https://github.com/bitnami/charts/issues/21805)
+
+## 9.16.0 (2023-12-28)
+
+* [bitnami/mysql] Add extraPodSpec support (#21749) ([81eba5b](https://github.com/bitnami/charts/commit/81eba5b)), closes [#21749](https://github.com/bitnami/charts/issues/21749)
+
+## 9.15.0 (2023-12-13)
+
+* [bitnami/mysql] Allow to set a persistentVolumeClaimRetentionPolicy (#21492) ([f6a203f](https://github.com/bitnami/charts/commit/f6a203f)), closes [#21492](https://github.com/bitnami/charts/issues/21492)
+
+## <small>9.14.4 (2023-11-21)</small>
+
+* [bitnami/*] Remove relative links to non-README sections, add verification for that and update TL;DR ([1103633](https://github.com/bitnami/charts/commit/1103633)), closes [#20967](https://github.com/bitnami/charts/issues/20967)
+* [bitnami/*] Rename solutions to "Bitnami package for ..." (#21038) ([b82f979](https://github.com/bitnami/charts/commit/b82f979)), closes [#21038](https://github.com/bitnami/charts/issues/21038)
+* [bitnami/mysql] Release 9.14.4 updating components versions (#21143) ([3e64395](https://github.com/bitnami/charts/commit/3e64395)), closes [#21143](https://github.com/bitnami/charts/issues/21143)
+
+## <small>9.14.3 (2023-11-08)</small>
+
+* [bitnami/mysql] Release 9.14.3 updating components versions (#20760) ([46b28f6](https://github.com/bitnami/charts/commit/46b28f6)), closes [#20760](https://github.com/bitnami/charts/issues/20760)
+
+## <small>9.14.2 (2023-11-06)</small>
+
+* [bitnami/mysql] Fix reference to defaultAuthenticationPlugin (#20604) ([7b367fc](https://github.com/bitnami/charts/commit/7b367fc)), closes [#20604](https://github.com/bitnami/charts/issues/20604)
+
+## <small>9.14.1 (2023-10-25)</small>
+
+* [bitnami/mysql] Release 9.14.1 updating components versions (#20422) ([1b44929](https://github.com/bitnami/charts/commit/1b44929)), closes [#20422](https://github.com/bitnami/charts/issues/20422)
+
+## 9.14.0 (2023-10-24)
+
+* [bitnami/mysql] feat: :sparkles: Add support for PSA restricted policy (#20359) ([e654d39](https://github.com/bitnami/charts/commit/e654d39)), closes [#20359](https://github.com/bitnami/charts/issues/20359)
+
+## 9.13.0 (2023-10-23)
+
+* [bitnami/*] Rename VMware Application Catalog (#20361) ([3acc734](https://github.com/bitnami/charts/commit/3acc734)), closes [#20361](https://github.com/bitnami/charts/issues/20361)
+* [bitnami/*] Skip image's tag in the README files of the Bitnami Charts (#19841) ([bb9a01b](https://github.com/bitnami/charts/commit/bb9a01b)), closes [#19841](https://github.com/bitnami/charts/issues/19841)
+* [bitnami/*] Standardize documentation (#19835) ([af5f753](https://github.com/bitnami/charts/commit/af5f753)), closes [#19835](https://github.com/bitnami/charts/issues/19835)
+* [bitnami/mysql] Adds a parameter to change the default authentication plugin (#19577) ([cda5505](https://github.com/bitnami/charts/commit/cda5505)), closes [#19577](https://github.com/bitnami/charts/issues/19577)
+
+## <small>9.12.5 (2023-10-12)</small>
+
+* [bitnami/mysql] Release 9.12.5 (#20183) ([f397151](https://github.com/bitnami/charts/commit/f397151)), closes [#20183](https://github.com/bitnami/charts/issues/20183)
+
+## <small>9.12.4 (2023-10-09)</small>
+
+* [bitnami/*] Update Helm charts prerequisites (#19745) ([eb755dd](https://github.com/bitnami/charts/commit/eb755dd)), closes [#19745](https://github.com/bitnami/charts/issues/19745)
+* [bitnami/mysql] Remove the specified collation config to keep it as default (#19766) ([227e813](https://github.com/bitnami/charts/commit/227e813)), closes [#19766](https://github.com/bitnami/charts/issues/19766)
+
+## <small>9.12.3 (2023-09-19)</small>
+
+* [bitnami/mysql] bug/mysql loadBalancerSourceRanges as list of IP Ranges (#19175) ([2101dc7](https://github.com/bitnami/charts/commit/2101dc7)), closes [#19175](https://github.com/bitnami/charts/issues/19175)
+* [bitnami/mysql] Release 9.12.3 (#19382) ([2b02ed8](https://github.com/bitnami/charts/commit/2b02ed8)), closes [#19382](https://github.com/bitnami/charts/issues/19382)
+* Revert "Autogenerate schema files (#19194)" (#19335) ([73d80be](https://github.com/bitnami/charts/commit/73d80be)), closes [#19194](https://github.com/bitnami/charts/issues/19194) [#19335](https://github.com/bitnami/charts/issues/19335)
+
+## <small>9.12.2 (2023-09-11)</small>
+
+* [bitnami/mysql: Use merge helper]: (#19078) ([d8b006e](https://github.com/bitnami/charts/commit/d8b006e)), closes [#19078](https://github.com/bitnami/charts/issues/19078)
+* Autogenerate schema files (#19194) ([a2c2090](https://github.com/bitnami/charts/commit/a2c2090)), closes [#19194](https://github.com/bitnami/charts/issues/19194)
+
+## <small>9.12.1 (2023-08-28)</small>
+
+* [bitnami/mysql] test: :white_check_mark: Add ginkgo persistence tests (#18735) ([329afd8](https://github.com/bitnami/charts/commit/329afd8)), closes [#18735](https://github.com/bitnami/charts/issues/18735)
+
+## 9.12.0 (2023-08-22)
+
+* [bitnami/mysql] Support for customizing standard labels (#18356) ([1e57297](https://github.com/bitnami/charts/commit/1e57297)), closes [#18356](https://github.com/bitnami/charts/issues/18356)
+
+## <small>9.11.2 (2023-08-20)</small>
+
+* [bitnami/mysql] Release 9.11.2 (#18692) ([1c5dafe](https://github.com/bitnami/charts/commit/1c5dafe)), closes [#18692](https://github.com/bitnami/charts/issues/18692)
+
+## <small>9.11.1 (2023-08-17)</small>
+
+* [bitnami/mysql] Release 9.11.1 (#18562) ([82ce020](https://github.com/bitnami/charts/commit/82ce020)), closes [#18562](https://github.com/bitnami/charts/issues/18562)
+
+## 9.11.0 (2023-08-15)
+
+* [bitnami/mysql] Update to mysql chart to have startdb script (#18344) ([22b07e0](https://github.com/bitnami/charts/commit/22b07e0)), closes [#18344](https://github.com/bitnami/charts/issues/18344)
+
+## <small>9.10.10 (2023-08-04)</small>
+
+* [bitnami/mysql] Fix mysql_exporter arguments for 0.15.0 (#18094) ([6ba4afb](https://github.com/bitnami/charts/commit/6ba4afb)), closes [#18094](https://github.com/bitnami/charts/issues/18094)
+
+## <small>9.10.9 (2023-07-26)</small>
+
+* [bitnami/mysql] Release 9.10.9 (#17935) ([5fc332c](https://github.com/bitnami/charts/commit/5fc332c)), closes [#17935](https://github.com/bitnami/charts/issues/17935)
+* Update README.md (#17830) ([567f1fc](https://github.com/bitnami/charts/commit/567f1fc)), closes [#17830](https://github.com/bitnami/charts/issues/17830)
+
+## <small>9.10.8 (2023-07-22)</small>
+
+* [bitnami/mysql] Release 9.10.8 (#17825) ([70d405f](https://github.com/bitnami/charts/commit/70d405f)), closes [#17825](https://github.com/bitnami/charts/issues/17825)
+
+## <small>9.10.7 (2023-07-18)</small>
+
+* [bitnami/mysql] Release 9.10.7 (#17760) ([eaef23c](https://github.com/bitnami/charts/commit/eaef23c)), closes [#17760](https://github.com/bitnami/charts/issues/17760)
+
+## <small>9.10.6 (2023-07-15)</small>
+
+* [bitnami/mysql] Release 9.10.6 (#17679) ([98ccf9a](https://github.com/bitnami/charts/commit/98ccf9a)), closes [#17679](https://github.com/bitnami/charts/issues/17679)
+
+## <small>9.10.5 (2023-07-05)</small>
+
+* [bitnami/mysql] Release 9.10.5 (#17491) ([5a13ff4](https://github.com/bitnami/charts/commit/5a13ff4)), closes [#17491](https://github.com/bitnami/charts/issues/17491)
+* Add copyright header (#17300) ([da68be8](https://github.com/bitnami/charts/commit/da68be8)), closes [#17300](https://github.com/bitnami/charts/issues/17300)
+* Update charts readme (#17217) ([31b3c0a](https://github.com/bitnami/charts/commit/31b3c0a)), closes [#17217](https://github.com/bitnami/charts/issues/17217)
+
+## <small>9.10.4 (2023-06-12)</small>
+
+* [bitnami/mysql] Bump version (#17096) ([56cd509](https://github.com/bitnami/charts/commit/56cd509)), closes [#17096](https://github.com/bitnami/charts/issues/17096)
+
+## <small>9.10.3 (2023-06-12)</small>
+
+* [bitnami/mysql,mariadb] Use default slow-query log file (#17065) ([3a34b6e](https://github.com/bitnami/charts/commit/3a34b6e)), closes [#17065](https://github.com/bitnami/charts/issues/17065)
+
+## <small>9.10.2 (2023-06-06)</small>
+
+* [bitnami/*] Change copyright section in READMEs (#17006) ([ef986a1](https://github.com/bitnami/charts/commit/ef986a1)), closes [#17006](https://github.com/bitnami/charts/issues/17006)
+* [bitnami/mysql] Release 9.10.2 (#17046) ([18536a6](https://github.com/bitnami/charts/commit/18536a6)), closes [#17046](https://github.com/bitnami/charts/issues/17046)
+* [bitnami/several] Change copyright section in READMEs (#16989) ([5b6a5cf](https://github.com/bitnami/charts/commit/5b6a5cf)), closes [#16989](https://github.com/bitnami/charts/issues/16989)
+
+## <small>9.10.1 (2023-05-21)</small>
+
+* [bitnami/mysql] Release 9.10.1 (#16792) ([5364a00](https://github.com/bitnami/charts/commit/5364a00)), closes [#16792](https://github.com/bitnami/charts/issues/16792)
+* Add wording for enterprise page (#16560) ([8f22774](https://github.com/bitnami/charts/commit/8f22774)), closes [#16560](https://github.com/bitnami/charts/issues/16560)
+
+## 9.10.0 (2023-05-09)
+
+* [bitnami/several] Adapt Chart.yaml to set desired OCI annotations (#16546) ([fc9b18f](https://github.com/bitnami/charts/commit/fc9b18f)), closes [#16546](https://github.com/bitnami/charts/issues/16546)
+
+## <small>9.9.1 (2023-05-09)</small>
+
+* [bitnami/mysql] Release 9.9.1 (#16483) ([0c0c5b9](https://github.com/bitnami/charts/commit/0c0c5b9)), closes [#16483](https://github.com/bitnami/charts/issues/16483)
+
+## 9.9.0 (2023-05-03)
+
+* [bitnami/mysql]: metrics service can specify clusterIP (#16077) ([712e1e5](https://github.com/bitnami/charts/commit/712e1e5)), closes [#16077](https://github.com/bitnami/charts/issues/16077)
+
+## <small>9.8.2 (2023-04-27)</small>
+
+* [bitnami/mysql] Use username as key in the Service Binding secret (#16253) ([af891d5](https://github.com/bitnami/charts/commit/af891d5)), closes [#16253](https://github.com/bitnami/charts/issues/16253)
+
+## <small>9.8.1 (2023-04-26)</small>
+
+* [bitnami/mysql] Release 9.8.1 (#16241) ([5980213](https://github.com/bitnami/charts/commit/5980213)), closes [#16241](https://github.com/bitnami/charts/issues/16241)
+
+## 9.8.0 (2023-04-20)
+
+* [bitnami/*] Make Helm charts 100% OCI (#15998) ([8841510](https://github.com/bitnami/charts/commit/8841510)), closes [#15998](https://github.com/bitnami/charts/issues/15998)
+
+## <small>9.7.2 (2023-04-19)</small>
+
+* [bitnami/mysql] Release 9.7.2 (#16134) ([3bdd763](https://github.com/bitnami/charts/commit/3bdd763)), closes [#16134](https://github.com/bitnami/charts/issues/16134)
+
+## <small>9.7.1 (2023-04-01)</small>
+
+* [bitnami/mysql] Release 9.7.1 (#15874) ([668ff13](https://github.com/bitnami/charts/commit/668ff13)), closes [#15874](https://github.com/bitnami/charts/issues/15874)
+
+## 9.7.0 (2023-03-22)
+
+* [bitnami/mysql] metrics containerSecurityContext (#15639) ([b0eb0e2](https://github.com/bitnami/charts/commit/b0eb0e2)), closes [#15639](https://github.com/bitnami/charts/issues/15639)
+
+## 9.6.0 (2023-03-09)
+
+* [bitnami/charts] Apply linter to README files (#15357) ([0e29e60](https://github.com/bitnami/charts/commit/0e29e60)), closes [#15357](https://github.com/bitnami/charts/issues/15357)
+* [bitnami/mysql] Adding the extraPorts mapping for additional protocols (#15329) ([800022c](https://github.com/bitnami/charts/commit/800022c)), closes [#15329](https://github.com/bitnami/charts/issues/15329)
+
+## <small>9.5.2 (2023-03-06)</small>
+
+* [bitnami/mysql] Release 9.5.2 (#15343) ([cc6a17f](https://github.com/bitnami/charts/commit/cc6a17f)), closes [#15343](https://github.com/bitnami/charts/issues/15343)
+
+## <small>9.5.1 (2023-03-01)</small>
+
+* [bitnami/mysql] Release 9.5.1 (#15267) ([785b327](https://github.com/bitnami/charts/commit/785b327)), closes [#15267](https://github.com/bitnami/charts/issues/15267)
+
+## 9.5.0 (2023-02-21)
+
+* [bitnami/mysql] feat: :sparkles: Add ServiceBinding-compatible secrets (#14912) ([4e92332](https://github.com/bitnami/charts/commit/4e92332)), closes [#14912](https://github.com/bitnami/charts/issues/14912)
+
+## <small>9.4.9 (2023-02-17)</small>
+
+* [bitnami/*] Change copyright date (#14682) ([add4ec7](https://github.com/bitnami/charts/commit/add4ec7)), closes [#14682](https://github.com/bitnami/charts/issues/14682)
+* [bitnami/*] Fix markdown linter issues (#14874) ([a51e0e8](https://github.com/bitnami/charts/commit/a51e0e8)), closes [#14874](https://github.com/bitnami/charts/issues/14874)
+* [bitnami/*] Fix markdown linter issues 2 (#14890) ([aa96572](https://github.com/bitnami/charts/commit/aa96572)), closes [#14890](https://github.com/bitnami/charts/issues/14890)
+* [bitnami/*] Remove unexpected extra spaces (#14873) ([c97c714](https://github.com/bitnami/charts/commit/c97c714)), closes [#14873](https://github.com/bitnami/charts/issues/14873)
+* [bitnami/mysql] Release 9.4.9 (#15011) ([e0d2754](https://github.com/bitnami/charts/commit/e0d2754)), closes [#15011](https://github.com/bitnami/charts/issues/15011)
+
+## <small>9.4.8 (2023-01-23)</small>
+
+* [bitnami/mysql] Release 9.4.8 (#14498) ([4ebb991](https://github.com/bitnami/charts/commit/4ebb991)), closes [#14498](https://github.com/bitnami/charts/issues/14498)
+
+## <small>9.4.7 (2023-01-22)</small>
+
+* [bitnami/*] Add license annotation and remove obsolete engine parameter (#14293) ([da2a794](https://github.com/bitnami/charts/commit/da2a794)), closes [#14293](https://github.com/bitnami/charts/issues/14293)
+* [bitnami/*] Change licenses annotation format (#14377) ([0ab7608](https://github.com/bitnami/charts/commit/0ab7608)), closes [#14377](https://github.com/bitnami/charts/issues/14377)
+* [bitnami/*] Unify READMEs (#14472) ([2064fb8](https://github.com/bitnami/charts/commit/2064fb8)), closes [#14472](https://github.com/bitnami/charts/issues/14472)
+* [bitnami/mysql] Fixed typo in mysql README (#14487) ([ad5128e](https://github.com/bitnami/charts/commit/ad5128e)), closes [#14487](https://github.com/bitnami/charts/issues/14487)
+
+## <small>9.4.6 (2023-01-09)</small>
+
+* [bitnami/mysql] Release 9.4.6 (#14235) ([4a7c9d4](https://github.com/bitnami/charts/commit/4a7c9d4)), closes [#14235](https://github.com/bitnami/charts/issues/14235)
+
+## <small>9.4.5 (2022-12-10)</small>
+
+* [bitnami/mysql] Release 9.4.5 (#13908) ([eb3e786](https://github.com/bitnami/charts/commit/eb3e786)), closes [#13908](https://github.com/bitnami/charts/issues/13908)
+
+## <small>9.4.4 (2022-11-18)</small>
+
+* [bitnami/mysql]: Add support for RuntimeClass (#13508) ([722e6de](https://github.com/bitnami/charts/commit/722e6de)), closes [#13508](https://github.com/bitnami/charts/issues/13508)
+
+## <small>9.4.3 (2022-11-10)</small>
+
+* [bitnami/mysql] Release 9.4.3 (#13461) ([ede78ae](https://github.com/bitnami/charts/commit/ede78ae)), closes [#13461](https://github.com/bitnami/charts/issues/13461)
+
+## <small>9.4.2 (2022-11-09)</small>
+
+* [bitnami/*] Use new default branch name in links (#12943) ([a529e02](https://github.com/bitnami/charts/commit/a529e02)), closes [#12943](https://github.com/bitnami/charts/issues/12943)
+* [bitnami/mysql] Added support for MySQL volume subPath (#13230) ([809d453](https://github.com/bitnami/charts/commit/809d453)), closes [#13230](https://github.com/bitnami/charts/issues/13230)
+
+## <small>9.4.1 (2022-10-11)</small>
+
+* [bitnami/mysql] Release 9.4.1 (#12904) ([03b0fde](https://github.com/bitnami/charts/commit/03b0fde)), closes [#12904](https://github.com/bitnami/charts/issues/12904)
+
+## 9.4.0 (2022-10-11)
+
+* [bitnami/mysql] Add custom annotations to headless services (#12295) ([4a6116b](https://github.com/bitnami/charts/commit/4a6116b)), closes [#12295](https://github.com/bitnami/charts/issues/12295)
+
+## <small>9.3.5 (2022-10-08)</small>
+
+* [bitnami/mysql] Release 9.3.5 (#12863) ([4da1248](https://github.com/bitnami/charts/commit/4da1248)), closes [#12863](https://github.com/bitnami/charts/issues/12863)
+* Generic README instructions related to the repo (#12792) ([3cf6b10](https://github.com/bitnami/charts/commit/3cf6b10)), closes [#12792](https://github.com/bitnami/charts/issues/12792)
+
+## <small>9.3.4 (2022-09-20)</small>
+
+* [bitnami/mysql] Use custom probes if given (#12532) ([1fb9f30](https://github.com/bitnami/charts/commit/1fb9f30)), closes [#12532](https://github.com/bitnami/charts/issues/12532) [#12354](https://github.com/bitnami/charts/issues/12354)
+
+## <small>9.3.3 (2022-09-16)</small>
+
+* [bitnami/mysql] change bind-address to * (#12443) ([b626bb2](https://github.com/bitnami/charts/commit/b626bb2)), closes [#12443](https://github.com/bitnami/charts/issues/12443)
+
+## <small>9.3.2 (2022-09-08)</small>
+
+* [bitnami/mysql] Release 9.3.2 (#12323) ([10449d8](https://github.com/bitnami/charts/commit/10449d8)), closes [#12323](https://github.com/bitnami/charts/issues/12323)
+
+## <small>9.3.1 (2022-08-23)</small>
+
+* [bitnami/mysql] Update Chart.lock (#12041) ([2ea1628](https://github.com/bitnami/charts/commit/2ea1628)), closes [#12041](https://github.com/bitnami/charts/issues/12041)
+
+## 9.3.0 (2022-08-22)
+
+* [bitnami/mysql] Add support for image digest apart from tag (#11910) ([a3d4c67](https://github.com/bitnami/charts/commit/a3d4c67)), closes [#11910](https://github.com/bitnami/charts/issues/11910)
+
+## <small>9.2.6 (2022-08-09)</small>
+
+* [bitnami/mysql] Release 9.2.6 (#11653) ([e7f2f80](https://github.com/bitnami/charts/commit/e7f2f80)), closes [#11653](https://github.com/bitnami/charts/issues/11653)
+
+## <small>9.2.5 (2022-08-04)</small>
+
+* [bitnami/mysql] Release 9.2.5 (#11573) ([cdc9ecd](https://github.com/bitnami/charts/commit/cdc9ecd)), closes [#11573](https://github.com/bitnami/charts/issues/11573)
+
+## <small>9.2.4 (2022-08-03)</small>
+
+* [bitnami/mysql] Release 9.2.4 (#11526) ([38cc057](https://github.com/bitnami/charts/commit/38cc057)), closes [#11526](https://github.com/bitnami/charts/issues/11526)
+
+## <small>9.2.3 (2022-07-27)</small>
+
+* [bitnami/mysql] Release 9.2.3 (#11383) ([cae0660](https://github.com/bitnami/charts/commit/cae0660)), closes [#11383](https://github.com/bitnami/charts/issues/11383)
+
+## <small>9.2.2 (2022-07-26)</small>
+
+* [bitnami/*] Update URLs to point to the new bitnami/containers monorepo (#11352) ([d665af0](https://github.com/bitnami/charts/commit/d665af0)), closes [#11352](https://github.com/bitnami/charts/issues/11352)
+* [bitnami/mysql] Release 9.2.2 (#11360) ([cd91c1c](https://github.com/bitnami/charts/commit/cd91c1c)), closes [#11360](https://github.com/bitnami/charts/issues/11360)
+
+## <small>9.2.1 (2022-07-18)</small>
+
+* [bitnami/mysql] Allow custom name of database role (#11167) ([415a515](https://github.com/bitnami/charts/commit/415a515)), closes [#11167](https://github.com/bitnami/charts/issues/11167)
+
+## 9.2.0 (2022-07-04)
+
+* [bitnami/mysql] Run initscripts on secondary nodes (#10994) ([695579c](https://github.com/bitnami/charts/commit/695579c)), closes [#10994](https://github.com/bitnami/charts/issues/10994)
+
+## <small>9.1.9 (2022-06-30)</small>
+
+* [bitnami/mysql] Release 9.1.9 (#10941) ([bb19e3e](https://github.com/bitnami/charts/commit/bb19e3e)), closes [#10941](https://github.com/bitnami/charts/issues/10941)
+
+## <small>9.1.8 (2022-06-22)</small>
+
+* [bitnami/mysql] Make auth.database Optional (#10553) ([af70740](https://github.com/bitnami/charts/commit/af70740)), closes [#10553](https://github.com/bitnami/charts/issues/10553)
+
+## <small>9.1.7 (2022-06-10)</small>
+
+* [bitnami/mysql] Release 9.1.7 updating components versions ([05e7a42](https://github.com/bitnami/charts/commit/05e7a42))
+
+## <small>9.1.6 (2022-06-09)</small>
+
+* [bitnami/*] Replace Kubeapps URL in READMEs (and kubeapps Chart.yaml) and remove BKPR references (#1 ([c6a7914](https://github.com/bitnami/charts/commit/c6a7914)), closes [#10600](https://github.com/bitnami/charts/issues/10600)
+* [bitnami/mysql] Remove primary/secondary labels from antiAffinity settings (#10527) ([6a85f6c](https://github.com/bitnami/charts/commit/6a85f6c)), closes [#10527](https://github.com/bitnami/charts/issues/10527)
+
+## <small>9.1.5 (2022-06-07)</small>
+
+* [bitnami/mysql] Release 9.1.5 updating components versions ([0fb0912](https://github.com/bitnami/charts/commit/0fb0912))
+
+## <small>9.1.4 (2022-06-03)</small>
+
+* [bitnami/mysql] fix mysql-secondary configuration (#10537) ([465d947](https://github.com/bitnami/charts/commit/465d947)), closes [#10537](https://github.com/bitnami/charts/issues/10537)
+
+## <small>9.1.3 (2022-06-01)</small>
+
+* [bitnami/several] Replace maintainers email by url (#10523) ([ff3cf61](https://github.com/bitnami/charts/commit/ff3cf61)), closes [#10523](https://github.com/bitnami/charts/issues/10523)
+
+## <small>9.1.2 (2022-05-30)</small>
+
+* [bitnami/several] Replace base64 --decode with base64 -d (#10495) ([099286a](https://github.com/bitnami/charts/commit/099286a)), closes [#10495](https://github.com/bitnami/charts/issues/10495)
+
+## <small>9.1.1 (2022-05-27)</small>
+
+* [bitnami/mysql] Fix Chart.yaml format ([cab842c](https://github.com/bitnami/charts/commit/cab842c))
+
+## 9.1.0 (2022-05-25)
+
+* [bitnami/mysql] add prometheusrule (#10259) ([286c3f1](https://github.com/bitnami/charts/commit/286c3f1)), closes [#10259](https://github.com/bitnami/charts/issues/10259)
+
+## <small>9.0.5 (2022-05-24)</small>
+
+* [bitnami/mysql] fix mysql slave auth after applying helm (#10378) ([74e8485](https://github.com/bitnami/charts/commit/74e8485)), closes [#10378](https://github.com/bitnami/charts/issues/10378)
+
+## <small>9.0.4 (2022-05-21)</small>
+
+* [bitnami/mysql] Release 9.0.4 updating components versions ([2b4030d](https://github.com/bitnami/charts/commit/2b4030d))
+
+## <small>9.0.3 (2022-05-20)</small>
+
+* [bitnami/mysql] Release 9.0.3 updating components versions ([2ced122](https://github.com/bitnami/charts/commit/2ced122))
+
+## <small>9.0.2 (2022-05-19)</small>
+
+* [bitnami/mysql] Release 9.0.2 updating components versions ([e5ea121](https://github.com/bitnami/charts/commit/e5ea121))
+
+## <small>9.0.1 (2022-05-18)</small>
+
+* [bitnami/*] Remove old 'ci' files (#10171) ([5df30c4](https://github.com/bitnami/charts/commit/5df30c4)), closes [#10171](https://github.com/bitnami/charts/issues/10171)
+* [bitnami/mysql] Release 9.0.1 updating components versions ([bb8dc55](https://github.com/bitnami/charts/commit/bb8dc55))
+
+## 9.0.0 (2022-05-11)
+
+* [bitnami/mysql] Chart standardised (#10046) ([9ac6cd9](https://github.com/bitnami/charts/commit/9ac6cd9)), closes [#10046](https://github.com/bitnami/charts/issues/10046)
+
+## <small>8.9.6 (2022-04-28)</small>
+
+* [bitnami/mysql] Release 8.9.6 updating components versions ([2b40222](https://github.com/bitnami/charts/commit/2b40222))
+
+## <small>8.9.5 (2022-04-27)</small>
+
+* [bitnami/mysql] Include long query config to secondary (#9941) ([198cb32](https://github.com/bitnami/charts/commit/198cb32)), closes [#9941](https://github.com/bitnami/charts/issues/9941)
+
+## <small>8.9.4 (2022-04-27)</small>
+
+* [bitnami/mysql] Release 8.9.4 updating components versions ([dbd539c](https://github.com/bitnami/charts/commit/dbd539c))
+
+## <small>8.9.3 (2022-04-26)</small>
+
+* [bitnami/mysql] Fix missing env var in NOTES (#9911) ([5918fa4](https://github.com/bitnami/charts/commit/5918fa4)), closes [#9911](https://github.com/bitnami/charts/issues/9911)
+
+## <small>8.9.2 (2022-04-20)</small>
+
+* [bitnami/mysql] Release 8.9.2 updating components versions ([520c9cb](https://github.com/bitnami/charts/commit/520c9cb))
+
+## <small>8.9.1 (2022-04-19)</small>
+
+* [bitnami/mysql] Release 8.9.1 updating components versions ([adde76a](https://github.com/bitnami/charts/commit/adde76a))
+
+## 8.9.0 (2022-04-08)
+
+* [bitnami/mysql] Add slow query configuration to MySQL (#9703) ([b0f80b8](https://github.com/bitnami/charts/commit/b0f80b8)), closes [#9703](https://github.com/bitnami/charts/issues/9703)
+
+## <small>8.8.35 (2022-04-07)</small>
+
+* [bitnami/mysql] Release 8.8.35 updating components versions ([005820b](https://github.com/bitnami/charts/commit/005820b))
+
+## <small>8.8.34 (2022-04-05)</small>
+
+* [bitnami/mysql] Release 8.8.34 updating components versions ([0d2ff8c](https://github.com/bitnami/charts/commit/0d2ff8c))
+
+## <small>8.8.33 (2022-04-05)</small>
+
+* [bitnami/mysql] remove empty password validation (#9640) ([62e2f92](https://github.com/bitnami/charts/commit/62e2f92)), closes [#9640](https://github.com/bitnami/charts/issues/9640)
+* [bitnami/mysql] Support templating in initdbScriptsConfigMap (#9594) ([2fff81c](https://github.com/bitnami/charts/commit/2fff81c)), closes [#9594](https://github.com/bitnami/charts/issues/9594)
+
+## <small>8.8.32 (2022-04-03)</small>
+
+* [bitnami/mysql] Release 8.8.32 updating components versions ([56483d5](https://github.com/bitnami/charts/commit/56483d5))
+
+## <small>8.8.31 (2022-04-02)</small>
+
+* [bitnami/mysql] Release 8.8.31 updating components versions ([8eeed10](https://github.com/bitnami/charts/commit/8eeed10))
+
+## <small>8.8.30 (2022-03-30)</small>
+
+* [bitnami/mysql] Support templating in auth.existingSecret (#9612) ([f98d8a5](https://github.com/bitnami/charts/commit/f98d8a5)), closes [#9612](https://github.com/bitnami/charts/issues/9612)
+
+## <small>8.8.29 (2022-03-28)</small>
+
+* [bitnami/mysql] Release 8.8.29 updating components versions ([2d27911](https://github.com/bitnami/charts/commit/2d27911))
+
+## <small>8.8.28 (2022-03-27)</small>
+
+* [bitnami/mysql] Release 8.8.28 updating components versions ([78e2c61](https://github.com/bitnami/charts/commit/78e2c61))
+
+## <small>8.8.27 (2022-03-17)</small>
+
+* [bitnami/mysql] Release 8.8.27 updating components versions ([28b9350](https://github.com/bitnami/charts/commit/28b9350))
+* delete unnecessary blank (#9397) ([a1593f1](https://github.com/bitnami/charts/commit/a1593f1)), closes [#9397](https://github.com/bitnami/charts/issues/9397)
+
+## <small>8.8.26 (2022-02-27)</small>
+
+* [bitnami/mysql] Release 8.8.26 updating components versions ([07a6841](https://github.com/bitnami/charts/commit/07a6841))
+
+## <small>8.8.25 (2022-02-21)</small>
+
+* [bitnami/mysql] Do not hardcode PDB apiVersion (#9106) ([51e5aaf](https://github.com/bitnami/charts/commit/51e5aaf)), closes [#9106](https://github.com/bitnami/charts/issues/9106)
+
+## <small>8.8.24 (2022-02-17)</small>
+
+* [bitnami/mysql] Release 8.8.24 updating components versions ([f36c2fd](https://github.com/bitnami/charts/commit/f36c2fd))
+* Non utf8 chars (#8923) ([6ffd18f](https://github.com/bitnami/charts/commit/6ffd18f)), closes [#8923](https://github.com/bitnami/charts/issues/8923)
+
+## <small>8.8.23 (2022-01-20)</small>
+
+* [bitnami/*] Update READMEs (#8716) ([b9a9533](https://github.com/bitnami/charts/commit/b9a9533)), closes [#8716](https://github.com/bitnami/charts/issues/8716)
+* [bitnami/several] Change prerequisites (#8725) ([8d740c5](https://github.com/bitnami/charts/commit/8d740c5)), closes [#8725](https://github.com/bitnami/charts/issues/8725)
+
+## <small>8.8.22 (2022-01-18)</small>
+
+* [bitnami/*] Readme automation (#8579) ([78d1938](https://github.com/bitnami/charts/commit/78d1938)), closes [#8579](https://github.com/bitnami/charts/issues/8579)
+* [bitnami/mysql] Release 8.8.22 updating components versions ([f8cf502](https://github.com/bitnami/charts/commit/f8cf502))
+
+## <small>8.8.21 (2022-01-12)</small>
+
+* [bitnami/mysql] Release 8.8.21 updating components versions ([878cad8](https://github.com/bitnami/charts/commit/878cad8))
+
+## <small>8.8.20 (2022-01-04)</small>
+
+* [bitnami/several] Add license to the README ([05f7633](https://github.com/bitnami/charts/commit/05f7633))
+* [bitnami/several] Add license to the README ([32fb238](https://github.com/bitnami/charts/commit/32fb238))
+* [bitnami/several] Add license to the README ([b87c2f7](https://github.com/bitnami/charts/commit/b87c2f7))
+* [bitnami/several] Fix issue with quote when followed by }} (#8561) ([58077af](https://github.com/bitnami/charts/commit/58077af)), closes [#8561](https://github.com/bitnami/charts/issues/8561)
+
+## <small>8.8.19 (2022-01-03)</small>
+
+* [bitnami/mysql] Prevent introduction of leading newline character in predefined password and replica ([b1aae55](https://github.com/bitnami/charts/commit/b1aae55)), closes [#8546](https://github.com/bitnami/charts/issues/8546)
+
+## <small>8.8.18 (2021-12-28)</small>
+
+* [bitnami/mysql] lookup existing secrets (#8504) ([7238fbe](https://github.com/bitnami/charts/commit/7238fbe)), closes [#8504](https://github.com/bitnami/charts/issues/8504)
+
+## <small>8.8.17 (2021-12-26)</small>
+
+* [bitnami/mysql] Release 8.8.17 updating components versions ([6cd6a78](https://github.com/bitnami/charts/commit/6cd6a78))
+
+## <small>8.8.16 (2021-12-10)</small>
+
+* [bitnami/cassandra,etcd,influxdb,metallb,mysql,postgresql,postgresql-ha,redis] Align networkpolicy   ([0404b1a](https://github.com/bitnami/charts/commit/0404b1a)), closes [#8336](https://github.com/bitnami/charts/issues/8336)
+* [bitnami/mysql] Fix existingConfigmap typo in values (#8360) ([2ab69f3](https://github.com/bitnami/charts/commit/2ab69f3)), closes [#8360](https://github.com/bitnami/charts/issues/8360)
+
+## <small>8.8.15 (2021-12-09)</small>
+
+* [bitnami/mysql] add commonAnnotations to initialization-configmap (#8309) ([48e8e9c](https://github.com/bitnami/charts/commit/48e8e9c)), closes [#8309](https://github.com/bitnami/charts/issues/8309)
+
+## <small>8.8.14 (2021-11-29)</small>
+
+* [bitnami/several] Regenerate README tables ([ac75243](https://github.com/bitnami/charts/commit/ac75243))
+* [bitnami/several] Replace HTTP by HTTPS when possible (#8259) ([eafb5bd](https://github.com/bitnami/charts/commit/eafb5bd)), closes [#8259](https://github.com/bitnami/charts/issues/8259)
+
+## <small>8.8.13 (2021-11-26)</small>
+
+* [bitnami/mysql] Release 8.8.13 updating components versions ([d436b22](https://github.com/bitnami/charts/commit/d436b22))
+* [bitnami/several] Fix deadlinks in README.md (#8215) ([99e90d2](https://github.com/bitnami/charts/commit/99e90d2)), closes [#8215](https://github.com/bitnami/charts/issues/8215)
+* [bitnami/several] Regenerate README tables ([412cf6a](https://github.com/bitnami/charts/commit/412cf6a))
+
+## <small>8.8.12 (2021-10-27)</small>
+
+* [bitnami/mysql] Release 8.8.12 updating components versions ([5f3d30a](https://github.com/bitnami/charts/commit/5f3d30a))
+
+## <small>8.8.11 (2021-10-22)</small>
+
+* [bitnami/several] Add chart info to NOTES.txt (#7889) ([a6751cd](https://github.com/bitnami/charts/commit/a6751cd)), closes [#7889](https://github.com/bitnami/charts/issues/7889)
+* [bitnami/several] Regenerate README tables ([73cabea](https://github.com/bitnami/charts/commit/73cabea))
+
+## <small>8.8.10 (2021-10-20)</small>
+
+* [bitnami/mysql] Release 8.8.10 updating components versions ([38c61b9](https://github.com/bitnami/charts/commit/38c61b9))
+
+## <small>8.8.9 (2021-10-19)</small>
+
+* [bitnami/several] Change pullPolicy for bitnami-shell image (#7852) ([9711a33](https://github.com/bitnami/charts/commit/9711a33)), closes [#7852](https://github.com/bitnami/charts/issues/7852)
+* [bitnami/several] Regenerate README tables ([ff170d1](https://github.com/bitnami/charts/commit/ff170d1))
+
+## <small>8.8.8 (2021-09-24)</small>
+
+* [bitnami/*] Generate READMEs with new generator version (#7614) ([e5ab2e6](https://github.com/bitnami/charts/commit/e5ab2e6)), closes [#7614](https://github.com/bitnami/charts/issues/7614)
+* [bitnami/mysql] Release 8.8.8 updating components versions ([93a52a0](https://github.com/bitnami/charts/commit/93a52a0))
+
+## <small>8.8.7 (2021-09-14)</small>
+
+* [bitnami/mysql] Fix Mysql root password in NOTES.txt (#7395) ([6e24065](https://github.com/bitnami/charts/commit/6e24065)), closes [#7395](https://github.com/bitnami/charts/issues/7395)
+* [bitnami/several] Regenerate README tables ([da2513b](https://github.com/bitnami/charts/commit/da2513b))
+
+## <small>8.8.6 (2021-08-25)</small>
+
+* [bitnami/mysql] Release 8.8.6 updating components versions ([315c1af](https://github.com/bitnami/charts/commit/315c1af))
+
+## <small>8.8.5 (2021-08-24)</small>
+
+* [bitnami/mysql] Release 8.8.5 updating components versions ([3673c39](https://github.com/bitnami/charts/commit/3673c39))
+
+## <small>8.8.4 (2021-08-18)</small>
+
+* [multiple] Updated image.tag section (#7257) ([a133bed](https://github.com/bitnami/charts/commit/a133bed)), closes [#7257](https://github.com/bitnami/charts/issues/7257)
+
+## <small>8.8.3 (2021-08-09)</small>
+
+* [bitnami/mysql] Improve default values for probes (#7170) ([3540910](https://github.com/bitnami/charts/commit/3540910)), closes [#7170](https://github.com/bitnami/charts/issues/7170)
+
+## <small>8.8.2 (2021-08-04)</small>
+
+* [bitnami/mysql] Release 8.8.2 updating components versions ([f866255](https://github.com/bitnami/charts/commit/f866255))
+
+## <small>8.8.1 (2021-07-28)</small>
+
+* [bitnami/several] Fix default values and regenerate README (III) (#7000) ([4d4fe83](https://github.com/bitnami/charts/commit/4d4fe83)), closes [#7000](https://github.com/bitnami/charts/issues/7000)
+
+## 8.8.0 (2021-07-27)
+
+* [bitnami/several] Add diagnostic mode (#7012) ([f1344b0](https://github.com/bitnami/charts/commit/f1344b0)), closes [#7012](https://github.com/bitnami/charts/issues/7012)
+
+## <small>8.7.3 (2021-07-22)</small>
+
+* [bitnami/mysql] Release 8.7.3 updating components versions ([e5d7627](https://github.com/bitnami/charts/commit/e5d7627))
+
+## <small>8.7.2 (2021-07-15)</small>
+
+* [bitnami/*] Adapt values.yaml of MySQL, NATS and  NGINX charts (#6910) ([97543ce](https://github.com/bitnami/charts/commit/97543ce)), closes [#6910](https://github.com/bitnami/charts/issues/6910)
+
+## <small>8.7.1 (2021-07-06)</small>
+
+* bitnami/mysql: add values.schema.json check (#6844) ([98b8f39](https://github.com/bitnami/charts/commit/98b8f39)), closes [#6844](https://github.com/bitnami/charts/issues/6844)
+
+## 8.7.0 (2021-06-28)
+
+* [bitnami/mysql] add networkpolicy for primary (#6720) (#6734) ([538b5fd](https://github.com/bitnami/charts/commit/538b5fd)), closes [#6720](https://github.com/bitnami/charts/issues/6720) [#6734](https://github.com/bitnami/charts/issues/6734) [#6720](https://github.com/bitnami/charts/issues/6720) [#6720](https://github.com/bitnami/charts/issues/6720) [#6720](https://github.com/bitnami/charts/issues/6720)
+
+## <small>8.6.4 (2021-06-26)</small>
+
+* [bitnami/mysql] Release 8.6.4 updating components versions ([9852b2e](https://github.com/bitnami/charts/commit/9852b2e))
+
+## <small>8.6.3 (2021-06-21)</small>
+
+* [bitnami/mysql] Release 8.6.3 updating components versions ([ab0a7d3](https://github.com/bitnami/charts/commit/ab0a7d3))
+
+## <small>8.6.2 (2021-06-10)</small>
+
+* [bitnami/mysql] Remove annotations from headless services (#6603) ([586c399](https://github.com/bitnami/charts/commit/586c399)), closes [#6603](https://github.com/bitnami/charts/issues/6603) [#6576](https://github.com/bitnami/charts/issues/6576)
+
+## <small>8.6.1 (2021-06-07)</small>
+
+* [bitnami/mysql] Remove references to deprecated approach to mount custom scripts (#6568) ([e83e5dc](https://github.com/bitnami/charts/commit/e83e5dc)), closes [#6568](https://github.com/bitnami/charts/issues/6568)
+
+## 8.6.0 (2021-06-02)
+
+* feat: mysql: add startupProb (#6507) ([75f4494](https://github.com/bitnami/charts/commit/75f4494)), closes [#6507](https://github.com/bitnami/charts/issues/6507)
+
+## <small>8.5.10 (2021-05-28)</small>
+
+* [bitnami/mysql] Release 8.5.10 updating components versions ([9c9070e](https://github.com/bitnami/charts/commit/9c9070e))
+
+## <small>8.5.9 (2021-05-24)</small>
+
+* [bitnami/mysql] Release 8.5.9 updating components versions ([fff8fc6](https://github.com/bitnami/charts/commit/fff8fc6))
+
+## <small>8.5.8 (2021-05-12)</small>
+
+* [bitnami/mysql] Release 8.5.8 updating components versions ([17013ee](https://github.com/bitnami/charts/commit/17013ee))
+
+## <small>8.5.7 (2021-05-05)</small>
+
+* Update NOTES.txt (#6292) ([ee5597c](https://github.com/bitnami/charts/commit/ee5597c)), closes [#6292](https://github.com/bitnami/charts/issues/6292)
+
+## <small>8.5.6 (2021-04-30)</small>
+
+* Fix typos in several README files (#6252) ([fd16565](https://github.com/bitnami/charts/commit/fd16565)), closes [#6252](https://github.com/bitnami/charts/issues/6252)
+
+## <small>8.5.5 (2021-04-22)</small>
+
+* [bitnami/mysql] fixing plugin_dir option in my.cnf (#6178) ([c868ad1](https://github.com/bitnami/charts/commit/c868ad1)), closes [#6178](https://github.com/bitnami/charts/issues/6178)
+
+## <small>8.5.4 (2021-04-20)</small>
+
+* [bitnami/mysql] Release 8.5.4 updating components versions ([73554f9](https://github.com/bitnami/charts/commit/73554f9))
+
+## <small>8.5.3 (2021-04-19)</small>
+
+* [bitnami/mysql] Release 8.5.3 updating components versions ([cda28ed](https://github.com/bitnami/charts/commit/cda28ed))
+
+## <small>8.5.2 (2021-04-16)</small>
+
+* T39353 Updated links (#6128) ([9d5aa6e](https://github.com/bitnami/charts/commit/9d5aa6e)), closes [#6128](https://github.com/bitnami/charts/issues/6128)
+
+## <small>8.5.1 (2021-03-20)</small>
+
+* [bitnami/mysql] Release 8.5.1 updating components versions ([50d9040](https://github.com/bitnami/charts/commit/50d9040))
+
+## 8.5.0 (2021-03-18)
+
+* [bitnami/mysql] Adding support to add the label passed using podLabels tags for primary or secondary ([a57bce0](https://github.com/bitnami/charts/commit/a57bce0)), closes [#5773](https://github.com/bitnami/charts/issues/5773) [#5562](https://github.com/bitnami/charts/issues/5562) [#5562](https://github.com/bitnami/charts/issues/5562) [#5662](https://github.com/bitnami/charts/issues/5662) [#5662](https://github.com/bitnami/charts/issues/5662) [#5662](https://github.com/bitnami/charts/issues/5662) [#5662](https://github.com/bitnami/charts/issues/5662) [#5662](https://github.com/bitnami/charts/issues/5662) [#5662](https://github.com/bitnami/charts/issues/5662) [#5662](https://github.com/bitnami/charts/issues/5662) [#5662](https://github.com/bitnami/charts/issues/5662) [#5662](https://github.com/bitnami/charts/issues/5662) [#5662](https://github.com/bitnami/charts/issues/5662) [#5662](https://github.com/bitnami/charts/issues/5662) [#5662](https://github.com/bitnami/charts/issues/5662) [#5662](https://github.com/bitnami/charts/issues/5662) [#5662](https://github.com/bitnami/charts/issues/5662) [#5662](https://github.com/bitnami/charts/issues/5662) [#5662](https://github.com/bitnami/charts/issues/5662) [#5662](https://github.com/bitnami/charts/issues/5662) [#5662](https://github.com/bitnami/charts/issues/5662) [#5662](https://github.com/bitnami/charts/issues/5662) [#5662](https://github.com/bitnami/charts/issues/5662) [#5662](https://github.com/bitnami/charts/issues/5662) [#5662](https://github.com/bitnami/charts/issues/5662) [#5662](https://github.com/bitnami/charts/issues/5662) [#5662](https://github.com/bitnami/charts/issues/5662) [#5662](https://github.com/bitnami/charts/issues/5662) [#5662](https://github.com/bitnami/charts/issues/5662)
+
+## <small>8.4.4 (2021-03-04)</small>
+
+* [bitnami/*] Remove minideb mentions (#5677) ([870bc4d](https://github.com/bitnami/charts/commit/870bc4d)), closes [#5677](https://github.com/bitnami/charts/issues/5677)
+
+## <small>8.4.3 (2021-02-22)</small>
+
+* [bitnami/*] Use common macro to define RBAC apiVersion (#5585) ([71fb99f](https://github.com/bitnami/charts/commit/71fb99f)), closes [#5585](https://github.com/bitnami/charts/issues/5585)
+
+## <small>8.4.2 (2021-02-18)</small>
+
+* [bitnami/mysql] Release 8.4.2 updating components versions ([3ff243f](https://github.com/bitnami/charts/commit/3ff243f))
+
+## <small>8.4.1 (2021-02-15)</small>
+
+* [bitnami/mysql] remove unnecessary bracket at NOTES.txt (#5490) ([160d31f](https://github.com/bitnami/charts/commit/160d31f)), closes [#5490](https://github.com/bitnami/charts/issues/5490)
+
+## 8.4.0 (2021-02-15)
+
+* [bitnami/*] Add notice regarding parameters immutability after chart installation (#4853) ([5f09573](https://github.com/bitnami/charts/commit/5f09573)), closes [#4853](https://github.com/bitnami/charts/issues/4853)
+* bitnami/mysql: add `externalTrafficPolicy` to service type `LoadBalancer` (#5498) ([e16aa93](https://github.com/bitnami/charts/commit/e16aa93)), closes [#5498](https://github.com/bitnami/charts/issues/5498)
+
+## <small>8.3.1 (2021-02-09)</small>
+
+* [bitnami/mysql] Fix *.pdb.enabled parameters (#5425) ([c2497c1](https://github.com/bitnami/charts/commit/c2497c1)), closes [#5425](https://github.com/bitnami/charts/issues/5425)
+
+## 8.3.0 (2021-01-28)
+
+* [bitnami/mysql] Add hostAlias (#5275) ([8176887](https://github.com/bitnami/charts/commit/8176887)), closes [#5275](https://github.com/bitnami/charts/issues/5275)
+
+## <small>8.2.8 (2021-01-27)</small>
+
+* [bitnami/mysql] Remove duplicate line in README.md (#5180) ([20251b6](https://github.com/bitnami/charts/commit/20251b6)), closes [#5180](https://github.com/bitnami/charts/issues/5180)
+* Improves Apache/MySQL README files (#4994) ([e40c914](https://github.com/bitnami/charts/commit/e40c914)), closes [#4994](https://github.com/bitnami/charts/issues/4994)
+
+## <small>8.2.7 (2021-01-19)</small>
+
+* [bitnami/*] Change helm version in the prerequisites (#5090) ([c5e67a3](https://github.com/bitnami/charts/commit/c5e67a3)), closes [#5090](https://github.com/bitnami/charts/issues/5090)
+* [bitnami/mysql] Drop values-production.yaml support (#5122) ([cc2adbc](https://github.com/bitnami/charts/commit/cc2adbc)), closes [#5122](https://github.com/bitnami/charts/issues/5122)
+
+## <small>8.2.6 (2021-01-19)</small>
+
+* [bitnami/mysql] Release 8.2.6 updating components versions ([b9f89fb](https://github.com/bitnami/charts/commit/b9f89fb))
+
+## <small>8.2.5 (2021-01-15)</small>
+
+* [bitnami/mysql] Fix of missing `extraDeploy` template. (#5042) ([9a447d7](https://github.com/bitnami/charts/commit/9a447d7)), closes [#5042](https://github.com/bitnami/charts/issues/5042)
+* Update README.md (#4978) ([846c0c7](https://github.com/bitnami/charts/commit/846c0c7)), closes [#4978](https://github.com/bitnami/charts/issues/4978)
+
+## <small>8.2.4 (2021-01-08)</small>
+
+* [bitnami/mysql] Release 8.2.4 updating components versions ([ba8c4e6](https://github.com/bitnami/charts/commit/ba8c4e6))
+
+## <small>8.2.3 (2020-12-16)</small>
+
+* [bitnami/{mariadb/mysql}] Fix for secrets (#4741) ([ee92677](https://github.com/bitnami/charts/commit/ee92677)), closes [#4741](https://github.com/bitnami/charts/issues/4741)
+* [bitnami/*] fix typos (#4699) ([49adc63](https://github.com/bitnami/charts/commit/49adc63)), closes [#4699](https://github.com/bitnami/charts/issues/4699)
+
+## <small>8.2.2 (2020-12-11)</small>
+
+* [bitnami/*] Update dependencies (#4694) ([2826c12](https://github.com/bitnami/charts/commit/2826c12)), closes [#4694](https://github.com/bitnami/charts/issues/4694)
+
+## <small>8.2.1 (2020-12-10)</small>
+
+* add annotations to volumeClaimTemplates in MySQL (#4660) ([90f2109](https://github.com/bitnami/charts/commit/90f2109)), closes [#4660](https://github.com/bitnami/charts/issues/4660)
+
+## 8.2.0 (2020-12-09)
+
+* [bitnami/mysql] feat: add headless services and fix a helper (#4554) ([2cf5a12](https://github.com/bitnami/charts/commit/2cf5a12)), closes [#4554](https://github.com/bitnami/charts/issues/4554)
+
+## <small>8.1.2 (2020-12-08)</small>
+
+* [bitnami/mysql,mariadb] Fix customPasswordFiles format in values.yaml ([df84f74](https://github.com/bitnami/charts/commit/df84f74))
+* [bitnami/mysql] Fix customPasswordFiles format in values.yaml ([88da3be](https://github.com/bitnami/charts/commit/88da3be))
+* [bitnami/mysql] Release 8.1.2 updating components versions ([bdc5f4c](https://github.com/bitnami/charts/commit/bdc5f4c))
+
+## <small>8.1.1 (2020-12-04)</small>
+
+* [bitnami/mysql] Fix: remove added pass (#4601) ([5f0b406](https://github.com/bitnami/charts/commit/5f0b406)), closes [#4601](https://github.com/bitnami/charts/issues/4601)
+
+## 8.1.0 (2020-12-03)
+
+* [bitnami/mysql] Support Vault secrets (#4580) ([a4b07de](https://github.com/bitnami/charts/commit/a4b07de)), closes [#4580](https://github.com/bitnami/charts/issues/4580)
+
+## 8.0.0 (2020-11-27)
+
+* [bitnami/mysql] New major version (#4501) ([36c62d9](https://github.com/bitnami/charts/commit/36c62d9)), closes [#4501](https://github.com/bitnami/charts/issues/4501)
+
+## 7.1.0 (2020-11-16)
+
+* [bitnami/mysql] Adding annocations to service account (#4357) ([9058d85](https://github.com/bitnami/charts/commit/9058d85)), closes [#4357](https://github.com/bitnami/charts/issues/4357)
+
+## <small>7.0.1 (2020-11-11)</small>
+
+* [bitnami/mysql] Release 7.0.1 updating components versions ([cb78541](https://github.com/bitnami/charts/commit/cb78541))
+
+## 7.0.0 (2020-11-11)
+
+* [bitnami/mysql] Major version. Adapt Chart to apiVersion: v2 (#4270) ([7cbbd6b](https://github.com/bitnami/charts/commit/7cbbd6b)), closes [#4270](https://github.com/bitnami/charts/issues/4270)
+
+## <small>6.14.12 (2020-11-11)</small>
+
+* [bitnami/*] Include link to Troubleshootin guide on README.md (#4136) ([c08a20e](https://github.com/bitnami/charts/commit/c08a20e)), closes [#4136](https://github.com/bitnami/charts/issues/4136)
+* [bitnami/mariadb/galera/mysql] Update initdbScripts documentation (#4060) ([5ca3b86](https://github.com/bitnami/charts/commit/5ca3b86)), closes [#4060](https://github.com/bitnami/charts/issues/4060)
+* [bitnami/mysql] Release 6.14.12 updating components versions ([a1e7cda](https://github.com/bitnami/charts/commit/a1e7cda))
+
+## <small>6.14.11 (2020-10-19)</small>
+
+* [bitnami/mysql] Release 6.14.11 updating components versions ([4fdfa71](https://github.com/bitnami/charts/commit/4fdfa71))
+
+## <small>6.14.10 (2020-09-21)</small>
+
+* [bitnami/mysql] Release 6.14.10 updating components versions ([a3da272](https://github.com/bitnami/charts/commit/a3da272))
+
+## <small>6.14.9 (2020-09-04)</small>
+
+* [bitnami/metrics-server] Add source repo (#3577) ([1ed12f9](https://github.com/bitnami/charts/commit/1ed12f9)), closes [#3577](https://github.com/bitnami/charts/issues/3577)
+* [bitnami/mysql] Release 6.14.9 updating components versions ([0982d85](https://github.com/bitnami/charts/commit/0982d85))
+
+## <small>6.14.8 (2020-08-05)</small>
+
+* [bitnami/*] Fix TL;DR typo in READMEs (#3280) ([3d7ab40](https://github.com/bitnami/charts/commit/3d7ab40)), closes [#3280](https://github.com/bitnami/charts/issues/3280)
+* [bitnami/mysql] Release 6.14.8 updating components versions ([eeda6fc](https://github.com/bitnami/charts/commit/eeda6fc))
+* Fix link to K8s docs ([ac4f973](https://github.com/bitnami/charts/commit/ac4f973))
+
+## <small>6.14.7 (2020-07-21)</small>
+
+* [bitnami/mysql] Release 6.14.7 updating components versions ([251ef31](https://github.com/bitnami/charts/commit/251ef31))
+
+## <small>6.14.6 (2020-07-20)</small>
+
+* [bitnami/mysql] Add missing category (#3164) ([2100917](https://github.com/bitnami/charts/commit/2100917)), closes [#3164](https://github.com/bitnami/charts/issues/3164)
+
+## <small>6.14.5 (2020-07-13)</small>
+
+* [bitnami/mysql] Add debug to slave statefulset (#3099) ([c0df593](https://github.com/bitnami/charts/commit/c0df593)), closes [#3099](https://github.com/bitnami/charts/issues/3099)
+
+## <small>6.14.4 (2020-06-24)</small>
+
+* [bitnami/mysql] Release 6.14.4 updating components versions ([1a0b53b](https://github.com/bitnami/charts/commit/1a0b53b))
+* [bitnami/several] Add instructions about how to use different branches (#2785) ([c315cb0](https://github.com/bitnami/charts/commit/c315cb0)), closes [#2785](https://github.com/bitnami/charts/issues/2785)
+
+## <small>6.14.3 (2020-06-05)</small>
+
+* [bitnami/several] Fix table rendering in some hubs (#2770) ([fe9fd8c](https://github.com/bitnami/charts/commit/fe9fd8c)), closes [#2770](https://github.com/bitnami/charts/issues/2770)
+
+## <small>6.14.2 (2020-06-02)</small>
+
+* [bitnami/mysql] Release 6.14.2 updating components versions ([f213f0e](https://github.com/bitnami/charts/commit/f213f0e))
+* Rename .yml extension to .yaml ([219f1cd](https://github.com/bitnami/charts/commit/219f1cd))
+
+## <small>6.14.1 (2020-06-02)</small>
+
+* [bitnami/mysql] Release 6.14.1 updating components versions ([97043b4](https://github.com/bitnami/charts/commit/97043b4))
+
+## 6.14.0 (2020-05-28)
+
+* [bitnami/mysql] Use existingSecret value as the secret's name (#2675) ([eb4e9f8](https://github.com/bitnami/charts/commit/eb4e9f8)), closes [#2675](https://github.com/bitnami/charts/issues/2675)
+
+## <small>6.13.2 (2020-05-22)</small>
+
+* [bitnami/mysql] fix bug chart never use existing secret (#2621) ([d926ce8](https://github.com/bitnami/charts/commit/d926ce8)), closes [#2621](https://github.com/bitnami/charts/issues/2621)
+
+## <small>6.13.1 (2020-05-22)</small>
+
+* [bitnami/mysql] Release 6.13.1 updating components versions ([29b2fc6](https://github.com/bitnami/charts/commit/29b2fc6))
+* update bitnami/common to be compatible with helm v2.12+ (#2615) ([c7751eb](https://github.com/bitnami/charts/commit/c7751eb)), closes [#2615](https://github.com/bitnami/charts/issues/2615)
+* Update README.md ([e673012](https://github.com/bitnami/charts/commit/e673012))
+
+## 6.13.0 (2020-05-14)
+
+* [bitnami/mysql] Set different nodePorts for master and slave. (#2579) ([6845d20](https://github.com/bitnami/charts/commit/6845d20)), closes [#2579](https://github.com/bitnami/charts/issues/2579)
+
+## 6.12.0 (2020-05-04)
+
+* [bitnami/mariadb,mysql,mariadb-galera] Add extraEnvVars support (#2480) ([646695d](https://github.com/bitnami/charts/commit/646695d)), closes [#2480](https://github.com/bitnami/charts/issues/2480) [#2457](https://github.com/bitnami/charts/issues/2457) [#2420](https://github.com/bitnami/charts/issues/2420) [#2481](https://github.com/bitnami/charts/issues/2481) [#2407](https://github.com/bitnami/charts/issues/2407) [#2496](https://github.com/bitnami/charts/issues/2496) [#2489](https://github.com/bitnami/charts/issues/2489) [#2486](https://github.com/bitnami/charts/issues/2486)
+
+## <small>6.11.5 (2020-04-22)</small>
+
+* [bitnami/mysql] Release 6.11.5 updating components versions ([f721f6d](https://github.com/bitnami/charts/commit/f721f6d))
+
+## <small>6.11.4 (2020-04-17)</small>
+
+* [bitnami/mysql] Release 6.11.4 updating components versions ([2e96ef0](https://github.com/bitnami/charts/commit/2e96ef0))
+
+## <small>6.11.3 (2020-04-16)</small>
+
+* [bitnami/mysql] Release 6.11.3 updating components versions ([f12527c](https://github.com/bitnami/charts/commit/f12527c))
+
+## <small>6.11.2 (2020-04-15)</small>
+
+* [bitnami/mysql] Release 6.11.2 updating components versions ([c081499](https://github.com/bitnami/charts/commit/c081499))
+
+## <small>6.11.1 (2020-03-26)</small>
+
+* [bitnami/mysql] Release 6.11.1 updating components versions ([b6c9098](https://github.com/bitnami/charts/commit/b6c9098))
+
+## 6.11.0 (2020-03-23)
+
+* Add serviceAccount.create and serviceAccount.name to mysql chart (#1982) ([dd54b15](https://github.com/bitnami/charts/commit/dd54b15)), closes [#1982](https://github.com/bitnami/charts/issues/1982)
+
+## <small>6.10.4 (2020-03-20)</small>
+
+* [bitnami/mysql] Release 6.10.4 updating components versions ([e333676](https://github.com/bitnami/charts/commit/e333676))
+
+## <small>6.10.3 (2020-03-12)</small>
+
+* [bitnami/mysql] Release 6.10.3 updating components versions ([7cdef83](https://github.com/bitnami/charts/commit/7cdef83))
+
+## <small>6.10.2 (2020-03-11)</small>
+
+* Move charts from upstreamed folder to bitnami (#2032) ([a0e44f7](https://github.com/bitnami/charts/commit/a0e44f7)), closes [#2032](https://github.com/bitnami/charts/issues/2032)
+
+## <small>6.10.1 (2020-03-05)</small>
+
+* fix:issues #2001 (#2002) ([9cfaa9a](https://github.com/bitnami/charts/commit/9cfaa9a)), closes [#2001](https://github.com/bitnami/charts/issues/2001) [#2002](https://github.com/bitnami/charts/issues/2002) [#2001](https://github.com/bitnami/charts/issues/2001)
+
+## 6.10.0 (2020-03-02)
+
+* [bitnami/mysql] Add parameter to configure container security policies (#1994) ([bb1eeb6](https://github.com/bitnami/charts/commit/bb1eeb6)), closes [#1994](https://github.com/bitnami/charts/issues/1994)
+* [bitnami/mysql] Fixed nodePort definition (typo) (#1981) ([964f0bc](https://github.com/bitnami/charts/commit/964f0bc)), closes [#1981](https://github.com/bitnami/charts/issues/1981)
+
+## <small>6.9.2 (2020-02-26)</small>
+
+* [bitnami/mysql] Release 6.9.2 updating components versions ([0d76072](https://github.com/bitnami/charts/commit/0d76072))
+
+## <small>6.9.1 (2020-02-25)</small>
+
+* [bitnami/mysql] Fix for initContainer volume-permissions (#1959) ([96f2e33](https://github.com/bitnami/charts/commit/96f2e33)), closes [#1959](https://github.com/bitnami/charts/issues/1959)
+
+## 6.9.0 (2020-02-19)
+
+* [bitnami/mysql] Match init script support to bitnami/mariadb (#1947) ([fbd69f5](https://github.com/bitnami/charts/commit/fbd69f5)), closes [#1947](https://github.com/bitnami/charts/issues/1947)
+
+## <small>6.8.1 (2020-02-18)</small>
+
+* [bitnami/mysql] Release 6.8.1 updating components versions ([51e73b9](https://github.com/bitnami/charts/commit/51e73b9))
+
+## 6.8.0 (2020-02-17)
+
+* [bitnami/mysql] Add different loadbalancer ip fields to the values (#1925) ([dc3eb98](https://github.com/bitnami/charts/commit/dc3eb98)), closes [#1925](https://github.com/bitnami/charts/issues/1925)
+* [bitnami/several] Adapt READMEs and helpers to Helm 3 (#1911) ([40ee57c](https://github.com/bitnami/charts/commit/40ee57c)), closes [#1911](https://github.com/bitnami/charts/issues/1911)
+
+## <small>6.7.7 (2020-02-10)</small>
+
+* [bitnami/several] Replace stretch by buster in minideb secondary containers (#1900) ([678febc](https://github.com/bitnami/charts/commit/678febc)), closes [#1900](https://github.com/bitnami/charts/issues/1900)
+
+## <small>6.7.6 (2020-01-24)</small>
+
+* Fix pod annotations ([1e250ce](https://github.com/bitnami/charts/commit/1e250ce))
+
+## <small>6.7.5 (2020-01-24)</small>
+
+* [bitnami/mysql] Release 6.7.5 updating components versions ([a2839da](https://github.com/bitnami/charts/commit/a2839da))
+
+## <small>6.7.4 (2020-01-14)</small>
+
+* [bitnami/mysql] Release 6.7.4 updating components versions ([f07f954](https://github.com/bitnami/charts/commit/f07f954))
+
+## <small>6.7.3 (2020-01-13)</small>
+
+* [bitnami/mysql] Release 6.7.3 updating components versions ([7a2cee6](https://github.com/bitnami/charts/commit/7a2cee6))
+
+## <small>6.7.2 (2020-01-10)</small>
+
+* [bitnami/mysql] Release 6.7.2 updating components versions ([bcf6b1c](https://github.com/bitnami/charts/commit/bcf6b1c))
+
+## <small>6.7.1 (2020-01-04)</small>
+
+* [bitnami/mysql] Update components versions ([223f8b3](https://github.com/bitnami/charts/commit/223f8b3))
+* add datadir path to mysqld configuration ([1d13d70](https://github.com/bitnami/charts/commit/1d13d70))
+* update chart version ([3a5308c](https://github.com/bitnami/charts/commit/3a5308c))
+
+## 6.7.0 (2019-12-05)
+
+* [bitnami/mysql] Update components versions ([dbae93f](https://github.com/bitnami/charts/commit/dbae93f))
+* [stable/mysql] Add support to mount secrets as volumes ([8ec0355](https://github.com/bitnami/charts/commit/8ec0355))
+* Fix upgrade ([767f99e](https://github.com/bitnami/charts/commit/767f99e))
+
+## 6.6.0 (2019-11-22)
+
+* [bitnami/mysql] lint chart ([a7e0c9f](https://github.com/bitnami/charts/commit/a7e0c9f))
+
+## <small>6.5.1 (2019-11-14)</small>
+
+* [bitnami/mysql] Release 6.5.1 updating components versions ([33347cd](https://github.com/bitnami/charts/commit/33347cd))
+
+## 6.5.0 (2019-11-01)
+
+* add `plugin_dir` configuration to the mysql configuration ([e56d2d5](https://github.com/bitnami/charts/commit/e56d2d5))
+
+## <small>6.4.9 (2019-10-24)</small>
+
+* Add semicolon to TL;DR section to unify all READMEs ([23863cd](https://github.com/bitnami/charts/commit/23863cd))
+
+## <small>6.4.8 (2019-10-24)</small>
+
+* Fix links because of section renaming ([8e6fa3b](https://github.com/bitnami/charts/commit/8e6fa3b))
+
+## <small>6.4.7 (2019-10-23)</small>
+
+* Adapt README in charts (II) ([4705a98](https://github.com/bitnami/charts/commit/4705a98))
+
+## <small>6.4.6 (2019-10-15)</small>
+
+* [bitnami/mysql] Update prerequisites ([355c340](https://github.com/bitnami/charts/commit/355c340))
+
+## <small>6.4.5 (2019-10-14)</small>
+
+* [bitnami/mysql] Release 6.4.5 updating components versions ([8406829](https://github.com/bitnami/charts/commit/8406829))
+
+## <small>6.4.4 (2019-10-09)</small>
+
+* [bitnami/mysql] Release 6.4.4 updating components versions ([e834515](https://github.com/bitnami/charts/commit/e834515))
+
+## <small>6.4.3 (2019-09-20)</small>
+
+* [bitnami/*] Update apiVersion on sts, deployments, daemonsets and podsecuritypolicies ([4dfac07](https://github.com/bitnami/charts/commit/4dfac07))
+
+## <small>6.4.2 (2019-09-09)</small>
+
+* [bitnami/mysql] Release 6.4.2 updating components versions ([c9029fb](https://github.com/bitnami/charts/commit/c9029fb))
+
+## <small>6.4.1 (2019-09-05)</small>
+
+* [bitnami/mysql] Fix affinity ([9fa44e2](https://github.com/bitnami/charts/commit/9fa44e2))
+* Use different affinity for master and slave in mysql ([5bbec9a](https://github.com/bitnami/charts/commit/5bbec9a))
+
+## 6.4.0 (2019-09-04)
+
+* Bump minor version ([10f1738](https://github.com/bitnami/charts/commit/10f1738))
+
+## <small>6.3.5 (2019-09-04)</small>
+
+* Add affinity to mysql ([bdf9474](https://github.com/bitnami/charts/commit/bdf9474))
+
+## <small>6.3.4 (2019-09-02)</small>
+
+* [bitnami/mysql] Release 6.3.4 updating components versions ([c1a2df9](https://github.com/bitnami/charts/commit/c1a2df9))
+* Use stretch instead of buster to be consistent ([decd85f](https://github.com/bitnami/charts/commit/decd85f))
+
+## <small>6.3.3 (2019-08-30)</small>
+
+* [bitnami/*] Use buster instead of latest as minideb tag and adapt sysctl ([921e811](https://github.com/bitnami/charts/commit/921e811))
+* [bitnami/mysql] Update components versions ([2700075](https://github.com/bitnami/charts/commit/2700075))
+
+## <small>6.3.2 (2019-08-22)</small>
+
+* [bitnami/*] Fix 'storageClass' macros ([f41c193](https://github.com/bitnami/charts/commit/f41c193))
+
+## <small>6.3.1 (2019-08-21)</small>
+
+* Refactor StorageClass template to support old Helm versions ([1d7f3df](https://github.com/bitnami/charts/commit/1d7f3df))
+* Refactor storageClassTemplate ([1872215](https://github.com/bitnami/charts/commit/1872215))
+
+## 6.3.0 (2019-08-19)
+
+* Add global variable to set the storage class to all of the Hekm Charts ([cdb4bdc](https://github.com/bitnami/charts/commit/cdb4bdc))
+* Update charts versions ([9459dbb](https://github.com/bitnami/charts/commit/9459dbb))
+
+## <small>6.2.2 (2019-08-13)</small>
+
+* Update README.md ([93e25e0](https://github.com/bitnami/charts/commit/93e25e0))
+* Updated version numbers ([aa0294b](https://github.com/bitnami/charts/commit/aa0294b))
+
+## <small>6.2.1 (2019-07-24)</small>
+
+* [bitnami/mysql] Fix typo in the README.md (#1312) ([94dc714](https://github.com/bitnami/charts/commit/94dc714)), closes [#1312](https://github.com/bitnami/charts/issues/1312)
+
+## 6.2.0 (2019-07-24)
+
+* [bitnami/mysql] Replace prom/mysqld-exporter with bitnami/mysqld-exporter (#1307) ([2359866](https://github.com/bitnami/charts/commit/2359866)), closes [#1307](https://github.com/bitnami/charts/issues/1307)
+
+## <small>6.1.1 (2019-07-24)</small>
+
+* [bitnami/mysql] Release 6.1.1 updating components versions ([a890653](https://github.com/bitnami/charts/commit/a890653))
+* Fix indentation ([c699e9f](https://github.com/bitnami/charts/commit/c699e9f))
+
+## 6.1.0 (2019-07-22)
+
+* Change mysql ([bc553ca](https://github.com/bitnami/charts/commit/bc553ca))
+
+## 6.0.0 (2019-07-17)
+
+* Implement again #1283 changes but bumping the major version ([1ce079c](https://github.com/bitnami/charts/commit/1ce079c)), closes [#1283](https://github.com/bitnami/charts/issues/1283)
+
+## <small>5.0.9 (2019-07-17)</small>
+
+* Address suggestion ([febf2c9](https://github.com/bitnami/charts/commit/febf2c9))
+* Revert pull request #1283 ([8e5940a](https://github.com/bitnami/charts/commit/8e5940a)), closes [#1283](https://github.com/bitnami/charts/issues/1283)
+
+## <small>5.0.8 (2019-07-11)</small>
+
+* Change domain by clusterDomain ([4effe5c](https://github.com/bitnami/charts/commit/4effe5c))
+* Standardize component.name & component.fullname functions ([775948e](https://github.com/bitnami/charts/commit/775948e))
+
+## <small>5.0.7 (2019-07-01)</small>
+
+* Create template for cluster domain on MySQL ([a73d149](https://github.com/bitnami/charts/commit/a73d149))
+
+## <small>5.0.6 (2019-06-10)</small>
+
+* Changes in README ([7ac4ec0](https://github.com/bitnami/charts/commit/7ac4ec0))
+
+## <small>5.0.5 (2019-06-10)</small>
+
+* Add command ([a0088d6](https://github.com/bitnami/charts/commit/a0088d6))
+* bitnami/mysql: update to 8.0.16 ([aa3d81b](https://github.com/bitnami/charts/commit/aa3d81b))
+
+## <small>5.0.4 (2019-06-07)</small>
+
+* [bitnami/mysql] Unify and document production values ([e78dec5](https://github.com/bitnami/charts/commit/e78dec5))
+
+## <small>5.0.3 (2019-05-29)</small>
+
+* Change syntax because of linter failing ([adfc357](https://github.com/bitnami/charts/commit/adfc357))
+* Fix https://github.com/helm/charts/pull/14199\#issuecomment-496883321 and support _sha256_ as an imm ([95957ea](https://github.com/bitnami/charts/commit/95957ea)), closes [#issuecomment-496883321](https://github.com/bitnami/charts/issues/issuecomment-496883321)
+* Use immutable tags in the main images ([17ca4f5](https://github.com/bitnami/charts/commit/17ca4f5))
+
+## <small>5.0.2 (2019-05-28)</small>
+
+* Prepare immutable tags ([f9093c1](https://github.com/bitnami/charts/commit/f9093c1))
+
+## <small>5.0.1 (2019-05-14)</small>
+
+* bitnami/mysql: update to 8.0.16 ([591e950](https://github.com/bitnami/charts/commit/591e950))
+
+## 5.0.0 (2019-05-13)
+
+* [bitnami/mysql] Update chart to MySQL 8.X ([cfd33b9](https://github.com/bitnami/charts/commit/cfd33b9))
+
+## <small>4.5.2 (2019-04-25)</small>
+
+* bitnami/mysql: update to 5.7.26 ([71c2f0a](https://github.com/bitnami/charts/commit/71c2f0a))
+
+## <small>4.5.1 (2019-04-12)</small>
+
+* Add comments warning about custom user strings ([3b2feee](https://github.com/bitnami/charts/commit/3b2feee))
+* Bump version ([e39b33e](https://github.com/bitnami/charts/commit/e39b33e))
+
+## 4.5.0 (2019-03-18)
+
+* Set rollingUpdate to null when updateStrategy is Recreate ([1a45bba](https://github.com/bitnami/charts/commit/1a45bba))
+* Use namespaces ([8c80056](https://github.com/bitnami/charts/commit/8c80056))
+
+## <small>4.4.1 (2019-03-14)</small>
+
+* Use global registry in secondary, metrics and other non-default images ([5d216bf](https://github.com/bitnami/charts/commit/5d216bf))
+
+## 4.4.0 (2019-03-12)
+
+* Fix typo ([9ee898e](https://github.com/bitnami/charts/commit/9ee898e))
+* Fix typo in helpers ([0a3a108](https://github.com/bitnami/charts/commit/0a3a108))
+* pullSecrets for production and metrics ([22d6e0b](https://github.com/bitnami/charts/commit/22d6e0b))
+
+## 4.3.0 (2019-03-11)
+
+* [bitnami/mysql] Add global imagePullSecrets to overwrite any other existing one ([c50e96d](https://github.com/bitnami/charts/commit/c50e96d))
+
+## <small>4.2.6 (2019-02-27)</small>
+
+* Add appiVersion to Chart.yaml ([08704a5](https://github.com/bitnami/charts/commit/08704a5))
+
+## <small>4.2.5 (2019-02-21)</small>
+
+* Update Chart.yaml ([0c3061d](https://github.com/bitnami/charts/commit/0c3061d))
+* Update README.md ([7fe6c95](https://github.com/bitnami/charts/commit/7fe6c95))
+
+## <small>4.2.4 (2019-02-07)</small>
+
+* Document the correct format for pullSecrets in READMEs ([9a2cf81](https://github.com/bitnami/charts/commit/9a2cf81))
+* Fix appVersion fields for some Chart.yaml files (#1048) ([697e18d](https://github.com/bitnami/charts/commit/697e18d)), closes [#1048](https://github.com/bitnami/charts/issues/1048)
+
+## <small>4.2.3 (2019-01-21)</small>
+
+* mysql: update to `5.7.25` ([3117eea](https://github.com/bitnami/charts/commit/3117eea))
+
+## <small>4.2.2 (2018-12-19)</small>
+
+* [bitnami/mysql] Allow including gzip files as initdb scripts ([3bb6043](https://github.com/bitnami/charts/commit/3bb6043))
+
+## <small>4.2.1 (2018-12-13)</small>
+
+* [bitnami/mysql] Avoid creating a Deployment for a test client to check connectivity with MySQL ([e6a3f92](https://github.com/bitnami/charts/commit/e6a3f92))
+
+## <small>4.1.2 (2018-10-22)</small>
+
+* mysql: bump chart appVersion to `5.7.24` ([972ea39](https://github.com/bitnami/charts/commit/972ea39))
+* mysql: bump chart version to `4.1.2` ([ab72ac0](https://github.com/bitnami/charts/commit/ab72ac0))
+* mysql: update to `5.7.24` ([fbb2532](https://github.com/bitnami/charts/commit/fbb2532))
+
+## <small>4.1.1 (2018-10-17)</small>
+
+* Add global registry option to Bitnami charts ([395ba08](https://github.com/bitnami/charts/commit/395ba08))
+* Apply some suggestions ([24706a6](https://github.com/bitnami/charts/commit/24706a6))
+* Bump versions ([0cfd3f4](https://github.com/bitnami/charts/commit/0cfd3f4))
+* Change logic to determine registry ([9ead294](https://github.com/bitnami/charts/commit/9ead294))
+* Check if global is set ([dec26e5](https://github.com/bitnami/charts/commit/dec26e5))
+* Fix typo ([93170ac](https://github.com/bitnami/charts/commit/93170ac))
+* Remove distro tags in charts ([427ac51](https://github.com/bitnami/charts/commit/427ac51))
+* Reword and update kafka dependencies ([be6cbed](https://github.com/bitnami/charts/commit/be6cbed))
+
+## 4.1.0 (2018-11-21)
+
+* Update Chart.yaml ([e2bebe8](https://github.com/bitnami/charts/commit/e2bebe8))
+
+## <small>4.0.7 (2018-10-12)</small>
+
+* [bitnami/mysql] Enable metrics and move the scraping to the pods ([c45f137](https://github.com/bitnami/charts/commit/c45f137))
+
+## <small>4.1.2 (2018-10-22)</small>
+
+* mysql: bump chart appVersion to `5.7.24` ([972ea39](https://github.com/bitnami/charts/commit/972ea39))
+* mysql: bump chart version to `4.1.2` ([ab72ac0](https://github.com/bitnami/charts/commit/ab72ac0))
+* mysql: update to `5.7.24` ([fbb2532](https://github.com/bitnami/charts/commit/fbb2532))
+
+## <small>4.1.1 (2018-10-17)</small>
+
+* Add global registry option to Bitnami charts ([395ba08](https://github.com/bitnami/charts/commit/395ba08))
+* Apply some suggestions ([24706a6](https://github.com/bitnami/charts/commit/24706a6))
+* Bump versions ([0cfd3f4](https://github.com/bitnami/charts/commit/0cfd3f4))
+* Change logic to determine registry ([9ead294](https://github.com/bitnami/charts/commit/9ead294))
+* Check if global is set ([dec26e5](https://github.com/bitnami/charts/commit/dec26e5))
+* Fix typo ([93170ac](https://github.com/bitnami/charts/commit/93170ac))
+* Remove distro tags in charts ([427ac51](https://github.com/bitnami/charts/commit/427ac51))
+* Reword and update kafka dependencies ([be6cbed](https://github.com/bitnami/charts/commit/be6cbed))
+
+## <small>4.0.7 (2018-10-12)</small>
+
+* [bitnami/mysql] Enable metrics and move the scraping to the pods ([c45f137](https://github.com/bitnami/charts/commit/c45f137))
+* Add missing conditionals ([78bd431](https://github.com/bitnami/charts/commit/78bd431))
+
+## <small>4.0.6 (2018-10-08)</small>
+
+* [stable/mysql] Avoid creating initialization config-map if not needed ([e2894cb](https://github.com/bitnami/charts/commit/e2894cb))
+
+## <small>4.0.5 (2018-10-05)</small>
+
+* Add kubeapps text to charts READMEs ([2f6dc51](https://github.com/bitnami/charts/commit/2f6dc51))
+
+## <small>4.0.4 (2018-10-02)</small>
+
+* [bitnami/mysql] Remove unnecessary env. variable on slave pods ([d9d9207](https://github.com/bitnami/charts/commit/d9d9207))
+
+## <small>4.0.3 (2018-09-25)</small>
+
+* [bitnami/mysql] Use Existing PVCs to store MySQL data ([05d02e7](https://github.com/bitnami/charts/commit/05d02e7))
+
+## <small>4.0.2 (2018-09-25)</small>
+
+* [bitnami/mysql] Fix issue with pvc on upgrades ([86f469f](https://github.com/bitnami/charts/commit/86f469f))
+
+## <small>4.0.1 (2018-09-24)</small>
+
+* [bitnami/mysql] Improve instructions to upgrade MySQL chart ([51bbbd6](https://github.com/bitnami/charts/commit/51bbbd6))
+
+## 4.0.0 (2018-09-24)
+
+* [bitnami/mysql] Use namespaces on 'slave.fullname' & 'master.fullname' macros to avoid conflicts wit ([51e05b6](https://github.com/bitnami/charts/commit/51e05b6))
+
+## <small>3.0.2 (2018-09-21)</small>
+
+* [bitnami/mysql] Increasing 'initialDelaySeconds' to avoid unnecessary resets ([fb97366](https://github.com/bitnami/charts/commit/fb97366))
+
+## <small>3.0.1 (2018-09-21)</small>
+
+* [bitnami/mysql] Use proper env. variable on slaves for Master port number & root user ([433fdf2](https://github.com/bitnami/charts/commit/433fdf2))
+
+## 3.0.0 (2018-09-21)
+
+* [bitnami/mysql] Fix chart not being upgradable ([27f73d2](https://github.com/bitnami/charts/commit/27f73d2))
+
+## <small>2.1.2 (2018-09-14)</small>
+
+* Add existing volume claim logic to MySQL ([fc0a1ed](https://github.com/bitnami/charts/commit/fc0a1ed))
+* Keeping images references ([530fc89](https://github.com/bitnami/charts/commit/530fc89))
+
+## <small>2.1.1 (2018-09-05)</small>
+
+* [bitnami/mysql] Improve Helpers functions to handle image names ([e35a7a9](https://github.com/bitnami/charts/commit/e35a7a9))
+* Allow using custom scripts to initialize ([2727e48](https://github.com/bitnami/charts/commit/2727e48))
+* Use proper image tag ([8915d53](https://github.com/bitnami/charts/commit/8915d53))
+
+## <small>2.0.2 (2018-07-27)</small>
+
+* mysql: bump chart appVersion to `5.7.23` ([e9362dc](https://github.com/bitnami/charts/commit/e9362dc))
+* mysql: bump chart version to `2.0.2` ([2b6cb94](https://github.com/bitnami/charts/commit/2b6cb94))
+* mysql: update to `5.7.23-debian-9` ([578c744](https://github.com/bitnami/charts/commit/578c744))
+
+## <small>2.0.1 (2018-07-25)</small>
+
+* Add missing labels to mysql ([5ad414e](https://github.com/bitnami/charts/commit/5ad414e))
+* Add README entries ([275bc79](https://github.com/bitnami/charts/commit/275bc79))
+
+## 2.0.0 (2018-07-25)
+
+* MySQL: Add non-root support and fix replication bug ([dabe689](https://github.com/bitnami/charts/commit/dabe689))
+* Fix replication issue with MySQL 8. It is also compatible with 5.7 ([8d1e237](https://github.com/bitnami/charts/commit/8d1e237))
+
+## <small>1.1.3 (2018-07-24)</small>
+
+* Fix replication issue with MySQL 8. It is also compatible with 5.7 ([e123153](https://github.com/bitnami/charts/commit/e123153))
+
+## <small>1.1.2 (2018-07-06)</small>
+
+* mysql: bump chart appVersion to `5.7.22-debian-9` ([8bab56d](https://github.com/bitnami/charts/commit/8bab56d))
+* mysql: bump chart version to `1.1.2` ([d45a984](https://github.com/bitnami/charts/commit/d45a984))
+* mysql: update to `5.7.22-debian-9` ([ffea6cc](https://github.com/bitnami/charts/commit/ffea6cc))
+* Fix consul, mysql and postgre helm chart testing issue using tag ([6f37eb7](https://github.com/bitnami/charts/commit/6f37eb7))
+
+## <small>1.1.1 (2018-06-04)</small>
+
+* Fix ES helm chart testing issue using tag ([657025b](https://github.com/bitnami/charts/commit/657025b))
+
+## 1.1.0 (2018-05-28)
+
+* Add production values file ([95d0252](https://github.com/bitnami/charts/commit/95d0252))
+* Add support for database replication ([b946014](https://github.com/bitnami/charts/commit/b946014))
+* MySQL standard service name. That way other applications can use MySQL with or without replication w ([9769a1e](https://github.com/bitnami/charts/commit/9769a1e))
+* README and variables improvements ([396d507](https://github.com/bitnami/charts/commit/396d507))
+
+## 1.0.0 (2018-05-09)
+
+* Add database replication for MySQL ([ac7043b](https://github.com/bitnami/charts/commit/ac7043b))
+
+## <small>0.1.14 (2018-05-03)</small>
+
+* [bitnami/mysql] update mysql chart version ([0514ac3](https://github.com/bitnami/charts/commit/0514ac3))
+
+## <small>0.1.13 (2018-04-13)</small>
+
+* Documentation fixes ([fdbcc57](https://github.com/bitnami/charts/commit/fdbcc57))
+
+## <small>0.1.12 (2018-04-13)</small>
+
+* Rename charts folders ([5413120](https://github.com/bitnami/charts/commit/5413120))

--- a/bitnami/mysql/Chart.lock
+++ b/bitnami/mysql/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.19.2
-digest: sha256:e670e1075bfafffe040fae1158f1fa1f592585f394b48704ba137d2d083b1571
-generated: "2024-04-30T12:52:54.336363963Z"
+  version: 2.19.3
+digest: sha256:de997835d9ce9a9deefc2d70d8c62b11aa1d1a76ece9e86a83736ab9f930bf4d
+generated: "2024-05-21T14:19:02.211899632+02:00"

--- a/bitnami/mysql/Chart.yaml
+++ b/bitnami/mysql/Chart.yaml
@@ -34,4 +34,4 @@ maintainers:
 name: mysql
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/mysql
-version: 10.2.4
+version: 10.3.0

--- a/bitnami/mysql/templates/NOTES.txt
+++ b/bitnami/mysql/templates/NOTES.txt
@@ -74,3 +74,4 @@ To access the MySQL Prometheus metrics from outside the cluster execute the foll
 {{ include "mysql.checkRollingTags" . }}
 {{- end }}
 {{- include "common.warnings.resources" (dict "sections" (list "metrics" "primary" "secondary" "volumePermissions") "context" $) }}
+{{- include "common.warnings.modifiedImages" (dict "images" (list .Values.image .Values.volumePermissions.image .Values.metrics.image) "context" $) }}


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Replacing the original images that have been tested and verified when releasing the chart is a dangerous practice in terms of security, performance and available features. This PR updates the `NOTES.txt` file using the `common.warnings.modifiedImages` helper developed in https://github.com/bitnami/charts/pull/25952.


<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

Users are more aware of the risks of changing original images.
<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

n/a
<!-- Describe any known limitations with your change -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
