### PR TITLE
[bitnami/thanos] feat: :sparkles: :lock: Add warning when original images are replaced

### DIFF
--- a/bitnami/thanos/CHANGELOG.md
+++ b/bitnami/thanos/CHANGELOG.md
@@ -1,0 +1,1552 @@
+# Changelog
+
+## 15.5.0 (2024-05-21)
+
+* [bitnami/thanos] feat: :sparkles: :lock: Add warning when original images are replaced ([#26283](https://github.com/bitnami/charts/pulls/26283))
+
+## <small>15.4.7 (2024-05-18)</small>
+
+* [bitnami/thanos] Release 15.4.7 updating components versions (#26083) ([e4c2454](https://github.com/bitnami/charts/commit/e4c2454)), closes [#26083](https://github.com/bitnami/charts/issues/26083)
+
+## <small>15.4.6 (2024-05-14)</small>
+
+* [bitnami/thanos] Release 15.4.6 updating components versions (#25829) ([bf6b3ec](https://github.com/bitnami/charts/commit/bf6b3ec)), closes [#25829](https://github.com/bitnami/charts/issues/25829)
+
+## <small>15.4.5 (2024-05-13)</small>
+
+* [bitnami/*] Change non-root and rolling-tags doc URLs (#25628) ([b067c94](https://github.com/bitnami/charts/commit/b067c94)), closes [#25628](https://github.com/bitnami/charts/issues/25628)
+* [bitnami/thanos] Release 15.4.5 updating components versions (#25715) ([41cae24](https://github.com/bitnami/charts/commit/41cae24)), closes [#25715](https://github.com/bitnami/charts/issues/25715)
+
+## <small>15.4.4 (2024-05-08)</small>
+
+* [bitnami/*] Set new header/owner (#25558) ([8d1dc11](https://github.com/bitnami/charts/commit/8d1dc11)), closes [#25558](https://github.com/bitnami/charts/issues/25558)
+* [bitnami/thanos] Release 15.4.4 updating components versions (#25622) ([8f47d6a](https://github.com/bitnami/charts/commit/8f47d6a)), closes [#25622](https://github.com/bitnami/charts/issues/25622)
+
+## <small>15.4.3 (2024-05-02)</small>
+
+* [bitnami/thanos] Release 15.4.3 updating components versions (#25503) ([b63467f](https://github.com/bitnami/charts/commit/b63467f)), closes [#25503](https://github.com/bitnami/charts/issues/25503)
+
+## <small>15.4.2 (2024-05-02)</small>
+
+* correct thanos statefulset-sharded cache config mounts (#25487) ([bb1ece6](https://github.com/bitnami/charts/commit/bb1ece6)), closes [#25487](https://github.com/bitnami/charts/issues/25487)
+
+## <small>15.4.1 (2024-04-26)</small>
+
+* [bitnami/thanos] Fix mountPath conflict thanos store (#25384) ([057cc2b](https://github.com/bitnami/charts/commit/057cc2b)), closes [#25384](https://github.com/bitnami/charts/issues/25384)
+
+## 15.4.0 (2024-04-25)
+
+* [bitnami/multiple charts] Fix typo: "NetworkPolice" vs "NetworkPolicy" (#25348) ([6970c1b](https://github.com/bitnami/charts/commit/6970c1b)), closes [#25348](https://github.com/bitnami/charts/issues/25348)
+* [bitnami/thanos] Add custom tsdb path (#25334) ([77c4c6f](https://github.com/bitnami/charts/commit/77c4c6f)), closes [#25334](https://github.com/bitnami/charts/issues/25334)
+* [bitnami/thanos] Use endpoint group optionally for Store Gateways (#25336) ([e416257](https://github.com/bitnami/charts/commit/e416257)), closes [#25336](https://github.com/bitnami/charts/issues/25336)
+* Replace VMware by Broadcom copyright text (#25306) ([a5e4bd0](https://github.com/bitnami/charts/commit/a5e4bd0)), closes [#25306](https://github.com/bitnami/charts/issues/25306)
+
+## 15.3.0 (2024-04-24)
+
+* [bitnami/thanos] Fix thanos query downstream URL with HTTPS enabled (#25175) ([252c4ef](https://github.com/bitnami/charts/commit/252c4ef)), closes [#25175](https://github.com/bitnami/charts/issues/25175)
+
+## <small>15.2.2 (2024-04-24)</small>
+
+* [bitnami/thanos] Fix thanos checksum annotations (#24737) ([b67cc70](https://github.com/bitnami/charts/commit/b67cc70)), closes [#24737](https://github.com/bitnami/charts/issues/24737)
+
+## <small>15.2.1 (2024-04-23)</small>
+
+* [bitnami/thanos] Fix storegateway cache configs (#25242) ([b2b8c91](https://github.com/bitnami/charts/commit/b2b8c91)), closes [#25242](https://github.com/bitnami/charts/issues/25242)
+
+## 15.2.0 (2024-04-23)
+
+* [bitnami/thanos] added pvc labels to thanos-receive (#24934) ([2acf132](https://github.com/bitnami/charts/commit/2acf132)), closes [#24934](https://github.com/bitnami/charts/issues/24934) [#24927](https://github.com/bitnami/charts/issues/24927)
+
+## <small>15.1.3 (2024-04-23)</small>
+
+* [bitnami/thanos] add terminationGracePeriodSeconds (#25315) ([aff45b2](https://github.com/bitnami/charts/commit/aff45b2)), closes [#25315](https://github.com/bitnami/charts/issues/25315)
+
+## <small>15.1.2 (2024-04-22)</small>
+
+* [bitnami/thanos] Fix compaction prometheusRule template (#25188) ([05ca034](https://github.com/bitnami/charts/commit/05ca034)), closes [#25188](https://github.com/bitnami/charts/issues/25188)
+
+## <small>15.1.1 (2024-04-22)</small>
+
+* Remove service monitor labels from headless services (#25171) ([38947e0](https://github.com/bitnami/charts/commit/38947e0)), closes [#25171](https://github.com/bitnami/charts/issues/25171)
+
+## 15.1.0 (2024-04-18)
+
+* [bitnami/thanos] Allow disabling mTLS for GRPC (#25189) ([a892573](https://github.com/bitnami/charts/commit/a892573)), closes [#25189](https://github.com/bitnami/charts/issues/25189)
+
+## <small>15.0.5 (2024-04-11)</small>
+
+* fix(thanos): enable Ingress only when component is enabled (#25103) ([f696f8c](https://github.com/bitnami/charts/commit/f696f8c)), closes [#25103](https://github.com/bitnami/charts/issues/25103)
+
+## <small>15.0.4 (2024-04-05)</small>
+
+* [bitnami/thanos] Release 15.0.4 updating components versions (#24978) ([5a26c10](https://github.com/bitnami/charts/commit/5a26c10)), closes [#24978](https://github.com/bitnami/charts/issues/24978)
+
+## <small>15.0.3 (2024-04-05)</small>
+
+* [bitnami/thanos] Release 15.0.3 (#24921) ([273bce4](https://github.com/bitnami/charts/commit/273bce4)), closes [#24921](https://github.com/bitnami/charts/issues/24921)
+
+## <small>15.0.2 (2024-04-03)</small>
+
+* [bitnami/thanos]Fix: Make prometheus rules reliable with release name (#24655) ([a2a6eab](https://github.com/bitnami/charts/commit/a2a6eab)), closes [#24655](https://github.com/bitnami/charts/issues/24655) [#24651](https://github.com/bitnami/charts/issues/24651) [#24651](https://github.com/bitnami/charts/issues/24651)
+* Update resourcesPreset comments (#24467) ([92e3e8a](https://github.com/bitnami/charts/commit/92e3e8a)), closes [#24467](https://github.com/bitnami/charts/issues/24467)
+
+## <small>15.0.1 (2024-04-03)</small>
+
+* [bitnami/thanos] fix: use https for queryURL when ingress is tls (#24456) ([78e9746](https://github.com/bitnami/charts/commit/78e9746)), closes [#24456](https://github.com/bitnami/charts/issues/24456)
+
+## 15.0.0 (2024-04-02)
+
+* [bitnami/thanos] feat!: :lock: :boom: Improve security defaults (#24715) ([566b718](https://github.com/bitnami/charts/commit/566b718)), closes [#24715](https://github.com/bitnami/charts/issues/24715)
+
+## <small>14.0.2 (2024-03-22)</small>
+
+* [bitnami/*] Reorder Chart sections (#24455) ([0cf4048](https://github.com/bitnami/charts/commit/0cf4048)), closes [#24455](https://github.com/bitnami/charts/issues/24455)
+* [bitnami/thanos] Fix thanos objstoreConfig and storegatewayConfigMap (#24603) ([9a0fece](https://github.com/bitnami/charts/commit/9a0fece)), closes [#24603](https://github.com/bitnami/charts/issues/24603)
+
+## <small>14.0.1 (2024-03-15)</small>
+
+* [bitnami/thanos] Fine-granted checksum calculation for deployment re-trigger (#24014) ([7469e43](https://github.com/bitnami/charts/commit/7469e43)), closes [#24014](https://github.com/bitnami/charts/issues/24014)
+
+## 14.0.0 (2024-03-15)
+
+* [bitnami/thanos] Update bundled MinIO (#24477) ([8dbd383](https://github.com/bitnami/charts/commit/8dbd383)), closes [#24477](https://github.com/bitnami/charts/issues/24477)
+
+## <small>13.4.1 (2024-03-07)</small>
+
+* [bitnami/thanos] Release 13.4.1 updating components versions (#24231) ([57995fd](https://github.com/bitnami/charts/commit/57995fd)), closes [#24231](https://github.com/bitnami/charts/issues/24231)
+
+## 13.4.0 (2024-03-06)
+
+* [bitnami/thanos] feat: :sparkles: :lock: Add automatic adaptation for Openshift restricted-v2 SCC (# ([8583f41](https://github.com/bitnami/charts/commit/8583f41)), closes [#24161](https://github.com/bitnami/charts/issues/24161)
+
+## 13.3.0 (2024-03-01)
+
+* [bitnami/thanos] feat: :sparkles: :lock: Add runAsGroup (#23995) ([0011046](https://github.com/bitnami/charts/commit/0011046)), closes [#23995](https://github.com/bitnami/charts/issues/23995)
+
+## <small>13.2.2 (2024-02-22)</small>
+
+* [bitnami/thanos] Release 13.2.2 updating components versions (#23833) ([4440601](https://github.com/bitnami/charts/commit/4440601)), closes [#23833](https://github.com/bitnami/charts/issues/23833)
+
+## <small>13.2.1 (2024-02-21)</small>
+
+* [bitnami/thanos] Release 13.2.1 updating components versions (#23699) ([e2491f9](https://github.com/bitnami/charts/commit/e2491f9)), closes [#23699](https://github.com/bitnami/charts/issues/23699)
+
+## 13.2.0 (2024-02-20)
+
+* [bitnami/*] Bump all versions (#23602) ([b70ee2a](https://github.com/bitnami/charts/commit/b70ee2a)), closes [#23602](https://github.com/bitnami/charts/issues/23602)
+
+## 13.1.0 (2024-02-16)
+
+* [bitnami/thanos] feat: :sparkles: :lock: Add resource preset support (#23527) ([1c268f3](https://github.com/bitnami/charts/commit/1c268f3)), closes [#23527](https://github.com/bitnami/charts/issues/23527)
+
+## 13.0.0 (2024-02-14)
+
+* [bitnami/thanos] feat!: :recycle: :lock: Refactor and enable NetworkPolicy by default (#22687) ([89643fd](https://github.com/bitnami/charts/commit/89643fd)), closes [#22687](https://github.com/bitnami/charts/issues/22687)
+
+## <small>12.23.2 (2024-02-07)</small>
+
+* [bitnami/thanos] Release 12.23.2 updating components versions (#23279) ([f03c904](https://github.com/bitnami/charts/commit/f03c904)), closes [#23279](https://github.com/bitnami/charts/issues/23279)
+
+## <small>12.23.1 (2024-02-03)</small>
+
+* [bitnami/thanos] Release 12.23.1 updating components versions (#23145) ([7cccb85](https://github.com/bitnami/charts/commit/7cccb85)), closes [#23145](https://github.com/bitnami/charts/issues/23145)
+
+## 12.23.0 (2024-01-29)
+
+* [bitnami/thanos] feat: Option to enable ephemeral persistent volume for compactor (#22808) ([055c8ed](https://github.com/bitnami/charts/commit/055c8ed)), closes [#22808](https://github.com/bitnami/charts/issues/22808)
+* [bitnami/thanos] Fix revisionHistoryLimit for thanos storegateway (#22751) ([bc4b1dc](https://github.com/bitnami/charts/commit/bc4b1dc)), closes [#22751](https://github.com/bitnami/charts/issues/22751)
+
+## <small>12.22.1 (2024-01-27)</small>
+
+* [bitnami/thanos] Release 12.22.1 updating components versions (#22803) ([dc6bce1](https://github.com/bitnami/charts/commit/dc6bce1)), closes [#22803](https://github.com/bitnami/charts/issues/22803)
+
+## 12.22.0 (2024-01-26)
+
+* [bitnami/*] Move documentation sections from docs.bitnami.com back to the README (#22203) ([7564f36](https://github.com/bitnami/charts/commit/7564f36)), closes [#22203](https://github.com/bitnami/charts/issues/22203)
+* [bitnami/thanos] Add revisionHistoryLimit option for each component (#22698) ([0413c10](https://github.com/bitnami/charts/commit/0413c10)), closes [#22698](https://github.com/bitnami/charts/issues/22698)
+
+## <small>12.21.2 (2024-01-24)</small>
+
+* [bitnami/thanos] fix: :bug: Set seLinuxOptions to null for Openshift compatibility (#22664) ([38e9c47](https://github.com/bitnami/charts/commit/38e9c47)), closes [#22664](https://github.com/bitnami/charts/issues/22664)
+* [thanos]: Add labels option for query service GRPC (#22228) ([325f583](https://github.com/bitnami/charts/commit/325f583)), closes [#22228](https://github.com/bitnami/charts/issues/22228)
+
+## <small>12.21.1 (2024-01-18)</small>
+
+* [bitnami/thanos] Release 12.21.1 updating components versions (#22343) ([106af76](https://github.com/bitnami/charts/commit/106af76)), closes [#22343](https://github.com/bitnami/charts/issues/22343)
+
+## 12.21.0 (2024-01-16)
+
+* [bitnami/thanos] fix: :lock: Improve podSecurityContext and containerSecurityContext with essential  ([c6fc750](https://github.com/bitnami/charts/commit/c6fc750)), closes [#22195](https://github.com/bitnami/charts/issues/22195)
+
+## <small>12.20.4 (2024-01-15)</small>
+
+* [bitnami/thanos] fix: :lock: Do not use the default service account (#22031) ([5ba6305](https://github.com/bitnami/charts/commit/5ba6305)), closes [#22031](https://github.com/bitnami/charts/issues/22031)
+
+## <small>12.20.3 (2024-01-12)</small>
+
+* [bitnami/*] Fix ref links (in comments) (#21822) ([e4fa296](https://github.com/bitnami/charts/commit/e4fa296)), closes [#21822](https://github.com/bitnami/charts/issues/21822)
+* [bitnami/thanos] Release 12.20.3 updating components versions (#22010) ([af1b1c9](https://github.com/bitnami/charts/commit/af1b1c9)), closes [#22010](https://github.com/bitnami/charts/issues/22010)
+
+## <small>12.20.2 (2024-01-10)</small>
+
+* [bitnami/*] Fix docs.bitnami.com broken links (#21901) ([f35506d](https://github.com/bitnami/charts/commit/f35506d)), closes [#21901](https://github.com/bitnami/charts/issues/21901)
+* [bitnami/*] Update copyright: Year and company (#21815) ([6c4bf75](https://github.com/bitnami/charts/commit/6c4bf75)), closes [#21815](https://github.com/bitnami/charts/issues/21815)
+* [bitnami/thanos] Release 12.20.2 updating components versions (#21972) ([d6544fb](https://github.com/bitnami/charts/commit/d6544fb)), closes [#21972](https://github.com/bitnami/charts/issues/21972)
+
+## <small>12.20.1 (2023-12-21)</small>
+
+* [bitnami/thanos]: Removing replicas in storegateway in sharded mode when autoscaling is enabled (#21 ([fcb2dbb](https://github.com/bitnami/charts/commit/fcb2dbb)), closes [#21515](https://github.com/bitnami/charts/issues/21515)
+
+## 12.20.0 (2023-12-19)
+
+* [bitnami/thanos] Add Configurability for runbookUrl Parameter (#21628) ([83d8843](https://github.com/bitnami/charts/commit/83d8843)), closes [#21628](https://github.com/bitnami/charts/issues/21628)
+
+## <small>12.19.1 (2023-12-19)</small>
+
+* [bitnami/thanos] Release 12.19.1 updating components versions (#21645) ([e21d642](https://github.com/bitnami/charts/commit/e21d642)), closes [#21645](https://github.com/bitnami/charts/issues/21645)
+
+## 12.19.0 (2023-12-19)
+
+* [bitnami/thanos] Add minReadySeconds to Thanos Receive (#21583) ([0c325af](https://github.com/bitnami/charts/commit/0c325af)), closes [#21583](https://github.com/bitnami/charts/issues/21583)
+
+## 12.18.0 (2023-12-13)
+
+* [bitnami/thanos] Implement tpl for ingress hostname/extraTls (#21351) ([daa7324](https://github.com/bitnami/charts/commit/daa7324)), closes [#21351](https://github.com/bitnami/charts/issues/21351)
+
+## 12.17.0 (2023-12-11)
+
+* [bitnami/thanos] feat: expose compactor cronjob ttlSecondsAfterFinished (#21411) ([d2a41e2](https://github.com/bitnami/charts/commit/d2a41e2)), closes [#21411](https://github.com/bitnami/charts/issues/21411)
+
+## <small>12.16.2 (2023-12-07)</small>
+
+* [bitnami/thanos] Release 12.16.2 updating components versions (#21436) ([f1d93a5](https://github.com/bitnami/charts/commit/f1d93a5)), closes [#21436](https://github.com/bitnami/charts/issues/21436)
+
+## <small>12.16.1 (2023-11-21)</small>
+
+* [bitnami/*] Rename solutions to "Bitnami package for ..." (#21038) ([b82f979](https://github.com/bitnami/charts/commit/b82f979)), closes [#21038](https://github.com/bitnami/charts/issues/21038)
+* [bitnami/thanos] Release 12.16.1 updating components versions (#21180) ([1d867ec](https://github.com/bitnami/charts/commit/1d867ec)), closes [#21180](https://github.com/bitnami/charts/issues/21180)
+
+## 12.16.0 (2023-11-20)
+
+* [bitnami/*] Remove relative links to non-README sections, add verification for that and update TL;DR ([1103633](https://github.com/bitnami/charts/commit/1103633)), closes [#20967](https://github.com/bitnami/charts/issues/20967)
+* [bitnami/thanos] feat: add generic ephemeral volume option for compactor (#21030) ([5f9344f](https://github.com/bitnami/charts/commit/5f9344f)), closes [#21030](https://github.com/bitnami/charts/issues/21030)
+
+## 12.15.0 (2023-11-10)
+
+* [bitnami/thanos] Automatically apply query-frontend's ingress hostname to alert.queryURL (#20795) ([fe05d92](https://github.com/bitnami/charts/commit/fe05d92)), closes [#20795](https://github.com/bitnami/charts/issues/20795)
+
+## <small>12.14.2 (2023-11-09)</small>
+
+* [bitnami/thanos] Release 12.14.2 updating components versions (#20831) ([f017cfa](https://github.com/bitnami/charts/commit/f017cfa)), closes [#20831](https://github.com/bitnami/charts/issues/20831)
+
+## <small>12.14.1 (2023-11-08)</small>
+
+* [bitnami/thanos] Release 12.14.1 updating components versions (#20788) ([8560811](https://github.com/bitnami/charts/commit/8560811)), closes [#20788](https://github.com/bitnami/charts/issues/20788)
+
+## 12.14.0 (2023-11-07)
+
+* [bitnami/thanos] feat: :sparkles: Add support for PSA restricted policy (#20553) ([af354f2](https://github.com/bitnami/charts/commit/af354f2)), closes [#20553](https://github.com/bitnami/charts/issues/20553)
+
+## <small>12.13.13 (2023-10-25)</small>
+
+* [bitnami/*] Rename VMware Application Catalog (#20361) ([3acc734](https://github.com/bitnami/charts/commit/3acc734)), closes [#20361](https://github.com/bitnami/charts/issues/20361)
+* [bitnami/*] Skip image's tag in the README files of the Bitnami Charts (#19841) ([bb9a01b](https://github.com/bitnami/charts/commit/bb9a01b)), closes [#19841](https://github.com/bitnami/charts/issues/19841)
+* [bitnami/*] Standardize documentation (#19835) ([af5f753](https://github.com/bitnami/charts/commit/af5f753)), closes [#19835](https://github.com/bitnami/charts/issues/19835)
+* [bitnami/thanos] Fix dup common labels in the query pdb (#20340) ([f762fd2](https://github.com/bitnami/charts/commit/f762fd2)), closes [#20340](https://github.com/bitnami/charts/issues/20340)
+
+## <small>12.13.12 (2023-10-19)</small>
+
+* [bitnami/thanos] Release 12.13.12 (#20320) ([71d96f9](https://github.com/bitnami/charts/commit/71d96f9)), closes [#20320](https://github.com/bitnami/charts/issues/20320)
+
+## <small>12.13.11 (2023-10-12)</small>
+
+* [bitnami/thanos] Release 12.13.11 (#20194) ([1071560](https://github.com/bitnami/charts/commit/1071560)), closes [#20194](https://github.com/bitnami/charts/issues/20194)
+
+## <small>12.13.10 (2023-10-11)</small>
+
+* [bitnami/thanos] Release 12.13.10 (#20065) ([ff73e64](https://github.com/bitnami/charts/commit/ff73e64)), closes [#20065](https://github.com/bitnami/charts/issues/20065)
+
+## <small>12.13.9 (2023-10-10)</small>
+
+* [bitnami/thanos] Release 12.13.9 (#19988) ([23fc196](https://github.com/bitnami/charts/commit/23fc196)), closes [#19988](https://github.com/bitnami/charts/issues/19988)
+
+## <small>12.13.8 (2023-10-10)</small>
+
+* [bitnami/*] Update Helm charts prerequisites (#19745) ([eb755dd](https://github.com/bitnami/charts/commit/eb755dd)), closes [#19745](https://github.com/bitnami/charts/issues/19745)
+* [bitnami/thanos] Release 12.13.8 (#19944) ([0b59eb2](https://github.com/bitnami/charts/commit/0b59eb2)), closes [#19944](https://github.com/bitnami/charts/issues/19944)
+
+## <small>12.13.7 (2023-10-04)</small>
+
+* [bitnami/thanos] Release 12.13.7 (#19753) ([b2abc7a](https://github.com/bitnami/charts/commit/b2abc7a)), closes [#19753](https://github.com/bitnami/charts/issues/19753)
+
+## <small>12.13.6 (2023-10-02)</small>
+
+* [bitnami/thanos] Use common capabilities for PSP (#19641) ([3bcbd9a](https://github.com/bitnami/charts/commit/3bcbd9a)), closes [#19641](https://github.com/bitnami/charts/issues/19641)
+
+## <small>12.13.5 (2023-09-20)</small>
+
+* [bitnami/thanos] Release 12.13.5 (#19432) ([9a0c3f9](https://github.com/bitnami/charts/commit/9a0c3f9)), closes [#19432](https://github.com/bitnami/charts/issues/19432)
+* Revert "Autogenerate schema files (#19194)" (#19335) ([73d80be](https://github.com/bitnami/charts/commit/73d80be)), closes [#19194](https://github.com/bitnami/charts/issues/19194) [#19335](https://github.com/bitnami/charts/issues/19335)
+
+## <small>12.13.4 (2023-09-18)</small>
+
+* [bitnami/thanos] Fix line break issue with serviceMonitor selector labels (#19286) ([c4e23e0](https://github.com/bitnami/charts/commit/c4e23e0)), closes [#19286](https://github.com/bitnami/charts/issues/19286)
+* Autogenerate schema files (#19194) ([a2c2090](https://github.com/bitnami/charts/commit/a2c2090)), closes [#19194](https://github.com/bitnami/charts/issues/19194)
+
+## <small>12.13.3 (2023-09-08)</small>
+
+* [bitnami/thanos]: Use merge helper (#19119) ([9f4fe77](https://github.com/bitnami/charts/commit/9f4fe77)), closes [#19119](https://github.com/bitnami/charts/issues/19119)
+
+## <small>12.13.2 (2023-09-06)</small>
+
+* [bitnami/thanos] Release 12.13.2 (#19134) ([fe00bbb](https://github.com/bitnami/charts/commit/fe00bbb)), closes [#19134](https://github.com/bitnami/charts/issues/19134)
+
+## <small>12.13.1 (2023-09-01)</small>
+
+* [bitnami/thanos] Release 12.13.1 (#18985) ([35ad4d9](https://github.com/bitnami/charts/commit/35ad4d9)), closes [#18985](https://github.com/bitnami/charts/issues/18985)
+
+## 12.13.0 (2023-08-30)
+
+* bitnami/thanos enable custom secretName for query.ingress and query.ingress.grpc (#18409) ([c78083c](https://github.com/bitnami/charts/commit/c78083c)), closes [#18409](https://github.com/bitnami/charts/issues/18409)
+
+## <small>12.12.1 (2023-08-28)</small>
+
+* [bitnami/thanos] Release 12.12.1 (#18915) ([3edf0a1](https://github.com/bitnami/charts/commit/3edf0a1)), closes [#18915](https://github.com/bitnami/charts/issues/18915)
+
+## 12.12.0 (2023-08-28)
+
+* [bitnami/thanos] Support for customizing standard labels (#18756) ([065a727](https://github.com/bitnami/charts/commit/065a727)), closes [#18756](https://github.com/bitnami/charts/issues/18756)
+
+## <small>12.11.4 (2023-08-24)</small>
+
+* [bitnami/thanos] thanos/receive/ingress.yaml: support custom portName on extraHosts (#17173) ([d81bc2c](https://github.com/bitnami/charts/commit/d81bc2c)), closes [#17173](https://github.com/bitnami/charts/issues/17173)
+
+## <small>12.11.3 (2023-08-23)</small>
+
+* [bitnami/thanos] Release 12.11.3 (#18820) ([dd716c2](https://github.com/bitnami/charts/commit/dd716c2)), closes [#18820](https://github.com/bitnami/charts/issues/18820)
+
+## <small>12.11.2 (2023-08-21)</small>
+
+* [bitnami/thanos] Release 12.11.2 (#18725) ([20ea1e4](https://github.com/bitnami/charts/commit/20ea1e4)), closes [#18725](https://github.com/bitnami/charts/issues/18725)
+
+## <small>12.11.1 (2023-08-17)</small>
+
+* [bitnami/thanos] Release 12.11.1 (#18494) ([29cf2a1](https://github.com/bitnami/charts/commit/29cf2a1)), closes [#18494](https://github.com/bitnami/charts/issues/18494)
+
+## 12.11.0 (2023-08-09)
+
+* [bitnami/thanos] Allow customizing the thanos-sidecar's job name in prometheus alerts (#18140) ([7c285a8](https://github.com/bitnami/charts/commit/7c285a8)), closes [#18140](https://github.com/bitnami/charts/issues/18140)
+
+## <small>12.10.1 (2023-07-31)</small>
+
+* [bitnami/thanos] Add ServiceMonitor labels for receive-headless service (#17685) ([50a6bb3](https://github.com/bitnami/charts/commit/50a6bb3)), closes [#17685](https://github.com/bitnami/charts/issues/17685)
+
+## 12.10.0 (2023-07-31)
+
+* add dnsPolicy support in query deployment (#17520) ([769740a](https://github.com/bitnami/charts/commit/769740a)), closes [#17520](https://github.com/bitnami/charts/issues/17520)
+
+## <small>12.9.1 (2023-07-26)</small>
+
+* [bitnami/thanos] Release 12.9.1 (#17960) ([4047bb4](https://github.com/bitnami/charts/commit/4047bb4)), closes [#17960](https://github.com/bitnami/charts/issues/17960)
+
+## 12.9.0 (2023-07-25)
+
+* [bitnami/thanos] Add support for custom receiver statfulset labels (#17849) ([da889f4](https://github.com/bitnami/charts/commit/da889f4)), closes [#17849](https://github.com/bitnami/charts/issues/17849)
+
+## <small>12.8.6 (2023-07-19)</small>
+
+* [bitnami/thanos] Allow template expressions in extraFlags (#17345) ([1cbe931](https://github.com/bitnami/charts/commit/1cbe931)), closes [#17345](https://github.com/bitnami/charts/issues/17345)
+
+## <small>12.8.5 (2023-07-17)</small>
+
+* [bitnami/thanos] Release 12.8.5 (#17740) ([2472b4f](https://github.com/bitnami/charts/commit/2472b4f)), closes [#17740](https://github.com/bitnami/charts/issues/17740)
+
+## <small>12.8.4 (2023-07-13)</small>
+
+* [bitnami/thanos] Release 12.8.4 (#17682) ([04864c1](https://github.com/bitnami/charts/commit/04864c1)), closes [#17682](https://github.com/bitnami/charts/issues/17682)
+* Add copyright header (#17300) ([da68be8](https://github.com/bitnami/charts/commit/da68be8)), closes [#17300](https://github.com/bitnami/charts/issues/17300)
+* Fix rule config (#17111) ([df77c5d](https://github.com/bitnami/charts/commit/df77c5d)), closes [#17111](https://github.com/bitnami/charts/issues/17111)
+
+## <small>12.8.3 (2023-06-22)</small>
+
+* [bitnami/thanos] Release 12.8.3 (#17305) ([d8d3b05](https://github.com/bitnami/charts/commit/d8d3b05)), closes [#17305](https://github.com/bitnami/charts/issues/17305)
+
+## <small>12.8.2 (2023-06-21)</small>
+
+* [bitnami/thanos] Release 12.8.2 (#17284) ([ac5606e](https://github.com/bitnami/charts/commit/ac5606e)), closes [#17284](https://github.com/bitnami/charts/issues/17284)
+* [bitnami/thanos] Remove namespace field for cluster wide resources (#17260) ([99bad99](https://github.com/bitnami/charts/commit/99bad99)), closes [#17260](https://github.com/bitnami/charts/issues/17260)
+* Update charts readme (#17217) ([31b3c0a](https://github.com/bitnami/charts/commit/31b3c0a)), closes [#17217](https://github.com/bitnami/charts/issues/17217)
+
+## <small>12.8.1 (2023-06-21)</small>
+
+* [bitnami/thanos] Release 12.8.1 (#17280) ([ad18684](https://github.com/bitnami/charts/commit/ad18684)), closes [#17280](https://github.com/bitnami/charts/issues/17280)
+
+## 12.8.0 (2023-06-20)
+
+* [bitnami/thanos] Exclude headless services from serviceMonitor (#17118) ([55acf31](https://github.com/bitnami/charts/commit/55acf31)), closes [#17118](https://github.com/bitnami/charts/issues/17118)
+
+## 12.7.0 (2023-06-19)
+
+* [bitnami/thanos] Add labels for Thanos Compactor PVC (#17171) ([0d90bba](https://github.com/bitnami/charts/commit/0d90bba)), closes [#17171](https://github.com/bitnami/charts/issues/17171)
+
+## <small>12.6.3 (2023-06-13)</small>
+
+* [bitnami/*] Change copyright section in READMEs (#17006) ([ef986a1](https://github.com/bitnami/charts/commit/ef986a1)), closes [#17006](https://github.com/bitnami/charts/issues/17006)
+* [bitnami/several] Change copyright section in READMEs (#16989) ([5b6a5cf](https://github.com/bitnami/charts/commit/5b6a5cf)), closes [#16989](https://github.com/bitnami/charts/issues/16989)
+* [bitnami/thanos]: conditionals for compactor cronjob (#16898) ([90b290b](https://github.com/bitnami/charts/commit/90b290b)), closes [#16898](https://github.com/bitnami/charts/issues/16898) [bitnami/charts#16742](https://github.com/bitnami/charts/issues/16742)
+
+## <small>12.6.2 (2023-05-21)</small>
+
+* [bitnami/thanos] Release 12.6.2 (#16801) ([a8032e6](https://github.com/bitnami/charts/commit/a8032e6)), closes [#16801](https://github.com/bitnami/charts/issues/16801)
+
+## <small>12.6.1 (2023-05-17)</small>
+
+* [bitnami/thanos] Added support for query-url for Thanos ruler  (#16112) ([1f0028b](https://github.com/bitnami/charts/commit/1f0028b)), closes [#16112](https://github.com/bitnami/charts/issues/16112)
+* Add wording for enterprise page (#16560) ([8f22774](https://github.com/bitnami/charts/commit/8f22774)), closes [#16560](https://github.com/bitnami/charts/issues/16560)
+
+## 12.6.0 (2023-05-09)
+
+* [bitnami/several] Adapt Chart.yaml to set desired OCI annotations (#16546) ([fc9b18f](https://github.com/bitnami/charts/commit/fc9b18f)), closes [#16546](https://github.com/bitnami/charts/issues/16546)
+
+## <small>12.5.2 (2023-05-09)</small>
+
+* [bitnami/thanos] Release 12.5.2 (#16543) ([68ec23f](https://github.com/bitnami/charts/commit/68ec23f)), closes [#16543](https://github.com/bitnami/charts/issues/16543)
+
+## <small>12.5.1 (2023-05-02)</small>
+
+* [bitnami/thanos] Release 12.5.1 (#16334) ([9306142](https://github.com/bitnami/charts/commit/9306142)), closes [#16334](https://github.com/bitnami/charts/issues/16334)
+
+## 12.5.0 (2023-04-20)
+
+* [bitnami/*] Make Helm charts 100% OCI (#15998) ([8841510](https://github.com/bitnami/charts/commit/8841510)), closes [#15998](https://github.com/bitnami/charts/issues/15998)
+
+## <small>12.4.3 (2023-04-18)</small>
+
+* [bitnami/thanos] Fix autoGenerated GRPC certs by using common CA (#16000) ([9c5b31b](https://github.com/bitnami/charts/commit/9c5b31b)), closes [#16000](https://github.com/bitnami/charts/issues/16000)
+
+## <small>12.4.2 (2023-04-03)</small>
+
+* [bitnami/thanos] Fix dnsConfig in sharded thanos storegateway (#15827) ([d061eac](https://github.com/bitnami/charts/commit/d061eac)), closes [#15827](https://github.com/bitnami/charts/issues/15827)
+
+## <small>12.4.1 (2023-04-01)</small>
+
+* [bitnami/thanos] Release 12.4.1 (#15901) ([76a8472](https://github.com/bitnami/charts/commit/76a8472)), closes [#15901](https://github.com/bitnami/charts/issues/15901)
+
+## 12.4.0 (2023-03-28)
+
+* [bitnami/thanos]: add dnsConfig option (#15694) ([b802b25](https://github.com/bitnami/charts/commit/b802b25)), closes [#15694](https://github.com/bitnami/charts/issues/15694)
+
+## <small>12.3.2 (2023-03-23)</small>
+
+* [bitnami/thanos] Release 12.3.2 (#15707) ([9a48a96](https://github.com/bitnami/charts/commit/9a48a96)), closes [#15707](https://github.com/bitnami/charts/issues/15707)
+
+## <small>12.3.1 (2023-03-19)</small>
+
+* [bitnami/thanos] Release 12.3.1 (#15619) ([3686549](https://github.com/bitnami/charts/commit/3686549)), closes [#15619](https://github.com/bitnami/charts/issues/15619)
+
+## 12.3.0 (2023-03-16)
+
+* [bitnami/thanos] Add HTTPS support to ServiceMonitors (#15397) ([97dbd2b](https://github.com/bitnami/charts/commit/97dbd2b)), closes [#15397](https://github.com/bitnami/charts/issues/15397)
+
+## <small>12.2.1 (2023-03-13)</small>
+
+* [bitnami/thanos] Release 12.2.1 (#15482) ([a27ae15](https://github.com/bitnami/charts/commit/a27ae15)), closes [#15482](https://github.com/bitnami/charts/issues/15482)
+
+## 12.2.0 (2023-03-10)
+
+* [bitnami/charts] Apply linter to README files (#15357) ([0e29e60](https://github.com/bitnami/charts/commit/0e29e60)), closes [#15357](https://github.com/bitnami/charts/issues/15357)
+* [bitnami/thanos] Add support for service.headless.annotations (#15446) ([b5430ea](https://github.com/bitnami/charts/commit/b5430ea)), closes [#15446](https://github.com/bitnami/charts/issues/15446)
+
+## <small>12.1.2 (2023-03-03)</small>
+
+* [bitnami/thanos]: Replace deprecated spec.serviceAccount field with spec.serviceAccountName (#15180) ([f9ab87f](https://github.com/bitnami/charts/commit/f9ab87f)), closes [#15180](https://github.com/bitnami/charts/issues/15180)
+
+## <small>12.1.1 (2023-03-01)</small>
+
+* [bitnami/thanos] Release 12.1.1 (#15250) ([a29838b](https://github.com/bitnami/charts/commit/a29838b)), closes [#15250](https://github.com/bitnami/charts/issues/15250)
+
+## 12.1.0 (2023-02-21)
+
+* [bitnami/thanos] Compactor cronjob (#14865) ([cae55cf](https://github.com/bitnami/charts/commit/cae55cf)), closes [#14865](https://github.com/bitnami/charts/issues/14865)
+
+## <small>12.0.6 (2023-02-17)</small>
+
+* [bitnami/*] Fix markdown linter issues (#14874) ([a51e0e8](https://github.com/bitnami/charts/commit/a51e0e8)), closes [#14874](https://github.com/bitnami/charts/issues/14874)
+* [bitnami/*] Fix markdown linter issues 2 (#14890) ([aa96572](https://github.com/bitnami/charts/commit/aa96572)), closes [#14890](https://github.com/bitnami/charts/issues/14890)
+* [bitnami/*] Remove unexpected extra spaces (#14873) ([c97c714](https://github.com/bitnami/charts/commit/c97c714)), closes [#14873](https://github.com/bitnami/charts/issues/14873)
+* [bitnami/thanos] Release 12.0.6 (#15033) ([37e26fb](https://github.com/bitnami/charts/commit/37e26fb)), closes [#15033](https://github.com/bitnami/charts/issues/15033)
+
+## <small>12.0.5 (2023-02-14)</small>
+
+* [bitnami/thanos] Add Support for timePartitioning resource management (#14780) ([cd1f358](https://github.com/bitnami/charts/commit/cd1f358)), closes [#14780](https://github.com/bitnami/charts/issues/14780)
+* [bitnami/thanos] Release 12.0.5 (#14866) ([f7cbb4d](https://github.com/bitnami/charts/commit/f7cbb4d)), closes [#14866](https://github.com/bitnami/charts/issues/14866)
+
+## <small>12.0.4 (2023-02-09)</small>
+
+* [bitnami/thanos] fix context for statefulset (#14797) ([3a7fa9c](https://github.com/bitnami/charts/commit/3a7fa9c)), closes [#14797](https://github.com/bitnami/charts/issues/14797)
+* [bitnami/thanos] Update README (#14217) ([2748063](https://github.com/bitnami/charts/commit/2748063)), closes [#14217](https://github.com/bitnami/charts/issues/14217)
+
+## <small>12.0.3 (2023-02-01)</small>
+
+* fix prometheusRule additionalLabels specification (#14674) ([38f2125](https://github.com/bitnami/charts/commit/38f2125)), closes [#14674](https://github.com/bitnami/charts/issues/14674)
+
+## <small>12.0.2 (2023-01-31)</small>
+
+* [bitnami/*] Change copyright date (#14682) ([add4ec7](https://github.com/bitnami/charts/commit/add4ec7)), closes [#14682](https://github.com/bitnami/charts/issues/14682)
+* [bitnami/thanos] Release 12.0.2 (#14691) ([e949840](https://github.com/bitnami/charts/commit/e949840)), closes [#14691](https://github.com/bitnami/charts/issues/14691)
+
+## <small>12.0.1 (2023-01-31)</small>
+
+* [bitnami/*] Unify READMEs (#14472) ([2064fb8](https://github.com/bitnami/charts/commit/2064fb8)), closes [#14472](https://github.com/bitnami/charts/issues/14472)
+* [bitnami/thanos] Don't regenerate self-signed certs on upgrade (#14664) ([f627ac2](https://github.com/bitnami/charts/commit/f627ac2)), closes [#14664](https://github.com/bitnami/charts/issues/14664)
+* [bitnami/thanos] Revisit tests (#14343) ([b055f10](https://github.com/bitnami/charts/commit/b055f10)), closes [#14343](https://github.com/bitnami/charts/issues/14343)
+
+## 12.0.0 (2023-01-19)
+
+* [bitnami/*] Add license annotation and remove obsolete engine parameter (#14293) ([da2a794](https://github.com/bitnami/charts/commit/da2a794)), closes [#14293](https://github.com/bitnami/charts/issues/14293)
+* [bitnami/*] Change licenses annotation format (#14377) ([0ab7608](https://github.com/bitnami/charts/commit/0ab7608)), closes [#14377](https://github.com/bitnami/charts/issues/14377)
+* [bitnami/thanos] Update MinIO subchart (#14448) ([50be8c9](https://github.com/bitnami/charts/commit/50be8c9)), closes [#14448](https://github.com/bitnami/charts/issues/14448)
+
+## <small>11.6.8 (2023-01-04)</small>
+
+* [bitnami/thanos] Release 11.6.8 (#14187) ([a2a28b2](https://github.com/bitnami/charts/commit/a2a28b2)), closes [#14187](https://github.com/bitnami/charts/issues/14187)
+
+## <small>11.6.7 (2023-01-03)</small>
+
+* [bitnami/thanos] Release 11.6.7 (#14170) ([d1d592d](https://github.com/bitnami/charts/commit/d1d592d)), closes [#14170](https://github.com/bitnami/charts/issues/14170)
+
+## <small>11.6.6 (2022-12-26)</small>
+
+* [bitnami/thanos] Release 11.6.6 (#14097) ([804c53c](https://github.com/bitnami/charts/commit/804c53c)), closes [#14097](https://github.com/bitnami/charts/issues/14097)
+
+## <small>11.6.5 (2022-12-14)</small>
+
+* [bitnami/thanos] Fix typo in chart values comments (#13933) ([4255d8f](https://github.com/bitnami/charts/commit/4255d8f)), closes [#13933](https://github.com/bitnami/charts/issues/13933)
+
+## <small>11.6.4 (2022-11-29)</small>
+
+* [bitnami/thanos] Release 11.6.4 (#13686) ([71f999e](https://github.com/bitnami/charts/commit/71f999e)), closes [#13686](https://github.com/bitnami/charts/issues/13686)
+* [bitnami/thanos] update PrometheusRule names to be unique (#13610) ([b57dada](https://github.com/bitnami/charts/commit/b57dada)), closes [#13610](https://github.com/bitnami/charts/issues/13610)
+
+## <small>11.6.3 (2022-11-24)</small>
+
+* [bitnami/thanos] Set custom topology key for podAntiAffinityPreset (#13581) ([3c43c64](https://github.com/bitnami/charts/commit/3c43c64)), closes [#13581](https://github.com/bitnami/charts/issues/13581)
+
+## <small>11.6.2 (2022-11-22)</small>
+
+* fix: Removed an extra curly brace, added a missing one (#13604) ([e875618](https://github.com/bitnami/charts/commit/e875618)), closes [#13604](https://github.com/bitnami/charts/issues/13604)
+
+## <small>11.6.1 (2022-11-17)</small>
+
+* [bitnami/thanos] fix apiversion hardcode for statefulset (#13542) ([42eae9e](https://github.com/bitnami/charts/commit/42eae9e)), closes [#13542](https://github.com/bitnami/charts/issues/13542)
+
+## 11.6.0 (2022-11-16)
+
+* [bitnami/thanos] Add prometheus alerts rules (#12873) ([1fbb541](https://github.com/bitnami/charts/commit/1fbb541)), closes [#12873](https://github.com/bitnami/charts/issues/12873)
+
+## <small>11.5.10 (2022-11-14)</small>
+
+* [bitnami/thanos] Fix issue with serviceAccount.create (#13502) ([1d57316](https://github.com/bitnami/charts/commit/1d57316)), closes [#13502](https://github.com/bitnami/charts/issues/13502)
+
+## <small>11.5.9 (2022-11-10)</small>
+
+* [bitnami/thanos] Fix documentation for ruler.alertmanagersConfig and ruler.alertmanagers (#13359) ([5fb0f61](https://github.com/bitnami/charts/commit/5fb0f61)), closes [#13359](https://github.com/bitnami/charts/issues/13359)
+
+## <small>11.5.8 (2022-11-08)</small>
+
+* [bitnami/thanos] Fix serviceAccount name logic for Thanos (#13406) ([2d6cc8f](https://github.com/bitnami/charts/commit/2d6cc8f)), closes [#13406](https://github.com/bitnami/charts/issues/13406)
+
+## <small>11.5.7 (2022-11-03)</small>
+
+* [bitnami/thanos] Modified serviceAccount name logic for Thanos (#13312) ([7915506](https://github.com/bitnami/charts/commit/7915506)), closes [#13312](https://github.com/bitnami/charts/issues/13312)
+
+## <small>11.5.6 (2022-10-31)</small>
+
+* [bitnami/*] Use new default branch name in links (#12943) ([a529e02](https://github.com/bitnami/charts/commit/a529e02)), closes [#12943](https://github.com/bitnami/charts/issues/12943)
+* Remove subPath from servicediscovery.yml (#12940) ([21e3cfd](https://github.com/bitnami/charts/commit/21e3cfd)), closes [#12940](https://github.com/bitnami/charts/issues/12940)
+
+## <small>11.5.5 (2022-10-07)</small>
+
+* [bitnami/thanos] Release 11.5.5 (#12848) ([8ef44e1](https://github.com/bitnami/charts/commit/8ef44e1)), closes [#12848](https://github.com/bitnami/charts/issues/12848)
+* Generic README instructions related to the repo (#12792) ([3cf6b10](https://github.com/bitnami/charts/commit/3cf6b10)), closes [#12792](https://github.com/bitnami/charts/issues/12792)
+
+## <small>11.5.4 (2022-10-03)</small>
+
+* [bitnami/thanos] Upgrade dependencies (#12755) ([4fc83d6](https://github.com/bitnami/charts/commit/4fc83d6)), closes [#12755](https://github.com/bitnami/charts/issues/12755)
+
+## <small>11.5.3 (2022-09-29)</small>
+
+* [bitnami/thanos] Release 11.5.3 updating components versions ([c21634b](https://github.com/bitnami/charts/commit/c21634b))
+
+## <small>11.5.2 (2022-09-28)</small>
+
+* [bitnami/thanos] Fix http config encoding (#12715) ([dbaa4a8](https://github.com/bitnami/charts/commit/dbaa4a8)), closes [#12715](https://github.com/bitnami/charts/issues/12715)
+
+## <small>11.5.1 (2022-09-19)</small>
+
+* [bitnami/thanos] Use custom probes if given (#12563) ([09dacb3](https://github.com/bitnami/charts/commit/09dacb3)), closes [#12563](https://github.com/bitnami/charts/issues/12563) [#12354](https://github.com/bitnami/charts/issues/12354)
+
+## 11.5.0 (2022-09-14)
+
+* [bitnami/thanos] Add support for HTTPS and basic auth experimental settings (#12404) ([422981c](https://github.com/bitnami/charts/commit/422981c)), closes [#12404](https://github.com/bitnami/charts/issues/12404)
+
+## <small>11.4.1 (2022-09-14)</small>
+
+* [bitnami/thanos] Fix receive-distributor nodeAffinityPreset (#12355) ([9e45e5d](https://github.com/bitnami/charts/commit/9e45e5d)), closes [#12355](https://github.com/bitnami/charts/issues/12355)
+
+## 11.4.0 (2022-09-02)
+
+* [bitnami/thanos] Allowed to add labels to query-frontend service and storegateway PVC (#11549) ([2da04d4](https://github.com/bitnami/charts/commit/2da04d4)), closes [#11549](https://github.com/bitnami/charts/issues/11549)
+
+## <small>11.3.1 (2022-08-30)</small>
+
+* [bitnami/thanos] Release 11.3.1 updating components versions ([9869e75](https://github.com/bitnami/charts/commit/9869e75))
+
+## 11.3.0 (2022-08-29)
+
+* [bitnami/thanos] feat: create sharded hpa and pdb for storegateway (#11426) ([cea7c08](https://github.com/bitnami/charts/commit/cea7c08)), closes [#11426](https://github.com/bitnami/charts/issues/11426)
+
+## <small>11.2.2 (2022-08-23)</small>
+
+* [bitnami/thanos] Update Chart.lock (#12108) ([c6b9ba3](https://github.com/bitnami/charts/commit/c6b9ba3)), closes [#12108](https://github.com/bitnami/charts/issues/12108)
+* Fix thanos compactor ingressclassname conditional (#11976) ([2881800](https://github.com/bitnami/charts/commit/2881800)), closes [#11976](https://github.com/bitnami/charts/issues/11976)
+
+## <small>11.2.1 (2022-08-22)</small>
+
+* [bitnami/thanos] Update Chart.lock (#11979) ([aa39c57](https://github.com/bitnami/charts/commit/aa39c57)), closes [#11979](https://github.com/bitnami/charts/issues/11979)
+
+## 11.2.0 (2022-08-22)
+
+* [bitnami/thanos] - Fix typo in k8s annotation (#11553) ([63a17fc](https://github.com/bitnami/charts/commit/63a17fc)), closes [#11553](https://github.com/bitnami/charts/issues/11553)
+* [bitnami/thanos] Add support for image digest apart from tag (#11955) ([7cd4152](https://github.com/bitnami/charts/commit/7cd4152)), closes [#11955](https://github.com/bitnami/charts/issues/11955)
+
+## <small>11.1.4 (2022-08-04)</small>
+
+* [bitnami/thanos] Release 11.1.4 updating components versions ([1765142](https://github.com/bitnami/charts/commit/1765142))
+
+## <small>11.1.3 (2022-07-27)</small>
+
+* [bitnami/*] Update URLs to point to the new bitnami/containers monorepo (#11352) ([d665af0](https://github.com/bitnami/charts/commit/d665af0)), closes [#11352](https://github.com/bitnami/charts/issues/11352)
+* [bitnami/thanos] Conditionally Set objstore arg and OBJSTORE_CONFIG for Thanos receive (#11274) ([fe373e8](https://github.com/bitnami/charts/commit/fe373e8)), closes [#11274](https://github.com/bitnami/charts/issues/11274)
+
+## <small>11.1.2 (2022-07-18)</small>
+
+* [bitnami/thanos] Release 11.1.2 updating components versions ([a49e568](https://github.com/bitnami/charts/commit/a49e568))
+
+## <small>11.1.1 (2022-07-15)</small>
+
+* replaced --store= with --endpoint (#11178) ([632a11d](https://github.com/bitnami/charts/commit/632a11d)), closes [#11178](https://github.com/bitnami/charts/issues/11178)
+
+## 11.1.0 (2022-07-12)
+
+* [bitnami/thanos] feat: update default prometheusrule value (#10979) ([3d81b51](https://github.com/bitnami/charts/commit/3d81b51)), closes [#10979](https://github.com/bitnami/charts/issues/10979)
+
+## 11.0.0 (2022-07-12)
+
+*  [bitnami/thanos]: Allow receiver to run without object store config (#11030) ([24fab8a](https://github.com/bitnami/charts/commit/24fab8a)), closes [#11030](https://github.com/bitnami/charts/issues/11030)
+* [bitnami/thanos] Creates separate service for grpc port of query module (#11051) ([dab4304](https://github.com/bitnami/charts/commit/dab4304)), closes [#11051](https://github.com/bitnami/charts/issues/11051)
+
+## <small>10.5.5 (2022-07-06)</small>
+
+* [bitnami/thanos] Release 10.5.5 updating components versions ([d4ef1ea](https://github.com/bitnami/charts/commit/d4ef1ea))
+
+## <small>10.5.4 (2022-06-29)</small>
+
+* [bitnami/thanos] Release 10.5.4 updating components versions ([6933c57](https://github.com/bitnami/charts/commit/6933c57))
+
+## <small>10.5.3 (2022-06-20)</small>
+
+* [bitnami/thanos] Fix customStartupProbe for thanos receive statefulset (#10780) ([2e87be1](https://github.com/bitnami/charts/commit/2e87be1)), closes [#10780](https://github.com/bitnami/charts/issues/10780)
+
+## <small>10.5.2 (2022-06-09)</small>
+
+* [bitnami/*] Replace Kubeapps URL in READMEs (and kubeapps Chart.yaml) and remove BKPR references (#1 ([c6a7914](https://github.com/bitnami/charts/commit/c6a7914)), closes [#10600](https://github.com/bitnami/charts/issues/10600)
+* [bitnami/thanos] Release 10.5.2 updating components versions ([f47996b](https://github.com/bitnami/charts/commit/f47996b))
+
+## <small>10.5.1 (2022-06-01)</small>
+
+* [bitnami/several] Replace maintainers email by url (#10523) ([ff3cf61](https://github.com/bitnami/charts/commit/ff3cf61)), closes [#10523](https://github.com/bitnami/charts/issues/10523)
+
+## 10.5.0 (2022-05-27)
+
+* [bitnami/thanos] Implement ServiceAccount.create and ServiceAccount.name with BWC (#10447) ([18f9389](https://github.com/bitnami/charts/commit/18f9389)), closes [#10447](https://github.com/bitnami/charts/issues/10447)
+
+## <small>10.4.3 (2022-05-26)</small>
+
+* [bitnami/thanos] Release 10.4.3 updating components versions ([295288d](https://github.com/bitnami/charts/commit/295288d))
+
+## <small>10.4.2 (2022-05-20)</small>
+
+* [bitnami/*] Fix HPA API version template usage (#10332) ([85ce7af](https://github.com/bitnami/charts/commit/85ce7af)), closes [#10332](https://github.com/bitnami/charts/issues/10332)
+
+## <small>10.4.1 (2022-05-19)</small>
+
+* [bitnami/thanos] Release 10.4.1 updating components versions ([c5c5446](https://github.com/bitnami/charts/commit/c5c5446))
+
+## 10.4.0 (2022-05-16)
+
+* [bitnami/*] add ingress extraRules feature (#10253) ([0f6cbb9](https://github.com/bitnami/charts/commit/0f6cbb9)), closes [#10253](https://github.com/bitnami/charts/issues/10253)
+
+## <small>10.3.10 (2022-05-13)</small>
+
+* [bitnami/thanos] Use the new helper for HPA API version (#10214) ([e4b6ee8](https://github.com/bitnami/charts/commit/e4b6ee8)), closes [#10214](https://github.com/bitnami/charts/issues/10214)
+
+## <small>10.3.9 (2022-05-13)</small>
+
+* [bitnami/*] Remove old 'ci' files (#10171) ([5df30c4](https://github.com/bitnami/charts/commit/5df30c4)), closes [#10171](https://github.com/bitnami/charts/issues/10171)
+* [bitnami/*] Unify k8s directives separators (#10185) ([2650214](https://github.com/bitnami/charts/commit/2650214)), closes [#10185](https://github.com/bitnami/charts/issues/10185)
+* [bitnami/thanos] Add missing namespace metadata (#10160) ([6c40169](https://github.com/bitnami/charts/commit/6c40169)), closes [#10160](https://github.com/bitnami/charts/issues/10160)
+
+## <small>10.3.8 (2022-05-11)</small>
+
+* [bitnami/*] Fix typo in comments (relay -> rely) (#10151) ([9cfe4a4](https://github.com/bitnami/charts/commit/9cfe4a4)), closes [#10151](https://github.com/bitnami/charts/issues/10151)
+
+## <small>10.3.7 (2022-05-05)</small>
+
+* [bitnami/thanos] Release 10.3.7 updating components versions ([e29e9a5](https://github.com/bitnami/charts/commit/e29e9a5))
+
+## <small>10.3.6 (2022-04-21)</small>
+
+* [bitnami/thanos] Release 10.3.6 updating components versions ([d13c99b](https://github.com/bitnami/charts/commit/d13c99b))
+
+## <small>10.3.5 (2022-04-20)</small>
+
+* [bitnami/thanos] set properly scope for include func in ingress  (#9824) ([d268423](https://github.com/bitnami/charts/commit/d268423)), closes [#9824](https://github.com/bitnami/charts/issues/9824)
+
+## <small>10.3.4 (2022-04-13)</small>
+
+* fix(thanos-storegateway): error in accessed value (#9762) ([1e7c762](https://github.com/bitnami/charts/commit/1e7c762)), closes [#9762](https://github.com/bitnami/charts/issues/9762)
+
+## <small>10.3.3 (2022-04-08)</small>
+
+* [bitnami/thanos] Use correct helpers for ingress-grpc.yaml (#9715) ([916552b](https://github.com/bitnami/charts/commit/916552b)), closes [#9715](https://github.com/bitnami/charts/issues/9715)
+
+## <small>10.3.2 (2022-04-06)</small>
+
+* [bitnami/thanos] Release 10.3.2 updating components versions ([0ecc1af](https://github.com/bitnami/charts/commit/0ecc1af))
+
+## <small>10.3.1 (2022-03-29)</small>
+
+* [bitnami/thanos] Release 10.3.1 updating components versions ([f5bc313](https://github.com/bitnami/charts/commit/f5bc313))
+
+## 10.3.0 (2022-03-29)
+
+* [bitnami/thanos] added Parameter for automountServiceAccountToken on every Deployment or Statefulset ([ebc73d5](https://github.com/bitnami/charts/commit/ebc73d5)), closes [#9590](https://github.com/bitnami/charts/issues/9590)
+
+## <small>10.2.3 (2022-03-24)</small>
+
+* [bitnami/thanos] Release 10.2.3 updating components versions ([6e4d898](https://github.com/bitnami/charts/commit/6e4d898))
+
+## <small>10.2.2 (2022-03-21)</small>
+
+* [bitnami/thanos] - updated version and fixed typo servername to serverName in deployment.yml (#9485) ([30c773f](https://github.com/bitnami/charts/commit/30c773f)), closes [#9485](https://github.com/bitnami/charts/issues/9485)
+
+## <small>10.2.1 (2022-03-18)</small>
+
+* [bitnami/thanos] Release 10.2.1 updating components versions ([2e4ab71](https://github.com/bitnami/charts/commit/2e4ab71))
+
+## 10.2.0 (2022-03-18)
+
+* [bitnami/thanos]  add replication-factor to receive-distributor and set replication-factor based on  ([7e3b2d2](https://github.com/bitnami/charts/commit/7e3b2d2)), closes [#9447](https://github.com/bitnami/charts/issues/9447)
+
+## <small>10.1.1 (2022-03-10)</small>
+
+* [bitnami/thanos] Release 10.1.1 updating components versions ([b1d6f97](https://github.com/bitnami/charts/commit/b1d6f97))
+
+## 10.1.0 (2022-03-10)
+
+* [bitnami/*] Fix non utf8 characters (#9347) ([0cec8a8](https://github.com/bitnami/charts/commit/0cec8a8)), closes [#9347](https://github.com/bitnami/charts/issues/9347)
+* Read only root file system thanos (#9358) ([4a34d72](https://github.com/bitnami/charts/commit/4a34d72)), closes [#9358](https://github.com/bitnami/charts/issues/9358)
+
+## 10.0.0 (2022-03-07)
+
+* [bitnami/thanos] Remove compatibility with MINIO_ACCESS_KEY and MINIO_SECRET_KEY (#9322) ([89cb308](https://github.com/bitnami/charts/commit/89cb308)), closes [#9322](https://github.com/bitnami/charts/issues/9322)
+
+## <small>9.0.13 (2022-03-04)</small>
+
+* [bitnami/several] Reorder subcharts (#9299) ([a041f6b](https://github.com/bitnami/charts/commit/a041f6b)), closes [#9299](https://github.com/bitnami/charts/issues/9299)
+
+## <small>9.0.12 (2022-03-03)</small>
+
+* [bitnami/thanos] Release 9.0.12 updating components versions ([4961e12](https://github.com/bitnami/charts/commit/4961e12))
+
+## <small>9.0.11 (2022-03-02)</small>
+
+* [bitnami/thanos] Fix: remove `replicas` setting if autoscaling is enabled. (#9254) ([7e76326](https://github.com/bitnami/charts/commit/7e76326)), closes [#9254](https://github.com/bitnami/charts/issues/9254)
+
+## <small>9.0.10 (2022-03-02)</small>
+
+* [bitnami/thanos] Fix: use name passed to receive.existingConfigmap if set (#9253) ([7946e12](https://github.com/bitnami/charts/commit/7946e12)), closes [#9253](https://github.com/bitnami/charts/issues/9253)
+
+## <small>9.0.9 (2022-03-01)</small>
+
+* [bitnami/thanos] Remove Replica Count if HPA is Enabled (#9235) ([0fc3c2f](https://github.com/bitnami/charts/commit/0fc3c2f)), closes [#9235](https://github.com/bitnami/charts/issues/9235)
+
+## <small>9.0.8 (2022-02-25)</small>
+
+* [bitnami/thanos] Added minio reference link in values.yaml (#9196) ([d97f4eb](https://github.com/bitnami/charts/commit/d97f4eb)), closes [#9196](https://github.com/bitnami/charts/issues/9196)
+
+## <small>9.0.7 (2022-02-25)</small>
+
+* [bitnami/thanos] Properly name HPA for receive-distributor (#9184) ([101b585](https://github.com/bitnami/charts/commit/101b585)), closes [#9184](https://github.com/bitnami/charts/issues/9184)
+
+## <small>9.0.6 (2022-02-24)</small>
+
+* [bitnami/Thanos] Add volumePermission initContainer for receive statefulset (#9172) ([f569b71](https://github.com/bitnami/charts/commit/f569b71)), closes [#9172](https://github.com/bitnami/charts/issues/9172)
+
+## <small>9.0.5 (2022-02-21)</small>
+
+* [bitnami/thanos] Do not hardcode PDB apiVersion (#9118) ([dbc4086](https://github.com/bitnami/charts/commit/dbc4086)), closes [#9118](https://github.com/bitnami/charts/issues/9118)
+
+## <small>9.0.4 (2022-02-09)</small>
+
+* [bitnami/thanos] Release 9.0.4 updating components versions ([415688c](https://github.com/bitnami/charts/commit/415688c))
+* Non utf8 chars (#8923) ([6ffd18f](https://github.com/bitnami/charts/commit/6ffd18f)), closes [#8923](https://github.com/bitnami/charts/issues/8923)
+
+## <small>9.0.3 (2022-02-02)</small>
+
+* [bitnami/*] Make use of new "common.ingress.certManagerRequest" helper (#8862) ([12e4c37](https://github.com/bitnami/charts/commit/12e4c37)), closes [#8862](https://github.com/bitnami/charts/issues/8862)
+
+## <small>9.0.2 (2022-01-28)</small>
+
+* [bitnami/thanos] fix receive-distributor pdb selector (#8810) ([6389b56](https://github.com/bitnami/charts/commit/6389b56)), closes [#8810](https://github.com/bitnami/charts/issues/8810)
+
+## <small>9.0.1 (2022-01-20)</small>
+
+* [bitnami/*] Update READMEs (#8716) ([b9a9533](https://github.com/bitnami/charts/commit/b9a9533)), closes [#8716](https://github.com/bitnami/charts/issues/8716)
+* [bitnami/several] Change prerequisites (#8725) ([8d740c5](https://github.com/bitnami/charts/commit/8d740c5)), closes [#8725](https://github.com/bitnami/charts/issues/8725)
+
+## 9.0.0 (2022-01-17)
+
+* [bitnami/*] Readme automation (#8579) ([78d1938](https://github.com/bitnami/charts/commit/78d1938)), closes [#8579](https://github.com/bitnami/charts/issues/8579)
+* [bitnami/thanos] Update MinIO subchart to newest major version (#8686) ([fdbefbf](https://github.com/bitnami/charts/commit/fdbefbf)), closes [#8686](https://github.com/bitnami/charts/issues/8686)
+
+## 8.3.0 (2022-01-05)
+
+* [bitnami/several] Adapt templating format (#8562) ([8cad18a](https://github.com/bitnami/charts/commit/8cad18a)), closes [#8562](https://github.com/bitnami/charts/issues/8562)
+* [bitnami/several] Add license to the README ([05f7633](https://github.com/bitnami/charts/commit/05f7633))
+* [bitnami/several] Add license to the README ([32fb238](https://github.com/bitnami/charts/commit/32fb238))
+* [bitnami/several] Add license to the README ([b87c2f7](https://github.com/bitnami/charts/commit/b87c2f7))
+* bitnami/thanos chart: readme typo (#8558) ([e8aa5f8](https://github.com/bitnami/charts/commit/e8aa5f8)), closes [#8558](https://github.com/bitnami/charts/issues/8558)
+
+## <small>8.2.5 (2021-12-22)</small>
+
+* [bitnami/thanos] Release 8.2.5 updating components versions ([c88784b](https://github.com/bitnami/charts/commit/c88784b))
+
+## <small>8.2.4 (2021-12-22)</small>
+
+* [bitnami/thanos] Release 8.2.4 updating components versions ([99ff271](https://github.com/bitnami/charts/commit/99ff271))
+
+## <small>8.2.3 (2021-12-17)</small>
+
+* [bitnami/thanos] fix auto Generated certificate  (#8405) ([8d4a546](https://github.com/bitnami/charts/commit/8d4a546)), closes [#8405](https://github.com/bitnami/charts/issues/8405)
+
+## <small>8.2.2 (2021-12-14)</small>
+
+* [bitnami/thanos] fix remote port in thanos-receive ingress (#8313) ([b8a5eb4](https://github.com/bitnami/charts/commit/b8a5eb4)), closes [#8313](https://github.com/bitnami/charts/issues/8313)
+* [bitnami/thanos] Release 8.2.2 updating components versions ([5d991d3](https://github.com/bitnami/charts/commit/5d991d3))
+
+## <small>8.2.1 (2021-12-09)</small>
+
+* [Thanos] Fix grpc.server.tls.autoGenerated doesn't work (#8323) ([42b51c5](https://github.com/bitnami/charts/commit/42b51c5)), closes [#8323](https://github.com/bitnami/charts/issues/8323)
+
+## 8.2.0 (2021-12-07)
+
+* [bitnami/thanos] Add networkpolicy support (#8283) ([d027f36](https://github.com/bitnami/charts/commit/d027f36)), closes [#8283](https://github.com/bitnami/charts/issues/8283)
+* Update Thanos Readme for minio configuration. (#8249) ([6eb0d3c](https://github.com/bitnami/charts/commit/6eb0d3c)), closes [#8249](https://github.com/bitnami/charts/issues/8249)
+
+## <small>8.1.2 (2021-11-29)</small>
+
+* [bitnami/several] Replace HTTP by HTTPS when possible (#8259) ([eafb5bd](https://github.com/bitnami/charts/commit/eafb5bd)), closes [#8259](https://github.com/bitnami/charts/issues/8259)
+
+## <small>8.1.1 (2021-11-26)</small>
+
+* [bitnami/thanos] Fix thanos query grpc nodeport (#8250) ([05c57f7](https://github.com/bitnami/charts/commit/05c57f7)), closes [#8250](https://github.com/bitnami/charts/issues/8250)
+
+## 8.1.0 (2021-11-23)
+
+* [bitnami/thanos] Add StoreGateway GRPC ingress (#8209) ([d35b691](https://github.com/bitnami/charts/commit/d35b691)), closes [#8209](https://github.com/bitnami/charts/issues/8209)
+
+## <small>8.0.3 (2021-11-15)</small>
+
+* [bitnami/thanos] fix port recive-distributor (#8099) ([17fd9b9](https://github.com/bitnami/charts/commit/17fd9b9)), closes [#8099](https://github.com/bitnami/charts/issues/8099)
+
+## <small>8.0.2 (2021-11-12)</small>
+
+* [thanos] fix non-autogenerated secrets type (#8105) ([f104c5d](https://github.com/bitnami/charts/commit/f104c5d)), closes [#8105](https://github.com/bitnami/charts/issues/8105)
+
+## <small>8.0.1 (2021-11-11)</small>
+
+* [bitnami/several] Regenerate README tables ([ef52074](https://github.com/bitnami/charts/commit/ef52074))
+* [bitnami/thanos] Fix Receiver Distributor (#8089) ([7f36a0c](https://github.com/bitnami/charts/commit/7f36a0c)), closes [#8089](https://github.com/bitnami/charts/issues/8089)
+
+## 8.0.0 (2021-11-05)
+
+* [bitnami/thanos] Chart standarized (#8023) ([5619131](https://github.com/bitnami/charts/commit/5619131)), closes [#8023](https://github.com/bitnami/charts/issues/8023)
+
+## 7.1.0 (2021-11-05)
+
+* [bitnami/thanos] Add additionalHeadless service to the querier component. (#7927) ([89d9d7d](https://github.com/bitnami/charts/commit/89d9d7d)), closes [#7927](https://github.com/bitnami/charts/issues/7927)
+
+## <small>7.0.5 (2021-11-02)</small>
+
+* [bitnami/thanos] Fix strategy configuration for Thanos Recieve (#7956) ([47abc23](https://github.com/bitnami/charts/commit/47abc23)), closes [#7956](https://github.com/bitnami/charts/issues/7956)
+
+## <small>7.0.4 (2021-10-29)</small>
+
+* corrects Thanos Query GRPC ingress service port for extraHosts (#7974) ([43beb15](https://github.com/bitnami/charts/commit/43beb15)), closes [#7974](https://github.com/bitnami/charts/issues/7974)
+
+## <small>7.0.3 (2021-10-29)</small>
+
+* [bitnami/*] Mark PodSecurityPolicy resources as deprecated (#7951) ([035d926](https://github.com/bitnami/charts/commit/035d926)), closes [#7951](https://github.com/bitnami/charts/issues/7951)
+* [bitnami/thanos] Fix Thanos Query GRPC Ingress service port (#7968) ([7db5ad3](https://github.com/bitnami/charts/commit/7db5ad3)), closes [#7968](https://github.com/bitnami/charts/issues/7968)
+
+## <small>7.0.2 (2021-10-28)</small>
+
+* [bitnami/thanos] Replace nodePorts.grpc/http to http/grpc.nodePorts in the servce sharded (#7940) ([1324736](https://github.com/bitnami/charts/commit/1324736)), closes [#7940](https://github.com/bitnami/charts/issues/7940)
+
+## <small>7.0.1 (2021-10-22)</small>
+
+* [bitnami/several] Add chart info to NOTES.txt (#7889) ([a6751cd](https://github.com/bitnami/charts/commit/a6751cd)), closes [#7889](https://github.com/bitnami/charts/issues/7889)
+* [bitnami/several] Regenerate README tables ([fbb0358](https://github.com/bitnami/charts/commit/fbb0358))
+
+## 7.0.0 (2021-10-21)
+
+* [bitnami/thanos] New major version (#7875) ([91120ea](https://github.com/bitnami/charts/commit/91120ea)), closes [#7875](https://github.com/bitnami/charts/issues/7875)
+
+## <small>6.0.14 (2021-10-19)</small>
+
+* [bitnami/several] Change pullPolicy for bitnami-shell image (#7852) ([9711a33](https://github.com/bitnami/charts/commit/9711a33)), closes [#7852](https://github.com/bitnami/charts/issues/7852)
+* [bitnami/several] Regenerate README tables ([d8e471f](https://github.com/bitnami/charts/commit/d8e471f))
+
+## <small>6.0.13 (2021-10-14)</small>
+
+* [bitnami/several] Regenerate README tables ([a678bc7](https://github.com/bitnami/charts/commit/a678bc7))
+* Fixed broken links in Airflow and Thanos READMEs (#7804) ([87ba524](https://github.com/bitnami/charts/commit/87ba524)), closes [#7804](https://github.com/bitnami/charts/issues/7804)
+
+## <small>6.0.12 (2021-10-06)</small>
+
+* [bitnami/several] Regenerate README tables ([cdcf8c1](https://github.com/bitnami/charts/commit/cdcf8c1))
+* [bitnami/thanos] Release 6.0.12 updating components versions ([995bb31](https://github.com/bitnami/charts/commit/995bb31))
+
+## <small>6.0.11 (2021-10-05)</small>
+
+* [bitnami/several] Regenerate README tables ([c3367d9](https://github.com/bitnami/charts/commit/c3367d9))
+* bitnami/thanos: Switch deployment strategy to 'Recreate' (#7402) ([bfe34d4](https://github.com/bitnami/charts/commit/bfe34d4)), closes [#7402](https://github.com/bitnami/charts/issues/7402)
+
+## <small>6.0.10 (2021-10-01)</small>
+
+* [bitnami/*] Drop support for deprecated cert-manager annotation (#7646) ([4297b79](https://github.com/bitnami/charts/commit/4297b79)), closes [#7646](https://github.com/bitnami/charts/issues/7646)
+
+## <small>6.0.4 (2021-09-30)</small>
+
+* [bitnami/several] Regenerate README tables ([5a24d1f](https://github.com/bitnami/charts/commit/5a24d1f))
+* [bitnami/thanos] compactor and storegateway svc ref in ingress with common name (#7548) ([2afda16](https://github.com/bitnami/charts/commit/2afda16)), closes [#7548](https://github.com/bitnami/charts/issues/7548)
+
+## <small>6.0.3 (2021-09-27)</small>
+
+* [bitnami/*] Generate READMEs with new generator version (#7614) ([e5ab2e6](https://github.com/bitnami/charts/commit/e5ab2e6)), closes [#7614](https://github.com/bitnami/charts/issues/7614)
+* [bitnami/several] Regenerate README tables ([79eac44](https://github.com/bitnami/charts/commit/79eac44))
+* [bitnami/thanos] Release 6.0.3 updating components versions ([8fefd0d](https://github.com/bitnami/charts/commit/8fefd0d))
+
+## <small>6.0.2 (2021-09-22)</small>
+
+* [bitnami/several] Regenerate README tables ([003a0fb](https://github.com/bitnami/charts/commit/003a0fb))
+* T41189 Fixed broken links in Thanos README (#7542) ([2d94f8c](https://github.com/bitnami/charts/commit/2d94f8c)), closes [#7542](https://github.com/bitnami/charts/issues/7542)
+
+## <small>6.0.1 (2021-09-16)</small>
+
+* [bitnami/thanos] Release 6.0.1 updating components versions ([a19ddba](https://github.com/bitnami/charts/commit/a19ddba))
+
+## 6.0.0 (2021-09-13)
+
+* [bitnami/several] Regenerate README tables ([a94b593](https://github.com/bitnami/charts/commit/a94b593))
+* [bitnami/thanos] Fix incorrect ingress name (#7442) ([2f783cb](https://github.com/bitnami/charts/commit/2f783cb)), closes [#7442](https://github.com/bitnami/charts/issues/7442)
+* [bitnami/thanos] Update subcharts (#7469) ([9beab3f](https://github.com/bitnami/charts/commit/9beab3f)), closes [#7469](https://github.com/bitnami/charts/issues/7469)
+
+## <small>5.5.1 (2021-09-10)</small>
+
+* [bitnami/several] Regenerate README tables ([dcb935c](https://github.com/bitnami/charts/commit/dcb935c))
+* [bitnami/thanos] Release 5.5.1 updating components versions ([82c1f72](https://github.com/bitnami/charts/commit/82c1f72))
+
+## 5.5.0 (2021-09-09)
+
+* [bitnami/several] Regenerate README tables ([e0a27b4](https://github.com/bitnami/charts/commit/e0a27b4))
+* [bitnami/thanos] Thanos receiver dualmode (#7148) ([418167c](https://github.com/bitnami/charts/commit/418167c)), closes [#7148](https://github.com/bitnami/charts/issues/7148)
+
+## 5.4.0 (2021-09-03)
+
+* [bitnami/several] Regenerate README tables ([6c9124f](https://github.com/bitnami/charts/commit/6c9124f))
+* [bitnami/thanos] add ingressClassName (#7374) ([55aa59e](https://github.com/bitnami/charts/commit/55aa59e)), closes [#7374](https://github.com/bitnami/charts/issues/7374)
+
+## <small>5.3.2 (2021-08-20)</small>
+
+* Bitnami/thanos receiver ingress issue (#7265) ([5286377](https://github.com/bitnami/charts/commit/5286377)), closes [#7265](https://github.com/bitnami/charts/issues/7265)
+
+## <small>5.3.1 (2021-08-12)</small>
+
+* [bitnami/thanos] Update thanos query to read sharded service (#7201) ([4bc6e08](https://github.com/bitnami/charts/commit/4bc6e08)), closes [#7201](https://github.com/bitnami/charts/issues/7201)
+
+## 5.3.0 (2021-08-12)
+
+* [bitnami/several] Regenerate README tables ([6c107e8](https://github.com/bitnami/charts/commit/6c107e8))
+* [bitnami/thanos] Add hash and time base partion for thanos store (#7049) ([404eb51](https://github.com/bitnami/charts/commit/404eb51)), closes [#7049](https://github.com/bitnami/charts/issues/7049)
+
+## <small>5.2.7 (2021-08-04)</small>
+
+* [bitnami/thanos] Release 5.2.7 updating components versions ([47fc2ee](https://github.com/bitnami/charts/commit/47fc2ee))
+
+## <small>5.2.6 (2021-08-02)</small>
+
+* [bitnami/thanos] Fix nil pointer exception when deploying Thanos with bucketweb ingress. (#7107) ([56297ba](https://github.com/bitnami/charts/commit/56297ba)), closes [#7107](https://github.com/bitnami/charts/issues/7107)
+
+## <small>5.2.5 (2021-07-27)</small>
+
+* [bitnami/several] Bump version and update READMEs (#7069) ([6340bff](https://github.com/bitnami/charts/commit/6340bff)), closes [#7069](https://github.com/bitnami/charts/issues/7069)
+
+## <small>5.2.4 (2021-07-27)</small>
+
+* Replace <sup> strings with &trade; in the README files (#7066) ([d298b49](https://github.com/bitnami/charts/commit/d298b49)), closes [#7066](https://github.com/bitnami/charts/issues/7066)
+
+## <small>5.2.3 (2021-07-22)</small>
+
+* [bitnami/thanos] Release 5.2.3 updating components versions ([f10d3e0](https://github.com/bitnami/charts/commit/f10d3e0))
+
+## <small>5.2.2 (2021-07-21)</small>
+
+* [bitnami/*] Replace nil values (#6993) ([2be11a7](https://github.com/bitnami/charts/commit/2be11a7)), closes [#6993](https://github.com/bitnami/charts/issues/6993)
+
+## <small>5.2.1 (2021-07-19)</small>
+
+* [bitnami/*] Adapt values.yaml of TensorFlow, TestLink and Thanos charts (#6965) ([71a2668](https://github.com/bitnami/charts/commit/71a2668)), closes [#6965](https://github.com/bitnami/charts/issues/6965)
+
+## 5.2.0 (2021-07-19)
+
+* [bitnami/thanos] Add Prometheus alerts for Thanos components (#6776) ([2d481f0](https://github.com/bitnami/charts/commit/2d481f0)), closes [#6776](https://github.com/bitnami/charts/issues/6776)
+
+## <small>5.1.1 (2021-07-13)</small>
+
+* [bitnami/thanos] Release 5.1.1 updating components versions ([74fe8aa](https://github.com/bitnami/charts/commit/74fe8aa))
+
+## 5.1.0 (2021-07-08)
+
+* [bitnami/thanos] Common labels thanos (#6885) ([2038d81](https://github.com/bitnami/charts/commit/2038d81)), closes [#6885](https://github.com/bitnami/charts/issues/6885)
+
+## 5.0.0 (2021-06-29)
+
+* [bitnami/thanos] Added containerSecurityContext and renamed securityContext to podSecurityContext (# ([1160eee](https://github.com/bitnami/charts/commit/1160eee)), closes [#6673](https://github.com/bitnami/charts/issues/6673)
+
+## 4.0.0 (2021-06-22)
+
+* [bitnami/thanos] Update Thanos' MinIO dependency to its latest major (#6732) ([e94fb6f](https://github.com/bitnami/charts/commit/e94fb6f)), closes [#6732](https://github.com/bitnami/charts/issues/6732)
+
+## <small>3.18.2 (2021-06-17)</small>
+
+* [bitnami/thanos] fix typo on receive component parameter documentation (#6687) ([bae7796](https://github.com/bitnami/charts/commit/bae7796)), closes [#6687](https://github.com/bitnami/charts/issues/6687)
+
+## <small>3.18.1 (2021-06-16)</small>
+
+* [bitnami/thanos] Add extended alertmanager configuration by flag or file (#6571) ([1b67f55](https://github.com/bitnami/charts/commit/1b67f55)), closes [#6571](https://github.com/bitnami/charts/issues/6571)
+* [bitnami/thanos] Modify autogenerate support to fix existingSecret (#6670) ([71eebdc](https://github.com/bitnami/charts/commit/71eebdc)), closes [#6670](https://github.com/bitnami/charts/issues/6670)
+
+## 3.18.0 (2021-06-10)
+
+* [bitnami/thanos] Add support for autogenerated certs (#6613) ([4435d7c](https://github.com/bitnami/charts/commit/4435d7c)), closes [#6613](https://github.com/bitnami/charts/issues/6613)
+
+## <small>3.17.8 (2021-06-04)</small>
+
+* [bitnami/thanos] Release 3.17.8 updating components versions ([065b110](https://github.com/bitnami/charts/commit/065b110))
+
+## <small>3.17.7 (2021-06-03)</small>
+
+* [bitnami/thanos] Release 3.17.7 updating components versions ([1292364](https://github.com/bitnami/charts/commit/1292364))
+
+## <small>3.17.6 (2021-05-31)</small>
+
+* [bitnami/thanos] fix securityContext for Receive (#6509) ([695d12b](https://github.com/bitnami/charts/commit/695d12b)), closes [#6509](https://github.com/bitnami/charts/issues/6509)
+
+## <small>3.17.5 (2021-05-28)</small>
+
+* [bitnami/thanos] Release 3.17.5 updating components versions ([e9a6e21](https://github.com/bitnami/charts/commit/e9a6e21))
+
+## <small>3.17.4 (2021-05-28)</small>
+
+* [bitnami/thanos] use multiple rules files (#6469) ([698aedc](https://github.com/bitnami/charts/commit/698aedc)), closes [#6469](https://github.com/bitnami/charts/issues/6469)
+
+## <small>3.17.3 (2021-05-21)</small>
+
+* [bitnami/thanos] Release 3.17.3 updating components versions ([e20c3e2](https://github.com/bitnami/charts/commit/e20c3e2))
+
+## <small>3.17.2 (2021-05-20)</small>
+
+* [bitnami/thanos] Release 3.17.2 updating components versions ([8fdcb1b](https://github.com/bitnami/charts/commit/8fdcb1b))
+
+## <small>3.17.1 (2021-05-17)</small>
+
+* [bitnami/thanos] Put /api/v1/receive at the first of rules (thanos-receive ingress) (#6382) ([aee8b9a](https://github.com/bitnami/charts/commit/aee8b9a)), closes [#6382](https://github.com/bitnami/charts/issues/6382)
+
+## 3.17.0 (2021-05-05)
+
+* [bitnami/thanos] Adding sidecars to services with ingress (#6259) ([3b7579b](https://github.com/bitnami/charts/commit/3b7579b)), closes [#6259](https://github.com/bitnami/charts/issues/6259)
+
+## 3.16.0 (2021-04-21)
+
+* feat(extraVolumes/Mounts): addition on all compoments (#6169) ([97c8a94](https://github.com/bitnami/charts/commit/97c8a94)), closes [#6169](https://github.com/bitnami/charts/issues/6169)
+
+## <small>3.15.1 (2021-04-16)</small>
+
+* [bitnami/thanos] fixed thanos/receive HPA (#6122) ([3f180c3](https://github.com/bitnami/charts/commit/3f180c3)), closes [#6122](https://github.com/bitnami/charts/issues/6122)
+
+## 3.15.0 (2021-04-02)
+
+* [bitnami/thanos] adding ability to pass env variables to containers (#5971) ([14777a2](https://github.com/bitnami/charts/commit/14777a2)), closes [#5971](https://github.com/bitnami/charts/issues/5971)
+* Added tls flag for thanos queryFrontend (#5959) ([a38f684](https://github.com/bitnami/charts/commit/a38f684)), closes [#5959](https://github.com/bitnami/charts/issues/5959)
+
+## <small>3.14.2 (2021-04-01)</small>
+
+* [bitnami/thanos] Release 3.14.2 updating components versions ([9d67a58](https://github.com/bitnami/charts/commit/9d67a58))
+
+## <small>3.14.1 (2021-03-26)</small>
+
+* [bitnami/thanos] Release 3.14.1 updating components versions ([636a0cf](https://github.com/bitnami/charts/commit/636a0cf))
+
+## 3.14.0 (2021-03-22)
+
+* bitnami/thanos - allow setting externalTrafficPolicy for services (#5860) ([a679659](https://github.com/bitnami/charts/commit/a679659)), closes [#5860](https://github.com/bitnami/charts/issues/5860)
+
+## <small>3.13.2 (2021-03-17)</small>
+
+* [bitnami/thanos] Parametrize Thanos Receive retention period (#5821) ([e1eea94](https://github.com/bitnami/charts/commit/e1eea94)), closes [#5821](https://github.com/bitnami/charts/issues/5821)
+
+## <small>3.13.1 (2021-03-12)</small>
+
+* [bitnami/thanos] introduce logFormat in Thanos components (#5747) ([5fd202d](https://github.com/bitnami/charts/commit/5fd202d)), closes [#5747](https://github.com/bitnami/charts/issues/5747)
+
+## 3.13.0 (2021-03-09)
+
+* [bitnami/thanos] Add ingress to ruler (#5736) ([555fc87](https://github.com/bitnami/charts/commit/555fc87)), closes [#5736](https://github.com/bitnami/charts/issues/5736)
+
+## 3.12.0 (2021-03-08)
+
+* [bitnami/thanos] Add PodLabels (#5718) ([b0bd9a6](https://github.com/bitnami/charts/commit/b0bd9a6)), closes [#5718](https://github.com/bitnami/charts/issues/5718)
+
+## <small>3.11.5 (2021-03-04)</small>
+
+* [bitnami/*] Remove minideb mentions (#5677) ([870bc4d](https://github.com/bitnami/charts/commit/870bc4d)), closes [#5677](https://github.com/bitnami/charts/issues/5677)
+
+## <small>3.11.4 (2021-02-24)</small>
+
+* [bitnami/thanos] Fixing hashrings.json for thanos-receive component. (#5604) ([0db206e](https://github.com/bitnami/charts/commit/0db206e)), closes [#5604](https://github.com/bitnami/charts/issues/5604) [#5549](https://github.com/bitnami/charts/issues/5549)
+
+## <small>3.11.3 (2021-02-22)</small>
+
+* [bitnami/*] Use common macro to define RBAC apiVersion (#5585) ([71fb99f](https://github.com/bitnami/charts/commit/71fb99f)), closes [#5585](https://github.com/bitnami/charts/issues/5585)
+
+## <small>3.11.2 (2021-02-19)</small>
+
+* [bitnami/thanos] Fixing weird behavior when helm library is used from flux and terraform (#5557) ([d56f21f](https://github.com/bitnami/charts/commit/d56f21f)), closes [#5557](https://github.com/bitnami/charts/issues/5557) [#5549](https://github.com/bitnami/charts/issues/5549)
+
+## <small>3.11.1 (2021-02-18)</small>
+
+* [bitnami/thanos] Fix query receive service discovery (#5510) ([3fe6864](https://github.com/bitnami/charts/commit/3fe6864)), closes [#5510](https://github.com/bitnami/charts/issues/5510)
+
+## 3.11.0 (2021-02-18)
+
+* [bitnami/thanos] Fixing local-endpoint to work also with scaling. (#5504) ([ed1a655](https://github.com/bitnami/charts/commit/ed1a655)), closes [#5504](https://github.com/bitnami/charts/issues/5504)
+
+## <small>3.10.1 (2021-02-17)</small>
+
+* [bitnami/thanos] fix receive serviceaccount ref to ruler (#5486) ([1b3b6ea](https://github.com/bitnami/charts/commit/1b3b6ea)), closes [#5486](https://github.com/bitnami/charts/issues/5486)
+
+## 3.10.0 (2021-02-17)
+
+* [bitnami/thanos] Add support to configurable replica label (#5512) ([447256b](https://github.com/bitnami/charts/commit/447256b)), closes [#5512](https://github.com/bitnami/charts/issues/5512)
+* [bitnami/thanos] Fix extraHosts fullnameOverride nil pointer (#5499) ([c813f9a](https://github.com/bitnami/charts/commit/c813f9a)), closes [#5499](https://github.com/bitnami/charts/issues/5499)
+
+## <small>3.9.1 (2021-02-16)</small>
+
+* Fix permissions image in thanos (#5506) ([30b36be](https://github.com/bitnami/charts/commit/30b36be)), closes [#5506](https://github.com/bitnami/charts/issues/5506)
+
+## 3.9.0 (2021-02-15)
+
+* [bitnami/thanos] Added support for headless (SRV Records) and Ingress for thanos receiver. (#5475) ([951c828](https://github.com/bitnami/charts/commit/951c828)), closes [#5475](https://github.com/bitnami/charts/issues/5475)
+
+## <small>3.8.6 (2021-02-15)</small>
+
+* [bitnami/thanos] fix query TLS client in a modular way (#5437) (#5457) ([bbbf490](https://github.com/bitnami/charts/commit/bbbf490)), closes [#5437](https://github.com/bitnami/charts/issues/5437) [#5457](https://github.com/bitnami/charts/issues/5457) [#5437](https://github.com/bitnami/charts/issues/5437) [#3988](https://github.com/bitnami/charts/issues/3988)
+
+## <small>3.8.5 (2021-02-12)</small>
+
+* [bitnami/thanos] Add receive to query dns discovery (#5467) ([0e3d0d6](https://github.com/bitnami/charts/commit/0e3d0d6)), closes [#5467](https://github.com/bitnami/charts/issues/5467)
+
+## <small>3.8.4 (2021-02-10)</small>
+
+* bitnami/thanos - Thanos Receive fixes (#5430) ([eaffdc0](https://github.com/bitnami/charts/commit/eaffdc0)), closes [#5430](https://github.com/bitnami/charts/issues/5430)
+
+## <small>3.8.3 (2021-02-08)</small>
+
+*  Update MinIO references, titles, descriptions and disclaimer (#5419) ([99fb55a](https://github.com/bitnami/charts/commit/99fb55a)), closes [#5419](https://github.com/bitnami/charts/issues/5419)
+
+## <small>3.8.2 (2021-02-08)</small>
+
+* [bitnami/thanos] Update ingress.yaml on all components to fix bad ingress behavior. (#5406) ([fe9bde9](https://github.com/bitnami/charts/commit/fe9bde9)), closes [#5406](https://github.com/bitnami/charts/issues/5406)
+
+## <small>3.8.1 (2021-02-04)</small>
+
+* [bitnami/several] Fix template issue when using ingress secrets (#5373) ([7fd5ea5](https://github.com/bitnami/charts/commit/7fd5ea5)), closes [#5373](https://github.com/bitnami/charts/issues/5373)
+
+## 3.8.0 (2021-02-02)
+
+* [bitnami/several] Monthly trademark review (#5375) ([307a73d](https://github.com/bitnami/charts/commit/307a73d)), closes [#5375](https://github.com/bitnami/charts/issues/5375)
+* [bitnami/thanos] Add storegateway secret grpc server tls support (#5344) ([307c637](https://github.com/bitnami/charts/commit/307c637)), closes [#5344](https://github.com/bitnami/charts/issues/5344)
+
+## <small>3.7.1 (2021-02-01)</small>
+
+* [bitnami/thanos] Release 3.7.1 updating components versions ([5adb4ea](https://github.com/bitnami/charts/commit/5adb4ea))
+
+## 3.7.0 (2021-01-29)
+
+* [bitnami/thanos] Add hostAliases (#5316) ([9d51691](https://github.com/bitnami/charts/commit/9d51691)), closes [#5316](https://github.com/bitnami/charts/issues/5316)
+
+## 3.6.0 (2021-01-28)
+
+* [bitnami/thanos]: query support for mounting existing secret for gRPC TLS confi… (#5058) ([f4f6e10](https://github.com/bitnami/charts/commit/f4f6e10)), closes [#5058](https://github.com/bitnami/charts/issues/5058)
+
+## 3.5.0 (2021-01-25)
+
+* [bitnami/thanos] Add receive component (#5069) ([faa2a87](https://github.com/bitnami/charts/commit/faa2a87)), closes [#5069](https://github.com/bitnami/charts/issues/5069)
+
+## <small>3.4.1 (2021-01-19)</small>
+
+* [bitnami/*] Change helm version in the prerequisites (#5090) ([c5e67a3](https://github.com/bitnami/charts/commit/c5e67a3)), closes [#5090](https://github.com/bitnami/charts/issues/5090)
+* [bitnami/thanos] Drop values-production.yaml support (#5133) ([6ba10e7](https://github.com/bitnami/charts/commit/6ba10e7)), closes [#5133](https://github.com/bitnami/charts/issues/5133)
+
+## 3.4.0 (2021-01-15)
+
+* [bitnami/*] Update ingress for serveral charts (#5012) ([e3bb5a6](https://github.com/bitnami/charts/commit/e3bb5a6)), closes [#5012](https://github.com/bitnami/charts/issues/5012)
+
+## <small>3.3.2 (2021-01-07)</small>
+
+* [bitnami/thanos] Release 3.3.2 updating components versions ([e135c0e](https://github.com/bitnami/charts/commit/e135c0e))
+
+## <small>3.3.1 (2021-01-07)</small>
+
+* [bitnami/minio,harbor,thanos,pytorch] Add trademark to MinIO (#4901) ([54e4bd7](https://github.com/bitnami/charts/commit/54e4bd7)), closes [#4901](https://github.com/bitnami/charts/issues/4901)
+
+## 3.3.0 (2020-12-15)
+
+* [bitnami/*] Affinity based on common presets (viii) (#4721) ([950ac9c](https://github.com/bitnami/charts/commit/950ac9c)), closes [#4721](https://github.com/bitnami/charts/issues/4721)
+* [bitnami/*] fix typos (#4699) ([49adc63](https://github.com/bitnami/charts/commit/49adc63)), closes [#4699](https://github.com/bitnami/charts/issues/4699)
+
+## <small>3.2.4 (2020-12-11)</small>
+
+* [bitnami/*] Update dependencies (#4694) ([2826c12](https://github.com/bitnami/charts/commit/2826c12)), closes [#4694](https://github.com/bitnami/charts/issues/4694)
+
+## <small>3.2.3 (2020-12-08)</small>
+
+* [bitnami/thanos] Release 3.2.3 updating components versions ([ef69f62](https://github.com/bitnami/charts/commit/ef69f62))
+
+## <small>3.2.2 (2020-12-01)</small>
+
+* [bitnami/thanos] Reorder HPA to prevent GitOps Diff (#4531) ([7acaf67](https://github.com/bitnami/charts/commit/7acaf67)), closes [#4531](https://github.com/bitnami/charts/issues/4531)
+
+## <small>3.2.1 (2020-11-26)</small>
+
+* [bitnami/thanos] Release 3.2.1 updating components versions ([09caa98](https://github.com/bitnami/charts/commit/09caa98))
+
+## 3.2.0 (2020-11-25)
+
+* [bitnami/thanos] allow $component.extraFlags to contain multi-line strings (#4473) ([2a349c6](https://github.com/bitnami/charts/commit/2a349c6)), closes [#4473](https://github.com/bitnami/charts/issues/4473)
+
+## <small>3.1.1 (2020-11-25)</small>
+
+* [bitnami/thanos] Release 3.1.1 updating components versions ([52b2238](https://github.com/bitnami/charts/commit/52b2238))
+
+## 3.1.0 (2020-11-24)
+
+* [bitnami/thanos] rename querier component to query (#4307) ([b9cc743](https://github.com/bitnami/charts/commit/b9cc743)), closes [#4307](https://github.com/bitnami/charts/issues/4307)
+
+## <small>3.0.1 (2020-11-19)</small>
+
+* [bitnami/thanos] Release 3.0.1 updating components versions ([6339dc6](https://github.com/bitnami/charts/commit/6339dc6))
+
+## 3.0.0 (2020-11-11)
+
+* [bitnami/thanos] Major version. Adapt Chart to apiVersion: v2 (#4317) ([5ec13cb](https://github.com/bitnami/charts/commit/5ec13cb)), closes [#4317](https://github.com/bitnami/charts/issues/4317)
+
+## <small>2.7.1 (2020-11-11)</small>
+
+* fix(thanos): add configmap checksum annotation to query-frontend and storegateway (#4247) ([a604dcd](https://github.com/bitnami/charts/commit/a604dcd)), closes [#4247](https://github.com/bitnami/charts/issues/4247)
+
+## 2.7.0 (2020-11-11)
+
+* [bitnami/thanos] fix: add tls switch to enable TLS with cert-manager for querier and bucketweb ingre ([85e5867](https://github.com/bitnami/charts/commit/85e5867)), closes [#4218](https://github.com/bitnami/charts/issues/4218)
+
+## 2.6.0 (2020-11-05)
+
+* [bitnami/*] Include link to Troubleshootin guide on README.md (#4136) ([c08a20e](https://github.com/bitnami/charts/commit/c08a20e)), closes [#4136](https://github.com/bitnami/charts/issues/4136)
+* [bitnami/thanos] allow overriding service selectors (#4211) ([843594f](https://github.com/bitnami/charts/commit/843594f)), closes [#4211](https://github.com/bitnami/charts/issues/4211)
+
+## <small>2.5.3 (2020-10-26)</small>
+
+* [bitnami/thanos] Release 2.5.3 updating components versions ([e4f2983](https://github.com/bitnami/charts/commit/e4f2983))
+
+## <small>2.5.2 (2020-10-26)</small>
+
+* Split Thanos ingress.yaml into two separate ingresses (#4101) ([3362d74](https://github.com/bitnami/charts/commit/3362d74)), closes [#4101](https://github.com/bitnami/charts/issues/4101)
+
+## <small>2.5.1 (2020-10-23)</small>
+
+* [bitnami/thanos] Expose missing podManagementPolicy key for statefulset (#4092) ([9704c29](https://github.com/bitnami/charts/commit/9704c29)), closes [#4092](https://github.com/bitnami/charts/issues/4092)
+
+## 2.5.0 (2020-10-21)
+
+* [bitnami/thanos] Add Thanos Query Frontend (#4009) ([3abd227](https://github.com/bitnami/charts/commit/3abd227)), closes [#4009](https://github.com/bitnami/charts/issues/4009)
+* Update README.md ([a78ebe0](https://github.com/bitnami/charts/commit/a78ebe0))
+
+## <small>2.4.6 (2020-10-14)</small>
+
+* feat(thanos): Enable thanos TLS client in a modular way (#3989) ([28a4845](https://github.com/bitnami/charts/commit/28a4845)), closes [#3989](https://github.com/bitnami/charts/issues/3989)
+
+## <small>2.4.5 (2020-10-08)</small>
+
+* [bitnami/thanos] Release 2.4.5 updating components versions ([53ed3f2](https://github.com/bitnami/charts/commit/53ed3f2))
+
+## <small>2.4.4 (2020-10-02)</small>
+
+* [bitnami/thanos] added psp for thanos querier (#3819) ([8976ec4](https://github.com/bitnami/charts/commit/8976ec4)), closes [#3819](https://github.com/bitnami/charts/issues/3819)
+
+## <small>2.4.3 (2020-10-02)</small>
+
+* [bitnami/thanos] Use GRPC extra hosts for thanos querier (#3837) ([94b5825](https://github.com/bitnami/charts/commit/94b5825)), closes [#3837](https://github.com/bitnami/charts/issues/3837)
+
+## <small>2.4.2 (2020-09-28)</small>
+
+* [bitnami/thanos] fixes thanos querier sdconfig mount as file, not as path (#3789) ([840d880](https://github.com/bitnami/charts/commit/840d880)), closes [#3789](https://github.com/bitnami/charts/issues/3789)
+
+## <small>2.4.1 (2020-09-16)</small>
+
+* [bitnami/thanos] Querier allow multiple replica labels (#3682) ([0e2351f](https://github.com/bitnami/charts/commit/0e2351f)), closes [#3682](https://github.com/bitnami/charts/issues/3682)
+
+## 2.4.0 (2020-09-15)
+
+* [bitnami/thanos] Fixes for Ingresses of Querier and Bucketweb in Thanos Chart (#3652) ([b96af28](https://github.com/bitnami/charts/commit/b96af28)), closes [#3652](https://github.com/bitnami/charts/issues/3652)
+
+## <small>2.3.4 (2020-09-08)</small>
+
+* [bitnami/thanos] Release 2.3.4 updating components versions ([c30dd7f](https://github.com/bitnami/charts/commit/c30dd7f))
+
+## <small>2.3.3 (2020-09-07)</small>
+
+* [bitnami/metrics-server] Add source repo (#3577) ([1ed12f9](https://github.com/bitnami/charts/commit/1ed12f9)), closes [#3577](https://github.com/bitnami/charts/issues/3577)
+* [bitnami/thanos] fix thanos ruler alert label drop (#3599) ([f34abeb](https://github.com/bitnami/charts/commit/f34abeb)), closes [#3599](https://github.com/bitnami/charts/issues/3599)
+
+## <small>2.3.2 (2020-08-19)</small>
+
+* Fix mountPath for existingObjstoreSecretItems (#3452) ([f5d4b4d](https://github.com/bitnami/charts/commit/f5d4b4d)), closes [#3452](https://github.com/bitnami/charts/issues/3452)
+
+## <small>2.3.1 (2020-08-14)</small>
+
+* fix(thanos) change objstore mount path for ruler (#3396) ([277cf7c](https://github.com/bitnami/charts/commit/277cf7c)), closes [#3396](https://github.com/bitnami/charts/issues/3396)
+
+## 2.3.0 (2020-08-12)
+
+* [bitnami/thanos]Add option to configure index storegateway (#3400) ([7bc2bce](https://github.com/bitnami/charts/commit/7bc2bce)), closes [#3400](https://github.com/bitnami/charts/issues/3400)
+
+## 2.2.0 (2020-08-12)
+
+* [bitnami/thanos] Add cache configuration blocks to Thanos store. Index and Bucket (#3387) ([2f2e1dd](https://github.com/bitnami/charts/commit/2f2e1dd)), closes [#3387](https://github.com/bitnami/charts/issues/3387) [#3384](https://github.com/bitnami/charts/issues/3384) [#3384](https://github.com/bitnami/charts/issues/3384)
+
+## <small>2.1.1 (2020-08-07)</small>
+
+* Hotfix. Didn't remove filename in mountPath (#3359) ([991b553](https://github.com/bitnami/charts/commit/991b553)), closes [#3359](https://github.com/bitnami/charts/issues/3359)
+
+## 2.1.0 (2020-08-07)
+
+* During PR version got bumped by bot. Fix it with new version (#3356) ([dc51a5b](https://github.com/bitnami/charts/commit/dc51a5b)), closes [#3356](https://github.com/bitnami/charts/issues/3356)
+* Move ruler rules to seperate folder (#3323) ([4f0976f](https://github.com/bitnami/charts/commit/4f0976f)), closes [#3323](https://github.com/bitnami/charts/issues/3323)
+* Update README.md ([939c616](https://github.com/bitnami/charts/commit/939c616))
+
+## <small>2.0.1 (2020-08-05)</small>
+
+* [bitnami/*] Fix TL;DR typo in READMEs (#3280) ([3d7ab40](https://github.com/bitnami/charts/commit/3d7ab40)), closes [#3280](https://github.com/bitnami/charts/issues/3280)
+* [bitnami/thanos] Release 2.0.1 updating components versions ([66139a3](https://github.com/bitnami/charts/commit/66139a3))
+
+## 2.0.0 (2020-07-30)
+
+* [bitnami/thanos] Improve the way boolean/multi flags are passed (#3245) ([8131746](https://github.com/bitnami/charts/commit/8131746)), closes [#3245](https://github.com/bitnami/charts/issues/3245)
+
+## <small>1.4.1 (2020-07-21)</small>
+
+* [bitnami/thanos] Release 1.4.1 updating components versions ([0a06d57](https://github.com/bitnami/charts/commit/0a06d57))
+
+## 1.4.0 (2020-07-21)
+
+* [bitnami/thanos] Additional labels for Prometheus ServiceMonitor (#3160) ([55b6e9f](https://github.com/bitnami/charts/commit/55b6e9f)), closes [#3160](https://github.com/bitnami/charts/issues/3160)
+
+## <small>1.3.4 (2020-07-15)</small>
+
+* [bitnami/thanos] Release 1.3.4 updating components versions ([3c3f801](https://github.com/bitnami/charts/commit/3c3f801))
+
+## <small>1.3.3 (2020-07-13)</small>
+
+* [bitnami/all] Add categories (#3075) ([63bde06](https://github.com/bitnami/charts/commit/63bde06)), closes [#3075](https://github.com/bitnami/charts/issues/3075)
+* [bitnami/thanos] Drop the replica label on alerts for Ruler (#3051) ([d2b35dc](https://github.com/bitnami/charts/commit/d2b35dc)), closes [#3051](https://github.com/bitnami/charts/issues/3051)
+
+## <small>1.3.2 (2020-07-10)</small>
+
+* guard servername verification for tls client auth (#3081) ([6687d63](https://github.com/bitnami/charts/commit/6687d63)), closes [#3081](https://github.com/bitnami/charts/issues/3081)
+
+## <small>1.3.1 (2020-07-09)</small>
+
+* [bitnami/thanos] Release 1.3.1 updating components versions ([8285ada](https://github.com/bitnami/charts/commit/8285ada))
+
+## 1.3.0 (2020-07-09)
+
+* [bitnami/thanos] grpc tls server/client for thanos querier (#3042) ([4bc2362](https://github.com/bitnami/charts/commit/4bc2362)), closes [#3042](https://github.com/bitnami/charts/issues/3042)
+
+## <small>1.2.1 (2020-07-08)</small>
+
+* [bitnami/thanos] Release 1.2.1 updating components versions ([cf93930](https://github.com/bitnami/charts/commit/cf93930))
+
+## 1.2.0 (2020-07-08)
+
+* [bitnami/thanos] add existing serviceaccount support (#3037) ([68f2496](https://github.com/bitnami/charts/commit/68f2496)), closes [#3037](https://github.com/bitnami/charts/issues/3037)
+
+## <small>1.1.3 (2020-07-03)</small>
+
+* [bitnami/thanos] Release 1.1.3 updating components versions ([7780a70](https://github.com/bitnami/charts/commit/7780a70))
+
+## <small>1.1.2 (2020-06-29)</small>
+
+* [bitnami/thanos] Fix bucket command (#2934) ([1122391](https://github.com/bitnami/charts/commit/1122391)), closes [#2934](https://github.com/bitnami/charts/issues/2934)
+
+## <small>1.1.1 (2020-06-22)</small>
+
+* [bitnami/thanos] Release 1.1.1 updating components versions ([63bff36](https://github.com/bitnami/charts/commit/63bff36))
+
+## 1.1.0 (2020-06-02)
+
+* [bitnami/thanos] Add Ingress for Querier GRPC service (#2702) ([f3a624f](https://github.com/bitnami/charts/commit/f3a624f)), closes [#2702](https://github.com/bitnami/charts/issues/2702)
+
+## <small>1.0.2 (2020-05-29)</small>
+
+* [bitnami/thanos] Release 1.0.2 updating components versions ([f17b87d](https://github.com/bitnami/charts/commit/f17b87d))
+
+## <small>1.0.1 (2020-05-29)</small>
+
+* [bitnami/thanos] fix tolerations defaults (#2699) ([1ddeb18](https://github.com/bitnami/charts/commit/1ddeb18)), closes [#2699](https://github.com/bitnami/charts/issues/2699)
+
+## 1.0.0 (2020-05-28)
+
+* [bitnami/thanos]: Move querier Ingress config to querier section (#2684) ([bb25f72](https://github.com/bitnami/charts/commit/bb25f72)), closes [#2684](https://github.com/bitnami/charts/issues/2684)
+
+## 0.7.0 (2020-05-26)
+
+* [bitnami/thanos]: Add bucketweb Ingress resource (#2656) ([d9ae4b8](https://github.com/bitnami/charts/commit/d9ae4b8)), closes [#2656](https://github.com/bitnami/charts/issues/2656)
+
+## 0.6.0 (2020-05-26)
+
+* [bitnami/thanos]: Add HPA for Thanos storegateway (#2643) ([0705d14](https://github.com/bitnami/charts/commit/0705d14)), closes [#2643](https://github.com/bitnami/charts/issues/2643)
+* update bitnami/common to be compatible with helm v2.12+ (#2615) ([c7751eb](https://github.com/bitnami/charts/commit/c7751eb)), closes [#2615](https://github.com/bitnami/charts/issues/2615)
+
+## <small>0.5.3 (2020-04-30)</small>
+
+* [bitnami/thanos] Release 0.5.3 updating components versions ([c24909e](https://github.com/bitnami/charts/commit/c24909e))
+
+## <small>0.5.2 (2020-04-22)</small>
+
+* [bitnami/thanos] Release 0.5.2 updating components versions ([b770b87](https://github.com/bitnami/charts/commit/b770b87))
+
+## <small>0.5.1 (2020-04-22)</small>
+
+* [bitnami/thanos] Release 0.5.1 updating components versions ([cd05d59](https://github.com/bitnami/charts/commit/cd05d59))
+
+## 0.5.0 (2020-04-21)
+
+* [bitnami/thanos] provide Objstore config via secret (#2366) ([65354b2](https://github.com/bitnami/charts/commit/65354b2)), closes [#2366](https://github.com/bitnami/charts/issues/2366) [#2366](https://github.com/bitnami/charts/issues/2366)
+
+## <small>0.4.3 (2020-04-16)</small>
+
+* [bitnami/thanos bitnami/memcached] Add global storageClass (#2344) ([693978d](https://github.com/bitnami/charts/commit/693978d)), closes [#2344](https://github.com/bitnami/charts/issues/2344)
+
+## <small>0.4.2 (2020-04-15)</small>
+
+* [bitnami/thanos] Release 0.4.2 updating components versions ([55cd51b](https://github.com/bitnami/charts/commit/55cd51b))
+
+## <small>0.4.1 (2020-04-13)</small>
+
+* [bitnami/thanos] Release 0.4.1 updating components versions ([337ecf0](https://github.com/bitnami/charts/commit/337ecf0))
+
+## 0.4.0 (2020-04-10)
+
+* [bitnami/thanos] Add support to create Headless services (#2263) ([a8f82eb](https://github.com/bitnami/charts/commit/a8f82eb)), closes [#2263](https://github.com/bitnami/charts/issues/2263)
+
+## <small>0.3.2 (2020-04-08)</small>
+
+* [bitnami/thanos] Add missing podAnnotations (#2250) ([231d067](https://github.com/bitnami/charts/commit/231d067)), closes [#2250](https://github.com/bitnami/charts/issues/2250)
+
+## <small>0.3.1 (2020-04-07)</small>
+
+* [bitnami/thanos] Release 0.3.1 updating components versions ([81bf5e2](https://github.com/bitnami/charts/commit/81bf5e2))
+
+## 0.3.0 (2020-04-07)
+
+* [bitnami/thanos] Adds support to add annotations to Service Accounts (#2182) ([50576ec](https://github.com/bitnami/charts/commit/50576ec)), closes [#2182](https://github.com/bitnami/charts/issues/2182)
+
+## <small>0.2.2 (2020-03-20)</small>
+
+* [bitnami/thanos] Release 0.2.2 updating components versions ([11bba72](https://github.com/bitnami/charts/commit/11bba72))
+
+## <small>0.2.1 (2020-03-16)</small>
+
+* [bitnami/thanos] Release 0.2.1 updating components versions ([d892bf6](https://github.com/bitnami/charts/commit/d892bf6))
+
+## 0.2.0 (2020-03-12)
+
+* [bitnami/thanos] use the `tpl` function in querier of helm3 (#2024) ([2982a65](https://github.com/bitnami/charts/commit/2982a65)), closes [#2024](https://github.com/bitnami/charts/issues/2024) [#2024](https://github.com/bitnami/charts/issues/2024)
+
+## <small>0.1.10 (2020-03-12)</small>
+
+* [bitnami/thanos] Release 0.1.10 updating components versions ([1d8c059](https://github.com/bitnami/charts/commit/1d8c059))
+
+## <small>0.1.9 (2020-03-11)</small>
+
+* Move charts from upstreamed folder to bitnami (#2032) ([a0e44f7](https://github.com/bitnami/charts/commit/a0e44f7)), closes [#2032](https://github.com/bitnami/charts/issues/2032)
+
+## <small>0.1.8 (2020-03-10)</small>
+
+* [bitnami/thanos] Fix pvc creation on compactor.enabled = false (#2020) ([b4fe943](https://github.com/bitnami/charts/commit/b4fe943)), closes [#2020](https://github.com/bitnami/charts/issues/2020)
+
+## <small>0.1.7 (2020-03-02)</small>
+
+* [bitnami/thanos] Release 0.1.7 updating components versions ([da01f27](https://github.com/bitnami/charts/commit/da01f27))
+
+## <small>0.1.6 (2020-02-27)</small>
+
+* [bitnami/thanos] Release 0.1.6 updating components versions ([c47901b](https://github.com/bitnami/charts/commit/c47901b))
+
+## <small>0.1.5 (2020-02-25)</small>
+
+* fixed indentation in thanos compactor pvc.yaml (#1970) ([8cea393](https://github.com/bitnami/charts/commit/8cea393)), closes [#1970](https://github.com/bitnami/charts/issues/1970)
+
+## <small>0.1.4 (2020-02-20)</small>
+
+* [bitnami/thanos] Release 0.1.4 updating components versions ([883a3fb](https://github.com/bitnami/charts/commit/883a3fb))
+
+## <small>0.1.3 (2020-02-19)</small>
+
+* [bitnami/*] Fix requirements.lock (#1950) ([1fa6eb9](https://github.com/bitnami/charts/commit/1fa6eb9)), closes [#1950](https://github.com/bitnami/charts/issues/1950)
+
+## <small>0.1.2 (2020-02-18)</small>
+
+* [bitnami/thanos] Release 0.1.2 updating components versions ([32957fd](https://github.com/bitnami/charts/commit/32957fd))
+* Fix Thanos 'requirements.lock' (#1923) ([313456a](https://github.com/bitnami/charts/commit/313456a)), closes [#1923](https://github.com/bitnami/charts/issues/1923)
+
+## <small>0.1.1 (2020-02-13)</small>
+
+* [bitnami/thanos] Use buster in secondary images (#1919) ([3e62376](https://github.com/bitnami/charts/commit/3e62376)), closes [#1919](https://github.com/bitnami/charts/issues/1919)
+
+## 0.1.0 (2020-02-12)
+
+* Add new chart: Thanos (#1893) ([e58eff5](https://github.com/bitnami/charts/commit/e58eff5)), closes [#1893](https://github.com/bitnami/charts/issues/1893)

--- a/bitnami/thanos/Chart.lock
+++ b/bitnami/thanos/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: minio
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 14.4.3
+  version: 14.5.0
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.19.2
-digest: sha256:f2381b803f5ce6e4c7c2a6fde1be7bec7fe22f5d22980bf730b2eef33bbc9560
-generated: "2024-05-18T03:02:12.615392141Z"
+  version: 2.19.3
+digest: sha256:914e5fd99e81f33b87e7716e370c4fb91f202f0e590d96306bbcc34d1f17ddd9
+generated: "2024-05-21T14:45:02.122673789+02:00"

--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: thanos
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/thanos
-version: 15.4.7
+version: 15.5.0

--- a/bitnami/thanos/templates/NOTES.txt
+++ b/bitnami/thanos/templates/NOTES.txt
@@ -77,3 +77,4 @@ WARNING: You deployed Thanos without enabling Thanos Query!!
 {{- include "thanos.validateValues" . }}
 {{- include "thanos.checkRollingTags" . }}
 {{- include "common.warnings.resources" (dict "sections" (list "bucketweb" "compactor" "query" "queryFrontend" "receive" "receiveDistributor" "ruler" "storegateway") "context" $) }}
+{{- include "common.warnings.modifiedImages" (dict "images" (list .Values.image .Values.volumePermissions.image) "context" $) }}


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Replacing the original images that have been tested and verified when releasing the chart is a dangerous practice in terms of security, performance and available features. This PR updates the `NOTES.txt` file using the `common.warnings.modifiedImages` helper developed in https://github.com/bitnami/charts/pull/25952.


<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

Users are more aware of the risks of changing original images.
<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

n/a
<!-- Describe any known limitations with your change -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
