### PR TITLE
[bitnami/vault] feat: :sparkles: :lock: Add warning when original images are replaced

### DIFF
--- a/bitnami/vault/CHANGELOG.md
+++ b/bitnami/vault/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
-## 1.2.3 (2024-05-21)
+## 1.3.0 (2024-05-21)
 
-* [bitnami/vault] Use different liveness/readiness probes ([#26162](https://github.com/bitnami/charts/pulls/26162))
+* [bitnami/vault] feat: :sparkles: :lock: Add warning when original images are replaced ([#26286](https://github.com/bitnami/charts/pulls/26286))
+
+## <small>1.2.3 (2024-05-21)</small>
+
+* [bitnami/*] ci: :construction_worker: Add tag and changelog support (#25359) ([91c707c](https://github.com/bitnami/charts/commit/91c707c)), closes [#25359](https://github.com/bitnami/charts/issues/25359)
+* [bitnami/vault] Use different liveness/readiness probes (#26162) ([0bdc654](https://github.com/bitnami/charts/commit/0bdc654)), closes [#26162](https://github.com/bitnami/charts/issues/26162)
 
 ## <small>1.2.2 (2024-05-18)</small>
 

--- a/bitnami/vault/Chart.yaml
+++ b/bitnami/vault/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: vault
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/vault
-version: 1.2.3
+version: 1.3.0

--- a/bitnami/vault/templates/NOTES.txt
+++ b/bitnami/vault/templates/NOTES.txt
@@ -50,3 +50,4 @@ Read the upstream vault documentation for unsealing and initializing the instanc
 {{- include "common.warnings.rollingTag" .Values.csiProvider.image }}
 {{- include "vault.validateValues" . }}
 {{- include "common.warnings.resources" (dict "sections" (list "csiProvider.agent" "csiProvider.provider" "injector" "server" "volumePermissions") "context" $) }}
+{{- include "common.warnings.modifiedImages" (dict "images" (list .Values.server.image .Values.csiProvider.image .Values.injector.image .Values.volumePermissions.image) "context" $) }}


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Replacing the original images that have been tested and verified when releasing the chart is a dangerous practice in terms of security, performance and available features. This PR updates the `NOTES.txt` file using the `common.warnings.modifiedImages` helper developed in https://github.com/bitnami/charts/pull/25952.


<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

Users are more aware of the risks of changing original images.
<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

n/a
<!-- Describe any known limitations with your change -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
