### PR TITLE
[bitnami/seaweedfs] feat: :sparkles: :lock: Add warning when original images are replaced

### DIFF
--- a/bitnami/seaweedfs/CHANGELOG.md
+++ b/bitnami/seaweedfs/CHANGELOG.md
@@ -1,0 +1,41 @@
+# Changelog
+
+## 0.2.0 (2024-05-21)
+
+* [bitnami/seaweedfs] feat: :sparkles: :lock: Add warning when original images are replaced ([#26276](https://github.com/bitnami/charts/pulls/26276))
+
+## <small>0.1.7 (2024-05-18)</small>
+
+* [bitnami/seaweedfs] Release 0.1.7 updating components versions (#26076) ([59768fc](https://github.com/bitnami/charts/commit/59768fc)), closes [#26076](https://github.com/bitnami/charts/issues/26076)
+
+## <small>0.1.6 (2024-05-14)</small>
+
+* [bitnami/seaweedfs] Release 0.1.6 updating components versions (#25844) ([2a102da](https://github.com/bitnami/charts/commit/2a102da)), closes [#25844](https://github.com/bitnami/charts/issues/25844)
+
+## <small>0.1.5 (2024-05-08)</small>
+
+* [bitnami/*] Change non-root and rolling-tags doc URLs (#25628) ([b067c94](https://github.com/bitnami/charts/commit/b067c94)), closes [#25628](https://github.com/bitnami/charts/issues/25628)
+* [bitnami/seaweedfs] Release 0.1.5 updating components versions (#25636) ([1919ba7](https://github.com/bitnami/charts/commit/1919ba7)), closes [#25636](https://github.com/bitnami/charts/issues/25636)
+
+## <small>0.1.4 (2024-05-08)</small>
+
+* [bitnami/*] Set new header/owner (#25558) ([8d1dc11](https://github.com/bitnami/charts/commit/8d1dc11)), closes [#25558](https://github.com/bitnami/charts/issues/25558)
+* [bitnami/seaweedfs] Release 0.1.4 updating components versions (#25621) ([99e1473](https://github.com/bitnami/charts/commit/99e1473)), closes [#25621](https://github.com/bitnami/charts/issues/25621)
+
+## <small>0.1.3 (2024-05-06)</small>
+
+* [bitnami/seaweedfs] Amend README instructions for  using CertManager to generate mTLS certs (#25172) ([613d43c](https://github.com/bitnami/charts/commit/613d43c)), closes [#25172](https://github.com/bitnami/charts/issues/25172)
+* [bitnami/seaweedfs] Release 0.1.3 updating components versions (#25551) ([48b5ee3](https://github.com/bitnami/charts/commit/48b5ee3)), closes [#25551](https://github.com/bitnami/charts/issues/25551)
+* Replace VMware by Broadcom copyright text (#25306) ([a5e4bd0](https://github.com/bitnami/charts/commit/a5e4bd0)), closes [#25306](https://github.com/bitnami/charts/issues/25306)
+
+## <small>0.1.2 (2024-04-15)</small>
+
+* [bitnami/seaweedfs] Release 0.1.2 updating components versions (#25168) ([d6f8af5](https://github.com/bitnami/charts/commit/d6f8af5)), closes [#25168](https://github.com/bitnami/charts/issues/25168)
+
+## <small>0.1.1 (2024-04-12)</small>
+
+* [bitnami/seaweedfs] Release 0.1.1 updating components versions (#25155) ([73df2e0](https://github.com/bitnami/charts/commit/73df2e0)), closes [#25155](https://github.com/bitnami/charts/issues/25155)
+
+## 0.1.0 (2024-04-12)
+
+* New chart: SeaweedFS (#24944) ([51ac5cd](https://github.com/bitnami/charts/commit/51ac5cd)), closes [#24944](https://github.com/bitnami/charts/issues/24944)

--- a/bitnami/seaweedfs/Chart.lock
+++ b/bitnami/seaweedfs/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 18.0.6
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.19.2
-digest: sha256:a543075b2f82f1b56b5492a5fed26b4721f5d92e8c7e9b5a8d2951fe7df6b6ee
-generated: "2024-05-18T02:57:39.817971257Z"
+  version: 2.19.3
+digest: sha256:2478b5905a3762c639243987d595ae8946c65c7ec7cd1999850fdcd50e514a61
+generated: "2024-05-21T14:39:05.507859562+02:00"

--- a/bitnami/seaweedfs/Chart.yaml
+++ b/bitnami/seaweedfs/Chart.yaml
@@ -39,4 +39,4 @@ maintainers:
 name: seaweedfs
 sources:
 - https://github.com/bitnami/containers/tree/main/bitnami/seaweedfs
-version: 0.1.7
+version: 0.2.0

--- a/bitnami/seaweedfs/templates/NOTES.txt
+++ b/bitnami/seaweedfs/templates/NOTES.txt
@@ -167,3 +167,4 @@ The chart was deployed enabling WebDAV, to access it from outside the cluster fo
 {{- include "common.warnings.rollingTag" .Values.image }}
 {{- include "common.warnings.rollingTag" .Values.volumePermissions.image }}
 {{- include "seaweedfs.validateValues" . }}
+{{- include "common.warnings.modifiedImages" (dict "images" (list .Values.image .Values.volumePermissions.image) "context" $) }}


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Replacing the original images that have been tested and verified when releasing the chart is a dangerous practice in terms of security, performance and available features. This PR updates the `NOTES.txt` file using the `common.warnings.modifiedImages` helper developed in https://github.com/bitnami/charts/pull/25952.


<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

Users are more aware of the risks of changing original images.
<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

n/a
<!-- Describe any known limitations with your change -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
