### PR TITLE
[bitnami/rabbitmq] feat: :sparkles: :lock: Add warning when original images are replaced

### DIFF
--- a/bitnami/rabbitmq/CHANGELOG.md
+++ b/bitnami/rabbitmq/CHANGELOG.md
@@ -1,0 +1,1699 @@
+# Changelog
+
+## 14.2.0 (2024-05-21)
+
+* [bitnami/rabbitmq] feat: :sparkles: :lock: Add warning when original images are replaced ([#26269](https://github.com/bitnami/charts/pulls/26269))
+
+## <small>14.1.5 (2024-05-18)</small>
+
+* [bitnami/rabbitmq] Release 14.1.5 updating components versions (#26071) ([e2f55cb](https://github.com/bitnami/charts/commit/e2f55cb)), closes [#26071](https://github.com/bitnami/charts/issues/26071)
+
+## <small>14.1.4 (2024-05-14)</small>
+
+* [bitnami/rabbitmq] Release 14.1.4 updating components versions (#25817) ([1f6861b](https://github.com/bitnami/charts/commit/1f6861b)), closes [#25817](https://github.com/bitnami/charts/issues/25817)
+
+## <small>14.1.3 (2024-05-13)</small>
+
+* [bitnami/*] Change non-root and rolling-tags doc URLs (#25628) ([b067c94](https://github.com/bitnami/charts/commit/b067c94)), closes [#25628](https://github.com/bitnami/charts/issues/25628)
+* [bitnami/*] Set new header/owner (#25558) ([8d1dc11](https://github.com/bitnami/charts/commit/8d1dc11)), closes [#25558](https://github.com/bitnami/charts/issues/25558)
+* [bitnami/rabbitmq] Release 14.1.3 updating components versions (#25713) ([57b655e](https://github.com/bitnami/charts/commit/57b655e)), closes [#25713](https://github.com/bitnami/charts/issues/25713)
+
+## <small>14.1.2 (2024-05-06)</small>
+
+* [bitnami/rabbitmq] Remove unicode characters (#25548) ([adb080c](https://github.com/bitnami/charts/commit/adb080c)), closes [#25548](https://github.com/bitnami/charts/issues/25548)
+
+## <small>14.1.1 (2024-05-01)</small>
+
+* [bitnami/rabbitmq] Release 14.1.1 updating components versions (#25480) ([0ea1ef5](https://github.com/bitnami/charts/commit/0ea1ef5)), closes [#25480](https://github.com/bitnami/charts/issues/25480)
+
+## 14.1.0 (2024-04-30)
+
+* [bitnami/multiple charts] Fix typo: "NetworkPolice" vs "NetworkPolicy" (#25348) ([6970c1b](https://github.com/bitnami/charts/commit/6970c1b)), closes [#25348](https://github.com/bitnami/charts/issues/25348)
+* [bitnami/rabbitmq] Add rbac.rules (#25442) ([d4f4745](https://github.com/bitnami/charts/commit/d4f4745)), closes [#25442](https://github.com/bitnami/charts/issues/25442)
+* Replace VMware by Broadcom copyright text (#25306) ([a5e4bd0](https://github.com/bitnami/charts/commit/a5e4bd0)), closes [#25306](https://github.com/bitnami/charts/issues/25306)
+
+## <small>14.0.2 (2024-04-23)</small>
+
+* [bitnami/rabbitmq]: Fix custom plugins installation (#25316) ([a3c7c6e](https://github.com/bitnami/charts/commit/a3c7c6e)), closes [#25316](https://github.com/bitnami/charts/issues/25316)
+
+## <small>14.0.1 (2024-04-15)</small>
+
+* [bitnami/rabbitmq] Add upgrade notes for version 3.13.x (#25095) ([7d3c0c6](https://github.com/bitnami/charts/commit/7d3c0c6)), closes [#25095](https://github.com/bitnami/charts/issues/25095)
+* [bitnami/rabbitmq] fix: :bug: :lock: Expose missing ports in deployment spec (#25135) ([103b903](https://github.com/bitnami/charts/commit/103b903)), closes [#25135](https://github.com/bitnami/charts/issues/25135)
+
+## 14.0.0 (2024-04-10)
+
+* [bitnami/rabbitmq] Release 14.0.0 updating components versions (#25093) ([51f843e](https://github.com/bitnami/charts/commit/51f843e)), closes [#25093](https://github.com/bitnami/charts/issues/25093)
+
+## <small>13.0.3 (2024-04-05)</small>
+
+* [bitnami/rabbitmq] Fix misleading memoryHighWatermark.value description in values (#24866) ([50dd177](https://github.com/bitnami/charts/commit/50dd177)), closes [#24866](https://github.com/bitnami/charts/issues/24866)
+* Update resourcesPreset comments (#24467) ([92e3e8a](https://github.com/bitnami/charts/commit/92e3e8a)), closes [#24467](https://github.com/bitnami/charts/issues/24467)
+
+## <small>13.0.2 (2024-04-02)</small>
+
+* [bitnami/rabbitmq] Release 13.0.2 updating components versions (#24805) ([88edbf0](https://github.com/bitnami/charts/commit/88edbf0)), closes [#24805](https://github.com/bitnami/charts/issues/24805)
+
+## <small>13.0.1 (2024-04-02)</small>
+
+* [bitnami/*] Reorder Chart sections (#24455) ([0cf4048](https://github.com/bitnami/charts/commit/0cf4048)), closes [#24455](https://github.com/bitnami/charts/issues/24455)
+* Fix invalid secret pointer in RabbitMQ ServiceAccount (#24750) ([d85830c](https://github.com/bitnami/charts/commit/d85830c)), closes [#24750](https://github.com/bitnami/charts/issues/24750) [#24738](https://github.com/bitnami/charts/issues/24738)
+
+## 13.0.0 (2024-03-15)
+
+* [bitnami/rabbitmq] docs: :memo: Add upgrade notes for 12.10.0 (#24322) ([65e3aad](https://github.com/bitnami/charts/commit/65e3aad)), closes [#24322](https://github.com/bitnami/charts/issues/24322)
+* [bitnami/rabbitmq] feat!: 🔒 💥 Improve security defaults (#24336) ([54e671f](https://github.com/bitnami/charts/commit/54e671f)), closes [#24336](https://github.com/bitnami/charts/issues/24336)
+
+## 12.15.0 (2024-03-06)
+
+* [bitnami/rabbitmq] feat: :sparkles: :lock: Add automatic adaptation for Openshift restricted-v2 SCC  ([63a0cc3](https://github.com/bitnami/charts/commit/63a0cc3)), closes [#24146](https://github.com/bitnami/charts/issues/24146)
+
+## <small>12.14.1 (2024-03-05)</small>
+
+* [bitnami/rabbitmq] fix error dereferencing nil resources (#23616) ([f75c6a8](https://github.com/bitnami/charts/commit/f75c6a8)), closes [#23616](https://github.com/bitnami/charts/issues/23616) [#23607](https://github.com/bitnami/charts/issues/23607)
+
+## 12.14.0 (2024-02-23)
+
+* [bitnami/rabbitmq] feat: :sparkles: :lock: Add readOnlyRootFilesystem support (#23745) ([68a606e](https://github.com/bitnami/charts/commit/68a606e)), closes [#23745](https://github.com/bitnami/charts/issues/23745)
+
+## <small>12.13.2 (2024-02-22)</small>
+
+* [bitnami/rabbitmq] Release 12.13.2 updating components versions (#23825) ([5dbad69](https://github.com/bitnami/charts/commit/5dbad69)), closes [#23825](https://github.com/bitnami/charts/issues/23825)
+
+## <small>12.13.1 (2024-02-21)</small>
+
+* [bitnami/rabbitmq] Release 12.13.1 updating components versions (#23691) ([1bf88ab](https://github.com/bitnami/charts/commit/1bf88ab)), closes [#23691](https://github.com/bitnami/charts/issues/23691)
+
+## 12.13.0 (2024-02-20)
+
+* [bitnami/*] Bump all versions (#23602) ([b70ee2a](https://github.com/bitnami/charts/commit/b70ee2a)), closes [#23602](https://github.com/bitnami/charts/issues/23602)
+
+## 12.12.0 (2024-02-19)
+
+* [bitnami/rabbitmq] Allow specifying service loadBalancerClass (#23561) ([5e8cda2](https://github.com/bitnami/charts/commit/5e8cda2)), closes [#23561](https://github.com/bitnami/charts/issues/23561)
+
+## 12.11.0 (2024-02-15)
+
+* [bitnami/rabbitmq] feat: :sparkles: :lock: Add resource preset support (#23514) ([b9339c7](https://github.com/bitnami/charts/commit/b9339c7)), closes [#23514](https://github.com/bitnami/charts/issues/23514)
+
+## 12.10.0 (2024-02-07)
+
+* [bitnami/rabbitmq] fix: :bug: Add allowExternalEgress to avoid breaking istio (#22972) ([b525212](https://github.com/bitnami/charts/commit/b525212)), closes [#22972](https://github.com/bitnami/charts/issues/22972)
+
+## <small>12.9.4 (2024-02-06)</small>
+
+* [bitnami/rabbitmq] fix: make toBytes handle numbers with a decimal dot (#22557) ([90f6e7f](https://github.com/bitnami/charts/commit/90f6e7f)), closes [#22557](https://github.com/bitnami/charts/issues/22557) [/github.com/redpanda-data/helm-charts/blob/main/charts/redpanda/templates/_helpers.tpl#L199C1-L236C12](https://github.com//github.com/redpanda-data/helm-charts/blob/main/charts/redpanda/templates/_helpers.tpl/issues/L199C1-L236C12)
+
+## <small>12.9.3 (2024-02-03)</small>
+
+* [bitnami/rabbitmq] Release 12.9.3 updating components versions (#23134) ([8b2dd63](https://github.com/bitnami/charts/commit/8b2dd63)), closes [#23134](https://github.com/bitnami/charts/issues/23134)
+
+## <small>12.9.2 (2024-02-01)</small>
+
+* [bitnami/rabbitmq] Fix variable naming in helpers template file (#22924) ([d828506](https://github.com/bitnami/charts/commit/d828506)), closes [#22924](https://github.com/bitnami/charts/issues/22924)
+
+## <small>12.9.1 (2024-02-01)</small>
+
+* [bitnami/rabbitmq] Release 12.9.1 updating components versions (#22998) ([47d3748](https://github.com/bitnami/charts/commit/47d3748)), closes [#22998](https://github.com/bitnami/charts/issues/22998)
+
+## 12.9.0 (2024-01-30)
+
+* [bitnami/rabbitmq] feat: :lock: Enable networkPolicy (#22741) ([a5a6c6c](https://github.com/bitnami/charts/commit/a5a6c6c)), closes [#22741](https://github.com/bitnami/charts/issues/22741)
+
+## <small>12.8.2 (2024-01-29)</small>
+
+* [bitnami/rabbitmq] Disable memoryHighWatermark by default in RabbitMQ (#22818) ([962aec3](https://github.com/bitnami/charts/commit/962aec3)), closes [#22818](https://github.com/bitnami/charts/issues/22818)
+
+## <small>12.8.1 (2024-01-26)</small>
+
+* [bitnami/*] Move documentation sections from docs.bitnami.com back to the README (#22203) ([7564f36](https://github.com/bitnami/charts/commit/7564f36)), closes [#22203](https://github.com/bitnami/charts/issues/22203)
+* [bitnami/rabbitmq] fix: :bug: Set seLinuxOptions to null for Openshift compatibility (#22651) ([92239a1](https://github.com/bitnami/charts/commit/92239a1)), closes [#22651](https://github.com/bitnami/charts/issues/22651)
+* #21359 Added erlang secret key for external sealed secrets (#22016) ([6154b1d](https://github.com/bitnami/charts/commit/6154b1d)), closes [#21359](https://github.com/bitnami/charts/issues/21359) [#22016](https://github.com/bitnami/charts/issues/22016)
+
+## 12.8.0 (2024-01-19)
+
+* [bitnami/rabbitmq] fix: :lock: Move service-account token auto-mount to pod declaration (#22453) ([0f92db5](https://github.com/bitnami/charts/commit/0f92db5)), closes [#22453](https://github.com/bitnami/charts/issues/22453)
+
+## <small>12.7.1 (2024-01-17)</small>
+
+* [bitnami/rabbitmq] fix: :lock: Improve podSecurityContext and containerSecurityContext with essentia ([4dab813](https://github.com/bitnami/charts/commit/4dab813)), closes [#22182](https://github.com/bitnami/charts/issues/22182)
+* [bitnami/rabbitmq] Release 12.7.1 updating components versions (#22328) ([f153cd4](https://github.com/bitnami/charts/commit/f153cd4)), closes [#22328](https://github.com/bitnami/charts/issues/22328)
+
+## 12.7.0 (2024-01-16)
+
+* [bitnami/rabbitmq] Add auth.existingSecret to support external sealed secrets (#21891) ([950dc61](https://github.com/bitnami/charts/commit/950dc61)), closes [#21891](https://github.com/bitnami/charts/issues/21891)
+
+## <small>12.6.3 (2024-01-12)</small>
+
+* [bitnami/*] Fix docs.bitnami.com broken links (#21901) ([f35506d](https://github.com/bitnami/charts/commit/f35506d)), closes [#21901](https://github.com/bitnami/charts/issues/21901)
+* [bitnami/*] Fix ref links (in comments) (#21822) ([e4fa296](https://github.com/bitnami/charts/commit/e4fa296)), closes [#21822](https://github.com/bitnami/charts/issues/21822)
+* Fix rendering of vm_memory_high_watermark param (#22017) ([f12f2b2](https://github.com/bitnami/charts/commit/f12f2b2)), closes [#22017](https://github.com/bitnami/charts/issues/22017)
+
+## <small>12.6.2 (2024-01-05)</small>
+
+* [bitnami/*] Update copyright: Year and company (#21815) ([6c4bf75](https://github.com/bitnami/charts/commit/6c4bf75)), closes [#21815](https://github.com/bitnami/charts/issues/21815)
+* [bitnami/rabbitmq] Release 12.6.2 updating components versions (#21868) ([a98d15c](https://github.com/bitnami/charts/commit/a98d15c)), closes [#21868](https://github.com/bitnami/charts/issues/21868)
+
+## <small>12.6.1 (2023-12-22)</small>
+
+* [bitnami/rabbitmq] Release 12.6.1 updating components versions (#21726) ([4960f0c](https://github.com/bitnami/charts/commit/4960f0c)), closes [#21726](https://github.com/bitnami/charts/issues/21726)
+
+## 12.6.0 (2023-12-19)
+
+* [bitnami/rabbitmq] Add support for defining cluster name (#21621) ([c50a384](https://github.com/bitnami/charts/commit/c50a384)), closes [#21621](https://github.com/bitnami/charts/issues/21621)
+
+## <small>12.5.7 (2023-12-17)</small>
+
+* [bitnami/rabbitmq] Release 12.5.7 updating components versions (#21604) ([a2b246f](https://github.com/bitnami/charts/commit/a2b246f)), closes [#21604](https://github.com/bitnami/charts/issues/21604)
+
+## <small>12.5.6 (2023-12-05)</small>
+
+* [bitnami/rabbitmq] Replace deprecated pull secret partial (#21395) ([7ce2a11](https://github.com/bitnami/charts/commit/7ce2a11)), closes [#21395](https://github.com/bitnami/charts/issues/21395)
+
+## <small>12.5.5 (2023-12-01)</small>
+
+* [bitnami/rabbitmq] Release 12.5.5 updating components versions (#21344) ([d45ae0b](https://github.com/bitnami/charts/commit/d45ae0b)), closes [#21344](https://github.com/bitnami/charts/issues/21344)
+
+## <small>12.5.4 (2023-11-22)</small>
+
+* [bitnami/rabbitmq] Release 12.5.4 updating components versions (#21204) ([26f1c0b](https://github.com/bitnami/charts/commit/26f1c0b)), closes [#21204](https://github.com/bitnami/charts/issues/21204)
+
+## <small>12.5.3 (2023-11-21)</small>
+
+* [bitnami/*] Rename solutions to "Bitnami package for ..." (#21038) ([b82f979](https://github.com/bitnami/charts/commit/b82f979)), closes [#21038](https://github.com/bitnami/charts/issues/21038)
+* [bitnami/rabbitmq] Release 12.5.3 updating components versions (#21170) ([65fd490](https://github.com/bitnami/charts/commit/65fd490)), closes [#21170](https://github.com/bitnami/charts/issues/21170)
+
+## <small>12.5.2 (2023-11-21)</small>
+
+* [bitnami/rabbitmq] Release 12.5.2 updating components versions (#21083) ([4675e03](https://github.com/bitnami/charts/commit/4675e03)), closes [#21083](https://github.com/bitnami/charts/issues/21083)
+
+## <small>12.5.1 (2023-11-17)</small>
+
+* [bitnami/*] Remove relative links to non-README sections, add verification for that and update TL;DR ([1103633](https://github.com/bitnami/charts/commit/1103633)), closes [#20967](https://github.com/bitnami/charts/issues/20967)
+* [bitnami/rabbitmq] Release 12.5.1 updating components versions (#21029) ([b311186](https://github.com/bitnami/charts/commit/b311186)), closes [#21029](https://github.com/bitnami/charts/issues/21029)
+
+## 12.5.0 (2023-11-15)
+
+* [bitnami/rabbitmq] Add Persistent Volume Claim Retention Policy to Rabbitmq Statefulsets   (#20915) ([0a70a6e](https://github.com/bitnami/charts/commit/0a70a6e)), closes [#20915](https://github.com/bitnami/charts/issues/20915)
+
+## <small>12.4.2 (2023-11-09)</small>
+
+* [bitnami/rabbitmq] Release 12.4.2 updating components versions (#20869) ([aacd84e](https://github.com/bitnami/charts/commit/aacd84e)), closes [#20869](https://github.com/bitnami/charts/issues/20869)
+
+## <small>12.4.1 (2023-11-08)</small>
+
+* [bitnami/rabbitmq] Release 12.4.1 updating components versions (#20707) ([5194f22](https://github.com/bitnami/charts/commit/5194f22)), closes [#20707](https://github.com/bitnami/charts/issues/20707)
+
+## 12.4.0 (2023-11-06)
+
+* [bitami/rabbitmq] Added ability to enable/disable allocateLoadBalancerNodePorts (#20503) ([8b508b0](https://github.com/bitnami/charts/commit/8b508b0)), closes [#20503](https://github.com/bitnami/charts/issues/20503)
+
+## <small>12.3.1 (2023-11-05)</small>
+
+* [bitnami/rabbitmq] Release 12.3.1 updating components versions (#20624) ([10bcb64](https://github.com/bitnami/charts/commit/10bcb64)), closes [#20624](https://github.com/bitnami/charts/issues/20624)
+
+## 12.3.0 (2023-10-24)
+
+* [bitnami/*] Rename VMware Application Catalog (#20361) ([3acc734](https://github.com/bitnami/charts/commit/3acc734)), closes [#20361](https://github.com/bitnami/charts/issues/20361)
+* [bitnami/*] Skip image's tag in the README files of the Bitnami Charts (#19841) ([bb9a01b](https://github.com/bitnami/charts/commit/bb9a01b)), closes [#19841](https://github.com/bitnami/charts/issues/19841)
+* [bitnami/*] Standardize documentation (#19835) ([af5f753](https://github.com/bitnami/charts/commit/af5f753)), closes [#19835](https://github.com/bitnami/charts/issues/19835)
+* [bitnami/rabbitmq] feat: :sparkles: Add support for PSA restricted policy (#20367) ([7fa78ed](https://github.com/bitnami/charts/commit/7fa78ed)), closes [#20367](https://github.com/bitnami/charts/issues/20367)
+
+## <small>12.2.5 (2023-10-18)</small>
+
+* [bitnami/rabbitmq] Release 12.2.5 (#20295) ([907aab9](https://github.com/bitnami/charts/commit/907aab9)), closes [#20295](https://github.com/bitnami/charts/issues/20295)
+
+## <small>12.2.4 (2023-10-16)</small>
+
+* bitnami/rabbitmq corrected clustering.partitionHandling enum values (#19558) ([6d3450c](https://github.com/bitnami/charts/commit/6d3450c)), closes [#19558](https://github.com/bitnami/charts/issues/19558)
+
+## <small>12.2.3 (2023-10-12)</small>
+
+* [bitnami/rabbitmq] Release 12.2.3 updating components versions (#20169) ([0820d76](https://github.com/bitnami/charts/commit/0820d76)), closes [#20169](https://github.com/bitnami/charts/issues/20169)
+
+## <small>12.2.2 (2023-10-12)</small>
+
+* [bitnami/rabbitmq] Release 12.2.2 (#20117) ([b0fe7a5](https://github.com/bitnami/charts/commit/b0fe7a5)), closes [#20117](https://github.com/bitnami/charts/issues/20117)
+
+## <small>12.2.1 (2023-10-09)</small>
+
+* [bitnami/*] Update Helm charts prerequisites (#19745) ([eb755dd](https://github.com/bitnami/charts/commit/eb755dd)), closes [#19745](https://github.com/bitnami/charts/issues/19745)
+* [bitnami/rabbitmq] Release 12.2.1 (#19937) ([84ef6b1](https://github.com/bitnami/charts/commit/84ef6b1)), closes [#19937](https://github.com/bitnami/charts/issues/19937)
+
+## 12.2.0 (2023-10-03)
+
+* bitnami/rabbitmq Add support for enableServiceLinks on rabbitmq chart (#19643) ([672284b](https://github.com/bitnami/charts/commit/672284b)), closes [#19643](https://github.com/bitnami/charts/issues/19643)
+
+## <small>12.1.7 (2023-09-25)</small>
+
+* [bitnami/rabbitmq] Release 12.1.7 (#19512) ([b93f8fa](https://github.com/bitnami/charts/commit/b93f8fa)), closes [#19512](https://github.com/bitnami/charts/issues/19512)
+
+## <small>12.1.6 (2023-09-22)</small>
+
+* [bitnami/rabbitmq] Release 12.1.6 (#19463) ([338a3d5](https://github.com/bitnami/charts/commit/338a3d5)), closes [#19463](https://github.com/bitnami/charts/issues/19463)
+
+## <small>12.1.5 (2023-09-21)</small>
+
+* [bitnami/rabbitmq] Release 12.1.5 (#19453) ([380b1f5](https://github.com/bitnami/charts/commit/380b1f5)), closes [#19453](https://github.com/bitnami/charts/issues/19453)
+* Autogenerate schema files (#19194) ([a2c2090](https://github.com/bitnami/charts/commit/a2c2090)), closes [#19194](https://github.com/bitnami/charts/issues/19194)
+* Revert "Autogenerate schema files (#19194)" (#19335) ([73d80be](https://github.com/bitnami/charts/commit/73d80be)), closes [#19194](https://github.com/bitnami/charts/issues/19194) [#19335](https://github.com/bitnami/charts/issues/19335)
+
+## <small>12.1.4 (2023-09-08)</small>
+
+* [bitnami/rabbitmq]: Use merge helper: (#19098) ([30353ba](https://github.com/bitnami/charts/commit/30353ba)), closes [#19098](https://github.com/bitnami/charts/issues/19098)
+
+## <small>12.1.3 (2023-08-28)</small>
+
+* [bitnami/rabbitmq] test: :white_check_mark: Add persistence tests (#18812) ([fd9745a](https://github.com/bitnami/charts/commit/fd9745a)), closes [#18812](https://github.com/bitnami/charts/issues/18812)
+
+## <small>12.1.2 (2023-08-25)</small>
+
+* [bitnami/rabbitmq] Release 12.1.2 (#18845) ([2daf44e](https://github.com/bitnami/charts/commit/2daf44e)), closes [#18845](https://github.com/bitnami/charts/issues/18845)
+
+## <small>12.1.1 (2023-08-24)</small>
+
+* [bitnami/rabbitmq] fix path to serviceMonitor annotations value (#18797) ([85fe75b](https://github.com/bitnami/charts/commit/85fe75b)), closes [#18797](https://github.com/bitnami/charts/issues/18797)
+
+## 12.1.0 (2023-08-22)
+
+* [bitnami/rabbitmq] Support for customizing standard labels (#18416) ([a070c62](https://github.com/bitnami/charts/commit/a070c62)), closes [#18416](https://github.com/bitnami/charts/issues/18416)
+
+## <small>12.0.13 (2023-08-20)</small>
+
+* [bitnami/rabbitmq] Release 12.0.13 (#18711) ([1bc09aa](https://github.com/bitnami/charts/commit/1bc09aa)), closes [#18711](https://github.com/bitnami/charts/issues/18711)
+
+## <small>12.0.12 (2023-08-18)</small>
+
+* [bitnami/rabbitmq] Release 12.0.12 (#18608) ([61384d6](https://github.com/bitnami/charts/commit/61384d6)), closes [#18608](https://github.com/bitnami/charts/issues/18608)
+
+## <small>12.0.11 (2023-08-17)</small>
+
+* [bitnami/rabbitmq] Release 12.0.11 (#18586) ([6bfa3bb](https://github.com/bitnami/charts/commit/6bfa3bb)), closes [#18586](https://github.com/bitnami/charts/issues/18586)
+
+## <small>12.0.10 (2023-08-04)</small>
+
+* [bitnami/rabbitmq] Fix issue with ingress.existingSecret (#18125) ([ba42210](https://github.com/bitnami/charts/commit/ba42210)), closes [#18125](https://github.com/bitnami/charts/issues/18125)
+
+## <small>12.0.9 (2023-07-26)</small>
+
+* [bitnami/rabbitmq] Release 12.0.9 (#17954) ([ed09fce](https://github.com/bitnami/charts/commit/ed09fce)), closes [#17954](https://github.com/bitnami/charts/issues/17954)
+
+## <small>12.0.8 (2023-07-22)</small>
+
+* [bitnami/rabbitmq] Release 12.0.8 (#17826) ([ac13413](https://github.com/bitnami/charts/commit/ac13413)), closes [#17826](https://github.com/bitnami/charts/issues/17826)
+
+## <small>12.0.7 (2023-07-17)</small>
+
+* [bitnami/rabbitmq] Release 12.0.7 (#17752) ([872f61f](https://github.com/bitnami/charts/commit/872f61f)), closes [#17752](https://github.com/bitnami/charts/issues/17752)
+
+## <small>12.0.6 (2023-07-13)</small>
+
+* [bitnami/rabbitmq] Release 12.0.6 (#17660) ([9f1bf9f](https://github.com/bitnami/charts/commit/9f1bf9f)), closes [#17660](https://github.com/bitnami/charts/issues/17660)
+
+## <small>12.0.5 (2023-07-13)</small>
+
+* [bitnami/rabbitmq] Updating the tls certs through values.yaml not restarting the pods (#17537) ([c0dea3c](https://github.com/bitnami/charts/commit/c0dea3c)), closes [#17537](https://github.com/bitnami/charts/issues/17537)
+
+## <small>12.0.4 (2023-06-27)</small>
+
+* [bitnami/rabbitmq] Release 12.0.4 (#17361) ([2d36d89](https://github.com/bitnami/charts/commit/2d36d89)), closes [#17361](https://github.com/bitnami/charts/issues/17361)
+* Add copyright header (#17300) ([da68be8](https://github.com/bitnami/charts/commit/da68be8)), closes [#17300](https://github.com/bitnami/charts/issues/17300)
+
+## <small>12.0.3 (2023-06-22)</small>
+
+* [bitnami/rabbitmq] Release 12.0.3 (#17319) ([2858f96](https://github.com/bitnami/charts/commit/2858f96)), closes [#17319](https://github.com/bitnami/charts/issues/17319)
+* Update charts readme (#17217) ([31b3c0a](https://github.com/bitnami/charts/commit/31b3c0a)), closes [#17217](https://github.com/bitnami/charts/issues/17217)
+
+## <small>12.0.2 (2023-06-19)</small>
+
+* [bitnami/rabbitmq] removed empty line added between password and cookie secret (#17162) ([4290ffe](https://github.com/bitnami/charts/commit/4290ffe)), closes [#17162](https://github.com/bitnami/charts/issues/17162)
+
+## <small>12.0.1 (2023-06-13)</small>
+
+* [bitnami/rabbitmq] Set full hostname in rabbitmq svcbind secret (#17056) ([8dfaf4d](https://github.com/bitnami/charts/commit/8dfaf4d)), closes [#17056](https://github.com/bitnami/charts/issues/17056)
+
+## 12.0.0 (2023-06-07)
+
+* [bitnami/rabbitmq] Release 12.0.0 (#17064) ([1b86d3b](https://github.com/bitnami/charts/commit/1b86d3b)), closes [#17064](https://github.com/bitnami/charts/issues/17064)
+
+## <small>11.16.2 (2023-06-05)</small>
+
+* [bitnami/*] Change copyright section in READMEs (#17006) ([ef986a1](https://github.com/bitnami/charts/commit/ef986a1)), closes [#17006](https://github.com/bitnami/charts/issues/17006)
+* [bitnami/rabbitmq] Release 11.16.2 (#17032) ([56326c7](https://github.com/bitnami/charts/commit/56326c7)), closes [#17032](https://github.com/bitnami/charts/issues/17032)
+
+## <small>11.16.1 (2023-06-01)</small>
+
+* [bitnami/rabbitmq] Release 11.16.1 (#16991) ([3f5cb79](https://github.com/bitnami/charts/commit/3f5cb79)), closes [#16991](https://github.com/bitnami/charts/issues/16991)
+* [bitnami/several] Change copyright section in READMEs (#16989) ([5b6a5cf](https://github.com/bitnami/charts/commit/5b6a5cf)), closes [#16989](https://github.com/bitnami/charts/issues/16989)
+
+## 11.16.0 (2023-05-31)
+
+* [bitnami/rabbitmq] Add possibility to specify `params` for ServiceMonitor (#16896) ([a5dba57](https://github.com/bitnami/charts/commit/a5dba57)), closes [#16896](https://github.com/bitnami/charts/issues/16896)
+
+## <small>11.15.7 (2023-05-31)</small>
+
+* Re add curl validation (#16976) ([94da8bb](https://github.com/bitnami/charts/commit/94da8bb)), closes [#16976](https://github.com/bitnami/charts/issues/16976) [#16916](https://github.com/bitnami/charts/issues/16916)
+
+## <small>11.15.6 (2023-05-31)</small>
+
+* [bitnami/rabbitmq] Release 11.15.6 (#16974) ([2daef2a](https://github.com/bitnami/charts/commit/2daef2a)), closes [#16974](https://github.com/bitnami/charts/issues/16974)
+* Changes auth.enableLoopbackUser parameter description (#16958) ([7bd397a](https://github.com/bitnami/charts/commit/7bd397a)), closes [#16958](https://github.com/bitnami/charts/issues/16958)
+
+## <small>11.15.5 (2023-05-30)</small>
+
+* [bitnami/rabbitmq] Release 11.15.5 (#16952) ([02bb38b](https://github.com/bitnami/charts/commit/02bb38b)), closes [#16952](https://github.com/bitnami/charts/issues/16952)
+
+## <small>11.15.4 (2023-05-29)</small>
+
+* [bitnami/rabbitmq] Release 11.15.4 (#16916) ([c6939a5](https://github.com/bitnami/charts/commit/c6939a5)), closes [#16916](https://github.com/bitnami/charts/issues/16916)
+
+## <small>11.15.3 (2023-05-21)</small>
+
+* [bitnami/rabbitmq] Release 11.15.3 (#16786) ([06e2ea2](https://github.com/bitnami/charts/commit/06e2ea2)), closes [#16786](https://github.com/bitnami/charts/issues/16786)
+
+## <small>11.15.2 (2023-05-13)</small>
+
+* [bitnami/rabbitmq] Release 11.15.2 (#16635) ([b9a8e74](https://github.com/bitnami/charts/commit/b9a8e74)), closes [#16635](https://github.com/bitnami/charts/issues/16635)
+
+## <small>11.15.1 (2023-05-11)</small>
+
+* [bitnami/rabbitmq] Use built-in probes if management is not installed (#16567) ([e3d48d6](https://github.com/bitnami/charts/commit/e3d48d6)), closes [#16567](https://github.com/bitnami/charts/issues/16567)
+* Add wording for enterprise page (#16560) ([8f22774](https://github.com/bitnami/charts/commit/8f22774)), closes [#16560](https://github.com/bitnami/charts/issues/16560)
+
+## 11.15.0 (2023-05-09)
+
+* [bitnami/several] Adapt Chart.yaml to set desired OCI annotations (#16546) ([fc9b18f](https://github.com/bitnami/charts/commit/fc9b18f)), closes [#16546](https://github.com/bitnami/charts/issues/16546)
+
+## <small>11.14.5 (2023-05-09)</small>
+
+* [bitnami/rabbitmq] Release 11.14.5 (#16497) ([32c0945](https://github.com/bitnami/charts/commit/32c0945)), closes [#16497](https://github.com/bitnami/charts/issues/16497)
+* Align tls port name to amqp-tls by default (#16335) ([1104e32](https://github.com/bitnami/charts/commit/1104e32)), closes [#16335](https://github.com/bitnami/charts/issues/16335)
+
+## <small>11.14.4 (2023-05-02)</small>
+
+* [bitnami/rabbitmq] Fix high CPU usage while idle (#16082) ([83827ce](https://github.com/bitnami/charts/commit/83827ce)), closes [#16082](https://github.com/bitnami/charts/issues/16082) [#11117](https://github.com/bitnami/charts/issues/11117) [#11180](https://github.com/bitnami/charts/issues/11180) [#11116](https://github.com/bitnami/charts/issues/11116)
+
+## <small>11.14.3 (2023-04-29)</small>
+
+* [bitnami/rabbitmq] Release 11.14.3 (#16285) ([81861c3](https://github.com/bitnami/charts/commit/81861c3)), closes [#16285](https://github.com/bitnami/charts/issues/16285)
+
+## <small>11.14.2 (2023-04-29)</small>
+
+* [bitnami/rabbitmq] Release 11.14.2 (#16271) ([5d68b21](https://github.com/bitnami/charts/commit/5d68b21)), closes [#16271](https://github.com/bitnami/charts/issues/16271)
+
+## <small>11.14.1 (2023-04-27)</small>
+
+* [bitnami/rabbitmq] Use username as key in the Service Binding secret (#16254) ([483fcc8](https://github.com/bitnami/charts/commit/483fcc8)), closes [#16254](https://github.com/bitnami/charts/issues/16254)
+
+## 11.14.0 (2023-04-20)
+
+* [bitnami/*] Make Helm charts 100% OCI (#15998) ([8841510](https://github.com/bitnami/charts/commit/8841510)), closes [#15998](https://github.com/bitnami/charts/issues/15998)
+
+## 11.13.0 (2023-04-04)
+
+* [bitnami/rabbitmq] Updated values.yaml (#15934) ([ac8e273](https://github.com/bitnami/charts/commit/ac8e273)), closes [#15934](https://github.com/bitnami/charts/issues/15934)
+
+## <small>11.12.3 (2023-04-04)</small>
+
+* Add missing version, kind to volumeClaimTemplates (#15943) ([b8ff10c](https://github.com/bitnami/charts/commit/b8ff10c)), closes [#15943](https://github.com/bitnami/charts/issues/15943)
+
+## <small>11.12.2 (2023-04-01)</small>
+
+* [bitnami/rabbitmq] Release 11.12.2 (#15905) ([9c16737](https://github.com/bitnami/charts/commit/9c16737)), closes [#15905](https://github.com/bitnami/charts/issues/15905)
+
+## <small>11.12.1 (2023-03-31)</small>
+
+* [bitnami/rabbitmq] Empty RABBITMQ_FEATURE_FLAGS variable causes some flags to be disabled (#15819) ([dcd192a](https://github.com/bitnami/charts/commit/dcd192a)), closes [#15819](https://github.com/bitnami/charts/issues/15819)
+
+## 11.12.0 (2023-03-21)
+
+* [bitnami/rabbitmq] Add support for service.headless.annotations (#15440) ([9db2941](https://github.com/bitnami/charts/commit/9db2941)), closes [#15440](https://github.com/bitnami/charts/issues/15440)
+
+## <small>11.11.2 (2023-03-20)</small>
+
+* [bitnami/rabbitmq] Release 11.11.2 (#15647) ([4eb06e0](https://github.com/bitnami/charts/commit/4eb06e0)), closes [#15647](https://github.com/bitnami/charts/issues/15647)
+
+## <small>11.11.1 (2023-03-19)</small>
+
+* [bitnami/rabbitmq] Release 11.11.1 (#15604) ([2c8446f](https://github.com/bitnami/charts/commit/2c8446f)), closes [#15604](https://github.com/bitnami/charts/issues/15604)
+
+## 11.11.0 (2023-03-17)
+
+* [bitnami/charts] Apply linter to README files (#15357) ([0e29e60](https://github.com/bitnami/charts/commit/0e29e60)), closes [#15357](https://github.com/bitnami/charts/issues/15357)
+* Add support for StatefulSet annotations (#15529) ([4566584](https://github.com/bitnami/charts/commit/4566584)), closes [#15529](https://github.com/bitnami/charts/issues/15529)
+
+## <small>11.10.3 (2023-03-07)</small>
+
+* [bitnami/rabbitmq] add PVC labels (#15352) ([bd0fbf7](https://github.com/bitnami/charts/commit/bd0fbf7)), closes [#15352](https://github.com/bitnami/charts/issues/15352)
+
+## <small>11.10.2 (2023-03-02)</small>
+
+* [bitnami/rabbitmq] Release 11.10.2 (#15305) ([1a09a4e](https://github.com/bitnami/charts/commit/1a09a4e)), closes [#15305](https://github.com/bitnami/charts/issues/15305)
+
+## <small>11.10.1 (2023-03-01)</small>
+
+* [bitnami/rabbitmq] Release 11.10.1 (#15269) ([505749e](https://github.com/bitnami/charts/commit/505749e)), closes [#15269](https://github.com/bitnami/charts/issues/15269)
+
+## 11.10.0 (2023-02-21)
+
+* [bitnami/rabbitmq] feat: :sparkles: Add ServiceBinding-compatible secrets (#14915) ([6256b83](https://github.com/bitnami/charts/commit/6256b83)), closes [#14915](https://github.com/bitnami/charts/issues/14915)
+
+## <small>11.9.3 (2023-02-17)</small>
+
+* [bitnami/rabbitmq] Release 11.9.3 (#15030) ([9b47294](https://github.com/bitnami/charts/commit/9b47294)), closes [#15030](https://github.com/bitnami/charts/issues/15030)
+
+## <small>11.9.2 (2023-02-17)</small>
+
+* [bitnami/*] Fix markdown linter issues (#14874) ([a51e0e8](https://github.com/bitnami/charts/commit/a51e0e8)), closes [#14874](https://github.com/bitnami/charts/issues/14874)
+* [bitnami/*] Fix markdown linter issues 2 (#14890) ([aa96572](https://github.com/bitnami/charts/commit/aa96572)), closes [#14890](https://github.com/bitnami/charts/issues/14890)
+* [bitnami/*] Remove unexpected extra spaces (#14873) ([c97c714](https://github.com/bitnami/charts/commit/c97c714)), closes [#14873](https://github.com/bitnami/charts/issues/14873)
+* [bitnami/rabbitmq] fix broken config option #14766 (#14859) ([75b0cf6](https://github.com/bitnami/charts/commit/75b0cf6)), closes [#14766](https://github.com/bitnami/charts/issues/14766) [#14859](https://github.com/bitnami/charts/issues/14859) [#14766](https://github.com/bitnami/charts/issues/14766) [#14766](https://github.com/bitnami/charts/issues/14766)
+
+## <small>11.9.1 (2023-02-12)</small>
+
+* [bitnami/rabbitmq] Release 11.9.1 (#14851) ([c7aa17e](https://github.com/bitnami/charts/commit/c7aa17e)), closes [#14851](https://github.com/bitnami/charts/issues/14851)
+
+## 11.9.0 (2023-02-06)
+
+* Charts failing because of the feature flags not enabled (#14387) ([814a95a](https://github.com/bitnami/charts/commit/814a95a)), closes [#14387](https://github.com/bitnami/charts/issues/14387)
+
+## 11.8.0 (2023-02-03)
+
+* [bitnami/rabbitmq] Add Possibility to set tcpListenOptions (#14719) ([37b6c5b](https://github.com/bitnami/charts/commit/37b6c5b)), closes [#14719](https://github.com/bitnami/charts/issues/14719) [#14702](https://github.com/bitnami/charts/issues/14702)
+
+## <small>11.7.1 (2023-02-02)</small>
+
+* [bitnami/rabbitmq] Don't regenerate self-signed certs on upgrade (#14653) ([1369f8e](https://github.com/bitnami/charts/commit/1369f8e)), closes [#14653](https://github.com/bitnami/charts/issues/14653)
+
+## 11.7.0 (2023-02-01)
+
+* [bitnami/*] Change copyright date (#14682) ([add4ec7](https://github.com/bitnami/charts/commit/add4ec7)), closes [#14682](https://github.com/bitnami/charts/issues/14682)
+* [bitnami/rabbitmq] Add ssl_options.password (#14463) ([9941124](https://github.com/bitnami/charts/commit/9941124)), closes [#14463](https://github.com/bitnami/charts/issues/14463) [#14373](https://github.com/bitnami/charts/issues/14373) [#14373](https://github.com/bitnami/charts/issues/14373)
+
+## <small>11.6.1 (2023-01-31)</small>
+
+* [bitnami/rabbitmq] Release 11.6.1 (#14675) ([54b2278](https://github.com/bitnami/charts/commit/54b2278)), closes [#14675](https://github.com/bitnami/charts/issues/14675)
+
+## 11.6.0 (2023-01-26)
+
+* [bitnam/rabbitmq] Choice of setting configuration and extraConfiguration as secret (#14519) ([5520624](https://github.com/bitnami/charts/commit/5520624)), closes [#14519](https://github.com/bitnami/charts/issues/14519) [#14444](https://github.com/bitnami/charts/issues/14444) [#14444](https://github.com/bitnami/charts/issues/14444) [#14444](https://github.com/bitnami/charts/issues/14444) [#14444](https://github.com/bitnami/charts/issues/14444) [#14444](https://github.com/bitnami/charts/issues/14444) [#14444](https://github.com/bitnami/charts/issues/14444) [#14444](https://github.com/bitnami/charts/issues/14444)
+
+## <small>11.5.1 (2023-01-25)</small>
+
+* [bitnami/rabbitmq] Release 11.5.1 (#14535) ([15e9c17](https://github.com/bitnami/charts/commit/15e9c17)), closes [#14535](https://github.com/bitnami/charts/issues/14535)
+
+## 11.5.0 (2023-01-23)
+
+* [bitnami/*] Change licenses annotation format (#14377) ([0ab7608](https://github.com/bitnami/charts/commit/0ab7608)), closes [#14377](https://github.com/bitnami/charts/issues/14377)
+* [bitnami/*] Unify READMEs (#14472) ([2064fb8](https://github.com/bitnami/charts/commit/2064fb8)), closes [#14472](https://github.com/bitnami/charts/issues/14472)
+* [bitnami/rabbitmq] Choice of enabling loopbackUser (#14467) ([3bb3c5e](https://github.com/bitnami/charts/commit/3bb3c5e)), closes [#14467](https://github.com/bitnami/charts/issues/14467) [#14445](https://github.com/bitnami/charts/issues/14445)
+
+## 11.4.0 (2023-01-12)
+
+* [bitnami/*] Add license annotation and remove obsolete engine parameter (#14293) ([da2a794](https://github.com/bitnami/charts/commit/da2a794)), closes [#14293](https://github.com/bitnami/charts/issues/14293)
+* Closes #14209 - Separate TLS certificate/key secret and CA configuration (#14233) ([55d5a72](https://github.com/bitnami/charts/commit/55d5a72)), closes [#14209](https://github.com/bitnami/charts/issues/14209) [#14233](https://github.com/bitnami/charts/issues/14233)
+
+## <small>11.3.2 (2023-01-11)</small>
+
+* [bitnami/rabbitmq] Fixes 14212 - Rabbitmq metrics port configuration follows containerPorts.metrics  ([98b293a](https://github.com/bitnami/charts/commit/98b293a)), closes [#14219](https://github.com/bitnami/charts/issues/14219)
+
+## <small>11.3.1 (2023-01-05)</small>
+
+* [bitnami/rabbitmq] Release 11.3.1 (#14198) ([057b9be](https://github.com/bitnami/charts/commit/057b9be)), closes [#14198](https://github.com/bitnami/charts/issues/14198)
+
+## 11.3.0 (2022-12-23)
+
+* [bitnami/rabbitmq] Set advanced configuration from an existing secret (#14071) ([a1b42f2](https://github.com/bitnami/charts/commit/a1b42f2)), closes [#14071](https://github.com/bitnami/charts/issues/14071)
+
+## <small>11.2.2 (2022-12-16)</small>
+
+* [bitnami/rabbitmq] Release 11.2.2 (#13991) ([46f96af](https://github.com/bitnami/charts/commit/46f96af)), closes [#13991](https://github.com/bitnami/charts/issues/13991)
+
+## <small>11.2.1 (2022-12-14)</small>
+
+* [bitnami/rabbitmq] Release 11.2.1 (#13949) ([fbcec45](https://github.com/bitnami/charts/commit/fbcec45)), closes [#13949](https://github.com/bitnami/charts/issues/13949)
+
+## 11.2.0 (2022-12-07)
+
+* [bitnami/rabbitmq] Add parameter for headless service naming customization (#13805) ([e963f17](https://github.com/bitnami/charts/commit/e963f17)), closes [#13805](https://github.com/bitnami/charts/issues/13805)
+
+## <small>11.1.5 (2022-11-29)</small>
+
+* [bitnami/rabbitmq] Release 11.1.5 (#13731) ([ff99dba](https://github.com/bitnami/charts/commit/ff99dba)), closes [#13731](https://github.com/bitnami/charts/issues/13731)
+
+## <small>11.1.4 (2022-11-21)</small>
+
+* [bitnami/rabbitmq] fix apiversion hardcode for NetworkPolicy (#13600) ([9073ee2](https://github.com/bitnami/charts/commit/9073ee2)), closes [#13600](https://github.com/bitnami/charts/issues/13600)
+
+## <small>11.1.3 (2022-11-18)</small>
+
+* [bitnami/rabbitmq]fix apiversion hardcode for statefulset (#13563) ([b014902](https://github.com/bitnami/charts/commit/b014902)), closes [#13563](https://github.com/bitnami/charts/issues/13563)
+
+## <small>11.1.2 (2022-11-10)</small>
+
+* [bitnami/rabbitmq] Release 11.1.2 (#13452) ([61cac97](https://github.com/bitnami/charts/commit/61cac97)), closes [#13452](https://github.com/bitnami/charts/issues/13452)
+
+## <small>11.1.1 (2022-10-27)</small>
+
+* [bitnami/rabbitmq] Configure password correctly when RABBITMQ_SECURE_PASSWORD is not enabled (#13141 ([e51cb75](https://github.com/bitnami/charts/commit/e51cb75)), closes [#13141](https://github.com/bitnami/charts/issues/13141)
+
+## 11.1.0 (2022-10-25)
+
+* [bitnami/rabbitmq]fix secure password env hardcode (#13056) ([dfad63c](https://github.com/bitnami/charts/commit/dfad63c)), closes [#13056](https://github.com/bitnami/charts/issues/13056)
+
+## <small>11.0.4 (2022-10-24)</small>
+
+* [bitnami/rabbitmq] Fix rolebinding creation (#13115) ([a946379](https://github.com/bitnami/charts/commit/a946379)), closes [#13115](https://github.com/bitnami/charts/issues/13115)
+
+## <small>11.0.3 (2022-10-19)</small>
+
+* [bitnami/rabbitmq] Release 11.0.3 (#13022) ([f57d296](https://github.com/bitnami/charts/commit/f57d296)), closes [#13022](https://github.com/bitnami/charts/issues/13022)
+
+## <small>11.0.2 (2022-10-18)</small>
+
+* [bitnami/*] Use new default branch name in links (#12943) ([a529e02](https://github.com/bitnami/charts/commit/a529e02)), closes [#12943](https://github.com/bitnami/charts/issues/12943)
+* [bitnami/rabbitmq] Release 11.0.2 (#12995) ([f15388e](https://github.com/bitnami/charts/commit/f15388e)), closes [#12995](https://github.com/bitnami/charts/issues/12995)
+* [bitnami/rabbitmq] Support ingress.existingSecret for Rabbitmq (#12908) ([a4b91d0](https://github.com/bitnami/charts/commit/a4b91d0)), closes [#12908](https://github.com/bitnami/charts/issues/12908)
+* [bitnami/rabbitmq] Update README after releasing version 11.0.0 (#12973) ([60f203c](https://github.com/bitnami/charts/commit/60f203c)), closes [#12973](https://github.com/bitnami/charts/issues/12973)
+
+## <small>11.0.1 (2022-10-17)</small>
+
+* [bitnami/rabbitmq] Release 11.0.1 (#12949) ([b1592ca](https://github.com/bitnami/charts/commit/b1592ca)), closes [#12949](https://github.com/bitnami/charts/issues/12949)
+
+## 11.0.0 (2022-10-11)
+
+* [bitnami/rabbitmq] Release 11.0.0 (#12909) ([bb360fe](https://github.com/bitnami/charts/commit/bb360fe)), closes [#12909](https://github.com/bitnami/charts/issues/12909)
+
+## <small>10.3.9 (2022-10-05)</small>
+
+* [bitnami/rabbitmq] Release 10.3.9 (#12824) ([93b0f1a](https://github.com/bitnami/charts/commit/93b0f1a)), closes [#12824](https://github.com/bitnami/charts/issues/12824)
+
+## <small>10.3.8 (2022-10-05)</small>
+
+* [bitnami/rabbitmq] Generic README instructions related to the repo (#12795) ([344317e](https://github.com/bitnami/charts/commit/344317e)), closes [#12795](https://github.com/bitnami/charts/issues/12795)
+* [bitnami/rabbitmq] Release 10.3.8 (#12813) ([7e7ce74](https://github.com/bitnami/charts/commit/7e7ce74)), closes [#12813](https://github.com/bitnami/charts/issues/12813)
+
+## <small>10.3.7 (2022-10-04)</small>
+
+* [bitnami/rabbitmq] Release 10.3.7 (#12802) ([25a91de](https://github.com/bitnami/charts/commit/25a91de)), closes [#12802](https://github.com/bitnami/charts/issues/12802)
+
+## <small>10.3.6 (2022-09-27)</small>
+
+* [bitnami/rabbitmq] Release 10.3.6 (#12684) ([ed47cdc](https://github.com/bitnami/charts/commit/ed47cdc)), closes [#12684](https://github.com/bitnami/charts/issues/12684)
+
+## <small>10.3.5 (2022-09-08)</small>
+
+* [bitnami/rabbitmq] Release 10.3.4 (#12331) ([2fd9cbe](https://github.com/bitnami/charts/commit/2fd9cbe)), closes [#12331](https://github.com/bitnami/charts/issues/12331)
+
+## <small>10.3.4 (2022-09-08)</small>
+
+* [bitnami/rabbitmq] Bump chart version (#12327) ([c9ab756](https://github.com/bitnami/charts/commit/c9ab756)), closes [#12327](https://github.com/bitnami/charts/issues/12327)
+* RabbitMQ: Use custom probes if given (#12303) ([99e9d0c](https://github.com/bitnami/charts/commit/99e9d0c)), closes [#12303](https://github.com/bitnami/charts/issues/12303)
+
+## <small>10.3.3 (2022-09-07)</small>
+
+* [bitnami/rabbitmq] Improve error handling message (#12227) (#12227) ([fdd88a5](https://github.com/bitnami/charts/commit/fdd88a5)), closes [#12227](https://github.com/bitnami/charts/issues/12227) [#12227](https://github.com/bitnami/charts/issues/12227)
+
+## <small>10.3.2 (2022-08-30)</small>
+
+* Fixing init scripts via configmap/secret (#12161) (#12170) ([39239fc](https://github.com/bitnami/charts/commit/39239fc)), closes [#12161](https://github.com/bitnami/charts/issues/12161) [#12170](https://github.com/bitnami/charts/issues/12170)
+
+## <small>10.3.1 (2022-08-23)</small>
+
+* [bitnami/rabbitmq] Update Chart.lock (#12070) ([7016384](https://github.com/bitnami/charts/commit/7016384)), closes [#12070](https://github.com/bitnami/charts/issues/12070)
+
+## 10.3.0 (2022-08-22)
+
+* [bitnami/rabbitmq] Add support for image digest apart from tag (#11938) ([704644f](https://github.com/bitnami/charts/commit/704644f)), closes [#11938](https://github.com/bitnami/charts/issues/11938)
+
+## <small>10.2.1 (2022-08-10)</small>
+
+* [bitnami/rabbitmq] Revert rabbitmq probes (#11177) ([1ae90e5](https://github.com/bitnami/charts/commit/1ae90e5)), closes [#11177](https://github.com/bitnami/charts/issues/11177) [#11117](https://github.com/bitnami/charts/issues/11117)
+
+## 10.2.0 (2022-08-10)
+
+* [bitnami/rabbitmq] Add init scripts support (#11013) ([a5ae293](https://github.com/bitnami/charts/commit/a5ae293)), closes [#11013](https://github.com/bitnami/charts/issues/11013)
+
+## <small>10.1.19 (2022-08-09)</small>
+
+* [bitnami/rabbitmq] Release 10.1.19 (#11668) ([d2cb921](https://github.com/bitnami/charts/commit/d2cb921)), closes [#11668](https://github.com/bitnami/charts/issues/11668)
+* Document data layout change in RabbitMQ 7.0.0 (#11461) ([08ac2ae](https://github.com/bitnami/charts/commit/08ac2ae)), closes [#11461](https://github.com/bitnami/charts/issues/11461)
+
+## <small>10.1.18 (2022-08-04)</small>
+
+* [bitnami/rabbitmq] Release 10.1.18 (#11596) ([ff20ed7](https://github.com/bitnami/charts/commit/ff20ed7)), closes [#11596](https://github.com/bitnami/charts/issues/11596)
+
+## <small>10.1.17 (2022-08-04)</small>
+
+* [bitnami/*] Update URLs to point to the new bitnami/containers monorepo (#11352) ([d665af0](https://github.com/bitnami/charts/commit/d665af0)), closes [#11352](https://github.com/bitnami/charts/issues/11352)
+* [bitnami/rabbitmq] Release 10.1.17 (#11512) ([3e7a378](https://github.com/bitnami/charts/commit/3e7a378)), closes [#11512](https://github.com/bitnami/charts/issues/11512)
+
+## <small>10.1.16 (2022-07-25)</small>
+
+* [bitnami/rabbitmq] Fix volume-permissions initContainer if runAsUser is auto (#11300) ([1d59ac4](https://github.com/bitnami/charts/commit/1d59ac4)), closes [#11300](https://github.com/bitnami/charts/issues/11300)
+
+## <small>10.1.15 (2022-07-22)</small>
+
+* [bitnami/rabbitmq] Release 10.1.15 (#11310) ([50463f3](https://github.com/bitnami/charts/commit/50463f3)), closes [#11310](https://github.com/bitnami/charts/issues/11310)
+
+## <small>10.1.14 (2022-07-12)</small>
+
+* [bitnami/rabbitmq] Fix high CPU usage while idle (#11117) ([73966c6](https://github.com/bitnami/charts/commit/73966c6)), closes [#11117](https://github.com/bitnami/charts/issues/11117) [#11116](https://github.com/bitnami/charts/issues/11116)
+
+## <small>10.1.13 (2022-07-08)</small>
+
+* [bitnami/rabbitmq] Allow set custom logging (#11049) ([5393b96](https://github.com/bitnami/charts/commit/5393b96)), closes [#11049](https://github.com/bitnami/charts/issues/11049)
+
+## <small>10.1.12 (2022-07-01)</small>
+
+* [bitnami/rabbitmq] Allow to customize volumePermissions.containerSecurityContext.runAsUser (#10901) ([bec65c1](https://github.com/bitnami/charts/commit/bec65c1)), closes [#10901](https://github.com/bitnami/charts/issues/10901)
+
+## <small>10.1.11 (2022-06-30)</small>
+
+* [bitnami/rabbitmq] Release 10.1.11 (#10957) ([5f40d6b](https://github.com/bitnami/charts/commit/5f40d6b)), closes [#10957](https://github.com/bitnami/charts/issues/10957)
+
+## <small>10.1.10 (2022-06-27)</small>
+
+* Reverts PR #10042 (#10886) ([ea8b0cf](https://github.com/bitnami/charts/commit/ea8b0cf)), closes [#10042](https://github.com/bitnami/charts/issues/10042) [#10886](https://github.com/bitnami/charts/issues/10886)
+
+## <small>10.1.9 (2022-06-22)</small>
+
+* [bitnami/rabbitmq] Use short DNS names for clustering (#10042) ([5858dd5](https://github.com/bitnami/charts/commit/5858dd5)), closes [#10042](https://github.com/bitnami/charts/issues/10042)
+
+## <small>10.1.8 (2022-06-15)</small>
+
+* [bitnami/rabbitmq] fix: Typo in the port name of rabbitmq notes (#10688) ([45ef50f](https://github.com/bitnami/charts/commit/45ef50f)), closes [#10688](https://github.com/bitnami/charts/issues/10688)
+
+## <small>10.1.7 (2022-06-11)</small>
+
+* [bitnami/rabbitmq] Release 10.1.7 updating components versions ([b13fc76](https://github.com/bitnami/charts/commit/b13fc76))
+
+## <small>10.1.6 (2022-06-10)</small>
+
+* [bitnami/*] Replace Kubeapps URL in READMEs (and kubeapps Chart.yaml) and remove BKPR references (#1 ([c6a7914](https://github.com/bitnami/charts/commit/c6a7914)), closes [#10600](https://github.com/bitnami/charts/issues/10600)
+* [bitnami/rabbitmq] Release 10.1.6 updating components versions ([12544dc](https://github.com/bitnami/charts/commit/12544dc))
+
+## <small>10.1.5 (2022-06-06)</small>
+
+* [bitnami/rabbitmq] Release 10.1.5 updating components versions ([58525ea](https://github.com/bitnami/charts/commit/58525ea))
+
+## <small>10.1.4 (2022-06-03)</small>
+
+* [bitnami/rabbitmq] Release 10.1.4 updating components versions ([09ed917](https://github.com/bitnami/charts/commit/09ed917))
+
+## <small>10.1.3 (2022-06-03)</small>
+
+* [bitnami/rabbitmq] fix: extraSecretsPrependReleaseName (#10558) ([8f37a00](https://github.com/bitnami/charts/commit/8f37a00)), closes [#10558](https://github.com/bitnami/charts/issues/10558)
+* [bitnami/several] Replace maintainers email by url (#10523) ([ff3cf61](https://github.com/bitnami/charts/commit/ff3cf61)), closes [#10523](https://github.com/bitnami/charts/issues/10523)
+
+## <small>10.1.2 (2022-06-01)</small>
+
+* [bitnami/rabbitmq] Release 10.1.2 updating components versions ([3fa150e](https://github.com/bitnami/charts/commit/3fa150e))
+
+## <small>10.1.1 (2022-05-30)</small>
+
+* [bitnami/several] Replace base64 --decode with base64 -d (#10495) ([099286a](https://github.com/bitnami/charts/commit/099286a)), closes [#10495](https://github.com/bitnami/charts/issues/10495)
+
+## 10.1.0 (2022-05-30)
+
+* [bitnami/rabbitmq] LDAP standardisation for LDAP (#10451) ([cebd4aa](https://github.com/bitnami/charts/commit/cebd4aa)), closes [#10451](https://github.com/bitnami/charts/issues/10451)
+
+## <small>10.0.1 (2022-05-27)</small>
+
+* [bitnami/rabbitmq] Release 10.0.1 updating components versions ([db7d2b2](https://github.com/bitnami/charts/commit/db7d2b2))
+
+## 10.0.0 (2022-05-26)
+
+* [bitnami/rabbitmq] feat!: :arrow_up: Bump default image to 3.10.x (#10401) ([ea20500](https://github.com/bitnami/charts/commit/ea20500)), closes [#10401](https://github.com/bitnami/charts/issues/10401)
+
+## <small>9.1.4 (2022-05-21)</small>
+
+* [bitnami/rabbitmq] Release 9.1.4 updating components versions ([783edd7](https://github.com/bitnami/charts/commit/783edd7))
+
+## <small>9.1.3 (2022-05-20)</small>
+
+* [bitnami/rabbitmq] Release 9.1.3 updating components versions ([daa8e96](https://github.com/bitnami/charts/commit/daa8e96))
+
+## <small>9.1.2 (2022-05-19)</small>
+
+* [bitnami/rabbitmq] Release 9.1.2 updating components versions ([0dac623](https://github.com/bitnami/charts/commit/0dac623))
+
+## <small>9.1.1 (2022-05-18)</small>
+
+* [bitnami/rabbitmq] Release 9.1.1 updating components versions ([d4891f2](https://github.com/bitnami/charts/commit/d4891f2))
+
+## 9.1.0 (2022-05-16)
+
+*  [bitnami/rabbitmq] helm install ignores setting clusterIP when using service type LoadBalancer  (#1 ([6be0864](https://github.com/bitnami/charts/commit/6be0864)), closes [#10176](https://github.com/bitnami/charts/issues/10176)
+* [bitnami/*] add ingress extraRules feature (#10253) ([0f6cbb9](https://github.com/bitnami/charts/commit/0f6cbb9)), closes [#10253](https://github.com/bitnami/charts/issues/10253)
+
+## <small>9.0.8 (2022-05-13)</small>
+
+* [bitnami/*] Remove old 'ci' files (#10171) ([5df30c4](https://github.com/bitnami/charts/commit/5df30c4)), closes [#10171](https://github.com/bitnami/charts/issues/10171)
+* [bitnami/*] Unify k8s directives separators (#10185) ([2650214](https://github.com/bitnami/charts/commit/2650214)), closes [#10185](https://github.com/bitnami/charts/issues/10185)
+
+## <small>9.0.7 (2022-05-11)</small>
+
+* [bitnami/*] Fix typo in comments (relay -> rely) (#10151) ([9cfe4a4](https://github.com/bitnami/charts/commit/9cfe4a4)), closes [#10151](https://github.com/bitnami/charts/issues/10151)
+
+## <small>9.0.6 (2022-05-11)</small>
+
+* [bitnami/rabbitmq] Fixed missing `$` in secrets (#10108) ([6362170](https://github.com/bitnami/charts/commit/6362170)), closes [#10108](https://github.com/bitnami/charts/issues/10108)
+
+## <small>9.0.5 (2022-05-11)</small>
+
+* [bitnami/rabbitmq] Release 9.0.5 updating components versions ([97d3e91](https://github.com/bitnami/charts/commit/97d3e91))
+
+## <small>9.0.4 (2022-05-10)</small>
+
+* [bitnami/rabbitmq] reuse secret data during upgrade with look up (#9724) ([03b72e6](https://github.com/bitnami/charts/commit/03b72e6)), closes [#9724](https://github.com/bitnami/charts/issues/9724)
+
+## <small>9.0.3 (2022-05-06)</small>
+
+* [bitnami/rabbitmq] Add '-r' to volumePermissions to not fail on empty xargs (#10053) ([e7d4f2f](https://github.com/bitnami/charts/commit/e7d4f2f)), closes [#10053](https://github.com/bitnami/charts/issues/10053)
+
+## <small>9.0.2 (2022-05-05)</small>
+
+* [bitnami/rabbitmq] Use short dns name for the Kubernetes api (#10019) ([ea783e2](https://github.com/bitnami/charts/commit/ea783e2)), closes [#10019](https://github.com/bitnami/charts/issues/10019)
+
+## <small>9.0.1 (2022-05-03)</small>
+
+* [bitnami/rabbitmq] Fix metrics service port value (#9987) ([76de19e](https://github.com/bitnami/charts/commit/76de19e)), closes [#9987](https://github.com/bitnami/charts/issues/9987)
+
+## 9.0.0 (2022-04-28)
+
+* [bitnami/rabbitmq] Chart standardised (#9817) ([3315cbd](https://github.com/bitnami/charts/commit/3315cbd)), closes [#9817](https://github.com/bitnami/charts/issues/9817)
+
+## <small>8.32.2 (2022-04-27)</small>
+
+* [bitnami/rabbitmq] Release 8.32.2 updating components versions ([d5f2aee](https://github.com/bitnami/charts/commit/d5f2aee))
+
+## <small>8.32.1 (2022-04-22)</small>
+
+* Fixed ingress bug with extraHosts in RabbitMQ chart. (#9843) ([aad0a78](https://github.com/bitnami/charts/commit/aad0a78)), closes [#9843](https://github.com/bitnami/charts/issues/9843)
+
+## 8.32.0 (2022-04-20)
+
+* [bitnami/rabbitmq] Add dnsConfig option to rabbitmq (#9810) ([7d6311c](https://github.com/bitnami/charts/commit/7d6311c)), closes [#9810](https://github.com/bitnami/charts/issues/9810)
+
+## <small>8.31.7 (2022-04-20)</small>
+
+* [bitnami/rabbitmq] Release 8.31.7 updating components versions ([ab38a81](https://github.com/bitnami/charts/commit/ab38a81))
+
+## <small>8.31.6 (2022-04-19)</small>
+
+* [bitnami/rabbitmq] Release 8.31.6 updating components versions ([4adbc6c](https://github.com/bitnami/charts/commit/4adbc6c))
+
+## <small>8.31.5 (2022-04-18)</small>
+
+* [bitnami/rabbitmq] Fix AMQP port installation notes (#9813) ([220c243](https://github.com/bitnami/charts/commit/220c243)), closes [#9813](https://github.com/bitnami/charts/issues/9813)
+
+## <small>8.31.4 (2022-04-13)</small>
+
+* [bitnami/rabbitmq] Release 8.31.4 updating components versions ([f256d28](https://github.com/bitnami/charts/commit/f256d28))
+
+## <small>8.31.3 (2022-04-07)</small>
+
+* [bitnami/rabbitmq] Release 8.31.3 updating components versions ([ca58d0c](https://github.com/bitnami/charts/commit/ca58d0c))
+
+## <small>8.31.2 (2022-04-02)</small>
+
+* [bitnami/rabbitmq] Release 8.31.2 updating components versions ([d1bb9eb](https://github.com/bitnami/charts/commit/d1bb9eb))
+
+## <small>8.31.1 (2022-04-02)</small>
+
+* [bitnami/rabbitmq] Release 8.31.1 updating components versions ([3a328ef](https://github.com/bitnami/charts/commit/3a328ef))
+
+## 8.31.0 (2022-04-01)
+
+* [bitnami/rabbitmq] Allow both definitions and setting credentials (#9638) ([ac845cb](https://github.com/bitnami/charts/commit/ac845cb)), closes [#9638](https://github.com/bitnami/charts/issues/9638)
+
+## <small>8.30.4 (2022-03-28)</small>
+
+* [bitnami/rabbitmq] Release 8.30.4 updating components versions ([2016a03](https://github.com/bitnami/charts/commit/2016a03))
+
+## <small>8.30.3 (2022-03-27)</small>
+
+* [bitnami/rabbitmq] Release 8.30.3 updating components versions ([2b8e2b3](https://github.com/bitnami/charts/commit/2b8e2b3))
+
+## <small>8.30.2 (2022-03-22)</small>
+
+* [bitnami/rabbitmq] Release 8.30.2 updating components versions ([8bfdcda](https://github.com/bitnami/charts/commit/8bfdcda))
+
+## <small>8.30.1 (2022-03-16)</small>
+
+* [bitnami/rabbitmq] Release 8.30.1 updating components versions ([935d857](https://github.com/bitnami/charts/commit/935d857))
+
+## 8.30.0 (2022-03-04)
+
+* [bitnami/rabbitmq] Add support for ingress alt backend (#9276) ([bfd233a](https://github.com/bitnami/charts/commit/bfd233a)), closes [#9276](https://github.com/bitnami/charts/issues/9276)
+
+## <small>8.29.3 (2022-02-27)</small>
+
+* [bitnami/rabbitmq] Release 8.29.3 updating components versions ([67fd7bb](https://github.com/bitnami/charts/commit/67fd7bb))
+
+## <small>8.29.2 (2022-02-24)</small>
+
+* [bitnami/rabbitmq] Release 8.29.2 updating components versions ([6a41a6f](https://github.com/bitnami/charts/commit/6a41a6f))
+
+## <small>8.29.1 (2022-02-20)</small>
+
+* [bitnami/rabbitmq] Release 8.29.1 updating components versions ([72e4509](https://github.com/bitnami/charts/commit/72e4509))
+
+## 8.29.0 (2022-02-10)
+
+* [bitnami/rabbitmq] Add support for custom mountPath and subpath (#8939) ([694e7f2](https://github.com/bitnami/charts/commit/694e7f2)), closes [#8939](https://github.com/bitnami/charts/issues/8939)
+* Non utf8 chars (#8923) ([6ffd18f](https://github.com/bitnami/charts/commit/6ffd18f)), closes [#8923](https://github.com/bitnami/charts/issues/8923)
+
+## <small>8.28.1 (2022-02-02)</small>
+
+* [bitnami/*] Make use of new "common.ingress.certManagerRequest" helper (#8862) ([12e4c37](https://github.com/bitnami/charts/commit/12e4c37)), closes [#8862](https://github.com/bitnami/charts/issues/8862)
+
+## 8.28.0 (2022-02-01)
+
+* [bitnami/rabbitmq] fix: Remove postStart hook (#8855) ([adc6b3d](https://github.com/bitnami/charts/commit/adc6b3d)), closes [#8855](https://github.com/bitnami/charts/issues/8855)
+
+## 8.27.0 (2022-01-24)
+
+* [bitnami/rabbitmq] Added option to disable epmd and dist port on service (#8750) ([74ede1e](https://github.com/bitnami/charts/commit/74ede1e)), closes [#8750](https://github.com/bitnami/charts/issues/8750)
+* [bitnami/several] Change prerequisites (#8725) ([8d740c5](https://github.com/bitnami/charts/commit/8d740c5)), closes [#8725](https://github.com/bitnami/charts/issues/8725)
+
+## <small>8.26.3 (2022-01-19)</small>
+
+* [bitnami/*] Update READMEs (#8716) ([b9a9533](https://github.com/bitnami/charts/commit/b9a9533)), closes [#8716](https://github.com/bitnami/charts/issues/8716)
+* [bitnami/rabbitmq] Release 8.26.3 updating components versions ([c071bb8](https://github.com/bitnami/charts/commit/c071bb8))
+
+## <small>8.26.2 (2022-01-19)</small>
+
+* [bitnami/*] Readme automation (#8579) ([78d1938](https://github.com/bitnami/charts/commit/78d1938)), closes [#8579](https://github.com/bitnami/charts/issues/8579)
+* [bitnami/rabbitmq] Release 8.26.2 updating components versions ([f1ea71c](https://github.com/bitnami/charts/commit/f1ea71c))
+
+## <small>8.26.1 (2022-01-11)</small>
+
+* [bitnami/rabbitmq] Release 8.26.1 updating components versions ([048e65e](https://github.com/bitnami/charts/commit/048e65e))
+
+## 8.26.0 (2022-01-07)
+
+* [bitnami/rabbitmq] Support for relabling and aligned service monitor with other charts (#8583) ([6e64d41](https://github.com/bitnami/charts/commit/6e64d41)), closes [#8583](https://github.com/bitnami/charts/issues/8583)
+
+## <small>8.25.1 (2022-01-06)</small>
+
+* [bitnami/rabbitmq] Release 8.25.1 updating components versions ([2a9e44a](https://github.com/bitnami/charts/commit/2a9e44a))
+
+## 8.25.0 (2022-01-05)
+
+* [bitnami/several] Adapt templating format (#8562) ([8cad18a](https://github.com/bitnami/charts/commit/8cad18a)), closes [#8562](https://github.com/bitnami/charts/issues/8562)
+* [bitnami/several] Add license to the README ([05f7633](https://github.com/bitnami/charts/commit/05f7633))
+* [bitnami/several] Add license to the README ([32fb238](https://github.com/bitnami/charts/commit/32fb238))
+* [bitnami/several] Add license to the README ([b87c2f7](https://github.com/bitnami/charts/commit/b87c2f7))
+
+## <small>8.24.13 (2022-01-01)</small>
+
+* [bitnami/rabbitmq] Release 8.24.13 updating components versions ([d1680a5](https://github.com/bitnami/charts/commit/d1680a5))
+* RabbitMQ chart copy updates (#8432) ([99b480d](https://github.com/bitnami/charts/commit/99b480d)), closes [#8432](https://github.com/bitnami/charts/issues/8432)
+
+## <small>8.24.12 (2021-12-13)</small>
+
+* [bitnami/RabbitMQ] Allow to set nodePort when type is LoadBalancer for all ports (#8369) ([4937d48](https://github.com/bitnami/charts/commit/4937d48)), closes [#8369](https://github.com/bitnami/charts/issues/8369)
+
+## <small>8.24.11 (2021-12-09)</small>
+
+* [bitnami/rabbitmq] fix error with scope of .Values in secrets template (#8339) ([8ca5052](https://github.com/bitnami/charts/commit/8ca5052)), closes [#8339](https://github.com/bitnami/charts/issues/8339)
+
+## <small>8.24.10 (2021-12-07)</small>
+
+* [bitnami/rabbitmq] fix common annotations in secrets template (#8329) ([c093be3](https://github.com/bitnami/charts/commit/c093be3)), closes [#8329](https://github.com/bitnami/charts/issues/8329)
+
+## <small>8.24.9 (2021-12-02)</small>
+
+* [bitnami/rabbitmq] Release 8.24.9 updating components versions ([2b811ea](https://github.com/bitnami/charts/commit/2b811ea))
+
+## <small>8.24.8 (2021-11-29)</small>
+
+* [bitnami/several] Regenerate README tables ([ac75243](https://github.com/bitnami/charts/commit/ac75243))
+* [bitnami/several] Replace HTTP by HTTPS when possible (#8259) ([eafb5bd](https://github.com/bitnami/charts/commit/eafb5bd)), closes [#8259](https://github.com/bitnami/charts/issues/8259)
+
+## <small>8.24.7 (2021-11-25)</small>
+
+* [bitnami/rabbitmq] Release 8.24.7 updating components versions ([6681ad5](https://github.com/bitnami/charts/commit/6681ad5))
+* [bitnami/several] Fix deadlinks in README.md (#8215) ([99e90d2](https://github.com/bitnami/charts/commit/99e90d2)), closes [#8215](https://github.com/bitnami/charts/issues/8215)
+
+## <small>8.24.6 (2021-11-23)</small>
+
+* [bitnami/rabbitmq] PodDisruptionBudget: support apiVersion policy/v1 (#8018) ([0c03c7c](https://github.com/bitnami/charts/commit/0c03c7c)), closes [#8018](https://github.com/bitnami/charts/issues/8018)
+* [bitnami/several] Regenerate README tables ([e8e4e6a](https://github.com/bitnami/charts/commit/e8e4e6a))
+
+## <small>8.24.5 (2021-11-21)</small>
+
+* [bitnami/rabbitmq] Release 8.24.5 updating components versions ([8d1d19f](https://github.com/bitnami/charts/commit/8d1d19f))
+
+## <small>8.24.4 (2021-11-16)</small>
+
+* [bitnami/rabbitmq] Set publishNotReadyAddresses to true in headless service (#8135) ([d82c934](https://github.com/bitnami/charts/commit/d82c934)), closes [#8135](https://github.com/bitnami/charts/issues/8135)
+* [bitnami/several] Regenerate README tables ([e6f742c](https://github.com/bitnami/charts/commit/e6f742c))
+
+## <small>8.24.3 (2021-11-12)</small>
+
+* [bitnami/rabbitmq] Release 8.24.3 updating components versions ([fb757a2](https://github.com/bitnami/charts/commit/fb757a2))
+* [bitnami/several] Regenerate README tables ([412cf6a](https://github.com/bitnami/charts/commit/412cf6a))
+
+## <small>8.24.2 (2021-10-27)</small>
+
+* [bitnami/rabbitmq] Release 8.24.2 updating components versions ([f682c81](https://github.com/bitnami/charts/commit/f682c81))
+
+## <small>8.24.1 (2021-10-22)</small>
+
+* [bitnami/several] Add chart info to NOTES.txt (#7889) ([a6751cd](https://github.com/bitnami/charts/commit/a6751cd)), closes [#7889](https://github.com/bitnami/charts/issues/7889)
+
+## 8.24.0 (2021-10-22)
+
+* [bitnami/rabbimq] Set cluster_partition_handling as parameter in values.yaml (#7874) ([5597ce8](https://github.com/bitnami/charts/commit/5597ce8)), closes [#7874](https://github.com/bitnami/charts/issues/7874)
+* [bitnami/several] Regenerate README tables ([73cabea](https://github.com/bitnami/charts/commit/73cabea))
+
+## <small>8.23.4 (2021-10-20)</small>
+
+* [bitnami/rabbitmq] Release 8.23.4 updating components versions ([10e4358](https://github.com/bitnami/charts/commit/10e4358))
+
+## <small>8.23.3 (2021-10-19)</small>
+
+* [bitnami/several] Change pullPolicy for bitnami-shell image (#7852) ([9711a33](https://github.com/bitnami/charts/commit/9711a33)), closes [#7852](https://github.com/bitnami/charts/issues/7852)
+
+## <small>8.23.2 (2021-10-19)</small>
+
+* [bitnami/rabbitmq] Fix default for topologySpreadConstraints (#7843) ([ede4f2b](https://github.com/bitnami/charts/commit/ede4f2b)), closes [#7843](https://github.com/bitnami/charts/issues/7843)
+
+## <small>8.23.1 (2021-10-14)</small>
+
+* [bitnami/*] Generate READMEs (#7790) ([0833a8c](https://github.com/bitnami/charts/commit/0833a8c)), closes [#7790](https://github.com/bitnami/charts/issues/7790)
+* bitnami/rabbitmq - Fix management port when service type is LoadBalancer (#7798) ([6f3e953](https://github.com/bitnami/charts/commit/6f3e953)), closes [#7798](https://github.com/bitnami/charts/issues/7798)
+
+## 8.23.0 (2021-10-13)
+
+* [bitnami/rabbitmq] Added option to configure automounting service credentials (#7745) ([6592de6](https://github.com/bitnami/charts/commit/6592de6)), closes [#7745](https://github.com/bitnami/charts/issues/7745)
+
+## <small>8.22.4 (2021-09-30)</small>
+
+* [bitnami/*] Drop support for deprecated cert-manager annotation (#7656) ([bbf403b](https://github.com/bitnami/charts/commit/bbf403b)), closes [#7656](https://github.com/bitnami/charts/issues/7656)
+* [bitnami/several] Regenerate README tables ([ff170d1](https://github.com/bitnami/charts/commit/ff170d1))
+
+## <small>8.22.3 (2021-09-24)</small>
+
+* [bitnami/*] Generate READMEs with new generator version (#7614) ([e5ab2e6](https://github.com/bitnami/charts/commit/e5ab2e6)), closes [#7614](https://github.com/bitnami/charts/issues/7614)
+* [bitnami/rabbitmq] Release 8.22.3 updating components versions ([d5301af](https://github.com/bitnami/charts/commit/d5301af))
+* [bitnami/several] Regenerate README tables ([003a0fb](https://github.com/bitnami/charts/commit/003a0fb))
+
+## <small>8.22.2 (2021-09-17)</small>
+
+* [bitnami/rabbitmq] Release 8.22.2 updating components versions ([b7c979a](https://github.com/bitnami/charts/commit/b7c979a))
+* [bitnami/several] Regenerate README tables ([5c79422](https://github.com/bitnami/charts/commit/5c79422))
+
+## <small>8.22.1 (2021-09-14)</small>
+
+* [bitnami/rabbitmq] Fix typo on values.yaml (#7477) ([ae013f8](https://github.com/bitnami/charts/commit/ae013f8)), closes [#7477](https://github.com/bitnami/charts/issues/7477)
+* [bitnami/several] Regenerate README tables ([dcb935c](https://github.com/bitnami/charts/commit/dcb935c))
+
+## 8.22.0 (2021-09-08)
+
+* [bitnami/rabbitmq] Add persistence annotations to PVC (#7380) ([457a3e5](https://github.com/bitnami/charts/commit/457a3e5)), closes [#7380](https://github.com/bitnami/charts/issues/7380)
+* [bitnami/several] Regenerate README tables ([8c2dfde](https://github.com/bitnami/charts/commit/8c2dfde))
+
+## 8.21.0 (2021-09-02)
+
+* [bitnami/rabbitmq] Add upgrade note for rabbitmq 3.9 (#7161) ([ba5e368](https://github.com/bitnami/charts/commit/ba5e368)), closes [#7161](https://github.com/bitnami/charts/issues/7161)
+* [bitnami/several] Regenerate README tables ([64d5d74](https://github.com/bitnami/charts/commit/64d5d74))
+
+## <small>8.20.5 (2021-08-28)</small>
+
+* [bitnami/rabbitmq] Release 8.20.5 updating components versions ([9dcc8d1](https://github.com/bitnami/charts/commit/9dcc8d1))
+* [bitnami/several] Regenerate README tables ([da2513b](https://github.com/bitnami/charts/commit/da2513b))
+
+## <small>8.20.4 (2021-08-26)</small>
+
+* [bitnami/rabbitmq] Release 8.20.4 updating components versions ([654d15a](https://github.com/bitnami/charts/commit/654d15a))
+
+## <small>8.20.3 (2021-08-25)</small>
+
+* [bitnami/rabbitmq] Release 8.20.3 updating components versions ([af5931b](https://github.com/bitnami/charts/commit/af5931b))
+
+## <small>8.20.2 (2021-08-20)</small>
+
+* bitnami/rabbitmq: enable tpl for auth.tls.existingSecret (#7276) ([20e83cb](https://github.com/bitnami/charts/commit/20e83cb)), closes [#7276](https://github.com/bitnami/charts/issues/7276)
+
+## <small>8.20.1 (2021-08-11)</small>
+
+* [bitnami/rabbitmq] Release 8.20.1 updating components versions ([22f189d](https://github.com/bitnami/charts/commit/22f189d))
+
+## 8.20.0 (2021-08-10)
+
+* [bitnami/rabbitmq] add service.portEnabled (#7150) ([1534730](https://github.com/bitnami/charts/commit/1534730)), closes [#7150](https://github.com/bitnami/charts/issues/7150)
+
+## <small>8.19.3 (2021-08-09)</small>
+
+* [bitnami/rabbitmq] Release 8.19.3 updating components versions ([e3e8ddf](https://github.com/bitnami/charts/commit/e3e8ddf))
+
+## <small>8.19.2 (2021-08-04)</small>
+
+* [bitnami/rabbitmq] Release 8.19.2 updating components versions ([622c582](https://github.com/bitnami/charts/commit/622c582))
+
+## <small>8.19.1 (2021-07-30)</small>
+
+* [bitnami/rabbitmq] Fix wrong link in README (#7087) ([785aa61](https://github.com/bitnami/charts/commit/785aa61)), closes [#7087](https://github.com/bitnami/charts/issues/7087)
+* [bitnami/several] Fix default values when using `foo: |` (#7092) ([fe91297](https://github.com/bitnami/charts/commit/fe91297)), closes [#7092](https://github.com/bitnami/charts/issues/7092)
+
+## 8.19.0 (2021-07-27)
+
+* [bitnami/several] Add diagnostic mode (#7012) ([f1344b0](https://github.com/bitnami/charts/commit/f1344b0)), closes [#7012](https://github.com/bitnami/charts/issues/7012)
+
+## <small>8.18.1 (2021-07-20)</small>
+
+* [bitnami/several] Fix default values and regenerate README (II) (#6994) ([d095793](https://github.com/bitnami/charts/commit/d095793)), closes [#6994](https://github.com/bitnami/charts/issues/6994)
+
+## 8.18.0 (2021-07-16)
+
+* [bitnami/rabbitmq] add extraDeploy support (#6926) (#6978) ([d3da8aa](https://github.com/bitnami/charts/commit/d3da8aa)), closes [#6926](https://github.com/bitnami/charts/issues/6926) [#6978](https://github.com/bitnami/charts/issues/6978)
+
+## 8.17.0 (2021-07-15)
+
+* bitnami/rabbitmq: add support for ingressClassName (#6905) ([f5c4490](https://github.com/bitnami/charts/commit/f5c4490)), closes [#6905](https://github.com/bitnami/charts/issues/6905) [#6905](https://github.com/bitnami/charts/issues/6905)
+
+## <small>8.16.4 (2021-07-14)</small>
+
+* [bitnami/*] Adapt values.yaml of PrestaShop, PyTorch and RabbitMQ charts (#6939) ([0a9d4c7](https://github.com/bitnami/charts/commit/0a9d4c7)), closes [#6939](https://github.com/bitnami/charts/issues/6939)
+
+## <small>8.16.3 (2021-07-09)</small>
+
+* [bitnami/rabbitmq] Fix default empty "initContainers" object (#6902) ([110c55a](https://github.com/bitnami/charts/commit/110c55a)), closes [#6902](https://github.com/bitnami/charts/issues/6902)
+
+## <small>8.16.2 (2021-07-06)</small>
+
+* [bitnami/rabbitmq] Release 8.16.2 updating components versions ([7dd4831](https://github.com/bitnami/charts/commit/7dd4831))
+
+## <small>8.16.1 (2021-06-27)</small>
+
+* [bitnami/rabbitmq] Release 8.16.1 updating components versions ([b9c0831](https://github.com/bitnami/charts/commit/b9c0831))
+
+## 8.16.0 (2021-06-16)
+
+* [bitnami/rabbitmq] Add support for autogenerated certs (#6528) ([2c88d0b](https://github.com/bitnami/charts/commit/2c88d0b)), closes [#6528](https://github.com/bitnami/charts/issues/6528)
+
+## <small>8.15.3 (2021-06-11)</small>
+
+* [bitnami/rabbitmq] Release 8.15.3 updating components versions ([8596db6](https://github.com/bitnami/charts/commit/8596db6))
+
+## <small>8.15.2 (2021-05-28)</small>
+
+* [bitnami/rabbitmq] Release 8.15.2 updating components versions ([99b28de](https://github.com/bitnami/charts/commit/99b28de))
+
+## <small>8.15.1 (2021-05-23)</small>
+
+* [bitnami/rabbitmq] Release 8.15.1 updating components versions ([d041833](https://github.com/bitnami/charts/commit/d041833))
+
+## 8.15.0 (2021-05-14)
+
+* [bitnami/rabbitmq] add commonAnnotations to values.yaml to apply it to all deployed resources (#6359 ([395934b](https://github.com/bitnami/charts/commit/395934b)), closes [#6359](https://github.com/bitnami/charts/issues/6359)
+
+## <small>8.14.1 (2021-05-12)</small>
+
+* [bitnami/rabbitmq] change the dafult port to tlsPort (#6331) ([9920a6f](https://github.com/bitnami/charts/commit/9920a6f)), closes [#6331](https://github.com/bitnami/charts/issues/6331) [#6330](https://github.com/bitnami/charts/issues/6330) [#6260](https://github.com/bitnami/charts/issues/6260) [#6325](https://github.com/bitnami/charts/issues/6325) [#6324](https://github.com/bitnami/charts/issues/6324)
+
+## 8.14.0 (2021-05-11)
+
+* [bitnami/rabbitmq] feat: servicemonitor and ingress configuration (#6260) ([07ab097](https://github.com/bitnami/charts/commit/07ab097)), closes [#6260](https://github.com/bitnami/charts/issues/6260)
+
+## <small>8.13.1 (2021-05-05)</small>
+
+* [bitnami/rabbitmq] Release 8.13.1 updating components versions ([4f6076e](https://github.com/bitnami/charts/commit/4f6076e))
+
+## 8.13.0 (2021-05-04)
+
+* [bitnami/rabbitmq] Improve Ingress TLS management (#6235) ([29ae259](https://github.com/bitnami/charts/commit/29ae259)), closes [#6235](https://github.com/bitnami/charts/issues/6235)
+
+## <small>8.12.3 (2021-05-04)</small>
+
+* [bitnami/rabbitmq] Release 8.12.3 updating components versions ([69645ae](https://github.com/bitnami/charts/commit/69645ae))
+
+## <small>8.12.2 (2021-04-30)</small>
+
+* Fix typos in several README files (#6252) ([fd16565](https://github.com/bitnami/charts/commit/fd16565)), closes [#6252](https://github.com/bitnami/charts/issues/6252)
+
+## <small>8.12.1 (2021-04-28)</small>
+
+* [bitnami/rabbitmq] Release 8.12.1 updating components versions ([da17ec2](https://github.com/bitnami/charts/commit/da17ec2))
+
+## 8.12.0 (2021-04-26)
+
+* [bitnami/rabbitmq]: allow to specify targetLabels on servicemonitor (#6202) ([a6824ea](https://github.com/bitnami/charts/commit/a6824ea)), closes [#6202](https://github.com/bitnami/charts/issues/6202)
+
+## <small>8.11.9 (2021-04-19)</small>
+
+* [bitnami/rabbitmq] delete release in values (#6149) ([80f51a5](https://github.com/bitnami/charts/commit/80f51a5)), closes [#6149](https://github.com/bitnami/charts/issues/6149)
+
+## <small>8.11.8 (2021-04-19)</small>
+
+* [bitnami/rabbitmq] add option to disable clustering entirely (#6129) ([30bb3da](https://github.com/bitnami/charts/commit/30bb3da)), closes [#6129](https://github.com/bitnami/charts/issues/6129)
+
+## <small>8.11.7 (2021-04-15)</small>
+
+* [bitnami/rabbitmq] Improved RabbitMQ README (#6105) ([dde65db](https://github.com/bitnami/charts/commit/dde65db)), closes [#6105](https://github.com/bitnami/charts/issues/6105)
+
+## <small>8.11.6 (2021-04-08)</small>
+
+* [bitnami/rabbitmq] Fix crash setting up metric.podAnnotions to null (#6047) ([0ab4f88](https://github.com/bitnami/charts/commit/0ab4f88)), closes [#6047](https://github.com/bitnami/charts/issues/6047)
+
+## <small>8.11.5 (2021-03-29)</small>
+
+* [bitnami/rabbitmq] Improve handling of load-definitions (#5939) ([44cc11d](https://github.com/bitnami/charts/commit/44cc11d)), closes [#5939](https://github.com/bitnami/charts/issues/5939)
+
+## <small>8.11.4 (2021-03-23)</small>
+
+* [bitnami/rabbitmq] Credentials during upgrade information in notes (#5871) ([78a1a10](https://github.com/bitnami/charts/commit/78a1a10)), closes [#5871](https://github.com/bitnami/charts/issues/5871)
+
+## <small>8.11.3 (2021-03-04)</small>
+
+* [bitnami/*] Remove minideb mentions (#5677) ([870bc4d](https://github.com/bitnami/charts/commit/870bc4d)), closes [#5677](https://github.com/bitnami/charts/issues/5677)
+
+## <small>8.11.2 (2021-03-03)</small>
+
+* [bitnami/rabbitmq] Release 8.11.2 updating components versions ([2af94b9](https://github.com/bitnami/charts/commit/2af94b9))
+
+## <small>8.11.1 (2021-02-27)</small>
+
+* [bitnami/rabbitmq] Release 8.11.1 updating components versions ([0df7737](https://github.com/bitnami/charts/commit/0df7737))
+
+## 8.11.0 (2021-02-24)
+
+* Added Topology Spread Constraints for pod assignment (#5599) ([a57b09b](https://github.com/bitnami/charts/commit/a57b09b)), closes [#5599](https://github.com/bitnami/charts/issues/5599)
+
+## <small>8.10.2 (2021-02-22)</small>
+
+* [bitnami/*] Use common macro to define RBAC apiVersion (#5585) ([71fb99f](https://github.com/bitnami/charts/commit/71fb99f)), closes [#5585](https://github.com/bitnami/charts/issues/5585)
+
+## <small>8.10.1 (2021-02-18)</small>
+
+* Add support for annotations on Rabbitmq Headless service (#5530) ([b1f12df](https://github.com/bitnami/charts/commit/b1f12df)), closes [#5530](https://github.com/bitnami/charts/issues/5530)
+
+## 8.10.0 (2021-02-17)
+
+* [bitnami/rabbitmq] Add the RabbitMQ Manager port enable/disable functionality in the service definit ([8f8994b](https://github.com/bitnami/charts/commit/8f8994b)), closes [#5516](https://github.com/bitnami/charts/issues/5516)
+
+## <small>8.9.3 (2021-02-17)</small>
+
+* [bitnami/*] Add notice regarding parameters immutability after chart installation (#4853) ([5f09573](https://github.com/bitnami/charts/commit/5f09573)), closes [#4853](https://github.com/bitnami/charts/issues/4853)
+* [bitnami/rabbitmq] Add section to cover cluster recovery (#5455) ([b947148](https://github.com/bitnami/charts/commit/b947148)), closes [#5455](https://github.com/bitnami/charts/issues/5455)
+* [bitnami/rabbitmq] Release 8.9.3 updating components versions ([8573a62](https://github.com/bitnami/charts/commit/8573a62))
+
+## <small>8.9.2 (2021-02-03)</small>
+
+* [bitnami/rabbitmq] Add comment in ingress.path value (#5379) ([ce2f21d](https://github.com/bitnami/charts/commit/ce2f21d)), closes [#5379](https://github.com/bitnami/charts/issues/5379)
+
+## <small>8.9.1 (2021-01-29)</small>
+
+* Fix template evaluation of podAnnotations (#5299) ([8745e16](https://github.com/bitnami/charts/commit/8745e16)), closes [#5299](https://github.com/bitnami/charts/issues/5299)
+
+## 8.9.0 (2021-01-28)
+
+* [bitnami/rabbitmq] Add hostAliases (#5304) ([f8ffed1](https://github.com/bitnami/charts/commit/f8ffed1)), closes [#5304](https://github.com/bitnami/charts/issues/5304)
+
+## 8.8.0 (2021-01-27)
+
+* [bitnami/rabbitmq] Fix forceBoot README typo (#5215) ([320dd74](https://github.com/bitnami/charts/commit/320dd74)), closes [#5215](https://github.com/bitnami/charts/issues/5215)
+* [bitnami/rabbitmq]: 8.8.0 - adds auth.tls.existingSecretFullChain option (#3192) ([7932e1b](https://github.com/bitnami/charts/commit/7932e1b)), closes [#3192](https://github.com/bitnami/charts/issues/3192)
+
+## <small>8.7.5 (2021-01-25)</small>
+
+* [bitnami/rabbitmq] Release 8.7.5 updating components versions ([a3b6935](https://github.com/bitnami/charts/commit/a3b6935))
+
+## <small>8.7.4 (2021-01-22)</small>
+
+* [bitnami/rabbitmq]: use managerPortName in ingress target port (#5184) ([de55fe1](https://github.com/bitnami/charts/commit/de55fe1)), closes [#5184](https://github.com/bitnami/charts/issues/5184)
+
+## <small>8.7.3 (2021-01-20)</small>
+
+* [bitnami/rabbitmq] Release 8.7.3 updating components versions ([b1bf54d](https://github.com/bitnami/charts/commit/b1bf54d))
+
+## <small>8.7.2 (2021-01-19)</small>
+
+* [bitnami/*] Change helm version in the prerequisites (#5090) ([c5e67a3](https://github.com/bitnami/charts/commit/c5e67a3)), closes [#5090](https://github.com/bitnami/charts/issues/5090)
+* [bitnami/rabbitmq] Drop values-production.yaml support (#5128) ([675d44b](https://github.com/bitnami/charts/commit/675d44b)), closes [#5128](https://github.com/bitnami/charts/issues/5128)
+
+## <small>8.7.1 (2021-01-18)</small>
+
+* [bitnami/rabbitmq] Fix critical rabbitmq helm scope bug (#5062) ([fbb0ef3](https://github.com/bitnami/charts/commit/fbb0ef3)), closes [#5062](https://github.com/bitnami/charts/issues/5062)
+
+## 8.7.0 (2021-01-15)
+
+* [bitnami/rabbitmq] Adapt ingress to k8s 1.20 (#5007) ([19f440e](https://github.com/bitnami/charts/commit/19f440e)), closes [#5007](https://github.com/bitnami/charts/issues/5007)
+
+## <small>8.6.4 (2021-01-13)</small>
+
+* extraSecrets prepend release name (#4960) ([6bc3701](https://github.com/bitnami/charts/commit/6bc3701)), closes [#4960](https://github.com/bitnami/charts/issues/4960)
+
+## <small>8.6.3 (2021-01-12)</small>
+
+* Add a toggle for podSecurityContext (#4957) ([0126ba9](https://github.com/bitnami/charts/commit/0126ba9)), closes [#4957](https://github.com/bitnami/charts/issues/4957)
+
+## <small>8.6.2 (2021-01-08)</small>
+
+* [bitnami/rabbitmq] Release 8.6.2 updating components versions ([16d2aaf](https://github.com/bitnami/charts/commit/16d2aaf))
+
+## <small>8.6.1 (2020-12-22)</small>
+
+* [bitnami/minio][bitnami/rabbitmq] Fix tls-secrets namespace scope (#4801) ([8058468](https://github.com/bitnami/charts/commit/8058468)), closes [#4801](https://github.com/bitnami/charts/issues/4801)
+
+## 8.6.0 (2020-12-18)
+
+* [bitnami/rabbitmq] Refine probes (#4747) ([80c02e3](https://github.com/bitnami/charts/commit/80c02e3)), closes [#4747](https://github.com/bitnami/charts/issues/4747)
+
+## <small>8.5.5 (2020-12-17)</small>
+
+* [bitnami/*] fix typos (#4699) ([49adc63](https://github.com/bitnami/charts/commit/49adc63)), closes [#4699](https://github.com/bitnami/charts/issues/4699)
+* [bitnami/rabbitmq] Release 8.5.5 updating components versions ([7bf6867](https://github.com/bitnami/charts/commit/7bf6867))
+
+## <small>8.5.4 (2020-12-11)</small>
+
+* [bitnami/*] Update dependencies (#4694) ([2826c12](https://github.com/bitnami/charts/commit/2826c12)), closes [#4694](https://github.com/bitnami/charts/issues/4694)
+
+## <small>8.5.3 (2020-12-11)</small>
+
+* [bitnami/rabbitmq] Release 8.5.3 updating components versions ([8546000](https://github.com/bitnami/charts/commit/8546000))
+
+## <small>8.5.2 (2020-12-10)</small>
+
+* [bitnami/*] Update CI *-values.yaml files (#4674) ([b473fa9](https://github.com/bitnami/charts/commit/b473fa9)), closes [#4674](https://github.com/bitnami/charts/issues/4674)
+
+## <small>8.5.1 (2020-12-09)</small>
+
+* [bitnami/rabbitmq] fix missing quote on namespace (#4663) ([e726d64](https://github.com/bitnami/charts/commit/e726d64)), closes [#4663](https://github.com/bitnami/charts/issues/4663)
+
+## 8.5.0 (2020-12-09)
+
+* [bitnami/rabbitmq] Add parameter to customize 'externalTrafficPolicy' (#4645) ([86aca4d](https://github.com/bitnami/charts/commit/86aca4d)), closes [#4645](https://github.com/bitnami/charts/issues/4645)
+
+## <small>8.4.3 (2020-12-08)</small>
+
+* [bitnami/rabbitmq] fix if statement for checksum/secret annotation (#4644) ([95fde31](https://github.com/bitnami/charts/commit/95fde31)), closes [#4644](https://github.com/bitnami/charts/issues/4644)
+
+## <small>8.4.2 (2020-12-08)</small>
+
+* [bitnami/rabbitmq] Fix rabbitmqctl command (#4636) ([e09301c](https://github.com/bitnami/charts/commit/e09301c)), closes [#4636](https://github.com/bitnami/charts/issues/4636)
+
+## <small>8.4.1 (2020-12-04)</small>
+
+* [bitnami/rabbitmq] Update readinessProbe to avoid deadlocks (#4598) ([aab5ec7](https://github.com/bitnami/charts/commit/aab5ec7)), closes [#4598](https://github.com/bitnami/charts/issues/4598)
+
+## 8.4.0 (2020-12-03)
+
+* [bitnami/rabbitmq] Affinity based on common presets (#4577) ([a318bec](https://github.com/bitnami/charts/commit/a318bec)), closes [#4577](https://github.com/bitnami/charts/issues/4577)
+
+## 8.3.0 (2020-12-02)
+
+* [bitnami/rabbitmq] Allow existingErlangSecret to be templatized (#4547) ([50c5d1a](https://github.com/bitnami/charts/commit/50c5d1a)), closes [#4547](https://github.com/bitnami/charts/issues/4547)
+* [bitnami/rabbitmq] Fix backwards compatibility of the nodeshutdown.sh script (#4495) ([e4fb3b0](https://github.com/bitnami/charts/commit/e4fb3b0)), closes [#4495](https://github.com/bitnami/charts/issues/4495)
+
+## 8.2.0 (2020-11-26)
+
+* [bitnami/rabbitmq] Start to use shutdown script waiting for synchronization (#4470) ([9524947](https://github.com/bitnami/charts/commit/9524947)), closes [#4470](https://github.com/bitnami/charts/issues/4470) [#3931](https://github.com/bitnami/charts/issues/3931) [#3931](https://github.com/bitnami/charts/issues/3931)
+
+## <small>8.1.1 (2020-11-24)</small>
+
+* [bitnami/rabbitmq] fix: align values.yaml and README.md (#4231) ([c6e5584](https://github.com/bitnami/charts/commit/c6e5584)), closes [#4231](https://github.com/bitnami/charts/issues/4231)
+
+## 8.1.0 (2020-11-23)
+
+* [bitnami/rabbitmq] Add statefulsetLabels, similar to podLabels (#4449) ([ab46e49](https://github.com/bitnami/charts/commit/ab46e49)), closes [#4449](https://github.com/bitnami/charts/issues/4449)
+
+## <small>8.0.5 (2020-11-19)</small>
+
+* [bitnami/rabbitmq] Add config checksum to the statefulset (#4423) ([ad61be2](https://github.com/bitnami/charts/commit/ad61be2)), closes [#4423](https://github.com/bitnami/charts/issues/4423)
+
+## <small>8.0.4 (2020-11-18)</small>
+
+* [bitnami/rabbitmq] Fix networkpolicy podSelector labels (#4409) ([b743bf6](https://github.com/bitnami/charts/commit/b743bf6)), closes [#4409](https://github.com/bitnami/charts/issues/4409)
+
+## <small>8.0.3 (2020-11-17)</small>
+
+* [bitnami/rabbitmq] Allow for templating in extraSecrets (#4378) ([db3dd28](https://github.com/bitnami/charts/commit/db3dd28)), closes [#4378](https://github.com/bitnami/charts/issues/4378)
+* Clarify configuration params (#4363) ([ebc07b9](https://github.com/bitnami/charts/commit/ebc07b9)), closes [#4363](https://github.com/bitnami/charts/issues/4363)
+
+## <small>8.0.2 (2020-11-12)</small>
+
+* [bitnami/rabbitmq]  Fix typo in svc-headless.yaml (#4309) ([7008521](https://github.com/bitnami/charts/commit/7008521)), closes [#4309](https://github.com/bitnami/charts/issues/4309)
+
+## <small>8.0.1 (2020-11-11)</small>
+
+* [bitnami/rabbitmq] Add how to configure the default user/vhost to README (#4256) ([00fe910](https://github.com/bitnami/charts/commit/00fe910)), closes [#4256](https://github.com/bitnami/charts/issues/4256) [#4122](https://github.com/bitnami/charts/issues/4122)
+
+## 8.0.0 (2020-11-11)
+
+* [bitnami/rabbitmq] Major version. Adapt Chart to apiVersion: v2 (#4288) ([ecb3d11](https://github.com/bitnami/charts/commit/ecb3d11)), closes [#4288](https://github.com/bitnami/charts/issues/4288)
+
+## 7.8.0 (2020-11-09)
+
+* [bitnami/rabbitmq] Allow port names customization in services (#4243) ([b2d5689](https://github.com/bitnami/charts/commit/b2d5689)), closes [#4243](https://github.com/bitnami/charts/issues/4243)
+
+## <small>7.7.1 (2020-10-28)</small>
+
+* [bitnami/*] Include link to Troubleshootin guide on README.md (#4136) ([c08a20e](https://github.com/bitnami/charts/commit/c08a20e)), closes [#4136](https://github.com/bitnami/charts/issues/4136)
+* [bitnami/rabbitmq] Allow integers for namespace (#4137) ([2643e7c](https://github.com/bitnami/charts/commit/2643e7c)), closes [#4137](https://github.com/bitnami/charts/issues/4137)
+
+## 7.7.0 (2020-10-27)
+
+* [bitnami/rabbitmq] Attach existing volume as persistence storage (#4102) ([d883c8b](https://github.com/bitnami/charts/commit/d883c8b)), closes [#4102](https://github.com/bitnami/charts/issues/4102)
+
+## <small>7.6.9 (2020-10-25)</small>
+
+* [bitnami/rabbitmq] Release 7.6.9 updating components versions ([b3ba436](https://github.com/bitnami/charts/commit/b3ba436))
+
+## <small>7.6.8 (2020-09-25)</small>
+
+* [bitnami/rabbitmq] Release 7.6.8 updating components versions ([e57038c](https://github.com/bitnami/charts/commit/e57038c))
+
+## <small>7.6.7 (2020-09-21)</small>
+
+* [bitnami/rabbitmq] Release 7.6.7 updating components versions ([8e388f5](https://github.com/bitnami/charts/commit/8e388f5))
+* Add links to docs.bitnami.com (#3715) ([2449278](https://github.com/bitnami/charts/commit/2449278)), closes [#3715](https://github.com/bitnami/charts/issues/3715)
+
+## <small>7.6.6 (2020-09-09)</small>
+
+* [bitnami/rabbitmq] Release 7.6.6 Changing default value for service.extraPorts (#3630) ([1b9ca8d](https://github.com/bitnami/charts/commit/1b9ca8d)), closes [#3630](https://github.com/bitnami/charts/issues/3630)
+
+## <small>7.6.5 (2020-09-04)</small>
+
+* [bitnami/metrics-server] Add source repo (#3577) ([1ed12f9](https://github.com/bitnami/charts/commit/1ed12f9)), closes [#3577](https://github.com/bitnami/charts/issues/3577)
+* [bitnami/rabbitmq] Release 7.6.5 updating components versions ([d695d12](https://github.com/bitnami/charts/commit/d695d12))
+
+## <small>7.6.4 (2020-08-24)</small>
+
+* Change documentation about 'load_definitions' (#3483) ([2833762](https://github.com/bitnami/charts/commit/2833762)), closes [#3483](https://github.com/bitnami/charts/issues/3483)
+
+## <small>7.6.3 (2020-08-19)</small>
+
+* [bitnami/rabbitmq] Release 7.6.3 updating components versions ([fafc4f8](https://github.com/bitnami/charts/commit/fafc4f8))
+
+## <small>7.6.2 (2020-08-18)</small>
+
+* [bitnami/rabbitmq] Run secret name through tpl (#3222) (#3445) ([8d0be4f](https://github.com/bitnami/charts/commit/8d0be4f)), closes [#3222](https://github.com/bitnami/charts/issues/3222) [#3445](https://github.com/bitnami/charts/issues/3445)
+
+## <small>7.6.1 (2020-08-14)</small>
+
+* [bitnami/rabbitmq] Evaluate extraConfiguration value as template (#3415) ([e713290](https://github.com/bitnami/charts/commit/e713290)), closes [#3415](https://github.com/bitnami/charts/issues/3415)
+
+## 7.6.0 (2020-08-13)
+
+* [bitnami/*] Use common helps for upgrade password errors (#3335) ([079f5bd](https://github.com/bitnami/charts/commit/079f5bd)), closes [#3335](https://github.com/bitnami/charts/issues/3335)
+
+## <small>7.5.8 (2020-08-05)</small>
+
+* [bitnami/*] Fix TL;DR typo in READMEs (#3280) ([3d7ab40](https://github.com/bitnami/charts/commit/3d7ab40)), closes [#3280](https://github.com/bitnami/charts/issues/3280)
+* [bitnami/rabbitmq] Release 7.5.8 updating components versions ([fc481d8](https://github.com/bitnami/charts/commit/fc481d8))
+
+## <small>7.5.7 (2020-07-22)</small>
+
+* Bugfix rabbitmq pre stop hook not applied when rebalance is true (#3171) ([cc3c27c](https://github.com/bitnami/charts/commit/cc3c27c)), closes [#3171](https://github.com/bitnami/charts/issues/3171)
+
+## <small>7.5.6 (2020-07-18)</small>
+
+* [bitnami/rabbitmq] Release 7.5.6 updating components versions ([c265119](https://github.com/bitnami/charts/commit/c265119))
+
+## <small>7.5.5 (2020-07-17)</small>
+
+* [bitnami/rabbitmq] Fix issue with mnesia dir when forcing boot (#3139) ([654eae7](https://github.com/bitnami/charts/commit/654eae7)), closes [#3139](https://github.com/bitnami/charts/issues/3139)
+
+## <small>7.5.4 (2020-07-15)</small>
+
+* [bitnami/all] Add categories (#3075) ([63bde06](https://github.com/bitnami/charts/commit/63bde06)), closes [#3075](https://github.com/bitnami/charts/issues/3075)
+* [bitnami/rabbitmq] Release 7.5.4 updating components versions ([874e4ce](https://github.com/bitnami/charts/commit/874e4ce))
+
+## <small>7.5.3 (2020-07-10)</small>
+
+* [bitnami/rabbitmq] Corrected example of extraContainerPorts (#3076) ([bcc42b4](https://github.com/bitnami/charts/commit/bcc42b4)), closes [#3076](https://github.com/bitnami/charts/issues/3076) [#2023](https://github.com/bitnami/charts/issues/2023) [#2027](https://github.com/bitnami/charts/issues/2027) [bitnami#2023](https://github.com/bitnami/issues/2023) [bitnami#2027](https://github.com/bitnami/issues/2027) [bitnami#2023](https://github.com/bitnami/issues/2023) [bitnami#2027](https://github.com/bitnami/issues/2027)
+
+## <small>7.5.2 (2020-07-09)</small>
+
+* [bitnami/rabbitmq] Show the correct secret names in post-install notes (#3050) ([c951672](https://github.com/bitnami/charts/commit/c951672)), closes [#3050](https://github.com/bitnami/charts/issues/3050)
+
+## <small>7.5.1 (2020-07-08)</small>
+
+* [bitnami/rabbitmq] Release 7.5.1 updating components versions ([f29183d](https://github.com/bitnami/charts/commit/f29183d))
+
+## 7.5.0 (2020-07-08)
+
+* [bitnami/rabbitmq] Add support for multiple LDAP servers (#3066) ([4a2884c](https://github.com/bitnami/charts/commit/4a2884c)), closes [#3066](https://github.com/bitnami/charts/issues/3066)
+
+## <small>7.4.8 (2020-07-08)</small>
+
+* [bitnami/rabbitmq] fix tls entries in ingress (#3065) ([d8fb355](https://github.com/bitnami/charts/commit/d8fb355)), closes [#3065](https://github.com/bitnami/charts/issues/3065)
+
+## <small>7.4.7 (2020-07-07)</small>
+
+* [bitnami/rabbitmq] Release 7.4.7 updating components versions ([176cd7d](https://github.com/bitnami/charts/commit/176cd7d))
+
+## <small>7.4.6 (2020-07-07)</small>
+
+* [bitnami/rabbitmq] Improve reliability and document post-scalation steps when scaling down (#3048) ([ad0f5b7](https://github.com/bitnami/charts/commit/ad0f5b7)), closes [#3048](https://github.com/bitnami/charts/issues/3048)
+
+## <small>7.4.5 (2020-07-03)</small>
+
+* [bitnami/rabbitmq] Release 7.4.5 updating components versions ([e4e7c4f](https://github.com/bitnami/charts/commit/e4e7c4f))
+
+## <small>7.4.4 (2020-07-03)</small>
+
+* [bitnami/rabbitmq] Use less intrusive probes (#3016) ([f5f3ad2](https://github.com/bitnami/charts/commit/f5f3ad2)), closes [#3016](https://github.com/bitnami/charts/issues/3016)
+
+## <small>7.4.3 (2020-07-01)</small>
+
+* [bitnami/rabbitmq] Release 7.4.3 updating components versions ([77e4d00](https://github.com/bitnami/charts/commit/77e4d00))
+
+## <small>7.4.2 (2020-07-01)</small>
+
+* [bitnami/rabbitmq] Update plugins section in the README (#2989) ([bc14dfd](https://github.com/bitnami/charts/commit/bc14dfd)), closes [#2989](https://github.com/bitnami/charts/issues/2989)
+
+## <small>7.4.1 (2020-07-01)</small>
+
+* [bitnami/rabbitmq] Release 7.4.1 updating components versions ([3ca06a6](https://github.com/bitnami/charts/commit/3ca06a6))
+
+## 7.4.0 (2020-07-01)
+
+* [bitnami/rabbitmq] Use existingSecret for ingress TLS (#2986) ([b293d3a](https://github.com/bitnami/charts/commit/b293d3a)), closes [#2986](https://github.com/bitnami/charts/issues/2986)
+
+## <small>7.3.3 (2020-06-29)</small>
+
+* [bitnami/rabbitmq] Release 7.3.3 updating components versions ([b3af237](https://github.com/bitnami/charts/commit/b3af237))
+
+## <small>7.3.2 (2020-06-29)</small>
+
+* [bitnami/rabbitmq] Fix a bug in readiness and liveness (#2949) ([157a0a7](https://github.com/bitnami/charts/commit/157a0a7)), closes [#2949](https://github.com/bitnami/charts/issues/2949)
+
+## <small>7.3.1 (2020-06-25)</small>
+
+* [bitnami/rabbitmq] Release 7.3.1 updating components versions ([be9d8e2](https://github.com/bitnami/charts/commit/be9d8e2))
+
+## 7.3.0 (2020-06-25)
+
+* [bitnami/rabbitmq] Provide mechanism to download community plugins during initialization (#2906) ([ba888ca](https://github.com/bitnami/charts/commit/ba888ca)), closes [#2906](https://github.com/bitnami/charts/issues/2906)
+
+## <small>7.2.1 (2020-06-24)</small>
+
+* [bitnami/rabbitmq] Release 7.2.1 updating components versions ([1e86fc8](https://github.com/bitnami/charts/commit/1e86fc8))
+
+## 7.2.0 (2020-06-24)
+
+* [bitnami/rabbitmq] Fix Ingress port and add custom path (#2897) ([206233c](https://github.com/bitnami/charts/commit/206233c)), closes [#2897](https://github.com/bitnami/charts/issues/2897)
+
+## <small>7.1.2 (2020-06-23)</small>
+
+* [bitnami/rabbitmq] Release 7.1.2 updating components versions ([2fa98fe](https://github.com/bitnami/charts/commit/2fa98fe))
+
+## <small>7.1.1 (2020-06-23)</small>
+
+* [bitnami/rabbitmq] Fix clustering when non-default k8s domain name is used (#2894) ([ac68b0f](https://github.com/bitnami/charts/commit/ac68b0f)), closes [#2894](https://github.com/bitnami/charts/issues/2894)
+
+## 7.1.0 (2020-06-22)
+
+* [bitnami/rabbitmq] Custom nodePort expose per port (#2825) ([78b4d60](https://github.com/bitnami/charts/commit/78b4d60)), closes [#2825](https://github.com/bitnami/charts/issues/2825)
+
+## <small>7.0.4 (2020-06-22)</small>
+
+* [bitnami/several] remove library/bitnami-common (#2879) ([d936fe3](https://github.com/bitnami/charts/commit/d936fe3)), closes [#2879](https://github.com/bitnami/charts/issues/2879)
+
+## <small>7.0.3 (2020-06-19)</small>
+
+* [bitnami/rabbitmq] Fix incorrect RabbitMQ advanced.config config map key (#2882) ([d81a958](https://github.com/bitnami/charts/commit/d81a958)), closes [#2882](https://github.com/bitnami/charts/issues/2882)
+
+## <small>7.0.2 (2020-06-19)</small>
+
+* [bitnami/rabbitmq] Allow customizing RabbitMQ username (#2884) ([dca246c](https://github.com/bitnami/charts/commit/dca246c)), closes [#2884](https://github.com/bitnami/charts/issues/2884)
+* [bitnami/rabbitmq] Fixing extraEnvVars (#2867) ([1a265f8](https://github.com/bitnami/charts/commit/1a265f8)), closes [#2867](https://github.com/bitnami/charts/issues/2867)
+
+## <small>7.0.1 (2020-06-19)</small>
+
+* [bitnami/rabbitmq] Release 7.0.1 updating components versions ([abba63f](https://github.com/bitnami/charts/commit/abba63f))
+* [multiple charts] Update hidden properties in the different JSON schemas (#2871) ([4cff6ba](https://github.com/bitnami/charts/commit/4cff6ba)), closes [#2871](https://github.com/bitnami/charts/issues/2871)
+
+## 7.0.0 (2020-06-17)
+
+* [bitnami/rabbitmq] Rely on container initialization + refactoring to follow Helm chart best practice ([43e7082](https://github.com/bitnami/charts/commit/43e7082)), closes [#2843](https://github.com/bitnami/charts/issues/2843)
+
+## <small>6.28.1 (2020-06-17)</small>
+
+* [bitnami/rabbitmq] Release 6.28.1 updating components versions ([11b7183](https://github.com/bitnami/charts/commit/11b7183))
+
+## 6.28.0 (2020-06-16)
+
+* [bitnami\rabbitmq] Added support of specific service account (#2569) ([7c03dab](https://github.com/bitnami/charts/commit/7c03dab)), closes [#2569](https://github.com/bitnami/charts/issues/2569)
+
+## <small>6.27.2 (2020-06-16)</small>
+
+* [bitnami/rabbitmq] Release 6.27.2 updating components versions ([77fd0e7](https://github.com/bitnami/charts/commit/77fd0e7))
+
+## <small>6.27.1 (2020-06-15)</small>
+
+* [bitnami/rabbitmq] Release 6.27.1 updating components versions ([c56fdc4](https://github.com/bitnami/charts/commit/c56fdc4))
+
+## 6.27.0 (2020-06-11)
+
+* [bitnami/rabbitmq] Add community plugins (#2729) ([979d876](https://github.com/bitnami/charts/commit/979d876)), closes [#2729](https://github.com/bitnami/charts/issues/2729)
+
+## 6.26.0 (2020-06-05)
+
+* [bitnami/rabbitmq] add podLabels to statefulset (#2744) ([a3abafe](https://github.com/bitnami/charts/commit/a3abafe)), closes [#2744](https://github.com/bitnami/charts/issues/2744)
+
+## <small>6.25.13 (2020-05-26)</small>
+
+* [bitnami/rabbitmq] make load definition secret name be templatable (#2654) ([e56173b](https://github.com/bitnami/charts/commit/e56173b)), closes [#2654](https://github.com/bitnami/charts/issues/2654)
+* update bitnami/common to be compatible with helm v2.12+ (#2615) ([c7751eb](https://github.com/bitnami/charts/commit/c7751eb)), closes [#2615](https://github.com/bitnami/charts/issues/2615)
+
+## <small>6.25.12 (2020-05-18)</small>
+
+* [bitnami/rabbitmq] improve network policy to include internal traffic (#2597) ([d6c55db](https://github.com/bitnami/charts/commit/d6c55db)), closes [#2597](https://github.com/bitnami/charts/issues/2597)
+
+## <small>6.25.11 (2020-05-13)</small>
+
+* [bitnami/rabbitmq] Release 6.25.11 updating components versions ([5e95a78](https://github.com/bitnami/charts/commit/5e95a78))
+
+## <small>6.25.10 (2020-05-13)</small>
+
+* [bitnami/rabbitmq] Release 6.25.10 updating components versions ([80e9483](https://github.com/bitnami/charts/commit/80e9483))
+
+## <small>6.25.9 (2020-05-08)</small>
+
+* [bitnami/rabbitmq] Add externalIP custom value (#2534) ([f1911e9](https://github.com/bitnami/charts/commit/f1911e9)), closes [#2534](https://github.com/bitnami/charts/issues/2534)
+
+## <small>6.25.8 (2020-05-07)</small>
+
+* [bitnami/rabbitmq] extraVolumeMounts new line fix (#2533) ([ecb5150](https://github.com/bitnami/charts/commit/ecb5150)), closes [#2533](https://github.com/bitnami/charts/issues/2533) [#2532](https://github.com/bitnami/charts/issues/2532)
+
+## <small>6.25.7 (2020-05-04)</small>
+
+* [bitnami/rabbitmq] fix extraPorts indentation (#2496) ([5fe117c](https://github.com/bitnami/charts/commit/5fe117c)), closes [#2496](https://github.com/bitnami/charts/issues/2496)
+
+## <small>6.25.6 (2020-04-30)</small>
+
+* Rabbitmq pod annotations (#2466) ([4cff212](https://github.com/bitnami/charts/commit/4cff212)), closes [#2466](https://github.com/bitnami/charts/issues/2466)
+
+## <small>6.25.5 (2020-04-22)</small>
+
+* [bitnami/rabbitmq] Release 6.25.5 updating components versions ([79eb3b5](https://github.com/bitnami/charts/commit/79eb3b5))
+
+## <small>6.25.4 (2020-04-16)</small>
+
+* [bitnami/rabbitmq] Release 6.25.4 updating components versions ([f0a4b14](https://github.com/bitnami/charts/commit/f0a4b14))
+* [bitnami/rabbitmq] Tune parameters to increase performance (#2252) ([4bcde72](https://github.com/bitnami/charts/commit/4bcde72)), closes [#2252](https://github.com/bitnami/charts/issues/2252)
+
+## <small>6.25.3 (2020-04-14)</small>
+
+* [bitnami/rabbitmq] Release 6.25.3 updating components versions ([0c4821c](https://github.com/bitnami/charts/commit/0c4821c))
+
+## <small>6.25.2 (2020-04-10)</small>
+
+* [bitnami/rabbitmq] Release 6.25.2 updating components versions ([1647de0](https://github.com/bitnami/charts/commit/1647de0))
+
+## <small>6.25.1 (2020-04-09)</small>
+
+* [bitnami/rabbitmq] livenessProbe and readinessProbe command override (#2219) ([93d59d3](https://github.com/bitnami/charts/commit/93d59d3)), closes [#2219](https://github.com/bitnami/charts/issues/2219)
+* [bitnami/rabbitmq] Release 6.25.1 updating components versions ([e56ced5](https://github.com/bitnami/charts/commit/e56ced5))
+
+## 6.25.0 (2020-04-08)
+
+* [bitnami/rabbitmq] Add ability to add service labels. (#2237) ([21dbb4a](https://github.com/bitnami/charts/commit/21dbb4a)), closes [#2237](https://github.com/bitnami/charts/issues/2237)
+
+## 6.24.0 (2020-04-06)
+
+* [bitnami/rabbitmq] Disable old metrics, enable new Prometheus auto-scraping (#2110) ([ab679d4](https://github.com/bitnami/charts/commit/ab679d4)), closes [#2110](https://github.com/bitnami/charts/issues/2110)
+
+## 6.23.0 (2020-04-02)
+
+* [bitnami/rabbitmq] Add a selector to persistentVolumeClaims to be able to target an existing persist ([3b9461c](https://github.com/bitnami/charts/commit/3b9461c)), closes [#2184](https://github.com/bitnami/charts/issues/2184)
+
+## 6.22.0 (2020-04-01)
+
+* [bitnami/rabbitmq] Add events create rule, needed by the rabbitmq_peer_discovery_k8s plugin (#2173) ([57f7074](https://github.com/bitnami/charts/commit/57f7074)), closes [#2173](https://github.com/bitnami/charts/issues/2173)
+
+## <small>6.21.1 (2020-03-31)</small>
+
+* [rabbitmq] fix missing $ in .Release.Namespace (#2165) ([4353b52](https://github.com/bitnami/charts/commit/4353b52)), closes [#2165](https://github.com/bitnami/charts/issues/2165)
+
+## 6.21.0 (2020-03-30)
+
+* [bitnami/rabbitmq] Introduced `.Release.Namespace`  in objects meta (#2159) ([16bd948](https://github.com/bitnami/charts/commit/16bd948)), closes [#2159](https://github.com/bitnami/charts/issues/2159)
+
+## <small>6.20.1 (2020-03-26)</small>
+
+* [bitnami/rabbitmq] Release 6.20.1 updating components versions ([94f00f4](https://github.com/bitnami/charts/commit/94f00f4))
+
+## 6.20.0 (2020-03-23)
+
+* Link secret in rabbitmq chart (#2107) ([1f6ef84](https://github.com/bitnami/charts/commit/1f6ef84)), closes [#2107](https://github.com/bitnami/charts/issues/2107)
+
+## <small>6.19.2 (2020-03-20)</small>
+
+* [bitnami/rabbitmq] Release 6.19.2 updating components versions ([4afe19b](https://github.com/bitnami/charts/commit/4afe19b))
+
+## <small>6.19.1 (2020-03-19)</small>
+
+* [bitnami/rabbitmq] Release 6.19.1 updating components versions ([3a01d45](https://github.com/bitnami/charts/commit/3a01d45))
+
+## 6.19.0 (2020-03-19)
+
+* Update Chart.yaml ([e2e8b29](https://github.com/bitnami/charts/commit/e2e8b29))
+
+## <small>6.19.9 (2020-03-17)</small>
+
+* [bitnami/rabbitmq] added instructions to use extra ports - closes #2023  (#2037) ([3f9c2ae](https://github.com/bitnami/charts/commit/3f9c2ae)), closes [#2023](https://github.com/bitnami/charts/issues/2023) [#2037](https://github.com/bitnami/charts/issues/2037)
+* [bitnami/rabbitmq] adding possibility to have extras volumes/volumesm… (#2042) ([4b06e0f](https://github.com/bitnami/charts/commit/4b06e0f)), closes [#2042](https://github.com/bitnami/charts/issues/2042)
+
+## <small>6.18.9 (2020-03-11)</small>
+
+* [bitnami/rabbitmq] Release 6.18.9 updating components versions ([c9ce341](https://github.com/bitnami/charts/commit/c9ce341))
+
+## <small>6.18.8 (2020-03-11)</small>
+
+* Move charts from upstreamed folder to bitnami (#2032) ([a0e44f7](https://github.com/bitnami/charts/commit/a0e44f7)), closes [#2032](https://github.com/bitnami/charts/issues/2032)
+
+## <small>6.18.7 (2020-03-10)</small>
+
+* [bitnami/redis & rabbit] Revert CI removal (#2025) ([f05c165](https://github.com/bitnami/charts/commit/f05c165)), closes [#2025](https://github.com/bitnami/charts/issues/2025)
+
+## <small>6.18.6 (2020-03-10)</small>
+
+* [bitnami/rabbitmq] Modify RabbitMQ notes for convenience. (#2021) ([61a2013](https://github.com/bitnami/charts/commit/61a2013)), closes [#2021](https://github.com/bitnami/charts/issues/2021)
+
+## <small>6.18.5 (2020-03-09)</small>
+
+* [bitnami/rabbitmq] Release 6.18.5 updating components versions ([80c8375](https://github.com/bitnami/charts/commit/80c8375))
+
+## <small>6.18.4 (2020-03-09)</small>
+
+* [bitnami/redis] Move chart from stable and remove ci folder (#2017) ([bb8e1cf](https://github.com/bitnami/charts/commit/bb8e1cf)), closes [#2017](https://github.com/bitnami/charts/issues/2017)
+
+## <small>6.18.3 (2020-03-06)</small>
+
+* [bitnami/rabbitmq] Release 6.18.3 updating components versions ([a6bf548](https://github.com/bitnami/charts/commit/a6bf548))
+
+## <small>6.18.2 (2020-03-06)</small>
+
+* [bitnami/rabbitmq] Release 6.18.2 updating components versions ([a84f789](https://github.com/bitnami/charts/commit/a84f789))
+
+## <small>6.18.1 (2020-03-06)</small>
+
+* [bitnami/rabbitmq] Copy rabbitmq chart from stable (https://github.com/helm/charts/pull/21310) ([861c8ff](https://github.com/bitnami/charts/commit/861c8ff))

--- a/bitnami/rabbitmq/Chart.lock
+++ b/bitnami/rabbitmq/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.19.2
-digest: sha256:e670e1075bfafffe040fae1158f1fa1f592585f394b48704ba137d2d083b1571
-generated: "2024-05-01T04:22:44.869852737Z"
+  version: 2.19.3
+digest: sha256:de997835d9ce9a9deefc2d70d8c62b11aa1d1a76ece9e86a83736ab9f930bf4d
+generated: "2024-05-21T14:33:11.666160182+02:00"

--- a/bitnami/rabbitmq/Chart.yaml
+++ b/bitnami/rabbitmq/Chart.yaml
@@ -30,4 +30,4 @@ maintainers:
 name: rabbitmq
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/rabbitmq
-version: 14.1.5
+version: 14.2.0

--- a/bitnami/rabbitmq/templates/NOTES.txt
+++ b/bitnami/rabbitmq/templates/NOTES.txt
@@ -153,3 +153,4 @@ Then, open the obtained URL in a browser.
 
 {{- end }}
 {{- include "common.warnings.resources" (dict "sections" (list "" "volumePermissions") "context" $) }}
+{{- include "common.warnings.modifiedImages" (dict "images" (list .Values.image .Values.volumePermissions.image) "context" $) }}


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Replacing the original images that have been tested and verified when releasing the chart is a dangerous practice in terms of security, performance and available features. This PR updates the `NOTES.txt` file using the `common.warnings.modifiedImages` helper developed in https://github.com/bitnami/charts/pull/25952.


<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

Users are more aware of the risks of changing original images.
<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

n/a
<!-- Describe any known limitations with your change -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
