### PR TITLE
[bitnami/postgresql] feat: :sparkles: :lock: Add warning when original images are replaced

### DIFF
--- a/bitnami/postgresql/CHANGELOG.md
+++ b/bitnami/postgresql/CHANGELOG.md
@@ -1,0 +1,2060 @@
+# Changelog
+
+## 15.4.0 (2024-05-21)
+
+* [bitnami/postgresql] feat: :sparkles: :lock: Add warning when original images are replaced ([#26264](https://github.com/bitnami/charts/pulls/26264))
+
+## <small>15.3.5 (2024-05-20)</small>
+
+* [bitnami/postgresql] Release 15.3.5 updating components versions (#26147) ([0bafcd7](https://github.com/bitnami/charts/commit/0bafcd7)), closes [#26147](https://github.com/bitnami/charts/issues/26147)
+
+## <small>15.3.4 (2024-05-20)</small>
+
+* [bitnami/postgresql] Release 15.3.4 updating components versions (#26142) ([231e25b](https://github.com/bitnami/charts/commit/231e25b)), closes [#26142](https://github.com/bitnami/charts/issues/26142)
+
+## <small>15.3.3 (2024-05-18)</small>
+
+* [bitnami/postgresql] Release 15.3.3 updating components versions (#26066) ([21f932c](https://github.com/bitnami/charts/commit/21f932c)), closes [#26066](https://github.com/bitnami/charts/issues/26066)
+
+## <small>15.3.2 (2024-05-14)</small>
+
+* [bitnami/postgresql] Release 15.3.2 updating components versions (#25812) ([3f7c2cb](https://github.com/bitnami/charts/commit/3f7c2cb)), closes [#25812](https://github.com/bitnami/charts/issues/25812)
+
+## <small>15.3.1 (2024-05-13)</small>
+
+* [bitnami/postgresql] Release 15.3.1 updating components versions (#25723) ([031d2cf](https://github.com/bitnami/charts/commit/031d2cf)), closes [#25723](https://github.com/bitnami/charts/issues/25723)
+
+## 15.3.0 (2024-05-13)
+
+*  [bitnami/postgresql] Allow loadBalancerClass to be customized (#25569) ([e6fecf9](https://github.com/bitnami/charts/commit/e6fecf9)), closes [#25569](https://github.com/bitnami/charts/issues/25569)
+
+## <small>15.2.13 (2024-05-13)</small>
+
+* [bitnami/postgresql] Allow backup pod to use DNS (#25534) ([960550a](https://github.com/bitnami/charts/commit/960550a)), closes [#25534](https://github.com/bitnami/charts/issues/25534)
+
+## <small>15.2.12 (2024-05-10)</small>
+
+* [bitnami/postgresql] Release 15.2.12 updating components versions (#25678) ([0fd1557](https://github.com/bitnami/charts/commit/0fd1557)), closes [#25678](https://github.com/bitnami/charts/issues/25678)
+
+## <small>15.2.11 (2024-05-10)</small>
+
+* [bitnami/postgresql] Release 15.2.11 updating components versions (#25672) ([9b809c6](https://github.com/bitnami/charts/commit/9b809c6)), closes [#25672](https://github.com/bitnami/charts/issues/25672)
+
+## <small>15.2.10 (2024-05-10)</small>
+
+* [bitnami/*] Change non-root and rolling-tags doc URLs (#25628) ([b067c94](https://github.com/bitnami/charts/commit/b067c94)), closes [#25628](https://github.com/bitnami/charts/issues/25628)
+* [bitnami/*] Set new header/owner (#25558) ([8d1dc11](https://github.com/bitnami/charts/commit/8d1dc11)), closes [#25558](https://github.com/bitnami/charts/issues/25558)
+* [bitnami/postgresql] add backup.cronjob.tolerations options (#25664) ([4a798ec](https://github.com/bitnami/charts/commit/4a798ec)), closes [#25664](https://github.com/bitnami/charts/issues/25664)
+
+## <small>15.2.9 (2024-05-06)</small>
+
+* [bitnami/postgresql] Remove unicode characters (#25546) ([219d22f](https://github.com/bitnami/charts/commit/219d22f)), closes [#25546](https://github.com/bitnami/charts/issues/25546)
+
+## <small>15.2.8 (2024-05-01)</small>
+
+* [bitnami/postgresql] Release 15.2.8 updating components versions (#25484) ([d3084fc](https://github.com/bitnami/charts/commit/d3084fc)), closes [#25484](https://github.com/bitnami/charts/issues/25484)
+
+## <small>15.2.7 (2024-04-25)</small>
+
+* [bitnami/postgresql] Release 15.2.7 updating components versions (#25391) ([0db34f6](https://github.com/bitnami/charts/commit/0db34f6)), closes [#25391](https://github.com/bitnami/charts/issues/25391)
+
+## <small>15.2.6 (2024-04-25)</small>
+
+* [bitnami/multiple charts] Fix typo: "NetworkPolice" vs "NetworkPolicy" (#25348) ([6970c1b](https://github.com/bitnami/charts/commit/6970c1b)), closes [#25348](https://github.com/bitnami/charts/issues/25348)
+* [bitnami/postgresql] Remove RW emptyDir for postgresql logs (#25206) ([8bae0c5](https://github.com/bitnami/charts/commit/8bae0c5)), closes [#25206](https://github.com/bitnami/charts/issues/25206)
+* Replace VMware by Broadcom copyright text (#25306) ([a5e4bd0](https://github.com/bitnami/charts/commit/a5e4bd0)), closes [#25306](https://github.com/bitnami/charts/issues/25306)
+
+## <small>15.2.5 (2024-04-10)</small>
+
+* [bitnami/postgresql] Release 15.2.5 updating components versions (#25099) ([eba61bd](https://github.com/bitnami/charts/commit/eba61bd)), closes [#25099](https://github.com/bitnami/charts/issues/25099)
+
+## <small>15.2.4 (2024-04-05)</small>
+
+* [bitnami/postgresql] Release 15.2.4 updating components versions (#24972) ([62e4683](https://github.com/bitnami/charts/commit/62e4683)), closes [#24972](https://github.com/bitnami/charts/issues/24972)
+
+## <small>15.2.3 (2024-04-05)</small>
+
+* [bitnami/postgresql] Release 15.2.3 (#24924) ([1f68239](https://github.com/bitnami/charts/commit/1f68239)), closes [#24924](https://github.com/bitnami/charts/issues/24924)
+* Update resourcesPreset comments (#24467) ([92e3e8a](https://github.com/bitnami/charts/commit/92e3e8a)), closes [#24467](https://github.com/bitnami/charts/issues/24467)
+
+## <small>15.2.2 (2024-04-02)</small>
+
+* [bitnami/postgresql] Release 15.2.2 updating components versions (#24840) ([34f94f3](https://github.com/bitnami/charts/commit/34f94f3)), closes [#24840](https://github.com/bitnami/charts/issues/24840)
+
+## <small>15.2.1 (2024-04-02)</small>
+
+* [bitnami/postgresql] fix: :bug: Always mount data directory (#24667) ([85f7422](https://github.com/bitnami/charts/commit/85f7422)), closes [#24667](https://github.com/bitnami/charts/issues/24667)
+
+## 15.2.0 (2024-04-01)
+
+* [bitnami/postgresql] Allow customizing primary persistence volume/claim (#24625) ([79b5845](https://github.com/bitnami/charts/commit/79b5845)), closes [#24625](https://github.com/bitnami/charts/issues/24625)
+
+## <small>15.1.4 (2024-03-25)</small>
+
+* [bitnami/postgresql] Release 15.1.4 updating components versions (#24641) ([9fea6e0](https://github.com/bitnami/charts/commit/9fea6e0)), closes [#24641](https://github.com/bitnami/charts/issues/24641)
+
+## <small>15.1.3 (2024-03-25)</small>
+
+* [bitnami/postgresql] Release 15.1.3 updating components versions (#24640) ([a318638](https://github.com/bitnami/charts/commit/a318638)), closes [#24640](https://github.com/bitnami/charts/issues/24640)
+
+## <small>15.1.2 (2024-03-21)</small>
+
+* [bitnami/postgresql] feat: add parameter backup.cronjob.storage.existingVolume (#23979) ([0a3ebd5](https://github.com/bitnami/charts/commit/0a3ebd5)), closes [#23979](https://github.com/bitnami/charts/issues/23979)
+* [bitnami/postgresql] fixing tls for cronjobs  (#24468) ([5e7f4e1](https://github.com/bitnami/charts/commit/5e7f4e1)), closes [#24468](https://github.com/bitnami/charts/issues/24468)
+
+## <small>15.1.1 (2024-03-21)</small>
+
+* [bitnami/postgres] don't include backup netpol when backup aren't enabled (#24572) ([10584d1](https://github.com/bitnami/charts/commit/10584d1)), closes [#24572](https://github.com/bitnami/charts/issues/24572)
+
+## 15.1.0 (2024-03-20)
+
+* [bitnami/postgresql] Add a NetworkPolicy to allow backup pods to access primary nodes (#24363) ([dc93455](https://github.com/bitnami/charts/commit/dc93455)), closes [#24363](https://github.com/bitnami/charts/issues/24363)
+
+## 15.0.0 (2024-03-18)
+
+* [bitnami/*] Reorder Chart sections (#24455) ([0cf4048](https://github.com/bitnami/charts/commit/0cf4048)), closes [#24455](https://github.com/bitnami/charts/issues/24455)
+* [bitnami/postgresql] feat!: :lock: :boom: Improve security defaults (#24171) ([3911a57](https://github.com/bitnami/charts/commit/3911a57)), closes [#24171](https://github.com/bitnami/charts/issues/24171)
+
+## <small>14.3.3 (2024-03-11)</small>
+
+* [bitnami/postgresql] Release 14.3.3 updating components versions (#24358) ([239ba28](https://github.com/bitnami/charts/commit/239ba28)), closes [#24358](https://github.com/bitnami/charts/issues/24358)
+
+## <small>14.3.2 (2024-03-11)</small>
+
+* [bitnami/postgresql] Fix TLS by removing faulty white trimming in cronjob.yaml (#24239) ([1a67326](https://github.com/bitnami/charts/commit/1a67326)), closes [#24239](https://github.com/bitnami/charts/issues/24239)
+* [bitnami/postgresql] Release 14.3.2 updating components versions (#24357) ([17bcbcb](https://github.com/bitnami/charts/commit/17bcbcb)), closes [#24357](https://github.com/bitnami/charts/issues/24357)
+
+## <small>14.3.1 (2024-03-07)</small>
+
+* [bitnami/postgresql] Release 14.3.1 updating components versions (#24237) ([33b8e70](https://github.com/bitnami/charts/commit/33b8e70)), closes [#24237](https://github.com/bitnami/charts/issues/24237)
+
+## 14.3.0 (2024-03-05)
+
+* [bitnami/postgresql]  postgresql backup container adds resources parameter (#23955) ([8da2a95](https://github.com/bitnami/charts/commit/8da2a95)), closes [#23955](https://github.com/bitnami/charts/issues/23955)
+* [bitnami/postgresql] feat: :sparkles: :lock: Add automatic adaptation for Openshift restricted-v2 SC ([1a2217f](https://github.com/bitnami/charts/commit/1a2217f)), closes [#24141](https://github.com/bitnami/charts/issues/24141)
+
+## <small>14.2.4 (2024-03-04)</small>
+
+* [bitnami/postgresql] Set allowExternalEgress=true by default (#24036) ([cfa4d49](https://github.com/bitnami/charts/commit/cfa4d49)), closes [#24036](https://github.com/bitnami/charts/issues/24036)
+
+## <small>14.2.3 (2024-02-23)</small>
+
+* Add missing version, kind to volumeClaimTemplates (#23862) ([50b25b8](https://github.com/bitnami/charts/commit/50b25b8)), closes [#23862](https://github.com/bitnami/charts/issues/23862)
+
+## <small>14.2.2 (2024-02-22)</small>
+
+* [bitnami/postgresql] Release 14.2.2 updating components versions (#23820) ([2da202b](https://github.com/bitnami/charts/commit/2da202b)), closes [#23820](https://github.com/bitnami/charts/issues/23820)
+
+## <small>14.2.1 (2024-02-21)</small>
+
+* [bitnami/postgresql] feat: :sparkles: :lock: Add readOnlyRootFilesystem support  (#23565) ([d96a96f](https://github.com/bitnami/charts/commit/d96a96f)), closes [#23565](https://github.com/bitnami/charts/issues/23565)
+* [bitnami/postgresql] Release 14.2.1 updating components versions (#23682) ([60d8d72](https://github.com/bitnami/charts/commit/60d8d72)), closes [#23682](https://github.com/bitnami/charts/issues/23682)
+
+## 14.2.0 (2024-02-20)
+
+* [bitnami/*] Bump all versions (#23602) ([b70ee2a](https://github.com/bitnami/charts/commit/b70ee2a)), closes [#23602](https://github.com/bitnami/charts/issues/23602)
+
+## <small>14.1.3 (2024-02-19)</small>
+
+* [bitnami/postgresql] Release 14.1.3 updating components versions (#23587) ([0c94e7a](https://github.com/bitnami/charts/commit/0c94e7a)), closes [#23587](https://github.com/bitnami/charts/issues/23587)
+
+## <small>14.1.2 (2024-02-18)</small>
+
+* [bitnami/postgresql] Release 14.1.2 updating components versions (#23585) ([0f5b808](https://github.com/bitnami/charts/commit/0f5b808)), closes [#23585](https://github.com/bitnami/charts/issues/23585)
+
+## <small>14.1.1 (2024-02-16)</small>
+
+* [bitnami/postgresql] Do not create a NetworkPolicy for "read" instance  when "standalone" (#23392) ([7ef876c](https://github.com/bitnami/charts/commit/7ef876c)), closes [#23392](https://github.com/bitnami/charts/issues/23392)
+
+## 14.1.0 (2024-02-15)
+
+* [bitnami/postgresql] feat: :sparkles: :lock: Add resource preset support (#23509) ([0c94e15](https://github.com/bitnami/charts/commit/0c94e15)), closes [#23509](https://github.com/bitnami/charts/issues/23509)
+
+## <small>14.0.5 (2024-02-12)</small>
+
+* [bitnami/postgresql] fix: :bug: Set correct references in network policy (#23328) ([e8c2230](https://github.com/bitnami/charts/commit/e8c2230)), closes [#23328](https://github.com/bitnami/charts/issues/23328)
+
+## <small>14.0.4 (2024-02-08)</small>
+
+* [bitnami/postgresql] Release 14.0.4 updating components versions (#23354) ([81e3d65](https://github.com/bitnami/charts/commit/81e3d65)), closes [#23354](https://github.com/bitnami/charts/issues/23354)
+
+## <small>14.0.3 (2024-02-08)</small>
+
+* [bitnami/postgresql] Release 14.0.3 updating components versions (#23350) ([60ea843](https://github.com/bitnami/charts/commit/60ea843)), closes [#23350](https://github.com/bitnami/charts/issues/23350)
+
+## <small>14.0.2 (2024-02-08)</small>
+
+* [bitnami/postgresql] Release 14.0.2 updating components versions (#23333) ([7f5a8e6](https://github.com/bitnami/charts/commit/7f5a8e6)), closes [#23333](https://github.com/bitnami/charts/issues/23333)
+
+## <small>14.0.1 (2024-02-03)</small>
+
+* [bitnami/postgresql] Release 14.0.1 updating components versions (#23129) ([e81bc0c](https://github.com/bitnami/charts/commit/e81bc0c)), closes [#23129](https://github.com/bitnami/charts/issues/23129)
+
+## 14.0.0 (2024-02-01)
+
+* [bitnami/postgresql] feat!: :lock: :recycle: Refactor and enable networkPolicy (#22750) ([2508c4b](https://github.com/bitnami/charts/commit/2508c4b)), closes [#22750](https://github.com/bitnami/charts/issues/22750)
+
+## <small>13.4.4 (2024-02-01)</small>
+
+* [bitnami/postgresql] Release 13.4.4 updating components versions (#23002) ([a87898d](https://github.com/bitnami/charts/commit/a87898d)), closes [#23002](https://github.com/bitnami/charts/issues/23002)
+
+## <small>13.4.3 (2024-01-29)</small>
+
+* [bitnami/postgresql] Release 13.4.3 updating components versions (#22811) ([fdc3ad4](https://github.com/bitnami/charts/commit/fdc3ad4)), closes [#22811](https://github.com/bitnami/charts/issues/22811)
+
+## <small>13.4.2 (2024-01-27)</small>
+
+* [bitnami/*] Move documentation sections from docs.bitnami.com back to the README (#22203) ([7564f36](https://github.com/bitnami/charts/commit/7564f36)), closes [#22203](https://github.com/bitnami/charts/issues/22203)
+* [bitnami/postgresql] fix: :bug: Set seLinuxOptions to null for Openshift compatibility (#22646) ([b119bec](https://github.com/bitnami/charts/commit/b119bec)), closes [#22646](https://github.com/bitnami/charts/issues/22646)
+* [bitnami/postgresql] Release 13.4.2 updating components versions (#22785) ([6682e9c](https://github.com/bitnami/charts/commit/6682e9c)), closes [#22785](https://github.com/bitnami/charts/issues/22785)
+
+## <small>13.4.1 (2024-01-23)</small>
+
+* [bitnami/postgresql] Release 13.4.1 updating components versions (#22677) ([0bb8b48](https://github.com/bitnami/charts/commit/0bb8b48)), closes [#22677](https://github.com/bitnami/charts/issues/22677)
+
+## 13.4.0 (2024-01-22)
+
+* [bitnami/postgresql] fix: :lock: Move service-account token auto-mount to pod declaration (#22450) ([002c752](https://github.com/bitnami/charts/commit/002c752)), closes [#22450](https://github.com/bitnami/charts/issues/22450)
+
+## <small>13.3.1 (2024-01-18)</small>
+
+* [bitnami/postgresql] Release 13.3.1 updating components versions (#22359) ([361f7ab](https://github.com/bitnami/charts/commit/361f7ab)), closes [#22359](https://github.com/bitnami/charts/issues/22359)
+
+## 13.3.0 (2024-01-17)
+
+* [bitnami/postgresql] fix: :lock: Improve podSecurityContext and containerSecurityContext with essent ([fe72f51](https://github.com/bitnami/charts/commit/fe72f51)), closes [#22177](https://github.com/bitnami/charts/issues/22177)
+
+## <small>13.2.30 (2024-01-15)</small>
+
+* [bitnami/*] Fix ref links (in comments) (#21822) ([e4fa296](https://github.com/bitnami/charts/commit/e4fa296)), closes [#21822](https://github.com/bitnami/charts/issues/21822)
+* [bitnami/postgresql] fix: :lock: Do not use the default service account (#22026) ([1b20745](https://github.com/bitnami/charts/commit/1b20745)), closes [#22026](https://github.com/bitnami/charts/issues/22026)
+
+## <small>13.2.29 (2024-01-10)</small>
+
+* [bitnami/*] Fix docs.bitnami.com broken links (#21901) ([f35506d](https://github.com/bitnami/charts/commit/f35506d)), closes [#21901](https://github.com/bitnami/charts/issues/21901)
+* [bitnami/postgresql] Release 13.2.29 updating components versions (#21970) ([dcfb216](https://github.com/bitnami/charts/commit/dcfb216)), closes [#21970](https://github.com/bitnami/charts/issues/21970)
+* fixed backup with autogenerated cert (#21888) ([2d25138](https://github.com/bitnami/charts/commit/2d25138)), closes [#21888](https://github.com/bitnami/charts/issues/21888)
+
+## <small>13.2.28 (2024-01-09)</small>
+
+* [bitnami/*] Update copyright: Year and company (#21815) ([6c4bf75](https://github.com/bitnami/charts/commit/6c4bf75)), closes [#21815](https://github.com/bitnami/charts/issues/21815)
+* [bitnami/postgresql] Release 13.2.28 updating components versions (#21902) ([d0f6b90](https://github.com/bitnami/charts/commit/d0f6b90)), closes [#21902](https://github.com/bitnami/charts/issues/21902)
+
+## <small>13.2.27 (2023-12-31)</small>
+
+* [bitnami/postgresql] Release 13.2.27 updating components versions (#21795) ([26711f8](https://github.com/bitnami/charts/commit/26711f8)), closes [#21795](https://github.com/bitnami/charts/issues/21795)
+
+## <small>13.2.26 (2023-12-27)</small>
+
+* [bitnami/postgresql] Release 13.2.26 updating components versions (#21774) ([0f0f93b](https://github.com/bitnami/charts/commit/0f0f93b)), closes [#21774](https://github.com/bitnami/charts/issues/21774)
+
+## <small>13.2.25 (2023-12-20)</small>
+
+* [bitnami/postgresql] Release 13.2.25 updating components versions (#21710) ([813da6b](https://github.com/bitnami/charts/commit/813da6b)), closes [#21710](https://github.com/bitnami/charts/issues/21710)
+
+## <small>13.2.24 (2023-12-05)</small>
+
+* [bitnami/postgresql] Replace deprecated pull secret partial (#21392) ([cee371d](https://github.com/bitnami/charts/commit/cee371d)), closes [#21392](https://github.com/bitnami/charts/issues/21392)
+
+## <small>13.2.23 (2023-11-30)</small>
+
+* [bitnami/postgresql] Release 13.2.23 updating components versions (#21336) ([c3dc56f](https://github.com/bitnami/charts/commit/c3dc56f)), closes [#21336](https://github.com/bitnami/charts/issues/21336)
+
+## <small>13.2.22 (2023-11-30)</small>
+
+* [bitnami/postgresql] Release 13.2.22 updating components versions (#21335) ([f759303](https://github.com/bitnami/charts/commit/f759303)), closes [#21335](https://github.com/bitnami/charts/issues/21335)
+
+## <small>13.2.21 (2023-11-27)</small>
+
+* [bitnami/postgresql] Release 13.2.21 updating components versions (#21276) ([46a4f54](https://github.com/bitnami/charts/commit/46a4f54)), closes [#21276](https://github.com/bitnami/charts/issues/21276)
+
+## <small>13.2.20 (2023-11-27)</small>
+
+* [bitnami/postgresql] Release 13.2.20 updating components versions (#21272) ([6de0ade](https://github.com/bitnami/charts/commit/6de0ade)), closes [#21272](https://github.com/bitnami/charts/issues/21272)
+
+## <small>13.2.19 (2023-11-27)</small>
+
+* [bitnami/postgresql] Fix PostgreSQL password in metrics container (#21202) ([a7b72aa](https://github.com/bitnami/charts/commit/a7b72aa)), closes [#21202](https://github.com/bitnami/charts/issues/21202)
+
+## <small>13.2.18 (2023-11-26)</small>
+
+* [bitnami/postgresql] Release 13.2.18 updating components versions (#21256) ([f4a4548](https://github.com/bitnami/charts/commit/f4a4548)), closes [#21256](https://github.com/bitnami/charts/issues/21256)
+
+## <small>13.2.17 (2023-11-26)</small>
+
+* [bitnami/postgresql] Release 13.2.17 updating components versions (#21255) ([e395fd8](https://github.com/bitnami/charts/commit/e395fd8)), closes [#21255](https://github.com/bitnami/charts/issues/21255)
+
+## <small>13.2.16 (2023-11-23)</small>
+
+* [bitnami/postgresql] value to configure posgres_exporter collectors (#21162) ([0ba581c](https://github.com/bitnami/charts/commit/0ba581c)), closes [#21162](https://github.com/bitnami/charts/issues/21162)
+* Update configmap.yaml (#21020) ([b91e518](https://github.com/bitnami/charts/commit/b91e518)), closes [#21020](https://github.com/bitnami/charts/issues/21020)
+
+## <small>13.2.15 (2023-11-21)</small>
+
+* [bitnami/*] Rename solutions to "Bitnami package for ..." (#21038) ([b82f979](https://github.com/bitnami/charts/commit/b82f979)), closes [#21038](https://github.com/bitnami/charts/issues/21038)
+* [bitnami/postgresql] Release 13.2.15 updating components versions (#21160) ([e6ec2c2](https://github.com/bitnami/charts/commit/e6ec2c2)), closes [#21160](https://github.com/bitnami/charts/issues/21160)
+
+## <small>13.2.14 (2023-11-20)</small>
+
+* [bitnami/postgresql] Release 13.2.14 updating components versions (#21068) ([576be48](https://github.com/bitnami/charts/commit/576be48)), closes [#21068](https://github.com/bitnami/charts/issues/21068)
+
+## <small>13.2.13 (2023-11-20)</small>
+
+* [bitnami/postgresql] Release 13.2.13 updating components versions (#21066) ([54a372f](https://github.com/bitnami/charts/commit/54a372f)), closes [#21066](https://github.com/bitnami/charts/issues/21066)
+
+## <small>13.2.12 (2023-11-20)</small>
+
+* [bitnami/postgresql] Release 13.2.12 updating components versions (#21057) ([0cffbfe](https://github.com/bitnami/charts/commit/0cffbfe)), closes [#21057](https://github.com/bitnami/charts/issues/21057)
+
+## <small>13.2.11 (2023-11-17)</small>
+
+* [bitnami/postgresql] Release 13.2.11 updating components versions (#21044) ([17e4ada](https://github.com/bitnami/charts/commit/17e4ada)), closes [#21044](https://github.com/bitnami/charts/issues/21044)
+
+## <small>13.2.10 (2023-11-17)</small>
+
+* [bitnami/*] Remove relative links to non-README sections, add verification for that and update TL;DR ([1103633](https://github.com/bitnami/charts/commit/1103633)), closes [#20967](https://github.com/bitnami/charts/issues/20967)
+* [bitnami/postgresql] Release 13.2.10 updating components versions (#21039) ([2b176c0](https://github.com/bitnami/charts/commit/2b176c0)), closes [#21039](https://github.com/bitnami/charts/issues/21039)
+
+## <small>13.2.9 (2023-11-13)</small>
+
+* [bitnami/postgresql] Release 13.2.9 updating components versions (#20930) ([02dc5ff](https://github.com/bitnami/charts/commit/02dc5ff)), closes [#20930](https://github.com/bitnami/charts/issues/20930)
+
+## <small>13.2.8 (2023-11-13)</small>
+
+* [bitnami/postgresql] Release 13.2.8 updating components versions (#20929) ([129cbf1](https://github.com/bitnami/charts/commit/129cbf1)), closes [#20929](https://github.com/bitnami/charts/issues/20929)
+
+## <small>13.2.7 (2023-11-13)</small>
+
+* [bitnami/postgresql] Release 13.2.7 updating components versions (#20918) ([860eb62](https://github.com/bitnami/charts/commit/860eb62)), closes [#20918](https://github.com/bitnami/charts/issues/20918)
+
+## <small>13.2.6 (2023-11-13)</small>
+
+* [bitnami/postgresql] Release 13.2.6 updating components versions (#20908) ([a942587](https://github.com/bitnami/charts/commit/a942587)), closes [#20908](https://github.com/bitnami/charts/issues/20908)
+
+## <small>13.2.5 (2023-11-10)</small>
+
+* [bitnami/postgresql] Release 13.2.5 updating components versions (#20889) ([ca3f6a7](https://github.com/bitnami/charts/commit/ca3f6a7)), closes [#20889](https://github.com/bitnami/charts/issues/20889)
+
+## <small>13.2.4 (2023-11-09)</small>
+
+* [bitnami/postgresql] Release 13.2.4 updating components versions (#20876) ([435c8af](https://github.com/bitnami/charts/commit/435c8af)), closes [#20876](https://github.com/bitnami/charts/issues/20876)
+
+## <small>13.2.3 (2023-11-08)</small>
+
+* [bitnami/postgresql] Release 13.2.3 updating components versions (#20772) ([0ed5ebf](https://github.com/bitnami/charts/commit/0ed5ebf)), closes [#20772](https://github.com/bitnami/charts/issues/20772)
+
+## <small>13.2.2 (2023-11-06)</small>
+
+* [bitnami/postgresql] Release 13.2.2 updating components versions (#20639) ([9b846d9](https://github.com/bitnami/charts/commit/9b846d9)), closes [#20639](https://github.com/bitnami/charts/issues/20639)
+
+## <small>13.2.1 (2023-11-03)</small>
+
+* [bitnami/postgresql] Release 13.2.1 updating components versions (#20614) ([68bad25](https://github.com/bitnami/charts/commit/68bad25)), closes [#20614](https://github.com/bitnami/charts/issues/20614)
+
+## 13.2.0 (2023-10-31)
+
+* [bitnami/*] Rename VMware Application Catalog (#20361) ([3acc734](https://github.com/bitnami/charts/commit/3acc734)), closes [#20361](https://github.com/bitnami/charts/issues/20361)
+* [bitnami/*] Skip image's tag in the README files of the Bitnami Charts (#19841) ([bb9a01b](https://github.com/bitnami/charts/commit/bb9a01b)), closes [#19841](https://github.com/bitnami/charts/issues/19841)
+* [bitnami/*] Standardize documentation (#19835) ([af5f753](https://github.com/bitnami/charts/commit/af5f753)), closes [#19835](https://github.com/bitnami/charts/issues/19835)
+* [bitnami/postgresql] feat: :sparkles: Add support for PSA restricted policy (#20527) ([8da833a](https://github.com/bitnami/charts/commit/8da833a)), closes [#20527](https://github.com/bitnami/charts/issues/20527)
+
+## <small>13.1.5 (2023-10-13)</small>
+
+* [bitnami/postgresql] Release 13.1.5 (#20212) ([0272334](https://github.com/bitnami/charts/commit/0272334)), closes [#20212](https://github.com/bitnami/charts/issues/20212)
+
+## <small>13.1.4 (2023-10-12)</small>
+
+* [bitnami/postgresql] Release 13.1.4 (#20187) ([477cb86](https://github.com/bitnami/charts/commit/477cb86)), closes [#20187](https://github.com/bitnami/charts/issues/20187)
+
+## <small>13.1.3 (2023-10-09)</small>
+
+* [bitnami/postgresql] Release 13.1.3 (#19931) ([2eb6312](https://github.com/bitnami/charts/commit/2eb6312)), closes [#19931](https://github.com/bitnami/charts/issues/19931)
+
+## <small>13.1.2 (2023-10-09)</small>
+
+* [bitnami/postgresql] Release 13.1.2 (#19882) ([5758fb2](https://github.com/bitnami/charts/commit/5758fb2)), closes [#19882](https://github.com/bitnami/charts/issues/19882)
+
+## <small>13.1.1 (2023-10-09)</small>
+
+* [bitnami/*] Update Helm charts prerequisites (#19745) ([eb755dd](https://github.com/bitnami/charts/commit/eb755dd)), closes [#19745](https://github.com/bitnami/charts/issues/19745)
+* [bitnami/postgresql] Release 13.1.1 (#19775) ([f783262](https://github.com/bitnami/charts/commit/f783262)), closes [#19775](https://github.com/bitnami/charts/issues/19775)
+
+## 13.1.0 (2023-10-05)
+
+* [bitnami/postgresql] Add TimeZone to CronJob of backup (#19516) ([94d976d](https://github.com/bitnami/charts/commit/94d976d)), closes [#19516](https://github.com/bitnami/charts/issues/19516)
+
+## <small>13.0.2 (2023-10-04)</small>
+
+* [bitnami/postgresql] Support disabling backup cron containerSecurityContext (#19676) ([5ff8ad5](https://github.com/bitnami/charts/commit/5ff8ad5)), closes [#19676](https://github.com/bitnami/charts/issues/19676)
+
+## <small>13.0.1 (2023-09-29)</small>
+
+* [bitnami/postgresql] Update README after major release (#19608) ([cd4442c](https://github.com/bitnami/charts/commit/cd4442c)), closes [#19608](https://github.com/bitnami/charts/issues/19608)
+* [bitnami/postgresql] Use common capabilities for PSP (#19637) ([5593291](https://github.com/bitnami/charts/commit/5593291)), closes [#19637](https://github.com/bitnami/charts/issues/19637)
+
+## 13.0.0 (2023-09-28)
+
+* [bitnami/postgresql] Release 13.0.0 (#19587) ([ed70b64](https://github.com/bitnami/charts/commit/ed70b64)), closes [#19587](https://github.com/bitnami/charts/issues/19587)
+
+## <small>12.12.10 (2023-09-27)</small>
+
+* [bitnami/postgresql] Fix port used by backup's CronJob (#19517) ([d278c2b](https://github.com/bitnami/charts/commit/d278c2b)), closes [#19517](https://github.com/bitnami/charts/issues/19517)
+
+## <small>12.12.9 (2023-09-26)</small>
+
+* [bitnami/postgresql] Release 12.12.9 updating components versions (#19530) ([70ca410](https://github.com/bitnami/charts/commit/70ca410)), closes [#19530](https://github.com/bitnami/charts/issues/19530)
+* bitnami/postgresql  Added ImagePullSecrets and ImagePullPolicy to be passed through to backup-cronjo ([29dbf3a](https://github.com/bitnami/charts/commit/29dbf3a)), closes [#19509](https://github.com/bitnami/charts/issues/19509)
+
+## <small>12.12.8 (2023-09-26)</small>
+
+* [bitnami/postgresql] Release 12.12.8 (#19521) ([ef790fa](https://github.com/bitnami/charts/commit/ef790fa)), closes [#19521](https://github.com/bitnami/charts/issues/19521)
+
+## <small>12.12.7 (2023-09-25)</small>
+
+* [bitnami/postgresql] Release 12.12.7 (#19506) ([f8d9491](https://github.com/bitnami/charts/commit/f8d9491)), closes [#19506](https://github.com/bitnami/charts/issues/19506)
+
+## <small>12.12.6 (2023-09-22)</small>
+
+* [bitnami/postgresql] Release 12.12.6 (#19481) ([acac1c2](https://github.com/bitnami/charts/commit/acac1c2)), closes [#19481](https://github.com/bitnami/charts/issues/19481)
+
+## <small>12.12.5 (2023-09-22)</small>
+
+* [bitnami/postgresql] Add SecurityContext to CronJob of backup (#19238) ([8edeb93](https://github.com/bitnami/charts/commit/8edeb93)), closes [#19238](https://github.com/bitnami/charts/issues/19238)
+
+## <small>12.12.4 (2023-09-20)</small>
+
+* [bitnami/postgresql] Release 12.12.4 (#19430) ([f8b45dc](https://github.com/bitnami/charts/commit/f8b45dc)), closes [#19430](https://github.com/bitnami/charts/issues/19430)
+
+## <small>12.12.3 (2023-09-19)</small>
+
+* [bitnami/postgresql] Add nodeSelector to Backup Cronjob spec (#19398) ([7eea12f](https://github.com/bitnami/charts/commit/7eea12f)), closes [#19398](https://github.com/bitnami/charts/issues/19398)
+
+## <small>12.11.4 (2023-09-19)</small>
+
+* [bitnami/postgresql] Release 12.11.4 (#19397) ([b6a06cc](https://github.com/bitnami/charts/commit/b6a06cc)), closes [#19397](https://github.com/bitnami/charts/issues/19397)
+
+## <small>12.11.3 (2023-09-18)</small>
+
+* [bitnami/postgresql] Release 12.11.3 (#19345) ([9407892](https://github.com/bitnami/charts/commit/9407892)), closes [#19345](https://github.com/bitnami/charts/issues/19345)
+* Revert "Autogenerate schema files (#19194)" (#19335) ([73d80be](https://github.com/bitnami/charts/commit/73d80be)), closes [#19194](https://github.com/bitnami/charts/issues/19194) [#19335](https://github.com/bitnami/charts/issues/19335)
+
+## <small>12.11.2 (2023-09-15)</small>
+
+* Autogenerate schema files (#19194) ([a2c2090](https://github.com/bitnami/charts/commit/a2c2090)), closes [#19194](https://github.com/bitnami/charts/issues/19194)
+* Fix global secretkeys usage (#19281) ([3c468cb](https://github.com/bitnami/charts/commit/3c468cb)), closes [#19281](https://github.com/bitnami/charts/issues/19281)
+
+## <small>12.11.1 (2023-09-08)</small>
+
+* [bitnami/postgresql] chore: :bookmark: Bump version ([26ddfc4](https://github.com/bitnami/charts/commit/26ddfc4))
+
+## 12.11.0 (2023-09-07)
+
+* [bitnami/postgresql] Version the helper functions (#17847) ([c1a1349](https://github.com/bitnami/charts/commit/c1a1349)), closes [#17847](https://github.com/bitnami/charts/issues/17847)
+
+## <small>12.10.2 (2023-09-07)</small>
+
+* [bitnami/postgresql] chore: :bookmark: Bump version ([b46e94e](https://github.com/bitnami/charts/commit/b46e94e))
+
+## <small>12.10.1 (2023-09-06)</small>
+
+* [bitnami/postgresql: Use merge helper]: (#19093) ([8eaef88](https://github.com/bitnami/charts/commit/8eaef88)), closes [#19093](https://github.com/bitnami/charts/issues/19093)
+
+## 12.10.0 (2023-08-25)
+
+* [bitnami/postgresql] Add Persistent Volume Claim Retention Policy to Postgresql Statefulsets (#18276 ([85635f4](https://github.com/bitnami/charts/commit/85635f4)), closes [#18276](https://github.com/bitnami/charts/issues/18276)
+
+## 12.9.0 (2023-08-23)
+
+* [bitnami/postgresql] Support for customizing standard labels (#18408) ([bf18e4b](https://github.com/bitnami/charts/commit/bf18e4b)), closes [#18408](https://github.com/bitnami/charts/issues/18408)
+
+## <small>12.8.5 (2023-08-22)</small>
+
+* [bitnami/postgresql] Release 12.8.5 (#18771) ([85ffc53](https://github.com/bitnami/charts/commit/85ffc53)), closes [#18771](https://github.com/bitnami/charts/issues/18771)
+
+## <small>12.8.4 (2023-08-21)</small>
+
+* [bitnami/postgresql] fix annotation typo (#18557) ([9748b69](https://github.com/bitnami/charts/commit/9748b69)), closes [#18557](https://github.com/bitnami/charts/issues/18557)
+
+## <small>12.8.3 (2023-08-17)</small>
+
+* [bitnami/postgresql] Release 12.8.3 (#18576) ([6c950c1](https://github.com/bitnami/charts/commit/6c950c1)), closes [#18576](https://github.com/bitnami/charts/issues/18576)
+
+## <small>12.8.2 (2023-08-10)</small>
+
+* [bitnami/postgresql] Release 12.8.2 (#18364) ([f34b599](https://github.com/bitnami/charts/commit/f34b599)), closes [#18364](https://github.com/bitnami/charts/issues/18364)
+
+## <small>12.8.1 (2023-08-08)</small>
+
+* [bitnami/postgresql] Release 12.8.1 (#18287) ([5887a90](https://github.com/bitnami/charts/commit/5887a90)), closes [#18287](https://github.com/bitnami/charts/issues/18287)
+
+## 12.8.0 (2023-08-01)
+
+* [bitnami/postgresql] Add trivial backup cronjob (#17852) ([56b223b](https://github.com/bitnami/charts/commit/56b223b)), closes [#17852](https://github.com/bitnami/charts/issues/17852)
+
+## <small>12.7.3 (2023-07-31)</small>
+
+* [bitnami/postgresql] Release 12.7.3 (#18068) ([0186212](https://github.com/bitnami/charts/commit/0186212)), closes [#18068](https://github.com/bitnami/charts/issues/18068)
+
+## <small>12.7.2 (2023-07-31)</small>
+
+* [bitnami/postgresql] Remove multi-line conditional (#17711) ([e7acf10](https://github.com/bitnami/charts/commit/e7acf10)), closes [#17711](https://github.com/bitnami/charts/issues/17711)
+
+## <small>12.7.1 (2023-07-27)</small>
+
+* [bitnami/postgresql] Release 12.7.1 (#17986) ([a071516](https://github.com/bitnami/charts/commit/a071516)), closes [#17986](https://github.com/bitnami/charts/issues/17986)
+
+## 12.7.0 (2023-07-26)
+
+* [bitnami/postgresql] set some bits compatible with pss restricted (#17388) ([beb65fa](https://github.com/bitnami/charts/commit/beb65fa)), closes [#17388](https://github.com/bitnami/charts/issues/17388)
+
+## <small>12.6.9 (2023-07-24)</small>
+
+* [bitnami/postgresql] Release 12.6.9 (#17840) ([5141c42](https://github.com/bitnami/charts/commit/5141c42)), closes [#17840](https://github.com/bitnami/charts/issues/17840)
+
+## <small>12.6.8 (2023-07-20)</small>
+
+* [bitnami/postgresl] Remove the password in text of the statefulset (#17780) ([3bfcc08](https://github.com/bitnami/charts/commit/3bfcc08)), closes [#17780](https://github.com/bitnami/charts/issues/17780)
+
+## <small>12.6.7 (2023-07-19)</small>
+
+* Fixes usePasswordFiles (#17773) ([14d2b9a](https://github.com/bitnami/charts/commit/14d2b9a)), closes [#17773](https://github.com/bitnami/charts/issues/17773)
+
+## <small>12.6.6 (2023-07-15)</small>
+
+* [bitnami/postgresql] Release 12.6.6 (#17705) ([3e6c481](https://github.com/bitnami/charts/commit/3e6c481)), closes [#17705](https://github.com/bitnami/charts/issues/17705)
+
+## <small>12.6.5 (2023-07-11)</small>
+
+* [bitnami/postgresql] fix invalid indentation for replica metrics extra envs (#17553) ([39b5188](https://github.com/bitnami/charts/commit/39b5188)), closes [#17553](https://github.com/bitnami/charts/issues/17553)
+
+## <small>12.6.4 (2023-07-07)</small>
+
+* [bitnami/postgresql] Fix postgres random password generation (#17502) ([afa4649](https://github.com/bitnami/charts/commit/afa4649)), closes [#17502](https://github.com/bitnami/charts/issues/17502)
+
+## <small>12.6.3 (2023-07-06)</small>
+
+* [bitnami/postgresql] Fix multi-element array for primary.service.loadBalancerSourceRanges (#17461) ([dc59153](https://github.com/bitnami/charts/commit/dc59153)), closes [#17461](https://github.com/bitnami/charts/issues/17461) [#17450](https://github.com/bitnami/charts/issues/17450)
+
+## <small>12.6.2 (2023-07-04)</small>
+
+* [bitnami/postgresql] Fix postgres password if customUser is empty (#17473) ([d6234d8](https://github.com/bitnami/charts/commit/d6234d8)), closes [#17473](https://github.com/bitnami/charts/issues/17473)
+
+## <small>12.6.1 (2023-07-04)</small>
+
+* [bitnami/postgresql] Fix issues when using enablePostgresUser=false (#17398) ([262f4f1](https://github.com/bitnami/charts/commit/262f4f1)), closes [#17398](https://github.com/bitnami/charts/issues/17398)
+
+## 12.6.0 (2023-06-29)
+
+* [bitnami/postgresql] checksum only data part of the ConfigMap (#17302) ([f5c4b4e](https://github.com/bitnami/charts/commit/f5c4b4e)), closes [#17302](https://github.com/bitnami/charts/issues/17302)
+
+## <small>12.5.9 (2023-06-29)</small>
+
+* [bitnami/postgresql] Release 12.5.9 (#17392) ([06ab2db](https://github.com/bitnami/charts/commit/06ab2db)), closes [#17392](https://github.com/bitnami/charts/issues/17392)
+* Add copyright header (#17300) ([da68be8](https://github.com/bitnami/charts/commit/da68be8)), closes [#17300](https://github.com/bitnami/charts/issues/17300)
+* Update charts readme (#17217) ([31b3c0a](https://github.com/bitnami/charts/commit/31b3c0a)), closes [#17217](https://github.com/bitnami/charts/issues/17217)
+
+## <small>12.5.8 (2023-06-19)</small>
+
+* [bitnami/PostgreSQL] Update statefulset to inlcude verbose PVC reference (#17140) ([ffa4eeb](https://github.com/bitnami/charts/commit/ffa4eeb)), closes [#17140](https://github.com/bitnami/charts/issues/17140)
+
+## <small>12.5.7 (2023-06-12)</small>
+
+* [bitnami/*] Change copyright section in READMEs (#17006) ([ef986a1](https://github.com/bitnami/charts/commit/ef986a1)), closes [#17006](https://github.com/bitnami/charts/issues/17006)
+* [bitnami/postgresql] Fix execution when enablePostgresUser is false (#17058) ([fc26fbd](https://github.com/bitnami/charts/commit/fc26fbd)), closes [#17058](https://github.com/bitnami/charts/issues/17058)
+* [bitnami/several] Change copyright section in READMEs (#16989) ([5b6a5cf](https://github.com/bitnami/charts/commit/5b6a5cf)), closes [#16989](https://github.com/bitnami/charts/issues/16989)
+
+## <small>12.5.6 (2023-05-30)</small>
+
+* [bitnami/postgresql] Fix mountPath for extendedConfiguration (#16874) ([f5e2881](https://github.com/bitnami/charts/commit/f5e2881)), closes [#16874](https://github.com/bitnami/charts/issues/16874)
+* [bitnami/postgresql] Release 12.5.6 (#16953) ([0448ae0](https://github.com/bitnami/charts/commit/0448ae0)), closes [#16953](https://github.com/bitnami/charts/issues/16953)
+
+## <small>12.5.5 (2023-05-23)</small>
+
+* [bitnami/postgresql] Allow usePasswordFile when using existingSecret + custom keys (#16729) ([ff3a5e0](https://github.com/bitnami/charts/commit/ff3a5e0)), closes [#16729](https://github.com/bitnami/charts/issues/16729)
+
+## <small>12.5.4 (2023-05-22)</small>
+
+* [bitnami/postgresql] Release 12.5.4 (#16861) ([d8aae34](https://github.com/bitnami/charts/commit/d8aae34)), closes [#16861](https://github.com/bitnami/charts/issues/16861)
+
+## <small>12.5.3 (2023-05-21)</small>
+
+* [bitnami/postgresql] Release 12.5.3 (#16838) ([de9b3a4](https://github.com/bitnami/charts/commit/de9b3a4)), closes [#16838](https://github.com/bitnami/charts/issues/16838)
+
+## <small>12.5.2 (2023-05-16)</small>
+
+* [bitnami/postgresql] Bump the version (#16668) ([7addf44](https://github.com/bitnami/charts/commit/7addf44)), closes [#16668](https://github.com/bitnami/charts/issues/16668)
+* fix(postgres): use correct default value type for networkPolicy customRules (#16646) ([901f3b8](https://github.com/bitnami/charts/commit/901f3b8)), closes [#16646](https://github.com/bitnami/charts/issues/16646)
+
+## <small>12.5.1 (2023-05-12)</small>
+
+* [bitnami/postgresql] Release 12.5.1 (#16621) ([7c233f3](https://github.com/bitnami/charts/commit/7c233f3)), closes [#16621](https://github.com/bitnami/charts/issues/16621)
+* Add wording for enterprise page (#16560) ([8f22774](https://github.com/bitnami/charts/commit/8f22774)), closes [#16560](https://github.com/bitnami/charts/issues/16560)
+
+## 12.5.0 (2023-05-09)
+
+* [bitnami/several] Adapt Chart.yaml to set desired OCI annotations (#16546) ([fc9b18f](https://github.com/bitnami/charts/commit/fc9b18f)), closes [#16546](https://github.com/bitnami/charts/issues/16546)
+
+## <small>12.4.3 (2023-05-09)</small>
+
+* [bitnami/postgresql] Release 12.4.3 (#16493) ([85c1bf6](https://github.com/bitnami/charts/commit/85c1bf6)), closes [#16493](https://github.com/bitnami/charts/issues/16493)
+
+## <small>12.4.2 (2023-04-27)</small>
+
+* [bitnami/postgresql] Use username as key in the Service Binding secret (#16249) ([c6daf3d](https://github.com/bitnami/charts/commit/c6daf3d)), closes [#16249](https://github.com/bitnami/charts/issues/16249)
+
+## <small>12.4.1 (2023-04-25)</small>
+
+* [bitnami/postgresql] Release 12.4.1 (#16225) ([d6f37c5](https://github.com/bitnami/charts/commit/d6f37c5)), closes [#16225](https://github.com/bitnami/charts/issues/16225)
+
+## 12.4.0 (2023-04-25)
+
+* [bitnami/several] Revert changes done by mistake in Chart.yaml repo (#16211) ([3a60f4b](https://github.com/bitnami/charts/commit/3a60f4b)), closes [#16211](https://github.com/bitnami/charts/issues/16211)
+
+## <small>12.3.2 (2023-04-25)</small>
+
+* [bitnami/postgresql] Release 12.3.2 (#16205) ([d1cbf66](https://github.com/bitnami/charts/commit/d1cbf66)), closes [#16205](https://github.com/bitnami/charts/issues/16205)
+
+## <small>12.3.1 (2023-04-21)</small>
+
+* [bitnami/postgresql] Release 12.3.1 (#16182) ([1426b53](https://github.com/bitnami/charts/commit/1426b53)), closes [#16182](https://github.com/bitnami/charts/issues/16182)
+
+## 12.3.0 (2023-04-20)
+
+* [bitnami/*] Make Helm charts 100% OCI (#15998) ([8841510](https://github.com/bitnami/charts/commit/8841510)), closes [#15998](https://github.com/bitnami/charts/issues/15998)
+
+## <small>12.2.8 (2023-04-14)</small>
+
+* [bitnami/postgresql] Release 12.2.8 (#16072) ([8f03dec](https://github.com/bitnami/charts/commit/8f03dec)), closes [#16072](https://github.com/bitnami/charts/issues/16072)
+
+## <small>12.2.7 (2023-04-01)</small>
+
+* [bitnami/postgresql] Release 12.2.7 (#15896) ([18e9565](https://github.com/bitnami/charts/commit/18e9565)), closes [#15896](https://github.com/bitnami/charts/issues/15896)
+
+## <small>12.2.6 (2023-03-22)</small>
+
+* [bitnami/postgresql] Release 12.2.6 (#15685) ([e42e0a1](https://github.com/bitnami/charts/commit/e42e0a1)), closes [#15685](https://github.com/bitnami/charts/issues/15685)
+
+## <small>12.2.5 (2023-03-20)</small>
+
+* [bitnami/postgresql] Release 12.2.5 (#15632) ([71f1ab5](https://github.com/bitnami/charts/commit/71f1ab5)), closes [#15632](https://github.com/bitnami/charts/issues/15632)
+
+## <small>12.2.4 (2023-03-19)</small>
+
+* [bitnami/postgresql] Release 12.2.4 (#15600) ([2b7e88c](https://github.com/bitnami/charts/commit/2b7e88c)), closes [#15600](https://github.com/bitnami/charts/issues/15600)
+
+## <small>12.2.3 (2023-03-14)</small>
+
+* [bitnami/charts] Apply linter to README files (#15357) ([0e29e60](https://github.com/bitnami/charts/commit/0e29e60)), closes [#15357](https://github.com/bitnami/charts/issues/15357)
+* [bitnami/postgresql] Release 12.2.3 (#15488) ([1b1ddca](https://github.com/bitnami/charts/commit/1b1ddca)), closes [#15488](https://github.com/bitnami/charts/issues/15488)
+
+## <small>12.2.2 (2023-03-01)</small>
+
+* [bitnami/postgresql] Release 12.2.2 (#15233) ([ceb1e4f](https://github.com/bitnami/charts/commit/ceb1e4f)), closes [#15233](https://github.com/bitnami/charts/issues/15233)
+* Fix postgres secret keys (#15023) ([eeb1faa](https://github.com/bitnami/charts/commit/eeb1faa)), closes [#15023](https://github.com/bitnami/charts/issues/15023)
+
+## <small>12.2.1 (2023-02-17)</small>
+
+* [bitnami/*] Fix markdown linter issues 2 (#14890) ([aa96572](https://github.com/bitnami/charts/commit/aa96572)), closes [#14890](https://github.com/bitnami/charts/issues/14890)
+* [bitnami/postgresql] Release 12.2.1 (#15025) ([727ecd8](https://github.com/bitnami/charts/commit/727ecd8)), closes [#15025](https://github.com/bitnami/charts/issues/15025)
+
+## 12.2.0 (2023-02-16)
+
+* [bitnami/*] Fix markdown linter issues (#14874) ([a51e0e8](https://github.com/bitnami/charts/commit/a51e0e8)), closes [#14874](https://github.com/bitnami/charts/issues/14874)
+* [bitnami/*] Remove unexpected extra spaces (#14873) ([c97c714](https://github.com/bitnami/charts/commit/c97c714)), closes [#14873](https://github.com/bitnami/charts/issues/14873)
+* [bitnami/postgresql] feat: :sparkles: Add ServiceBinding-compatible secrets (#14893) ([68f6708](https://github.com/bitnami/charts/commit/68f6708)), closes [#14893](https://github.com/bitnami/charts/issues/14893)
+
+## <small>12.1.15 (2023-02-09)</small>
+
+* [bitnami/postgresql] Release 12.1.15 (#14821) ([9334f82](https://github.com/bitnami/charts/commit/9334f82)), closes [#14821](https://github.com/bitnami/charts/issues/14821)
+
+## <small>12.1.14 (2023-02-02)</small>
+
+* [bitnami/postgresql] Don't regenerate self-signed certs on upgrade (#14651) ([c9c6d20](https://github.com/bitnami/charts/commit/c9c6d20)), closes [#14651](https://github.com/bitnami/charts/issues/14651)
+* [bitnami/postgresql] Release 12.1.14 (#14717) ([02daab3](https://github.com/bitnami/charts/commit/02daab3)), closes [#14717](https://github.com/bitnami/charts/issues/14717)
+
+## <small>12.1.13 (2023-01-31)</small>
+
+* [bitnami/*] Change copyright date (#14682) ([add4ec7](https://github.com/bitnami/charts/commit/add4ec7)), closes [#14682](https://github.com/bitnami/charts/issues/14682)
+* [bitnami/postgresql] skip empty resources (#14602) ([5ee97f7](https://github.com/bitnami/charts/commit/5ee97f7)), closes [#14602](https://github.com/bitnami/charts/issues/14602)
+
+## <small>12.1.12 (2023-01-30)</small>
+
+* [bitnami/postgresql] Release 12.1.12 (#14593) ([b55c70e](https://github.com/bitnami/charts/commit/b55c70e)), closes [#14593](https://github.com/bitnami/charts/issues/14593)
+
+## <small>12.1.11 (2023-01-26)</small>
+
+* [bitnami/postgresql] Release 12.1.11 (#14558) ([bab9d74](https://github.com/bitnami/charts/commit/bab9d74)), closes [#14558](https://github.com/bitnami/charts/issues/14558)
+
+## <small>12.1.10 (2023-01-26)</small>
+
+* [bitnami/*] Add license annotation and remove obsolete engine parameter (#14293) ([da2a794](https://github.com/bitnami/charts/commit/da2a794)), closes [#14293](https://github.com/bitnami/charts/issues/14293)
+* [bitnami/*] Change licenses annotation format (#14377) ([0ab7608](https://github.com/bitnami/charts/commit/0ab7608)), closes [#14377](https://github.com/bitnami/charts/issues/14377)
+* [bitnami/*] Unify READMEs (#14472) ([2064fb8](https://github.com/bitnami/charts/commit/2064fb8)), closes [#14472](https://github.com/bitnami/charts/issues/14472)
+* [bitnami/postgresql] Add note about password issue when reinstalling helm chart (#14547) ([8b8c516](https://github.com/bitnami/charts/commit/8b8c516)), closes [#14547](https://github.com/bitnami/charts/issues/14547)
+
+## <small>12.1.9 (2023-01-11)</small>
+
+* [bitnami/postgresql] Release 12.1.9 (#14277) ([84b7a8a](https://github.com/bitnami/charts/commit/84b7a8a)), closes [#14277](https://github.com/bitnami/charts/issues/14277)
+
+## <small>12.1.8 (2023-01-09)</small>
+
+* [bitnami/postgresql] update chart version for conflict (#14240) ([9356608](https://github.com/bitnami/charts/commit/9356608)), closes [#14240](https://github.com/bitnami/charts/issues/14240)
+* feat(postgresql): allow auth.database to be templated (#14166) ([0a70ca9](https://github.com/bitnami/charts/commit/0a70ca9)), closes [#14166](https://github.com/bitnami/charts/issues/14166)
+
+## <small>12.1.7 (2023-01-05)</small>
+
+* [bitnami/postgresql] Release 12.1.7 (#14194) ([6524f2c](https://github.com/bitnami/charts/commit/6524f2c)), closes [#14194](https://github.com/bitnami/charts/issues/14194)
+
+## <small>12.1.6 (2022-12-20)</small>
+
+* [bitnami/postgresql] Renamed statefulset custom-metrics name to match metrics-configmap (#13953) ([1601a1b](https://github.com/bitnami/charts/commit/1601a1b)), closes [#13953](https://github.com/bitnami/charts/issues/13953)
+
+## <small>12.1.5 (2022-12-16)</small>
+
+* [bitnami/postgresql] Release 12.1.5 (#13987) ([a74a2cb](https://github.com/bitnami/charts/commit/a74a2cb)), closes [#13987](https://github.com/bitnami/charts/issues/13987)
+
+## <small>12.1.4 (2022-12-14)</small>
+
+* [bitnami/postgresql] Release 12.1.4 (#13964) ([c053dea](https://github.com/bitnami/charts/commit/c053dea)), closes [#13964](https://github.com/bitnami/charts/issues/13964)
+
+## <small>12.1.3 (2022-12-01)</small>
+
+* [bitnami/postgresql] Release 12.1.3 (#13795) ([a327cfa](https://github.com/bitnami/charts/commit/a327cfa)), closes [#13795](https://github.com/bitnami/charts/issues/13795)
+
+## <small>12.1.2 (2022-11-11)</small>
+
+* [bitnami/postgresql] Release 12.1.2 (#13470) ([4f6fd65](https://github.com/bitnami/charts/commit/4f6fd65)), closes [#13470](https://github.com/bitnami/charts/issues/13470)
+
+## <small>12.1.1 (2022-11-09)</small>
+
+* [bitnami/postgresql] Release 12.1.1 (#13447) ([1ddbe4a](https://github.com/bitnami/charts/commit/1ddbe4a)), closes [#13447](https://github.com/bitnami/charts/issues/13447)
+* Update OpenShift specifc security settings (#13265) ([4ca827c](https://github.com/bitnami/charts/commit/4ca827c)), closes [#13265](https://github.com/bitnami/charts/issues/13265)
+
+## 12.1.0 (2022-11-03)
+
+* [bitnami/postgresql] Annotations for headless service (#13269) ([a4f111f](https://github.com/bitnami/charts/commit/a4f111f)), closes [#13269](https://github.com/bitnami/charts/issues/13269)
+
+## <small>12.0.1 (2022-11-01)</small>
+
+* [bitnami/*] Update upgrading notes of PostgreSQL and PostgreSQL HA (#13226) ([a5a7d0e](https://github.com/bitnami/charts/commit/a5a7d0e)), closes [#13226](https://github.com/bitnami/charts/issues/13226)
+* [bitnami/postgresql] Release 12.0.1 (#13281) ([d839514](https://github.com/bitnami/charts/commit/d839514)), closes [#13281](https://github.com/bitnami/charts/issues/13281)
+
+## 12.0.0 (2022-10-27)
+
+* [bitnami/postgresql] Release 12.0.0 (#13203) ([cc87b46](https://github.com/bitnami/charts/commit/cc87b46)), closes [#13203](https://github.com/bitnami/charts/issues/13203)
+
+## <small>11.9.13 (2022-10-26)</small>
+
+* [bitnami/postgresql] Release 11.9.13 (#13168) ([c607694](https://github.com/bitnami/charts/commit/c607694)), closes [#13168](https://github.com/bitnami/charts/issues/13168)
+
+## <small>11.9.12 (2022-10-25)</small>
+
+* [bitnami/postgresql] Release 11.9.12 (#13146) ([b92ee13](https://github.com/bitnami/charts/commit/b92ee13)), closes [#13146](https://github.com/bitnami/charts/issues/13146)
+
+## <small>11.9.11 (2022-10-18)</small>
+
+* [bitnami/postgresql] Release 11.9.11 (#13010) ([9ac77f4](https://github.com/bitnami/charts/commit/9ac77f4)), closes [#13010](https://github.com/bitnami/charts/issues/13010)
+
+## <small>11.9.10 (2022-10-17)</small>
+
+* [bitnami/postgresql] Release 11.9.10 (#12993) ([e52f958](https://github.com/bitnami/charts/commit/e52f958)), closes [#12993](https://github.com/bitnami/charts/issues/12993)
+
+## <small>11.9.9 (2022-10-17)</small>
+
+* [bitnami/*] Use new default branch name in links (#12943) ([a529e02](https://github.com/bitnami/charts/commit/a529e02)), closes [#12943](https://github.com/bitnami/charts/issues/12943)
+* [bitnami/postgresql] Release 11.9.9 (#12991) ([d58c9d6](https://github.com/bitnami/charts/commit/d58c9d6)), closes [#12991](https://github.com/bitnami/charts/issues/12991)
+
+## <small>11.9.8 (2022-10-07)</small>
+
+* [bitnami/postgresql] Release 11.9.8 (#12837) ([d3ec8fa](https://github.com/bitnami/charts/commit/d3ec8fa)), closes [#12837](https://github.com/bitnami/charts/issues/12837)
+
+## <small>11.9.7 (2022-10-05)</small>
+
+* [bitnami/postgresql] Update maintainers (#12818) ([8de3271](https://github.com/bitnami/charts/commit/8de3271)), closes [#12818](https://github.com/bitnami/charts/issues/12818)
+* Generic README instructions related to the repo (#12792) ([3cf6b10](https://github.com/bitnami/charts/commit/3cf6b10)), closes [#12792](https://github.com/bitnami/charts/issues/12792)
+
+## <small>11.9.6 (2022-10-03)</small>
+
+* [bitnami/postgresql] Use plain connections from metrics sidecar (#12735) ([e07416d](https://github.com/bitnami/charts/commit/e07416d)), closes [#12735](https://github.com/bitnami/charts/issues/12735)
+
+## <small>11.9.5 (2022-09-30)</small>
+
+* [bitnami/postgresql] Release 11.9.5 (#12763) ([42ecc41](https://github.com/bitnami/charts/commit/42ecc41)), closes [#12763](https://github.com/bitnami/charts/issues/12763)
+
+## <small>11.9.4 (2022-09-30)</small>
+
+* [bitnami/postgresql] Release 11.9.4 (#12744) ([1fe59b8](https://github.com/bitnami/charts/commit/1fe59b8)), closes [#12744](https://github.com/bitnami/charts/issues/12744)
+
+## <small>11.9.3 (2022-09-28)</small>
+
+* [bitnami/postgresql] Release 11.9.3 (#12720) ([340dd2a](https://github.com/bitnami/charts/commit/340dd2a)), closes [#12720](https://github.com/bitnami/charts/issues/12720)
+
+## <small>11.9.2 (2022-09-28)</small>
+
+* [bitnami/postgresql] Use custom probes if given (#12548) ([99ea23d](https://github.com/bitnami/charts/commit/99ea23d)), closes [#12548](https://github.com/bitnami/charts/issues/12548) [#12354](https://github.com/bitnami/charts/issues/12354)
+
+## <small>11.9.1 (2022-09-15)</small>
+
+* [bitnami/postgresql] Release 11.9.1 (#12435) ([376814f](https://github.com/bitnami/charts/commit/376814f)), closes [#12435](https://github.com/bitnami/charts/issues/12435)
+
+## 11.9.0 (2022-09-13)
+
+* [bitnami/postgresql] Add labels to volume claim template (#12353) ([7745b21](https://github.com/bitnami/charts/commit/7745b21)), closes [#12353](https://github.com/bitnami/charts/issues/12353)
+
+## <small>11.8.2 (2022-09-13)</small>
+
+* [bitnami/postgresql] Release 11.8.2 (#12395) ([7dbfe5d](https://github.com/bitnami/charts/commit/7dbfe5d)), closes [#12395](https://github.com/bitnami/charts/issues/12395)
+
+## <small>11.8.1 (2022-08-23)</small>
+
+* [bitnami/postgresql] Update Chart.lock (#12073) ([b96782b](https://github.com/bitnami/charts/commit/b96782b)), closes [#12073](https://github.com/bitnami/charts/issues/12073)
+
+## 11.8.0 (2022-08-22)
+
+* [bitnami/postgresql] Add support for image digest apart from tag (#11942) ([65a637d](https://github.com/bitnami/charts/commit/65a637d)), closes [#11942](https://github.com/bitnami/charts/issues/11942)
+
+## <small>11.7.6 (2022-08-21)</small>
+
+* [bitnami/postgresql] Release 11.7.6 (#11964) ([7e27b34](https://github.com/bitnami/charts/commit/7e27b34)), closes [#11964](https://github.com/bitnami/charts/issues/11964)
+
+## <small>11.7.5 (2022-08-20)</small>
+
+* [bitnami/postgresql] Release 11.7.5 (#11868) ([bf274f7](https://github.com/bitnami/charts/commit/bf274f7)), closes [#11868](https://github.com/bitnami/charts/issues/11868)
+
+## <small>11.7.4 (2022-08-19)</small>
+
+* [bitnami/postgresql] Release 11.7.4 (#11860) ([c7d6cc7](https://github.com/bitnami/charts/commit/c7d6cc7)), closes [#11860](https://github.com/bitnami/charts/issues/11860)
+
+## <small>11.7.3 (2022-08-17)</small>
+
+* [bitnami/postgresql] Release 11.7.3 (#11816) ([a3d2ec6](https://github.com/bitnami/charts/commit/a3d2ec6)), closes [#11816](https://github.com/bitnami/charts/issues/11816)
+
+## <small>11.7.2 (2022-08-16)</small>
+
+* [bitnami/postgresql] Release 11.7.2 (#11789) ([d255e13](https://github.com/bitnami/charts/commit/d255e13)), closes [#11789](https://github.com/bitnami/charts/issues/11789)
+
+## <small>11.7.1 (2022-08-11)</small>
+
+* [bitnami/postgresql] Release 11.7.1 (#11735) ([5149dea](https://github.com/bitnami/charts/commit/5149dea)), closes [#11735](https://github.com/bitnami/charts/issues/11735)
+
+## 11.7.0 (2022-08-11)
+
+* [bitnami/postgresql] Allow custom role name for postgresql (#11626) ([110c42e](https://github.com/bitnami/charts/commit/110c42e)), closes [#11626](https://github.com/bitnami/charts/issues/11626)
+
+## <small>11.6.26 (2022-08-09)</small>
+
+* [bitnami/postgresql] Release 11.6.26 (#11662) ([5759dab](https://github.com/bitnami/charts/commit/5759dab)), closes [#11662](https://github.com/bitnami/charts/issues/11662)
+
+## <small>11.6.25 (2022-08-05)</small>
+
+* [bitnami/postgresql] extended configuration for read replicas (#11458) ([58137be](https://github.com/bitnami/charts/commit/58137be)), closes [#11458](https://github.com/bitnami/charts/issues/11458) [#11450](https://github.com/bitnami/charts/issues/11450)
+* [bitnami/postgresql] replication documentation (#11421) ([4955d1d](https://github.com/bitnami/charts/commit/4955d1d)), closes [#11421](https://github.com/bitnami/charts/issues/11421) [#11394](https://github.com/bitnami/charts/issues/11394)
+
+## <small>11.6.24 (2022-08-04)</small>
+
+* [bitnami/postgresql] Release 11.6.24 (#11585) ([44c6dd3](https://github.com/bitnami/charts/commit/44c6dd3)), closes [#11585](https://github.com/bitnami/charts/issues/11585)
+
+## <small>11.6.23 (2022-08-04)</small>
+
+* [bitnami/postgresql] extended configuration for read PVC (#11460) ([651b581](https://github.com/bitnami/charts/commit/651b581)), closes [#11460](https://github.com/bitnami/charts/issues/11460) [#11449](https://github.com/bitnami/charts/issues/11449)
+
+## <small>11.6.22 (2022-08-03)</small>
+
+* [bitnami/postgresql] Release 11.6.22 (#11548) ([52540e9](https://github.com/bitnami/charts/commit/52540e9)), closes [#11548](https://github.com/bitnami/charts/issues/11548)
+
+## <small>11.6.21 (2022-08-01)</small>
+
+* [bitnami/postgresql] Release 11.6.21 (#11441) ([21cc5f9](https://github.com/bitnami/charts/commit/21cc5f9)), closes [#11441](https://github.com/bitnami/charts/issues/11441)
+
+## <small>11.6.20 (2022-07-30)</small>
+
+* [bitnami/*] Update URLs to point to the new bitnami/containers monorepo (#11352) ([d665af0](https://github.com/bitnami/charts/commit/d665af0)), closes [#11352](https://github.com/bitnami/charts/issues/11352)
+* [bitnami/postgresql] Release 11.6.20 (#11437) ([6d9e5c2](https://github.com/bitnami/charts/commit/6d9e5c2)), closes [#11437](https://github.com/bitnami/charts/issues/11437)
+
+## <small>11.6.19 (2022-07-24)</small>
+
+* [bitnami/postgresql] Release 11.6.19 (#11323) ([9efa515](https://github.com/bitnami/charts/commit/9efa515)), closes [#11323](https://github.com/bitnami/charts/issues/11323)
+
+## <small>11.6.18 (2022-07-20)</small>
+
+* [bitnami/postgresql] Release 11.6.18 (#11283) ([cdb4962](https://github.com/bitnami/charts/commit/cdb4962)), closes [#11283](https://github.com/bitnami/charts/issues/11283)
+
+## <small>11.6.17 (2022-07-19)</small>
+
+* [bitnami/postgresql] Release 11.6.17 (#11236) ([6de5828](https://github.com/bitnami/charts/commit/6de5828)), closes [#11236](https://github.com/bitnami/charts/issues/11236)
+
+## <small>11.6.16 (2022-07-12)</small>
+
+* [bitnami/postgresql] Release 11.6.16 (#11155) ([73e661a](https://github.com/bitnami/charts/commit/73e661a)), closes [#11155](https://github.com/bitnami/charts/issues/11155)
+
+## <small>11.6.15 (2022-07-06)</small>
+
+* [bitnami/postgresql] Release 11.6.15 (#11065) ([c4033c8](https://github.com/bitnami/charts/commit/c4033c8)), closes [#11065](https://github.com/bitnami/charts/issues/11065)
+
+## <small>11.6.14 (2022-07-05)</small>
+
+* Fix postgresql read servicemonitor scraping metrics on primary pod (#11018) ([7ba5148](https://github.com/bitnami/charts/commit/7ba5148)), closes [#11018](https://github.com/bitnami/charts/issues/11018)
+
+## <small>11.6.13 (2022-07-04)</small>
+
+* [bitnami/postgresql] add warning regarding setting the password  (#10881) ([69de31e](https://github.com/bitnami/charts/commit/69de31e)), closes [#10881](https://github.com/bitnami/charts/issues/10881)
+
+## <small>11.6.12 (2022-06-30)</small>
+
+* [bitnami/postgresql] Release 11.6.12 (#10971) ([e8f47f9](https://github.com/bitnami/charts/commit/e8f47f9)), closes [#10971](https://github.com/bitnami/charts/issues/10971)
+
+## <small>11.6.11 (2022-06-29)</small>
+
+* [bitnami/postgresql] Typo (#10924) ([d379a39](https://github.com/bitnami/charts/commit/d379a39)), closes [#10924](https://github.com/bitnami/charts/issues/10924)
+
+## <small>11.6.10 (2022-06-25)</small>
+
+* [bitnami/postgresql] Release 11.6.10 updating components versions ([2e145c8](https://github.com/bitnami/charts/commit/2e145c8))
+
+## <small>11.6.9 (2022-06-24)</small>
+
+* [bitnami/postgresql] Release 11.6.9 updating components versions ([9ce3859](https://github.com/bitnami/charts/commit/9ce3859))
+
+## <small>11.6.8 (2022-06-22)</small>
+
+* [bitnami/postgresql] fix postgresql.replicationPasswordKey secret key logic (#10794) ([97cfeb4](https://github.com/bitnami/charts/commit/97cfeb4)), closes [#10794](https://github.com/bitnami/charts/issues/10794)
+
+## <small>11.6.7 (2022-06-17)</small>
+
+* [bitnami/postgresql] Release 11.6.7 updating components versions ([1012be6](https://github.com/bitnami/charts/commit/1012be6))
+
+## <small>11.6.6 (2022-06-10)</small>
+
+* [bitnami/postgresql] Release 11.6.6 updating components versions ([37b811c](https://github.com/bitnami/charts/commit/37b811c))
+
+## <small>11.6.5 (2022-06-08)</small>
+
+* [bitnami/*] Replace Kubeapps URL in READMEs (and kubeapps Chart.yaml) and remove BKPR references (#1 ([c6a7914](https://github.com/bitnami/charts/commit/c6a7914)), closes [#10600](https://github.com/bitnami/charts/issues/10600)
+* [bitnami/postgresql] Fix topologySpreadConstraints default values (#10640) ([85ff7f5](https://github.com/bitnami/charts/commit/85ff7f5)), closes [#10640](https://github.com/bitnami/charts/issues/10640)
+
+## <small>11.6.4 (2022-06-07)</small>
+
+* [bitnami/postgresql] Release 11.6.4 updating components versions ([aa2e023](https://github.com/bitnami/charts/commit/aa2e023))
+
+## <small>11.6.3 (2022-06-04)</small>
+
+* [bitnami/postgresql] Release 11.6.3 updating components versions ([540669f](https://github.com/bitnami/charts/commit/540669f))
+
+## <small>11.6.2 (2022-06-02)</small>
+
+* [bitnami/postgresql] Ldap postgresql (#10528) ([af0ded6](https://github.com/bitnami/charts/commit/af0ded6)), closes [#10528](https://github.com/bitnami/charts/issues/10528)
+
+## <small>11.6.1 (2022-06-01)</small>
+
+* [bitnami/several] Replace maintainers email by url (#10523) ([ff3cf61](https://github.com/bitnami/charts/commit/ff3cf61)), closes [#10523](https://github.com/bitnami/charts/issues/10523)
+
+## 11.6.0 (2022-05-31)
+
+* [bitnami/postgresql] LDAP standardisation (#10464) ([4bfda62](https://github.com/bitnami/charts/commit/4bfda62)), closes [#10464](https://github.com/bitnami/charts/issues/10464)
+
+## <small>11.5.2 (2022-05-30)</small>
+
+* [bitnami/several] Replace base64 --decode with base64 -d (#10495) ([099286a](https://github.com/bitnami/charts/commit/099286a)), closes [#10495](https://github.com/bitnami/charts/issues/10495)
+
+## <small>11.5.1 (2022-05-30)</small>
+
+* [bitnami/postgresql] Fix issue with upgrade to 11.3.0 (#10452) ([38ecf5a](https://github.com/bitnami/charts/commit/38ecf5a)), closes [#10452](https://github.com/bitnami/charts/issues/10452)
+
+## 11.5.0 (2022-05-27)
+
+* [bitnami/postgresql] Fix LDAP settings (#10449) ([3f94d34](https://github.com/bitnami/charts/commit/3f94d34)), closes [#10449](https://github.com/bitnami/charts/issues/10449)
+
+## 11.4.0 (2022-05-26)
+
+* [bitnami/postgresql] Add missing service parameter (#10434) ([dae498b](https://github.com/bitnami/charts/commit/dae498b)), closes [#10434](https://github.com/bitnami/charts/issues/10434)
+
+## 11.3.0 (2022-05-26)
+
+* [bitnami/postgresql] Make existing secret key names choosable (#10347) ([2c207c0](https://github.com/bitnami/charts/commit/2c207c0)), closes [#10347](https://github.com/bitnami/charts/issues/10347)
+
+## <small>11.2.6 (2022-05-21)</small>
+
+* [bitnami/postgresql] Release 11.2.6 updating components versions ([7ab2181](https://github.com/bitnami/charts/commit/7ab2181))
+
+## <small>11.2.5 (2022-05-20)</small>
+
+* [bitnami/postgresql] Release 11.2.5 updating components versions ([fbdd2c9](https://github.com/bitnami/charts/commit/fbdd2c9))
+
+## <small>11.2.4 (2022-05-18)</small>
+
+* [bitnami/postgresql] Release 11.2.4 updating components versions ([9ae8afb](https://github.com/bitnami/charts/commit/9ae8afb))
+
+## <small>11.2.3 (2022-05-16)</small>
+
+* [bitnami/postgresql] Release 11.2.3 updating components versions ([8a35afa](https://github.com/bitnami/charts/commit/8a35afa))
+
+## <small>11.2.2 (2022-05-16)</small>
+
+* [bitnami/postgresql] Fix path to entrypoint.sh (#10056) ([b92c842](https://github.com/bitnami/charts/commit/b92c842)), closes [#10056](https://github.com/bitnami/charts/issues/10056)
+* Fix error 'Error: ConfigMap in version v1 cannot be handled as a ConfigMap' (#10222) ([905260a](https://github.com/bitnami/charts/commit/905260a)), closes [#10222](https://github.com/bitnami/charts/issues/10222)
+
+## <small>11.2.1 (2022-05-13)</small>
+
+* [bitnami/postgresql] Release 11.2.1 updating components versions ([8b0d74c](https://github.com/bitnami/charts/commit/8b0d74c))
+
+## 11.2.0 (2022-05-13)
+
+* [bitnami/postgresql] Add metrics support to read replica (#9881) ([50bcacc](https://github.com/bitnami/charts/commit/50bcacc)), closes [#9881](https://github.com/bitnami/charts/issues/9881)
+
+## <small>11.1.29 (2022-05-13)</small>
+
+* [bitnami/*] Remove old 'ci' files (#10171) ([5df30c4](https://github.com/bitnami/charts/commit/5df30c4)), closes [#10171](https://github.com/bitnami/charts/issues/10171)
+* [bitnami/postgresql] Release 11.1.29 updating components versions ([b42600d](https://github.com/bitnami/charts/commit/b42600d))
+
+## <small>11.1.28 (2022-05-05)</small>
+
+* [bitnami/postgresql] Release 11.1.28 updating components versions ([b955e3c](https://github.com/bitnami/charts/commit/b955e3c))
+
+## <small>11.1.27 (2022-05-04)</small>
+
+* [bitnami/postgresql] Release 11.1.27 updating components versions ([4cab988](https://github.com/bitnami/charts/commit/4cab988))
+
+## <small>11.1.26 (2022-05-02)</small>
+
+* [bitnami/postgresql] Release 11.1.26 updating components versions ([35bc32d](https://github.com/bitnami/charts/commit/35bc32d))
+
+## <small>11.1.25 (2022-04-26)</small>
+
+* [bitnami/postgresql] Remove unnecessary quotes (#9841) ([1d2fc06](https://github.com/bitnami/charts/commit/1d2fc06)), closes [#9841](https://github.com/bitnami/charts/issues/9841)
+
+## <small>11.1.24 (2022-04-24)</small>
+
+* [bitnami/postgresql] Release 11.1.24 updating components versions ([2fb5f5a](https://github.com/bitnami/charts/commit/2fb5f5a))
+
+## <small>11.1.23 (2022-04-22)</small>
+
+* [bitnami/postgresql] Release 11.1.23 updating components versions ([8d9c25b](https://github.com/bitnami/charts/commit/8d9c25b))
+
+## <small>11.1.22 (2022-04-20)</small>
+
+* [bitnami/postgresql] Release 11.1.22 updating components versions ([7d36205](https://github.com/bitnami/charts/commit/7d36205))
+
+## <small>11.1.21 (2022-04-19)</small>
+
+* [bitnami/postgresql] Release 11.1.21 updating components versions ([634995a](https://github.com/bitnami/charts/commit/634995a))
+* [bitnami/postgresql] Update README with documentation of required keys for auth secrets (#9670) ([2ffbdff](https://github.com/bitnami/charts/commit/2ffbdff)), closes [#9670](https://github.com/bitnami/charts/issues/9670)
+
+## <small>11.1.20 (2022-04-16)</small>
+
+* [bitnami/postgresql] Release 11.1.20 updating components versions ([f98daf3](https://github.com/bitnami/charts/commit/f98daf3))
+
+## <small>11.1.19 (2022-04-07)</small>
+
+* [bitnami/postgresql] Release 11.1.19 updating components versions ([ea7531a](https://github.com/bitnami/charts/commit/ea7531a))
+
+## <small>11.1.18 (2022-04-07)</small>
+
+* [bitnami/postgresql] Add quote to namespace (#9691) ([515833f](https://github.com/bitnami/charts/commit/515833f)), closes [#9691](https://github.com/bitnami/charts/issues/9691)
+
+## <small>11.1.17 (2022-04-06)</small>
+
+* [bitnami/postgresql] Release 11.1.17 updating components versions ([b933e90](https://github.com/bitnami/charts/commit/b933e90))
+
+## <small>11.1.16 (2022-04-05)</small>
+
+* [bitnami/postgresql] Release 11.1.16 updating components versions ([b091550](https://github.com/bitnami/charts/commit/b091550))
+
+## <small>11.1.15 (2022-04-03)</small>
+
+* [bitnami/postgresql] Release 11.1.15 updating components versions ([a1c6668](https://github.com/bitnami/charts/commit/a1c6668))
+
+## <small>11.1.14 (2022-04-02)</small>
+
+* [bitnami/postgresql] Release 11.1.14 updating components versions ([6a32408](https://github.com/bitnami/charts/commit/6a32408))
+
+## <small>11.1.13 (2022-04-01)</small>
+
+* Add missing quote in postgresql RBAC Role manifest (#9651) ([b87abf3](https://github.com/bitnami/charts/commit/b87abf3)), closes [#9651](https://github.com/bitnami/charts/issues/9651)
+
+## <small>11.1.12 (2022-03-28)</small>
+
+* [bitnami/postgresql] Release 11.1.12 updating components versions ([44c70b3](https://github.com/bitnami/charts/commit/44c70b3))
+
+## <small>11.1.11 (2022-03-27)</small>
+
+* [bitnami/postgresql] Release 11.1.11 updating components versions ([f288cf2](https://github.com/bitnami/charts/commit/f288cf2))
+
+## <small>11.1.10 (2022-03-26)</small>
+
+* [bitnami/postgresql] Release 11.1.10 updating components versions ([077c6b3](https://github.com/bitnami/charts/commit/077c6b3))
+
+## <small>11.1.9 (2022-03-18)</small>
+
+* [bitnami/postgresql] Quote POSTGRESQL_INITSCRIPTS_PASSWORD (#9453) ([dcc33b4](https://github.com/bitnami/charts/commit/dcc33b4)), closes [#9453](https://github.com/bitnami/charts/issues/9453) [#9445](https://github.com/bitnami/charts/issues/9445)
+
+## <small>11.1.8 (2022-03-16)</small>
+
+* [bitnami/postgresql] Release 11.1.8 updating components versions ([bcfe8d0](https://github.com/bitnami/charts/commit/bcfe8d0))
+
+## <small>11.1.7 (2022-03-14)</small>
+
+* [bitnami/postgresql] Release 11.1.7 updating components versions ([027d9a0](https://github.com/bitnami/charts/commit/027d9a0))
+
+## <small>11.1.6 (2022-03-10)</small>
+
+* fix missing namespace in network policies (#9369) ([d7fb427](https://github.com/bitnami/charts/commit/d7fb427)), closes [#9369](https://github.com/bitnami/charts/issues/9369)
+
+## <small>11.1.5 (2022-03-09)</small>
+
+* [bitnami/postgresql] Release 11.1.5 updating components versions ([2e9e8bb](https://github.com/bitnami/charts/commit/2e9e8bb))
+
+## <small>11.1.4 (2022-03-06)</small>
+
+* [bitnami/postgresql] Release 11.1.4 updating components versions ([8d9ca8b](https://github.com/bitnami/charts/commit/8d9ca8b))
+
+## <small>11.1.3 (2022-02-27)</small>
+
+* [bitnami/postgresql] Release 11.1.3 updating components versions ([63264c9](https://github.com/bitnami/charts/commit/63264c9))
+
+## <small>11.1.2 (2022-02-26)</small>
+
+* [bitnami/postgresql] docs: :memo: Add note about using the container entrypoint (#9160) ([f547c0a](https://github.com/bitnami/charts/commit/f547c0a)), closes [#9160](https://github.com/bitnami/charts/issues/9160)
+* [bitnami/postgresql] Release 11.1.2 updating components versions ([61501b4](https://github.com/bitnami/charts/commit/61501b4))
+
+## <small>11.1.1 (2022-02-22)</small>
+
+* [bitnami/postgresql] Release 11.1.1 updating components versions ([60388c2](https://github.com/bitnami/charts/commit/60388c2))
+
+## 11.1.0 (2022-02-22)
+
+* Add hostIPC option for PostgreSQL StatefulSets (#9148) ([2f7d7dc](https://github.com/bitnami/charts/commit/2f7d7dc)), closes [#9148](https://github.com/bitnami/charts/issues/9148)
+
+## <small>11.0.8 (2022-02-21)</small>
+
+* [bitnami/postgresql] Add flag '-r' to xargs in volumePermissions init-container (#9137) ([49fcd78](https://github.com/bitnami/charts/commit/49fcd78)), closes [#9137](https://github.com/bitnami/charts/issues/9137)
+* Add hostNetwork option for PostgreSQL StatefulSets (#9064) ([a71f525](https://github.com/bitnami/charts/commit/a71f525)), closes [#9064](https://github.com/bitnami/charts/issues/9064)
+
+## <small>11.0.7 (2022-02-21)</small>
+
+* Fix Typo in README (#9031) ([b0c3bfd](https://github.com/bitnami/charts/commit/b0c3bfd)), closes [#9031](https://github.com/bitnami/charts/issues/9031)
+
+## <small>11.0.6 (2022-02-17)</small>
+
+* [bitnami/postgresql] fix init-chmod-data resources value rendering (#9053) ([1b4eac8](https://github.com/bitnami/charts/commit/1b4eac8)), closes [#9053](https://github.com/bitnami/charts/issues/9053)
+
+## <small>11.0.5 (2022-02-17)</small>
+
+* [bitnami/postgresql] Allow enabling TLS without volume-permissions (#9016) ([6cb95db](https://github.com/bitnami/charts/commit/6cb95db)), closes [#9016](https://github.com/bitnami/charts/issues/9016)
+
+## <small>11.0.4 (2022-02-14)</small>
+
+* [bitnami/postgresql] Fix init scripts cm reference (#9000) ([6fd13e2](https://github.com/bitnami/charts/commit/6fd13e2)), closes [#9000](https://github.com/bitnami/charts/issues/9000)
+
+## <small>11.0.3 (2022-02-11)</small>
+
+* Non utf8 chars (#8923) ([6ffd18f](https://github.com/bitnami/charts/commit/6ffd18f)), closes [#8923](https://github.com/bitnami/charts/issues/8923)
+* Postgresql .Values.global.postgresql.auth.username should overwrite .Values.auth.username, (#8966) ([c75fef7](https://github.com/bitnami/charts/commit/c75fef7)), closes [#8966](https://github.com/bitnami/charts/issues/8966)
+
+## <small>11.0.2 (2022-02-04)</small>
+
+* [bitnami/postgresql] Fix PostgreSLQ password in metrics container (#8901) ([86646ba](https://github.com/bitnami/charts/commit/86646ba)), closes [#8901](https://github.com/bitnami/charts/issues/8901)
+
+## <small>11.0.1 (2022-02-03)</small>
+
+* [bitnami/postgresql] Fix "postgresql.primary.extendedConfigmapName" named template (#8885) ([8dc8906](https://github.com/bitnami/charts/commit/8dc8906)), closes [#8885](https://github.com/bitnami/charts/issues/8885)
+* Fix typo in values.yaml ([7e84425](https://github.com/bitnami/charts/commit/7e84425))
+
+## 11.0.0 (2022-02-02)
+
+* [bitnami/postgresql] Chart standardization (#8827) ([50946fd](https://github.com/bitnami/charts/commit/50946fd)), closes [#8827](https://github.com/bitnami/charts/issues/8827)
+
+## <small>10.16.3 (2022-02-02)</small>
+
+* [bitnami/postgresql] Release 10.16.3 updating components versions ([2710bae](https://github.com/bitnami/charts/commit/2710bae))
+
+## <small>10.16.2 (2022-01-20)</small>
+
+* [bitnami/*] Readme automation (#8579) ([78d1938](https://github.com/bitnami/charts/commit/78d1938)), closes [#8579](https://github.com/bitnami/charts/issues/8579)
+* [bitnami/*] Update READMEs (#8716) ([b9a9533](https://github.com/bitnami/charts/commit/b9a9533)), closes [#8716](https://github.com/bitnami/charts/issues/8716)
+* [bitnami/several] Change prerequisites (#8725) ([8d740c5](https://github.com/bitnami/charts/commit/8d740c5)), closes [#8725](https://github.com/bitnami/charts/issues/8725)
+
+## <small>10.16.1 (2022-01-12)</small>
+
+* [bitnami/postgresql]: Fix typo (#8632) ([c7ad959](https://github.com/bitnami/charts/commit/c7ad959)), closes [#8632](https://github.com/bitnami/charts/issues/8632)
+
+## 10.16.0 (2022-01-11)
+
+* [bitnami/postgresql]: add snapshot recovery (#8618) ([e73f9a7](https://github.com/bitnami/charts/commit/e73f9a7)), closes [#8618](https://github.com/bitnami/charts/issues/8618)
+
+## <small>10.15.2 (2022-01-11)</small>
+
+* [bitnami/postgresql] Release 10.15.2 updating components versions ([f5c23f6](https://github.com/bitnami/charts/commit/f5c23f6))
+* [bitnami/postgresql]: fix unique services template render (#8581) ([66f657d](https://github.com/bitnami/charts/commit/66f657d)), closes [#8581](https://github.com/bitnami/charts/issues/8581)
+
+## <small>10.15.1 (2022-01-06)</small>
+
+* [bitnami/postgresql] Release 10.15.1 updating components versions ([2efb970](https://github.com/bitnami/charts/commit/2efb970))
+
+## 10.15.0 (2022-01-05)
+
+* [bitnami/several] Adapt templating format (#8562) ([8cad18a](https://github.com/bitnami/charts/commit/8cad18a)), closes [#8562](https://github.com/bitnami/charts/issues/8562)
+
+## <small>10.14.4 (2022-01-04)</small>
+
+* [bitnami/postgresql] Release 10.14.4 updating components versions ([ad7ac95](https://github.com/bitnami/charts/commit/ad7ac95))
+
+## <small>10.14.3 (2022-01-04)</small>
+
+* [bitnami/postgresql] Release 10.14.3 updating components versions ([9f7ac81](https://github.com/bitnami/charts/commit/9f7ac81))
+* [bitnami/several] Add license to the README ([05f7633](https://github.com/bitnami/charts/commit/05f7633))
+* [bitnami/several] Add license to the README ([32fb238](https://github.com/bitnami/charts/commit/32fb238))
+* [bitnami/several] Add license to the README ([b87c2f7](https://github.com/bitnami/charts/commit/b87c2f7))
+
+## <small>10.14.2 (2021-12-31)</small>
+
+* [bitnami/postgresql] Release 10.14.2 updating components versions ([4b05bb5](https://github.com/bitnami/charts/commit/4b05bb5))
+
+## <small>10.14.1 (2021-12-31)</small>
+
+* remove password empty validation (#8534) ([a6a4cd1](https://github.com/bitnami/charts/commit/a6a4cd1)), closes [#8534](https://github.com/bitnami/charts/issues/8534)
+
+## 10.14.0 (2021-12-28)
+
+* [bitnami/postgresql] feat: :sparkles: Allow separate container port  and service port (#8506) ([9d6fbea](https://github.com/bitnami/charts/commit/9d6fbea)), closes [#8506](https://github.com/bitnami/charts/issues/8506)
+
+## <small>10.13.15 (2021-12-22)</small>
+
+* [bitnami/postgresql] lookup existing secrets before generating random secrets (#8320) ([00fbcf1](https://github.com/bitnami/charts/commit/00fbcf1)), closes [#8320](https://github.com/bitnami/charts/issues/8320)
+
+## <small>10.13.14 (2021-12-10)</small>
+
+* Render template values inside initDbScripts (#8368) ([73ae007](https://github.com/bitnami/charts/commit/73ae007)), closes [#8368](https://github.com/bitnami/charts/issues/8368)
+
+## <small>10.13.13 (2021-12-10)</small>
+
+* [bitnami/postgresql] Add template render for extraVolumeMounts (#8355) ([b547831](https://github.com/bitnami/charts/commit/b547831)), closes [#8355](https://github.com/bitnami/charts/issues/8355)
+
+## <small>10.13.12 (2021-12-09)</small>
+
+* [bitnami/cassandra,etcd,influxdb,metallb,mysql,postgresql,postgresql-ha,redis] Align networkpolicy   ([0404b1a](https://github.com/bitnami/charts/commit/0404b1a)), closes [#8336](https://github.com/bitnami/charts/issues/8336)
+
+## <small>10.13.11 (2021-12-02)</small>
+
+* [bitnami/*] Fix parameters for schema generation (#8297) ([d7d52ac](https://github.com/bitnami/charts/commit/d7d52ac)), closes [#8297](https://github.com/bitnami/charts/issues/8297)
+* [bitnami/several] Regenerate README tables ([a7b2fde](https://github.com/bitnami/charts/commit/a7b2fde))
+
+## <small>10.13.10 (2021-11-30)</small>
+
+* [bitnami/postgresql] Release 10.13.10 updating components versions ([197a5ba](https://github.com/bitnami/charts/commit/197a5ba))
+
+## <small>10.13.9 (2021-11-29)</small>
+
+* [bitnami/several] Regenerate README tables ([e6f742c](https://github.com/bitnami/charts/commit/e6f742c))
+* [bitnami/several] Replace HTTP by HTTPS when possible (#8259) ([eafb5bd](https://github.com/bitnami/charts/commit/eafb5bd)), closes [#8259](https://github.com/bitnami/charts/issues/8259)
+
+## <small>10.13.8 (2021-11-11)</small>
+
+* [bitnami/postgresql] Release 10.13.8 updating components versions ([e732946](https://github.com/bitnami/charts/commit/e732946))
+* [bitnami/several] Regenerate README tables ([14b89ea](https://github.com/bitnami/charts/commit/14b89ea))
+
+## <small>10.13.7 (2021-11-09)</small>
+
+* [bitnami/postgresql] Release 10.13.7 updating components versions ([2e175bd](https://github.com/bitnami/charts/commit/2e175bd))
+* [bitnami/several] Regenerate README tables ([94d0553](https://github.com/bitnami/charts/commit/94d0553))
+
+## <small>10.13.6 (2021-11-09)</small>
+
+* [bitnami/postgresql] Release 10.13.6 updating components versions ([eec1fd2](https://github.com/bitnami/charts/commit/eec1fd2))
+* [bitnami/several] Regenerate README tables ([ef52074](https://github.com/bitnami/charts/commit/ef52074))
+
+## <small>10.13.5 (2021-11-06)</small>
+
+* [bitnami/postgresql] Release 10.13.5 updating components versions ([1829119](https://github.com/bitnami/charts/commit/1829119))
+* [bitnami/several] Regenerate README tables ([3cefed3](https://github.com/bitnami/charts/commit/3cefed3))
+
+## <small>10.13.4 (2021-11-01)</small>
+
+* [bitnami/postgresql] Release 10.13.4 updating components versions ([43ecac9](https://github.com/bitnami/charts/commit/43ecac9))
+
+## <small>10.13.3 (2021-11-01)</small>
+
+* [bitnami/postgresql] Release 10.13.3 updating components versions ([bae6820](https://github.com/bitnami/charts/commit/bae6820))
+
+## <small>10.13.2 (2021-10-30)</small>
+
+* [bitnami/postgresql] Release 10.13.2 updating components versions ([dc5ec05](https://github.com/bitnami/charts/commit/dc5ec05))
+
+## <small>10.13.1 (2021-10-29)</small>
+
+* [bitnami/postgresql] Release 10.13.1 updating components versions ([b6fd8cd](https://github.com/bitnami/charts/commit/b6fd8cd))
+
+## 10.13.0 (2021-10-28)
+
+* [bitnami/postgresql] add common labels (#7952) ([e2404c6](https://github.com/bitnami/charts/commit/e2404c6)), closes [#7952](https://github.com/bitnami/charts/issues/7952)
+
+## <small>10.12.9 (2021-10-28)</small>
+
+* [bitnami/*] Mark PodSecurityPolicy resources as deprecated (#7951) ([035d926](https://github.com/bitnami/charts/commit/035d926)), closes [#7951](https://github.com/bitnami/charts/issues/7951)
+* [bitnami/postgresql] Add template render for labels on primary and readreplicas (#7908) ([9a5a9f3](https://github.com/bitnami/charts/commit/9a5a9f3)), closes [#7908](https://github.com/bitnami/charts/issues/7908)
+* [bitnami/several] Regenerate README tables ([412cf6a](https://github.com/bitnami/charts/commit/412cf6a))
+
+## <small>10.12.8 (2021-10-26)</small>
+
+* [bitnami/postgresql] Release 10.12.8 updating components versions ([e2ce1a5](https://github.com/bitnami/charts/commit/e2ce1a5))
+
+## <small>10.12.7 (2021-10-22)</small>
+
+* [bitnami/several] Add chart info to NOTES.txt (#7889) ([a6751cd](https://github.com/bitnami/charts/commit/a6751cd)), closes [#7889](https://github.com/bitnami/charts/issues/7889)
+* [bitnami/several] Regenerate README tables ([73cabea](https://github.com/bitnami/charts/commit/73cabea))
+
+## <small>10.12.6 (2021-10-21)</small>
+
+* [bitnami/postgresql] Release 10.12.6 updating components versions ([0c8b19d](https://github.com/bitnami/charts/commit/0c8b19d))
+
+## <small>10.12.5 (2021-10-19)</small>
+
+* [bitnami/several] Change pullPolicy for bitnami-shell image (#7852) ([9711a33](https://github.com/bitnami/charts/commit/9711a33)), closes [#7852](https://github.com/bitnami/charts/issues/7852)
+* [bitnami/several] Regenerate README tables ([dd25873](https://github.com/bitnami/charts/commit/dd25873))
+
+## <small>10.12.4 (2021-10-13)</small>
+
+* [bitnami/postgresql] Release 10.12.4 updating components versions ([b30ed79](https://github.com/bitnami/charts/commit/b30ed79))
+* [bitnami/several] Regenerate README tables ([194a909](https://github.com/bitnami/charts/commit/194a909))
+
+## <small>10.12.3 (2021-10-11)</small>
+
+* [bitnami/postgresql] Release 10.12.3 updating components versions ([7671c64](https://github.com/bitnami/charts/commit/7671c64))
+
+## <small>10.12.2 (2021-10-05)</small>
+
+* [bitnami/*] Revert changes in values.schemas.json (#7699) ([aaa314f](https://github.com/bitnami/charts/commit/aaa314f)), closes [#7699](https://github.com/bitnami/charts/issues/7699)
+
+## <small>10.12.1 (2021-10-05)</small>
+
+* [bitnami/postgresql] Fix README format (#7698) ([76ceb2c](https://github.com/bitnami/charts/commit/76ceb2c)), closes [#7698](https://github.com/bitnami/charts/issues/7698)
+
+## 10.12.0 (2021-09-29)
+
+* [bitnami/apache,tomcat] add extraPodSpec (#7580) ([e3a8529](https://github.com/bitnami/charts/commit/e3a8529)), closes [#7580](https://github.com/bitnami/charts/issues/7580)
+
+## 10.11.0 (2021-09-27)
+
+* [bitnami/apache,postgresql,tomcat] add topologySpreadConstraints (#7598) ([557bfe9](https://github.com/bitnami/charts/commit/557bfe9)), closes [#7598](https://github.com/bitnami/charts/issues/7598)
+
+## <small>10.10.3 (2021-09-24)</small>
+
+* [bitnami/*] Generate READMEs with new generator version (#7614) ([e5ab2e6](https://github.com/bitnami/charts/commit/e5ab2e6)), closes [#7614](https://github.com/bitnami/charts/issues/7614)
+* [bitnami/postgresql, zookeeper] Modify extravolumes and integrate sidecars (#7555) ([c4c4082](https://github.com/bitnami/charts/commit/c4c4082)), closes [#7555](https://github.com/bitnami/charts/issues/7555)
+* [bitnami/several] Regenerate README tables ([79eac44](https://github.com/bitnami/charts/commit/79eac44))
+
+## <small>10.10.2 (2021-09-22)</small>
+
+* [bitnami/postgresql] Release 10.10.2 updating components versions ([edba74c](https://github.com/bitnami/charts/commit/edba74c))
+* [bitnami/several] Regenerate README tables ([003a0fb](https://github.com/bitnami/charts/commit/003a0fb))
+
+## <small>10.10.1 (2021-09-16)</small>
+
+* Fix linting issue from PR7490 (#7506) ([ede16d7](https://github.com/bitnami/charts/commit/ede16d7)), closes [#7506](https://github.com/bitnami/charts/issues/7506)
+
+## 10.10.0 (2021-09-16)
+
+* [bitnami/postgresql] add `externalTrafficPolicy` to service type `LoadBalancer` (#7490) ([553182e](https://github.com/bitnami/charts/commit/553182e)), closes [#7490](https://github.com/bitnami/charts/issues/7490)
+
+## <small>10.9.6 (2021-09-15)</small>
+
+* [bitnami/postgresql] Release 10.9.6 updating components versions ([c8142cd](https://github.com/bitnami/charts/commit/c8142cd))
+* [bitnami/several] Regenerate README tables ([c01cbe5](https://github.com/bitnami/charts/commit/c01cbe5))
+
+## <small>10.9.5 (2021-09-07)</small>
+
+* [bitnami/postgresql] Release 10.9.5 updating components versions ([94b8fdc](https://github.com/bitnami/charts/commit/94b8fdc))
+* [bitnami/several] Regenerate README tables ([da2513b](https://github.com/bitnami/charts/commit/da2513b))
+
+## <small>10.9.4 (2021-08-25)</small>
+
+* [bitnami/postgresql] Release 10.9.4 updating components versions ([7cbc202](https://github.com/bitnami/charts/commit/7cbc202))
+* [bitnami/several] Regenerate README tables ([6c9124f](https://github.com/bitnami/charts/commit/6c9124f))
+
+## <small>10.9.3 (2021-08-18)</small>
+
+* [multiple] Updated image.tag section (#7257) ([a133bed](https://github.com/bitnami/charts/commit/a133bed)), closes [#7257](https://github.com/bitnami/charts/issues/7257)
+
+## <small>10.9.2 (2021-08-12)</small>
+
+* [bitnami/postgresql] Release 10.9.2 updating components versions ([c0cf478](https://github.com/bitnami/charts/commit/c0cf478))
+* [bitnami/several] Regenerate README tables ([6c107e8](https://github.com/bitnami/charts/commit/6c107e8))
+
+## <small>10.9.1 (2021-08-04)</small>
+
+* [bitnami/postgresql] Release 10.9.1 updating components versions ([95fa5ae](https://github.com/bitnami/charts/commit/95fa5ae))
+
+## 10.9.0 (2021-08-02)
+
+* [bitnami/postgresql] Add relabelings / metricRelabelings to ServiceMonitor (#7082) ([481cc7e](https://github.com/bitnami/charts/commit/481cc7e)), closes [#7082](https://github.com/bitnami/charts/issues/7082)
+* [bitnami/several] Add diagnostic mode (#7012) ([f1344b0](https://github.com/bitnami/charts/commit/f1344b0)), closes [#7012](https://github.com/bitnami/charts/issues/7012)
+* [bitnami/several] Upadte READMEs ([eb3c291](https://github.com/bitnami/charts/commit/eb3c291))
+
+## 10.8.0 (2021-07-27)
+
+* [bitnami/postgresql] Add lifecycleHooks value to the postgresql chart (#7055) ([e631584](https://github.com/bitnami/charts/commit/e631584)), closes [#7055](https://github.com/bitnami/charts/issues/7055)
+
+## <small>10.7.1 (2021-07-23)</small>
+
+* [bitnami/postgresql] Change postgresqlExtendedConf default value from string to object (#7038) ([c55ff60](https://github.com/bitnami/charts/commit/c55ff60)), closes [#7038](https://github.com/bitnami/charts/issues/7038)
+
+## 10.7.0 (2021-07-21)
+
+* [bitnami/postgresql] Add option to create services for each read replica (#6990) ([3d76ba7](https://github.com/bitnami/charts/commit/3d76ba7)), closes [#6990](https://github.com/bitnami/charts/issues/6990) [bitnami/charts#6954](https://github.com/bitnami/charts/issues/6954)
+
+## <small>10.6.1 (2021-07-20)</small>
+
+* [bitnami/several] Fix default values and regenerate README (II) (#6994) ([d095793](https://github.com/bitnami/charts/commit/d095793)), closes [#6994](https://github.com/bitnami/charts/issues/6994)
+
+## 10.6.0 (2021-07-19)
+
+* [bitnami/postgresql] disable automounting of service account token (#6967) ([3a60437](https://github.com/bitnami/charts/commit/3a60437)), closes [#6967](https://github.com/bitnami/charts/issues/6967)
+
+## <small>10.5.3 (2021-07-14)</small>
+
+* [bitnami/*] Adapt values.yaml of phpMyAdmin, PostgreSQL and PostgreSQL HA charts (#6933) ([49f0bed](https://github.com/bitnami/charts/commit/49f0bed)), closes [#6933](https://github.com/bitnami/charts/issues/6933)
+
+## <small>10.5.2 (2021-07-06)</small>
+
+* [bitnami/postgresql] Release 10.5.2 updating components versions ([d7e126c](https://github.com/bitnami/charts/commit/d7e126c))
+
+## <small>10.5.1 (2021-06-29)</small>
+
+* [bitnami/postgresql] Release 10.5.1 updating components versions ([859c5bf](https://github.com/bitnami/charts/commit/859c5bf))
+
+## 10.5.0 (2021-06-14)
+
+* [bitnami/postgresql] Add support for autogenerated certs (#6609) ([112db1c](https://github.com/bitnami/charts/commit/112db1c)), closes [#6609](https://github.com/bitnami/charts/issues/6609)
+
+## <small>10.4.10 (2021-06-09)</small>
+
+* [bitnami/postgresql] Release 10.4.10 updating components versions ([8671e25](https://github.com/bitnami/charts/commit/8671e25))
+
+## <small>10.4.9 (2021-06-03)</small>
+
+* [bitnami/postgresql] Release 10.4.9 updating components versions ([36ab336](https://github.com/bitnami/charts/commit/36ab336))
+
+## <small>10.4.8 (2021-05-27)</small>
+
+* [bitnami/postgresql] Release 10.4.8 updating components versions ([bd13ba8](https://github.com/bitnami/charts/commit/bd13ba8))
+
+## <small>10.4.7 (2021-05-25)</small>
+
+* [bitnami/postgresql] Release 10.4.7 updating components versions ([86aeb2c](https://github.com/bitnami/charts/commit/86aeb2c))
+
+## <small>10.4.6 (2021-05-19)</small>
+
+* [bitnami/postgresql] Release 10.4.6 updating components versions ([14c777e](https://github.com/bitnami/charts/commit/14c777e))
+
+## <small>10.4.5 (2021-05-14)</small>
+
+* [bitnami/postgresql] Release 10.4.5 updating components versions ([091d4c9](https://github.com/bitnami/charts/commit/091d4c9))
+
+## <small>10.4.4 (2021-05-14)</small>
+
+* [bitnami/postgresql] Release 10.4.4 updating components versions ([ff6296d](https://github.com/bitnami/charts/commit/ff6296d))
+
+## <small>10.4.3 (2021-05-07)</small>
+
+* [bitnami/postgresql] Release 10.4.3 updating components versions ([03f8228](https://github.com/bitnami/charts/commit/03f8228))
+
+## <small>10.4.2 (2021-05-04)</small>
+
+* [bitnami/postgresql] Release 10.4.2 updating components versions ([b23c573](https://github.com/bitnami/charts/commit/b23c573))
+
+## <small>10.4.1 (2021-05-02)</small>
+
+* [bitnami/postgresql] Release 10.4.1 updating components versions ([157448a](https://github.com/bitnami/charts/commit/157448a))
+
+## 10.4.0 (2021-04-29)
+
+* [bitnami/postgresql] SHM: remove size limit on the emptyDir. (#6232) ([1dbd2a2](https://github.com/bitnami/charts/commit/1dbd2a2)), closes [#6232](https://github.com/bitnami/charts/issues/6232)
+
+## <small>10.3.18 (2021-04-20)</small>
+
+* [bitnami/postgresql] Release 10.3.18 updating components versions ([31a3bef](https://github.com/bitnami/charts/commit/31a3bef))
+
+## <small>10.3.17 (2021-04-11)</small>
+
+* [bitnami/postgresql] Release 10.3.17 updating components versions ([4c72712](https://github.com/bitnami/charts/commit/4c72712))
+
+## <small>10.3.16 (2021-04-09)</small>
+
+* [bitnami/postgresql] Release 10.3.16 updating components versions ([0c80da7](https://github.com/bitnami/charts/commit/0c80da7))
+
+## <small>10.3.15 (2021-04-03)</small>
+
+* [bitnami/postgresql] Fix postgresql.conf generation from values (#5865) ([c572e0b](https://github.com/bitnami/charts/commit/c572e0b)), closes [#5865](https://github.com/bitnami/charts/issues/5865)
+* [bitnami/postgresql] Release 10.3.15 updating components versions ([4085304](https://github.com/bitnami/charts/commit/4085304))
+
+## <small>10.3.14 (2021-03-30)</small>
+
+* [bitnami/postgresql] Release 10.3.14 updating components versions ([40075c7](https://github.com/bitnami/charts/commit/40075c7))
+
+## <small>10.3.13 (2021-03-12)</small>
+
+* [bitnami/postgresql] Release 10.3.13 updating components versions ([0391090](https://github.com/bitnami/charts/commit/0391090))
+
+## <small>10.3.12 (2021-03-11)</small>
+
+* [bitnami/postgresql] Release 10.3.12 updating components versions ([daa0007](https://github.com/bitnami/charts/commit/daa0007))
+
+## <small>10.3.11 (2021-03-05)</small>
+
+* [bitnami/postgresql] Release 10.3.11 updating components versions ([cb37a0e](https://github.com/bitnami/charts/commit/cb37a0e))
+
+## <small>10.3.10 (2021-03-04)</small>
+
+* [bitnami/*] Remove minideb mentions (#5677) ([870bc4d](https://github.com/bitnami/charts/commit/870bc4d)), closes [#5677](https://github.com/bitnami/charts/issues/5677)
+
+## <small>10.3.9 (2021-03-04)</small>
+
+* [bitnami/postgresql] Release 10.3.9 updating components versions ([99d7551](https://github.com/bitnami/charts/commit/99d7551))
+
+## <small>10.3.8 (2021-03-03)</small>
+
+* [bitnami/postgresql] Don't put postgresql-postgres-password in secret when not needed (#5635) ([db08f68](https://github.com/bitnami/charts/commit/db08f68)), closes [#5635](https://github.com/bitnami/charts/issues/5635) [#4380](https://github.com/bitnami/charts/issues/4380)
+
+## <small>10.3.7 (2021-02-26)</small>
+
+* [bitnami/postgresql] Release 10.3.7 updating components versions ([a69d08a](https://github.com/bitnami/charts/commit/a69d08a))
+
+## <small>10.3.6 (2021-02-24)</small>
+
+* [bitnami/postgresql] Release 10.3.6 updating components versions ([078cc97](https://github.com/bitnami/charts/commit/078cc97))
+
+## <small>10.3.5 (2021-02-22)</small>
+
+* [bitnami/*] Use common macro to define RBAC apiVersion (#5585) ([71fb99f](https://github.com/bitnami/charts/commit/71fb99f)), closes [#5585](https://github.com/bitnami/charts/issues/5585)
+
+## <small>10.3.4 (2021-02-20)</small>
+
+* [bitnami/postgresql] Release 10.3.4 updating components versions ([02d06a0](https://github.com/bitnami/charts/commit/02d06a0))
+
+## <small>10.3.3 (2021-02-19)</small>
+
+* [bitnami/postgresql] Release 10.3.3 updating components versions ([b10f2aa](https://github.com/bitnami/charts/commit/b10f2aa))
+
+## <small>10.3.2 (2021-02-15)</small>
+
+* add template postgresql.name (#5489) ([a334a13](https://github.com/bitnami/charts/commit/a334a13)), closes [#5489](https://github.com/bitnami/charts/issues/5489)
+
+## <small>10.3.1 (2021-02-11)</small>
+
+* [bitnami/postgresql] Release 10.3.1 updating components versions ([c2bb81e](https://github.com/bitnami/charts/commit/c2bb81e))
+* Fix typo "sed" => "used" (#5461) ([4373a9a](https://github.com/bitnami/charts/commit/4373a9a)), closes [#5461](https://github.com/bitnami/charts/issues/5461)
+
+## 10.3.0 (2021-02-11)
+
+* [bitnami/*] Add notice regarding parameters immutability after chart installation (#4853) ([5f09573](https://github.com/bitnami/charts/commit/5f09573)), closes [#4853](https://github.com/bitnami/charts/issues/4853)
+* [bitnami/postgresql] add optional startup probe to postgresql (#5445) ([bc9ad41](https://github.com/bitnami/charts/commit/bc9ad41)), closes [#5445](https://github.com/bitnami/charts/issues/5445)
+
+## <small>10.2.8 (2021-02-08)</small>
+
+* [bitnami/postgresql] Release 10.2.8 updating components versions ([bc4c881](https://github.com/bitnami/charts/commit/bc4c881))
+
+## <small>10.2.7 (2021-02-04)</small>
+
+* [bitnami/postgresql] Release 10.2.7 updating components versions ([4383712](https://github.com/bitnami/charts/commit/4383712))
+
+## <small>10.2.6 (2021-01-29)</small>
+
+* [bitnami/Postgresql] Add explicit namespace field on resources (#5333) ([fc694c5](https://github.com/bitnami/charts/commit/fc694c5)), closes [#5333](https://github.com/bitnami/charts/issues/5333)
+
+## <small>10.2.5 (2021-01-25)</small>
+
+* [bitnami/*] Unify icons in Chart.yaml and add missing fields (#5206) ([0462921](https://github.com/bitnami/charts/commit/0462921)), closes [#5206](https://github.com/bitnami/charts/issues/5206)
+
+## <small>10.2.4 (2021-01-22)</small>
+
+* [bitnami/postgresql] Fix value KeepalivesCount typo (#5171) ([09249d3](https://github.com/bitnami/charts/commit/09249d3)), closes [#5171](https://github.com/bitnami/charts/issues/5171)
+
+## <small>10.2.3 (2021-01-19)</small>
+
+* [bitnami/*] Change helm version in the prerequisites (#5090) ([c5e67a3](https://github.com/bitnami/charts/commit/c5e67a3)), closes [#5090](https://github.com/bitnami/charts/issues/5090)
+* [bitnami/postgresql] Drop values-production.yaml support (#5125) ([131711c](https://github.com/bitnami/charts/commit/131711c)), closes [#5125](https://github.com/bitnami/charts/issues/5125)
+
+## <small>10.2.2 (2021-01-12)</small>
+
+* [bitnami/postgresql] Release 10.2.2 updating components versions ([49f9f9f](https://github.com/bitnami/charts/commit/49f9f9f))
+* Clarify sharedBuffers example in postgresql README (#4883) ([38c8044](https://github.com/bitnami/charts/commit/38c8044)), closes [#4883](https://github.com/bitnami/charts/issues/4883)
+
+## <small>10.2.1 (2021-01-04)</small>
+
+* [bitnami/postgresql] Release 10.2.1 updating components versions ([ed749c0](https://github.com/bitnami/charts/commit/ed749c0))
+* Fix REAMDE (#4816) ([2fe0b09](https://github.com/bitnami/charts/commit/2fe0b09)), closes [#4816](https://github.com/bitnami/charts/issues/4816)
+* Fixes some spacing in README.md (#4742) ([2c96f0c](https://github.com/bitnami/charts/commit/2c96f0c)), closes [#4742](https://github.com/bitnami/charts/issues/4742)
+
+## 10.2.0 (2020-12-14)
+
+* [bitnami/*] Affinity based on common presets (vii) (#4701) ([52a2c99](https://github.com/bitnami/charts/commit/52a2c99)), closes [#4701](https://github.com/bitnami/charts/issues/4701)
+* [bitnami/*] fix typos (#4699) ([49adc63](https://github.com/bitnami/charts/commit/49adc63)), closes [#4699](https://github.com/bitnami/charts/issues/4699)
+
+## <small>10.1.4 (2020-12-11)</small>
+
+* [bitnami/*] Update dependencies (#4694) ([2826c12](https://github.com/bitnami/charts/commit/2826c12)), closes [#4694](https://github.com/bitnami/charts/issues/4694)
+
+## <small>10.1.3 (2020-12-07)</small>
+
+* [bitnami/postgresql] Release 10.1.3 updating components versions ([94676b3](https://github.com/bitnami/charts/commit/94676b3))
+
+## <small>10.1.2 (2020-12-04)</small>
+
+* [bitnami/*] Add upgrade details to README (#4480) ([10bd8e1](https://github.com/bitnami/charts/commit/10bd8e1)), closes [#4480](https://github.com/bitnami/charts/issues/4480)
+* [bitnami/postgresql] Release 10.1.2 updating components versions ([494e84e](https://github.com/bitnami/charts/commit/494e84e))
+
+## <small>10.1.1 (2020-11-25)</small>
+
+* [bitnami/postgresql] `postgresql-postgres-password` doesn't work with `global.postgresqlUsername` an ([e0c026c](https://github.com/bitnami/charts/commit/e0c026c)), closes [#3130](https://github.com/bitnami/charts/issues/3130) [#4380](https://github.com/bitnami/charts/issues/4380) [#3130](https://github.com/bitnami/charts/issues/3130) [#3130](https://github.com/bitnami/charts/issues/3130)
+
+## 10.1.0 (2020-11-20)
+
+*  [bitnami/postgresql] Implement persistence selector (#4437) ([e383a6e](https://github.com/bitnami/charts/commit/e383a6e)), closes [#4437](https://github.com/bitnami/charts/issues/4437)
+
+## <small>10.0.2 (2020-11-18)</small>
+
+* [bitnami/postgresql] Fix typo in values.yaml (#4399) ([cf49c8a](https://github.com/bitnami/charts/commit/cf49c8a)), closes [#4399](https://github.com/bitnami/charts/issues/4399)
+* Update README.md ([2006fdf](https://github.com/bitnami/charts/commit/2006fdf))
+
+## <small>10.0.1 (2020-11-17)</small>
+
+* [bitnami/postgresql] Release 10.0.1 updating components versions ([323a092](https://github.com/bitnami/charts/commit/323a092))
+
+## 10.0.0 (2020-11-17)
+
+* [bitnami/postgresql] Adapt to Helm v3 and change nomenclature (#4385) ([7eabc85](https://github.com/bitnami/charts/commit/7eabc85)), closes [#4385](https://github.com/bitnami/charts/issues/4385)
+
+### Breaking change
+
+* removal of Master/Slave
+* Some additional clean up post merge of terms
+* [bitnami/postgresql] Major version. Adapt Chart to apiVersion: v2
+* Update Chart.yaml
+* Delete empty section from README
+Co-authored-by: W. Kavanaugh Latiolais <kavlatiolais@gmail.com>
+Co-authored-by: Carlos Rodríguez Hernández <carlosrh@vmware.com>
+
+## <small>9.8.13 (2020-11-14)</small>
+
+* [bitnami/postgresql] Release 9.8.13 updating components versions ([fd890aa](https://github.com/bitnami/charts/commit/fd890aa))
+
+## <small>9.8.12 (2020-11-12)</small>
+
+* [bitnami/postgresql] Release 9.8.12 updating components versions ([a13c592](https://github.com/bitnami/charts/commit/a13c592))
+
+## <small>9.8.11 (2020-11-04)</small>
+
+* [bitnami/postgresql] fix: update values to avoid warnings (#4212) ([2eec409](https://github.com/bitnami/charts/commit/2eec409)), closes [#4212](https://github.com/bitnami/charts/issues/4212)
+
+## <small>9.8.10 (2020-11-04)</small>
+
+* [bitnami/postgresql] Release 9.8.10 updating components versions ([3c992aa](https://github.com/bitnami/charts/commit/3c992aa))
+
+## <small>9.8.9 (2020-10-30)</small>
+
+* [bitnami/postgresql] Fix secret logic for passwords (#4123) ([ea13243](https://github.com/bitnami/charts/commit/ea13243)), closes [#4123](https://github.com/bitnami/charts/issues/4123)
+
+## <small>9.8.8 (2020-10-30)</small>
+
+* [bitnami/*] Extra manifests should be top-level (#4161) ([b3a95b7](https://github.com/bitnami/charts/commit/b3a95b7)), closes [#4161](https://github.com/bitnami/charts/issues/4161)
+* [bitnami/*] Include link to Troubleshootin guide on README.md (#4136) ([c08a20e](https://github.com/bitnami/charts/commit/c08a20e)), closes [#4136](https://github.com/bitnami/charts/issues/4136)
+
+## <small>9.8.7 (2020-10-27)</small>
+
+* [bitnami/postgresql] Fix slave.extraInitContainers value (#4124) ([a92fbbe](https://github.com/bitnami/charts/commit/a92fbbe)), closes [#4124](https://github.com/bitnami/charts/issues/4124)
+
+## <small>9.8.6 (2020-10-23)</small>
+
+* [bitnami/postgresql] Fix extraDeploy, customLivenessProbe and customReadinessProbe values (#4090) ([05eae06](https://github.com/bitnami/charts/commit/05eae06)), closes [#4090](https://github.com/bitnami/charts/issues/4090)
+
+## <small>9.8.5 (2020-10-22)</small>
+
+* [bitnami/postgresql] Permit init-container start with root user.  (#4072) ([6b8c191](https://github.com/bitnami/charts/commit/6b8c191)), closes [#4072](https://github.com/bitnami/charts/issues/4072)
+
+## <small>9.8.4 (2020-10-13)</small>
+
+* [bitnami/postgresql] Added `publishNotReadyAddresses: true` to svc-headless.yaml (#3990) ([46039b3](https://github.com/bitnami/charts/commit/46039b3)), closes [#3990](https://github.com/bitnami/charts/issues/3990)
+
+## <small>9.8.3 (2020-10-08)</small>
+
+* [bitnami/postgresql] Allow exporter port in network-policy if metrics enabled (#3944) ([b5c34a1](https://github.com/bitnami/charts/commit/b5c34a1)), closes [#3944](https://github.com/bitnami/charts/issues/3944)
+
+## <small>9.8.2 (2020-10-06)</small>
+
+* [bitnami/postgresql] Release 9.8.2 updating components versions ([64cb5fd](https://github.com/bitnami/charts/commit/64cb5fd))
+
+## <small>9.8.1 (2020-09-29)</small>
+
+* [bitnami/postgresql] Release 9.8.1 updating components versions ([cc9375d](https://github.com/bitnami/charts/commit/cc9375d))
+
+## 9.8.0 (2020-09-29)
+
+* [bitnami/postgresql] Allow specifying different resource requests/limits on slaves (#3800) ([204d41d](https://github.com/bitnami/charts/commit/204d41d)), closes [#3800](https://github.com/bitnami/charts/issues/3800)
+
+## <small>9.7.4 (2020-09-29)</small>
+
+* [bitnami/postgresql] Revert #3768 due to being a breaking change (#3808) ([a933a38](https://github.com/bitnami/charts/commit/a933a38)), closes [#3768](https://github.com/bitnami/charts/issues/3768) [#3808](https://github.com/bitnami/charts/issues/3808) [#3768](https://github.com/bitnami/charts/issues/3768)
+
+## <small>9.7.3 (2020-09-25)</small>
+
+* [bitnami/postgresql] Added labels for volumeClaimTemplates (#3768) ([03f324b](https://github.com/bitnami/charts/commit/03f324b)), closes [#3768](https://github.com/bitnami/charts/issues/3768)
+
+## <small>9.7.2 (2020-09-24)</small>
+
+* [bitnami/postgresql] Release 9.7.2 updating components versions ([c45bc6f](https://github.com/bitnami/charts/commit/c45bc6f))
+* [bitnami/postgresql] Use common functions for tplValues (#3730) ([af4ae62](https://github.com/bitnami/charts/commit/af4ae62)), closes [#3730](https://github.com/bitnami/charts/issues/3730)
+
+## <small>9.7.1 (2020-09-23)</small>
+
+* [bitnami/chart] postgre #3722: In exsistingSecret: Switched password keys (#3744) ([1517668](https://github.com/bitnami/charts/commit/1517668)), closes [#3722](https://github.com/bitnami/charts/issues/3722) [#3744](https://github.com/bitnami/charts/issues/3744)
+
+## 9.7.0 (2020-09-21)
+
+* [bitnami/postgresql] Add customLivenessProbe and customReadinessProbe (#3728) ([a729b97](https://github.com/bitnami/charts/commit/a729b97)), closes [#3728](https://github.com/bitnami/charts/issues/3728)
+
+## 9.6.0 (2020-09-18)
+
+* [bitnami/postgresql] Add improvements to comply with STIG (#3712) ([f193e43](https://github.com/bitnami/charts/commit/f193e43)), closes [#3712](https://github.com/bitnami/charts/issues/3712)
+
+## 9.5.0 (2020-09-17)
+
+* [bitnami/postgresql] Add arbitrary securityContext configuration to improve security (#3687) ([49a39d6](https://github.com/bitnami/charts/commit/49a39d6)), closes [#3687](https://github.com/bitnami/charts/issues/3687)
+
+## <small>9.4.1 (2020-09-08)</small>
+
+* [bitnami/metrics-server] Add source repo (#3577) ([1ed12f9](https://github.com/bitnami/charts/commit/1ed12f9)), closes [#3577](https://github.com/bitnami/charts/issues/3577)
+* [bitnami/postgresql] Release 9.4.1 updating components versions ([730e66f](https://github.com/bitnami/charts/commit/730e66f))
+
+## 9.4.0 (2020-09-02)
+
+* [bitnami/postgresql] - Add PostgreSQL cross cluster replication ability (#3574) ([b481f63](https://github.com/bitnami/charts/commit/b481f63)), closes [#3574](https://github.com/bitnami/charts/issues/3574)
+
+## <small>9.3.4 (2020-09-01)</small>
+
+* [bitnami/postgres] Add chown on .Values.persistence.mountPath (#3348) ([e7c2b1d](https://github.com/bitnami/charts/commit/e7c2b1d)), closes [#3348](https://github.com/bitnami/charts/issues/3348)
+
+## <small>9.3.3 (2020-08-27)</small>
+
+* [bitnami/postgresql] Fix slave' statefulset when persistence is disabled (#3527) ([3910de7](https://github.com/bitnami/charts/commit/3910de7)), closes [#3527](https://github.com/bitnami/charts/issues/3527)
+
+## <small>9.3.2 (2020-08-18)</small>
+
+* [bitnami/postgresql] Release 9.3.2 updating components versions ([4f8c352](https://github.com/bitnami/charts/commit/4f8c352))
+
+## <small>9.3.1 (2020-08-18)</small>
+
+* [bitnami/postgresql] Fix Postgres password with externalSecret (#3408) ([e64df12](https://github.com/bitnami/charts/commit/e64df12)), closes [#3408](https://github.com/bitnami/charts/issues/3408)
+
+## 9.3.0 (2020-08-18)
+
+* [bitnami/postgresql] feat: add new value to enabled slave persistence (#3438) ([b27b99d](https://github.com/bitnami/charts/commit/b27b99d)), closes [#3438](https://github.com/bitnami/charts/issues/3438)
+
+## <small>9.2.1 (2020-08-14)</small>
+
+* [bitnami/postgresql] Release 9.2.1 updating components versions ([61e3273](https://github.com/bitnami/charts/commit/61e3273))
+
+## 9.2.0 (2020-08-13)
+
+* [bitnami/*] Use common helps for upgrade password errors (#3335) ([079f5bd](https://github.com/bitnami/charts/commit/079f5bd)), closes [#3335](https://github.com/bitnami/charts/issues/3335)
+
+## <small>9.1.4 (2020-08-06)</small>
+
+* [bitnami/postgresql] Release 9.1.4 updating components versions ([47b3f22](https://github.com/bitnami/charts/commit/47b3f22))
+
+## <small>9.1.3 (2020-08-05)</small>
+
+* [bitnami/*] Fix TL;DR typo in READMEs (#3280) ([3d7ab40](https://github.com/bitnami/charts/commit/3d7ab40)), closes [#3280](https://github.com/bitnami/charts/issues/3280)
+* [bitnami/postgresql] Add upgrade notes for 9.X.X (#3322) ([c093a61](https://github.com/bitnami/charts/commit/c093a61)), closes [#3322](https://github.com/bitnami/charts/issues/3322)
+* [bitnami/postgresql] Release 9.1.3 updating components versions ([ffb6263](https://github.com/bitnami/charts/commit/ffb6263))
+
+## <small>9.1.2 (2020-07-29)</small>
+
+* [bitnami/postgresql] Release 9.1.2 updating components versions ([0f4eab3](https://github.com/bitnami/charts/commit/0f4eab3))
+
+## <small>9.1.1 (2020-07-15)</small>
+
+* [bitnami/postgresql] Release 9.1.1 updating components versions ([92ad3e7](https://github.com/bitnami/charts/commit/92ad3e7))
+
+## 9.1.0 (2020-07-14)
+
+* [bitnami/postgresql] Postgresql TLS Support (#3057) ([6c855ff](https://github.com/bitnami/charts/commit/6c855ff)), closes [#3057](https://github.com/bitnami/charts/issues/3057)
+
+## 9.0.0 (2020-07-14)
+
+* [bitnami/all] Add categories (#3075) ([63bde06](https://github.com/bitnami/charts/commit/63bde06)), closes [#3075](https://github.com/bitnami/charts/issues/3075)
+* [bitnami/postgresql] Helm label best practices (#3021) ([693e765](https://github.com/bitnami/charts/commit/693e765)), closes [#3021](https://github.com/bitnami/charts/issues/3021)
+
+## <small>8.10.14 (2020-07-07)</small>
+
+* [bitnami/postgresql] Release 8.10.14 updating components versions ([18f8014](https://github.com/bitnami/charts/commit/18f8014))
+
+## <small>8.10.13 (2020-07-02)</small>
+
+* [bitnami/postgresql] Release 8.10.13 updating components versions ([8d6dcd5](https://github.com/bitnami/charts/commit/8d6dcd5))
+
+## <small>8.10.12 (2020-07-02)</small>
+
+* [bitnami/postgresql] Fix typo on README.md (#2999) ([0d46f5d](https://github.com/bitnami/charts/commit/0d46f5d)), closes [#2999](https://github.com/bitnami/charts/issues/2999) [/github.com/bitnami/charts/blob/master/bitnami/postgresql/values.yaml#L93](https://github.com//github.com/bitnami/charts/blob/master/bitnami/postgresql/values.yaml/issues/L93) [/github.com/bitnami/charts/blob/master/bitnami/postgresql/templates/statefulset.yaml#L70](https://github.com//github.com/bitnami/charts/blob/master/bitnami/postgresql/templates/statefulset.yaml/issues/L70)
+
+## <small>8.10.11 (2020-06-29)</small>
+
+* [bitnami/postgresql] Release 8.10.11 updating components versions ([5c5bcf9](https://github.com/bitnami/charts/commit/5c5bcf9))
+
+## <small>8.10.10 (2020-06-26)</small>
+
+* [bitnami/postgresql] Release 8.10.10 updating components versions ([cbde80c](https://github.com/bitnami/charts/commit/cbde80c))
+
+## <small>8.10.9 (2020-06-26)</small>
+
+* [bitnami/postgresql] Update readme with delete PVC details (#2926) ([d133baf](https://github.com/bitnami/charts/commit/d133baf)), closes [#2926](https://github.com/bitnami/charts/issues/2926)
+
+## <small>8.10.8 (2020-06-24)</small>
+
+* [bitnami/postgresql] Release 8.10.8 updating components versions ([a36d455](https://github.com/bitnami/charts/commit/a36d455))
+
+## <small>8.10.7 (2020-06-23)</small>
+
+* Master StatefulSet annotations fix (#2899) ([abc14b5](https://github.com/bitnami/charts/commit/abc14b5)), closes [#2899](https://github.com/bitnami/charts/issues/2899)
+
+## <small>8.10.6 (2020-06-19)</small>
+
+* [bitnami/postgresql] Release 8.10.6 updating components versions ([f9cb010](https://github.com/bitnami/charts/commit/f9cb010))
+* [bitnami/several] Add instructions about how to use different branches (#2785) ([c315cb0](https://github.com/bitnami/charts/commit/c315cb0)), closes [#2785](https://github.com/bitnami/charts/issues/2785)
+* [multiple charts] Update hidden properties in the different JSON schemas (#2871) ([4cff6ba](https://github.com/bitnami/charts/commit/4cff6ba)), closes [#2871](https://github.com/bitnami/charts/issues/2871)
+
+## <small>8.10.5 (2020-06-03)</small>
+
+* [bitnami/postgresql] Release 8.10.5 updating components versions ([dac5aab](https://github.com/bitnami/charts/commit/dac5aab))
+
+## <small>8.10.4 (2020-05-29)</small>
+
+* [bitnami/postgresql] update readme regarding postgres username and password (#2661) ([1ca7dd4](https://github.com/bitnami/charts/commit/1ca7dd4)), closes [#2661](https://github.com/bitnami/charts/issues/2661)
+
+## <small>8.10.3 (2020-05-28)</small>
+
+* [bitnami/postgresql] Fix extraInitContainers usage (#2689) ([56b036c](https://github.com/bitnami/charts/commit/56b036c)), closes [#2689](https://github.com/bitnami/charts/issues/2689)
+
+## <small>8.10.2 (2020-05-27)</small>
+
+* [bitnami/postgresql] Release 8.10.2 updating components versions ([b476dcd](https://github.com/bitnami/charts/commit/b476dcd))
+
+## <small>8.10.1 (2020-05-26)</small>
+
+* [bitnami/postgresql] Fix customMetrics example (#2552) ([97038a4](https://github.com/bitnami/charts/commit/97038a4)), closes [#2552](https://github.com/bitnami/charts/issues/2552)
+* [bitnami/postgresql] fixed a typo in values files (#2649) ([98fb584](https://github.com/bitnami/charts/commit/98fb584)), closes [#2649](https://github.com/bitnami/charts/issues/2649) [#2649](https://github.com/bitnami/charts/issues/2649)
+
+## 8.10.0 (2020-05-21)
+
+* [bitnami/postgresql] Support all metrics env vars (#2620) ([0351483](https://github.com/bitnami/charts/commit/0351483)), closes [#2620](https://github.com/bitnami/charts/issues/2620)
+
+## <small>8.9.9 (2020-05-21)</small>
+
+* [bitnami/postgresql] Release 8.9.9 updating components versions ([90a6422](https://github.com/bitnami/charts/commit/90a6422))
+* update bitnami/common to be compatible with helm v2.12+ (#2615) ([c7751eb](https://github.com/bitnami/charts/commit/c7751eb)), closes [#2615](https://github.com/bitnami/charts/issues/2615)
+
+## <small>8.9.8 (2020-05-18)</small>
+
+* [bitnami/postgresql] Release 8.9.8 updating components versions ([33517f8](https://github.com/bitnami/charts/commit/33517f8))
+
+## <small>8.9.7 (2020-05-14)</small>
+
+* [bitnami/postgresql] Release 8.9.7 updating components versions ([a78d819](https://github.com/bitnami/charts/commit/a78d819))
+
+## <small>8.9.6 (2020-05-08)</small>
+
+* [bitnami/postgresql] Release 8.9.6 updating components versions ([5888685](https://github.com/bitnami/charts/commit/5888685))
+
+## <small>8.9.5 (2020-05-08)</small>
+
+* [bitnami/postgresql] Release 8.9.5 updating components versions ([3cfdf68](https://github.com/bitnami/charts/commit/3cfdf68))
+
+## <small>8.9.4 (2020-05-01)</small>
+
+* [bitnami/postgresql] Release 8.9.4 updating components versions ([09ba156](https://github.com/bitnami/charts/commit/09ba156))
+
+## <small>8.9.3 (2020-04-28)</small>
+
+* [bitnami/postgresql] Fix conf.d permissions with postgresqlextendedConf (#2383) ([d88de83](https://github.com/bitnami/charts/commit/d88de83)), closes [#2383](https://github.com/bitnami/charts/issues/2383)
+* [bitnami/postgresql] Release 8.9.3 updating components versions ([21f231d](https://github.com/bitnami/charts/commit/21f231d))
+* Update README.md ([3fa18e5](https://github.com/bitnami/charts/commit/3fa18e5))
+
+## <small>8.9.2 (2020-04-23)</small>
+
+* [bitnami/postgresql] Fix pod labels in master statefulservice (#2392) ([67e1008](https://github.com/bitnami/charts/commit/67e1008)), closes [#2392](https://github.com/bitnami/charts/issues/2392)
+
+## <small>8.9.1 (2020-04-22)</small>
+
+* [bitnami/postgresql] Release 8.9.1 updating components versions ([3bec415](https://github.com/bitnami/charts/commit/3bec415))
+
+## 8.9.0 (2020-04-20)
+
+* [bitnami/postgresql] Add option to add annotations to all generated resources (#2368) ([1765929](https://github.com/bitnami/charts/commit/1765929)), closes [#2368](https://github.com/bitnami/charts/issues/2368)
+
+## 8.8.0 (2020-04-17)
+
+* [bitnami/postgresql] Add PSP, Role and RoleBinding to chart (#2313) ([c60c746](https://github.com/bitnami/charts/commit/c60c746)), closes [#2313](https://github.com/bitnami/charts/issues/2313)
+
+## <small>8.7.4 (2020-04-15)</small>
+
+* [bitnami/postgresql] Release 8.7.4 updating components versions ([734e060](https://github.com/bitnami/charts/commit/734e060))
+
+## <small>8.7.3 (2020-04-09)</small>
+
+* [bitnami/postgresql] Avoid using 'deepCopy' since it's not supported in Helm old versions (#2275) ([d128498](https://github.com/bitnami/charts/commit/d128498)), closes [#2275](https://github.com/bitnami/charts/issues/2275)
+
+## <small>8.7.2 (2020-04-07)</small>
+
+* [bitnami/postgresql] Fix svc-read.yaml error (#2241) ([25de34c](https://github.com/bitnami/charts/commit/25de34c)), closes [#2241](https://github.com/bitnami/charts/issues/2241)
+
+## <small>8.7.1 (2020-04-06)</small>
+
+* [bitnami/postgresql] Release 8.7.1 updating components versions ([102f747](https://github.com/bitnami/charts/commit/102f747))
+
+## 8.7.0 (2020-04-06)
+
+* [bitnami/postgresql] fix replication with nodePort service type  #2063  (#2192) ([fa546fc](https://github.com/bitnami/charts/commit/fa546fc)), closes [#2063](https://github.com/bitnami/charts/issues/2063) [#2192](https://github.com/bitnami/charts/issues/2192)
+
+## <small>8.6.13 (2020-04-03)</small>
+
+* [bitnami/postgresql] Tpl usage in existing secret (#2211) ([27bf542](https://github.com/bitnami/charts/commit/27bf542)), closes [#2211](https://github.com/bitnami/charts/issues/2211)
+
+## <small>8.6.12 (2020-03-31)</small>
+
+* [bitnami/postgresql] Release 8.6.12 updating components versions ([1d9296f](https://github.com/bitnami/charts/commit/1d9296f))
+
+## <small>8.6.11 (2020-03-30)</small>
+
+* [bitnami/postgresql] Fix conf permissions with postgresql.extendedConf (#2141) ([8fce43b](https://github.com/bitnami/charts/commit/8fce43b)), closes [#2141](https://github.com/bitnami/charts/issues/2141)
+
+## <small>8.6.10 (2020-03-26)</small>
+
+* [bitnami/postgresql] Release 8.6.10 updating components versions ([3306f53](https://github.com/bitnami/charts/commit/3306f53))
+
+## <small>8.6.9 (2020-03-23)</small>
+
+* [bitnami/postgresql] Fix loadBalancerSourceRanges in svc-read (#2117) ([429df27](https://github.com/bitnami/charts/commit/429df27)), closes [#2117](https://github.com/bitnami/charts/issues/2117)
+
+## <small>8.6.8 (2020-03-20)</small>
+
+* [bitnami/postgresql] Release 8.6.8 updating components versions ([590c6b0](https://github.com/bitnami/charts/commit/590c6b0))
+
+## <small>8.6.7 (2020-03-20)</small>
+
+* [bitnami/postgresql] Update README.md + yamllint (#2097) ([0587893](https://github.com/bitnami/charts/commit/0587893)), closes [#2097](https://github.com/bitnami/charts/issues/2097)
+
+## <small>8.6.6 (2020-03-20)</small>
+
+* [bitnami/postgresql]fix credetials for initdbScripts (#2083) ([dc4a34b](https://github.com/bitnami/charts/commit/dc4a34b)), closes [#2083](https://github.com/bitnami/charts/issues/2083)
+
+## <small>8.6.5 (2020-03-18)</small>
+
+* [bitnami/postgresql] Evaluate extraEnvVarsCM as a template (#2059) ([730ef6c](https://github.com/bitnami/charts/commit/730ef6c)), closes [#2059](https://github.com/bitnami/charts/issues/2059)
+
+## <small>8.6.4 (2020-03-11)</small>
+
+* [bitnami/postgresql] Release 8.6.4 updating components versions ([a4df45b](https://github.com/bitnami/charts/commit/a4df45b))
+
+## <small>8.6.3 (2020-03-11)</small>
+
+* Move charts from upstreamed folder to bitnami (#2032) ([a0e44f7](https://github.com/bitnami/charts/commit/a0e44f7)), closes [#2032](https://github.com/bitnami/charts/issues/2032)
+* Remove PostgreSQL chart from Bitnami ([5e80f54](https://github.com/bitnami/charts/commit/5e80f54))
+
+## <small>3.1.1 (2018-10-17)</small>
+
+* Apply some suggestions ([24706a6](https://github.com/bitnami/charts/commit/24706a6))
+* Bump versions ([0cfd3f4](https://github.com/bitnami/charts/commit/0cfd3f4))
+* Change logic to determine registry ([9ead294](https://github.com/bitnami/charts/commit/9ead294))
+* Check if global is set ([dec26e5](https://github.com/bitnami/charts/commit/dec26e5))
+* Fix typo ([93170ac](https://github.com/bitnami/charts/commit/93170ac))
+* Remove distro tags in charts ([427ac51](https://github.com/bitnami/charts/commit/427ac51))
+* Reword and update kafka dependencies ([be6cbed](https://github.com/bitnami/charts/commit/be6cbed))
+
+## 3.1.0 (2018-10-11)
+
+* Add global registry option to Bitnami charts ([395ba08](https://github.com/bitnami/charts/commit/395ba08))
+* Bump chart version ([4010d13](https://github.com/bitnami/charts/commit/4010d13))
+* Change name truncation to 63 instead of 24 ([e42a923](https://github.com/bitnami/charts/commit/e42a923))
+
+## <small>3.0.2 (2018-10-05)</small>
+
+* Add ) ([728466a](https://github.com/bitnami/charts/commit/728466a))
+* Add kubeapps text to charts READMEs ([2f6dc51](https://github.com/bitnami/charts/commit/2f6dc51))
+* Fix go template inside go template ([a140313](https://github.com/bitnami/charts/commit/a140313))
+
+## <small>3.0.1 (2018-09-27)</small>
+
+* Improve getting LoadBalancer address in Bitnami charts NOTES.txt ([a641728](https://github.com/bitnami/charts/commit/a641728))
+
+## 3.0.0 (2018-09-21)
+
+* [bitnami/postgresql] Fix chart not being upgradable ([65a1e5e](https://github.com/bitnami/charts/commit/65a1e5e))
+
+## <small>2.1.3 (2018-08-13)</small>
+
+* postgresql: bump chart appVersion to `10.5.0` ([7d98698](https://github.com/bitnami/charts/commit/7d98698))
+* postgresql: bump chart version to `2.1.3` ([3192d7c](https://github.com/bitnami/charts/commit/3192d7c))
+* postgresql: update to `10.5.0-debian-9` ([422a538](https://github.com/bitnami/charts/commit/422a538))
+
+## <small>2.1.2 (2018-08-06)</small>
+
+* Improve notes to access deployed services ([0071eb5](https://github.com/bitnami/charts/commit/0071eb5))
+
+## <small>2.1.1 (2018-07-30)</small>
+
+* Add missing release and charts labels in pods ([dfd13a2](https://github.com/bitnami/charts/commit/dfd13a2))
+
+## 2.1.0 (2018-07-27)
+
+* Allow using custom scripts to initialize PostgreSQL ([b92ea0d](https://github.com/bitnami/charts/commit/b92ea0d))
+
+## <small>2.0.1 (2018-07-26)</small>
+
+* Add documentation for custom postgresql.conf files ([58800b3](https://github.com/bitnami/charts/commit/58800b3))
+* Update chart version. Use the main tag for the image ([2b0272b](https://github.com/bitnami/charts/commit/2b0272b))
+
+## 2.0.0 (2018-07-25)
+
+* [Postgresql] add non-root support ([130f090](https://github.com/bitnami/charts/commit/130f090))
+
+## <small>1.0.5 (2018-07-23)</small>
+
+* Use env var instead of showing the password for the cli ([0125d8b](https://github.com/bitnami/charts/commit/0125d8b))
+
+## <small>1.0.4 (2018-07-23)</small>
+
+* Fix svc type for values-production.yaml ([24cd97d](https://github.com/bitnami/charts/commit/24cd97d))
+* Fix svc type for values-production.yaml ([29abeb2](https://github.com/bitnami/charts/commit/29abeb2))
+
+## <small>1.0.3 (2018-07-06)</small>
+
+* postgresql: bump chart appVersion to `10.4.0-debian-9` ([4a13616](https://github.com/bitnami/charts/commit/4a13616))
+* postgresql: bump chart version to `1.0.3` ([a3b1015](https://github.com/bitnami/charts/commit/a3b1015))
+* postgresql: update to `10.4.0-debian-9` ([80b8bf4](https://github.com/bitnami/charts/commit/80b8bf4))
+
+## <small>1.0.2 (2018-06-07)</small>
+
+* Fix capitalization of clusterIP parameter ([2d0656f](https://github.com/bitnami/charts/commit/2d0656f))
+* Fix consul, mysql and postgre helm chart testing issue using tag ([6f37eb7](https://github.com/bitnami/charts/commit/6f37eb7))
+
+## <small>1.0.1 (2018-06-04)</small>
+
+* Apply Juan comments ([7425941](https://github.com/bitnami/charts/commit/7425941))
+* Delete unnecessaty file ([fbafc63](https://github.com/bitnami/charts/commit/fbafc63))
+* Fix ES helm chart testing issue using tag ([657025b](https://github.com/bitnami/charts/commit/657025b))
+
+## 1.0.0 (2018-05-29)
+
+* Support replication for PostgreSQL chart ([7527ab5](https://github.com/bitnami/charts/commit/7527ab5))
+
+## <small>0.4.25 (2018-05-15)</small>
+
+* postgresql: bump chart appVersion to `10.4.0` ([70178ef](https://github.com/bitnami/charts/commit/70178ef))
+* postgresql: bump chart version to `0.4.25` ([7f48795](https://github.com/bitnami/charts/commit/7f48795))
+* postgresql: update to `10.4.0` ([590549a](https://github.com/bitnami/charts/commit/590549a))
+
+## <small>0.4.24 (2018-04-13)</small>
+
+* Documentation fixes ([fdbcc57](https://github.com/bitnami/charts/commit/fdbcc57))
+
+## <small>0.4.23 (2018-04-13)</small>
+
+* Rename charts folders ([5413120](https://github.com/bitnami/charts/commit/5413120))

--- a/bitnami/postgresql/Chart.yaml
+++ b/bitnami/postgresql/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: postgresql
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/postgresql
-version: 15.3.5
+version: 15.4.0

--- a/bitnami/postgresql/templates/NOTES.txt
+++ b/bitnami/postgresql/templates/NOTES.txt
@@ -114,3 +114,4 @@ WARNING: The configured password will be ignored on new installation in case whe
 {{- include "common.warnings.rollingTag" .Values.image -}}
 {{- include "common.warnings.rollingTag" .Values.volumePermissions.image }}
 {{- include "common.warnings.resources" (dict "sections" (list "metrics" "primary" "readReplicas" "volumePermissions") "context" $) }}
+{{- include "common.warnings.modifiedImages" (dict "images" (list .Values.image .Values.volumePermissions.image .Values.metrics.image) "context" $) }}


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Replacing the original images that have been tested and verified when releasing the chart is a dangerous practice in terms of security, performance and available features. This PR updates the `NOTES.txt` file using the `common.warnings.modifiedImages` helper developed in https://github.com/bitnami/charts/pull/25952.


<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

Users are more aware of the risks of changing original images.
<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

n/a
<!-- Describe any known limitations with your change -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
