### PR TITLE
[bitnami/spark] feat: :sparkles: :lock: Add warning when original images are replaced

### DIFF
--- a/bitnami/spark/CHANGELOG.md
+++ b/bitnami/spark/CHANGELOG.md
@@ -1,0 +1,990 @@
+# Changelog
+
+## 9.1.0 (2024-05-21)
+
+* [bitnami/spark] feat: :sparkles: :lock: Add warning when original images are replaced ([#26279](https://github.com/bitnami/charts/pulls/26279))
+
+## <small>9.0.4 (2024-05-21)</small>
+
+* [bitnami/spark] Use different liveness/readiness probes (#26135) ([e9b9c5a](https://github.com/bitnami/charts/commit/e9b9c5a)), closes [#26135](https://github.com/bitnami/charts/issues/26135)
+
+## <small>9.0.3 (2024-05-18)</small>
+
+* [bitnami/spark] Release 9.0.3 updating components versions (#26079) ([8869b45](https://github.com/bitnami/charts/commit/8869b45)), closes [#26079](https://github.com/bitnami/charts/issues/26079)
+
+## <small>9.0.2 (2024-05-14)</small>
+
+* [bitnami/*] Change non-root and rolling-tags doc URLs (#25628) ([b067c94](https://github.com/bitnami/charts/commit/b067c94)), closes [#25628](https://github.com/bitnami/charts/issues/25628)
+* [bitnami/*] Set new header/owner (#25558) ([8d1dc11](https://github.com/bitnami/charts/commit/8d1dc11)), closes [#25558](https://github.com/bitnami/charts/issues/25558)
+* [bitnami/multiple charts] Fix typo: "NetworkPolice" vs "NetworkPolicy" (#25348) ([6970c1b](https://github.com/bitnami/charts/commit/6970c1b)), closes [#25348](https://github.com/bitnami/charts/issues/25348)
+* [bitnami/spark] Release 9.0.2 updating components versions (#25827) ([4ee33eb](https://github.com/bitnami/charts/commit/4ee33eb)), closes [#25827](https://github.com/bitnami/charts/issues/25827)
+* Replace VMware by Broadcom copyright text (#25306) ([a5e4bd0](https://github.com/bitnami/charts/commit/a5e4bd0)), closes [#25306](https://github.com/bitnami/charts/issues/25306)
+
+## <small>9.0.1 (2024-04-06)</small>
+
+* [bitnami/*] Reorder Chart sections (#24455) ([0cf4048](https://github.com/bitnami/charts/commit/0cf4048)), closes [#24455](https://github.com/bitnami/charts/issues/24455)
+* [bitnami/spark] Release 9.0.1 (#25020) ([7e08ecc](https://github.com/bitnami/charts/commit/7e08ecc)), closes [#25020](https://github.com/bitnami/charts/issues/25020)
+* Update resourcesPreset comments (#24467) ([92e3e8a](https://github.com/bitnami/charts/commit/92e3e8a)), closes [#24467](https://github.com/bitnami/charts/issues/24467)
+
+## 9.0.0 (2024-03-15)
+
+* [bitnami/spark] feat!: 🔒 💥 Improve security defaults (#24278) ([d286df6](https://github.com/bitnami/charts/commit/d286df6)), closes [#24278](https://github.com/bitnami/charts/issues/24278)
+
+## <small>8.9.1 (2024-03-12)</small>
+
+* [bitnami/spark] fix: work directory permissions (#24331) ([314d6ae](https://github.com/bitnami/charts/commit/314d6ae)), closes [#24331](https://github.com/bitnami/charts/issues/24331)
+
+## 8.9.0 (2024-03-05)
+
+* [bitnami/spark] feat: :sparkles: :lock: Add automatic adaptation for Openshift restricted-v2 SCC (#2 ([d4228e3](https://github.com/bitnami/charts/commit/d4228e3)), closes [#24156](https://github.com/bitnami/charts/issues/24156)
+
+## 8.8.0 (2024-03-04)
+
+* [bitnami/spark] feat: :sparkles: :lock: Add readOnlyRootFilesystem support (#23993) ([a718e62](https://github.com/bitnami/charts/commit/a718e62)), closes [#23993](https://github.com/bitnami/charts/issues/23993)
+
+## <small>8.7.3 (2024-02-26)</small>
+
+* [bitnami/spark] Release 8.7.3 updating components versions (#23923) ([411d948](https://github.com/bitnami/charts/commit/411d948)), closes [#23923](https://github.com/bitnami/charts/issues/23923)
+
+## <small>8.7.2 (2024-02-22)</small>
+
+* [bitnami/spark] Release 8.7.2 updating components versions (#23831) ([9af4200](https://github.com/bitnami/charts/commit/9af4200)), closes [#23831](https://github.com/bitnami/charts/issues/23831)
+
+## <small>8.7.1 (2024-02-21)</small>
+
+* [bitnami/spark] Release 8.7.1 updating components versions (#23695) ([3412f80](https://github.com/bitnami/charts/commit/3412f80)), closes [#23695](https://github.com/bitnami/charts/issues/23695)
+
+## 8.7.0 (2024-02-20)
+
+* [bitnami/*] Bump all versions (#23602) ([b70ee2a](https://github.com/bitnami/charts/commit/b70ee2a)), closes [#23602](https://github.com/bitnami/charts/issues/23602)
+
+## 8.6.0 (2024-02-15)
+
+* [bitnami/spark] feat: :sparkles: :lock: Add resource preset support (#23523) ([da9f7aa](https://github.com/bitnami/charts/commit/da9f7aa)), closes [#23523](https://github.com/bitnami/charts/issues/23523)
+
+## <small>8.5.2 (2024-02-03)</small>
+
+* [bitnami/spark] Release 8.5.2 updating components versions (#23139) ([e546181](https://github.com/bitnami/charts/commit/e546181)), closes [#23139](https://github.com/bitnami/charts/issues/23139)
+
+## <small>8.5.1 (2024-02-02)</small>
+
+* [bitnami/spark] Release 8.5.1 updating components versions (#23048) ([e251ed0](https://github.com/bitnami/charts/commit/e251ed0)), closes [#23048](https://github.com/bitnami/charts/issues/23048)
+
+## 8.5.0 (2024-02-01)
+
+* [bitnami/spark] fix: :bug: Add allowExternalEgress to avoid breaking istio (#22969) ([b137e74](https://github.com/bitnami/charts/commit/b137e74)), closes [#22969](https://github.com/bitnami/charts/issues/22969)
+
+## 8.4.0 (2024-01-30)
+
+* [bitnami/spark] feat: :lock: Enable networkPolicy (#22719) ([501f18f](https://github.com/bitnami/charts/commit/501f18f)), closes [#22719](https://github.com/bitnami/charts/issues/22719)
+
+## <small>8.3.2 (2024-01-27)</small>
+
+* [bitnami/spark] Release 8.3.2 updating components versions (#22789) ([79ab195](https://github.com/bitnami/charts/commit/79ab195)), closes [#22789](https://github.com/bitnami/charts/issues/22789)
+
+## <small>8.3.1 (2024-01-26)</small>
+
+* [bitnami/*] Move documentation sections from docs.bitnami.com back to the README (#22203) ([7564f36](https://github.com/bitnami/charts/commit/7564f36)), closes [#22203](https://github.com/bitnami/charts/issues/22203)
+* [bitnami/spark] fix: :bug: Set seLinuxOptions to null for Openshift compatibility (#22660) ([aa83635](https://github.com/bitnami/charts/commit/aa83635)), closes [#22660](https://github.com/bitnami/charts/issues/22660)
+
+## 8.3.0 (2024-01-19)
+
+* [bitnami/spark] fix: :lock: Move service-account token auto-mount to pod declaration (#22462) ([9a999e2](https://github.com/bitnami/charts/commit/9a999e2)), closes [#22462](https://github.com/bitnami/charts/issues/22462)
+
+## <small>8.2.1 (2024-01-18)</small>
+
+* [bitnami/spark] Release 8.2.1 updating components versions (#22327) ([d72dbfb](https://github.com/bitnami/charts/commit/d72dbfb)), closes [#22327](https://github.com/bitnami/charts/issues/22327)
+
+## 8.2.0 (2024-01-16)
+
+* [bitnami/spark] fix: :lock: Improve podSecurityContext and containerSecurityContext with essential s ([48eab32](https://github.com/bitnami/charts/commit/48eab32)), closes [#22191](https://github.com/bitnami/charts/issues/22191)
+
+## <small>8.1.8 (2024-01-12)</small>
+
+* [bitnami/*] Fix docs.bitnami.com broken links (#21901) ([f35506d](https://github.com/bitnami/charts/commit/f35506d)), closes [#21901](https://github.com/bitnami/charts/issues/21901)
+* [bitnami/*] Fix ref links (in comments) (#21822) ([e4fa296](https://github.com/bitnami/charts/commit/e4fa296)), closes [#21822](https://github.com/bitnami/charts/issues/21822)
+* [bitnami/*] Update copyright: Year and company (#21815) ([6c4bf75](https://github.com/bitnami/charts/commit/6c4bf75)), closes [#21815](https://github.com/bitnami/charts/issues/21815)
+* [bitnami/spark] fix: :lock: Do not automount the service account token unless necessary (#22063) ([28c91ad](https://github.com/bitnami/charts/commit/28c91ad)), closes [#22063](https://github.com/bitnami/charts/issues/22063)
+
+## <small>8.1.7 (2024-01-01)</small>
+
+* [bitnami/spark] Release 8.1.7 updating components versions (#21807) ([9a3c18b](https://github.com/bitnami/charts/commit/9a3c18b)), closes [#21807](https://github.com/bitnami/charts/issues/21807)
+
+## <small>8.1.6 (2023-11-21)</small>
+
+* [bitnami/*] Rename solutions to "Bitnami package for ..." (#21038) ([b82f979](https://github.com/bitnami/charts/commit/b82f979)), closes [#21038](https://github.com/bitnami/charts/issues/21038)
+* [bitnami/spark] Release 8.1.6 updating components versions (#21175) ([f2c35e5](https://github.com/bitnami/charts/commit/f2c35e5)), closes [#21175](https://github.com/bitnami/charts/issues/21175)
+
+## <small>8.1.5 (2023-11-16)</small>
+
+* [bitnami/spark] Release 8.1.5 updating components versions (#21012) ([b048970](https://github.com/bitnami/charts/commit/b048970)), closes [#21012](https://github.com/bitnami/charts/issues/21012)
+
+## <small>8.1.4 (2023-11-16)</small>
+
+* [bitnami/*] Remove relative links to non-README sections, add verification for that and update TL;DR ([1103633](https://github.com/bitnami/charts/commit/1103633)), closes [#20967](https://github.com/bitnami/charts/issues/20967)
+* [bitnami/spark] Release 8.1.4 updating components versions (#21006) ([8e38c5b](https://github.com/bitnami/charts/commit/8e38c5b)), closes [#21006](https://github.com/bitnami/charts/issues/21006)
+
+## <small>8.1.3 (2023-11-16)</small>
+
+* [bitnami/spark] Release 8.1.3 updating components versions (#20995) ([7328ac8](https://github.com/bitnami/charts/commit/7328ac8)), closes [#20995](https://github.com/bitnami/charts/issues/20995)
+
+## <small>8.1.2 (2023-11-15)</small>
+
+* [bitnami/spark] Release 8.1.2 updating components versions (#20980) ([5e34289](https://github.com/bitnami/charts/commit/5e34289)), closes [#20980](https://github.com/bitnami/charts/issues/20980)
+
+## <small>8.1.1 (2023-11-08)</small>
+
+* [bitnami/spark] Release 8.1.1 updating components versions (#20705) ([db2ff46](https://github.com/bitnami/charts/commit/db2ff46)), closes [#20705](https://github.com/bitnami/charts/issues/20705)
+
+## 8.1.0 (2023-11-06)
+
+* [bitnami/spark] feat: :sparkles: Add support for PSA restricted policy (#20548) ([7839640](https://github.com/bitnami/charts/commit/7839640)), closes [#20548](https://github.com/bitnami/charts/issues/20548)
+
+## <small>8.0.3 (2023-11-04)</small>
+
+* [bitnami/*] Rename VMware Application Catalog (#20361) ([3acc734](https://github.com/bitnami/charts/commit/3acc734)), closes [#20361](https://github.com/bitnami/charts/issues/20361)
+* [bitnami/spark] Release 8.0.3 updating components versions (#20617) ([1a4567c](https://github.com/bitnami/charts/commit/1a4567c)), closes [#20617](https://github.com/bitnami/charts/issues/20617)
+
+## <small>8.0.2 (2023-10-22)</small>
+
+* [bitnami/*] Skip image's tag in the README files of the Bitnami Charts (#19841) ([bb9a01b](https://github.com/bitnami/charts/commit/bb9a01b)), closes [#19841](https://github.com/bitnami/charts/issues/19841)
+* [bitnami/*] Standardize documentation (#19835) ([af5f753](https://github.com/bitnami/charts/commit/af5f753)), closes [#19835](https://github.com/bitnami/charts/issues/19835)
+* [bitnami/spark] Release 8.0.2 updating components versions (#20351) ([c35b2ea](https://github.com/bitnami/charts/commit/c35b2ea)), closes [#20351](https://github.com/bitnami/charts/issues/20351)
+
+## <small>8.0.1 (2023-10-15)</small>
+
+* [bitnami/*] Update Helm charts prerequisites (#19745) ([eb755dd](https://github.com/bitnami/charts/commit/eb755dd)), closes [#19745](https://github.com/bitnami/charts/issues/19745)
+* [bitnami/spark] bump bitnami/common (#20081) ([9b49b71](https://github.com/bitnami/charts/commit/9b49b71)), closes [#20081](https://github.com/bitnami/charts/issues/20081)
+
+## 8.0.0 (2023-09-22)
+
+* [bitnami/spark] Release 8.0.0 (#19477) ([8cccc58](https://github.com/bitnami/charts/commit/8cccc58)), closes [#19477](https://github.com/bitnami/charts/issues/19477)
+
+## <small>7.2.2 (2023-09-22)</small>
+
+* [bitnami/spark] Release 7.2.2 (#19462) ([49615de](https://github.com/bitnami/charts/commit/49615de)), closes [#19462](https://github.com/bitnami/charts/issues/19462)
+* Autogenerate schema files (#19194) ([a2c2090](https://github.com/bitnami/charts/commit/a2c2090)), closes [#19194](https://github.com/bitnami/charts/issues/19194)
+* Revert "Autogenerate schema files (#19194)" (#19335) ([73d80be](https://github.com/bitnami/charts/commit/73d80be)), closes [#19194](https://github.com/bitnami/charts/issues/19194) [#19335](https://github.com/bitnami/charts/issues/19335)
+
+## <small>7.2.1 (2023-09-07)</small>
+
+* [bitnami/spark: Use merge helper]: (#19108) ([5b0d0eb](https://github.com/bitnami/charts/commit/5b0d0eb)), closes [#19108](https://github.com/bitnami/charts/issues/19108)
+
+## 7.2.0 (2023-08-24)
+
+* [bitnami/spark] Support for customizing standard labels (#18440) ([64b4ae4](https://github.com/bitnami/charts/commit/64b4ae4)), closes [#18440](https://github.com/bitnami/charts/issues/18440)
+
+## <small>7.1.5 (2023-08-23)</small>
+
+* [bitnami/spark] Release 7.1.5 (#18801) ([359dd02](https://github.com/bitnami/charts/commit/359dd02)), closes [#18801](https://github.com/bitnami/charts/issues/18801)
+
+## <small>7.1.4 (2023-08-22)</small>
+
+* [bitnami/spark] Release 7.1.4 (#18786) ([65d0ccb](https://github.com/bitnami/charts/commit/65d0ccb)), closes [#18786](https://github.com/bitnami/charts/issues/18786)
+
+## <small>7.1.3 (2023-08-17)</small>
+
+* [bitnami/spark] Release 7.1.3 (#18593) ([719498b](https://github.com/bitnami/charts/commit/719498b)), closes [#18593](https://github.com/bitnami/charts/issues/18593)
+
+## <small>7.1.2 (2023-07-26)</small>
+
+* [bitnami/spark] Release 7.1.2 (#17970) ([23d4a73](https://github.com/bitnami/charts/commit/23d4a73)), closes [#17970](https://github.com/bitnami/charts/issues/17970)
+
+## <small>7.1.1 (2023-07-13)</small>
+
+* [bitnami/spark] Release 7.1.1 (#17665) ([1913b12](https://github.com/bitnami/charts/commit/1913b12)), closes [#17665](https://github.com/bitnami/charts/issues/17665)
+
+## 7.1.0 (2023-06-28)
+
+* [bitnami/spark] Add extraVolumeClaimTemplates in master and worker StatefulSets (#17353) ([4bc8009](https://github.com/bitnami/charts/commit/4bc8009)), closes [#17353](https://github.com/bitnami/charts/issues/17353)
+* Add copyright header (#17300) ([da68be8](https://github.com/bitnami/charts/commit/da68be8)), closes [#17300](https://github.com/bitnami/charts/issues/17300)
+
+## <small>7.0.2 (2023-06-24)</small>
+
+* [bitnami/*] Change copyright section in READMEs (#17006) ([ef986a1](https://github.com/bitnami/charts/commit/ef986a1)), closes [#17006](https://github.com/bitnami/charts/issues/17006)
+* [bitnami/spark] Release 7.0.2 (#17339) ([f37a095](https://github.com/bitnami/charts/commit/f37a095)), closes [#17339](https://github.com/bitnami/charts/issues/17339)
+* Update charts readme (#17217) ([31b3c0a](https://github.com/bitnami/charts/commit/31b3c0a)), closes [#17217](https://github.com/bitnami/charts/issues/17217)
+
+## <small>7.0.1 (2023-06-02)</small>
+
+* [bitnami/several] Change copyright section in READMEs (#16989) ([5b6a5cf](https://github.com/bitnami/charts/commit/5b6a5cf)), closes [#16989](https://github.com/bitnami/charts/issues/16989)
+* [bitnami/spark] Release 7.0.1 (#17000) ([443d63e](https://github.com/bitnami/charts/commit/443d63e)), closes [#17000](https://github.com/bitnami/charts/issues/17000)
+
+## 7.0.0 (2023-05-26)
+
+* [bitnami/spark] Release 7.0.0 (#16936) ([30ddde3](https://github.com/bitnami/charts/commit/30ddde3)), closes [#16936](https://github.com/bitnami/charts/issues/16936)
+
+## <small>6.6.3 (2023-05-21)</small>
+
+* [bitnami/spark] Release 6.6.3 (#16810) ([e5101b4](https://github.com/bitnami/charts/commit/e5101b4)), closes [#16810](https://github.com/bitnami/charts/issues/16810)
+
+## <small>6.6.2 (2023-05-17)</small>
+
+* [bitnami/spark] Release 6.6.2 (#16700) ([63b6f70](https://github.com/bitnami/charts/commit/63b6f70)), closes [#16700](https://github.com/bitnami/charts/issues/16700)
+
+## <small>6.6.1 (2023-05-15)</small>
+
+* [bitnami/spark] Release 6.6.1 (#16656) ([ee49050](https://github.com/bitnami/charts/commit/ee49050)), closes [#16656](https://github.com/bitnami/charts/issues/16656)
+* Add wording for enterprise page (#16560) ([8f22774](https://github.com/bitnami/charts/commit/8f22774)), closes [#16560](https://github.com/bitnami/charts/issues/16560)
+
+## 6.6.0 (2023-05-09)
+
+* [bitnami/several] Adapt Chart.yaml to set desired OCI annotations (#16546) ([fc9b18f](https://github.com/bitnami/charts/commit/fc9b18f)), closes [#16546](https://github.com/bitnami/charts/issues/16546)
+
+## <small>6.5.3 (2023-05-09)</small>
+
+* [bitnami/spark] Release 6.5.3 (#16524) ([4f8fb8e](https://github.com/bitnami/charts/commit/4f8fb8e)), closes [#16524](https://github.com/bitnami/charts/issues/16524)
+
+## <small>6.5.2 (2023-05-04)</small>
+
+* [bitnami/spark] Release 6.5.2 (#16389) ([120a268](https://github.com/bitnami/charts/commit/120a268)), closes [#16389](https://github.com/bitnami/charts/issues/16389)
+
+## <small>6.5.1 (2023-05-02)</small>
+
+* Revert change existingConfigmap (#16264) ([813a2a0](https://github.com/bitnami/charts/commit/813a2a0)), closes [#16264](https://github.com/bitnami/charts/issues/16264)
+
+## 6.5.0 (2023-04-20)
+
+* [bitnami/*] Make Helm charts 100% OCI (#15998) ([8841510](https://github.com/bitnami/charts/commit/8841510)), closes [#15998](https://github.com/bitnami/charts/issues/15998)
+
+## <small>6.4.4 (2023-04-19)</small>
+
+* [bitnami/spark] Update config path (#16127) ([fa162bd](https://github.com/bitnami/charts/commit/fa162bd)), closes [#16127](https://github.com/bitnami/charts/issues/16127)
+
+## <small>6.4.3 (2023-04-04)</small>
+
+* [bitnami/spark] Release 6.4.3 (#15964) ([dfa0358](https://github.com/bitnami/charts/commit/dfa0358)), closes [#15964](https://github.com/bitnami/charts/issues/15964)
+
+## <small>6.4.2 (2023-04-01)</small>
+
+* [bitnami/spark] Release 6.4.2 (#15919) ([4a4945f](https://github.com/bitnami/charts/commit/4a4945f)), closes [#15919](https://github.com/bitnami/charts/issues/15919)
+
+## <small>6.4.1 (2023-03-19)</small>
+
+* [bitnami/spark] Release 6.4.1 (#15625) ([452088f](https://github.com/bitnami/charts/commit/452088f)), closes [#15625](https://github.com/bitnami/charts/issues/15625)
+
+## 6.4.0 (2023-03-10)
+
+* [bitnami/charts] Apply linter to README files (#15357) ([0e29e60](https://github.com/bitnami/charts/commit/0e29e60)), closes [#15357](https://github.com/bitnami/charts/issues/15357)
+* [bitnami/spark] Add support for service.headless.annotations (#15445) ([8b86cb9](https://github.com/bitnami/charts/commit/8b86cb9)), closes [#15445](https://github.com/bitnami/charts/issues/15445)
+
+## <small>6.3.18 (2023-03-01)</small>
+
+* [bitnami/spark] Release 6.3.18 (#15252) ([28df688](https://github.com/bitnami/charts/commit/28df688)), closes [#15252](https://github.com/bitnami/charts/issues/15252)
+* Fixes dead links (#15065) ([9e99fd9](https://github.com/bitnami/charts/commit/9e99fd9)), closes [#15065](https://github.com/bitnami/charts/issues/15065)
+
+## <small>6.3.17 (2023-02-17)</small>
+
+* [bitnami/*] Change copyright date (#14682) ([add4ec7](https://github.com/bitnami/charts/commit/add4ec7)), closes [#14682](https://github.com/bitnami/charts/issues/14682)
+* [bitnami/*] Fix markdown linter issues (#14874) ([a51e0e8](https://github.com/bitnami/charts/commit/a51e0e8)), closes [#14874](https://github.com/bitnami/charts/issues/14874)
+* [bitnami/*] Fix markdown linter issues 2 (#14890) ([aa96572](https://github.com/bitnami/charts/commit/aa96572)), closes [#14890](https://github.com/bitnami/charts/issues/14890)
+* [bitnami/*] Remove unexpected extra spaces (#14873) ([c97c714](https://github.com/bitnami/charts/commit/c97c714)), closes [#14873](https://github.com/bitnami/charts/issues/14873)
+* [bitnami/spark] Release 6.3.17 (#15035) ([e94c890](https://github.com/bitnami/charts/commit/e94c890)), closes [#15035](https://github.com/bitnami/charts/issues/15035)
+
+## <small>6.3.16 (2023-01-31)</small>
+
+* [bitnami/spark] Don't regenerate self-signed certs on upgrade (#14662) ([00d6c6f](https://github.com/bitnami/charts/commit/00d6c6f)), closes [#14662](https://github.com/bitnami/charts/issues/14662)
+
+## <small>6.3.15 (2023-01-26)</small>
+
+* [bitnami/*] Change licenses annotation format (#14377) ([0ab7608](https://github.com/bitnami/charts/commit/0ab7608)), closes [#14377](https://github.com/bitnami/charts/issues/14377)
+* [bitnami/*] Unify READMEs (#14472) ([2064fb8](https://github.com/bitnami/charts/commit/2064fb8)), closes [#14472](https://github.com/bitnami/charts/issues/14472)
+* [bitnami/spark] Release 6.3.15 (#14557) ([dd72e7a](https://github.com/bitnami/charts/commit/dd72e7a)), closes [#14557](https://github.com/bitnami/charts/issues/14557)
+
+## <small>6.3.14 (2023-01-12)</small>
+
+* [bitnami/*] Add license annotation and remove obsolete engine parameter (#14293) ([da2a794](https://github.com/bitnami/charts/commit/da2a794)), closes [#14293](https://github.com/bitnami/charts/issues/14293)
+* [bitnami/spark] Release 6.3.14 (#14320) ([7fcb1e2](https://github.com/bitnami/charts/commit/7fcb1e2)), closes [#14320](https://github.com/bitnami/charts/issues/14320)
+
+## <small>6.3.13 (2022-12-23)</small>
+
+* [bitnami/spark] Release 6.3.13 (#14086) ([9e82e06](https://github.com/bitnami/charts/commit/9e82e06)), closes [#14086](https://github.com/bitnami/charts/issues/14086)
+
+## <small>6.3.12 (2022-12-10)</small>
+
+* [bitnami/spark] Release 6.3.12 (#13896) ([54f8ae4](https://github.com/bitnami/charts/commit/54f8ae4)), closes [#13896](https://github.com/bitnami/charts/issues/13896)
+
+## <small>6.3.11 (2022-11-17)</small>
+
+* [bitnami/spark]  Fixed the mount path of shared-certs volume (#13342) ([645343b](https://github.com/bitnami/charts/commit/645343b)), closes [#13342](https://github.com/bitnami/charts/issues/13342)
+* [bitnami/spark] fix apiversion hardcode for statefulset (#13555) ([d0abca6](https://github.com/bitnami/charts/commit/d0abca6)), closes [#13555](https://github.com/bitnami/charts/issues/13555)
+
+## <small>6.3.10 (2022-11-10)</small>
+
+* [bitnami/spark] Release 6.3.10 (#13451) ([3d56557](https://github.com/bitnami/charts/commit/3d56557)), closes [#13451](https://github.com/bitnami/charts/issues/13451)
+
+## <small>6.3.9 (2022-10-31)</small>
+
+* [bitnami/spark] Release 6.3.9 (#13260) ([04df40c](https://github.com/bitnami/charts/commit/04df40c)), closes [#13260](https://github.com/bitnami/charts/issues/13260)
+
+## <small>6.3.8 (2022-10-26)</small>
+
+* optimize annos (#13123) ([8c93586](https://github.com/bitnami/charts/commit/8c93586)), closes [#13123](https://github.com/bitnami/charts/issues/13123)
+
+## <small>6.3.7 (2022-10-24)</small>
+
+* [bitnami/*] Use new default branch name in links (#12943) ([a529e02](https://github.com/bitnami/charts/commit/a529e02)), closes [#12943](https://github.com/bitnami/charts/issues/12943)
+* [bitnami/spark] Fix render namespace for spark (#13079) ([d41ac4a](https://github.com/bitnami/charts/commit/d41ac4a)), closes [#13079](https://github.com/bitnami/charts/issues/13079)
+
+## <small>6.3.6 (2022-10-10)</small>
+
+* [bitnami/spark] Release 6.3.6 (#12891) ([c87a772](https://github.com/bitnami/charts/commit/c87a772)), closes [#12891](https://github.com/bitnami/charts/issues/12891)
+
+## <small>6.3.5 (2022-10-05)</small>
+
+* [bitnami/spark] Release 6.3.5 (#12821) ([0b16b8d](https://github.com/bitnami/charts/commit/0b16b8d)), closes [#12821](https://github.com/bitnami/charts/issues/12821)
+* Generic README instructions related to the repo (#12792) ([3cf6b10](https://github.com/bitnami/charts/commit/3cf6b10)), closes [#12792](https://github.com/bitnami/charts/issues/12792)
+
+## <small>6.3.4 (2022-09-20)</small>
+
+* [bitnami/spark] Use custom probes if given (#12559) ([1226dfd](https://github.com/bitnami/charts/commit/1226dfd)), closes [#12559](https://github.com/bitnami/charts/issues/12559) [#12354](https://github.com/bitnami/charts/issues/12354)
+
+## <small>6.3.3 (2022-09-16)</small>
+
+* [bitnami/spark] Release 6.3.3 (#12462) ([03dc563](https://github.com/bitnami/charts/commit/03dc563)), closes [#12462](https://github.com/bitnami/charts/issues/12462)
+
+## <small>6.3.2 (2022-09-08)</small>
+
+* [bitnami/spark] Release 6.3.2 (#12343) ([c838927](https://github.com/bitnami/charts/commit/c838927)), closes [#12343](https://github.com/bitnami/charts/issues/12343)
+
+## <small>6.3.1 (2022-08-23)</small>
+
+* [bitnami/spark] Update Chart.lock (#12066) ([f82f237](https://github.com/bitnami/charts/commit/f82f237)), closes [#12066](https://github.com/bitnami/charts/issues/12066)
+
+## 6.3.0 (2022-08-22)
+
+* [bitnami/spark] Add support for image digest apart from tag (#11959) ([e04b98a](https://github.com/bitnami/charts/commit/e04b98a)), closes [#11959](https://github.com/bitnami/charts/issues/11959)
+
+## <small>6.2.4 (2022-08-09)</small>
+
+* [bitnami/spark] Release 6.2.4 updating components versions ([5f9fbf4](https://github.com/bitnami/charts/commit/5f9fbf4))
+
+## <small>6.2.3 (2022-08-02)</small>
+
+* [bitnami/spark] Release 6.2.3 updating components versions ([dafc551](https://github.com/bitnami/charts/commit/dafc551))
+
+## <small>6.2.2 (2022-07-28)</small>
+
+* [bitnami/*] Update URLs to point to the new bitnami/containers monorepo (#11352) ([d665af0](https://github.com/bitnami/charts/commit/d665af0)), closes [#11352](https://github.com/bitnami/charts/issues/11352)
+* [bitnami/spark] Release 6.2.2 updating components versions ([bf56fb2](https://github.com/bitnami/charts/commit/bf56fb2))
+
+## <small>6.2.1 (2022-07-22)</small>
+
+* [bitnami/spark] Release 6.2.1 updating components versions ([fcaaa70](https://github.com/bitnami/charts/commit/fcaaa70))
+
+## 6.2.0 (2022-07-22)
+
+* [bitnami/spark] Init support scripts for spark chart added (#11297) ([f870f9c](https://github.com/bitnami/charts/commit/f870f9c)), closes [#11297](https://github.com/bitnami/charts/issues/11297)
+
+## <small>6.1.14 (2022-07-18)</small>
+
+* [bitnami/spark] Release 6.1.14 updating components versions ([b244712](https://github.com/bitnami/charts/commit/b244712))
+
+## <small>6.1.13 (2022-06-27)</small>
+
+* [bitnami/spark] Release 6.1.13 updating components versions ([b795ee6](https://github.com/bitnami/charts/commit/b795ee6))
+
+## <small>6.1.12 (2022-06-24)</small>
+
+* [bitnami/spark] Release 6.1.12 updating components versions ([59b6ffb](https://github.com/bitnami/charts/commit/59b6ffb))
+
+## <small>6.1.11 (2022-06-22)</small>
+
+* [bitnami/spark] Release 6.1.11 updating components versions ([30c3571](https://github.com/bitnami/charts/commit/30c3571))
+
+## <small>6.1.10 (2022-06-14)</small>
+
+* [bitnami/spark] fix: :bug: Use proper type for sidecars and init containers (#10759) ([05ca42c](https://github.com/bitnami/charts/commit/05ca42c)), closes [#10759](https://github.com/bitnami/charts/issues/10759)
+
+## <small>6.1.9 (2022-06-10)</small>
+
+* [bitnami/spark] Release 6.1.9 updating components versions ([6b8b678](https://github.com/bitnami/charts/commit/6b8b678))
+
+## <small>6.1.8 (2022-06-07)</small>
+
+* [bitnami/*] Replace Kubeapps URL in READMEs (and kubeapps Chart.yaml) and remove BKPR references (#1 ([c6a7914](https://github.com/bitnami/charts/commit/c6a7914)), closes [#10600](https://github.com/bitnami/charts/issues/10600)
+* Fix tolerations and topologySpreadConstraints default values (#10645) ([de31b1d](https://github.com/bitnami/charts/commit/de31b1d)), closes [#10645](https://github.com/bitnami/charts/issues/10645)
+
+## <small>6.1.7 (2022-06-06)</small>
+
+* [bitnami/spark] Release 6.1.7 updating components versions ([e1a840b](https://github.com/bitnami/charts/commit/e1a840b))
+
+## <small>6.1.6 (2022-06-01)</small>
+
+* [bitnami/several] Replace maintainers email by url (#10523) ([ff3cf61](https://github.com/bitnami/charts/commit/ff3cf61)), closes [#10523](https://github.com/bitnami/charts/issues/10523)
+
+## <small>6.1.5 (2022-05-21)</small>
+
+* [bitnami/spark] Release 6.1.5 updating components versions ([2ad5f3f](https://github.com/bitnami/charts/commit/2ad5f3f))
+
+## <small>6.1.4 (2022-05-20)</small>
+
+* [bitnami/*] Fix HPA API version template usage (#10332) ([85ce7af](https://github.com/bitnami/charts/commit/85ce7af)), closes [#10332](https://github.com/bitnami/charts/issues/10332)
+
+## <small>6.1.3 (2022-05-20)</small>
+
+* [bitnami/spark] Release 6.1.3 updating components versions ([dd96236](https://github.com/bitnami/charts/commit/dd96236))
+
+## <small>6.1.2 (2022-05-19)</small>
+
+* [bitnami/spark] Release 6.1.2 updating components versions ([f3bc122](https://github.com/bitnami/charts/commit/f3bc122))
+
+## <small>6.1.1 (2022-05-18)</small>
+
+* [bitnami/spark] Release 6.1.1 updating components versions ([d8fed4c](https://github.com/bitnami/charts/commit/d8fed4c))
+
+## 6.1.0 (2022-05-16)
+
+* [bitnami/*] add ingress extraRules feature (#10253) ([0f6cbb9](https://github.com/bitnami/charts/commit/0f6cbb9)), closes [#10253](https://github.com/bitnami/charts/issues/10253)
+
+## <small>6.0.3 (2022-05-13)</small>
+
+* [bitnami/spark] Use the new helper for HPA API version (#10212) ([491dc4d](https://github.com/bitnami/charts/commit/491dc4d)), closes [#10212](https://github.com/bitnami/charts/issues/10212)
+
+## <small>6.0.2 (2022-05-13)</small>
+
+* [bitnami/*] Remove old 'ci' files (#10171) ([5df30c4](https://github.com/bitnami/charts/commit/5df30c4)), closes [#10171](https://github.com/bitnami/charts/issues/10171)
+* [bitnami/*] Unify k8s directives separators (#10185) ([2650214](https://github.com/bitnami/charts/commit/2650214)), closes [#10185](https://github.com/bitnami/charts/issues/10185)
+
+## <small>6.0.1 (2022-05-12)</small>
+
+* [bitnami/spark] Add missing namespace metadata (#10158) ([aab98ad](https://github.com/bitnami/charts/commit/aab98ad)), closes [#10158](https://github.com/bitnami/charts/issues/10158)
+
+## 6.0.0 (2022-04-26)
+
+* [bitnami/spark] Chart standarization (#9826) ([03eeed7](https://github.com/bitnami/charts/commit/03eeed7)), closes [#9826](https://github.com/bitnami/charts/issues/9826)
+
+## <small>5.9.11 (2022-04-20)</small>
+
+* [bitnami/spark] Release 5.9.11 updating components versions ([2e08520](https://github.com/bitnami/charts/commit/2e08520))
+
+## <small>5.9.10 (2022-04-19)</small>
+
+* [bitnami/spark] Release 5.9.10 updating components versions ([08d9e21](https://github.com/bitnami/charts/commit/08d9e21))
+
+## <small>5.9.9 (2022-04-12)</small>
+
+* [bitnami/spark] Provide environment variables to driver command (#9753) ([5b1b331](https://github.com/bitnami/charts/commit/5b1b331)), closes [#9753](https://github.com/bitnami/charts/issues/9753)
+
+## <small>5.9.8 (2022-04-05)</small>
+
+* [bitnami/spark] Release 5.9.8 updating components versions ([c2ea8ee](https://github.com/bitnami/charts/commit/c2ea8ee))
+
+## <small>5.9.7 (2022-04-02)</small>
+
+* [bitnami/spark] Release 5.9.7 updating components versions ([da9e720](https://github.com/bitnami/charts/commit/da9e720))
+
+## <small>5.9.6 (2022-03-27)</small>
+
+* [bitnami/spark] Release 5.9.6 updating components versions ([24f9e0e](https://github.com/bitnami/charts/commit/24f9e0e))
+
+## <small>5.9.5 (2022-03-23)</small>
+
+* [bitnami/spark] fix: :bug: Move mounted configuration to /bitnami/spark (#9536) ([43722a1](https://github.com/bitnami/charts/commit/43722a1)), closes [#9536](https://github.com/bitnami/charts/issues/9536)
+
+## <small>5.9.4 (2022-03-16)</small>
+
+* [bitnami/spark] Release 5.9.4 updating components versions ([cca8c10](https://github.com/bitnami/charts/commit/cca8c10))
+
+## <small>5.9.3 (2022-02-27)</small>
+
+* [bitnami/spark] Release 5.9.3 updating components versions ([4c6f913](https://github.com/bitnami/charts/commit/4c6f913))
+
+## <small>5.9.2 (2022-02-09)</small>
+
+* [bitnami/spark] Release 5.9.2 updating components versions ([d603535](https://github.com/bitnami/charts/commit/d603535))
+
+## <small>5.9.1 (2022-02-07)</small>
+
+* [bitnami/spark] Release 5.9.1 updating components versions ([c48834d](https://github.com/bitnami/charts/commit/c48834d))
+* Non utf8 chars (#8923) ([6ffd18f](https://github.com/bitnami/charts/commit/6ffd18f)), closes [#8923](https://github.com/bitnami/charts/issues/8923)
+
+## 5.9.0 (2022-02-03)
+
+* [bitnami/spark] Open up https if security.ssl.enabled (#8844) ([97744e7](https://github.com/bitnami/charts/commit/97744e7)), closes [#8844](https://github.com/bitnami/charts/issues/8844) [#8417](https://github.com/bitnami/charts/issues/8417) [#8446](https://github.com/bitnami/charts/issues/8446)
+
+## <small>5.8.6 (2022-02-01)</small>
+
+* [bitnami/spark] Document configuring Spark Master as reverse proxy (#8845) ([8efcb5c](https://github.com/bitnami/charts/commit/8efcb5c)), closes [#8845](https://github.com/bitnami/charts/issues/8845) [#8121](https://github.com/bitnami/charts/issues/8121) [#5997](https://github.com/bitnami/charts/issues/5997)
+
+## <small>5.8.5 (2022-01-28)</small>
+
+* [bitnami/spark] Release 5.8.5 updating components versions ([9c934ee](https://github.com/bitnami/charts/commit/9c934ee))
+
+## <small>5.8.4 (2022-01-20)</small>
+
+* [bitnami/*] Readme automation (#8579) ([78d1938](https://github.com/bitnami/charts/commit/78d1938)), closes [#8579](https://github.com/bitnami/charts/issues/8579)
+* [bitnami/*] Update READMEs (#8716) ([b9a9533](https://github.com/bitnami/charts/commit/b9a9533)), closes [#8716](https://github.com/bitnami/charts/issues/8716)
+* [bitnami/several] Change prerequisites (#8725) ([8d740c5](https://github.com/bitnami/charts/commit/8d740c5)), closes [#8725](https://github.com/bitnami/charts/issues/8725)
+
+## <small>5.8.3 (2022-01-13)</small>
+
+* [bitnami/spark] Release 5.8.3 updating components versions ([074c852](https://github.com/bitnami/charts/commit/074c852))
+
+## <small>5.8.2 (2022-01-12)</small>
+
+* [bitnami/spark] Release 5.8.2 updating components versions ([139adbc](https://github.com/bitnami/charts/commit/139adbc))
+
+## <small>5.8.1 (2022-01-10)</small>
+
+* bitnami/spark: updated svc-master and master statefulset  to expose https port when ssl is enabled.  ([0e18898](https://github.com/bitnami/charts/commit/0e18898)), closes [#8608](https://github.com/bitnami/charts/issues/8608)
+
+## 5.8.0 (2022-01-05)
+
+* [bitnami/several] Adapt templating format (#8562) ([8cad18a](https://github.com/bitnami/charts/commit/8cad18a)), closes [#8562](https://github.com/bitnami/charts/issues/8562)
+* [bitnami/several] Add license to the README ([05f7633](https://github.com/bitnami/charts/commit/05f7633))
+* [bitnami/several] Add license to the README ([32fb238](https://github.com/bitnami/charts/commit/32fb238))
+* [bitnami/several] Add license to the README ([b87c2f7](https://github.com/bitnami/charts/commit/b87c2f7))
+
+## <small>5.7.14 (2021-12-31)</small>
+
+* [bitnami/several] Regenerate README tables ([a43cca7](https://github.com/bitnami/charts/commit/a43cca7))
+* [bitnami/spark] Release 5.7.14 updating components versions ([5aa9638](https://github.com/bitnami/charts/commit/5aa9638))
+
+## <small>5.7.13 (2021-12-01)</small>
+
+* [bitnami/spark] Release 5.7.13 updating components versions ([a945faf](https://github.com/bitnami/charts/commit/a945faf))
+
+## <small>5.7.12 (2021-11-29)</small>
+
+* [bitnami/several] Regenerate README tables ([ac75243](https://github.com/bitnami/charts/commit/ac75243))
+* [bitnami/several] Replace HTTP by HTTPS when possible (#8259) ([eafb5bd](https://github.com/bitnami/charts/commit/eafb5bd)), closes [#8259](https://github.com/bitnami/charts/issues/8259)
+
+## <small>5.7.11 (2021-11-26)</small>
+
+* [bitnami/spark] Release 5.7.11 updating components versions ([8af6827](https://github.com/bitnami/charts/commit/8af6827))
+
+## <small>5.7.10 (2021-11-18)</small>
+
+* [bitnami/several] Regenerate README tables ([3cefed3](https://github.com/bitnami/charts/commit/3cefed3))
+* [bitnami/spark] Update spark-submit example inline with Spark docs (#8145) ([1b0e502](https://github.com/bitnami/charts/commit/1b0e502)), closes [#8145](https://github.com/bitnami/charts/issues/8145)
+* Update "spark-submit" example in README.md ([2e99b7d](https://github.com/bitnami/charts/commit/2e99b7d))
+
+## <small>5.7.9 (2021-11-02)</small>
+
+* [bitnami/several] Regenerate README tables ([412cf6a](https://github.com/bitnami/charts/commit/412cf6a))
+* [bitnami/spark] Add ServiceAccount to Spark Worker and Master. (#7992) ([ab31422](https://github.com/bitnami/charts/commit/ab31422)), closes [#7992](https://github.com/bitnami/charts/issues/7992)
+
+## <small>5.7.8 (2021-10-27)</small>
+
+* [bitnami/spark] Release 5.7.8 updating components versions ([029c30f](https://github.com/bitnami/charts/commit/029c30f))
+
+## <small>5.7.7 (2021-10-26)</small>
+
+* [bitnami/several] Regenerate README tables ([c82619f](https://github.com/bitnami/charts/commit/c82619f))
+* [bitnami/spark] Release 5.7.7 updating components versions ([5b0182b](https://github.com/bitnami/charts/commit/5b0182b))
+
+## <small>5.7.6 (2021-10-24)</small>
+
+* [bitnami/spark] Release 5.7.6 updating components versions ([cc8e1e4](https://github.com/bitnami/charts/commit/cc8e1e4))
+
+## <small>5.7.5 (2021-10-22)</small>
+
+* [bitnami/several] Add chart info to NOTES.txt (#7889) ([a6751cd](https://github.com/bitnami/charts/commit/a6751cd)), closes [#7889](https://github.com/bitnami/charts/issues/7889)
+
+## <small>5.7.4 (2021-10-01)</small>
+
+* [bitnami/*] Drop support for deprecated cert-manager annotation (#7646) ([4297b79](https://github.com/bitnami/charts/commit/4297b79)), closes [#7646](https://github.com/bitnami/charts/issues/7646)
+* [bitnami/*] Generate READMEs with new generator version (#7614) ([e5ab2e6](https://github.com/bitnami/charts/commit/e5ab2e6)), closes [#7614](https://github.com/bitnami/charts/issues/7614)
+
+## <small>5.7.3 (2021-09-24)</small>
+
+* [bitnami/several] Regenerate README tables ([da2513b](https://github.com/bitnami/charts/commit/da2513b))
+* [bitnami/spark] Release 5.7.3 updating components versions ([5eb8c87](https://github.com/bitnami/charts/commit/5eb8c87))
+
+## <small>5.7.2 (2021-08-25)</small>
+
+* [bitnami/several] Update READMEs (#7108) ([44961d9](https://github.com/bitnami/charts/commit/44961d9)), closes [#7108](https://github.com/bitnami/charts/issues/7108)
+* [bitnami/spark] Release 5.7.2 updating components versions ([ca634f3](https://github.com/bitnami/charts/commit/ca634f3))
+
+## <small>5.7.1 (2021-07-29)</small>
+
+* [bitnami/spark] Release 5.7.1 updating components versions ([e90d267](https://github.com/bitnami/charts/commit/e90d267))
+
+## 5.7.0 (2021-07-27)
+
+* [bitnami/several] Add diagnostic mode (#7012) ([f1344b0](https://github.com/bitnami/charts/commit/f1344b0)), closes [#7012](https://github.com/bitnami/charts/issues/7012)
+
+## <small>5.6.3 (2021-07-21)</small>
+
+* [bitnami/*] Replace nil values (#6993) ([2be11a7](https://github.com/bitnami/charts/commit/2be11a7)), closes [#6993](https://github.com/bitnami/charts/issues/6993)
+
+## <small>5.6.2 (2021-07-15)</small>
+
+* [bitnami/*] Adapt values.yaml of Spark, Spring Cloud Data Flow and SuiteCRM charts (#6951) ([647d72d](https://github.com/bitnami/charts/commit/647d72d)), closes [#6951](https://github.com/bitnami/charts/issues/6951)
+
+## <small>5.6.1 (2021-06-29)</small>
+
+* [bitnami/spark] Release 5.6.1 updating components versions ([0f583a9](https://github.com/bitnami/charts/commit/0f583a9))
+
+## 5.6.0 (2021-06-29)
+
+* [bitnami/spark] Add runAsGroup support (#6789) ([18a71dc](https://github.com/bitnami/charts/commit/18a71dc)), closes [#6789](https://github.com/bitnami/charts/issues/6789)
+
+## <small>5.5.3 (2021-06-21)</small>
+
+* [bitnami/spark] Release 5.5.3 updating components versions ([0233241](https://github.com/bitnami/charts/commit/0233241))
+
+## <small>5.5.2 (2021-06-19)</small>
+
+* [bitnami/spark] Release 5.5.2 updating components versions ([9b9927a](https://github.com/bitnami/charts/commit/9b9927a))
+
+## <small>5.5.1 (2021-06-18)</small>
+
+* [bitnami/spark] Release 5.5.1 updating components versions ([e2a8105](https://github.com/bitnami/charts/commit/e2a8105))
+
+## 5.5.0 (2021-06-16)
+
+* [bitnami/spark] Add support for autogenerated certs (#6531) ([cc1cc8e](https://github.com/bitnami/charts/commit/cc1cc8e)), closes [#6531](https://github.com/bitnami/charts/issues/6531)
+
+## <small>5.4.5 (2021-06-10)</small>
+
+* T40023 Updated Spark README (#6614) ([b0399d9](https://github.com/bitnami/charts/commit/b0399d9)), closes [#6614](https://github.com/bitnami/charts/issues/6614)
+
+## <small>5.4.4 (2021-06-02)</small>
+
+* [bitnami/spark] Release 5.4.4 updating components versions ([8fd8cf2](https://github.com/bitnami/charts/commit/8fd8cf2))
+
+## <small>5.4.3 (2021-05-20)</small>
+
+* [bitnami/spark] Release 5.4.3 updating components versions ([59441b0](https://github.com/bitnami/charts/commit/59441b0))
+
+## <small>5.4.2 (2021-04-20)</small>
+
+* [bitnami/spark] Release 5.4.2 updating components versions ([d1ba23d](https://github.com/bitnami/charts/commit/d1ba23d))
+
+## <small>5.4.1 (2021-04-08)</small>
+
+* [bitnami/spark] Release 5.4.1 updating components versions ([5c0a34b](https://github.com/bitnami/charts/commit/5c0a34b))
+
+## 5.4.0 (2021-03-29)
+
+* Add parameter for workers podManagementPolicy (#5942) ([143bece](https://github.com/bitnami/charts/commit/143bece)), closes [#5942](https://github.com/bitnami/charts/issues/5942)
+
+## <small>5.3.1 (2021-03-09)</small>
+
+* [bitnami/spark] Release 5.3.1 updating components versions ([927f1a3](https://github.com/bitnami/charts/commit/927f1a3))
+
+## 5.3.0 (2021-03-09)
+
+* [bitnami/spark] Added hostNetwork in the spark charts (#5705) ([4a0bf2f](https://github.com/bitnami/charts/commit/4a0bf2f)), closes [#5705](https://github.com/bitnami/charts/issues/5705)
+
+## <small>5.2.3 (2021-03-04)</small>
+
+* [bitnami/*] Remove minideb mentions (#5677) ([870bc4d](https://github.com/bitnami/charts/commit/870bc4d)), closes [#5677](https://github.com/bitnami/charts/issues/5677)
+
+## <small>5.2.2 (2021-02-25)</small>
+
+* fix ingress.yaml annotations (#5607) ([4ac2aa5](https://github.com/bitnami/charts/commit/4ac2aa5)), closes [#5607](https://github.com/bitnami/charts/issues/5607)
+
+## <small>5.2.1 (2021-02-19)</small>
+
+* [bitnami/spark] Release 5.2.1 updating components versions ([d5a3c8d](https://github.com/bitnami/charts/commit/d5a3c8d))
+
+## 5.2.0 (2021-02-18)
+
+* Add seLinuxOptions to securityContext (#5511) ([0609061](https://github.com/bitnami/charts/commit/0609061)), closes [#5511](https://github.com/bitnami/charts/issues/5511)
+
+## <small>5.1.2 (2021-02-11)</small>
+
+* [bitnami/spark] Fix ingress service name (#5389) ([0c0d96b](https://github.com/bitnami/charts/commit/0c0d96b)), closes [#5389](https://github.com/bitnami/charts/issues/5389)
+
+## <small>5.1.1 (2021-02-02)</small>
+
+* [bitnami/spark] Release 5.1.1 updating components versions ([05408f0](https://github.com/bitnami/charts/commit/05408f0))
+
+## 5.1.0 (2021-01-28)
+
+* [bitnami/spark] Add hostAliases (#5308) ([ab283aa](https://github.com/bitnami/charts/commit/ab283aa)), closes [#5308](https://github.com/bitnami/charts/issues/5308)
+
+## <small>5.0.2 (2021-01-25)</small>
+
+* [bitnami/*] Unify icons in Chart.yaml and add missing fields (#5206) ([0462921](https://github.com/bitnami/charts/commit/0462921)), closes [#5206](https://github.com/bitnami/charts/issues/5206)
+
+## <small>5.0.1 (2021-01-19)</small>
+
+* [bitnami/*] Change helm version in the prerequisites (#5090) ([c5e67a3](https://github.com/bitnami/charts/commit/c5e67a3)), closes [#5090](https://github.com/bitnami/charts/issues/5090)
+* [bitnami/spark] Drop values-production.yaml support (#5131) ([71da09b](https://github.com/bitnami/charts/commit/71da09b)), closes [#5131](https://github.com/bitnami/charts/issues/5131)
+
+## 5.0.0 (2021-01-15)
+
+* [bitnami/spark] Major change: adapt ingress (#5010) ([40f6d48](https://github.com/bitnami/charts/commit/40f6d48)), closes [#5010](https://github.com/bitnami/charts/issues/5010)
+
+## <small>4.4.1 (2021-01-03)</small>
+
+* [bitnami/spark] Release 4.4.1 updating components versions ([d2983a3](https://github.com/bitnami/charts/commit/d2983a3))
+
+## 4.4.0 (2020-12-18)
+
+* [bitnami/spark] feat: add extraports to workers so we can monitor jobs (#4762) ([27476d0](https://github.com/bitnami/charts/commit/27476d0)), closes [#4762](https://github.com/bitnami/charts/issues/4762)
+
+## 4.3.0 (2020-12-15)
+
+* [bitnami/*] Affinity based on common presets (viii) (#4721) ([950ac9c](https://github.com/bitnami/charts/commit/950ac9c)), closes [#4721](https://github.com/bitnami/charts/issues/4721)
+* [bitnami/*] fix typos (#4699) ([49adc63](https://github.com/bitnami/charts/commit/49adc63)), closes [#4699](https://github.com/bitnami/charts/issues/4699)
+
+## <small>4.2.3 (2020-12-11)</small>
+
+* [bitnami/*] Update dependencies (#4694) ([2826c12](https://github.com/bitnami/charts/commit/2826c12)), closes [#4694](https://github.com/bitnami/charts/issues/4694)
+
+## <small>4.2.2 (2020-12-08)</small>
+
+* [bitnami/spark] Fix Prometheus metrics pod annotations (#4647) ([8b8ba9a](https://github.com/bitnami/charts/commit/8b8ba9a)), closes [#4647](https://github.com/bitnami/charts/issues/4647)
+* Add empty list for annotations (#4627) ([c15f09b](https://github.com/bitnami/charts/commit/c15f09b)), closes [#4627](https://github.com/bitnami/charts/issues/4627)
+* Reorder service and metrics to follow the standard guidelines (#4631) ([9f00de9](https://github.com/bitnami/charts/commit/9f00de9)), closes [#4631](https://github.com/bitnami/charts/issues/4631)
+
+## <small>4.2.1 (2020-12-04)</small>
+
+* [bitnami/spark] Release 4.2.1 updating components versions ([2d58081](https://github.com/bitnami/charts/commit/2d58081))
+
+## 4.2.0 (2020-12-04)
+
+* [bitnami/spark] Adds support for Spark metrics (#4605) ([53bec24](https://github.com/bitnami/charts/commit/53bec24)), closes [#4605](https://github.com/bitnami/charts/issues/4605)
+
+## 4.1.0 (2020-11-12)
+
+* [bitnami/spark] Adding extra pod labels (#4311) ([8baa73c](https://github.com/bitnami/charts/commit/8baa73c)), closes [#4311](https://github.com/bitnami/charts/issues/4311)
+
+## 4.0.0 (2020-11-10)
+
+* [bitnami/*] Include link to Troubleshootin guide on README.md (#4136) ([c08a20e](https://github.com/bitnami/charts/commit/c08a20e)), closes [#4136](https://github.com/bitnami/charts/issues/4136)
+* [bitnami/spark] Major version. Adapt Chart to apiVersion: v2 (#4290) ([fd3a4c7](https://github.com/bitnami/charts/commit/fd3a4c7)), closes [#4290](https://github.com/bitnami/charts/issues/4290)
+
+## <small>3.0.3 (2020-10-16)</small>
+
+* [bitnami/spark] Release 3.0.3 updating components versions ([9a042b7](https://github.com/bitnami/charts/commit/9a042b7))
+
+## <small>3.0.2 (2020-09-22)</small>
+
+* [bitnami/spark] Release 3.0.2 updating components versions ([f066d7b](https://github.com/bitnami/charts/commit/f066d7b))
+
+## <small>3.0.1 (2020-09-09)</small>
+
+* [bitnami/metrics-server] Add source repo (#3577) ([1ed12f9](https://github.com/bitnami/charts/commit/1ed12f9)), closes [#3577](https://github.com/bitnami/charts/issues/3577)
+* [bitnami/spark] Release 3.0.1 updating components versions ([82e8b49](https://github.com/bitnami/charts/commit/82e8b49))
+
+## 3.0.0 (2020-09-02)
+
+* [bitnami/spark] Add bitnami/common subchart and update components (#3588) ([218f995](https://github.com/bitnami/charts/commit/218f995)), closes [#3588](https://github.com/bitnami/charts/issues/3588)
+
+## <small>2.0.2 (2020-08-23)</small>
+
+* [bitnami/*] Fix TL;DR typo in READMEs (#3280) ([3d7ab40](https://github.com/bitnami/charts/commit/3d7ab40)), closes [#3280](https://github.com/bitnami/charts/issues/3280)
+* [bitnami/spark] Release 2.0.2 updating components versions ([795e5be](https://github.com/bitnami/charts/commit/795e5be))
+
+## <small>2.0.1 (2020-07-24)</small>
+
+* [bitnami/all] Add categories (#3075) ([63bde06](https://github.com/bitnami/charts/commit/63bde06)), closes [#3075](https://github.com/bitnami/charts/issues/3075)
+* [bitnami/spark] Release 2.0.1 updating components versions ([946abd1](https://github.com/bitnami/charts/commit/946abd1))
+
+## 2.0.0 (2020-06-25)
+
+* [bitnami/spark] Release 2.0.0 updating components versions ([37a89a6](https://github.com/bitnami/charts/commit/37a89a6))
+
+## <small>1.2.28 (2020-06-24)</small>
+
+* [bitnami/spark] Release 1.2.28 updating components versions ([d303f42](https://github.com/bitnami/charts/commit/d303f42))
+
+## <small>1.2.27 (2020-06-17)</small>
+
+* [bitnami/spark] Improve NOTES.txt to use the proper jar example (#2864) ([d8d7666](https://github.com/bitnami/charts/commit/d8d7666)), closes [#2864](https://github.com/bitnami/charts/issues/2864)
+
+## <small>1.2.26 (2020-06-11)</small>
+
+* [bitnami/spark] Release 1.2.26 updating components versions ([ab5c5dc](https://github.com/bitnami/charts/commit/ab5c5dc))
+
+## <small>1.2.25 (2020-06-10)</small>
+
+* [bitnami/spark] Release 1.2.25 updating components versions ([ceae2e6](https://github.com/bitnami/charts/commit/ceae2e6))
+
+## <small>1.2.24 (2020-06-09)</small>
+
+* [bitnami/spark] Release 1.2.24 updating components versions ([6c1827c](https://github.com/bitnami/charts/commit/6c1827c))
+
+## <small>1.2.23 (2020-06-08)</small>
+
+* [bitnami/several] Fix trailing spaces to make helm lint work on all of them (#2705) ([bafba3f](https://github.com/bitnami/charts/commit/bafba3f)), closes [#2705](https://github.com/bitnami/charts/issues/2705)
+* [bitnami/spark] Release 1.2.23 updating components versions ([ed61403](https://github.com/bitnami/charts/commit/ed61403))
+
+## <small>1.2.22 (2020-05-27)</small>
+
+* [bitnami/spark] Release 1.2.22 updating components versions ([d798bca](https://github.com/bitnami/charts/commit/d798bca))
+* update bitnami/common to be compatible with helm v2.12+ (#2615) ([c7751eb](https://github.com/bitnami/charts/commit/c7751eb)), closes [#2615](https://github.com/bitnami/charts/issues/2615)
+
+## <small>1.2.21 (2020-05-15)</small>
+
+* [bitnami/spark] Added pod annotations to spark chart (#2590) ([1ef0043](https://github.com/bitnami/charts/commit/1ef0043)), closes [#2590](https://github.com/bitnami/charts/issues/2590)
+
+## <small>1.2.20 (2020-05-11)</small>
+
+* [bitnami/spark] Release 1.2.20 updating components versions ([7debe69](https://github.com/bitnami/charts/commit/7debe69))
+
+## <small>1.2.19 (2020-05-08)</small>
+
+* [bitnami/spark] Release 1.2.19 updating components versions ([687bfdd](https://github.com/bitnami/charts/commit/687bfdd))
+
+## <small>1.2.18 (2020-04-22)</small>
+
+* [bitnami/spark] Release 1.2.18 updating components versions ([5e04a5d](https://github.com/bitnami/charts/commit/5e04a5d))
+
+## <small>1.2.17 (2020-04-17)</small>
+
+* [bitnami/spark] Release 1.2.17 updating components versions ([581866f](https://github.com/bitnami/charts/commit/581866f))
+
+## <small>1.2.16 (2020-04-16)</small>
+
+* [bitnami/spark] Release 1.2.16 updating components versions ([c9f8077](https://github.com/bitnami/charts/commit/c9f8077))
+
+## <small>1.2.15 (2020-04-07)</small>
+
+* [bitnami/spark] Release 1.2.15 updating components versions ([5905a05](https://github.com/bitnami/charts/commit/5905a05))
+
+## <small>1.2.14 (2020-04-06)</small>
+
+* [bitnami/spark] Release 1.2.14 updating components versions ([8e8b6da](https://github.com/bitnami/charts/commit/8e8b6da))
+
+## <small>1.2.13 (2020-03-30)</small>
+
+* [bitnami/spark] Release 1.2.13 updating components versions ([e07d9d9](https://github.com/bitnami/charts/commit/e07d9d9))
+
+## <small>1.2.12 (2020-03-26)</small>
+
+* [bitnami/spark] Release 1.2.12 updating components versions ([184e9f6](https://github.com/bitnami/charts/commit/184e9f6))
+
+## <small>1.2.11 (2020-03-20)</small>
+
+* [bitnami/spark] Release 1.2.11 updating components versions ([d3ce4f4](https://github.com/bitnami/charts/commit/d3ce4f4))
+
+## <small>1.2.10 (2020-03-12)</small>
+
+* [bitnami/spark] Release 1.2.10 updating components versions ([c8a461d](https://github.com/bitnami/charts/commit/c8a461d))
+
+## <small>1.2.9 (2020-03-11)</small>
+
+* Move charts from upstreamed folder to bitnami (#2032) ([a0e44f7](https://github.com/bitnami/charts/commit/a0e44f7)), closes [#2032](https://github.com/bitnami/charts/issues/2032)
+
+## <small>1.2.8 (2020-02-26)</small>
+
+* [bitnami/spark] Release 1.2.8 updating components versions ([1da43fd](https://github.com/bitnami/charts/commit/1da43fd))
+
+## <small>1.2.7 (2020-02-11)</small>
+
+* [bitnami/several] Adapt READMEs and helpers to Helm 3 (#1911) ([40ee57c](https://github.com/bitnami/charts/commit/40ee57c)), closes [#1911](https://github.com/bitnami/charts/issues/1911)
+
+## <small>1.2.6 (2020-02-09)</small>
+
+* [bitnami/spark] Release 1.2.6 updating components versions ([d6af4cc](https://github.com/bitnami/charts/commit/d6af4cc))
+
+## <small>1.2.5 (2020-01-24)</small>
+
+* [bitnami/spark] Release 1.2.5 updating components versions ([47d63ea](https://github.com/bitnami/charts/commit/47d63ea))
+* bump version of the chart ([264636c](https://github.com/bitnami/charts/commit/264636c))
+* make instruction more accurate on cluster ip scenario ([8892589](https://github.com/bitnami/charts/commit/8892589))
+* PR requests ([8a46490](https://github.com/bitnami/charts/commit/8a46490))
+* remove awk usage from NOTE.txt ([e9728b9](https://github.com/bitnami/charts/commit/e9728b9))
+* submit applications depend on the service type ([ab4fc22](https://github.com/bitnami/charts/commit/ab4fc22))
+
+## <small>1.2.3 (2020-01-14)</small>
+
+* [bitnami/spark] Release 1.2.3 updating components versions ([f5603b7](https://github.com/bitnami/charts/commit/f5603b7))
+
+## <small>1.2.2 (2020-01-10)</small>
+
+* [bitnami/spark] Release 1.2.2 updating components versions ([244ccdb](https://github.com/bitnami/charts/commit/244ccdb))
+* fix some linting errors ([c8c5a04](https://github.com/bitnami/charts/commit/c8c5a04))
+
+## <small>1.2.1 (2020-01-03)</small>
+
+* added abitlity to mount extra volumes in spark workers ([05dda9a](https://github.com/bitnami/charts/commit/05dda9a))
+* added to readme and values-production.yaml ([149fc14](https://github.com/bitnami/charts/commit/149fc14))
+* bumped minor version ([28ddd37](https://github.com/bitnami/charts/commit/28ddd37))
+* code review fix ([334ce5c](https://github.com/bitnami/charts/commit/334ce5c))
+* code review fixes ([02930b6](https://github.com/bitnami/charts/commit/02930b6))
+* fix spark notes errors with the service name ([063c016](https://github.com/bitnami/charts/commit/063c016))
+* Fixes to spark/templates/statefulset-master.yaml ([c934d16](https://github.com/bitnami/charts/commit/c934d16))
+* Fixes to spark/templates/statefulset-worker.yaml ([762fb2d](https://github.com/bitnami/charts/commit/762fb2d))
+* Update README.md ([7568a1a](https://github.com/bitnami/charts/commit/7568a1a))
+
+## 1.2.0 (2019-12-10)
+
+* [bitnami/spark] Update components versions ([c29b51b](https://github.com/bitnami/charts/commit/c29b51b))
+* Fix boolean logic with regards to spark secure connections ([df6d303](https://github.com/bitnami/charts/commit/df6d303))
+* restored auto generated password secret name ([0376591](https://github.com/bitnami/charts/commit/0376591))
+
+## 1.1.0 (2019-11-27)
+
+* [bitnami/spark] Lint chart + standardisation ([a139de3](https://github.com/bitnami/charts/commit/a139de3))
+
+## <small>1.0.12 (2019-11-20)</small>
+
+* Fix headless service selector ([5c6d252](https://github.com/bitnami/charts/commit/5c6d252))
+
+## <small>1.0.11 (2019-11-04)</small>
+
+* [bitnami/spark] Release 1.0.11 updating components versions ([98f1e6b](https://github.com/bitnami/charts/commit/98f1e6b))
+
+## <small>1.0.10 (2019-10-24)</small>
+
+* Fix links because of section renaming ([8e6fa3b](https://github.com/bitnami/charts/commit/8e6fa3b))
+
+## <small>1.0.9 (2019-10-23)</small>
+
+* Adapt README in charts (III) ([98eadc4](https://github.com/bitnami/charts/commit/98eadc4))
+
+## <small>1.0.8 (2019-10-15)</small>
+
+* [bitnami/spark] Update prerequisites ([29eb6b8](https://github.com/bitnami/charts/commit/29eb6b8))
+
+## <small>1.0.7 (2019-10-05)</small>
+
+* [bitnami/spark] Release 1.0.7 updating components versions ([617143b](https://github.com/bitnami/charts/commit/617143b))
+
+## <small>1.0.6 (2019-09-05)</small>
+
+* [bitnami/spark] Release 1.0.6 updating components versions ([a35a2f6](https://github.com/bitnami/charts/commit/a35a2f6))
+
+## <small>1.0.5 (2019-09-03)</small>
+
+* [bitnami/spark] Release 1.0.5 updating components versions ([24dc259](https://github.com/bitnami/charts/commit/24dc259))
+
+## <small>1.0.4 (2019-09-02)</small>
+
+* [bitnami/spark] Release 1.0.4 updating components versions ([68fb4e4](https://github.com/bitnami/charts/commit/68fb4e4))
+
+## <small>1.0.3 (2019-08-13)</small>
+
+* Moves replicaMax under autoscaling, adds differences of configuration (values / values-production) t ([a515699](https://github.com/bitnami/charts/commit/a515699))
+* Removes unneeded salida.yml, adds values.yaml ([b7a3bf5](https://github.com/bitnami/charts/commit/b7a3bf5))
+* Update README.md ([544680f](https://github.com/bitnami/charts/commit/544680f))
+* Updated version numbers ([aa0294b](https://github.com/bitnami/charts/commit/aa0294b))
+
+## <small>1.0.2 (2019-08-07)</small>
+
+* Bumps version in Chart.yaml ([7407a00](https://github.com/bitnami/charts/commit/7407a00))
+* Fixes for autoscaling enabled issues ([ed12fbd](https://github.com/bitnami/charts/commit/ed12fbd))
+
+## <small>1.0.1 (2019-07-23)</small>
+
+* [bitnami/spark] Fix affinity ([5d008b1](https://github.com/bitnami/charts/commit/5d008b1))
+
+## 1.0.0 (2019-07-17)
+
+* Implement again #1283 changes but bumping the major version ([1ce079c](https://github.com/bitnami/charts/commit/1ce079c)), closes [#1283](https://github.com/bitnami/charts/issues/1283)
+* Revert pull request #1283 ([8e5940a](https://github.com/bitnami/charts/commit/8e5940a)), closes [#1283](https://github.com/bitnami/charts/issues/1283)
+
+## <small>0.0.4 (2019-07-12)</small>
+
+* [bitnami/spark] Release 0.0.4 updating components versions ([740eced](https://github.com/bitnami/charts/commit/740eced))
+* Standardize component.name & component.fullname functions ([775948e](https://github.com/bitnami/charts/commit/775948e))
+
+## <small>0.0.3 (2019-07-05)</small>
+
+* Change Spark default service webPort ([19904a0](https://github.com/bitnami/charts/commit/19904a0))
+
+## <small>0.0.2 (2019-07-02)</small>
+
+* Add template for image on Spark Chart ([7a6535f](https://github.com/bitnami/charts/commit/7a6535f))
+
+## <small>0.0.1 (2019-06-28)</small>
+
+* Add Spark Helm Chart ([448c8a6](https://github.com/bitnami/charts/commit/448c8a6))

--- a/bitnami/spark/Chart.lock
+++ b/bitnami/spark/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.19.2
-digest: sha256:e670e1075bfafffe040fae1158f1fa1f592585f394b48704ba137d2d083b1571
-generated: "2024-05-14T05:16:26.424303488Z"
+  version: 2.19.3
+digest: sha256:de997835d9ce9a9deefc2d70d8c62b11aa1d1a76ece9e86a83736ab9f930bf4d
+generated: "2024-05-21T14:41:18.903529117+02:00"

--- a/bitnami/spark/Chart.yaml
+++ b/bitnami/spark/Chart.yaml
@@ -27,4 +27,4 @@ maintainers:
 name: spark
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/spark
-version: 9.0.4
+version: 9.1.0

--- a/bitnami/spark/templates/NOTES.txt
+++ b/bitnami/spark/templates/NOTES.txt
@@ -101,3 +101,4 @@ In order to replicate the container startup scripts execute this command:
 {{ include "spark.checkRollingTags" . }}
 {{ include "spark.validateValues" . }}
 {{- include "common.warnings.resources" (dict "sections" (list "master" "security.ssl" "worker") "context" $) }}
+{{- include "common.warnings.modifiedImages" (dict "images" (list .Values.image) "context" $) }}


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Replacing the original images that have been tested and verified when releasing the chart is a dangerous practice in terms of security, performance and available features. This PR updates the `NOTES.txt` file using the `common.warnings.modifiedImages` helper developed in https://github.com/bitnami/charts/pull/25952.


<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

Users are more aware of the risks of changing original images.
<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

n/a
<!-- Describe any known limitations with your change -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
