### PR TITLE
[bitnami/tomcat] feat: :sparkles: :lock: Add warning when original images are replaced

### DIFF
--- a/bitnami/tomcat/CHANGELOG.md
+++ b/bitnami/tomcat/CHANGELOG.md
@@ -1,0 +1,1381 @@
+# Changelog
+
+## 11.1.0 (2024-05-21)
+
+* [bitnami/tomcat] feat: :sparkles: :lock: Add warning when original images are replaced ([#26284](https://github.com/bitnami/charts/pulls/26284))
+
+## <small>11.0.5 (2024-05-18)</small>
+
+* [bitnami/tomcat] Release 11.0.5 updating components versions (#26084) ([91e743e](https://github.com/bitnami/charts/commit/91e743e)), closes [#26084](https://github.com/bitnami/charts/issues/26084)
+
+## <small>11.0.4 (2024-05-14)</small>
+
+* [bitnami/tomcat] Release 11.0.4 updating components versions (#25843) ([02abcc9](https://github.com/bitnami/charts/commit/02abcc9)), closes [#25843](https://github.com/bitnami/charts/issues/25843)
+
+## <small>11.0.3 (2024-05-14)</small>
+
+* [bitnami/*] Change non-root and rolling-tags doc URLs (#25628) ([b067c94](https://github.com/bitnami/charts/commit/b067c94)), closes [#25628](https://github.com/bitnami/charts/issues/25628)
+* [bitnami/*] Set new header/owner (#25558) ([8d1dc11](https://github.com/bitnami/charts/commit/8d1dc11)), closes [#25558](https://github.com/bitnami/charts/issues/25558)
+* [bitnami/multiple charts] Fix typo: "NetworkPolice" vs "NetworkPolicy" (#25348) ([6970c1b](https://github.com/bitnami/charts/commit/6970c1b)), closes [#25348](https://github.com/bitnami/charts/issues/25348)
+* [bitnami/tomcat] Release 11.0.3 updating components versions (#25838) ([74451fa](https://github.com/bitnami/charts/commit/74451fa)), closes [#25838](https://github.com/bitnami/charts/issues/25838)
+* Replace VMware by Broadcom copyright text (#25306) ([a5e4bd0](https://github.com/bitnami/charts/commit/a5e4bd0)), closes [#25306](https://github.com/bitnami/charts/issues/25306)
+
+## <small>11.0.2 (2024-04-24)</small>
+
+* [bitnami/tomcat] Release 11.0.2 updating components versions (#25349) ([21cad47](https://github.com/bitnami/charts/commit/21cad47)), closes [#25349](https://github.com/bitnami/charts/issues/25349)
+
+## <small>11.0.1 (2024-04-05)</small>
+
+* [bitnami/tomcat] Release 11.0.1 (#24963) ([369e42c](https://github.com/bitnami/charts/commit/369e42c)), closes [#24963](https://github.com/bitnami/charts/issues/24963)
+* Update resourcesPreset comments (#24467) ([92e3e8a](https://github.com/bitnami/charts/commit/92e3e8a)), closes [#24467](https://github.com/bitnami/charts/issues/24467)
+
+## 11.0.0 (2024-04-01)
+
+* [bitnami/tomcat] feat!: :lock: :boom: Improve security defaults (#24716) ([d7df41a](https://github.com/bitnami/charts/commit/d7df41a)), closes [#24716](https://github.com/bitnami/charts/issues/24716)
+
+## <small>10.17.2 (2024-03-26)</small>
+
+* [bitnami/*] Reorder Chart sections (#24455) ([0cf4048](https://github.com/bitnami/charts/commit/0cf4048)), closes [#24455](https://github.com/bitnami/charts/issues/24455)
+* [bitnami/tomcat] Release 10.17.2 updating components versions (#24665) ([cd35ecd](https://github.com/bitnami/charts/commit/cd35ecd)), closes [#24665](https://github.com/bitnami/charts/issues/24665)
+
+## <small>10.17.1 (2024-03-15)</small>
+
+* [bitnami/tomcat] Release 10.17.1 updating components versions (#24462) ([320b0b7](https://github.com/bitnami/charts/commit/320b0b7)), closes [#24462](https://github.com/bitnami/charts/issues/24462)
+
+## 10.17.0 (2024-03-06)
+
+* [bitnami/tomcat] feat: :sparkles: :lock: Add automatic adaptation for Openshift restricted-v2 SCC (# ([1eb070c](https://github.com/bitnami/charts/commit/1eb070c)), closes [#24162](https://github.com/bitnami/charts/issues/24162)
+
+## <small>10.16.2 (2024-02-22)</small>
+
+* [bitnami/tomcat] Release 10.16.2 updating components versions (#23834) ([0ea9f2e](https://github.com/bitnami/charts/commit/0ea9f2e)), closes [#23834](https://github.com/bitnami/charts/issues/23834)
+
+## <small>10.16.1 (2024-02-21)</small>
+
+* [bitnami/tomcat] Release 10.16.1 updating components versions (#23632) ([d29cdd5](https://github.com/bitnami/charts/commit/d29cdd5)), closes [#23632](https://github.com/bitnami/charts/issues/23632)
+
+## 10.16.0 (2024-02-20)
+
+* [bitnami/*] Bump all versions (#23602) ([b70ee2a](https://github.com/bitnami/charts/commit/b70ee2a)), closes [#23602](https://github.com/bitnami/charts/issues/23602)
+
+## 10.15.0 (2024-02-19)
+
+* [bitnami/tomcat] Add existing secret management (#23558) ([4fd3c1f](https://github.com/bitnami/charts/commit/4fd3c1f)), closes [#23558](https://github.com/bitnami/charts/issues/23558)
+
+## 10.14.0 (2024-02-15)
+
+* [bitnami/tomcat] feat: :sparkles: :lock: Add resource preset support (#23528) ([f9c2fb2](https://github.com/bitnami/charts/commit/f9c2fb2)), closes [#23528](https://github.com/bitnami/charts/issues/23528)
+
+## <small>10.13.5 (2024-02-03)</small>
+
+* [bitnami/tomcat] Release 10.13.5 updating components versions (#23146) ([2031845](https://github.com/bitnami/charts/commit/2031845)), closes [#23146](https://github.com/bitnami/charts/issues/23146)
+
+## <small>10.13.4 (2024-01-30)</small>
+
+* Fix http port (#22881) ([ed967b6](https://github.com/bitnami/charts/commit/ed967b6)), closes [#22881](https://github.com/bitnami/charts/issues/22881)
+
+## <small>10.13.3 (2024-01-30)</small>
+
+* [bitnami/tomcat] Release 10.13.3 updating components versions (#22860) ([e0d3c9d](https://github.com/bitnami/charts/commit/e0d3c9d)), closes [#22860](https://github.com/bitnami/charts/issues/22860)
+
+## <small>10.13.2 (2024-01-27)</small>
+
+* [bitnami/tomcat] Release 10.13.2 updating components versions (#22786) ([8f9e65a](https://github.com/bitnami/charts/commit/8f9e65a)), closes [#22786](https://github.com/bitnami/charts/issues/22786)
+
+## <small>10.13.1 (2024-01-25)</small>
+
+* [bitnami/*] Move documentation sections from docs.bitnami.com back to the README (#22203) ([7564f36](https://github.com/bitnami/charts/commit/7564f36)), closes [#22203](https://github.com/bitnami/charts/issues/22203)
+* [bitnami/tomcat] fix: :bug: Set seLinuxOptions to null for Openshift compatibility (#22665) ([fc30b94](https://github.com/bitnami/charts/commit/fc30b94)), closes [#22665](https://github.com/bitnami/charts/issues/22665)
+
+## 10.13.0 (2024-01-19)
+
+* [bitnami/tomcat] fix: :lock: Move service-account token auto-mount to pod declaration (#22501) ([d63b4d6](https://github.com/bitnami/charts/commit/d63b4d6)), closes [#22501](https://github.com/bitnami/charts/issues/22501)
+
+## <small>10.12.1 (2024-01-17)</small>
+
+* [bitnami/tomcat] Release 10.12.1 updating components versions (#22333) ([7cdb8eb](https://github.com/bitnami/charts/commit/7cdb8eb)), closes [#22333](https://github.com/bitnami/charts/issues/22333)
+
+## 10.12.0 (2024-01-16)
+
+* [bitnami/*] Fix ref links (in comments) (#21822) ([e4fa296](https://github.com/bitnami/charts/commit/e4fa296)), closes [#21822](https://github.com/bitnami/charts/issues/21822)
+* [bitnami/tomcat] fix: :lock: Improve podSecurityContext and containerSecurityContext with essential  ([aec8201](https://github.com/bitnami/charts/commit/aec8201)), closes [#22196](https://github.com/bitnami/charts/issues/22196)
+
+## <small>10.11.11 (2024-01-10)</small>
+
+* [bitnami/*] Fix docs.bitnami.com broken links (#21901) ([f35506d](https://github.com/bitnami/charts/commit/f35506d)), closes [#21901](https://github.com/bitnami/charts/issues/21901)
+* [bitnami/*] Update copyright: Year and company (#21815) ([6c4bf75](https://github.com/bitnami/charts/commit/6c4bf75)), closes [#21815](https://github.com/bitnami/charts/issues/21815)
+* [bitnami/tomcat] Release 10.11.11 updating components versions (#21974) ([85f7e32](https://github.com/bitnami/charts/commit/85f7e32)), closes [#21974](https://github.com/bitnami/charts/issues/21974)
+
+## <small>10.11.10 (2023-12-14)</small>
+
+* [bitnami/tomcat] Release 10.11.10 updating components versions (#21559) ([ac6de95](https://github.com/bitnami/charts/commit/ac6de95)), closes [#21559](https://github.com/bitnami/charts/issues/21559)
+
+## <small>10.11.9 (2023-12-07)</small>
+
+* [bitnami/tomcat] Release 10.11.9 updating components versions (#21459) ([a5d5ec4](https://github.com/bitnami/charts/commit/a5d5ec4)), closes [#21459](https://github.com/bitnami/charts/issues/21459)
+
+## <small>10.11.8 (2023-12-04)</small>
+
+* [bitnami/tomcat] Release 10.11.8 updating components versions (#21367) ([cd119c6](https://github.com/bitnami/charts/commit/cd119c6)), closes [#21367](https://github.com/bitnami/charts/issues/21367)
+
+## <small>10.11.7 (2023-12-04)</small>
+
+* [bitnami/tomcat] Release 10.11.7 updating components versions (#21366) ([374dca6](https://github.com/bitnami/charts/commit/374dca6)), closes [#21366](https://github.com/bitnami/charts/issues/21366)
+
+## <small>10.11.6 (2023-11-21)</small>
+
+* [bitnami/*] Rename solutions to "Bitnami package for ..." (#21038) ([b82f979](https://github.com/bitnami/charts/commit/b82f979)), closes [#21038](https://github.com/bitnami/charts/issues/21038)
+* [bitnami/tomcat] Release 10.11.6 updating components versions (#21181) ([2557749](https://github.com/bitnami/charts/commit/2557749)), closes [#21181](https://github.com/bitnami/charts/issues/21181)
+
+## <small>10.11.5 (2023-11-21)</small>
+
+* [bitnami/tomcat] Release 10.11.5 updating components versions (#21075) ([27f4a04](https://github.com/bitnami/charts/commit/27f4a04)), closes [#21075](https://github.com/bitnami/charts/issues/21075)
+
+## <small>10.11.4 (2023-11-20)</small>
+
+* [bitnami/*] Remove relative links to non-README sections, add verification for that and update TL;DR ([1103633](https://github.com/bitnami/charts/commit/1103633)), closes [#20967](https://github.com/bitnami/charts/issues/20967)
+* [bitnami/tomcat] Release 10.11.4 updating components versions (#21071) ([531728c](https://github.com/bitnami/charts/commit/531728c)), closes [#21071](https://github.com/bitnami/charts/issues/21071)
+
+## <small>10.11.3 (2023-11-15)</small>
+
+* [bitnami/tomcat] Release 10.11.3 updating components versions (#20957) ([5e6e40e](https://github.com/bitnami/charts/commit/5e6e40e)), closes [#20957](https://github.com/bitnami/charts/issues/20957)
+
+## <small>10.11.2 (2023-11-09)</small>
+
+* [bitnami/tomcat] Release 10.11.2 updating components versions (#20829) ([4ba73d1](https://github.com/bitnami/charts/commit/4ba73d1)), closes [#20829](https://github.com/bitnami/charts/issues/20829)
+
+## <small>10.11.1 (2023-11-08)</small>
+
+* [bitnami/tomcat] Release 10.11.1 updating components versions (#20718) ([24caefc](https://github.com/bitnami/charts/commit/24caefc)), closes [#20718](https://github.com/bitnami/charts/issues/20718)
+
+## 10.11.0 (2023-10-31)
+
+* [bitnami/*] Rename VMware Application Catalog (#20361) ([3acc734](https://github.com/bitnami/charts/commit/3acc734)), closes [#20361](https://github.com/bitnami/charts/issues/20361)
+* [bitnami/*] Skip image's tag in the README files of the Bitnami Charts (#19841) ([bb9a01b](https://github.com/bitnami/charts/commit/bb9a01b)), closes [#19841](https://github.com/bitnami/charts/issues/19841)
+* [bitnami/*] Standardize documentation (#19835) ([af5f753](https://github.com/bitnami/charts/commit/af5f753)), closes [#19835](https://github.com/bitnami/charts/issues/19835)
+* [bitnami/tomcat] feat: :sparkles: Add support for PSA restricted policy (#20554) ([cd9ec2f](https://github.com/bitnami/charts/commit/cd9ec2f)), closes [#20554](https://github.com/bitnami/charts/issues/20554)
+
+## <small>10.10.10 (2023-10-16)</small>
+
+* [bitnami/tomcat] Release 10.10.10 (#20259) ([99d14d1](https://github.com/bitnami/charts/commit/99d14d1)), closes [#20259](https://github.com/bitnami/charts/issues/20259)
+
+## <small>10.10.9 (2023-10-12)</small>
+
+* [bitnami/tomcat] Release 10.10.9 (#20195) ([91e78b6](https://github.com/bitnami/charts/commit/91e78b6)), closes [#20195](https://github.com/bitnami/charts/issues/20195)
+
+## <small>10.10.8 (2023-10-11)</small>
+
+* [bitnami/tomcat] Release 10.10.8 (#20024) ([9f8270e](https://github.com/bitnami/charts/commit/9f8270e)), closes [#20024](https://github.com/bitnami/charts/issues/20024)
+
+## <small>10.10.7 (2023-10-10)</small>
+
+* [bitnami/tomcat] Release 10.10.7 (#19958) ([aab8a76](https://github.com/bitnami/charts/commit/aab8a76)), closes [#19958](https://github.com/bitnami/charts/issues/19958)
+
+## <small>10.10.6 (2023-10-09)</small>
+
+* [bitnami/*] Update Helm charts prerequisites (#19745) ([eb755dd](https://github.com/bitnami/charts/commit/eb755dd)), closes [#19745](https://github.com/bitnami/charts/issues/19745)
+* [bitnami/tomcat] Release 10.10.6 (#19941) ([3a94f3a](https://github.com/bitnami/charts/commit/3a94f3a)), closes [#19941](https://github.com/bitnami/charts/issues/19941)
+
+## <small>10.10.5 (2023-10-04)</small>
+
+* [bitnami/tomcat] Release 10.10.5 (#19754) ([d75bc07](https://github.com/bitnami/charts/commit/d75bc07)), closes [#19754](https://github.com/bitnami/charts/issues/19754)
+
+## <small>10.10.4 (2023-09-25)</small>
+
+* [bitnami/tomcat] Release 10.10.4 (#19494) ([3dd4bd8](https://github.com/bitnami/charts/commit/3dd4bd8)), closes [#19494](https://github.com/bitnami/charts/issues/19494)
+* Autogenerate schema files (#19194) ([a2c2090](https://github.com/bitnami/charts/commit/a2c2090)), closes [#19194](https://github.com/bitnami/charts/issues/19194)
+* Revert "Autogenerate schema files (#19194)" (#19335) ([73d80be](https://github.com/bitnami/charts/commit/73d80be)), closes [#19194](https://github.com/bitnami/charts/issues/19194) [#19335](https://github.com/bitnami/charts/issues/19335)
+
+## <small>10.10.3 (2023-09-07)</small>
+
+* [bitnami/tomcat: Use merge helper]: (#19113) ([bc4dcd4](https://github.com/bitnami/charts/commit/bc4dcd4)), closes [#19113](https://github.com/bitnami/charts/issues/19113)
+
+## <small>10.10.2 (2023-08-26)</small>
+
+* [bitnami/tomcat] Release 10.10.2 (#18881) ([0a43278](https://github.com/bitnami/charts/commit/0a43278)), closes [#18881](https://github.com/bitnami/charts/issues/18881)
+
+## <small>10.10.1 (2023-08-26)</small>
+
+* [bitnami/tomcat] Release 10.10.1 (#18880) ([05dea87](https://github.com/bitnami/charts/commit/05dea87)), closes [#18880](https://github.com/bitnami/charts/issues/18880)
+
+## 10.10.0 (2023-08-22)
+
+* [bitnami/tomcat] Support for customizing standard labels (#18442) ([70598b3](https://github.com/bitnami/charts/commit/70598b3)), closes [#18442](https://github.com/bitnami/charts/issues/18442)
+
+## <small>10.9.10 (2023-08-21)</small>
+
+* [bitnami/tomcat] Release 10.9.10 (#18724) ([09545f7](https://github.com/bitnami/charts/commit/09545f7)), closes [#18724](https://github.com/bitnami/charts/issues/18724)
+
+## <small>10.9.9 (2023-08-17)</small>
+
+* [bitnami/tomcat] Release 10.9.9 (#18599) ([7e8d13c](https://github.com/bitnami/charts/commit/7e8d13c)), closes [#18599](https://github.com/bitnami/charts/issues/18599)
+
+## <small>10.9.8 (2023-08-15)</small>
+
+* [bitnami/tomcat] Release 10.9.8 (#18425) ([4073e5d](https://github.com/bitnami/charts/commit/4073e5d)), closes [#18425](https://github.com/bitnami/charts/issues/18425)
+
+## <small>10.9.7 (2023-08-09)</small>
+
+* [bitnami/tomcat] Release 10.9.7 (#18330) ([f8c1564](https://github.com/bitnami/charts/commit/f8c1564)), closes [#18330](https://github.com/bitnami/charts/issues/18330)
+
+## <small>10.9.6 (2023-07-26)</small>
+
+* [bitnami/tomcat] Release 10.9.6 (#17976) ([11f0269](https://github.com/bitnami/charts/commit/11f0269)), closes [#17976](https://github.com/bitnami/charts/issues/17976)
+
+## <small>10.9.5 (2023-07-13)</small>
+
+* [bitnami/tomcat] Release 10.9.5 (#17666) ([1fe0ab8](https://github.com/bitnami/charts/commit/1fe0ab8)), closes [#17666](https://github.com/bitnami/charts/issues/17666)
+
+## <small>10.9.4 (2023-07-11)</small>
+
+* [bitnami/tomcat] Release 10.9.4 (#17550) ([84b2301](https://github.com/bitnami/charts/commit/84b2301)), closes [#17550](https://github.com/bitnami/charts/issues/17550)
+* Add copyright header (#17300) ([da68be8](https://github.com/bitnami/charts/commit/da68be8)), closes [#17300](https://github.com/bitnami/charts/issues/17300)
+* Update charts readme (#17217) ([31b3c0a](https://github.com/bitnami/charts/commit/31b3c0a)), closes [#17217](https://github.com/bitnami/charts/issues/17217)
+
+## <small>10.9.3 (2023-06-13)</small>
+
+* [bitnami/*] Change copyright section in READMEs (#17006) ([ef986a1](https://github.com/bitnami/charts/commit/ef986a1)), closes [#17006](https://github.com/bitnami/charts/issues/17006)
+* [bitnami/tomcat] Release 10.9.3 (#17100) ([21fdb25](https://github.com/bitnami/charts/commit/21fdb25)), closes [#17100](https://github.com/bitnami/charts/issues/17100)
+
+## <small>10.9.2 (2023-06-02)</small>
+
+* [bitnami/several] Change copyright section in READMEs (#16989) ([5b6a5cf](https://github.com/bitnami/charts/commit/5b6a5cf)), closes [#16989](https://github.com/bitnami/charts/issues/16989)
+* [bitnami/tomcat] Release 10.9.2 (#17010) ([3e2fa06](https://github.com/bitnami/charts/commit/3e2fa06)), closes [#17010](https://github.com/bitnami/charts/issues/17010)
+
+## <small>10.9.1 (2023-05-21)</small>
+
+* [bitnami/tomcat] Release 10.9.1 (#16821) ([5fa9e06](https://github.com/bitnami/charts/commit/5fa9e06)), closes [#16821](https://github.com/bitnami/charts/issues/16821)
+* Add wording for enterprise page (#16560) ([8f22774](https://github.com/bitnami/charts/commit/8f22774)), closes [#16560](https://github.com/bitnami/charts/issues/16560)
+
+## 10.9.0 (2023-05-09)
+
+* [bitnami/several] Adapt Chart.yaml to set desired OCI annotations (#16546) ([fc9b18f](https://github.com/bitnami/charts/commit/fc9b18f)), closes [#16546](https://github.com/bitnami/charts/issues/16546)
+
+## <small>10.8.2 (2023-05-09)</small>
+
+* [bitnami/tomcat] Release 10.8.2 (#16503) ([607c88b](https://github.com/bitnami/charts/commit/607c88b)), closes [#16503](https://github.com/bitnami/charts/issues/16503)
+
+## <small>10.8.1 (2023-04-25)</small>
+
+* [bitnami/tomcat] Release 10.8.1 (#16223) ([b6a9071](https://github.com/bitnami/charts/commit/b6a9071)), closes [#16223](https://github.com/bitnami/charts/issues/16223)
+
+## 10.8.0 (2023-04-25)
+
+* [bitnami/several] Revert changes done by mistake in Chart.yaml repo (#16211) ([3a60f4b](https://github.com/bitnami/charts/commit/3a60f4b)), closes [#16211](https://github.com/bitnami/charts/issues/16211)
+
+## <small>10.7.1 (2023-04-20)</small>
+
+* [bitnami/tomcat] Release 10.7.1 (#16142) ([fdcdaca](https://github.com/bitnami/charts/commit/fdcdaca)), closes [#16142](https://github.com/bitnami/charts/issues/16142)
+
+## 10.7.0 (2023-04-20)
+
+* [bitnami/*] Make Helm charts 100% OCI (#15998) ([8841510](https://github.com/bitnami/charts/commit/8841510)), closes [#15998](https://github.com/bitnami/charts/issues/15998)
+
+## <small>10.6.3 (2023-04-18)</small>
+
+* [bitnami/tomcat] Release 10.6.3 updating components versions (#16117) ([03b4037](https://github.com/bitnami/charts/commit/03b4037)), closes [#16117](https://github.com/bitnami/charts/issues/16117)
+
+## <small>10.6.2 (2023-04-03)</small>
+
+* [bitnami/tomcat] Release 10.6.2 (#15942) ([d9d5ba4](https://github.com/bitnami/charts/commit/d9d5ba4)), closes [#15942](https://github.com/bitnami/charts/issues/15942)
+
+## <small>10.6.1 (2023-04-01)</small>
+
+* [bitnami/tomcat] Release 10.6.1 (#15910) ([0671702](https://github.com/bitnami/charts/commit/0671702)), closes [#15910](https://github.com/bitnami/charts/issues/15910)
+
+## 10.6.0 (2023-03-21)
+
+* [bitnami/tomcat] Add support for service.headless.annotations (#15447) ([03faa8d](https://github.com/bitnami/charts/commit/03faa8d)), closes [#15447](https://github.com/bitnami/charts/issues/15447)
+
+## <small>10.5.20 (2023-03-19)</small>
+
+* [bitnami/tomcat] Release 10.5.20 (#15618) ([fcaf566](https://github.com/bitnami/charts/commit/fcaf566)), closes [#15618](https://github.com/bitnami/charts/issues/15618)
+
+## <small>10.5.19 (2023-03-13)</small>
+
+* [bitnami/charts] Apply linter to README files (#15357) ([0e29e60](https://github.com/bitnami/charts/commit/0e29e60)), closes [#15357](https://github.com/bitnami/charts/issues/15357)
+* [bitnami/tomcat] Release 10.5.19 (#15476) ([825e916](https://github.com/bitnami/charts/commit/825e916)), closes [#15476](https://github.com/bitnami/charts/issues/15476)
+
+## <small>10.5.18 (2023-03-02)</small>
+
+* [bitnami/tomcat] promrule additional labels (#15162) ([fcde50e](https://github.com/bitnami/charts/commit/fcde50e)), closes [#15162](https://github.com/bitnami/charts/issues/15162)
+
+## <small>10.5.17 (2023-03-01)</small>
+
+* [bitnami/tomcat] Release 10.5.17 (#15259) ([7f6ab6b](https://github.com/bitnami/charts/commit/7f6ab6b)), closes [#15259](https://github.com/bitnami/charts/issues/15259)
+
+## <small>10.5.16 (2023-02-17)</small>
+
+* [bitnami/*] Fix markdown linter issues (#14874) ([a51e0e8](https://github.com/bitnami/charts/commit/a51e0e8)), closes [#14874](https://github.com/bitnami/charts/issues/14874)
+* [bitnami/*] Fix markdown linter issues 2 (#14890) ([aa96572](https://github.com/bitnami/charts/commit/aa96572)), closes [#14890](https://github.com/bitnami/charts/issues/14890)
+* [bitnami/*] Remove unexpected extra spaces (#14873) ([c97c714](https://github.com/bitnami/charts/commit/c97c714)), closes [#14873](https://github.com/bitnami/charts/issues/14873)
+* [bitnami/tomcat] Release 10.5.16 (#15029) ([ae49765](https://github.com/bitnami/charts/commit/ae49765)), closes [#15029](https://github.com/bitnami/charts/issues/15029)
+
+## <small>10.5.15 (2023-02-14)</small>
+
+* [bitnami/tomcat] Release 10.5.15 (#14870) ([cd5cd65](https://github.com/bitnami/charts/commit/cd5cd65)), closes [#14870](https://github.com/bitnami/charts/issues/14870)
+
+## <small>10.5.14 (2023-02-03)</small>
+
+* [bitnami/tomcat] Release 10.5.14 (#14744) ([eabc7d5](https://github.com/bitnami/charts/commit/eabc7d5)), closes [#14744](https://github.com/bitnami/charts/issues/14744)
+
+## <small>10.5.13 (2023-02-02)</small>
+
+* [bitnami/tomcat] Release 10.5.13 (#14716) ([2537a44](https://github.com/bitnami/charts/commit/2537a44)), closes [#14716](https://github.com/bitnami/charts/issues/14716)
+
+## <small>10.5.12 (2023-02-01)</small>
+
+* [bitnami/tomcat] Release 10.5.12 (#14701) ([b8173e6](https://github.com/bitnami/charts/commit/b8173e6)), closes [#14701](https://github.com/bitnami/charts/issues/14701)
+
+## <small>10.5.11 (2023-02-01)</small>
+
+* [bitnami/*] Change copyright date (#14682) ([add4ec7](https://github.com/bitnami/charts/commit/add4ec7)), closes [#14682](https://github.com/bitnami/charts/issues/14682)
+* [bitnami/tomcat] Release 10.5.11 (#14693) ([3905114](https://github.com/bitnami/charts/commit/3905114)), closes [#14693](https://github.com/bitnami/charts/issues/14693)
+
+## <small>10.5.10 (2023-01-31)</small>
+
+* [bitnami/*] Unify READMEs (#14472) ([2064fb8](https://github.com/bitnami/charts/commit/2064fb8)), closes [#14472](https://github.com/bitnami/charts/issues/14472)
+* [bitnami/tomcat] Don't regenerate self-signed certs on upgrade (#14665) ([083c966](https://github.com/bitnami/charts/commit/083c966)), closes [#14665](https://github.com/bitnami/charts/issues/14665)
+
+## <small>10.5.9 (2023-01-20)</small>
+
+* [bitnami/*] Change licenses annotation format (#14377) ([0ab7608](https://github.com/bitnami/charts/commit/0ab7608)), closes [#14377](https://github.com/bitnami/charts/issues/14377)
+* [bitnami/tomcat] Release 10.5.9 (#14460) ([d9896e6](https://github.com/bitnami/charts/commit/d9896e6)), closes [#14460](https://github.com/bitnami/charts/issues/14460)
+
+## <small>10.5.8 (2023-01-14)</small>
+
+* [bitnami/*] Add license annotation and remove obsolete engine parameter (#14293) ([da2a794](https://github.com/bitnami/charts/commit/da2a794)), closes [#14293](https://github.com/bitnami/charts/issues/14293)
+* [bitnami/tomcat] Release 10.5.8 (#14354) ([f4906a9](https://github.com/bitnami/charts/commit/f4906a9)), closes [#14354](https://github.com/bitnami/charts/issues/14354)
+
+## <small>10.5.7 (2023-01-09)</small>
+
+* [bitnami/tomcat] Release 10.5.7 (#14232) ([75b54b0](https://github.com/bitnami/charts/commit/75b54b0)), closes [#14232](https://github.com/bitnami/charts/issues/14232)
+
+## <small>10.5.6 (2022-12-10)</small>
+
+* [bitnami/tomcat] Release 10.5.6 (#13904) ([089b26d](https://github.com/bitnami/charts/commit/089b26d)), closes [#13904](https://github.com/bitnami/charts/issues/13904)
+
+## <small>10.5.5 (2022-12-10)</small>
+
+* [bitnami/tomcat] Release 10.5.5 (#13894) ([8b6bdb2](https://github.com/bitnami/charts/commit/8b6bdb2)), closes [#13894](https://github.com/bitnami/charts/issues/13894)
+
+## <small>10.5.4 (2022-11-25)</small>
+
+* [bitnami/tomcat] Release 10.5.4 (#13696) ([cc5f089](https://github.com/bitnami/charts/commit/cc5f089)), closes [#13696](https://github.com/bitnami/charts/issues/13696)
+
+## <small>10.5.3 (2022-11-15)</small>
+
+* [bitnami/tomcat] Release 10.5.3 (#13517) ([912800d](https://github.com/bitnami/charts/commit/912800d)), closes [#13517](https://github.com/bitnami/charts/issues/13517)
+
+## <small>10.5.2 (2022-11-11)</small>
+
+* [bitnami/tomcat] fix memory opts for jmx-exporter (#13449) ([3c37292](https://github.com/bitnami/charts/commit/3c37292)), closes [#13449](https://github.com/bitnami/charts/issues/13449)
+
+## <small>10.5.1 (2022-11-08)</small>
+
+* [bitnami/tomcat] Release 10.5.1 (#13392) ([8a2e991](https://github.com/bitnami/charts/commit/8a2e991)), closes [#13392](https://github.com/bitnami/charts/issues/13392)
+
+## 10.5.0 (2022-11-03)
+
+* [bitnami/tomcat] removed enforcement of tomcatPassword (#12296) (#13101) ([60d2b11](https://github.com/bitnami/charts/commit/60d2b11)), closes [#12296](https://github.com/bitnami/charts/issues/12296) [#13101](https://github.com/bitnami/charts/issues/13101)
+
+## <small>10.4.9 (2022-10-26)</small>
+
+* optimize extraPodSpec style for pod tpl (#13110) ([a39e51e](https://github.com/bitnami/charts/commit/a39e51e)), closes [#13110](https://github.com/bitnami/charts/issues/13110)
+
+## <small>10.4.8 (2022-10-21)</small>
+
+* [bitnami/*] Use new default branch name in links (#12943) ([a529e02](https://github.com/bitnami/charts/commit/a529e02)), closes [#12943](https://github.com/bitnami/charts/issues/12943)
+* [bitnami/tomcat] fix extraPodSpec bad indentation (#12464) ([f158f85](https://github.com/bitnami/charts/commit/f158f85)), closes [#12464](https://github.com/bitnami/charts/issues/12464)
+
+## <small>10.4.7 (2022-10-12)</small>
+
+* [bitnami/tomcat] Release 10.4.7 (#12915) ([d8ca2d7](https://github.com/bitnami/charts/commit/d8ca2d7)), closes [#12915](https://github.com/bitnami/charts/issues/12915)
+
+## <small>10.4.6 (2022-10-07)</small>
+
+* [bitnami/tomcat] Release 10.4.6 (#12860) ([bece24c](https://github.com/bitnami/charts/commit/bece24c)), closes [#12860](https://github.com/bitnami/charts/issues/12860)
+* Generic README instructions related to the repo (#12792) ([3cf6b10](https://github.com/bitnami/charts/commit/3cf6b10)), closes [#12792](https://github.com/bitnami/charts/issues/12792)
+
+## <small>10.4.5 (2022-09-19)</small>
+
+* [bitnami/tomcat] Release 10.4.5 (#12579) ([669a762](https://github.com/bitnami/charts/commit/669a762)), closes [#12579](https://github.com/bitnami/charts/issues/12579)
+
+## <small>10.4.4 (2022-09-19)</small>
+
+* [bitnami/tomcat] Use custom probes if given (#12564) ([c21f6c9](https://github.com/bitnami/charts/commit/c21f6c9)), closes [#12564](https://github.com/bitnami/charts/issues/12564) [#12354](https://github.com/bitnami/charts/issues/12354)
+
+## <small>10.4.3 (2022-08-25)</small>
+
+* [bitnami/tomcat] Release 10.4.3 (#12146) ([cd71797](https://github.com/bitnami/charts/commit/cd71797)), closes [#12146](https://github.com/bitnami/charts/issues/12146)
+
+## <small>10.4.2 (2022-08-23)</small>
+
+* [bitnami/tomcat] Update Chart.lock (#12064) ([94d48e3](https://github.com/bitnami/charts/commit/94d48e3)), closes [#12064](https://github.com/bitnami/charts/issues/12064)
+
+## <small>10.4.1 (2022-08-23)</small>
+
+* [bitnami/tomcat] default to current namespace for podmonitor (#11972) ([3cf24c1](https://github.com/bitnami/charts/commit/3cf24c1)), closes [#11972](https://github.com/bitnami/charts/issues/11972) [#10429](https://github.com/bitnami/charts/issues/10429)
+
+## 10.4.0 (2022-08-22)
+
+* [bitnami/tomcat] Add support for image digest apart from tag (#11954) ([0c4b7c2](https://github.com/bitnami/charts/commit/0c4b7c2)), closes [#11954](https://github.com/bitnami/charts/issues/11954)
+* [bitnami/tomcat] securityContext for jmx-exporter (#11804) ([806a75f](https://github.com/bitnami/charts/commit/806a75f)), closes [#11804](https://github.com/bitnami/charts/issues/11804)
+
+## <small>10.3.15 (2022-08-17)</small>
+
+* [bitnami/tomcat] Release 10.3.15 updating components versions ([7d0af78](https://github.com/bitnami/charts/commit/7d0af78))
+
+## <small>10.3.14 (2022-08-09)</small>
+
+* [bitnami/tomcat] Release 10.3.14 updating components versions ([224d1e5](https://github.com/bitnami/charts/commit/224d1e5))
+
+## <small>10.3.13 (2022-08-09)</small>
+
+* [bitnami/tomcat] Release 10.3.13 updating components versions ([06a4b52](https://github.com/bitnami/charts/commit/06a4b52))
+
+## <small>10.3.12 (2022-08-02)</small>
+
+* [bitnami/tomcat] Release 10.3.12 updating components versions ([3716515](https://github.com/bitnami/charts/commit/3716515))
+
+## <small>10.3.11 (2022-07-26)</small>
+
+* [bitnami/*] Update URLs to point to the new bitnami/containers monorepo (#11352) ([d665af0](https://github.com/bitnami/charts/commit/d665af0)), closes [#11352](https://github.com/bitnami/charts/issues/11352)
+* [bitnami/tomcat] Release 10.3.11 updating components versions ([1a7d537](https://github.com/bitnami/charts/commit/1a7d537))
+
+## <small>10.3.10 (2022-07-14)</small>
+
+* [bitnami/tomcat] Release 10.3.10 updating components versions ([c6a91f1](https://github.com/bitnami/charts/commit/c6a91f1))
+
+## <small>10.3.9 (2022-06-28)</small>
+
+* [bitnami/tomcat] Release 10.3.9 updating components versions ([c35f654](https://github.com/bitnami/charts/commit/c35f654))
+
+## <small>10.3.8 (2022-06-17)</small>
+
+* [bitnami/tomcat] Release 10.3.8 updating components versions ([c28f216](https://github.com/bitnami/charts/commit/c28f216))
+
+## <small>10.3.7 (2022-06-15)</small>
+
+* [bitnami/tomcat] Release 10.3.7 updating components versions ([d5a341f](https://github.com/bitnami/charts/commit/d5a341f))
+
+## <small>10.3.6 (2022-06-11)</small>
+
+* [bitnami/tomcat] Release 10.3.6 updating components versions ([21ebfdb](https://github.com/bitnami/charts/commit/21ebfdb))
+
+## <small>10.3.5 (2022-06-10)</small>
+
+* [bitnami/*] Replace Kubeapps URL in READMEs (and kubeapps Chart.yaml) and remove BKPR references (#1 ([c6a7914](https://github.com/bitnami/charts/commit/c6a7914)), closes [#10600](https://github.com/bitnami/charts/issues/10600)
+* [bitnami/tomcat] Release 10.3.5 updating components versions ([a869e1e](https://github.com/bitnami/charts/commit/a869e1e))
+
+## <small>10.3.4 (2022-06-06)</small>
+
+* [bitnami/tomcat] Release 10.3.4 updating components versions ([61abce7](https://github.com/bitnami/charts/commit/61abce7))
+
+## <small>10.3.3 (2022-06-01)</small>
+
+* [bitnami/several] Replace maintainers email by url (#10523) ([ff3cf61](https://github.com/bitnami/charts/commit/ff3cf61)), closes [#10523](https://github.com/bitnami/charts/issues/10523)
+
+## <small>10.3.2 (2022-05-30)</small>
+
+* [bitnami/several] Replace base64 --decode with base64 -d (#10495) ([099286a](https://github.com/bitnami/charts/commit/099286a)), closes [#10495](https://github.com/bitnami/charts/issues/10495)
+
+## <small>10.3.1 (2022-05-30)</small>
+
+* [bitnami/tomcat] fix data type (#10477) ([34b62e2](https://github.com/bitnami/charts/commit/34b62e2)), closes [#10477](https://github.com/bitnami/charts/issues/10477)
+
+## 10.3.0 (2022-05-26)
+
+* [bitnami/tomcat] Add missing service parameter (#10429) ([083704e](https://github.com/bitnami/charts/commit/083704e)), closes [#10429](https://github.com/bitnami/charts/issues/10429)
+
+## <small>10.2.4 (2022-05-21)</small>
+
+* [bitnami/tomcat] Release 10.2.4 updating components versions ([3b045c9](https://github.com/bitnami/charts/commit/3b045c9))
+
+## <small>10.2.3 (2022-05-20)</small>
+
+* [bitnami/tomcat] Release 10.2.3 updating components versions ([10cd58d](https://github.com/bitnami/charts/commit/10cd58d))
+
+## <small>10.2.2 (2022-05-18)</small>
+
+* [bitnami/tomcat] Release 10.2.2 updating components versions ([166e9e6](https://github.com/bitnami/charts/commit/166e9e6))
+
+## <small>10.2.1 (2022-05-17)</small>
+
+* [bitnami/tomcat] Release 10.2.1 updating components versions ([c830c5e](https://github.com/bitnami/charts/commit/c830c5e))
+
+## 10.2.0 (2022-05-16)
+
+* [bitnami/*] add ingress extraRules feature (#10253) ([0f6cbb9](https://github.com/bitnami/charts/commit/0f6cbb9)), closes [#10253](https://github.com/bitnami/charts/issues/10253)
+
+## <small>10.1.23 (2022-05-13)</small>
+
+* [bitnami/*] Remove old 'ci' files (#10171) ([5df30c4](https://github.com/bitnami/charts/commit/5df30c4)), closes [#10171](https://github.com/bitnami/charts/issues/10171)
+* [bitnami/*] Unify k8s directives separators (#10185) ([2650214](https://github.com/bitnami/charts/commit/2650214)), closes [#10185](https://github.com/bitnami/charts/issues/10185)
+
+## <small>10.1.22 (2022-05-10)</small>
+
+* [bitnami/tomcat] Release 10.1.22 updating components versions ([fc964e5](https://github.com/bitnami/charts/commit/fc964e5))
+
+## <small>10.1.21 (2022-04-20)</small>
+
+* [bitnami/tomcat] Release 10.1.21 updating components versions ([94ef871](https://github.com/bitnami/charts/commit/94ef871))
+
+## <small>10.1.20 (2022-04-19)</small>
+
+* [bitnami/tomcat] Release 10.1.20 updating components versions ([520ed3e](https://github.com/bitnami/charts/commit/520ed3e))
+
+## <small>10.1.19 (2022-04-02)</small>
+
+* [bitnami/tomcat] Release 10.1.19 updating components versions ([7cf7ff2](https://github.com/bitnami/charts/commit/7cf7ff2))
+
+## <small>10.1.18 (2022-04-01)</small>
+
+* [bitnami/tomcat] Release 10.1.18 updating components versions ([6245e19](https://github.com/bitnami/charts/commit/6245e19))
+
+## <small>10.1.17 (2022-03-28)</small>
+
+* [bitnami/tomcat] Release 10.1.17 updating components versions ([1a1e6a2](https://github.com/bitnami/charts/commit/1a1e6a2))
+
+## <small>10.1.16 (2022-03-27)</small>
+
+* [bitnami/tomcat] Release 10.1.16 updating components versions ([cf92ae8](https://github.com/bitnami/charts/commit/cf92ae8))
+
+## <small>10.1.15 (2022-03-22)</small>
+
+* [bitnami/tomcat] Release 10.1.15 updating components versions ([a5920bc](https://github.com/bitnami/charts/commit/a5920bc))
+
+## <small>10.1.14 (2022-03-17)</small>
+
+* [bitnami/tomcat] Release 10.1.14 updating components versions ([de5b0ad](https://github.com/bitnami/charts/commit/de5b0ad))
+
+## <small>10.1.13 (2022-03-15)</small>
+
+* [bitnami/tomcat] Release 10.1.13 updating components versions ([ec650f3](https://github.com/bitnami/charts/commit/ec650f3))
+
+## <small>10.1.12 (2022-02-28)</small>
+
+* [bitnami/tomcat] Release 10.1.12 updating components versions ([dd57d77](https://github.com/bitnami/charts/commit/dd57d77))
+
+## <small>10.1.11 (2022-02-27)</small>
+
+* [bitnami/tomcat] Release 10.1.11 updating components versions ([c948125](https://github.com/bitnami/charts/commit/c948125))
+
+## <small>10.1.10 (2022-02-21)</small>
+
+* [bitnami/tomcat] Release 10.1.10 updating components versions ([b0e55b1](https://github.com/bitnami/charts/commit/b0e55b1))
+
+## <small>10.1.9 (2022-02-11)</small>
+
+* [bitnami/tomcat] Another monitoring fixes (#8940) ([a956bad](https://github.com/bitnami/charts/commit/a956bad)), closes [#8940](https://github.com/bitnami/charts/issues/8940)
+
+## <small>10.1.8 (2022-02-09)</small>
+
+* [bitnami/tomcat] Release 10.1.8 updating components versions ([255c661](https://github.com/bitnami/charts/commit/255c661))
+
+## <small>10.1.7 (2022-02-04)</small>
+
+* [bitnami/tomcat] monitoring fixes (#8863) ([7e2bcb3](https://github.com/bitnami/charts/commit/7e2bcb3)), closes [#8863](https://github.com/bitnami/charts/issues/8863)
+
+## <small>10.1.6 (2022-02-01)</small>
+
+* [bitnami/*] Fix non-utf8 characters (#8826) ([aebe0ed](https://github.com/bitnami/charts/commit/aebe0ed)), closes [#8826](https://github.com/bitnami/charts/issues/8826)
+* [bitnami/tomcat] Release 10.1.6 updating components versions ([5b659de](https://github.com/bitnami/charts/commit/5b659de))
+* [bitnami/tomcat] wrong indent for containerExtraPorts fix (#8736) ([9206f25](https://github.com/bitnami/charts/commit/9206f25)), closes [#8736](https://github.com/bitnami/charts/issues/8736)
+
+## <small>10.1.5 (2022-01-20)</small>
+
+* [bitnami/tomcat] Release 10.1.5 updating components versions ([c95a036](https://github.com/bitnami/charts/commit/c95a036))
+
+## <small>10.1.4 (2022-01-20)</small>
+
+* [bitnami/*] Update READMEs (#8716) ([b9a9533](https://github.com/bitnami/charts/commit/b9a9533)), closes [#8716](https://github.com/bitnami/charts/issues/8716)
+* [bitnami/several] Change prerequisites (#8725) ([8d740c5](https://github.com/bitnami/charts/commit/8d740c5)), closes [#8725](https://github.com/bitnami/charts/issues/8725)
+
+## <small>10.1.3 (2022-01-19)</small>
+
+* [bitnami/*] Readme automation (#8579) ([78d1938](https://github.com/bitnami/charts/commit/78d1938)), closes [#8579](https://github.com/bitnami/charts/issues/8579)
+* [bitnami/tomcat] Fix extraVolumes parameter (#8684) ([6b2cba8](https://github.com/bitnami/charts/commit/6b2cba8)), closes [#8684](https://github.com/bitnami/charts/issues/8684)
+
+## <small>10.1.2 (2022-01-14)</small>
+
+* [bitnami/tomcat] Fix storageclass indentation (#8667) ([c6cf895](https://github.com/bitnami/charts/commit/c6cf895)), closes [#8667](https://github.com/bitnami/charts/issues/8667)
+
+## <small>10.1.1 (2022-01-11)</small>
+
+* [bitnami/tomcat] Release 10.1.1 updating components versions ([b16b22c](https://github.com/bitnami/charts/commit/b16b22c))
+
+## 10.1.0 (2022-01-05)
+
+* [bitnami/several] Adapt templating format (#8562) ([8cad18a](https://github.com/bitnami/charts/commit/8cad18a)), closes [#8562](https://github.com/bitnami/charts/issues/8562)
+* [bitnami/several] Add license to the README ([05f7633](https://github.com/bitnami/charts/commit/05f7633))
+* [bitnami/several] Add license to the README ([32fb238](https://github.com/bitnami/charts/commit/32fb238))
+* [bitnami/several] Add license to the README ([b87c2f7](https://github.com/bitnami/charts/commit/b87c2f7))
+
+## 10.0.0 (2021-12-29)
+
+* [bitnami/tomcat] Chart standardized (#7707) ([897ba8e](https://github.com/bitnami/charts/commit/897ba8e)), closes [#7707](https://github.com/bitnami/charts/issues/7707)
+
+## 9.7.0 (2021-12-16)
+
+* [bitnami/tomcat] Add prometheusRules support (#8401) ([a5486ab](https://github.com/bitnami/charts/commit/a5486ab)), closes [#8401](https://github.com/bitnami/charts/issues/8401)
+
+## <small>9.6.3 (2021-12-08)</small>
+
+* [bitnami/tomcat] Release 9.6.3 updating components versions ([786de9a](https://github.com/bitnami/charts/commit/786de9a))
+
+## <small>9.6.2 (2021-12-07)</small>
+
+* [bitnami/tomcat] Fix Networkpolicy (#8300) ([bff2b3e](https://github.com/bitnami/charts/commit/bff2b3e)), closes [#8300](https://github.com/bitnami/charts/issues/8300)
+
+## <small>9.6.1 (2021-11-29)</small>
+
+* [bitnami/several] Regenerate README tables ([e8e4e6a](https://github.com/bitnami/charts/commit/e8e4e6a))
+* [bitnami/several] Replace HTTP by HTTPS when possible (#8259) ([eafb5bd](https://github.com/bitnami/charts/commit/eafb5bd)), closes [#8259](https://github.com/bitnami/charts/issues/8259)
+
+## 9.6.0 (2021-11-22)
+
+* [bitnami/several] Regenerate README tables ([3d7ca74](https://github.com/bitnami/charts/commit/3d7ca74))
+* [bitnami/tomcat] Add networkpolicy support (#8192) ([afcf09e](https://github.com/bitnami/charts/commit/afcf09e)), closes [#8192](https://github.com/bitnami/charts/issues/8192)
+
+## <small>9.5.4 (2021-11-16)</small>
+
+* [bitnami/several] Regenerate README tables ([3cefed3](https://github.com/bitnami/charts/commit/3cefed3))
+* [bitnami/tomcat] Release 9.5.4 updating components versions ([c26a3c1](https://github.com/bitnami/charts/commit/c26a3c1))
+* Update readme to correct parameter name. (#8017) ([aab292e](https://github.com/bitnami/charts/commit/aab292e)), closes [#8017](https://github.com/bitnami/charts/issues/8017)
+
+## <small>9.5.3 (2021-10-30)</small>
+
+* [bitnami/several] Regenerate README tables ([412cf6a](https://github.com/bitnami/charts/commit/412cf6a))
+* [bitnami/tomcat] Release 9.5.3 updating components versions ([f3f7f8a](https://github.com/bitnami/charts/commit/f3f7f8a))
+
+## <small>9.5.2 (2021-10-26)</small>
+
+* [bitnami/tomcat] Release 9.5.2 updating components versions ([629f219](https://github.com/bitnami/charts/commit/629f219))
+
+## <small>9.5.1 (2021-10-22)</small>
+
+* [bitnami/several] Add chart info to NOTES.txt (#7889) ([a6751cd](https://github.com/bitnami/charts/commit/a6751cd)), closes [#7889](https://github.com/bitnami/charts/issues/7889)
+* [bitnami/several] Regenerate README tables ([73cabea](https://github.com/bitnami/charts/commit/73cabea))
+
+## 9.5.0 (2021-10-20)
+
+* [bitnami/tomcat] Add JMX metrics support (#7623) ([1de6cc9](https://github.com/bitnami/charts/commit/1de6cc9)), closes [#7623](https://github.com/bitnami/charts/issues/7623)
+
+## <small>9.4.5 (2021-10-19)</small>
+
+* [bitnami/several] Change pullPolicy for bitnami-shell image (#7852) ([9711a33](https://github.com/bitnami/charts/commit/9711a33)), closes [#7852](https://github.com/bitnami/charts/issues/7852)
+* [bitnami/several] Regenerate README tables ([681f9fa](https://github.com/bitnami/charts/commit/681f9fa))
+
+## <small>9.4.4 (2021-10-19)</small>
+
+* [bitnami/several] Regenerate README tables ([cdcf8c1](https://github.com/bitnami/charts/commit/cdcf8c1))
+* [bitnami/tomcat] Release 9.4.4 updating components versions ([0b39fcc](https://github.com/bitnami/charts/commit/0b39fcc))
+
+## <small>9.4.3 (2021-10-05)</small>
+
+* [bitnami/*] Revert changes in values.schemas.json (#7699) ([aaa314f](https://github.com/bitnami/charts/commit/aaa314f)), closes [#7699](https://github.com/bitnami/charts/issues/7699)
+
+## <small>9.4.2 (2021-10-04)</small>
+
+* [bitnami/tomcat] Release 9.4.2 updating components versions ([3e53023](https://github.com/bitnami/charts/commit/3e53023))
+
+## <small>9.4.1 (2021-10-01)</small>
+
+* [bitnami/*] Drop support for deprecated cert-manager annotation (#7646) ([4297b79](https://github.com/bitnami/charts/commit/4297b79)), closes [#7646](https://github.com/bitnami/charts/issues/7646)
+
+## 9.4.0 (2021-09-29)
+
+* [bitnami/apache,tomcat] add extraPodSpec (#7580) ([e3a8529](https://github.com/bitnami/charts/commit/e3a8529)), closes [#7580](https://github.com/bitnami/charts/issues/7580)
+* [bitnami/several] Regenerate README tables ([9d60bbd](https://github.com/bitnami/charts/commit/9d60bbd))
+
+## 9.3.0 (2021-09-27)
+
+* [bitnami/*] Generate READMEs with new generator version (#7614) ([e5ab2e6](https://github.com/bitnami/charts/commit/e5ab2e6)), closes [#7614](https://github.com/bitnami/charts/issues/7614)
+* [bitnami/apache,postgresql,tomcat] add topologySpreadConstraints (#7598) ([557bfe9](https://github.com/bitnami/charts/commit/557bfe9)), closes [#7598](https://github.com/bitnami/charts/issues/7598)
+* [bitnami/several] Regenerate README tables ([a8d100a](https://github.com/bitnami/charts/commit/a8d100a))
+
+## <small>9.2.27 (2021-09-23)</small>
+
+* [bitnami/several] Regenerate README tables ([b294dc2](https://github.com/bitnami/charts/commit/b294dc2))
+* [bitnami/tomcat] Release 9.2.27 updating components versions ([84ee61c](https://github.com/bitnami/charts/commit/84ee61c))
+
+## <small>9.2.26 (2021-09-13)</small>
+
+* [bitnami/several] Regenerate README tables ([e0a27b4](https://github.com/bitnami/charts/commit/e0a27b4))
+* [bitnami/tomcat] Release 9.2.26 updating components versions ([720b8f7](https://github.com/bitnami/charts/commit/720b8f7))
+
+## <small>9.2.25 (2021-09-03)</small>
+
+* [bitnami/several] Regenerate README tables ([da2513b](https://github.com/bitnami/charts/commit/da2513b))
+* [bitnami/tomcat] Release 9.2.25 updating components versions ([d75ce0e](https://github.com/bitnami/charts/commit/d75ce0e))
+
+## <small>9.2.24 (2021-08-25)</small>
+
+* [bitnami/tomcat] Release 9.2.24 updating components versions ([d28bd32](https://github.com/bitnami/charts/commit/d28bd32))
+
+## <small>9.2.23 (2021-08-25)</small>
+
+* [bitnami/several] Regenerate README tables ([6c9124f](https://github.com/bitnami/charts/commit/6c9124f))
+* [bitnami/tomcat] Release 9.2.23 updating components versions ([faa5287](https://github.com/bitnami/charts/commit/faa5287))
+
+## <small>9.2.22 (2021-08-18)</small>
+
+* [multiple] Updated image.tag section (#7257) ([a133bed](https://github.com/bitnami/charts/commit/a133bed)), closes [#7257](https://github.com/bitnami/charts/issues/7257)
+
+## <small>9.2.21 (2021-08-13)</small>
+
+* [bitnami/several] Regenerate README tables ([6c107e8](https://github.com/bitnami/charts/commit/6c107e8))
+* [bitnami/tomcat] Release 9.2.21 updating components versions ([6ced21c](https://github.com/bitnami/charts/commit/6ced21c))
+
+## <small>9.2.20 (2021-08-06)</small>
+
+* [bitnami/several] Update READMEs (#7108) ([44961d9](https://github.com/bitnami/charts/commit/44961d9)), closes [#7108](https://github.com/bitnami/charts/issues/7108)
+* [bitnami/tomcat] Release 9.2.20 updating components versions ([a1a4afd](https://github.com/bitnami/charts/commit/a1a4afd))
+
+## <small>9.2.19 (2021-07-30)</small>
+
+* [bitnami/tomcat] README changes (#7011) ([7733ba0](https://github.com/bitnami/charts/commit/7733ba0)), closes [#7011](https://github.com/bitnami/charts/issues/7011)
+* [bitnami/tomcat] Release 9.2.19 updating components versions ([8f14c8a](https://github.com/bitnami/charts/commit/8f14c8a))
+
+## <small>9.2.18 (2021-07-21)</small>
+
+* [bitnami/*] Replace nil values (#6993) ([2be11a7](https://github.com/bitnami/charts/commit/2be11a7)), closes [#6993](https://github.com/bitnami/charts/issues/6993)
+
+## <small>9.2.17 (2021-07-16)</small>
+
+* [bitnami/*] Adapt values.yaml of common library, Tomcat, Wavefront and ZooKeeper charts (#6970) ([fb2693b](https://github.com/bitnami/charts/commit/fb2693b)), closes [#6970](https://github.com/bitnami/charts/issues/6970)
+
+## <small>9.2.16 (2021-07-07)</small>
+
+* [bitnami/tomcat] Release 9.2.16 updating components versions ([2516808](https://github.com/bitnami/charts/commit/2516808))
+
+## <small>9.2.15 (2021-07-06)</small>
+
+* [bitnami/tomcat] Release 9.2.15 updating components versions ([37e51ca](https://github.com/bitnami/charts/commit/37e51ca))
+
+## <small>9.2.14 (2021-06-18)</small>
+
+* [bitnami/tomcat] Release 9.2.14 updating components versions ([29612a7](https://github.com/bitnami/charts/commit/29612a7))
+
+## <small>9.2.13 (2021-06-17)</small>
+
+* [bitnami/tomcat] Release 9.2.13 updating components versions ([ebc3774](https://github.com/bitnami/charts/commit/ebc3774))
+
+## <small>9.2.12 (2021-06-15)</small>
+
+* [bitnami/tomcat] Release 9.2.12 updating components versions ([5216b53](https://github.com/bitnami/charts/commit/5216b53))
+
+## <small>9.2.11 (2021-06-11)</small>
+
+* [bitnami/tomcat] Release 9.2.11 updating components versions ([d65e4ef](https://github.com/bitnami/charts/commit/d65e4ef))
+
+## <small>9.2.10 (2021-06-08)</small>
+
+* [bitnami/tomcat] Release 9.2.10 updating components versions ([d427be6](https://github.com/bitnami/charts/commit/d427be6))
+
+## <small>9.2.9 (2021-06-01)</small>
+
+* [bitnami/tomcat] initContainers and sidecars indent fix (#6513) ([20a3c3f](https://github.com/bitnami/charts/commit/20a3c3f)), closes [#6513](https://github.com/bitnami/charts/issues/6513) [#6501](https://github.com/bitnami/charts/issues/6501)
+
+## <small>9.2.8 (2021-05-28)</small>
+
+* [bitnami/tomcat] Release 9.2.8 updating components versions ([a3ed947](https://github.com/bitnami/charts/commit/a3ed947))
+
+## <small>9.2.7 (2021-05-13)</small>
+
+* [bitnami/tomcat] Release 9.2.7 updating components versions ([5d871b6](https://github.com/bitnami/charts/commit/5d871b6))
+
+## <small>9.2.6 (2021-05-13)</small>
+
+* [bitnami/tomcat] Release 9.2.6 updating components versions ([fc95b11](https://github.com/bitnami/charts/commit/fc95b11))
+
+## <small>9.2.5 (2021-04-26)</small>
+
+* [bitnami/tomcat] Release 9.2.5 updating components versions ([ab63a56](https://github.com/bitnami/charts/commit/ab63a56))
+
+## <small>9.2.4 (2021-04-23)</small>
+
+* [bitnami/tomcat] fix indent & improve volume claim in sts (#6195) ([806c0e8](https://github.com/bitnami/charts/commit/806c0e8)), closes [#6195](https://github.com/bitnami/charts/issues/6195)
+
+## <small>9.2.3 (2021-04-22)</small>
+
+* [bitnami/tomcat] Release 9.2.3 updating components versions ([f27244a](https://github.com/bitnami/charts/commit/f27244a))
+
+## <small>9.2.2 (2021-04-22)</small>
+
+* [bitnami/tomcat] Fix incorrect identation using imagePullSecrets (#6185) ([103756f](https://github.com/bitnami/charts/commit/103756f)), closes [#6185](https://github.com/bitnami/charts/issues/6185)
+
+## <small>9.2.1 (2021-04-20)</small>
+
+* [bitnami/tomcat] Release 9.2.1 updating components versions ([08407b0](https://github.com/bitnami/charts/commit/08407b0))
+
+## 9.2.0 (2021-04-20)
+
+* [bitnami/tomcat] deployment, statefulset choice (#6134) ([2f2e3f8](https://github.com/bitnami/charts/commit/2f2e3f8)), closes [#6134](https://github.com/bitnami/charts/issues/6134)
+
+## 9.1.0 (2021-04-15)
+
+* [bitnami/tomcat] add containerExtraPorts (#6108) ([f21aa57](https://github.com/bitnami/charts/commit/f21aa57)), closes [#6108](https://github.com/bitnami/charts/issues/6108)
+
+## 9.0.0 (2021-04-08)
+
+* [bitnami/tomcat] Release 9.0.0 updating components versions ([cf9da28](https://github.com/bitnami/charts/commit/cf9da28))
+
+## <small>8.3.1 (2021-04-01)</small>
+
+* [bitnami/tomcat] Release 8.3.1 updating components versions ([dc07c3b](https://github.com/bitnami/charts/commit/dc07c3b))
+
+## 8.3.0 (2021-03-29)
+
+* [bitnami/tomcat] Fix missing replicaCount (#5938) ([e7e7d1c](https://github.com/bitnami/charts/commit/e7e7d1c)), closes [#5938](https://github.com/bitnami/charts/issues/5938)
+
+## <small>8.2.5 (2021-03-11)</small>
+
+* [bitnami/tomcat] Release 8.2.5 updating components versions ([61c0e12](https://github.com/bitnami/charts/commit/61c0e12))
+
+## <small>8.2.4 (2021-03-04)</small>
+
+* [bitnami/*] Remove minideb mentions (#5677) ([870bc4d](https://github.com/bitnami/charts/commit/870bc4d)), closes [#5677](https://github.com/bitnami/charts/issues/5677)
+
+## <small>8.2.3 (2021-02-18)</small>
+
+* [bitnami/*] Add notice regarding parameters immutability after chart installation (#4853) ([5f09573](https://github.com/bitnami/charts/commit/5f09573)), closes [#4853](https://github.com/bitnami/charts/issues/4853)
+* [bitnami/tomcat] Release 8.2.3 updating components versions ([fabc7e5](https://github.com/bitnami/charts/commit/fabc7e5))
+
+## <small>8.2.2 (2021-02-03)</small>
+
+* [bitnami/tomcat] Release 8.2.2 updating components versions ([f6ffb7d](https://github.com/bitnami/charts/commit/f6ffb7d))
+
+## <small>8.2.1 (2021-01-29)</small>
+
+* [bitnami/tomcat] Release 8.2.1 updating components versions ([a70dc22](https://github.com/bitnami/charts/commit/a70dc22))
+
+## 8.2.0 (2021-01-29)
+
+* [bitnami/tomcat] Add hostAliases (#5317) ([73811e2](https://github.com/bitnami/charts/commit/73811e2)), closes [#5317](https://github.com/bitnami/charts/issues/5317)
+
+## <small>8.1.1 (2021-01-25)</small>
+
+* [bitnami/*] Change helm version in the prerequisites (#5090) ([c5e67a3](https://github.com/bitnami/charts/commit/c5e67a3)), closes [#5090](https://github.com/bitnami/charts/issues/5090)
+* [bitnami/*] Unify icons in Chart.yaml and add missing fields (#5206) ([0462921](https://github.com/bitnami/charts/commit/0462921)), closes [#5206](https://github.com/bitnami/charts/issues/5206)
+
+## 8.1.0 (2021-01-15)
+
+* [bitnami/*] Update ingress for serveral charts (#5012) ([e3bb5a6](https://github.com/bitnami/charts/commit/e3bb5a6)), closes [#5012](https://github.com/bitnami/charts/issues/5012)
+
+## <small>8.0.3 (2021-01-14)</small>
+
+* [bitnami/tomcat] Release 8.0.3 updating components versions ([3c08f19](https://github.com/bitnami/charts/commit/3c08f19))
+
+## <small>8.0.2 (2021-01-08)</small>
+
+* [bitnami/*] Fix typo in README (leaviness > liveness) (#4917) ([80ca826](https://github.com/bitnami/charts/commit/80ca826)), closes [#4917](https://github.com/bitnami/charts/issues/4917)
+
+## <small>8.0.1 (2021-01-05)</small>
+
+* [bitnami/tomcat] Release 8.0.1 updating components versions ([d603616](https://github.com/bitnami/charts/commit/d603616))
+
+## 8.0.0 (2020-12-16)
+
+* [bitnami/*] Affinity based on common presets (ix) (#4727) ([a0db323](https://github.com/bitnami/charts/commit/a0db323)), closes [#4727](https://github.com/bitnami/charts/issues/4727)
+* [bitnami/*] fix typos (#4699) ([49adc63](https://github.com/bitnami/charts/commit/49adc63)), closes [#4699](https://github.com/bitnami/charts/issues/4699)
+
+## <small>7.1.2 (2020-12-09)</small>
+
+* [bitnami/tomcat] Release 7.1.2 updating components versions ([c37c4cb](https://github.com/bitnami/charts/commit/c37c4cb))
+
+## <small>7.1.1 (2020-12-08)</small>
+
+* [bitnami/tomcat] Fix commonLabels format in values.yaml ([cd7e0bf](https://github.com/bitnami/charts/commit/cd7e0bf))
+* [bitnami/tomcat] Release 7.1.1 updating components versions ([dc3d0c3](https://github.com/bitnami/charts/commit/dc3d0c3))
+
+## 7.1.0 (2020-12-08)
+
+* [bitnami/tomcat] feat: allow custom values for labels and matchLabels (#4359) ([1d2f51d](https://github.com/bitnami/charts/commit/1d2f51d)), closes [#4359](https://github.com/bitnami/charts/issues/4359)
+
+## <small>7.0.1 (2020-12-04)</small>
+
+* [bitnami/tomcat] Release 7.0.1 updating components versions ([64c5622](https://github.com/bitnami/charts/commit/64c5622))
+
+## 7.0.0 (2020-11-10)
+
+* [bitnami/tomcat] Major version. Adapt Chart to apiVersion: v2 (#4259) ([51658e7](https://github.com/bitnami/charts/commit/51658e7)), closes [#4259](https://github.com/bitnami/charts/issues/4259)
+
+## 6.7.0 (2020-11-02)
+
+* [bitnami/tomcat] feat: allow custom values for liveness and readiness probe (#4167) ([e0b2702](https://github.com/bitnami/charts/commit/e0b2702)), closes [#4167](https://github.com/bitnami/charts/issues/4167)
+
+## 6.6.0 (2020-10-29)
+
+* [bitnami/*] Include link to Troubleshootin guide on README.md (#4136) ([c08a20e](https://github.com/bitnami/charts/commit/c08a20e)), closes [#4136](https://github.com/bitnami/charts/issues/4136)
+* [bitnami/tomcat] feat: add extra env vars (#4114) ([94f7e8c](https://github.com/bitnami/charts/commit/94f7e8c)), closes [#4114](https://github.com/bitnami/charts/issues/4114)
+
+## <small>6.5.3 (2020-10-16)</small>
+
+* [bitnami/tomcat] Release 6.5.3 updating components versions ([8498ce6](https://github.com/bitnami/charts/commit/8498ce6))
+
+## <small>6.5.2 (2020-10-12)</small>
+
+* [bitnami/tomcat] Release 6.5.2 updating components versions ([2825db1](https://github.com/bitnami/charts/commit/2825db1))
+
+## <small>6.5.1 (2020-10-10)</small>
+
+* [bitnami/tomcat] Release 6.5.1 updating components versions ([098fdb9](https://github.com/bitnami/charts/commit/098fdb9))
+
+## 6.5.0 (2020-10-05)
+
+* [bitnami/tomcat] add replicas to tomcat  deployment (#3803) ([f8fa6f6](https://github.com/bitnami/charts/commit/f8fa6f6)), closes [#3803](https://github.com/bitnami/charts/issues/3803)
+
+## <small>6.4.1 (2020-09-24)</small>
+
+* [bitnami/tomcat] Release 6.4.1 updating components versions ([2160d93](https://github.com/bitnami/charts/commit/2160d93))
+
+## 6.4.0 (2020-09-23)
+
+* [bitnami/tomcat] add command option to image (#3734) ([6da71b3](https://github.com/bitnami/charts/commit/6da71b3)), closes [#3734](https://github.com/bitnami/charts/issues/3734)
+
+## <small>6.3.17 (2020-09-16)</small>
+
+* [bitnami/tomcat] Release 6.3.17 updating components versions ([033787e](https://github.com/bitnami/charts/commit/033787e))
+
+## <small>6.3.16 (2020-09-08)</small>
+
+* [bitnami/metrics-server] Add source repo (#3577) ([1ed12f9](https://github.com/bitnami/charts/commit/1ed12f9)), closes [#3577](https://github.com/bitnami/charts/issues/3577)
+* [bitnami/tomcat] Release 6.3.16 updating components versions ([4edc063](https://github.com/bitnami/charts/commit/4edc063))
+
+## <small>6.3.15 (2020-08-26)</small>
+
+* [bitnami/tomcat] Release 6.3.15 updating components versions ([d43d231](https://github.com/bitnami/charts/commit/d43d231))
+
+## <small>6.3.14 (2020-08-04)</small>
+
+* [bitnami/tomcat] Release 6.3.14 updating components versions ([330f9a6](https://github.com/bitnami/charts/commit/330f9a6))
+
+## <small>6.3.13 (2020-07-31)</small>
+
+* [bitnami/*] Fix TL;DR typo in READMEs (#3280) ([3d7ab40](https://github.com/bitnami/charts/commit/3d7ab40)), closes [#3280](https://github.com/bitnami/charts/issues/3280)
+* [bitnami/all] Add categories (#3075) ([63bde06](https://github.com/bitnami/charts/commit/63bde06)), closes [#3075](https://github.com/bitnami/charts/issues/3075)
+* [bitnami/tomcat] Release 6.3.13 updating components versions ([22de9cb](https://github.com/bitnami/charts/commit/22de9cb))
+
+## <small>6.3.12 (2020-07-07)</small>
+
+* [bitnami/tomcat] Release 6.3.12 updating components versions ([9be3481](https://github.com/bitnami/charts/commit/9be3481))
+
+## <small>6.3.11 (2020-06-23)</small>
+
+* [bitnami/tomcat] Release 6.3.11 updating components versions ([55b3785](https://github.com/bitnami/charts/commit/55b3785))
+
+## <small>6.3.10 (2020-06-10)</small>
+
+* [bitnami/several] Add instructions about how to use different branches (#2785) ([c315cb0](https://github.com/bitnami/charts/commit/c315cb0)), closes [#2785](https://github.com/bitnami/charts/issues/2785)
+* [bitnami/tomcat] Release 6.3.10 updating components versions ([b4145a5](https://github.com/bitnami/charts/commit/b4145a5))
+
+## <small>6.3.9 (2020-06-08)</small>
+
+* [bitnami/tomcat] Release 6.3.9 updating components versions ([9ff95b6](https://github.com/bitnami/charts/commit/9ff95b6))
+
+## <small>6.3.8 (2020-06-05)</small>
+
+* [bitnami/tomcat] Release 6.3.8 updating components versions ([dbda185](https://github.com/bitnami/charts/commit/dbda185))
+* Add support for helm lint and helm install in PRs via GH Actions (#2721) ([5ed97f0](https://github.com/bitnami/charts/commit/5ed97f0)), closes [#2721](https://github.com/bitnami/charts/issues/2721)
+
+## <small>6.3.7 (2020-05-20)</small>
+
+* [bitnami/tomcat] Release 6.3.7 updating components versions ([055ca1e](https://github.com/bitnami/charts/commit/055ca1e))
+* update bitnami/common to be compatible with helm v2.12+ (#2615) ([c7751eb](https://github.com/bitnami/charts/commit/c7751eb)), closes [#2615](https://github.com/bitnami/charts/issues/2615)
+
+## <small>6.3.6 (2020-04-30)</small>
+
+* [bitnami/tomcat] Release 6.3.6 updating components versions ([09a3e0e](https://github.com/bitnami/charts/commit/09a3e0e))
+
+## <small>6.3.5 (2020-04-22)</small>
+
+* [bitnami/tomcat] Release 6.3.5 updating components versions ([da1e075](https://github.com/bitnami/charts/commit/da1e075))
+
+## <small>6.3.4 (2020-04-16)</small>
+
+* [bitnami/tomcat] Release 6.3.4 updating components versions ([df94e5c](https://github.com/bitnami/charts/commit/df94e5c))
+
+## <small>6.3.3 (2020-04-09)</small>
+
+* [bitnami/tomcat] Release 6.3.3 updating components versions ([5474884](https://github.com/bitnami/charts/commit/5474884))
+
+## <small>6.3.2 (2020-04-06)</small>
+
+* [bitnami/tomcat] Release 6.3.2 updating components versions ([16e4f8f](https://github.com/bitnami/charts/commit/16e4f8f))
+
+## <small>6.3.1 (2020-03-26)</small>
+
+* [bitnami/tomcat] Release 6.3.1 updating components versions ([d88a99f](https://github.com/bitnami/charts/commit/d88a99f))
+
+## 6.3.0 (2020-03-26)
+
+* [bitnami/tomcat] Allow setting existing PVCs (#2130) ([a4573d8](https://github.com/bitnami/charts/commit/a4573d8)), closes [#2130](https://github.com/bitnami/charts/issues/2130)
+
+## <small>6.2.10 (2020-03-26)</small>
+
+* [bitnami/tomcat] Release 6.2.10 updating components versions ([246c4ea](https://github.com/bitnami/charts/commit/246c4ea))
+
+## <small>6.2.9 (2020-03-24)</small>
+
+* [bitnami/tomcat] Release 6.2.9 updating components versions ([20206c2](https://github.com/bitnami/charts/commit/20206c2))
+
+## <small>6.2.8 (2020-03-20)</small>
+
+* [bitnami/tomcat] Release 6.2.8 updating components versions ([47152eb](https://github.com/bitnami/charts/commit/47152eb))
+
+## <small>6.2.7 (2020-03-17)</small>
+
+* [bitnami/tomcat] Release 6.2.7 updating components versions ([92f250b](https://github.com/bitnami/charts/commit/92f250b))
+
+## <small>6.2.6 (2020-03-12)</small>
+
+* [bitnami/tomcat] Release 6.2.6 updating components versions ([c064167](https://github.com/bitnami/charts/commit/c064167))
+
+## <small>6.2.5 (2020-03-11)</small>
+
+* Move charts from upstreamed folder to bitnami (#2032) ([a0e44f7](https://github.com/bitnami/charts/commit/a0e44f7)), closes [#2032](https://github.com/bitnami/charts/issues/2032)
+
+## <small>6.2.4 (2020-02-26)</small>
+
+* [bitnami/tomcat] Release 6.2.4 updating components versions ([4c1e070](https://github.com/bitnami/charts/commit/4c1e070))
+
+## <small>6.2.3 (2020-02-12)</small>
+
+* [bitnami/tomcat] Release 6.2.3 updating components versions ([57cc37c](https://github.com/bitnami/charts/commit/57cc37c))
+
+## <small>6.2.2 (2020-02-11)</small>
+
+* [bitnami/tomcat,wildfly,consul] Fix upgrade repo ([3d3fdbe](https://github.com/bitnami/charts/commit/3d3fdbe))
+
+## <small>6.2.1 (2020-02-11)</small>
+
+* [bitnami/several] Adapt READMEs and helpers to Helm 3 (#1911) ([40ee57c](https://github.com/bitnami/charts/commit/40ee57c)), closes [#1911](https://github.com/bitnami/charts/issues/1911)
+
+## 6.2.0 (2020-02-11)
+
+* [bitnami/tomcat] adds `updateStrategy` chart parameter (#1907) ([585179b](https://github.com/bitnami/charts/commit/585179b)), closes [#1907](https://github.com/bitnami/charts/issues/1907)
+
+## <small>6.1.6 (2020-02-10)</small>
+
+* [bitnami/several] Replace stretch by buster in minideb secondary containers (#1900) ([678febc](https://github.com/bitnami/charts/commit/678febc)), closes [#1900](https://github.com/bitnami/charts/issues/1900)
+
+## <small>6.1.5 (2020-01-23)</small>
+
+* [bitnami/tomcat] Release 6.1.5 updating components versions ([b564fac](https://github.com/bitnami/charts/commit/b564fac))
+
+## <small>6.1.4 (2020-01-14)</small>
+
+* [bitnami/tomcat] Release 6.1.4 updating components versions ([dc6ab48](https://github.com/bitnami/charts/commit/dc6ab48))
+
+## <small>6.1.3 (2019-12-24)</small>
+
+* [bitnami/tomcat] Release 6.1.3 updating components versions ([0e87c18](https://github.com/bitnami/charts/commit/0e87c18))
+
+## <small>6.1.2 (2019-12-13)</small>
+
+* [bitnami/tomcat] Release 6.1.2 updating components versions ([53f3316](https://github.com/bitnami/charts/commit/53f3316))
+
+## <small>6.1.1 (2019-12-12)</small>
+
+* [bitnami/tocat] Fix tplValue macro ([146093d](https://github.com/bitnami/charts/commit/146093d))
+* [bitnami/tomcat] Update components versions ([1fc0d7d](https://github.com/bitnami/charts/commit/1fc0d7d))
+
+## 6.1.0 (2019-11-28)
+
+* [bitnami/tomcat] Lint chart + standardisation ([ecd81cf](https://github.com/bitnami/charts/commit/ecd81cf))
+
+## <small>6.0.6 (2019-11-22)</small>
+
+* [bitnami/tomcat] Release 6.0.6 updating components versions ([68d859e](https://github.com/bitnami/charts/commit/68d859e))
+
+## <small>6.0.5 (2019-11-18)</small>
+
+* [bitnami/tomcat] Release 6.0.5 updating components versions ([a057767](https://github.com/bitnami/charts/commit/a057767))
+
+## <small>6.0.4 (2019-10-24)</small>
+
+* Fix links because of section renaming ([8e6fa3b](https://github.com/bitnami/charts/commit/8e6fa3b))
+
+## <small>6.0.3 (2019-10-23)</small>
+
+* Adapt README in charts (III) ([98eadc4](https://github.com/bitnami/charts/commit/98eadc4))
+
+## <small>5.0.2 (2019-10-15)</small>
+
+* [bitnami/tomcat] Update prerequisites ([c107254](https://github.com/bitnami/charts/commit/c107254))
+
+## <small>6.0.1 (2019-10-16)</small>
+
+* [bitnami/tomcat] Release 6.0.1 updating components versions ([af3bbd5](https://github.com/bitnami/charts/commit/af3bbd5))
+
+## 6.0.0 (2019-10-16)
+
+* Update Ingress configuration for Tomcat ([42d47ba](https://github.com/bitnami/charts/commit/42d47ba))
+
+## <small>5.0.2 (2019-10-15)</small>
+
+* [bitnami/tomcat] Update prerequisites ([c107254](https://github.com/bitnami/charts/commit/c107254))
+
+## <small>5.0.1 (2019-10-03)</small>
+
+* [bitnami/*] Fix broken links to NGINX Ingress Annotations docs ([42a2f47](https://github.com/bitnami/charts/commit/42a2f47))
+
+## 5.0.0 (2019-09-25)
+
+* Remove empty line ([0f940cb](https://github.com/bitnami/charts/commit/0f940cb))
+* Update version due container update ([c4e86c4](https://github.com/bitnami/charts/commit/c4e86c4))
+
+## <small>4.4.3 (2019-09-25)</small>
+
+* Bumps version due to container major changes ([215dea8](https://github.com/bitnami/charts/commit/215dea8))
+* Revert tomcat container version ([dcc728a](https://github.com/bitnami/charts/commit/dcc728a))
+
+## <small>4.4.2 (2019-09-24)</small>
+
+* [bitnami/tomcat] Release 4.4.2 updating components versions ([35f52d5](https://github.com/bitnami/charts/commit/35f52d5))
+
+## <small>4.4.1 (2019-09-20)</small>
+
+* [bitnami/*] Update apiVersion on sts, deployments, daemonsets and podsecuritypolicies ([4dfac07](https://github.com/bitnami/charts/commit/4dfac07))
+
+## 4.4.0 (2019-09-04)
+
+* Bump minor version ([10f1738](https://github.com/bitnami/charts/commit/10f1738))
+
+## <small>4.3.5 (2019-09-04)</small>
+
+* Add affinity to tomcat ([c7f1e41](https://github.com/bitnami/charts/commit/c7f1e41))
+
+## <small>4.3.4 (2019-09-02)</small>
+
+* [bitnami/tomcat] Release 4.3.4 updating components versions ([c4e87be](https://github.com/bitnami/charts/commit/c4e87be))
+* Use stretch instead of buster to be consistent ([decd85f](https://github.com/bitnami/charts/commit/decd85f))
+
+## <small>4.3.3 (2019-08-30)</small>
+
+* [bitnami/*] Use buster instead of latest as minideb tag and adapt sysctl ([921e811](https://github.com/bitnami/charts/commit/921e811))
+
+## <small>4.3.2 (2019-08-22)</small>
+
+* [bitnami/*] Fix 'storageClass' macros ([f41c193](https://github.com/bitnami/charts/commit/f41c193))
+
+## <small>4.3.1 (2019-08-21)</small>
+
+* Refactor StorageClass template to support old Helm versions ([1d7f3df](https://github.com/bitnami/charts/commit/1d7f3df))
+
+## 4.3.0 (2019-08-20)
+
+* Add global variable to set the storage class to all of the Hekm Charts ([cdb4bdc](https://github.com/bitnami/charts/commit/cdb4bdc))
+* Delete global storageClass when the chart has not dependencies and delete template for storageClass  ([2b5302c](https://github.com/bitnami/charts/commit/2b5302c))
+* Refactor storageClassTemplate ([1872215](https://github.com/bitnami/charts/commit/1872215))
+* Update charts versions ([9459dbb](https://github.com/bitnami/charts/commit/9459dbb))
+
+## <small>4.2.2 (2019-08-19)</small>
+
+* [bitnami/tomcat] Release 4.2.2 updating components versions ([92c0ac0](https://github.com/bitnami/charts/commit/92c0ac0))
+
+## <small>4.2.1 (2019-08-13)</small>
+
+* [bitnami/tomcat] Update components versions ([67be321](https://github.com/bitnami/charts/commit/67be321))
+* Add ingress controller to Tomcat ([ccb2f70](https://github.com/bitnami/charts/commit/ccb2f70))
+* Update README.md ([9f90f52](https://github.com/bitnami/charts/commit/9f90f52))
+* Updated version numbers ([aa0294b](https://github.com/bitnami/charts/commit/aa0294b))
+
+## 4.2.0 (2019-07-25)
+
+* Add ingress controller to Tomcat ([da5502b](https://github.com/bitnami/charts/commit/da5502b))
+* Fix indentation ([c699e9f](https://github.com/bitnami/charts/commit/c699e9f))
+
+## 4.1.0 (2019-07-22)
+
+* Change tomcat ([cbc2d88](https://github.com/bitnami/charts/commit/cbc2d88))
+
+## 4.0.0 (2019-07-17)
+
+* Implement again #1283 changes but bumping the major version ([1ce079c](https://github.com/bitnami/charts/commit/1ce079c)), closes [#1283](https://github.com/bitnami/charts/issues/1283)
+
+## <small>3.0.10 (2019-07-17)</small>
+
+* Revert pull request #1283 ([8e5940a](https://github.com/bitnami/charts/commit/8e5940a)), closes [#1283](https://github.com/bitnami/charts/issues/1283)
+* Undo breaking changes on labels ([ae05c77](https://github.com/bitnami/charts/commit/ae05c77))
+
+## <small>3.0.9 (2019-07-11)</small>
+
+* Standardize component.name & component.fullname functions ([775948e](https://github.com/bitnami/charts/commit/775948e))
+
+## <small>3.0.8 (2019-07-10)</small>
+
+* [bitnami/tomcat] Release 3.0.8 updating components versions ([86882e5](https://github.com/bitnami/charts/commit/86882e5))
+
+## <small>3.0.7 (2019-07-01)</small>
+
+* [bitnami/tomcat] Release 3.0.7 updating components versions ([fb0e504](https://github.com/bitnami/charts/commit/fb0e504))
+
+## <small>3.0.6 (2019-06-10)</small>
+
+* bitnami/tomcat: update to 9.0.21 ([1adb146](https://github.com/bitnami/charts/commit/1adb146))
+
+## <small>3.0.5 (2019-06-10)</small>
+
+* Changes in README ([7ac4ec0](https://github.com/bitnami/charts/commit/7ac4ec0))
+
+## <small>3.0.4 (2019-06-10)</small>
+
+* bitnami/tomcat: update to 9.0.20 ([4d5be42](https://github.com/bitnami/charts/commit/4d5be42))
+
+## <small>3.0.3 (2019-05-29)</small>
+
+* Change syntax because of linter failing ([adfc357](https://github.com/bitnami/charts/commit/adfc357))
+* Fix https://github.com/helm/charts/pull/14199\#issuecomment-496883321 and support _sha256_ as an imm ([95957ea](https://github.com/bitnami/charts/commit/95957ea)), closes [#issuecomment-496883321](https://github.com/bitnami/charts/issues/issuecomment-496883321)
+* Use immutable tags in the main images ([17ca4f5](https://github.com/bitnami/charts/commit/17ca4f5))
+
+## <small>3.0.2 (2019-05-28)</small>
+
+* Prepare immutable tags ([f9093c1](https://github.com/bitnami/charts/commit/f9093c1))
+
+## <small>3.0.1 (2019-05-14)</small>
+
+* bitnami/tomcat: update to 9.0.20 ([ffd5ba6](https://github.com/bitnami/charts/commit/ffd5ba6))
+
+## 3.0.0 (2019-05-13)
+
+* [bitnami/tomcat] Update chart to Tomcat 9.0 ([7d7dbb2](https://github.com/bitnami/charts/commit/7d7dbb2))
+
+## <small>2.2.2 (2019-04-14)</small>
+
+* bitnami/tomcat: update to 8.5.40 ([3c1c7b5](https://github.com/bitnami/charts/commit/3c1c7b5))
+
+## <small>2.2.1 (2019-03-26)</small>
+
+* bitnami/tomcat: update to 8.5.39 ([ca4ffdd](https://github.com/bitnami/charts/commit/ca4ffdd))
+* Fix typo ([60408b9](https://github.com/bitnami/charts/commit/60408b9))
+* Fix typo in helpers ([7ad303e](https://github.com/bitnami/charts/commit/7ad303e))
+* Remove unnecessary metrics conditions ([ad58c07](https://github.com/bitnami/charts/commit/ad58c07))
+
+## 2.2.0 (2019-03-11)
+
+* [bitnami/tomcat] Add global imagePullSecrets to overwrite any other existing one ([d53e152](https://github.com/bitnami/charts/commit/d53e152))
+
+## <small>2.1.5 (2019-02-27)</small>
+
+* Add appiVersion to Chart.yaml ([08704a5](https://github.com/bitnami/charts/commit/08704a5))
+
+## <small>2.1.4 (2019-02-21)</small>
+
+* Update Chart.yaml ([c69d536](https://github.com/bitnami/charts/commit/c69d536))
+* Update README.md ([30888a6](https://github.com/bitnami/charts/commit/30888a6))
+
+## <small>2.1.3 (2019-02-11)</small>
+
+* bitnami/tomcat: update to 8.5.38 ([e0b5fa9](https://github.com/bitnami/charts/commit/e0b5fa9))
+
+## <small>2.1.2 (2019-01-25)</small>
+
+* Document the correct format for pullSecrets in READMEs ([9a2cf81](https://github.com/bitnami/charts/commit/9a2cf81))
+
+## <small>2.1.1 (2018-12-20)</small>
+
+* tomcat: bump chart appVersion to `8.5.37` ([93db0ae](https://github.com/bitnami/charts/commit/93db0ae))
+* tomcat: bump chart version to `2.1.1` ([781e59a](https://github.com/bitnami/charts/commit/781e59a))
+* tomcat: update to `8.5.37` ([32f33bd](https://github.com/bitnami/charts/commit/32f33bd))
+* Add instructions to upgrade ([125713a](https://github.com/bitnami/charts/commit/125713a))
+* Update Revision ([af5458d](https://github.com/bitnami/charts/commit/af5458d))
+
+## 2.1.0 (2018-12-11)
+
+* [bitnami/tomcat] Adapt Chart to non-root container ([470a40d](https://github.com/bitnami/charts/commit/470a40d))
+
+## 2.0.0 (2018-11-21)
+
+* [bitnami/tomcat] Add service.port to values.yaml ([44f7b39](https://github.com/bitnami/charts/commit/44f7b39))
+
+## <small>1.1.2 (2018-11-09)</small>
+
+* tomcat: bump chart appVersion to `8.5.35` ([d3b547e](https://github.com/bitnami/charts/commit/d3b547e))
+* tomcat: bump chart version to `1.1.2` ([82420ba](https://github.com/bitnami/charts/commit/82420ba))
+* tomcat: update to `8.5.35` ([85f3201](https://github.com/bitnami/charts/commit/85f3201))
+
+## <small>1.1.1 (2018-10-17)</small>
+
+* Apply some suggestions ([24706a6](https://github.com/bitnami/charts/commit/24706a6))
+* Bump versions ([0cfd3f4](https://github.com/bitnami/charts/commit/0cfd3f4))
+* Change logic to determine registry ([9ead294](https://github.com/bitnami/charts/commit/9ead294))
+* Check if global is set ([dec26e5](https://github.com/bitnami/charts/commit/dec26e5))
+* Fix typo ([93170ac](https://github.com/bitnami/charts/commit/93170ac))
+* Remove distro tags in charts ([427ac51](https://github.com/bitnami/charts/commit/427ac51))
+* Reword and update kafka dependencies ([be6cbed](https://github.com/bitnami/charts/commit/be6cbed))
+
+## 1.1.0 (2018-10-11)
+
+* Add global registry option to Bitnami charts ([395ba08](https://github.com/bitnami/charts/commit/395ba08))
+
+## <small>1.0.2 (2018-10-05)</small>
+
+* Add ) ([728466a](https://github.com/bitnami/charts/commit/728466a))
+* Add kubeapps text to charts READMEs ([2f6dc51](https://github.com/bitnami/charts/commit/2f6dc51))
+* Fix go template inside go template ([a140313](https://github.com/bitnami/charts/commit/a140313))
+
+## <small>1.0.1 (2018-09-27)</small>
+
+* Improve getting LoadBalancer address in Bitnami charts NOTES.txt ([a641728](https://github.com/bitnami/charts/commit/a641728))
+
+## 1.0.0 (2018-09-21)
+
+* [bitnami/tomcat] Fix chart not being upgradable ([03a6294](https://github.com/bitnami/charts/commit/03a6294))
+
+## <small>0.4.33 (2018-09-11)</small>
+
+* tomcat: bump chart appVersion to `8.5.34` ([1ee2be4](https://github.com/bitnami/charts/commit/1ee2be4))
+* tomcat: bump chart version to `0.4.33` ([867062d](https://github.com/bitnami/charts/commit/867062d))
+* tomcat: update to `8.5.34-debian-9` ([19d6f87](https://github.com/bitnami/charts/commit/19d6f87))
+
+## <small>0.4.32 (2018-08-21)</small>
+
+* tomcat: bump chart appVersion to `8.5.33` ([31ea378](https://github.com/bitnami/charts/commit/31ea378))
+* tomcat: bump chart version to `0.4.32` ([aeffb86](https://github.com/bitnami/charts/commit/aeffb86))
+* tomcat: update to `8.5.33-debian-9` ([98ee082](https://github.com/bitnami/charts/commit/98ee082))
+
+## <small>0.4.31 (2018-08-06)</small>
+
+* Improve notes to access deployed services ([0071eb5](https://github.com/bitnami/charts/commit/0071eb5))
+
+## <small>0.4.30 (2018-07-31)</small>
+
+* Bump versions ([776b4b2](https://github.com/bitnami/charts/commit/776b4b2))
+* Fix versions ([5698a75](https://github.com/bitnami/charts/commit/5698a75))
+
+## <small>0.4.29 (2018-07-30)</small>
+
+* Add missing release and charts labels in pods ([dfd13a2](https://github.com/bitnami/charts/commit/dfd13a2))
+
+## <small>0.4.28 (2018-07-06)</small>
+
+* tomcat: bump chart appVersion to `8.5.32-debian-9` ([7ae6a14](https://github.com/bitnami/charts/commit/7ae6a14))
+* tomcat: bump chart version to `0.4.28` ([8203d9e](https://github.com/bitnami/charts/commit/8203d9e))
+* tomcat: update to `8.5.32-debian-9` ([5ea5345](https://github.com/bitnami/charts/commit/5ea5345))
+
+## <small>0.4.27 (2018-06-27)</small>
+
+* tomcat: bump chart appVersion to `8.5.32` ([c993c81](https://github.com/bitnami/charts/commit/c993c81))
+* tomcat: bump chart version to `0.4.27` ([f097cfc](https://github.com/bitnami/charts/commit/f097cfc))
+* tomcat: update to `8.5.32` ([039832f](https://github.com/bitnami/charts/commit/039832f))
+
+## <small>0.4.26 (2018-05-04)</small>
+
+* tomcat: bump chart appVersion to `8.5.31` ([f2de720](https://github.com/bitnami/charts/commit/f2de720))
+* tomcat: bump chart version to `0.4.26` ([6b19f1f](https://github.com/bitnami/charts/commit/6b19f1f))
+* tomcat: update to `8.5.31` ([519eee5](https://github.com/bitnami/charts/commit/519eee5))
+
+## <small>0.4.25 (2018-05-02)</small>
+
+* Remove default values from templates/ as they are in values.yaml file ([f061393](https://github.com/bitnami/charts/commit/f061393))
+
+## <small>0.4.24 (2018-04-13)</small>
+
+* Documentation fixes ([fdbcc57](https://github.com/bitnami/charts/commit/fdbcc57))
+
+## <small>0.4.23 (2018-04-13)</small>
+
+* Rename charts folders ([5413120](https://github.com/bitnami/charts/commit/5413120))

--- a/bitnami/tomcat/Chart.lock
+++ b/bitnami/tomcat/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.19.2
-digest: sha256:e670e1075bfafffe040fae1158f1fa1f592585f394b48704ba137d2d083b1571
-generated: "2024-05-14T05:22:18.861225748Z"
+  version: 2.19.3
+digest: sha256:de997835d9ce9a9deefc2d70d8c62b11aa1d1a76ece9e86a83736ab9f930bf4d
+generated: "2024-05-21T14:45:51.167235703+02:00"

--- a/bitnami/tomcat/Chart.yaml
+++ b/bitnami/tomcat/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: tomcat
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/tomcat
-version: 11.0.5
+version: 11.1.0

--- a/bitnami/tomcat/templates/NOTES.txt
+++ b/bitnami/tomcat/templates/NOTES.txt
@@ -49,3 +49,4 @@ APP VERSION: {{ .Chart.AppVersion }}
 
 {{- include "tomcat.checkRollingTags" . }}
 {{- include "common.warnings.resources" (dict "sections" (list "metrics.jmx" "" "volumePermissions") "context" $) }}
+{{- include "common.warnings.modifiedImages" (dict "images" (list .Values.image .Values.volumePermissions.image .Values.metrics.jmx.image) "context" $) }}


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Replacing the original images that have been tested and verified when releasing the chart is a dangerous practice in terms of security, performance and available features. This PR updates the `NOTES.txt` file using the `common.warnings.modifiedImages` helper developed in https://github.com/bitnami/charts/pull/25952.


<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

Users are more aware of the risks of changing original images.
<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

n/a
<!-- Describe any known limitations with your change -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
