### PR TITLE
[bitnami/redis] feat: :sparkles: :lock: Add warning when original images are replaced

### DIFF
--- a/bitnami/redis/CHANGELOG.md
+++ b/bitnami/redis/CHANGELOG.md
@@ -1,0 +1,1805 @@
+# Changelog
+
+## 19.4.0 (2024-05-21)
+
+* [bitnami/redis] feat: :sparkles: :lock: Add warning when original images are replaced ([#26271](https://github.com/bitnami/charts/pulls/26271))
+
+## <small>19.3.4 (2024-05-19)</small>
+
+* [bitnami/redis] Release 19.3.4 updating components versions (#26103) ([e3e4772](https://github.com/bitnami/charts/commit/e3e4772)), closes [#26103](https://github.com/bitnami/charts/issues/26103)
+
+## <small>19.3.3 (2024-05-18)</small>
+
+* [bitnami/redis] Release 19.3.3 updating components versions (#26073) ([22a9c69](https://github.com/bitnami/charts/commit/22a9c69)), closes [#26073](https://github.com/bitnami/charts/issues/26073)
+
+## <small>19.3.2 (2024-05-14)</small>
+
+* [bitnami/redis] Release 19.3.2 updating components versions (#25821) ([e014e10](https://github.com/bitnami/charts/commit/e014e10)), closes [#25821](https://github.com/bitnami/charts/issues/25821)
+
+## <small>19.3.1 (2024-05-13)</small>
+
+* [bitnami/redis] Release 19.3.1 updating components versions (#25710) ([8fac519](https://github.com/bitnami/charts/commit/8fac519)), closes [#25710](https://github.com/bitnami/charts/issues/25710)
+
+## 19.3.0 (2024-05-09)
+
+* [bitnami/*] Change non-root and rolling-tags doc URLs (#25628) ([b067c94](https://github.com/bitnami/charts/commit/b067c94)), closes [#25628](https://github.com/bitnami/charts/issues/25628)
+* [bitnami/redis] Add option to change port name in master service (#25579) ([8e553bb](https://github.com/bitnami/charts/commit/8e553bb)), closes [#25579](https://github.com/bitnami/charts/issues/25579) [#25228](https://github.com/bitnami/charts/issues/25228)
+
+## 19.2.0 (2024-05-07)
+
+* [bitnami/*] Set new header/owner (#25558) ([8d1dc11](https://github.com/bitnami/charts/commit/8d1dc11)), closes [#25558](https://github.com/bitnami/charts/issues/25558)
+* [bitnami/redis] Add support for dedicated values for sentinel master service (#24549) ([1c55b64](https://github.com/bitnami/charts/commit/1c55b64)), closes [#24549](https://github.com/bitnami/charts/issues/24549)
+
+## <small>19.1.5 (2024-04-26)</small>
+
+* [bitnami/redis] Release 19.1.5 updating components versions (#25415) ([16129d4](https://github.com/bitnami/charts/commit/16129d4)), closes [#25415](https://github.com/bitnami/charts/issues/25415)
+* Replace VMware by Broadcom copyright text (#25306) ([a5e4bd0](https://github.com/bitnami/charts/commit/a5e4bd0)), closes [#25306](https://github.com/bitnami/charts/issues/25306)
+
+## <small>19.1.4 (2024-04-25)</small>
+
+* [bitnami/redis] Fix "resources" sections warning for sentinel deployment (#25211) ([6706b0c](https://github.com/bitnami/charts/commit/6706b0c)), closes [#25211](https://github.com/bitnami/charts/issues/25211)
+
+## <small>19.1.3 (2024-04-23)</small>
+
+* Fix relabelling var scope in pod-monitor (#25237) ([17d9741](https://github.com/bitnami/charts/commit/17d9741)), closes [#25237](https://github.com/bitnami/charts/issues/25237)
+
+## <small>19.1.2 (2024-04-18)</small>
+
+* [bitnami/redis] Release 19.1.2 updating components versions (#25229) ([81c381c](https://github.com/bitnami/charts/commit/81c381c)), closes [#25229](https://github.com/bitnami/charts/issues/25229)
+
+## <small>19.1.1 (2024-04-17)</small>
+
+* [bitnami/redis] Release 19.1.1 (#25209) ([cd63f2d](https://github.com/bitnami/charts/commit/cd63f2d)), closes [#25209](https://github.com/bitnami/charts/issues/25209)
+
+## 19.1.0 (2024-04-08)
+
+* [bitnami/redis] Improve restart behavior in sentinel mode (#25019) ([18f1135](https://github.com/bitnami/charts/commit/18f1135)), closes [#25019](https://github.com/bitnami/charts/issues/25019)
+* Update resourcesPreset comments (#24467) ([92e3e8a](https://github.com/bitnami/charts/commit/92e3e8a)), closes [#24467](https://github.com/bitnami/charts/issues/24467)
+
+## <small>19.0.2 (2024-04-01)</small>
+
+* allow to set containerSecurityContext on kubectl container to fix issue e.g. with OpenShift (#24730) ([4fda65b](https://github.com/bitnami/charts/commit/4fda65b)), closes [#24730](https://github.com/bitnami/charts/issues/24730)
+
+## <small>19.0.1 (2024-03-20)</small>
+
+* [bitnami/redis] fix: :bug: Set seLinuxOptions to {} (#24555) ([392851d](https://github.com/bitnami/charts/commit/392851d)), closes [#24555](https://github.com/bitnami/charts/issues/24555)
+
+## 19.0.0 (2024-03-19)
+
+* [bitnami/redis] feat!: 🔒 💥 Improve security defaults (#24282) ([b4725cc](https://github.com/bitnami/charts/commit/b4725cc)), closes [#24282](https://github.com/bitnami/charts/issues/24282)
+
+## <small>18.19.4 (2024-03-18)</small>
+
+* [bitnami/redis] handling of deprecated relabellings (#24506) ([2de2898](https://github.com/bitnami/charts/commit/2de2898)), closes [#24506](https://github.com/bitnami/charts/issues/24506)
+
+## <small>18.19.3 (2024-03-18)</small>
+
+* [bitnami/*] Reorder Chart sections (#24455) ([0cf4048](https://github.com/bitnami/charts/commit/0cf4048)), closes [#24455](https://github.com/bitnami/charts/issues/24455)
+* [bitnami/redis] Fix (r) and reg typos in README.md (#24445) ([fef29ff](https://github.com/bitnami/charts/commit/fef29ff)), closes [#24445](https://github.com/bitnami/charts/issues/24445)
+* [bitnami/redis] typofix in metric relabelings value (#23859) ([abed681](https://github.com/bitnami/charts/commit/abed681)), closes [#23859](https://github.com/bitnami/charts/issues/23859)
+
+## <small>18.19.2 (2024-03-11)</small>
+
+* [bitnami/redis] Fix wrong TLS port environment variable name in Sentinel scripts (#24188) ([e76f135](https://github.com/bitnami/charts/commit/e76f135)), closes [#24188](https://github.com/bitnami/charts/issues/24188)
+
+## <small>18.19.1 (2024-03-08)</small>
+
+* [bitnami/redis] Release 18.19.1 updating components versions (#24300) ([f851e9f](https://github.com/bitnami/charts/commit/f851e9f)), closes [#24300](https://github.com/bitnami/charts/issues/24300)
+
+## 18.19.0 (2024-03-08)
+
+* [bitname/redis] Redis sentinel master service (#21913) ([9186bd9](https://github.com/bitnami/charts/commit/9186bd9)), closes [#21913](https://github.com/bitnami/charts/issues/21913)
+
+## <small>18.18.1 (2024-03-08)</small>
+
+* Fix typo in usePasswordFiles variable name (#24256) ([69db9d6](https://github.com/bitnami/charts/commit/69db9d6)), closes [#24256](https://github.com/bitnami/charts/issues/24256)
+
+## 18.18.0 (2024-03-05)
+
+* [bitnami/redis] feat: :sparkles: :lock: Add automatic adaptation for Openshift restricted-v2 SCC (#2 ([063463f](https://github.com/bitnami/charts/commit/063463f)), closes [#24149](https://github.com/bitnami/charts/issues/24149)
+
+## <small>18.17.1 (2024-03-04)</small>
+
+* [bitnami/redis] Fix ordering of annotations (#23972) ([03f66cf](https://github.com/bitnami/charts/commit/03f66cf)), closes [#23972](https://github.com/bitnami/charts/issues/23972)
+
+## 18.17.0 (2024-02-27)
+
+* [bitnami/redis] Allow no secret with password (#23886) ([d8c34d6](https://github.com/bitnami/charts/commit/d8c34d6)), closes [#23886](https://github.com/bitnami/charts/issues/23886)
+
+## <small>18.16.1 (2024-02-22)</small>
+
+* [bitnami/redis] Release 18.16.1 updating components versions (#23826) ([7c8d50f](https://github.com/bitnami/charts/commit/7c8d50f)), closes [#23826](https://github.com/bitnami/charts/issues/23826)
+
+## 18.16.0 (2024-02-21)
+
+* [bitnami/redis] feat: :sparkles: :lock: Add readOnlyRootFilesystem support (#23622) ([3054892](https://github.com/bitnami/charts/commit/3054892)), closes [#23622](https://github.com/bitnami/charts/issues/23622)
+
+## <small>18.15.1 (2024-02-21)</small>
+
+* [bitnami/redis] Release 18.15.1 updating components versions (#23692) ([f2f9358](https://github.com/bitnami/charts/commit/f2f9358)), closes [#23692](https://github.com/bitnami/charts/issues/23692)
+
+## 18.15.0 (2024-02-20)
+
+* [bitnami/*] Bump all versions (#23602) ([b70ee2a](https://github.com/bitnami/charts/commit/b70ee2a)), closes [#23602](https://github.com/bitnami/charts/issues/23602)
+
+## 18.14.0 (2024-02-16)
+
+* [bitnami/redis] feat: :sparkles: :lock: Add resource preset support (#23516) ([b18b776](https://github.com/bitnami/charts/commit/b18b776)), closes [#23516](https://github.com/bitnami/charts/issues/23516)
+
+## 18.13.0 (2024-02-13)
+
+* [bitnami/redis] - add missing fields in service/pod monitor (#22809) ([4d174a3](https://github.com/bitnami/charts/commit/4d174a3)), closes [#22809](https://github.com/bitnami/charts/issues/22809)
+
+## <small>18.12.1 (2024-02-03)</small>
+
+* [bitnami/redis] Release 18.12.1 updating components versions (#23137) ([6f15fa9](https://github.com/bitnami/charts/commit/6f15fa9)), closes [#23137](https://github.com/bitnami/charts/issues/23137)
+
+## 18.12.0 (2024-02-01)
+
+* [bitnami/redis] fix: :bug: Add allowExternalEgress to avoid breaking istio and fix metrics port (#22 ([2b78bee](https://github.com/bitnami/charts/commit/2b78bee)), closes [#22955](https://github.com/bitnami/charts/issues/22955)
+
+## <small>18.11.1 (2024-02-01)</small>
+
+* [bitnami/redis] Release 18.11.1 updating components versions (#23008) ([9672d37](https://github.com/bitnami/charts/commit/9672d37)), closes [#23008](https://github.com/bitnami/charts/issues/23008)
+
+## 18.11.0 (2024-01-30)
+
+* [bitnami/redis] feat: :lock: Enable networkPolicy (#22738) ([f1c7b0d](https://github.com/bitnami/charts/commit/f1c7b0d)), closes [#22738](https://github.com/bitnami/charts/issues/22738)
+
+## 18.10.0 (2024-01-30)
+
+* [bitnami/redis] Fix the PodMonitor implementation (#22676) ([3095a12](https://github.com/bitnami/charts/commit/3095a12)), closes [#22676](https://github.com/bitnami/charts/issues/22676)
+
+## <small>18.9.1 (2024-01-29)</small>
+
+* fix(redis): fix standalone redis missing service account (#22747) ([bf435ef](https://github.com/bitnami/charts/commit/bf435ef)), closes [#22747](https://github.com/bitnami/charts/issues/22747)
+
+## 18.9.0 (2024-01-26)
+
+* [bitnami/redis] - add support for additional-endpoints in service/pod monitor (#22250) ([259c9dd](https://github.com/bitnami/charts/commit/259c9dd)), closes [#22250](https://github.com/bitnami/charts/issues/22250)
+
+## <small>18.8.3 (2024-01-26)</small>
+
+* [bitnami/redis] Do not create master and replica serviceaccounts when using sentinel (#22716) ([13c6479](https://github.com/bitnami/charts/commit/13c6479)), closes [#22716](https://github.com/bitnami/charts/issues/22716)
+
+## <small>18.8.2 (2024-01-25)</small>
+
+* [bitnami/redis] create service account when using sentinel and replication (#22223) ([3efd491](https://github.com/bitnami/charts/commit/3efd491)), closes [#22223](https://github.com/bitnami/charts/issues/22223)
+
+## <small>18.8.1 (2024-01-25)</small>
+
+* [bitnami/*] Move documentation sections from docs.bitnami.com back to the README (#22203) ([7564f36](https://github.com/bitnami/charts/commit/7564f36)), closes [#22203](https://github.com/bitnami/charts/issues/22203)
+* [bitnami/redis] fix: :bug: Set seLinuxOptions to null for Openshift compatibility (#22653) ([6ea5ea5](https://github.com/bitnami/charts/commit/6ea5ea5)), closes [#22653](https://github.com/bitnami/charts/issues/22653)
+
+## 18.8.0 (2024-01-22)
+
+* [bitnami/redis] fix: :lock: Move service-account token auto-mount to pod declaration (#22455) ([08679ba](https://github.com/bitnami/charts/commit/08679ba)), closes [#22455](https://github.com/bitnami/charts/issues/22455)
+
+## <small>18.7.1 (2024-01-18)</small>
+
+* [bitnami/redis] Release 18.7.1 updating components versions (#22336) ([11d7707](https://github.com/bitnami/charts/commit/11d7707)), closes [#22336](https://github.com/bitnami/charts/issues/22336)
+
+## 18.7.0 (2024-01-17)
+
+* [bitnami/redis] fix: :lock: Improve podSecurityContext and containerSecurityContext with essential s ([2198b3f](https://github.com/bitnami/charts/commit/2198b3f)), closes [#22184](https://github.com/bitnami/charts/issues/22184)
+
+## <small>18.6.4 (2024-01-15)</small>
+
+* [bitnami/*] Fix ref links (in comments) (#21822) ([e4fa296](https://github.com/bitnami/charts/commit/e4fa296)), closes [#21822](https://github.com/bitnami/charts/issues/21822)
+* [bitnami/redis] fix: :lock: Do not use the default service account (#22028) ([5fae3b4](https://github.com/bitnami/charts/commit/5fae3b4)), closes [#22028](https://github.com/bitnami/charts/issues/22028)
+
+## <small>18.6.3 (2024-01-09)</small>
+
+* [bitnami/*] Fix docs.bitnami.com broken links (#21901) ([f35506d](https://github.com/bitnami/charts/commit/f35506d)), closes [#21901](https://github.com/bitnami/charts/issues/21901)
+* [bitnami/redis] Release 18.6.3 updating components versions (#21921) ([3a51ea4](https://github.com/bitnami/charts/commit/3a51ea4)), closes [#21921](https://github.com/bitnami/charts/issues/21921)
+
+## <small>18.6.2 (2024-01-04)</small>
+
+* [bitnami/*] Update copyright: Year and company (#21815) ([6c4bf75](https://github.com/bitnami/charts/commit/6c4bf75)), closes [#21815](https://github.com/bitnami/charts/issues/21815)
+* [bitnami/redis] Use correct context to retrieve node ports for sentinel service (#21830) ([910d599](https://github.com/bitnami/charts/commit/910d599)), closes [#21830](https://github.com/bitnami/charts/issues/21830)
+
+## <small>18.6.1 (2023-12-19)</small>
+
+* [bitnami/redis] Release 18.6.1 updating components versions (#21655) ([816f235](https://github.com/bitnami/charts/commit/816f235)), closes [#21655](https://github.com/bitnami/charts/issues/21655)
+
+## 18.6.0 (2023-12-19)
+
+* Add loadBalancerClass configuration to Redis service (#21586) ([ef28cdc](https://github.com/bitnami/charts/commit/ef28cdc)), closes [#21586](https://github.com/bitnami/charts/issues/21586)
+
+## 18.5.0 (2023-12-11)
+
+* [bitnami/*] Remove relative links to non-README sections, add verification for that and update TL;DR ([1103633](https://github.com/bitnami/charts/commit/1103633)), closes [#20967](https://github.com/bitnami/charts/issues/20967)
+* bitnami/redis Add namespaceOverride capability to redis chart (#21479) ([98db876](https://github.com/bitnami/charts/commit/98db876)), closes [#21479](https://github.com/bitnami/charts/issues/21479)
+* Update readme-generator links (#21043) ([1581eba](https://github.com/bitnami/charts/commit/1581eba)), closes [#21043](https://github.com/bitnami/charts/issues/21043)
+
+## 18.4.0 (2023-11-16)
+
+* [bitnami/redis] Implementing an option to define masters as DaemonSets #20939 (#20939) ([a53f6eb](https://github.com/bitnami/charts/commit/a53f6eb)), closes [#20939](https://github.com/bitnami/charts/issues/20939) [#20939](https://github.com/bitnami/charts/issues/20939)
+
+## <small>18.3.3 (2023-11-14)</small>
+
+* [bitnami/redis] Increase sentinel master retry sleep time to 5s (#20612) ([0140f33](https://github.com/bitnami/charts/commit/0140f33)), closes [#20612](https://github.com/bitnami/charts/issues/20612)
+
+## <small>18.3.2 (2023-11-09)</small>
+
+* [bitnami/redis] Release 18.3.2 updating components versions (#20872) ([6693b83](https://github.com/bitnami/charts/commit/6693b83)), closes [#20872](https://github.com/bitnami/charts/issues/20872)
+
+## <small>18.3.1 (2023-11-09)</small>
+
+* [bitnami/redis] Replace deprecated pull secret partial (#20666) ([e03531b](https://github.com/bitnami/charts/commit/e03531b)), closes [#20666](https://github.com/bitnami/charts/issues/20666)
+
+## 18.3.0 (2023-11-09)
+
+* [bitnami/redis] Implementing an option to define replicas as Daemonsets (#20003) ([9237563](https://github.com/bitnami/charts/commit/9237563)), closes [#20003](https://github.com/bitnami/charts/issues/20003)
+
+## <small>18.2.2 (2023-11-08)</small>
+
+* [bitnami/redis] Release 18.2.2 updating components versions (#20784) ([e61f423](https://github.com/bitnami/charts/commit/e61f423)), closes [#20784](https://github.com/bitnami/charts/issues/20784)
+
+## <small>18.2.1 (2023-11-05)</small>
+
+* [bitnami/redis] Release 18.2.1 updating components versions (#20625) ([6228abc](https://github.com/bitnami/charts/commit/6228abc)), closes [#20625](https://github.com/bitnami/charts/issues/20625)
+
+## 18.2.0 (2023-10-27)
+
+* [bitnami/*] Rename VMware Application Catalog (#20361) ([3acc734](https://github.com/bitnami/charts/commit/3acc734)), closes [#20361](https://github.com/bitnami/charts/issues/20361)
+* [bitnami/*] Skip image's tag in the README files of the Bitnami Charts (#19841) ([bb9a01b](https://github.com/bitnami/charts/commit/bb9a01b)), closes [#19841](https://github.com/bitnami/charts/issues/19841)
+* [bitnami/*] Standardize documentation (#19835) ([af5f753](https://github.com/bitnami/charts/commit/af5f753)), closes [#19835](https://github.com/bitnami/charts/issues/19835)
+* [bitnami/redis] - Add support for PodMonitor (#20409) ([0d40a6c](https://github.com/bitnami/charts/commit/0d40a6c)), closes [#20409](https://github.com/bitnami/charts/issues/20409)
+
+## <small>18.1.6 (2023-10-19)</small>
+
+* [bitnami/redis] Release 18.1.6 (#20324) ([9f486b3](https://github.com/bitnami/charts/commit/9f486b3)), closes [#20324](https://github.com/bitnami/charts/issues/20324)
+
+## <small>18.1.5 (2023-10-12)</small>
+
+* [bitnami/redis] Release 18.1.5 (#20171) ([fda443a](https://github.com/bitnami/charts/commit/fda443a)), closes [#20171](https://github.com/bitnami/charts/issues/20171)
+
+## <small>18.1.4 (2023-10-11)</small>
+
+* [bitnami/redis] Support `persistentVolumeClaimRetentionPolicy` for redis (#19689) ([5658fa8](https://github.com/bitnami/charts/commit/5658fa8)), closes [#19689](https://github.com/bitnami/charts/issues/19689)
+
+## <small>18.1.3 (2023-10-09)</small>
+
+* [bitnami/*] Update Helm charts prerequisites (#19745) ([eb755dd](https://github.com/bitnami/charts/commit/eb755dd)), closes [#19745](https://github.com/bitnami/charts/issues/19745)
+* [bitnami/redis] Release 18.1.3 (#19831) ([88ae1d4](https://github.com/bitnami/charts/commit/88ae1d4)), closes [#19831](https://github.com/bitnami/charts/issues/19831)
+
+## <small>18.1.2 (2023-10-02)</small>
+
+* [bitnami/redis] Use common capabilities for PSP (#19639) ([9c636a3](https://github.com/bitnami/charts/commit/9c636a3)), closes [#19639](https://github.com/bitnami/charts/issues/19639)
+
+## <small>18.1.1 (2023-09-28)</small>
+
+* [bitnami/redis] add kind & apiVersion for pvc template in statefulset (#19484) ([56fb647](https://github.com/bitnami/charts/commit/56fb647)), closes [#19484](https://github.com/bitnami/charts/issues/19484)
+
+## 18.1.0 (2023-09-22)
+
+* [bitnami/redis] add customization of metrics networkpolicy  (#19468) ([153184f](https://github.com/bitnami/charts/commit/153184f)), closes [#19468](https://github.com/bitnami/charts/issues/19468)
+* Autogenerate schema files (#19194) ([a2c2090](https://github.com/bitnami/charts/commit/a2c2090)), closes [#19194](https://github.com/bitnami/charts/issues/19194)
+* Revert "Autogenerate schema files (#19194)" (#19335) ([73d80be](https://github.com/bitnami/charts/commit/73d80be)), closes [#19194](https://github.com/bitnami/charts/issues/19194) [#19335](https://github.com/bitnami/charts/issues/19335)
+
+## <small>18.0.4 (2023-09-07)</small>
+
+* [bitnami/redis] Release 18.0.4 (#19153) ([2cc47e7](https://github.com/bitnami/charts/commit/2cc47e7)), closes [#19153](https://github.com/bitnami/charts/issues/19153)
+
+## <small>18.0.3 (2023-09-06)</small>
+
+* [bitnami/redis]: Use merge helper (#19103) ([e60facd](https://github.com/bitnami/charts/commit/e60facd)), closes [#19103](https://github.com/bitnami/charts/issues/19103)
+
+## <small>18.0.2 (2023-09-04)</small>
+
+* [bitnami/redis] expose service binding with correct uri (#18922) ([5c7fed5](https://github.com/bitnami/charts/commit/5c7fed5)), closes [#18922](https://github.com/bitnami/charts/issues/18922)
+
+## <small>18.0.1 (2023-08-28)</small>
+
+* [bitnami/redis] test: :white_check_mark: Add persistence tests (#18813) ([3e580e2](https://github.com/bitnami/charts/commit/3e580e2)), closes [#18813](https://github.com/bitnami/charts/issues/18813)
+* [bitnami/redis] Update upgrading notes for version 18.x.x (#18891) ([d9aa73d](https://github.com/bitnami/charts/commit/d9aa73d)), closes [#18891](https://github.com/bitnami/charts/issues/18891)
+
+## 18.0.0 (2023-08-25)
+
+* [bitnami/redis] Release 18.0.0 (#18874) ([cc5eb96](https://github.com/bitnami/charts/commit/cc5eb96)), closes [#18874](https://github.com/bitnami/charts/issues/18874)
+
+## <small>17.17.1 (2023-08-25)</small>
+
+* [bitnami/redis] Release 17.17.1 (#18862) ([b2beb14](https://github.com/bitnami/charts/commit/b2beb14)), closes [#18862](https://github.com/bitnami/charts/issues/18862)
+
+## 17.17.0 (2023-08-25)
+
+* [bitnami/redis] Support enableServiceLinks (#18779) ([c72422d](https://github.com/bitnami/charts/commit/c72422d)), closes [#18779](https://github.com/bitnami/charts/issues/18779)
+
+## 17.16.0 (2023-08-23)
+
+* [bitnami/redis] Support for customizing standard labels (#18418) ([e3c2335](https://github.com/bitnami/charts/commit/e3c2335)), closes [#18418](https://github.com/bitnami/charts/issues/18418)
+
+## <small>17.15.6 (2023-08-21)</small>
+
+* [bitnami/redis] Release 17.15.6 (#18713) ([e6ea66e](https://github.com/bitnami/charts/commit/e6ea66e)), closes [#18713](https://github.com/bitnami/charts/issues/18713)
+
+## <small>17.15.5 (2023-08-17)</small>
+
+* [bitnami/redis] Release 17.15.5 (#18589) ([cbef828](https://github.com/bitnami/charts/commit/cbef828)), closes [#18589](https://github.com/bitnami/charts/issues/18589)
+
+## <small>17.15.4 (2023-08-15)</small>
+
+* [bitnami/redis] Release 17.15.4 (#18431) ([e912de6](https://github.com/bitnami/charts/commit/e912de6)), closes [#18431](https://github.com/bitnami/charts/issues/18431)
+
+## <small>17.15.3 (2023-08-10)</small>
+
+* [bitnami/redis] Fix values for sentinel replica emptyDir volume (#18337) ([c6c5114](https://github.com/bitnami/charts/commit/c6c5114)), closes [#18337](https://github.com/bitnami/charts/issues/18337)
+
+## <small>17.15.2 (2023-08-10)</small>
+
+* [bitnami/redis] Define missing HEADLESS_SERVICE for start-replica.sh (#18312) ([a95bc61](https://github.com/bitnami/charts/commit/a95bc61)), closes [#18312](https://github.com/bitnami/charts/issues/18312)
+
+## <small>17.15.1 (2023-08-10)</small>
+
+* [bitnami/redis] fix redis sentinel start up (#18321) ([71a2db0](https://github.com/bitnami/charts/commit/71a2db0)), closes [#18321](https://github.com/bitnami/charts/issues/18321)
+
+## 17.15.0 (2023-08-09)
+
+* [bitnami/redis] checksum only data part of ConfigMap/Secret (#17579) ([de01284](https://github.com/bitnami/charts/commit/de01284)), closes [#17579](https://github.com/bitnami/charts/issues/17579)
+
+## <small>17.14.6 (2023-08-07)</small>
+
+* [bitnami/redis] retry when get master info failed (#18228) ([429ed7f](https://github.com/bitnami/charts/commit/429ed7f)), closes [#18228](https://github.com/bitnami/charts/issues/18228)
+
+## <small>17.14.5 (2023-08-02)</small>
+
+* [bitnami/redis] fix redis sentinel start up (#17932) ([13a5749](https://github.com/bitnami/charts/commit/13a5749)), closes [#17932](https://github.com/bitnami/charts/issues/17932)
+
+## <small>17.14.4 (2023-08-01)</small>
+
+* [bitnami/redis] Release 17.14.4 (#18129) ([cdb6e00](https://github.com/bitnami/charts/commit/cdb6e00)), closes [#18129](https://github.com/bitnami/charts/issues/18129)
+
+## <small>17.14.3 (2023-07-28)</small>
+
+* [bitnami/redis] Release 17.14.3 (#18021) ([f094056](https://github.com/bitnami/charts/commit/f094056)), closes [#18021](https://github.com/bitnami/charts/issues/18021)
+
+## <small>17.14.2 (2023-07-26)</small>
+
+* [bitnami/redis] Release 17.14.2 (#17958) ([472b8af](https://github.com/bitnami/charts/commit/472b8af)), closes [#17958](https://github.com/bitnami/charts/issues/17958)
+
+## <small>17.14.1 (2023-07-26)</small>
+
+* [bitnami/redis] Allow templatable values for `.Values.auth.existingSecretPasswordKey` (#17723) ([344db98](https://github.com/bitnami/charts/commit/344db98)), closes [#17723](https://github.com/bitnami/charts/issues/17723)
+
+## 17.14.0 (2023-07-26)
+
+* [bitnami/redis] Try to seed redis with pss-restricted (#17237) ([d542b49](https://github.com/bitnami/charts/commit/d542b49)), closes [#17237](https://github.com/bitnami/charts/issues/17237)
+
+## <small>17.13.2 (2023-07-15)</small>
+
+* [bitnami/redis] Release 17.13.2 (#17720) ([df883f2](https://github.com/bitnami/charts/commit/df883f2)), closes [#17720](https://github.com/bitnami/charts/issues/17720)
+
+## <small>17.13.1 (2023-07-15)</small>
+
+* [bitnami/redis] Release 17.13.1 (#17713) ([3ed0eb6](https://github.com/bitnami/charts/commit/3ed0eb6)), closes [#17713](https://github.com/bitnami/charts/issues/17713)
+
+## 17.13.0 (2023-07-14)
+
+* [bitnami/redis] add sampleLimit and targetLimit for redis chart (#17587) ([ea241c0](https://github.com/bitnami/charts/commit/ea241c0)), closes [#17587](https://github.com/bitnami/charts/issues/17587)
+
+## 17.12.0 (2023-07-13)
+
+* [bitnami/redis] don't include `@` for unauthenticated URI (#17493) ([1713a0f](https://github.com/bitnami/charts/commit/1713a0f)), closes [#17493](https://github.com/bitnami/charts/issues/17493)
+* Use os-shell in tempate and Jaeger runtime params (#17557) ([91a49eb](https://github.com/bitnami/charts/commit/91a49eb)), closes [#17557](https://github.com/bitnami/charts/issues/17557)
+
+## <small>17.11.8 (2023-07-11)</small>
+
+* [bitnami/redis] Release 17.11.8 (#17545) ([e6061e4](https://github.com/bitnami/charts/commit/e6061e4)), closes [#17545](https://github.com/bitnami/charts/issues/17545)
+
+## <small>17.11.7 (2023-07-05)</small>
+
+* [bitnami/redis] Add missing apiVersion and kind to redis volumeClaimTemplates (#17466) ([4d1ee86](https://github.com/bitnami/charts/commit/4d1ee86)), closes [#17466](https://github.com/bitnami/charts/issues/17466)
+* Add copyright header (#17300) ([da68be8](https://github.com/bitnami/charts/commit/da68be8)), closes [#17300](https://github.com/bitnami/charts/issues/17300)
+* Update charts readme (#17217) ([31b3c0a](https://github.com/bitnami/charts/commit/31b3c0a)), closes [#17217](https://github.com/bitnami/charts/issues/17217)
+
+## <small>17.11.6 (2023-06-19)</small>
+
+* [bitnami/redis] Add automountServiceAccountToken in pod specs (#17175) ([d42df30](https://github.com/bitnami/charts/commit/d42df30)), closes [#17175](https://github.com/bitnami/charts/issues/17175)
+
+## <small>17.11.5 (2023-06-14)</small>
+
+* [bitnami/redis] Release 17.11.5 (#17122) ([86fea96](https://github.com/bitnami/charts/commit/86fea96)), closes [#17122](https://github.com/bitnami/charts/issues/17122)
+
+## <small>17.11.4 (2023-06-13)</small>
+
+* [bitnami/*] Change copyright section in READMEs (#17006) ([ef986a1](https://github.com/bitnami/charts/commit/ef986a1)), closes [#17006](https://github.com/bitnami/charts/issues/17006)
+* [bitnami/redis] Modify Sentinel liveness Probe timeout to not restart during tilt-mode (#17103) ([15d4417](https://github.com/bitnami/charts/commit/15d4417)), closes [#17103](https://github.com/bitnami/charts/issues/17103)
+* [bitnami/several] Change copyright section in READMEs (#16989) ([5b6a5cf](https://github.com/bitnami/charts/commit/5b6a5cf)), closes [#16989](https://github.com/bitnami/charts/issues/16989)
+
+## <small>17.11.3 (2023-05-21)</small>
+
+* [bitnami/redis] Release 17.11.3 (#16788) ([0831617](https://github.com/bitnami/charts/commit/0831617)), closes [#16788](https://github.com/bitnami/charts/issues/16788)
+
+## <small>17.11.2 (2023-05-18)</small>
+
+*  [bitnami/redis]  add support for headless metrics service (#16545) ([4b79ebe](https://github.com/bitnami/charts/commit/4b79ebe)), closes [#16545](https://github.com/bitnami/charts/issues/16545)
+
+## <small>17.11.1 (2023-05-17)</small>
+
+* Add wording for enterprise page (#16560) ([8f22774](https://github.com/bitnami/charts/commit/8f22774)), closes [#16560](https://github.com/bitnami/charts/issues/16560)
+* Fix PVC labeling for bitnami/redis Helm chart (#16678) ([277efc3](https://github.com/bitnami/charts/commit/277efc3)), closes [#16678](https://github.com/bitnami/charts/issues/16678)
+
+## 17.11.0 (2023-05-09)
+
+* [bitnami/several] Adapt Chart.yaml to set desired OCI annotations (#16546) ([fc9b18f](https://github.com/bitnami/charts/commit/fc9b18f)), closes [#16546](https://github.com/bitnami/charts/issues/16546)
+
+## <small>17.10.3 (2023-05-09)</small>
+
+* [bitnami/redis] Release 17.10.3 (#16495) ([52238da](https://github.com/bitnami/charts/commit/52238da)), closes [#16495](https://github.com/bitnami/charts/issues/16495)
+
+## <small>17.10.2 (2023-05-05)</small>
+
+* [bitnami/redis] Fix replica-announce-ip wrong number of arguments whe… (#16234) ([b63df9d](https://github.com/bitnami/charts/commit/b63df9d)), closes [#16234](https://github.com/bitnami/charts/issues/16234)
+
+## <small>17.10.1 (2023-04-25)</small>
+
+* redis chart: sort alphabetically hpa metrics, fixes #16198 (#16199) ([0f3be36](https://github.com/bitnami/charts/commit/0f3be36)), closes [#16198](https://github.com/bitnami/charts/issues/16198) [#16199](https://github.com/bitnami/charts/issues/16199) [#16198](https://github.com/bitnami/charts/issues/16198)
+
+## 17.10.0 (2023-04-20)
+
+* [bitnami/*] Make Helm charts 100% OCI (#15998) ([8841510](https://github.com/bitnami/charts/commit/8841510)), closes [#15998](https://github.com/bitnami/charts/issues/15998)
+
+## <small>17.9.5 (2023-04-17)</small>
+
+* [bitnami/redis] Release 17.9.5 (#16099) ([b449511](https://github.com/bitnami/charts/commit/b449511)), closes [#16099](https://github.com/bitnami/charts/issues/16099)
+
+## <small>17.9.4 (2023-04-13)</small>
+
+* [bitnami/redis] Add notes about RDB compatibility in upgrades (#15737) ([5b8193e](https://github.com/bitnami/charts/commit/5b8193e)), closes [#15737](https://github.com/bitnami/charts/issues/15737)
+* [bitnami/redis] upgrade redis-exporter (#16036) ([a67e6c4](https://github.com/bitnami/charts/commit/a67e6c4)), closes [#16036](https://github.com/bitnami/charts/issues/16036)
+
+## <small>17.9.3 (2023-04-01)</small>
+
+* [bitnami/redis] Release 17.9.3 (#15894) ([0ceacff](https://github.com/bitnami/charts/commit/0ceacff)), closes [#15894](https://github.com/bitnami/charts/issues/15894)
+
+## <small>17.9.2 (2023-03-24)</small>
+
+* [bitnami/redis] Release 17.9.2 (#15719) ([ab7a23f](https://github.com/bitnami/charts/commit/ab7a23f)), closes [#15719](https://github.com/bitnami/charts/issues/15719)
+
+## <small>17.9.1 (2023-03-23)</small>
+
+* [bitnami/redis] Add support for Sentinel resource annotations (#15652) ([47fadd1](https://github.com/bitnami/charts/commit/47fadd1)), closes [#15652](https://github.com/bitnami/charts/issues/15652)
+* [bitnami/redis] Fix wrong password given in service bindings (#15672) ([bc2d03c](https://github.com/bitnami/charts/commit/bc2d03c)), closes [#15672](https://github.com/bitnami/charts/issues/15672)
+
+## 17.9.0 (2023-03-21)
+
+* [bitnami/redis] Add support for service.headless.annotations (#15441) ([cec500e](https://github.com/bitnami/charts/commit/cec500e)), closes [#15441](https://github.com/bitnami/charts/issues/15441)
+
+## <small>17.8.7 (2023-03-20)</small>
+
+* [bitnami/redis] Release 17.8.7 (#15642) ([4e62884](https://github.com/bitnami/charts/commit/4e62884)), closes [#15642](https://github.com/bitnami/charts/issues/15642)
+
+## <small>17.8.6 (2023-03-19)</small>
+
+* [bitnami/redis] Release 17.8.6 (#15602) ([5c241dc](https://github.com/bitnami/charts/commit/5c241dc)), closes [#15602](https://github.com/bitnami/charts/issues/15602)
+
+## <small>17.8.5 (2023-03-14)</small>
+
+* Use existingSecretPasswordKey instead of hardcoded value (#15490) ([33ab645](https://github.com/bitnami/charts/commit/33ab645)), closes [#15490](https://github.com/bitnami/charts/issues/15490)
+
+## <small>17.8.4 (2023-03-10)</small>
+
+* [bitnami/charts] Apply linter to README files (#15357) ([0e29e60](https://github.com/bitnami/charts/commit/0e29e60)), closes [#15357](https://github.com/bitnami/charts/issues/15357)
+* [bitnami/redis] minReadySeconds feature only requires k8s >=1.23 (#15417) ([a748281](https://github.com/bitnami/charts/commit/a748281)), closes [#15417](https://github.com/bitnami/charts/issues/15417) [#13783](https://github.com/bitnami/charts/issues/13783)
+
+## <small>17.8.3 (2023-03-07)</small>
+
+* [bitnami/redis] add PVC labels (#15353) ([7109c7b](https://github.com/bitnami/charts/commit/7109c7b)), closes [#15353](https://github.com/bitnami/charts/issues/15353)
+
+## <small>17.8.2 (2023-03-01)</small>
+
+* [bitnami/redis] Release 17.8.2 (#15284) ([bca8bc7](https://github.com/bitnami/charts/commit/bca8bc7)), closes [#15284](https://github.com/bitnami/charts/issues/15284)
+* [bitnami/redis] Use SIGTERM on timeout for probes (#15057) ([6ab7b61](https://github.com/bitnami/charts/commit/6ab7b61)), closes [#15057](https://github.com/bitnami/charts/issues/15057)
+
+## <small>17.8.1 (2023-02-28)</small>
+
+* [bitnami/redis] Release 17.8.1 (#15183) ([0b73498](https://github.com/bitnami/charts/commit/0b73498)), closes [#15183](https://github.com/bitnami/charts/issues/15183)
+
+## 17.8.0 (2023-02-21)
+
+* [bitnami/redis] feat: :sparkles: Add ServiceBinding-compatible secrets (#14906) ([20196ce](https://github.com/bitnami/charts/commit/20196ce)), closes [#14906](https://github.com/bitnami/charts/issues/14906)
+* [bitnami/redis] Fix missing metrics.command key (#15066) ([52a754d](https://github.com/bitnami/charts/commit/52a754d)), closes [#15066](https://github.com/bitnami/charts/issues/15066)
+
+## <small>17.7.6 (2023-02-21)</small>
+
+* [bitnami/redis] Release 17.7.6 (#15074) ([61309d1](https://github.com/bitnami/charts/commit/61309d1)), closes [#15074](https://github.com/bitnami/charts/issues/15074)
+
+## <small>17.7.5 (2023-02-17)</small>
+
+* [bitnami/*] Fix markdown linter issues 2 (#14890) ([aa96572](https://github.com/bitnami/charts/commit/aa96572)), closes [#14890](https://github.com/bitnami/charts/issues/14890)
+* [bitnami/redis] Release 17.7.5 (#15014) ([8a86a04](https://github.com/bitnami/charts/commit/8a86a04)), closes [#15014](https://github.com/bitnami/charts/issues/15014)
+
+## <small>17.7.4 (2023-02-15)</small>
+
+* [bitnami/*] Fix markdown linter issues (#14874) ([a51e0e8](https://github.com/bitnami/charts/commit/a51e0e8)), closes [#14874](https://github.com/bitnami/charts/issues/14874)
+* [bitnami/redis] Release 17.7.4 (#14898) ([9d615e7](https://github.com/bitnami/charts/commit/9d615e7)), closes [#14898](https://github.com/bitnami/charts/issues/14898)
+
+## <small>17.7.3 (2023-02-09)</small>
+
+* [bitnami/redis] Add commonLabels also to pods: master, replicas, sentinel (#14244) ([529e070](https://github.com/bitnami/charts/commit/529e070)), closes [#14244](https://github.com/bitnami/charts/issues/14244)
+
+## <small>17.7.2 (2023-02-06)</small>
+
+* [bitnami/redis] fix wrong propagation of loadBalancerSourceRanges (#14728) ([db79cb9](https://github.com/bitnami/charts/commit/db79cb9)), closes [#14728](https://github.com/bitnami/charts/issues/14728)
+
+## <small>17.7.1 (2023-02-03)</small>
+
+* [bitnami/redis] Don't regenerate self-signed certs on upgrade (#14655) ([9c8766a](https://github.com/bitnami/charts/commit/9c8766a)), closes [#14655](https://github.com/bitnami/charts/issues/14655)
+
+## 17.7.0 (2023-02-02)
+
+* [bitnami/*] Change copyright date (#14682) ([add4ec7](https://github.com/bitnami/charts/commit/add4ec7)), closes [#14682](https://github.com/bitnami/charts/issues/14682)
+* [bitnami/redis] Allow option to disable hostnames usage when configuring nodes (#14599) ([0343396](https://github.com/bitnami/charts/commit/0343396)), closes [#14599](https://github.com/bitnami/charts/issues/14599)
+
+## 17.6.0 (2023-01-23)
+
+* [bitnami/redis] make emptyDir sizeLimit work everywhere (#14399) ([6d8e53a](https://github.com/bitnami/charts/commit/6d8e53a)), closes [#14399](https://github.com/bitnami/charts/issues/14399)
+
+## <small>17.5.1 (2023-01-20)</small>
+
+* [bitnami/*] Unify READMEs (#14472) ([2064fb8](https://github.com/bitnami/charts/commit/2064fb8)), closes [#14472](https://github.com/bitnami/charts/issues/14472)
+* [bitnami/redis] Fix missing Helm value rendering for metrics container probes (#14473) ([829caf3](https://github.com/bitnami/charts/commit/829caf3)), closes [#14473](https://github.com/bitnami/charts/issues/14473) [#14420](https://github.com/bitnami/charts/issues/14420)
+
+## 17.5.0 (2023-01-20)
+
+* [bitnami/redis] add probes for metrics container (#14420) ([8410bf9](https://github.com/bitnami/charts/commit/8410bf9)), closes [#14420](https://github.com/bitnami/charts/issues/14420)
+
+## <small>17.4.3 (2023-01-16)</small>
+
+* [bitnami/*] Add license annotation and remove obsolete engine parameter (#14293) ([da2a794](https://github.com/bitnami/charts/commit/da2a794)), closes [#14293](https://github.com/bitnami/charts/issues/14293)
+* [bitnami/*] Change licenses annotation format (#14377) ([0ab7608](https://github.com/bitnami/charts/commit/0ab7608)), closes [#14377](https://github.com/bitnami/charts/issues/14377)
+* [bitnami/redis] Release 17.4.3 (#14388) ([9d6b54d](https://github.com/bitnami/charts/commit/9d6b54d)), closes [#14388](https://github.com/bitnami/charts/issues/14388)
+
+## <small>17.4.2 (2023-01-09)</small>
+
+* [bitnami/redis] Sentinel deployment: Fix Failover at graceful shutdown (#14133) ([0274e44](https://github.com/bitnami/charts/commit/0274e44)), closes [#14133](https://github.com/bitnami/charts/issues/14133) [#13021](https://github.com/bitnami/charts/issues/13021) [#12598](https://github.com/bitnami/charts/issues/12598) [#13956](https://github.com/bitnami/charts/issues/13956) [/github.com/bitnami/charts/pull/13021#issuecomment-1289177976](https://github.com//github.com/bitnami/charts/pull/13021/issues/issuecomment-1289177976) [#13956](https://github.com/bitnami/charts/issues/13956)
+
+## <small>17.4.1 (2023-01-03)</small>
+
+* [bitnami/redis] Release 17.4.1 (#14171) ([a633b06](https://github.com/bitnami/charts/commit/a633b06)), closes [#14171](https://github.com/bitnami/charts/issues/14171)
+
+## 17.4.0 (2022-12-23)
+
+* Adding ExternalIPs Feature (#14061) ([b8da23d](https://github.com/bitnami/charts/commit/b8da23d)), closes [#14061](https://github.com/bitnami/charts/issues/14061)
+
+## <small>17.3.18 (2022-12-22)</small>
+
+* [bitnami/redis] Release 17.3.18 (#14074) ([fd90280](https://github.com/bitnami/charts/commit/fd90280)), closes [#14074](https://github.com/bitnami/charts/issues/14074)
+
+## <small>17.3.17 (2022-12-16)</small>
+
+* [bitnami/redis] Release 17.3.17 (#13992) ([e24fc41](https://github.com/bitnami/charts/commit/e24fc41)), closes [#13992](https://github.com/bitnami/charts/issues/13992)
+
+## <small>17.3.16 (2022-12-12)</small>
+
+* [bitnami/redis] Release 17.3.16 (#13935) ([2f01e0c](https://github.com/bitnami/charts/commit/2f01e0c)), closes [#13935](https://github.com/bitnami/charts/issues/13935)
+
+## <small>17.3.15 (2022-12-12)</small>
+
+* [bitnami/redis] Enable to set up Recreate updateStrategy for redis (#13822) ([c2ac835](https://github.com/bitnami/charts/commit/c2ac835)), closes [#13822](https://github.com/bitnami/charts/issues/13822)
+* [bitnami/redis] Release 17.3.15 (#13924) ([439ee4d](https://github.com/bitnami/charts/commit/439ee4d)), closes [#13924](https://github.com/bitnami/charts/issues/13924)
+
+## <small>17.3.14 (2022-12-04)</small>
+
+* [bitnami/redis] Release 17.3.14 (#13826) ([edc69f0](https://github.com/bitnami/charts/commit/edc69f0)), closes [#13826](https://github.com/bitnami/charts/issues/13826)
+
+## <small>17.3.13 (2022-12-01)</small>
+
+* [bitnami/redis] Add version checking to minReadySeconds parameter (#13783) ([4ab9ed9](https://github.com/bitnami/charts/commit/4ab9ed9)), closes [#13783](https://github.com/bitnami/charts/issues/13783)
+
+## <small>17.3.12 (2022-12-01)</small>
+
+* [bitnami/redis] Add minReadySeconds configuration (#13596) ([3667a06](https://github.com/bitnami/charts/commit/3667a06)), closes [#13596](https://github.com/bitnami/charts/issues/13596)
+
+## <small>17.3.11 (2022-11-15)</small>
+
+* [bitnami/redis] Allow auth.existingSecret to be templated (#13504) ([145e3a2](https://github.com/bitnami/charts/commit/145e3a2)), closes [#13504](https://github.com/bitnami/charts/issues/13504)
+
+## <small>17.3.10 (2022-11-14)</small>
+
+* [bitnami/redis] Fix suport for persistent volume claim for sentinel (#13477) ([a561d0e](https://github.com/bitnami/charts/commit/a561d0e)), closes [#13477](https://github.com/bitnami/charts/issues/13477)
+
+## <small>17.3.9 (2022-11-10)</small>
+
+* [bitnami/redis] Add suport for volume subPathExpr (#13402) ([13683d0](https://github.com/bitnami/charts/commit/13683d0)), closes [#13402](https://github.com/bitnami/charts/issues/13402)
+
+## <small>17.3.8 (2022-11-04)</small>
+
+* [bitnami/redis] Fix data loss when executing failover (#13021) ([b2c51d6](https://github.com/bitnami/charts/commit/b2c51d6)), closes [#13021](https://github.com/bitnami/charts/issues/13021)
+* [bitnami/redis] Release 17.3.8 (#13352) ([9ddc653](https://github.com/bitnami/charts/commit/9ddc653)), closes [#13352](https://github.com/bitnami/charts/issues/13352)
+
+## <small>17.3.7 (2022-10-21)</small>
+
+* [bitnami/redis] Fix redis master.api.svc.cluster.local missing (#13053) ([96e0229](https://github.com/bitnami/charts/commit/96e0229)), closes [#13053](https://github.com/bitnami/charts/issues/13053)
+
+## <small>17.3.6 (2022-10-18)</small>
+
+* [bitnami/*] Use new default branch name in links (#12943) ([a529e02](https://github.com/bitnami/charts/commit/a529e02)), closes [#12943](https://github.com/bitnami/charts/issues/12943)
+* [bitnami/redis] Allow podSelector from any namespaceSelector (#12624) ([847dc49](https://github.com/bitnami/charts/commit/847dc49)), closes [#12624](https://github.com/bitnami/charts/issues/12624) [#12607](https://github.com/bitnami/charts/issues/12607) [#12607](https://github.com/bitnami/charts/issues/12607)
+
+## <small>17.3.5 (2022-10-11)</small>
+
+* [bitnami/redis] Add functionality to ignore overrides when sentinel config is supplied (#12844) ([6d27b51](https://github.com/bitnami/charts/commit/6d27b51)), closes [#12844](https://github.com/bitnami/charts/issues/12844)
+
+## <small>17.3.4 (2022-10-10)</small>
+
+* [bitnami/redis] Release 17.3.4 (#12883) ([9c5c770](https://github.com/bitnami/charts/commit/9c5c770)), closes [#12883](https://github.com/bitnami/charts/issues/12883)
+
+## <small>17.3.3 (2022-10-10)</small>
+
+* Fixed typo that causes chart failed to render using DH param in TLS options. (#12872) ([7f3f7f7](https://github.com/bitnami/charts/commit/7f3f7f7)), closes [#12872](https://github.com/bitnami/charts/issues/12872)
+
+## <small>17.3.2 (2022-10-05)</small>
+
+* [bitnami/redis] Update maintainers (#12819) ([f394f63](https://github.com/bitnami/charts/commit/f394f63)), closes [#12819](https://github.com/bitnami/charts/issues/12819)
+* Generic README instructions related to the repo (#12792) ([3cf6b10](https://github.com/bitnami/charts/commit/3cf6b10)), closes [#12792](https://github.com/bitnami/charts/issues/12792)
+
+## <small>17.3.1 (2022-09-30)</small>
+
+* [bitnami/redis] Release 17.3.1 (#12764) ([5fbae13](https://github.com/bitnami/charts/commit/5fbae13)), closes [#12764](https://github.com/bitnami/charts/issues/12764)
+
+## 17.3.0 (2022-09-29)
+
+* [bitnami/redis] Add metrics.extraEnvVars to replica pods (#12594) ([4495d01](https://github.com/bitnami/charts/commit/4495d01)), closes [#12594](https://github.com/bitnami/charts/issues/12594)
+
+## 17.2.0 (2022-09-23)
+
+* [bitnami/redis] Make podTargetLabels configurable on servicemonitor (#12405) ([4e406ee](https://github.com/bitnami/charts/commit/4e406ee)), closes [#12405](https://github.com/bitnami/charts/issues/12405)
+
+## <small>17.1.8 (2022-09-21)</small>
+
+* [bitnami/redis] Release 17.1.8 (#12627) ([4b0bd72](https://github.com/bitnami/charts/commit/4b0bd72)), closes [#12627](https://github.com/bitnami/charts/issues/12627)
+
+## <small>17.1.7 (2022-09-20)</small>
+
+* [bitnami/redis] Use custom probes if given (#12553) ([71a1e2d](https://github.com/bitnami/charts/commit/71a1e2d)), closes [#12553](https://github.com/bitnami/charts/issues/12553) [#12354](https://github.com/bitnami/charts/issues/12354)
+
+## <small>17.1.6 (2022-09-16)</small>
+
+* [bitnami/redis] Release 17.1.6 (#12456) ([d69844d](https://github.com/bitnami/charts/commit/d69844d)), closes [#12456](https://github.com/bitnami/charts/issues/12456)
+* Fix Sentinel + SSL (#12428) ([c5b366e](https://github.com/bitnami/charts/commit/c5b366e)), closes [#12428](https://github.com/bitnami/charts/issues/12428)
+
+## <small>17.1.5 (2022-09-14)</small>
+
+* [bitnami/redis] Add seperate serviceAccunts to master and replicas (#11757) ([e9081af](https://github.com/bitnami/charts/commit/e9081af)), closes [#11757](https://github.com/bitnami/charts/issues/11757)
+
+## <small>17.1.4 (2022-09-05)</small>
+
+* [bitnami/redis] Use consistent prometheusrules templating (#12249) ([99ea3c6](https://github.com/bitnami/charts/commit/99ea3c6)), closes [#12249](https://github.com/bitnami/charts/issues/12249)
+
+## <small>17.1.3 (2022-09-01)</small>
+
+* [bitnami/redis] prevents incorrect master host to be written to sentinel.conf (#12150) ([c6aa735](https://github.com/bitnami/charts/commit/c6aa735)), closes [#12150](https://github.com/bitnami/charts/issues/12150)
+* [bitnami/redis] Release 17.1.3 (#12245) ([b2ea2b9](https://github.com/bitnami/charts/commit/b2ea2b9)), closes [#12245](https://github.com/bitnami/charts/issues/12245)
+
+## <small>17.1.2 (2022-08-24)</small>
+
+* [bitnami/redis] Fix probe bug, fix config bug, better default timeout, inclusivity (#11418) ([19b3ccb](https://github.com/bitnami/charts/commit/19b3ccb)), closes [#11418](https://github.com/bitnami/charts/issues/11418)
+
+## <small>17.1.1 (2022-08-23)</small>
+
+* [bitnami/redis] Update Chart.lock (#12068) ([7c05995](https://github.com/bitnami/charts/commit/7c05995)), closes [#12068](https://github.com/bitnami/charts/issues/12068)
+
+## 17.1.0 (2022-08-22)
+
+* [bitnami/redis] Add support for image digest apart from tag (#11936) ([0549e73](https://github.com/bitnami/charts/commit/0549e73)), closes [#11936](https://github.com/bitnami/charts/issues/11936)
+
+## <small>17.0.11 (2022-08-17)</small>
+
+* [bitnami/redis] Add 17.x.x upgrading notes (#11710) ([88d1fbf](https://github.com/bitnami/charts/commit/88d1fbf)), closes [#11710](https://github.com/bitnami/charts/issues/11710)
+* [bitnami/redis] Fix sentinel start command parameters order (#11794) ([c02db57](https://github.com/bitnami/charts/commit/c02db57)), closes [#11794](https://github.com/bitnami/charts/issues/11794)
+
+## <small>17.0.10 (2022-08-09)</small>
+
+* [bitnami/redis] Support disabling annotations in external-dns (#11077) ([117226b](https://github.com/bitnami/charts/commit/117226b)), closes [#11077](https://github.com/bitnami/charts/issues/11077)
+
+## <small>17.0.9 (2022-08-09)</small>
+
+* [bitnami/redis] Release 17.0.9 (#11661) ([9dd93b1](https://github.com/bitnami/charts/commit/9dd93b1)), closes [#11661](https://github.com/bitnami/charts/issues/11661)
+
+## <small>17.0.8 (2022-08-04)</small>
+
+* [bitnami/redis] Release 17.0.8 (#11583) ([25d1076](https://github.com/bitnami/charts/commit/25d1076)), closes [#11583](https://github.com/bitnami/charts/issues/11583)
+
+## <small>17.0.7 (2022-08-03)</small>
+
+* [bitnami/redis] Release 17.0.7 (#11523) ([9ff0c4c](https://github.com/bitnami/charts/commit/9ff0c4c)), closes [#11523](https://github.com/bitnami/charts/issues/11523)
+
+## <small>17.0.6 (2022-07-27)</small>
+
+* [bitnami/*] Update URLs to point to the new bitnami/containers monorepo (#11352) ([d665af0](https://github.com/bitnami/charts/commit/d665af0)), closes [#11352](https://github.com/bitnami/charts/issues/11352)
+* [bitnami/redis] Fix OutOfSync HPAs with ArgoCD (#11313) ([acf3721](https://github.com/bitnami/charts/commit/acf3721)), closes [#11313](https://github.com/bitnami/charts/issues/11313)
+
+## <small>17.0.5 (2022-07-22)</small>
+
+* [bitnami/redis] Release 17.0.5 (#11318) ([475e2c6](https://github.com/bitnami/charts/commit/475e2c6)), closes [#11318](https://github.com/bitnami/charts/issues/11318)
+
+## <small>17.0.4 (2022-07-22)</small>
+
+* [bitnami/redis] Add timeout to redis-cli in start-sentinel.sh (#11298) ([74e05c5](https://github.com/bitnami/charts/commit/74e05c5)), closes [#11298](https://github.com/bitnami/charts/issues/11298) [#11294](https://github.com/bitnami/charts/issues/11294)
+
+## <small>17.0.3 (2022-07-21)</small>
+
+* [bitnami/redis] Release 17.0.3 (#11295) ([72ed751](https://github.com/bitnami/charts/commit/72ed751)), closes [#11295](https://github.com/bitnami/charts/issues/11295)
+
+## <small>17.0.2 (2022-07-19)</small>
+
+* [bitnami/redis] Release 17.0.2 (#11238) ([31a26f4](https://github.com/bitnami/charts/commit/31a26f4)), closes [#11238](https://github.com/bitnami/charts/issues/11238)
+
+## <small>17.0.1 (2022-07-13)</small>
+
+* [bitnami/redis] Release 17.0.1 (#11162) ([7e4b785](https://github.com/bitnami/charts/commit/7e4b785)), closes [#11162](https://github.com/bitnami/charts/issues/11162)
+
+## 17.0.0 (2022-07-12)
+
+* [bitnami/redis] Release 17.0.0 (#11151) ([a1e0d3b](https://github.com/bitnami/charts/commit/a1e0d3b)), closes [#11151](https://github.com/bitnami/charts/issues/11151)
+
+## <small>16.13.2 (2022-07-04)</small>
+
+* [bitnami/redis] Release 16.13.2 (#11019) ([d4dba2b](https://github.com/bitnami/charts/commit/d4dba2b)), closes [#11019](https://github.com/bitnami/charts/issues/11019)
+
+## <small>16.13.1 (2022-06-30)</small>
+
+* [bitnami/redis] Release 16.13.1 (#10942) ([a984c4b](https://github.com/bitnami/charts/commit/a984c4b)), closes [#10942](https://github.com/bitnami/charts/issues/10942)
+
+## 16.13.0 (2022-06-24)
+
+* [bitnami/redis] Replace --slaveof with --replicaof and remove redundant slave-read-only=yes (#10655) ([a6f1b9d](https://github.com/bitnami/charts/commit/a6f1b9d)), closes [#10655](https://github.com/bitnami/charts/issues/10655)
+
+## <small>16.12.3 (2022-06-22)</small>
+
+* [bitnami/redis] Fix for REDIS_MASTER_HOST (#10797) ([94282aa](https://github.com/bitnami/charts/commit/94282aa)), closes [#10797](https://github.com/bitnami/charts/issues/10797) [#10621](https://github.com/bitnami/charts/issues/10621)
+
+## <small>16.12.2 (2022-06-14)</small>
+
+*  [bitnami/redis] fix psp name in role (#10733) ([3e38c26](https://github.com/bitnami/charts/commit/3e38c26)), closes [#10733](https://github.com/bitnami/charts/issues/10733)
+
+## <small>16.12.1 (2022-06-10)</small>
+
+* [bitnami/redis] Release 16.12.1 updating components versions ([8874a9d](https://github.com/bitnami/charts/commit/8874a9d))
+
+## 16.12.0 (2022-06-07)
+
+* [bitnami/*] Replace Kubeapps URL in READMEs (and kubeapps Chart.yaml) and remove BKPR references (#1 ([c6a7914](https://github.com/bitnami/charts/commit/c6a7914)), closes [#10600](https://github.com/bitnami/charts/issues/10600)
+* [bitnami/redis] Allow deploying multiple masters (#10047) ([a1aa868](https://github.com/bitnami/charts/commit/a1aa868)), closes [#10047](https://github.com/bitnami/charts/issues/10047)
+
+## <small>16.11.3 (2022-06-06)</small>
+
+* [bitnami/redis] Release 16.11.3 updating components versions ([e067f11](https://github.com/bitnami/charts/commit/e067f11))
+
+## <small>16.11.2 (2022-06-02)</small>
+
+* Update Redis trademark references ([2cada87](https://github.com/bitnami/charts/commit/2cada87))
+
+## <small>16.11.1 (2022-06-01)</small>
+
+* [bitnami/several] Replace maintainers email by url (#10523) ([ff3cf61](https://github.com/bitnami/charts/commit/ff3cf61)), closes [#10523](https://github.com/bitnami/charts/issues/10523)
+
+## 16.11.0 (2022-06-01)
+
+* [bitnami/redis] Add existingClaim in replicas as we have in master (#10507) ([2df41f3](https://github.com/bitnami/charts/commit/2df41f3)), closes [#10507](https://github.com/bitnami/charts/issues/10507)
+
+## <small>16.10.1 (2022-05-30)</small>
+
+* [bitnami/several] Replace base64 --decode with base64 -d (#10495) ([099286a](https://github.com/bitnami/charts/commit/099286a)), closes [#10495](https://github.com/bitnami/charts/issues/10495)
+
+## 16.10.0 (2022-05-26)
+
+* [bitnami/redis] Add missing service parameter (#10433) ([cb6b590](https://github.com/bitnami/charts/commit/cb6b590)), closes [#10433](https://github.com/bitnami/charts/issues/10433)
+* [bitnami/redis] Fix #10314: don't use sentinel auth in sentinel prestop hook when sentinel auth is d ([2110b26](https://github.com/bitnami/charts/commit/2110b26)), closes [#10314](https://github.com/bitnami/charts/issues/10314) [#10368](https://github.com/bitnami/charts/issues/10368) [#10314](https://github.com/bitnami/charts/issues/10314)
+
+## <small>16.9.11 (2022-05-23)</small>
+
+* [bitnami/redis] Use the new helper for HPA API version (#10211) ([55930ea](https://github.com/bitnami/charts/commit/55930ea)), closes [#10211](https://github.com/bitnami/charts/issues/10211)
+
+## <small>16.9.10 (2022-05-22)</small>
+
+* [bitnami/redis] Release 16.9.10 updating components versions ([81551c1](https://github.com/bitnami/charts/commit/81551c1))
+
+## <small>16.9.9 (2022-05-22)</small>
+
+* [bitnami/redis] Release 16.9.9 updating components versions ([3ef7fbe](https://github.com/bitnami/charts/commit/3ef7fbe))
+
+## <small>16.9.8 (2022-05-21)</small>
+
+* [bitnami/redis] Release 16.9.8 updating components versions ([4cb74f8](https://github.com/bitnami/charts/commit/4cb74f8))
+
+## <small>16.9.7 (2022-05-19)</small>
+
+* [bitnami/redis] Release 16.9.7 updating components versions ([c3d2738](https://github.com/bitnami/charts/commit/c3d2738))
+
+## <small>16.9.6 (2022-05-18)</small>
+
+* [bitnami/redis] Release 16.9.6 updating components versions ([22e89b4](https://github.com/bitnami/charts/commit/22e89b4))
+
+## <small>16.9.5 (2022-05-16)</small>
+
+* [bitnami/redis] fix wrongly placed metrics extra volume mounts (#10189) ([80aaf6e](https://github.com/bitnami/charts/commit/80aaf6e)), closes [#10189](https://github.com/bitnami/charts/issues/10189)
+
+## <small>16.9.4 (2022-05-13)</small>
+
+* [bitnami/*] Remove old 'ci' files (#10171) ([5df30c4](https://github.com/bitnami/charts/commit/5df30c4)), closes [#10171](https://github.com/bitnami/charts/issues/10171)
+* [bitnami/*] Unify k8s directives separators (#10185) ([2650214](https://github.com/bitnami/charts/commit/2650214)), closes [#10185](https://github.com/bitnami/charts/issues/10185)
+
+## <small>16.9.3 (2022-05-12)</small>
+
+* [bitnami/redis] Add missing namespace metadata (#10156) ([e1ba9a7](https://github.com/bitnami/charts/commit/e1ba9a7)), closes [#10156](https://github.com/bitnami/charts/issues/10156)
+
+## <small>16.9.2 (2022-05-10)</small>
+
+* [bitnami/redis] fix missing metrics customization to Sentinel (#10085) ([78bb169](https://github.com/bitnami/charts/commit/78bb169)), closes [#10085](https://github.com/bitnami/charts/issues/10085)
+* [bitnami/redis] Fix PersistentVolumeClaim storage class indentation (#10078) ([e9db4b4](https://github.com/bitnami/charts/commit/e9db4b4)), closes [#10078](https://github.com/bitnami/charts/issues/10078)
+
+## <small>16.9.1 (2022-05-09)</small>
+
+* [bitnami/redis] fix wrong ports in NOTES.txt (#10041) ([a99c4c3](https://github.com/bitnami/charts/commit/a99c4c3)), closes [#10041](https://github.com/bitnami/charts/issues/10041)
+
+## 16.9.0 (2022-05-06)
+
+* [bitnami: redis] Adds sizeLimit for redis-tmp-conf volume of replica component in redis chart (#9963 ([6c015c8](https://github.com/bitnami/charts/commit/6c015c8)), closes [#9963](https://github.com/bitnami/charts/issues/9963)
+* [bitnami/redis] Fix issue with duplicated lifecycles (#10031) ([a8097c6](https://github.com/bitnami/charts/commit/a8097c6)), closes [#10031](https://github.com/bitnami/charts/issues/10031)
+
+## <small>16.8.10 (2022-05-05)</small>
+
+* [bitnami/redis] Reuse certs from existing secrets  (#9907) ([80b6ced](https://github.com/bitnami/charts/commit/80b6ced)), closes [#9907](https://github.com/bitnami/charts/issues/9907) [#9785](https://github.com/bitnami/charts/issues/9785)
+
+## <small>16.8.9 (2022-04-27)</small>
+
+* [bitnami/redis] Release 16.8.9 updating components versions ([0d7d24f](https://github.com/bitnami/charts/commit/0d7d24f))
+
+## <small>16.8.8 (2022-04-27)</small>
+
+* [bitnami/redis] Add internalTrafficPolicy support on master and replicas (#9925) ([5ab189e](https://github.com/bitnami/charts/commit/5ab189e)), closes [#9925](https://github.com/bitnami/charts/issues/9925)
+* Fixed invalid variable (#9825) ([3dfdfa8](https://github.com/bitnami/charts/commit/3dfdfa8)), closes [#9825](https://github.com/bitnami/charts/issues/9825)
+
+## <small>16.8.7 (2022-04-20)</small>
+
+* [bitnami/redis] Release 16.8.7 updating components versions ([df99160](https://github.com/bitnami/charts/commit/df99160))
+
+## <small>16.8.6 (2022-04-19)</small>
+
+* [bitnami/redis] Release 16.8.6 updating components versions ([d9be196](https://github.com/bitnami/charts/commit/d9be196))
+
+## <small>16.8.5 (2022-04-07)</small>
+
+* [bitnami/redis] Release 16.8.5 updating components versions ([cd4d9be](https://github.com/bitnami/charts/commit/cd4d9be))
+
+## <small>16.8.4 (2022-04-05)</small>
+
+* [bitnami/redis] Release 16.8.4 updating components versions ([02777f9](https://github.com/bitnami/charts/commit/02777f9))
+
+## <small>16.8.3 (2022-04-05)</small>
+
+* [bitnami/redis] Always include sentinel-data volume (#9685) ([d5a4ab7](https://github.com/bitnami/charts/commit/d5a4ab7)), closes [#9685](https://github.com/bitnami/charts/issues/9685)
+
+## <small>16.8.2 (2022-04-03)</small>
+
+* [bitnami/redis] Release 16.8.2 updating components versions ([581974b](https://github.com/bitnami/charts/commit/581974b))
+
+## <small>16.8.1 (2022-04-02)</small>
+
+* [bitnami/redis] Release 16.8.1 updating components versions ([ae98824](https://github.com/bitnami/charts/commit/ae98824))
+
+## 16.8.0 (2022-03-31)
+
+* [bitnami/redis] Support dnsConfig (#9615) ([2fa5aad](https://github.com/bitnami/charts/commit/2fa5aad)), closes [#9615](https://github.com/bitnami/charts/issues/9615)
+
+## 16.7.0 (2022-03-28)
+
+* [bitnami/redis] Add possibility to set annotations for secret only (#9363) ([acba292](https://github.com/bitnami/charts/commit/acba292)), closes [#9363](https://github.com/bitnami/charts/issues/9363) [#9355](https://github.com/bitnami/charts/issues/9355)
+
+## <small>16.6.2 (2022-03-28)</small>
+
+* [bitnami/redis] Release 16.6.2 updating components versions ([e7cce8d](https://github.com/bitnami/charts/commit/e7cce8d))
+* [bitnami/redis]: fixing typo in `egress` part of `NetworkPolicy` (from `ingress`) (#9589) ([4445bb1](https://github.com/bitnami/charts/commit/4445bb1)), closes [#9589](https://github.com/bitnami/charts/issues/9589)
+
+## <small>16.6.1 (2022-03-27)</small>
+
+* [bitnami/redis] Release 16.6.1 updating components versions ([0d96252](https://github.com/bitnami/charts/commit/0d96252))
+
+## 16.6.0 (2022-03-23)
+
+* [bitnami/redis] Added extraEnvVars for metrics container (#9482) ([573f241](https://github.com/bitnami/charts/commit/573f241)), closes [#9482](https://github.com/bitnami/charts/issues/9482)
+
+## <small>16.5.5 (2022-03-22)</small>
+
+* [bitnami/redis] fix topology spread constraints templating (#9499) ([c9a77bd](https://github.com/bitnami/charts/commit/c9a77bd)), closes [#9499](https://github.com/bitnami/charts/issues/9499)
+* Bug fix (#9452) ([0fbde0f](https://github.com/bitnami/charts/commit/0fbde0f)), closes [#9452](https://github.com/bitnami/charts/issues/9452)
+
+## <small>16.5.4 (2022-03-17)</small>
+
+* [bitnami/redis] fix sentinel deployment (#9412) ([d5483cd](https://github.com/bitnami/charts/commit/d5483cd)), closes [#9412](https://github.com/bitnami/charts/issues/9412)
+* [bitnami/redis] Relocate comment in values (#9455) ([a0f0579](https://github.com/bitnami/charts/commit/a0f0579)), closes [#9455](https://github.com/bitnami/charts/issues/9455)
+
+## <small>16.5.3 (2022-03-16)</small>
+
+* [bitnami/redis] Add sizeLimit option for emptyDir volumes. (#9418) ([6a0f13d](https://github.com/bitnami/charts/commit/6a0f13d)), closes [#9418](https://github.com/bitnami/charts/issues/9418)
+* README tidy (#9407) ([6c2381e](https://github.com/bitnami/charts/commit/6c2381e)), closes [#9407](https://github.com/bitnami/charts/issues/9407)
+* Update README.md ([a69286e](https://github.com/bitnami/charts/commit/a69286e))
+
+## <small>16.5.2 (2022-03-09)</small>
+
+* [bitnami/redis] Fix 9279 (#9355) ([38643ef](https://github.com/bitnami/charts/commit/38643ef)), closes [#9355](https://github.com/bitnami/charts/issues/9355)
+
+## <small>16.5.1 (2022-03-09)</small>
+
+* [bitnami/redis] Fix readiness script typo (#9280) ([316512c](https://github.com/bitnami/charts/commit/316512c)), closes [#9280](https://github.com/bitnami/charts/issues/9280)
+
+## 16.5.0 (2022-03-04)
+
+* [bitnami/redis] feat: :sparkles: Add experimental persistence to sentinel configuration (#9282) ([fd4d96a](https://github.com/bitnami/charts/commit/fd4d96a)), closes [#9282](https://github.com/bitnami/charts/issues/9282)
+
+## <small>16.4.5 (2022-03-01)</small>
+
+* [bitnami/redis] Release 16.4.5 updating components versions ([176180a](https://github.com/bitnami/charts/commit/176180a))
+
+## <small>16.4.4 (2022-02-27)</small>
+
+* [bitnami/redis] Release 16.4.4 updating components versions ([0f3b31c](https://github.com/bitnami/charts/commit/0f3b31c))
+
+## <small>16.4.3 (2022-02-25)</small>
+
+* [bitnami/redis] Release 16.4.3 updating components versions ([c637f2d](https://github.com/bitnami/charts/commit/c637f2d))
+
+## <small>16.4.2 (2022-02-24)</small>
+
+* [bitnami/redis] Removing second timeout on Sentinel command (#9183) ([a847f9d](https://github.com/bitnami/charts/commit/a847f9d)), closes [#9183](https://github.com/bitnami/charts/issues/9183)
+
+## <small>16.4.1 (2022-02-23)</small>
+
+* [bitnami/redis] Removing timeout on Sentinel command (#9169) ([d6d66f1](https://github.com/bitnami/charts/commit/d6d66f1)), closes [#9169](https://github.com/bitnami/charts/issues/9169)
+* [bitnami/redis] Support specifying external master host to bootstrap from (#8816) ([32b2253](https://github.com/bitnami/charts/commit/32b2253)), closes [#8816](https://github.com/bitnami/charts/issues/8816)
+
+## 16.4.0 (2022-02-09)
+
+* [bitnami/redis] Allow to change Workload as StatefulSet or Deployment (#8846) ([74a9a67](https://github.com/bitnami/charts/commit/74a9a67)), closes [#8846](https://github.com/bitnami/charts/issues/8846)
+* Non utf8 chars (#8923) ([6ffd18f](https://github.com/bitnami/charts/commit/6ffd18f)), closes [#8923](https://github.com/bitnami/charts/issues/8923)
+
+## <small>16.3.1 (2022-02-04)</small>
+
+* [bitnami/redis] Release 16.3.1 updating components versions ([a2e8bea](https://github.com/bitnami/charts/commit/a2e8bea))
+
+## 16.3.0 (2022-02-01)
+
+* [bitnami/redis] Support custom init command for metrics container (#8831) ([bb6c295](https://github.com/bitnami/charts/commit/bb6c295)), closes [#8831](https://github.com/bitnami/charts/issues/8831)
+* Fix link (#8828) ([3f937fc](https://github.com/bitnami/charts/commit/3f937fc)), closes [#8828](https://github.com/bitnami/charts/issues/8828)
+
+## <small>16.2.1 (2022-01-28)</small>
+
+* [bitnami/redis] Eliminate role-specific config in sentinel deployment (#8781) ([4d4841f](https://github.com/bitnami/charts/commit/4d4841f)), closes [#8781](https://github.com/bitnami/charts/issues/8781)
+
+## 16.2.0 (2022-01-26)
+
+* [bitnami/redis][bitnami/redis-cluster] Make probes MASTERDOWN aware and include timeout message (#87 ([72691ea](https://github.com/bitnami/charts/commit/72691ea)), closes [#8767](https://github.com/bitnami/charts/issues/8767)
+
+## <small>16.1.1 (2022-01-25)</small>
+
+* [bitnami/redis] Fix Redis Sentinel TLS issues (#8765) ([2294b17](https://github.com/bitnami/charts/commit/2294b17)), closes [#8765](https://github.com/bitnami/charts/issues/8765)
+* [bitnami/redis] Fix redis standalone section README (#8710) ([3809d53](https://github.com/bitnami/charts/commit/3809d53)), closes [#8710](https://github.com/bitnami/charts/issues/8710)
+
+## 16.1.0 (2022-01-20)
+
+* [bitnami/redis] Enables Redis to utilize external-dns (#8570) ([69feea9](https://github.com/bitnami/charts/commit/69feea9)), closes [#8570](https://github.com/bitnami/charts/issues/8570)
+
+## <small>16.0.1 (2022-01-20)</small>
+
+* [bitnami/*] Update READMEs (#8716) ([b9a9533](https://github.com/bitnami/charts/commit/b9a9533)), closes [#8716](https://github.com/bitnami/charts/issues/8716)
+* [bitnami/several] Change prerequisites (#8725) ([8d740c5](https://github.com/bitnami/charts/commit/8d740c5)), closes [#8725](https://github.com/bitnami/charts/issues/8725)
+
+## 16.0.0 (2022-01-18)
+
+* [bitnami/redis] Chart standardized (#7505) ([d42a1d5](https://github.com/bitnami/charts/commit/d42a1d5)), closes [#7505](https://github.com/bitnami/charts/issues/7505)
+
+## <small>15.7.6 (2022-01-18)</small>
+
+* [bitnami/*] Readme automation (#8579) ([78d1938](https://github.com/bitnami/charts/commit/78d1938)), closes [#8579](https://github.com/bitnami/charts/issues/8579)
+* [bitnami/redis] Revert PR 8641 (#8709) ([b2a00a6](https://github.com/bitnami/charts/commit/b2a00a6)), closes [#8709](https://github.com/bitnami/charts/issues/8709)
+
+## <small>15.7.5 (2022-01-13)</small>
+
+* [bitnami/redis] Add retry_while function to get_sentinel_master_info in start-node.sh (#8641) ([69e3518](https://github.com/bitnami/charts/commit/69e3518)), closes [#8641](https://github.com/bitnami/charts/issues/8641)
+
+## <small>15.7.4 (2022-01-11)</small>
+
+* [bitnami/redis] Release 15.7.4 updating components versions ([bd27919](https://github.com/bitnami/charts/commit/bd27919))
+
+## <small>15.7.3 (2022-01-11)</small>
+
+* [bitnami/redis] add timeout to redis container for sentinel (#8616) ([b778d18](https://github.com/bitnami/charts/commit/b778d18)), closes [#8616](https://github.com/bitnami/charts/issues/8616)
+
+## <small>15.7.2 (2022-01-10)</small>
+
+* [bitnami/redis] Fix MASTER invalid argument (using with sentinel) (#8563) ([cfeb69f](https://github.com/bitnami/charts/commit/cfeb69f)), closes [#8563](https://github.com/bitnami/charts/issues/8563)
+
+## <small>15.7.1 (2022-01-05)</small>
+
+* [bitnami/redis] Release 15.7.1 updating components versions ([0d4a8be](https://github.com/bitnami/charts/commit/0d4a8be))
+
+## 15.7.0 (2022-01-05)
+
+* [bitnami/several] Adapt templating format (#8562) ([8cad18a](https://github.com/bitnami/charts/commit/8cad18a)), closes [#8562](https://github.com/bitnami/charts/issues/8562)
+* [bitnami/several] Add license to the README ([05f7633](https://github.com/bitnami/charts/commit/05f7633))
+* [bitnami/several] Add license to the README ([32fb238](https://github.com/bitnami/charts/commit/32fb238))
+* [bitnami/several] Add license to the README ([b87c2f7](https://github.com/bitnami/charts/commit/b87c2f7))
+
+## <small>15.6.10 (2021-12-29)</small>
+
+* [bitnami/redis] remove password empty validation (#8518) ([d81a614](https://github.com/bitnami/charts/commit/d81a614)), closes [#8518](https://github.com/bitnami/charts/issues/8518)
+
+## <small>15.6.9 (2021-12-27)</small>
+
+* [bitnami/redis] Release 15.6.9 updating components versions ([c6797d4](https://github.com/bitnami/charts/commit/c6797d4))
+* * [bitnami/redis] Fix env variable name (#8477) ([3532d83](https://github.com/bitnami/charts/commit/3532d83)), closes [#8477](https://github.com/bitnami/charts/issues/8477)
+* lookup existing secret before generate (#8486) ([7040eb8](https://github.com/bitnami/charts/commit/7040eb8)), closes [#8486](https://github.com/bitnami/charts/issues/8486)
+
+## <small>15.6.8 (2021-12-23)</small>
+
+* [bitnami/redis] redis sentinel startup (#8476) ([e4b2ab4](https://github.com/bitnami/charts/commit/e4b2ab4)), closes [#8476](https://github.com/bitnami/charts/issues/8476)
+
+## <small>15.6.7 (2021-12-15)</small>
+
+* [bitnami/redis] Fix spreadConstraints description (#8426) ([400b323](https://github.com/bitnami/charts/commit/400b323)), closes [#8426](https://github.com/bitnami/charts/issues/8426)
+
+## <small>15.6.6 (2021-12-15)</small>
+
+* [bitnami/redis] fixed the bug related to issue #7283 (#8337) ([54678db](https://github.com/bitnami/charts/commit/54678db)), closes [#7283](https://github.com/bitnami/charts/issues/7283) [#8337](https://github.com/bitnami/charts/issues/8337)
+
+## <small>15.6.5 (2021-12-15)</small>
+
+* [bitnami/redis] corrected array defaults in readme (#8340) ([4165502](https://github.com/bitnami/charts/commit/4165502)), closes [#8340](https://github.com/bitnami/charts/issues/8340)
+
+## <small>15.6.4 (2021-12-09)</small>
+
+* [bitnami/cassandra,etcd,influxdb,metallb,mysql,postgresql,postgresql-ha,redis] Align networkpolicy   ([0404b1a](https://github.com/bitnami/charts/commit/0404b1a)), closes [#8336](https://github.com/bitnami/charts/issues/8336)
+* [bitnami/several] Regenerate README tables ([a43cca7](https://github.com/bitnami/charts/commit/a43cca7))
+
+## <small>15.6.3 (2021-12-01)</small>
+
+* [bitnami/redis] Release 15.6.3 updating components versions ([82880f0](https://github.com/bitnami/charts/commit/82880f0))
+
+## <small>15.6.2 (2021-11-29)</small>
+
+* [bitnami/several] Regenerate README tables ([ac75243](https://github.com/bitnami/charts/commit/ac75243))
+* [bitnami/several] Replace HTTP by HTTPS when possible (#8259) ([eafb5bd](https://github.com/bitnami/charts/commit/eafb5bd)), closes [#8259](https://github.com/bitnami/charts/issues/8259)
+
+## <small>15.6.1 (2021-11-25)</small>
+
+* [bitnami/redis] Release 15.6.1 updating components versions ([844a4dc](https://github.com/bitnami/charts/commit/844a4dc))
+* [bitnami/several] Fix deadlinks in README.md (#8215) ([99e90d2](https://github.com/bitnami/charts/commit/99e90d2)), closes [#8215](https://github.com/bitnami/charts/issues/8215)
+
+## 15.6.0 (2021-11-22)
+
+* [bitnami/redis] Support custom dataSource to allow creating volumes from VolumeSnapshots (#8185) ([b6c94ab](https://github.com/bitnami/charts/commit/b6c94ab)), closes [#8185](https://github.com/bitnami/charts/issues/8185)
+
+## <small>15.5.5 (2021-11-12)</small>
+
+* bitnami/redis: Specify password via REDISCLI_AUTH to avoid leaking password via logs (#8077) ([6d6b4d7](https://github.com/bitnami/charts/commit/6d6b4d7)), closes [#8077](https://github.com/bitnami/charts/issues/8077)
+
+## <small>15.5.4 (2021-11-02)</small>
+
+* [bitnami/redis] Ignore auth for sentinel liveness if auth is disabled (#7996) ([5ad6586](https://github.com/bitnami/charts/commit/5ad6586)), closes [#7996](https://github.com/bitnami/charts/issues/7996)
+
+## <small>15.5.3 (2021-10-28)</small>
+
+* [bitnami/*] Mark PodSecurityPolicy resources as deprecated (#7951) ([035d926](https://github.com/bitnami/charts/commit/035d926)), closes [#7951](https://github.com/bitnami/charts/issues/7951)
+* [bitnami/several] Regenerate README tables ([412cf6a](https://github.com/bitnami/charts/commit/412cf6a))
+
+## <small>15.5.2 (2021-10-26)</small>
+
+* [bitnami/redis] Release 15.5.2 updating components versions ([bd0a85c](https://github.com/bitnami/charts/commit/bd0a85c))
+
+## <small>15.5.1 (2021-10-22)</small>
+
+* [bitnami/several] Add chart info to NOTES.txt (#7889) ([a6751cd](https://github.com/bitnami/charts/commit/a6751cd)), closes [#7889](https://github.com/bitnami/charts/issues/7889)
+
+## 15.5.0 (2021-10-21)
+
+* [bitnami/redis] Fix sentinel pre stop (#7835) ([225f24f](https://github.com/bitnami/charts/commit/225f24f)), closes [#7835](https://github.com/bitnami/charts/issues/7835)
+* [bitnami/redis] Use memory for emptyDirs (#7826) ([08910e2](https://github.com/bitnami/charts/commit/08910e2)), closes [#7826](https://github.com/bitnami/charts/issues/7826)
+
+## <small>15.4.2 (2021-10-19)</small>
+
+* [bitnami/several] Change pullPolicy for bitnami-shell image (#7852) ([9711a33](https://github.com/bitnami/charts/commit/9711a33)), closes [#7852](https://github.com/bitnami/charts/issues/7852)
+* [bitnami/several] Regenerate README tables ([cdcf8c1](https://github.com/bitnami/charts/commit/cdcf8c1))
+
+## <small>15.4.1 (2021-10-04)</small>
+
+* [bitnami/redis] Release 15.4.1 updating components versions ([f8ec0a8](https://github.com/bitnami/charts/commit/f8ec0a8))
+* [bitnami/several] Regenerate README tables ([9d60bbd](https://github.com/bitnami/charts/commit/9d60bbd))
+
+## 15.4.0 (2021-09-27)
+
+* [bitnami/redis] Allow the use of NodePort to allow for external access (#7461) ([722dead](https://github.com/bitnami/charts/commit/722dead)), closes [#7461](https://github.com/bitnami/charts/issues/7461)
+
+## <small>15.3.3 (2021-09-26)</small>
+
+* [bitnami/ several charts] Redis dependency upgrade (#7481) ([bbed564](https://github.com/bitnami/charts/commit/bbed564)), closes [#7481](https://github.com/bitnami/charts/issues/7481)
+* [bitnami/*] Generate READMEs with new generator version (#7614) ([e5ab2e6](https://github.com/bitnami/charts/commit/e5ab2e6)), closes [#7614](https://github.com/bitnami/charts/issues/7614)
+* [bitnami/redis] Release 15.3.3 updating components versions ([ff9f760](https://github.com/bitnami/charts/commit/ff9f760))
+* prefix portName correctly (#7422) ([a235f1e](https://github.com/bitnami/charts/commit/a235f1e)), closes [#7422](https://github.com/bitnami/charts/issues/7422)
+
+## <small>15.3.2 (2021-09-08)</small>
+
+* [bitnami/redis] Do not set StatefulSet.replicas if autoscaling is enabled (#7417) ([6bf9730](https://github.com/bitnami/charts/commit/6bf9730)), closes [#7417](https://github.com/bitnami/charts/issues/7417)
+
+## <small>15.3.1 (2021-09-03)</small>
+
+* [bitnami/redis] Update apiVersion of PDB to policy/v1 on 1.21+ cluster (via common.capabilities.poli ([fc6852f](https://github.com/bitnami/charts/commit/fc6852f)), closes [#7370](https://github.com/bitnami/charts/issues/7370)
+
+## 15.3.0 (2021-09-01)
+
+* [bitnami/redis] Add the ability to add environment variables to Sentinel containers (#7366) ([7676482](https://github.com/bitnami/charts/commit/7676482)), closes [#7366](https://github.com/bitnami/charts/issues/7366)
+
+## <small>15.2.1 (2021-09-01)</small>
+
+* [bitnami/redis] fix hpa condition (#7365) ([f01935d](https://github.com/bitnami/charts/commit/f01935d)), closes [#7365](https://github.com/bitnami/charts/issues/7365)
+* [bitnami/several] Regenerate README tables ([64d5d74](https://github.com/bitnami/charts/commit/64d5d74))
+
+## 15.2.0 (2021-08-31)
+
+* [bitnami/redis]: Set the scaleTargetRef.name based on which SS is used (#7341) ([a34880b](https://github.com/bitnami/charts/commit/a34880b)), closes [#7341](https://github.com/bitnami/charts/issues/7341)
+
+## 15.1.0 (2021-08-30)
+
+* [bitnami/redis] Add relabelings to ServiceMonitor (#7337) ([bc57136](https://github.com/bitnami/charts/commit/bc57136)), closes [#7337](https://github.com/bitnami/charts/issues/7337)
+
+## <small>15.0.4 (2021-08-30)</small>
+
+* [bitnami/redis]: hotfix, regenerate sentinel config at each boot-up (#7333) ([18ecfc2](https://github.com/bitnami/charts/commit/18ecfc2)), closes [#7333](https://github.com/bitnami/charts/issues/7333)
+
+## <small>15.0.3 (2021-08-27)</small>
+
+* [bitnami/redis] Release 15.0.3 updating components versions ([6ab1d26](https://github.com/bitnami/charts/commit/6ab1d26))
+
+## <small>15.0.2 (2021-08-27)</small>
+
+* [bitnami/several] Regenerate README tables ([da2513b](https://github.com/bitnami/charts/commit/da2513b))
+* Add condition for empty REDIS_PASSWORD in healthchecks (#7315) ([a94d6ce](https://github.com/bitnami/charts/commit/a94d6ce)), closes [#7315](https://github.com/bitnami/charts/issues/7315)
+
+## <small>15.0.1 (2021-08-25)</small>
+
+* [bitnami/redis] Release 15.0.1 updating components versions ([2f07d84](https://github.com/bitnami/charts/commit/2f07d84))
+
+## 15.0.0 (2021-08-25)
+
+* redis: Enhance sentinel resiliency, harmozine sentinel behaviour by using staticID as default behavi ([9559497](https://github.com/bitnami/charts/commit/9559497)), closes [#7278](https://github.com/bitnami/charts/issues/7278)
+
+## <small>14.8.11 (2021-08-18)</small>
+
+* [multiple] Updated image.tag section (#7257) ([a133bed](https://github.com/bitnami/charts/commit/a133bed)), closes [#7257](https://github.com/bitnami/charts/issues/7257)
+
+## <small>14.8.10 (2021-08-17)</small>
+
+* [bitnami/redis] Fix clustering when service port != container port (#7246) ([7d2926a](https://github.com/bitnami/charts/commit/7d2926a)), closes [#7246](https://github.com/bitnami/charts/issues/7246)
+
+## <small>14.8.9 (2021-08-17)</small>
+
+* [bitnami/redis] fix redis available issue after master node restarted (#7182) ([d50b1f7](https://github.com/bitnami/charts/commit/d50b1f7)), closes [#7182](https://github.com/bitnami/charts/issues/7182)
+* [bitnami/several] Regenerate README tables ([6c107e8](https://github.com/bitnami/charts/commit/6c107e8))
+
+## <small>14.8.8 (2021-08-04)</small>
+
+* [bitnami/redis] Release 14.8.8 updating components versions ([a531a7e](https://github.com/bitnami/charts/commit/a531a7e))
+* [bitnami/several] Fix default values when using `foo: |` (#7092) ([fe91297](https://github.com/bitnami/charts/commit/fe91297)), closes [#7092](https://github.com/bitnami/charts/issues/7092)
+* [bitnami/several] Unify upgrading section ([baf2283](https://github.com/bitnami/charts/commit/baf2283))
+
+## <small>14.8.7 (2021-07-30)</small>
+
+* [bitnami/redis] Helm upgrade should work with global password (#7062) ([169aefa](https://github.com/bitnami/charts/commit/169aefa)), closes [#7062](https://github.com/bitnami/charts/issues/7062) [#7018](https://github.com/bitnami/charts/issues/7018)
+
+## <small>14.8.6 (2021-07-27)</small>
+
+* [bitnami/several] Bump version and update READMEs (#7069) ([6340bff](https://github.com/bitnami/charts/commit/6340bff)), closes [#7069](https://github.com/bitnami/charts/issues/7069)
+* Replace <sup> strings with &trade; in the README files (#7066) ([d298b49](https://github.com/bitnami/charts/commit/d298b49)), closes [#7066](https://github.com/bitnami/charts/issues/7066)
+
+## <small>14.8.5 (2021-07-27)</small>
+
+* [bitnami/redis]: Add an extra VolumeMount to the metrics sidecar (#6806) ([20e4cad](https://github.com/bitnami/charts/commit/20e4cad)), closes [#6806](https://github.com/bitnami/charts/issues/6806)
+
+## <small>14.8.4 (2021-07-26)</small>
+
+* [bitnami/redis] fix typo in values.yaml (#7052) ([7d0372f](https://github.com/bitnami/charts/commit/7d0372f)), closes [#7052](https://github.com/bitnami/charts/issues/7052)
+
+## <small>14.8.3 (2021-07-22)</small>
+
+* [bitnami/redis] Release 14.8.3 updating components versions ([eb51dc4](https://github.com/bitnami/charts/commit/eb51dc4))
+
+## <small>14.8.2 (2021-07-21)</small>
+
+* [bitnami/*] Replace nil values (#6993) ([2be11a7](https://github.com/bitnami/charts/commit/2be11a7)), closes [#6993](https://github.com/bitnami/charts/issues/6993)
+* edited README to clarify option of enabling Redis Sentinel with Redis Helm Chart (#7005) ([25d0851](https://github.com/bitnami/charts/commit/25d0851)), closes [#7005](https://github.com/bitnami/charts/issues/7005)
+
+## <small>14.8.1 (2021-07-21)</small>
+
+* [bitnami/redis] Release 14.8.1 updating components versions ([0f28955](https://github.com/bitnami/charts/commit/0f28955))
+
+## 14.8.0 (2021-07-19)
+
+* [bitnami/redis] Remove sentinel exporter (#6787) ([06d8d05](https://github.com/bitnami/charts/commit/06d8d05)), closes [#6787](https://github.com/bitnami/charts/issues/6787)
+
+## <small>14.7.2 (2021-07-16)</small>
+
+* [bitnami/*] Adapt values.yaml of Redis cluster, Redmine and Solr charts (#6947) ([dde06ff](https://github.com/bitnami/charts/commit/dde06ff)), closes [#6947](https://github.com/bitnami/charts/issues/6947)
+
+## <small>14.7.1 (2021-07-14)</small>
+
+* [bitnami/redis] Fix: Redis initialDelaySeconds too short (#6944) ([27b6e44](https://github.com/bitnami/charts/commit/27b6e44)), closes [#6944](https://github.com/bitnami/charts/issues/6944)
+
+## 14.7.0 (2021-07-13)
+
+* [bitnami/mongodb,mariadb-galera,redis] Add diagnostic mode (#6936) ([a907452](https://github.com/bitnami/charts/commit/a907452)), closes [#6936](https://github.com/bitnami/charts/issues/6936)
+
+## <small>14.6.6 (2021-07-07)</small>
+
+* [bitnami/redis] Fix issue with IP detection when mawk is used (#6870) ([309c7c6](https://github.com/bitnami/charts/commit/309c7c6)), closes [#6870](https://github.com/bitnami/charts/issues/6870)
+
+## <small>14.6.5 (2021-07-06)</small>
+
+* Redis: Specify master replicas to be 1 (#6860) ([b6023fe](https://github.com/bitnami/charts/commit/b6023fe)), closes [#6860](https://github.com/bitnami/charts/issues/6860)
+
+## <small>14.6.4 (2021-07-05)</small>
+
+* values.schema: add enum to json file (#6835) ([84e5c5a](https://github.com/bitnami/charts/commit/84e5c5a)), closes [#6835](https://github.com/bitnami/charts/issues/6835)
+
+## <small>14.6.3 (2021-06-30)</small>
+
+* [bitnami/*] Add localhost altName to autogenerated certs (#6791) ([5c8972e](https://github.com/bitnami/charts/commit/5c8972e)), closes [#6791](https://github.com/bitnami/charts/issues/6791)
+
+## <small>14.6.2 (2021-06-21)</small>
+
+* [bitnami/redis] Release 14.6.2 updating components versions ([21cba6c](https://github.com/bitnami/charts/commit/21cba6c))
+
+## <small>14.6.1 (2021-06-19)</small>
+
+* [bitnami/redis] Release 14.6.1 updating components versions ([691b0b7](https://github.com/bitnami/charts/commit/691b0b7))
+
+## 14.6.0 (2021-06-18)
+
+* [bitnami/redis] Add support for autogenerated certs (#6529) ([100835f](https://github.com/bitnami/charts/commit/100835f)), closes [#6529](https://github.com/bitnami/charts/issues/6529)
+
+## 14.5.0 (2021-06-17)
+
+* [bitnami/redis] Service account automountServiceAccountToken (#6682) ([0960099](https://github.com/bitnami/charts/commit/0960099)), closes [#6682](https://github.com/bitnami/charts/issues/6682)
+
+## 14.4.0 (2021-06-07)
+
+* [bitnami/redis] Added HPA for redis (#6556) ([ee4c2fe](https://github.com/bitnami/charts/commit/ee4c2fe)), closes [#6556](https://github.com/bitnami/charts/issues/6556)
+
+## <small>14.3.4 (2021-06-07)</small>
+
+* [bitnami/redis] use `.Values.tls.certificatesSecret` as a template (#6584) ([c5b90b1](https://github.com/bitnami/charts/commit/c5b90b1)), closes [#6584](https://github.com/bitnami/charts/issues/6584)
+
+## <small>14.3.3 (2021-06-02)</small>
+
+* [bitnami/redis] Release 14.3.3 updating components versions ([a2f34a1](https://github.com/bitnami/charts/commit/a2f34a1))
+
+## <small>14.3.2 (2021-05-27)</small>
+
+* [bitnami/redis] Release 14.3.2 updating components versions ([9f01357](https://github.com/bitnami/charts/commit/9f01357))
+* Update templates for readme generator (#6472) ([5643220](https://github.com/bitnami/charts/commit/5643220)), closes [#6472](https://github.com/bitnami/charts/issues/6472)
+
+## <small>14.3.1 (2021-05-26)</small>
+
+* fix(bitnami/redis): Fix hardcoded target port name in headless service (#6462) ([afab282](https://github.com/bitnami/charts/commit/afab282)), closes [#6462](https://github.com/bitnami/charts/issues/6462)
+
+## 14.3.0 (2021-05-24)
+
+* [bitnami/redis] add enable flag for PSP (#5760) ([f7b7c15](https://github.com/bitnami/charts/commit/f7b7c15)), closes [#5760](https://github.com/bitnami/charts/issues/5760)
+
+## <small>14.2.1 (2021-05-23)</small>
+
+* [bitnami/redis] Release 14.2.1 updating components versions ([201af34](https://github.com/bitnami/charts/commit/201af34))
+
+## 14.2.0 (2021-05-20)
+
+* [bitnami/redis] IPv4/IPv6 dualstack compatibility fixes (#6350) ([c80bd0f](https://github.com/bitnami/charts/commit/c80bd0f)), closes [#6350](https://github.com/bitnami/charts/issues/6350)
+* Update README to refer chart documentation (#6238) ([2bcc211](https://github.com/bitnami/charts/commit/2bcc211)), closes [#6238](https://github.com/bitnami/charts/issues/6238)
+
+## <small>14.1.1 (2021-05-04)</small>
+
+* [bitnami/redis] Release 14.1.1 updating components versions ([d14bba3](https://github.com/bitnami/charts/commit/d14bba3))
+* Update README.md ([6a787e2](https://github.com/bitnami/charts/commit/6a787e2))
+
+## 14.1.0 (2021-04-23)
+
+* [bitnami/redis] Improve sentinel prestop hook to prevent service interruption (#6080) ([943c301](https://github.com/bitnami/charts/commit/943c301)), closes [#6080](https://github.com/bitnami/charts/issues/6080) [#5528](https://github.com/bitnami/charts/issues/5528)
+
+## <small>14.0.2 (2021-04-21)</small>
+
+* [bitnami/redis] Add missiing subPath to redis slave (#6137) ([af68055](https://github.com/bitnami/charts/commit/af68055)), closes [#6137](https://github.com/bitnami/charts/issues/6137)
+
+## <small>14.0.1 (2021-04-20)</small>
+
+* [bitnami/redis] Release 14.0.1 updating components versions ([6049e49](https://github.com/bitnami/charts/commit/6049e49))
+
+## 14.0.0 (2021-04-19)
+
+* [bitnami/redis] New major version (#6102) ([49d2fce](https://github.com/bitnami/charts/commit/49d2fce)), closes [#6102](https://github.com/bitnami/charts/issues/6102)
+
+## <small>13.0.2 (2021-04-19)</small>
+
+* [bitnami/redis] fix hardcoded value for sentinel masterset (#6146) ([4600dcb](https://github.com/bitnami/charts/commit/4600dcb)), closes [#6146](https://github.com/bitnami/charts/issues/6146)
+
+## <small>13.0.1 (2021-04-09)</small>
+
+* [bitnami/redis] Fix for NetworkPolicy blocking sentinel metrics exporter (#6050) ([7c48ded](https://github.com/bitnami/charts/commit/7c48ded)), closes [#6050](https://github.com/bitnami/charts/issues/6050)
+
+## 13.0.0 (2021-04-09)
+
+* [bitnami/redis] Updating redis version from 6.0 to 6.2, bumping major version of the chart (#5990) ([ab70480](https://github.com/bitnami/charts/commit/ab70480)), closes [#5990](https://github.com/bitnami/charts/issues/5990)
+
+## <small>12.10.1 (2021-04-05)</small>
+
+* [bitnami/redis] Add Redis Sentinel Exporter (#4916) ([b27be24](https://github.com/bitnami/charts/commit/b27be24)), closes [#4916](https://github.com/bitnami/charts/issues/4916)
+* [bitnami/redis] Release 12.10.1 updating components versions ([89ba29c](https://github.com/bitnami/charts/commit/89ba29c))
+
+## 12.10.0 (2021-03-31)
+
+* [bitnami/redis] exporter presents client certs to server only in mtls context (#5964) ([4c4620b](https://github.com/bitnami/charts/commit/4c4620b)), closes [#5964](https://github.com/bitnami/charts/issues/5964)
+
+## <small>12.9.2 (2021-03-31)</small>
+
+* [bitnami/redis] Fix priorityClassName (#5956) ([6802bd8](https://github.com/bitnami/charts/commit/6802bd8)), closes [#5956](https://github.com/bitnami/charts/issues/5956)
+
+## <small>12.9.1 (2021-03-30)</small>
+
+* [bitnami/redis] Fixing indentation on redis slave volume mount (#5949) ([bb1b36a](https://github.com/bitnami/charts/commit/bb1b36a)), closes [#5949](https://github.com/bitnami/charts/issues/5949)
+
+## 12.9.0 (2021-03-25)
+
+* [bitnami/redis] Add extraVolumes & extraVolumeMounts suport (#5897) ([3e46013](https://github.com/bitnami/charts/commit/3e46013)), closes [#5897](https://github.com/bitnami/charts/issues/5897)
+* fix: typo (#5790) ([96784f3](https://github.com/bitnami/charts/commit/96784f3)), closes [#5790](https://github.com/bitnami/charts/issues/5790)
+
+## <small>12.8.3 (2021-03-05)</small>
+
+* [bitnami/redis] Service port rename for istio protocol selection (#5679) ([a0eaa5f](https://github.com/bitnami/charts/commit/a0eaa5f)), closes [#5679](https://github.com/bitnami/charts/issues/5679)
+* [bitnami/redis*] Remove procps installation from README example ([402a6cd](https://github.com/bitnami/charts/commit/402a6cd))
+
+## <small>12.8.2 (2021-03-04)</small>
+
+* [bitnami/*] Remove minideb mentions (#5677) ([870bc4d](https://github.com/bitnami/charts/commit/870bc4d)), closes [#5677](https://github.com/bitnami/charts/issues/5677)
+
+## <small>12.8.1 (2021-03-02)</small>
+
+* [bitnami/redis] Release 12.8.1 updating components versions ([dd8945d](https://github.com/bitnami/charts/commit/dd8945d))
+
+## 12.8.0 (2021-02-26)
+
+* [bitnami/redis] PreStop Hook to Initiate Failover for Sentinel on PodTermination (#5528) ([17271c2](https://github.com/bitnami/charts/commit/17271c2)), closes [#5528](https://github.com/bitnami/charts/issues/5528)
+
+## <small>12.7.7 (2021-02-24)</small>
+
+* [bitnami/redis] Fix issues in initialization/restarts (#5603) ([2dc23f8](https://github.com/bitnami/charts/commit/2dc23f8)), closes [#5603](https://github.com/bitnami/charts/issues/5603)
+* [bitnami/redis] mount /tmp as emptyDir (#5601) ([4bc8949](https://github.com/bitnami/charts/commit/4bc8949)), closes [#5601](https://github.com/bitnami/charts/issues/5601)
+
+## <small>12.7.6 (2021-02-24)</small>
+
+* [bitnami/redis] Release 12.7.6 updating components versions ([bee5261](https://github.com/bitnami/charts/commit/bee5261))
+
+## <small>12.7.5 (2021-02-22)</small>
+
+* [bitnami/*] Add notice regarding parameters immutability after chart installation (#4853) ([5f09573](https://github.com/bitnami/charts/commit/5f09573)), closes [#4853](https://github.com/bitnami/charts/issues/4853)
+* [bitnami/*] Use common macro to define RBAC apiVersion (#5585) ([71fb99f](https://github.com/bitnami/charts/commit/71fb99f)), closes [#5585](https://github.com/bitnami/charts/issues/5585)
+
+## <small>12.7.4 (2021-02-05)</small>
+
+* [bitnami/redis] Release 12.7.4 updating components versions ([41be44c](https://github.com/bitnami/charts/commit/41be44c))
+
+## <small>12.7.3 (2021-02-03)</small>
+
+* fix: update priorityClassName to avoid warnings (#5357) ([3a232d7](https://github.com/bitnami/charts/commit/3a232d7)), closes [#5357](https://github.com/bitnami/charts/issues/5357)
+
+## <small>12.7.2 (2021-02-02)</small>
+
+* [bitnami/redis] fix: volumeClaimTemplates labels error (#5298) ([1d2da65](https://github.com/bitnami/charts/commit/1d2da65)), closes [#5298](https://github.com/bitnami/charts/issues/5298)
+
+## <small>12.7.1 (2021-02-02)</small>
+
+* [bitnami/several] Monthly trademark review (#5375) ([307a73d](https://github.com/bitnami/charts/commit/307a73d)), closes [#5375](https://github.com/bitnami/charts/issues/5375)
+
+## 12.7.0 (2021-01-28)
+
+* [bitnami/redis] Add hostAliases (#5305) ([b6753bb](https://github.com/bitnami/charts/commit/b6753bb)), closes [#5305](https://github.com/bitnami/charts/issues/5305)
+* fix a typo in the readme.md file for usage of redis metrics extraarge when enable tls (#5232) ([1fa614a](https://github.com/bitnami/charts/commit/1fa614a)), closes [#5232](https://github.com/bitnami/charts/issues/5232)
+
+## <small>12.6.4 (2021-01-25)</small>
+
+* [bitnami/redis] update redis README.md for the usage of metrics.extraArgs when redis tls is enabled  ([5e25590](https://github.com/bitnami/charts/commit/5e25590)), closes [#5207](https://github.com/bitnami/charts/issues/5207)
+
+## <small>12.6.3 (2021-01-21)</small>
+
+* [bitnami/redis] Redis slave volume init fix (#5059) ([90509a9](https://github.com/bitnami/charts/commit/90509a9)), closes [#5059](https://github.com/bitnami/charts/issues/5059)
+
+## <small>12.6.2 (2021-01-19)</small>
+
+* [bitnami/*] Change helm version in the prerequisites (#5090) ([c5e67a3](https://github.com/bitnami/charts/commit/c5e67a3)), closes [#5090](https://github.com/bitnami/charts/issues/5090)
+* [bitnami/redis] Drop values-production.yaml support (#5129) ([d9cf2ac](https://github.com/bitnami/charts/commit/d9cf2ac)), closes [#5129](https://github.com/bitnami/charts/issues/5129)
+
+## <small>12.6.1 (2021-01-19)</small>
+
+* [bitnami/redis-sentinel] Add preExec to start-node.sh (#5035) ([6361aa7](https://github.com/bitnami/charts/commit/6361aa7)), closes [#5035](https://github.com/bitnami/charts/issues/5035)
+
+## 12.6.0 (2021-01-15)
+
+* [bitnami/redis] Add label and annotations for Redis Statefulset volumeClaimTemplates (#5039) ([d5a4224](https://github.com/bitnami/charts/commit/d5a4224)), closes [#5039](https://github.com/bitnami/charts/issues/5039)
+
+## <small>12.5.1 (2021-01-15)</small>
+
+* [bitnami/redis] Release 12.5.1 updating components versions ([75f4aee](https://github.com/bitnami/charts/commit/75f4aee))
+* [bitnami/several] Add Redis trademark (#5023) ([dfa89b8](https://github.com/bitnami/charts/commit/dfa89b8)), closes [#5023](https://github.com/bitnami/charts/issues/5023)
+* Update README.md ([1724740](https://github.com/bitnami/charts/commit/1724740))
+
+## 12.5.0 (2021-01-14)
+
+* Add extraEnvVars and preExec to sentinel node (#4985) ([849f801](https://github.com/bitnami/charts/commit/849f801)), closes [#4985](https://github.com/bitnami/charts/issues/4985)
+
+## 12.4.0 (2021-01-12)
+
+* [Redis] Make metrics relabeling configurable (#4942) ([f2129ba](https://github.com/bitnami/charts/commit/f2129ba)), closes [#4942](https://github.com/bitnami/charts/issues/4942)
+
+## <small>12.3.3 (2021-01-08)</small>
+
+* [bitnami/redis] Fix Redis Sentinel Setup (#4911) ([b7836ee](https://github.com/bitnami/charts/commit/b7836ee)), closes [#4911](https://github.com/bitnami/charts/issues/4911)
+
+## <small>12.3.2 (2021-01-05)</small>
+
+* [bitnami/redis] Fix Redis sentinel synchronization and user creation permission error (#4820) ([a6c17cf](https://github.com/bitnami/charts/commit/a6c17cf)), closes [#4820](https://github.com/bitnami/charts/issues/4820)
+
+## <small>12.3.1 (2021-01-04)</small>
+
+* [bitnami/redis] Attach existing volume as persistence storage (#4863) ([3b26941](https://github.com/bitnami/charts/commit/3b26941)), closes [#4863](https://github.com/bitnami/charts/issues/4863)
+
+## 12.3.0 (2020-12-31)
+
+* [bitnami/redis] add external traffic policy support (#4856) ([fe65ab7](https://github.com/bitnami/charts/commit/fe65ab7)), closes [#4856](https://github.com/bitnami/charts/issues/4856)
+
+## <small>12.2.4 (2020-12-22)</small>
+
+* [bitnami/redis] Fix redis label (#4763) ([2870136](https://github.com/bitnami/charts/commit/2870136)), closes [#4763](https://github.com/bitnami/charts/issues/4763)
+
+## <small>12.2.3 (2020-12-16)</small>
+
+* [bitnami/redis] Fix Sentinel Redis with TLS (#4726) ([2cd3ec6](https://github.com/bitnami/charts/commit/2cd3ec6)), closes [#4726](https://github.com/bitnami/charts/issues/4726)
+
+## <small>12.2.2 (2020-12-14)</small>
+
+* [bitnami/*] fix typos (#4699) ([49adc63](https://github.com/bitnami/charts/commit/49adc63)), closes [#4699](https://github.com/bitnami/charts/issues/4699)
+* [bitnami/redis] existingClaim using tpl function (#4717) ([be187be](https://github.com/bitnami/charts/commit/be187be)), closes [#4717](https://github.com/bitnami/charts/issues/4717)
+
+## <small>12.2.1 (2020-12-10)</small>
+
+* [bitnami/*] Update CI *-values.yaml files (#4674) ([b473fa9](https://github.com/bitnami/charts/commit/b473fa9)), closes [#4674](https://github.com/bitnami/charts/issues/4674)
+
+## 12.2.0 (2020-12-10)
+
+* [bitname/redis] Add custom annotations to master and slave statefulsets (#4667) ([113dcd7](https://github.com/bitnami/charts/commit/113dcd7)), closes [#4667](https://github.com/bitnami/charts/issues/4667)
+
+## <small>12.1.3 (2020-12-08)</small>
+
+* [bitnami/redis] Release 12.1.3 updating components versions ([544b7bc](https://github.com/bitnami/charts/commit/544b7bc))
+* Container security configuration applied to metrics container (#4628) ([922a2c0](https://github.com/bitnami/charts/commit/922a2c0)), closes [#4628](https://github.com/bitnami/charts/issues/4628)
+
+## <small>12.1.2 (2020-12-07)</small>
+
+* [bitnami/redis] wait for new master when using sentinel and the master pod has been restarted/destro ([239e2d8](https://github.com/bitnami/charts/commit/239e2d8)), closes [#4478](https://github.com/bitnami/charts/issues/4478)
+
+## <small>12.1.1 (2020-11-19)</small>
+
+* [bitnami/redis] Use env var for password to avoid warnings (#4392) ([c1bfc0e](https://github.com/bitnami/charts/commit/c1bfc0e)), closes [#4392](https://github.com/bitnami/charts/issues/4392)
+
+## 12.1.0 (2020-11-17)
+
+* [bitnami/redis] Add annotations on service account. (#4358) ([ab11db5](https://github.com/bitnami/charts/commit/ab11db5)), closes [#4358](https://github.com/bitnami/charts/issues/4358)
+
+## <small>12.0.1 (2020-11-16)</small>
+
+* [bitnami/redis] Non-special node 0 in stateful sets (#4201) ([ede737f](https://github.com/bitnami/charts/commit/ede737f)), closes [#4201](https://github.com/bitnami/charts/issues/4201)
+
+## 12.0.0 (2020-11-10)
+
+* [bitnami/redis] Major version. Adapt Chart to apiVersion: v2 (#4263) ([a53c8b5](https://github.com/bitnami/charts/commit/a53c8b5)), closes [#4263](https://github.com/bitnami/charts/issues/4263)
+
+## <small>11.3.4 (2020-11-04)</small>
+
+* [bitnami/redis] Makes password argument conditional for TLS as well (#4196) ([2ed85a6](https://github.com/bitnami/charts/commit/2ed85a6)), closes [#4196](https://github.com/bitnami/charts/issues/4196)
+
+## <small>11.3.3 (2020-11-04)</small>
+
+* [bitnami/redis] Force redis-exporter to use TLS (#4195) ([abb7aef](https://github.com/bitnami/charts/commit/abb7aef)), closes [#4195](https://github.com/bitnami/charts/issues/4195)
+
+## <small>11.3.2 (2020-11-04)</small>
+
+* [bitnami/redis] Fix sentinel when password contains '%' (#4200) ([1561d7c](https://github.com/bitnami/charts/commit/1561d7c)), closes [#4200](https://github.com/bitnami/charts/issues/4200)
+
+## <small>11.3.1 (2020-11-03)</small>
+
+* [bitnami/redis] Fix: "sh -c" for volume-permissions initContainer (#4191) ([d562cff](https://github.com/bitnami/charts/commit/d562cff)), closes [#4191](https://github.com/bitnami/charts/issues/4191)
+
+## 11.3.0 (2020-11-02)
+
+* [bitnami/*] Include link to Troubleshootin guide on README.md (#4136) ([c08a20e](https://github.com/bitnami/charts/commit/c08a20e)), closes [#4136](https://github.com/bitnami/charts/issues/4136)
+* [bitnami/redis*] Set metrics exporter CA certificate env variable (#4169) ([5127668](https://github.com/bitnami/charts/commit/5127668)), closes [#4169](https://github.com/bitnami/charts/issues/4169)
+
+## <small>11.2.3 (2020-10-27)</small>
+
+* [bitnami/redis] Release 11.2.3 updating components versions ([4aad73a](https://github.com/bitnami/charts/commit/4aad73a))
+
+## <small>11.2.2 (2020-10-23)</small>
+
+* [bitnami/redis] Add quote to namespace (#4094) ([cc3744c](https://github.com/bitnami/charts/commit/cc3744c)), closes [#4094](https://github.com/bitnami/charts/issues/4094)
+
+## <small>11.2.1 (2020-10-16)</small>
+
+* [bitnami/redis] Fix example PrometheusRule (#4012) ([1585993](https://github.com/bitnami/charts/commit/1585993)), closes [#4012](https://github.com/bitnami/charts/issues/4012)
+
+## 11.2.0 (2020-10-15)
+
+* [bitnami/redis] Add labels to Redis Statefulset (#4015) ([7772b2d](https://github.com/bitnami/charts/commit/7772b2d)), closes [#4015](https://github.com/bitnami/charts/issues/4015)
+
+## <small>11.1.4 (2020-10-14)</small>
+
+* [bitnami/redis] Fix podSecurityPolicy creation (#4007) ([e843628](https://github.com/bitnami/charts/commit/e843628)), closes [#4007](https://github.com/bitnami/charts/issues/4007)
+
+## <small>11.1.3 (2020-10-14)</small>
+
+* [bitnami/redis] Fix priorityClassName (#4010) ([eaac9f5](https://github.com/bitnami/charts/commit/eaac9f5)), closes [#4010](https://github.com/bitnami/charts/issues/4010)
+
+## <small>11.1.1 (2020-10-10)</small>
+
+* [bitnami/redis] Release 11.1.1 updating components versions ([a4b5833](https://github.com/bitnami/charts/commit/a4b5833))
+* Drop securityContext.sysctls from README as it does not have a specific default value (#3929) ([99c3ab6](https://github.com/bitnami/charts/commit/99c3ab6)), closes [#3929](https://github.com/bitnami/charts/issues/3929)
+
+## 11.1.0 (2020-10-06)
+
+* [bitnami/redis] Add arbitrary securityContext configuration to improve security (#3900) ([cbb82d2](https://github.com/bitnami/charts/commit/cbb82d2)), closes [#3900](https://github.com/bitnami/charts/issues/3900)
+
+## <small>11.0.7 (2020-10-05)</small>
+
+* [bitnami/redis] volume-permissions container not start (#3851) ([bd582e2](https://github.com/bitnami/charts/commit/bd582e2)), closes [#3851](https://github.com/bitnami/charts/issues/3851)
+
+## <small>11.0.6 (2020-09-28)</small>
+
+* [bitnami/redis] Add namespace in Pod Disruption Budget template (#3785) ([d99b35c](https://github.com/bitnami/charts/commit/d99b35c)), closes [#3785](https://github.com/bitnami/charts/issues/3785)
+
+## <small>11.0.5 (2020-09-25)</small>
+
+* Restore Redis Master and Slave 'command' functionality, with new variables (#3773) ([f712bbf](https://github.com/bitnami/charts/commit/f712bbf)), closes [#3773](https://github.com/bitnami/charts/issues/3773)
+
+## <small>11.0.4 (2020-09-23)</small>
+
+* [bitnami/redis] Allow use without cluster/sentinel (#3738) ([8ea9663](https://github.com/bitnami/charts/commit/8ea9663)), closes [#3738](https://github.com/bitnami/charts/issues/3738)
+* [bitnami/redis] Bump chart version ([ebf43f9](https://github.com/bitnami/charts/commit/ebf43f9))
+
+## <small>11.0.3 (2020-09-23)</small>
+
+* [bitnami/redis] Fix no-password sentinel bug (#3742) ([923a446](https://github.com/bitnami/charts/commit/923a446)), closes [#3742](https://github.com/bitnami/charts/issues/3742)
+* Typo in comment fixed: namespacess -> namespaces (#3735) ([7c5816f](https://github.com/bitnami/charts/commit/7c5816f)), closes [#3735](https://github.com/bitnami/charts/issues/3735)
+
+## <small>11.0.2 (2020-09-21)</small>
+
+* [bitnami/redis] Fix Sentinel with TLS config (#3736) ([b67d1ae](https://github.com/bitnami/charts/commit/b67d1ae)), closes [#3736](https://github.com/bitnami/charts/issues/3736)
+
+## <small>11.0.1 (2020-09-21)</small>
+
+* [bitnami/redis] Add exec to forward signals to redis (#3711) ([1c9a9aa](https://github.com/bitnami/charts/commit/1c9a9aa)), closes [#3711](https://github.com/bitnami/charts/issues/3711)
+
+## 11.0.0 (2020-09-17)
+
+* [bitnami/redis] Removes master/slave when using sentinel (#3658) ([782f4bf](https://github.com/bitnami/charts/commit/782f4bf)), closes [#3658](https://github.com/bitnami/charts/issues/3658)
+
+## 10.9.0 (2020-09-15)
+
+* [bitnami/redis] Add extraEnv value to redis chart (#3651) ([10b54e8](https://github.com/bitnami/charts/commit/10b54e8)), closes [#3651](https://github.com/bitnami/charts/issues/3651)
+
+## <small>10.8.2 (2020-09-10)</small>
+
+* [bitnami/metrics-server] Add source repo (#3577) ([1ed12f9](https://github.com/bitnami/charts/commit/1ed12f9)), closes [#3577](https://github.com/bitnami/charts/issues/3577)
+* [bitnami/redis] Release 10.8.2 updating components versions ([6e0654c](https://github.com/bitnami/charts/commit/6e0654c))
+
+## <small>10.8.1 (2020-09-01)</small>
+
+* [bitnami/redis] Release 10.8.1 updating components versions ([f8002d6](https://github.com/bitnami/charts/commit/f8002d6))
+
+## 10.8.0 (2020-09-01)
+
+* [bitnami/redis] prevent zombie PIDs in redis health checks (#3559) ([abfeef4](https://github.com/bitnami/charts/commit/abfeef4)), closes [#3559](https://github.com/bitnami/charts/issues/3559)
+
+## <small>10.7.17 (2020-08-28)</small>
+
+* [bitnami/redis] Added Tolerations as valid Value for Redis Config (#3481) ([fd52e8b](https://github.com/bitnami/charts/commit/fd52e8b)), closes [#3481](https://github.com/bitnami/charts/issues/3481)
+* [bitnami/redis] Release 10.7.17 updating components versions ([e188282](https://github.com/bitnami/charts/commit/e188282))
+* Update README.md (#3507) ([cfc838f](https://github.com/bitnami/charts/commit/cfc838f)), closes [#3507](https://github.com/bitnami/charts/issues/3507)
+
+## <small>10.7.16 (2020-08-07)</small>
+
+* [bitnami/redis] Release 10.7.16 updating components versions ([ae30b5d](https://github.com/bitnami/charts/commit/ae30b5d))
+
+## <small>10.7.15 (2020-08-07)</small>
+
+* [bitnami/redis] Fix matchLabels for PDB (#3357) ([a980170](https://github.com/bitnami/charts/commit/a980170)), closes [#3357](https://github.com/bitnami/charts/issues/3357)
+
+## <small>10.7.14 (2020-08-05)</small>
+
+* [bitnami/redis] Release 10.7.14 updating components versions ([c1eb55f](https://github.com/bitnami/charts/commit/c1eb55f))
+
+## <small>10.7.13 (2020-08-03)</small>
+
+* [bitnami/redis] Fix liveness/readiness probe inconsistencies between README and values.yaml (#3308) ([85bf04c](https://github.com/bitnami/charts/commit/85bf04c)), closes [#3308](https://github.com/bitnami/charts/issues/3308)
+
+## <small>10.7.12 (2020-07-31)</small>
+
+* [bitnami/*] Fix TL;DR typo in READMEs (#3280) ([3d7ab40](https://github.com/bitnami/charts/commit/3d7ab40)), closes [#3280](https://github.com/bitnami/charts/issues/3280)
+* [bitnami/all] Add categories (#3075) ([63bde06](https://github.com/bitnami/charts/commit/63bde06)), closes [#3075](https://github.com/bitnami/charts/issues/3075)
+* [bitnami/redis] Release 10.7.12 updating components versions ([e615089](https://github.com/bitnami/charts/commit/e615089))
+
+## <small>10.7.11 (2020-07-09)</small>
+
+* [bitnami/redis] Release 10.7.11 updating components versions ([e2ff529](https://github.com/bitnami/charts/commit/e2ff529))
+
+## <small>10.7.10 (2020-07-09)</small>
+
+* [redis/chart] Add tls-replication yes to master sentinel (#3061) ([3dba0bb](https://github.com/bitnami/charts/commit/3dba0bb)), closes [#3061](https://github.com/bitnami/charts/issues/3061)
+
+## <small>10.7.9 (2020-07-01)</small>
+
+* [bitnami/redis] Release 10.7.9 updating components versions ([7b5656a](https://github.com/bitnami/charts/commit/7b5656a))
+* [bitnami/redis] update rest of health checks for TLS (#2976) ([0f307a1](https://github.com/bitnami/charts/commit/0f307a1)), closes [#2976](https://github.com/bitnami/charts/issues/2976)
+
+## <small>10.7.8 (2020-07-01)</small>
+
+* [bitnami/redis] fix copy/paste error in comment (#2972) ([6ab1eb4](https://github.com/bitnami/charts/commit/6ab1eb4)), closes [#2972](https://github.com/bitnami/charts/issues/2972)
+
+## <small>10.7.7 (2020-06-30)</small>
+
+* [bitnami/redis] Release 10.7.7 updating components versions ([93bf956](https://github.com/bitnami/charts/commit/93bf956))
+
+## <small>10.7.6 (2020-06-30)</small>
+
+* [bitnami/redis] only send cert in healthcheck if authClients is true (#2966) ([8df88a8](https://github.com/bitnami/charts/commit/8df88a8)), closes [#2966](https://github.com/bitnami/charts/issues/2966)
+
+## <small>10.7.5 (2020-06-24)</small>
+
+* [bitnami/redis] Release 10.7.5 updating components versions ([63b654f](https://github.com/bitnami/charts/commit/63b654f))
+
+## <small>10.7.4 (2020-06-19)</small>
+
+* [bitnami/redis] Added pdb for redis chart (#2822) ([bde8277](https://github.com/bitnami/charts/commit/bde8277)), closes [#2822](https://github.com/bitnami/charts/issues/2822)
+
+## <small>10.7.3 (2020-06-18)</small>
+
+* [bitnami/redis] Release 10.7.3 updating components versions ([f00032a](https://github.com/bitnami/charts/commit/f00032a))
+* [multiple charts] Update hidden properties in the different JSON schemas (#2871) ([4cff6ba](https://github.com/bitnami/charts/commit/4cff6ba)), closes [#2871](https://github.com/bitnami/charts/issues/2871)
+
+## <small>10.7.2 (2020-06-17)</small>
+
+* [bitnami/redis] Fix conditional to mount TLS certificates on slave statefulset with persistence disa ([df10486](https://github.com/bitnami/charts/commit/df10486)), closes [#2852](https://github.com/bitnami/charts/issues/2852)
+
+## <small>10.7.1 (2020-06-11)</small>
+
+* [bitnami/redis] Release 10.7.1 updating components versions ([0a1e132](https://github.com/bitnami/charts/commit/0a1e132))
+
+## 10.7.0 (2020-06-10)
+
+* [bitnami/redis] Add TLS support (#2753) ([bc85818](https://github.com/bitnami/charts/commit/bc85818)), closes [#2753](https://github.com/bitnami/charts/issues/2753)
+
+## <small>10.6.19 (2020-06-10)</small>
+
+* [bitnami/redis] Release 10.6.19 updating components versions ([010d6eb](https://github.com/bitnami/charts/commit/010d6eb))
+* [bitnami/several] Add instructions about how to use different branches (#2785) ([c315cb0](https://github.com/bitnami/charts/commit/c315cb0)), closes [#2785](https://github.com/bitnami/charts/issues/2785)
+
+## <small>10.6.18 (2020-06-03)</small>
+
+* [bitnami/redis] Release 10.6.18 updating components versions ([780db91](https://github.com/bitnami/charts/commit/780db91))
+
+## <small>10.6.17 (2020-05-28)</small>
+
+* [bitnami/redis] Release 10.6.17 updating components versions ([0e678a2](https://github.com/bitnami/charts/commit/0e678a2))
+
+## <small>10.6.16 (2020-05-28)</small>
+
+* [bitnami/redis] Release 10.6.16 updating components versions ([10096b6](https://github.com/bitnami/charts/commit/10096b6))
+
+## <small>10.6.15 (2020-05-20)</small>
+
+* [bitnami/redis] Add Topology Spread Constraints (#2582) ([6dbafa0](https://github.com/bitnami/charts/commit/6dbafa0)), closes [#2582](https://github.com/bitnami/charts/issues/2582)
+* update bitnami/common to be compatible with helm v2.12+ (#2615) ([c7751eb](https://github.com/bitnami/charts/commit/c7751eb)), closes [#2615](https://github.com/bitnami/charts/issues/2615)
+
+## <small>10.6.14 (2020-05-18)</small>
+
+* [bitnami/redis] Release 10.6.14 updating components versions ([ba1441a](https://github.com/bitnami/charts/commit/ba1441a))
+
+## <small>10.6.13 (2020-05-06)</small>
+
+* [bitnami/redis] Release 10.6.13 updating components versions ([5c87bf9](https://github.com/bitnami/charts/commit/5c87bf9))
+
+## <small>10.6.12 (2020-05-01)</small>
+
+* [bitnami/redis] Fix zombie processes in readiness/liveness check (#2453) ([b9414f4](https://github.com/bitnami/charts/commit/b9414f4)), closes [#2453](https://github.com/bitnami/charts/issues/2453)
+
+## <small>10.6.11 (2020-04-27)</small>
+
+* [bitnami/redis] Release 10.6.11 updating components versions ([00efc57](https://github.com/bitnami/charts/commit/00efc57))
+
+## <small>10.6.10 (2020-04-21)</small>
+
+* [bitnami/redis] Release 10.6.10 updating components versions ([855b55e](https://github.com/bitnami/charts/commit/855b55e))
+
+## <small>10.6.9 (2020-04-20)</small>
+
+* [bitnami/redis bitnami/redis-cluster] Fix metrics loadBalancerIP spacing (#2348) ([5da46ac](https://github.com/bitnami/charts/commit/5da46ac)), closes [#2348](https://github.com/bitnami/charts/issues/2348)
+
+## <small>10.6.8 (2020-04-17)</small>
+
+*  [bitnami/redis bitnami/redis-cluster] Only scrape metrics from the metrics service (#2349) ([ddad11f](https://github.com/bitnami/charts/commit/ddad11f)), closes [#2349](https://github.com/bitnami/charts/issues/2349)
+
+## <small>10.6.7 (2020-04-16)</small>
+
+* [bitnami/redis] Release 10.6.7 updating components versions ([035ee49](https://github.com/bitnami/charts/commit/035ee49))
+
+## <small>10.6.6 (2020-04-15)</small>
+
+* [bitnami/redis-cluster bitnami/redis] Add note about how to choose between both charts (#2287) ([58a1942](https://github.com/bitnami/charts/commit/58a1942)), closes [#2287](https://github.com/bitnami/charts/issues/2287)
+
+## <small>10.6.5 (2020-04-10)</small>
+
+* [bitnami/redis] Release 10.6.5 updating components versions ([a8fc69e](https://github.com/bitnami/charts/commit/a8fc69e))
+
+## <small>10.6.4 (2020-04-09)</small>
+
+* [stable/redis] Allow custom probes for other images (#2022) ([ced9652](https://github.com/bitnami/charts/commit/ced9652)), closes [#2022](https://github.com/bitnami/charts/issues/2022)
+
+## <small>10.6.3 (2020-04-07)</small>
+
+* [bitnami/redis] Fixed default slave count in README.md (#2248) ([ff04780](https://github.com/bitnami/charts/commit/ff04780)), closes [#2248](https://github.com/bitnami/charts/issues/2248)
+
+## <small>10.6.2 (2020-04-03)</small>
+
+* [bitnami/redis] Fix PrometheusRule examples. (#2203) ([63a72ac](https://github.com/bitnami/charts/commit/63a72ac)), closes [#2203](https://github.com/bitnami/charts/issues/2203)
+* [bitnami/redis] Release 10.6.2 updating components versions ([7e4ec35](https://github.com/bitnami/charts/commit/7e4ec35))
+
+## <small>10.6.1 (2020-04-03)</small>
+
+* [bitnami/redis]: Fix container name (#2198) ([478f4a3](https://github.com/bitnami/charts/commit/478f4a3)), closes [#2198](https://github.com/bitnami/charts/issues/2198)
+
+## 10.6.0 (2020-03-30)
+
+* [bitnami/redis] Introduced `.Release.Namespace` in objects meta (#2156) ([d4d63e9](https://github.com/bitnami/charts/commit/d4d63e9)), closes [#2156](https://github.com/bitnami/charts/issues/2156)
+
+## <small>10.5.14 (2020-03-26)</small>
+
+* [bitnami/redis] Release 10.5.14 updating components versions ([1af5233](https://github.com/bitnami/charts/commit/1af5233))
+
+## <small>10.5.13 (2020-03-20)</small>
+
+* [bitnami/redis] Release 10.5.13 updating components versions ([7df8c65](https://github.com/bitnami/charts/commit/7df8c65))
+* Fix liveness probe with redis v4 (#2078) ([589eeb9](https://github.com/bitnami/charts/commit/589eeb9)), closes [#2078](https://github.com/bitnami/charts/issues/2078)
+
+## <small>10.5.12 (2020-03-18)</small>
+
+* [bitnami/redis] Release 10.5.12 updating components versions ([9956835](https://github.com/bitnami/charts/commit/9956835))
+
+## <small>10.5.11 (2020-03-12)</small>
+
+* [bitnami/redis] Release 10.5.11 updating components versions ([cb6479c](https://github.com/bitnami/charts/commit/cb6479c))
+
+## <small>10.5.10 (2020-03-12)</small>
+
+* [bitnami/redis] Release 10.5.10 updating components versions ([218dd1f](https://github.com/bitnami/charts/commit/218dd1f))
+
+## <small>10.5.9 (2020-03-11)</small>
+
+* Move charts from upstreamed folder to bitnami (#2032) ([a0e44f7](https://github.com/bitnami/charts/commit/a0e44f7)), closes [#2032](https://github.com/bitnami/charts/issues/2032)
+
+## <small>10.5.8 (2020-03-10)</small>
+
+* [bitnami/redis & rabbit] Revert CI removal (#2025) ([f05c165](https://github.com/bitnami/charts/commit/f05c165)), closes [#2025](https://github.com/bitnami/charts/issues/2025)
+
+## <small>10.5.7 (2020-03-09)</small>
+
+* [bitnami/redis] Release 10.5.7 updating components versions ([a981041](https://github.com/bitnami/charts/commit/a981041))
+
+## <small>10.5.6 (2020-03-09)</small>
+
+* [bitnami/redis] Move chart from stable and remove ci folder (#2017) ([bb8e1cf](https://github.com/bitnami/charts/commit/bb8e1cf)), closes [#2017](https://github.com/bitnami/charts/issues/2017)

--- a/bitnami/redis/Chart.lock
+++ b/bitnami/redis/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.19.2
-digest: sha256:e670e1075bfafffe040fae1158f1fa1f592585f394b48704ba137d2d083b1571
-generated: "2024-05-13T11:37:01.073376388Z"
+  version: 2.19.3
+digest: sha256:de997835d9ce9a9deefc2d70d8c62b11aa1d1a76ece9e86a83736ab9f930bf4d
+generated: "2024-05-21T14:34:40.55761424+02:00"

--- a/bitnami/redis/Chart.yaml
+++ b/bitnami/redis/Chart.yaml
@@ -36,4 +36,4 @@ maintainers:
 name: redis
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/redis
-version: 19.3.4
+version: 19.4.0

--- a/bitnami/redis/templates/NOTES.txt
+++ b/bitnami/redis/templates/NOTES.txt
@@ -210,3 +210,4 @@ YOU NEED TO PERFORM AN UPGRADE FOR THE SERVICES AND WORKLOAD TO BE CREATED
   {{- $resourceSections = append $resourceSections "master" -}}
 {{- end }}
 {{- include "common.warnings.resources" (dict "sections" $resourceSections "context" $) }}
+{{- include "common.warnings.modifiedImages" (dict "images" (list .Values.image .Values.sentinel.image .Values.metrics.image .Values.volumePermissions.image .Values.kubectl.image .Values.sysctl.image) "context" $) }}


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Replacing the original images that have been tested and verified when releasing the chart is a dangerous practice in terms of security, performance and available features. This PR updates the `NOTES.txt` file using the `common.warnings.modifiedImages` helper developed in https://github.com/bitnami/charts/pull/25952.


<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

Users are more aware of the risks of changing original images.
<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

n/a
<!-- Describe any known limitations with your change -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
