### PR TITLE
[bitnami/zookeeper] feat: :sparkles: :lock: Add warning when original images are replaced

### DIFF
--- a/bitnami/zookeeper/CHANGELOG.md
+++ b/bitnami/zookeeper/CHANGELOG.md
@@ -1,0 +1,1411 @@
+# Changelog
+
+## 13.3.0 (2024-05-21)
+
+* [bitnami/zookeeper] feat: :sparkles: :lock: Add warning when original images are replaced ([#26290](https://github.com/bitnami/charts/pulls/26290))
+
+## <small>13.2.3 (2024-05-20)</small>
+
+* [bitnami/zookeeper] Increase probeCommandTimeout for livenessProbe (#26123) ([e55fd37](https://github.com/bitnami/charts/commit/e55fd37)), closes [#26123](https://github.com/bitnami/charts/issues/26123)
+
+## <small>13.2.2 (2024-05-18)</small>
+
+* [bitnami/zookeeper] Release 13.2.2 updating components versions (#26090) ([700c9e7](https://github.com/bitnami/charts/commit/700c9e7)), closes [#26090](https://github.com/bitnami/charts/issues/26090)
+
+## <small>13.2.1 (2024-05-14)</small>
+
+* [bitnami/*] Change non-root and rolling-tags doc URLs (#25628) ([b067c94](https://github.com/bitnami/charts/commit/b067c94)), closes [#25628](https://github.com/bitnami/charts/issues/25628)
+* [bitnami/*] Set new header/owner (#25558) ([8d1dc11](https://github.com/bitnami/charts/commit/8d1dc11)), closes [#25558](https://github.com/bitnami/charts/issues/25558)
+* [bitnami/multiple charts] Fix typo: "NetworkPolice" vs "NetworkPolicy" (#25348) ([6970c1b](https://github.com/bitnami/charts/commit/6970c1b)), closes [#25348](https://github.com/bitnami/charts/issues/25348)
+* [bitnami/zookeeper] Release 13.2.1 updating components versions (#25833) ([6a67295](https://github.com/bitnami/charts/commit/6a67295)), closes [#25833](https://github.com/bitnami/charts/issues/25833)
+* Replace VMware by Broadcom copyright text (#25306) ([a5e4bd0](https://github.com/bitnami/charts/commit/a5e4bd0)), closes [#25306](https://github.com/bitnami/charts/issues/25306)
+
+## 13.2.0 (2024-04-23)
+
+* [bitnami/zookeeper] fix: :bug: :lock: Expose missing ports in deployment spec (#25141) ([fccf9e7](https://github.com/bitnami/charts/commit/fccf9e7)), closes [#25141](https://github.com/bitnami/charts/issues/25141)
+
+## <small>13.1.1 (2024-04-05)</small>
+
+* [bitnami/zookeeper] Release 13.1.1 (#24993) ([f528919](https://github.com/bitnami/charts/commit/f528919)), closes [#24993](https://github.com/bitnami/charts/issues/24993)
+* Update resourcesPreset comments (#24467) ([92e3e8a](https://github.com/bitnami/charts/commit/92e3e8a)), closes [#24467](https://github.com/bitnami/charts/issues/24467)
+
+## 13.1.0 (2024-04-02)
+
+* [bitnami/zookeeper] Add revisionHistoryLimit variable for statefulset (#24690) ([dc4d75b](https://github.com/bitnami/charts/commit/dc4d75b)), closes [#24690](https://github.com/bitnami/charts/issues/24690)
+
+## <small>13.0.1 (2024-03-25)</small>
+
+* [bitnami/zookeeper] fix: :bug: Set seLinuxOptions to {} (#24645) ([916e478](https://github.com/bitnami/charts/commit/916e478)), closes [#24645](https://github.com/bitnami/charts/issues/24645)
+
+## 13.0.0 (2024-03-18)
+
+* [bitnami/*] Reorder Chart sections (#24455) ([0cf4048](https://github.com/bitnami/charts/commit/0cf4048)), closes [#24455](https://github.com/bitnami/charts/issues/24455)
+* [bitnami/zookeeper] feat!: 🔒 💥 Improve security defaults (#24273) ([aba387a](https://github.com/bitnami/charts/commit/aba387a)), closes [#24273](https://github.com/bitnami/charts/issues/24273)
+
+## <small>12.12.1 (2024-03-12)</small>
+
+* [bitnami/zookeeper] Release 12.12.1 updating components versions (#24365) ([f2c959a](https://github.com/bitnami/charts/commit/f2c959a)), closes [#24365](https://github.com/bitnami/charts/issues/24365)
+
+## 12.12.0 (2024-03-06)
+
+* [bitnami/zookeeper] feat: :sparkles: :lock: Add automatic adaptation for Openshift restricted-v2 SCC ([ef7ba6f](https://github.com/bitnami/charts/commit/ef7ba6f)), closes [#24168](https://github.com/bitnami/charts/issues/24168)
+
+## <small>12.11.1 (2024-02-27)</small>
+
+* [bitnami/zookeeper] Release 12.10.2 updating components versions (#23839) ([354e377](https://github.com/bitnami/charts/commit/354e377)), closes [#23839](https://github.com/bitnami/charts/issues/23839)
+
+## 12.11.0 (2024-02-23)
+
+* [bitnami/zookeeper] feat: :sparkles: :lock: Add readOnlyRootFilesystem support (#23846) ([cf84d03](https://github.com/bitnami/charts/commit/cf84d03)), closes [#23846](https://github.com/bitnami/charts/issues/23846)
+
+## <small>12.10.1 (2024-02-21)</small>
+
+* [bitnami/zookeeper] Release 12.10.1 updating components versions (#23633) ([0f76174](https://github.com/bitnami/charts/commit/0f76174)), closes [#23633](https://github.com/bitnami/charts/issues/23633)
+
+## 12.10.0 (2024-02-20)
+
+* [bitnami/*] Bump all versions (#23602) ([b70ee2a](https://github.com/bitnami/charts/commit/b70ee2a)), closes [#23602](https://github.com/bitnami/charts/issues/23602)
+
+## 12.9.0 (2024-02-20)
+
+* [bitnami/zookeeper] feat: :sparkles: :lock: Add resource preset support (#23533) ([bf5a2f3](https://github.com/bitnami/charts/commit/bf5a2f3)), closes [#23533](https://github.com/bitnami/charts/issues/23533)
+
+## <small>12.8.1 (2024-02-03)</small>
+
+* [bitnami/zookeeper] Release 12.8.1 updating components versions (#23153) ([5b2ebdb](https://github.com/bitnami/charts/commit/5b2ebdb)), closes [#23153](https://github.com/bitnami/charts/issues/23153)
+
+## 12.8.0 (2024-02-01)
+
+* [bitnami/zookeeper] fix: :bug: Add allowExternalEgress to avoid breaking istio (#22979) ([f8b6366](https://github.com/bitnami/charts/commit/f8b6366)), closes [#22979](https://github.com/bitnami/charts/issues/22979)
+
+## 12.7.0 (2024-01-26)
+
+* [bitnami/*] Move documentation sections from docs.bitnami.com back to the README (#22203) ([7564f36](https://github.com/bitnami/charts/commit/7564f36)), closes [#22203](https://github.com/bitnami/charts/issues/22203)
+* [bitnami/zookeeper] feat: :lock: Enable networkPolicy (#22546) ([bfcd007](https://github.com/bitnami/charts/commit/bfcd007)), closes [#22546](https://github.com/bitnami/charts/issues/22546)
+
+## <small>12.6.1 (2024-01-24)</small>
+
+* [bitnami/zookeeper] fix: :bug: Set seLinuxOptions to null for Openshift compatibility (#22670) ([21ec07d](https://github.com/bitnami/charts/commit/21ec07d)), closes [#22670](https://github.com/bitnami/charts/issues/22670)
+
+## 12.6.0 (2024-01-22)
+
+* [bitnami/zookeeper] fix: :lock: Move service-account token auto-mount to pod declaration (#22470) ([4ce4037](https://github.com/bitnami/charts/commit/4ce4037)), closes [#22470](https://github.com/bitnami/charts/issues/22470)
+
+## <small>12.5.1 (2024-01-18)</small>
+
+* [bitnami/zookeeper] Release 12.5.1 updating components versions (#22344) ([40b5d40](https://github.com/bitnami/charts/commit/40b5d40)), closes [#22344](https://github.com/bitnami/charts/issues/22344)
+
+## 12.5.0 (2024-01-16)
+
+* [bitnami/zookeeper] Enable automatic purging of snapshots by default (#21918) ([d60fae7](https://github.com/bitnami/charts/commit/d60fae7)), closes [#21918](https://github.com/bitnami/charts/issues/21918)
+* [bitnami/zookeeper] fix: :lock: Improve podSecurityContext and containerSecurityContext with essenti ([3b94a4a](https://github.com/bitnami/charts/commit/3b94a4a)), closes [#22201](https://github.com/bitnami/charts/issues/22201)
+
+## <small>12.4.4 (2024-01-12)</small>
+
+* [bitnami/zookeeper] fix: :lock: Do not use the default service account (#22034) ([89a9485](https://github.com/bitnami/charts/commit/89a9485)), closes [#22034](https://github.com/bitnami/charts/issues/22034)
+
+## <small>12.4.3 (2024-01-11)</small>
+
+* [bitnami/*] Fix ref links (in comments) (#21822) ([e4fa296](https://github.com/bitnami/charts/commit/e4fa296)), closes [#21822](https://github.com/bitnami/charts/issues/21822)
+* [bitnami/zookeeper] Update probes to use new healthcheck.sh (#21984) ([941d300](https://github.com/bitnami/charts/commit/941d300)), closes [#21984](https://github.com/bitnami/charts/issues/21984)
+
+## <small>12.4.2 (2024-01-11)</small>
+
+* [bitnami/*] Fix docs.bitnami.com broken links (#21901) ([f35506d](https://github.com/bitnami/charts/commit/f35506d)), closes [#21901](https://github.com/bitnami/charts/issues/21901)
+* [bitnami/*] Update copyright: Year and company (#21815) ([6c4bf75](https://github.com/bitnami/charts/commit/6c4bf75)), closes [#21815](https://github.com/bitnami/charts/issues/21815)
+* [bitnami/zookeeper] Release 12.4.2 updating components versions (#21982) ([07e5ad7](https://github.com/bitnami/charts/commit/07e5ad7)), closes [#21982](https://github.com/bitnami/charts/issues/21982)
+
+## <small>12.4.1 (2024-01-01)</small>
+
+* [bitnami/zookeeper] Release 12.4.1 updating components versions (#21808) ([6ac0abf](https://github.com/bitnami/charts/commit/6ac0abf)), closes [#21808](https://github.com/bitnami/charts/issues/21808)
+
+## 12.4.0 (2023-12-18)
+
+* [bitnami/zookeeper] Allowing for customize dnsPolicy and dnsConfig for ZooKeeper (#21519) ([895433f](https://github.com/bitnami/charts/commit/895433f)), closes [#21519](https://github.com/bitnami/charts/issues/21519)
+
+## <small>12.3.4 (2023-12-11)</small>
+
+* [bitnami/zookeeper] Make Zookeeper DefaultMode YAML 1.2 Compliant (#21081) ([c82d4ab](https://github.com/bitnami/charts/commit/c82d4ab)), closes [#21081](https://github.com/bitnami/charts/issues/21081)
+
+## <small>12.3.3 (2023-11-22)</small>
+
+* [bitnami/*] Remove relative links to non-README sections, add verification for that and update TL;DR ([1103633](https://github.com/bitnami/charts/commit/1103633)), closes [#20967](https://github.com/bitnami/charts/issues/20967)
+* [bitnami/*] Rename solutions to "Bitnami package for ..." (#21038) ([b82f979](https://github.com/bitnami/charts/commit/b82f979)), closes [#21038](https://github.com/bitnami/charts/issues/21038)
+* [bitnami/zookeeper] Release 12.3.3 updating components versions (#21186) ([3fef8e6](https://github.com/bitnami/charts/commit/3fef8e6)), closes [#21186](https://github.com/bitnami/charts/issues/21186)
+
+## <small>12.3.2 (2023-11-08)</small>
+
+* [bitnami/zookeeper] Release 12.3.2 updating components versions (#20716) ([224890d](https://github.com/bitnami/charts/commit/224890d)), closes [#20716](https://github.com/bitnami/charts/issues/20716)
+
+## <small>12.3.1 (2023-11-07)</small>
+
+* [bitnami/zookeeper] Fix: randomly failing readiness/liveness probes (#20572) ([6c9461d](https://github.com/bitnami/charts/commit/6c9461d)), closes [#20572](https://github.com/bitnami/charts/issues/20572) [bitnami/charts#20564](https://github.com/bitnami/charts/issues/20564)
+
+## 12.3.0 (2023-11-06)
+
+* [bitnami/zookeeper] feat: :sparkles: Add support for PSA restricted policy (#20560) ([5da500d](https://github.com/bitnami/charts/commit/5da500d)), closes [#20560](https://github.com/bitnami/charts/issues/20560)
+
+## 12.2.0 (2023-11-03)
+
+* [bitnami/*] Rename VMware Application Catalog (#20361) ([3acc734](https://github.com/bitnami/charts/commit/3acc734)), closes [#20361](https://github.com/bitnami/charts/issues/20361)
+* [bitnami/*] Skip image's tag in the README files of the Bitnami Charts (#19841) ([bb9a01b](https://github.com/bitnami/charts/commit/bb9a01b)), closes [#19841](https://github.com/bitnami/charts/issues/19841)
+* [bitnami/*] Standardize documentation (#19835) ([af5f753](https://github.com/bitnami/charts/commit/af5f753)), closes [#19835](https://github.com/bitnami/charts/issues/19835)
+* [bitnami/zookeeper] Add support for enableServiceLinks on zookeeper chart (#20583) ([3624013](https://github.com/bitnami/charts/commit/3624013)), closes [#20583](https://github.com/bitnami/charts/issues/20583)
+
+## <small>12.1.6 (2023-10-12)</small>
+
+* [bitnami/zookeeper] Release 12.1.6 updating components versions (#20193) ([db6690a](https://github.com/bitnami/charts/commit/db6690a)), closes [#20193](https://github.com/bitnami/charts/issues/20193)
+
+## <small>12.1.5 (2023-10-12)</small>
+
+* [bitnami/zookeeper] Release 12.1.5 (#20116) ([196b620](https://github.com/bitnami/charts/commit/196b620)), closes [#20116](https://github.com/bitnami/charts/issues/20116)
+
+## <small>12.1.4 (2023-10-11)</small>
+
+* [bitnami/*] Update Helm charts prerequisites (#19745) ([eb755dd](https://github.com/bitnami/charts/commit/eb755dd)), closes [#19745](https://github.com/bitnami/charts/issues/19745)
+* [bitnami/zookeeper] Release 12.1.4 (#20061) ([9e47148](https://github.com/bitnami/charts/commit/9e47148)), closes [#20061](https://github.com/bitnami/charts/issues/20061)
+* Autogenerate schema files (#19194) ([a2c2090](https://github.com/bitnami/charts/commit/a2c2090)), closes [#19194](https://github.com/bitnami/charts/issues/19194)
+* Revert "Autogenerate schema files (#19194)" (#19335) ([73d80be](https://github.com/bitnami/charts/commit/73d80be)), closes [#19194](https://github.com/bitnami/charts/issues/19194) [#19335](https://github.com/bitnami/charts/issues/19335)
+
+## <small>12.1.3 (2023-09-08)</small>
+
+* [bitnami/zookeeper]: Use merge helper (#19118) ([68e51cd](https://github.com/bitnami/charts/commit/68e51cd)), closes [#19118](https://github.com/bitnami/charts/issues/19118)
+
+## <small>12.1.2 (2023-08-31)</small>
+
+* [bitnami/zookeeper] Release 12.1.2 (#18964) ([5f12492](https://github.com/bitnami/charts/commit/5f12492)), closes [#18964](https://github.com/bitnami/charts/issues/18964)
+
+## <small>12.1.1 (2023-08-28)</small>
+
+* [bitnami/zookeeper] Add reference to release 12.0.0 (#18803) ([c46f6c4](https://github.com/bitnami/charts/commit/c46f6c4)), closes [#18803](https://github.com/bitnami/charts/issues/18803)
+* [bitnami/zookeeper] test: :white_check_mark: Add persistence test (#18817) ([aa54bd9](https://github.com/bitnami/charts/commit/aa54bd9)), closes [#18817](https://github.com/bitnami/charts/issues/18817) [#18777](https://github.com/bitnami/charts/issues/18777) [#18848](https://github.com/bitnami/charts/issues/18848) [#18484](https://github.com/bitnami/charts/issues/18484) [#18853](https://github.com/bitnami/charts/issues/18853) [#18852](https://github.com/bitnami/charts/issues/18852) [#18509](https://github.com/bitnami/charts/issues/18509) [#18834](https://github.com/bitnami/charts/issues/18834) [#18849](https://github.com/bitnami/charts/issues/18849) [#18850](https://github.com/bitnami/charts/issues/18850) [#18627](https://github.com/bitnami/charts/issues/18627) [#18304](https://github.com/bitnami/charts/issues/18304) [#18455](https://github.com/bitnami/charts/issues/18455) [#18845](https://github.com/bitnami/charts/issues/18845) [#18844](https://github.com/bitnami/charts/issues/18844) [#18841](https://github.com/bitnami/charts/issues/18841) [#18838](https://github.com/bitnami/charts/issues/18838) [#18832](https://github.com/bitnami/charts/issues/18832) [#18313](https://github.com/bitnami/charts/issues/18313) [#18440](https://github.com/bitnami/charts/issues/18440) [#18622](https://github.com/bitnami/charts/issues/18622) [#18445](https://github.com/bitnami/charts/issues/18445) [#18481](https://github.com/bitnami/charts/issues/18481) [#18738](https://github.com/bitnami/charts/issues/18738) [#18457](https://github.com/bitnami/charts/issues/18457) [#18609](https://github.com/bitnami/charts/issues/18609) [#18833](https://github.com/bitnami/charts/issues/18833) [#18549](https://github.com/bitnami/charts/issues/18549) [#18829](https://github.com/bitnami/charts/issues/18829) [#18831](https://github.com/bitnami/charts/issues/18831) [#17173](https://github.com/bitnami/charts/issues/17173) [#18815](https://github.com/bitnami/charts/issues/18815) [#18469](https://github.com/bitnami/charts/issues/18469) [#18464](https://github.com/bitnami/charts/issues/18464) [#18465](https://github.com/bitnami/charts/issues/18465) [#18468](https://github.com/bitnami/charts/issues/18468) [#18467](https://github.com/bitnami/charts/issues/18467) [#18466](https://github.com/bitnami/charts/issues/18466) [#18613](https://github.com/bitnami/charts/issues/18613) [#18743](https://github.com/bitnami/charts/issues/18743) [#18739](https://github.com/bitnami/charts/issues/18739) [#18550](https://github.com/bitnami/charts/issues/18550) [#18750](https://github.com/bitnami/charts/issues/18750) [#18486](https://github.com/bitnami/charts/issues/18486) [#18353](https://github.com/bitnami/charts/issues/18353) [#18417](https://github.com/bitnami/charts/issues/18417) [#18797](https://github.com/bitnami/charts/issues/18797) [#18826](https://github.com/bitnami/charts/issues/18826) [#18825](https://github.com/bitnami/charts/issues/18825) [#18824](https://github.com/bitnami/charts/issues/18824) [#18820](https://github.com/bitnami/charts/issues/18820) [#18818](https://github.com/bitnami/charts/issues/18818) [#18819](https://github.com/bitnami/charts/issues/18819) [#18459](https://github.com/bitnami/charts/issues/18459) [#18479](https://github.com/bitnami/charts/issues/18479) [#18485](https://github.com/bitnami/charts/issues/18485)
+
+## 12.1.0 (2023-08-22)
+
+* [bitnami/zookeeper] Support for customizing standard labels (#18449) ([0584dee](https://github.com/bitnami/charts/commit/0584dee)), closes [#18449](https://github.com/bitnami/charts/issues/18449)
+
+## <small>12.0.1 (2023-08-21)</small>
+
+* [bitnami/zookeeper] Release 12.0.1 (#18730) ([93f343d](https://github.com/bitnami/charts/commit/93f343d)), closes [#18730](https://github.com/bitnami/charts/issues/18730)
+
+## 12.0.0 (2023-08-18)
+
+* [bitnami/zookeeper] Release 12.0.0 (#18641) ([fb297d4](https://github.com/bitnami/charts/commit/fb297d4)), closes [#18641](https://github.com/bitnami/charts/issues/18641)
+
+## <small>11.4.11 (2023-08-18)</small>
+
+* [bitnami/zookeeper] Release 11.4.11 (#18605) ([13b4fe7](https://github.com/bitnami/charts/commit/13b4fe7)), closes [#18605](https://github.com/bitnami/charts/issues/18605)
+
+## <small>11.4.10 (2023-07-26)</small>
+
+* [bitnami/zookeeper] Release 11.4.10 (#17981) ([62f6655](https://github.com/bitnami/charts/commit/62f6655)), closes [#17981](https://github.com/bitnami/charts/issues/17981)
+
+## <small>11.4.9 (2023-07-22)</small>
+
+* [bitnami/zookeeper] Release 11.4.9 (#17824) ([ba21223](https://github.com/bitnami/charts/commit/ba21223)), closes [#17824](https://github.com/bitnami/charts/issues/17824)
+
+## <small>11.4.8 (2023-07-18)</small>
+
+* [bitnami/zookeeper] Release 11.4.8 (#17765) ([4d9f38c](https://github.com/bitnami/charts/commit/4d9f38c)), closes [#17765](https://github.com/bitnami/charts/issues/17765)
+
+## <small>11.4.7 (2023-07-18)</small>
+
+* [bitnami/zookeeper] Release 11.4.7 (#17756) ([7ce1e40](https://github.com/bitnami/charts/commit/7ce1e40)), closes [#17756](https://github.com/bitnami/charts/issues/17756)
+
+## <small>11.4.6 (2023-07-17)</small>
+
+* [bitnami/zookeeper] Release 11.4.6 (#17734) ([b4fb4a8](https://github.com/bitnami/charts/commit/b4fb4a8)), closes [#17734](https://github.com/bitnami/charts/issues/17734)
+
+## <small>11.4.5 (2023-07-17)</small>
+
+* [bitnami/zookeeper] Release 11.4.5 (#17732) ([f1fd432](https://github.com/bitnami/charts/commit/f1fd432)), closes [#17732](https://github.com/bitnami/charts/issues/17732)
+
+## <small>11.4.4 (2023-07-15)</small>
+
+* [bitnami/zookeeper] Release 11.4.4 (#17672) ([21f8bf9](https://github.com/bitnami/charts/commit/21f8bf9)), closes [#17672](https://github.com/bitnami/charts/issues/17672)
+* Add copyright header (#17300) ([da68be8](https://github.com/bitnami/charts/commit/da68be8)), closes [#17300](https://github.com/bitnami/charts/issues/17300)
+* Update charts readme (#17217) ([31b3c0a](https://github.com/bitnami/charts/commit/31b3c0a)), closes [#17217](https://github.com/bitnami/charts/issues/17217)
+
+## <small>11.4.3 (2023-06-20)</small>
+
+* [bitnami/*] Change copyright section in READMEs (#17006) ([ef986a1](https://github.com/bitnami/charts/commit/ef986a1)), closes [#17006](https://github.com/bitnami/charts/issues/17006)
+* [bitnami/several] Change copyright section in READMEs (#16989) ([5b6a5cf](https://github.com/bitnami/charts/commit/5b6a5cf)), closes [#16989](https://github.com/bitnami/charts/issues/16989)
+* [bitnami/zookeeper] Release 11.4.3 (#17232) ([c986429](https://github.com/bitnami/charts/commit/c986429)), closes [#17232](https://github.com/bitnami/charts/issues/17232)
+
+## <small>11.4.2 (2023-05-21)</small>
+
+* [bitnami/zookeeper] Release 11.4.2 (#16814) ([359a001](https://github.com/bitnami/charts/commit/359a001)), closes [#16814](https://github.com/bitnami/charts/issues/16814)
+
+## <small>11.4.1 (2023-05-16)</small>
+
+* Bugfix: Use the correct variable for logging Zookeeper hostname (#16614) ([b645a50](https://github.com/bitnami/charts/commit/b645a50)), closes [#16614](https://github.com/bitnami/charts/issues/16614)
+* Add wording for enterprise page (#16560) ([8f22774](https://github.com/bitnami/charts/commit/8f22774)), closes [#16560](https://github.com/bitnami/charts/issues/16560)
+
+## 11.4.0 (2023-05-09)
+
+* [bitnami/several] Adapt Chart.yaml to set desired OCI annotations (#16546) ([fc9b18f](https://github.com/bitnami/charts/commit/fc9b18f)), closes [#16546](https://github.com/bitnami/charts/issues/16546)
+
+## <small>11.3.2 (2023-05-09)</small>
+
+* [bitnami/zookeeper] Release 11.3.2 (#16501) ([d78a595](https://github.com/bitnami/charts/commit/d78a595)), closes [#16501](https://github.com/bitnami/charts/issues/16501)
+
+## <small>11.3.1 (2023-04-25)</small>
+
+* [bitnami/zookeeper] Release 11.3.1 (#16224) ([779552d](https://github.com/bitnami/charts/commit/779552d)), closes [#16224](https://github.com/bitnami/charts/issues/16224)
+
+## 11.3.0 (2023-04-25)
+
+* [bitnami/several] Revert changes done by mistake in Chart.yaml repo (#16211) ([3a60f4b](https://github.com/bitnami/charts/commit/3a60f4b)), closes [#16211](https://github.com/bitnami/charts/issues/16211)
+
+## <small>11.2.1 (2023-04-20)</small>
+
+* [bitnami/zookeeper] Release 11.2.1 (#16144) ([ad2a53e](https://github.com/bitnami/charts/commit/ad2a53e)), closes [#16144](https://github.com/bitnami/charts/issues/16144)
+
+## 11.2.0 (2023-04-20)
+
+* [bitnami/*] Make Helm charts 100% OCI (#15998) ([8841510](https://github.com/bitnami/charts/commit/8841510)), closes [#15998](https://github.com/bitnami/charts/issues/15998)
+
+## <small>11.1.6 (2023-04-01)</small>
+
+* [bitnami/zookeeper] Release 11.1.6 (#15902) ([f0fd9a4](https://github.com/bitnami/charts/commit/f0fd9a4)), closes [#15902](https://github.com/bitnami/charts/issues/15902)
+
+## <small>11.1.5 (2023-03-19)</small>
+
+* [bitnami/charts] Apply linter to README files (#15357) ([0e29e60](https://github.com/bitnami/charts/commit/0e29e60)), closes [#15357](https://github.com/bitnami/charts/issues/15357)
+* [bitnami/zookeeper] Release 11.1.5 (#15621) ([6da1ce8](https://github.com/bitnami/charts/commit/6da1ce8)), closes [#15621](https://github.com/bitnami/charts/issues/15621)
+
+## <small>11.1.4 (2023-03-01)</small>
+
+* [bitnami/zookeeper] Release 11.1.4 (#15246) ([8bf7055](https://github.com/bitnami/charts/commit/8bf7055)), closes [#15246](https://github.com/bitnami/charts/issues/15246)
+
+## <small>11.1.3 (2023-02-17)</small>
+
+* [bitnami/*] Fix markdown linter issues (#14874) ([a51e0e8](https://github.com/bitnami/charts/commit/a51e0e8)), closes [#14874](https://github.com/bitnami/charts/issues/14874)
+* [bitnami/*] Fix markdown linter issues 2 (#14890) ([aa96572](https://github.com/bitnami/charts/commit/aa96572)), closes [#14890](https://github.com/bitnami/charts/issues/14890)
+* [bitnami/*] Remove unexpected extra spaces (#14873) ([c97c714](https://github.com/bitnami/charts/commit/c97c714)), closes [#14873](https://github.com/bitnami/charts/issues/14873)
+* [bitnami/zookeeper] Release 11.1.3 (#15034) ([2cc0a4a](https://github.com/bitnami/charts/commit/2cc0a4a)), closes [#15034](https://github.com/bitnami/charts/issues/15034)
+
+## <small>11.1.2 (2023-01-31)</small>
+
+* [bitnami/*] Change copyright date (#14682) ([add4ec7](https://github.com/bitnami/charts/commit/add4ec7)), closes [#14682](https://github.com/bitnami/charts/issues/14682)
+* [bitnami/zookeeper] Don't regenerate self-signed certs on upgrade (#14668) ([a2ab8a5](https://github.com/bitnami/charts/commit/a2ab8a5)), closes [#14668](https://github.com/bitnami/charts/issues/14668)
+
+## <small>11.1.1 (2023-01-30)</small>
+
+* [bitnami/*] Change licenses annotation format (#14377) ([0ab7608](https://github.com/bitnami/charts/commit/0ab7608)), closes [#14377](https://github.com/bitnami/charts/issues/14377)
+* [bitnami/*] Unify READMEs (#14472) ([2064fb8](https://github.com/bitnami/charts/commit/2064fb8)), closes [#14472](https://github.com/bitnami/charts/issues/14472)
+* [bitnami/zookeeper] Release 11.1.1 (#14596) ([e22e05d](https://github.com/bitnami/charts/commit/e22e05d)), closes [#14596](https://github.com/bitnami/charts/issues/14596)
+
+## 11.1.0 (2023-01-16)
+
+* [bitnami/*] Add license annotation and remove obsolete engine parameter (#14293) ([da2a794](https://github.com/bitnami/charts/commit/da2a794)), closes [#14293](https://github.com/bitnami/charts/issues/14293)
+* [bitnami/zookeeper] Configure headless service name (#14144) ([6ac4738](https://github.com/bitnami/charts/commit/6ac4738)), closes [#14144](https://github.com/bitnami/charts/issues/14144)
+
+## <small>11.0.3 (2023-01-09)</small>
+
+* [bitnami/zookeeper] Release 11.0.3 (#14228) ([b689998](https://github.com/bitnami/charts/commit/b689998)), closes [#14228](https://github.com/bitnami/charts/issues/14228)
+
+## <small>11.0.2 (2022-12-14)</small>
+
+* zookeeper: Don't re-initialize keystores after success (#13574) ([60bd5de](https://github.com/bitnami/charts/commit/60bd5de)), closes [#13574](https://github.com/bitnami/charts/issues/13574)
+
+## <small>11.0.1 (2022-12-10)</small>
+
+* [bitnami/zookeeper] Add upgrading notes (#13838) ([0ec8b75](https://github.com/bitnami/charts/commit/0ec8b75)), closes [#13838](https://github.com/bitnami/charts/issues/13838)
+* [bitnami/zookeeper] Release 11.0.1 (#13898) ([39ef99b](https://github.com/bitnami/charts/commit/39ef99b)), closes [#13898](https://github.com/bitnami/charts/issues/13898)
+
+## 11.0.0 (2022-12-05)
+
+* [bitnami/zookeeper] replace commonAnnotations & commonLabels with persistence.annotations & persiste ([456968f](https://github.com/bitnami/charts/commit/456968f)), closes [#13662](https://github.com/bitnami/charts/issues/13662)
+
+## <small>10.2.5 (2022-11-15)</small>
+
+* [bitnami/zookeeper] Release 10.2.5 (#13521) ([60db9a1](https://github.com/bitnami/charts/commit/60db9a1)), closes [#13521](https://github.com/bitnami/charts/issues/13521)
+
+## <small>10.2.4 (2022-10-25)</small>
+
+* [bitnami/*] Use new default branch name in links (#12943) ([a529e02](https://github.com/bitnami/charts/commit/a529e02)), closes [#12943](https://github.com/bitnami/charts/issues/12943)
+* [bitnami/zookeeper] Bump version (#13137) ([d2722b9](https://github.com/bitnami/charts/commit/d2722b9)), closes [#13137](https://github.com/bitnami/charts/issues/13137)
+* [bitnami/zookeeper] Fix volume permission (#13128) ([7d5fba2](https://github.com/bitnami/charts/commit/7d5fba2)), closes [#13128](https://github.com/bitnami/charts/issues/13128)
+
+## <small>10.2.3 (2022-10-16)</small>
+
+* [bitnami/zookeeper] Release 10.2.3 (#12968) ([8b0ef5f](https://github.com/bitnami/charts/commit/8b0ef5f)), closes [#12968](https://github.com/bitnami/charts/issues/12968)
+* Generic README instructions related to the repo (#12792) ([3cf6b10](https://github.com/bitnami/charts/commit/3cf6b10)), closes [#12792](https://github.com/bitnami/charts/issues/12792)
+
+## <small>10.2.2 (2022-09-22)</small>
+
+* [bitnami/zookeeper] Use custom probes if given (#12571) ([a1700ab](https://github.com/bitnami/charts/commit/a1700ab)), closes [#12571](https://github.com/bitnami/charts/issues/12571) [#12354](https://github.com/bitnami/charts/issues/12354)
+
+## <small>10.2.1 (2022-09-16)</small>
+
+* [bitnami/zookeeper] Release 10.2.1 (#12455) ([b9e02c1](https://github.com/bitnami/charts/commit/b9e02c1)), closes [#12455](https://github.com/bitnami/charts/issues/12455)
+
+## 10.2.0 (2022-09-14)
+
+* [bitnami/zookeeper] Disallowing privilege escalation for zookeeper (#12314) ([6dbe584](https://github.com/bitnami/charts/commit/6dbe584)), closes [#12314](https://github.com/bitnami/charts/issues/12314) [#12268](https://github.com/bitnami/charts/issues/12268) [#12285](https://github.com/bitnami/charts/issues/12285) [#12268](https://github.com/bitnami/charts/issues/12268) [#12285](https://github.com/bitnami/charts/issues/12285)
+
+## <small>10.1.1 (2022-08-23)</small>
+
+* [bitnami/zookeeper] Update Chart.lock (#12061) ([f600d60](https://github.com/bitnami/charts/commit/f600d60)), closes [#12061](https://github.com/bitnami/charts/issues/12061)
+
+## 10.1.0 (2022-08-22)
+
+* [bitnami/zookeeper] Add support for image digest apart from tag (#11885) ([9bfa9e1](https://github.com/bitnami/charts/commit/9bfa9e1)), closes [#11885](https://github.com/bitnami/charts/issues/11885)
+
+## <small>10.0.9 (2022-08-22)</small>
+
+* [bitnami/zookeeper] Release 10.0.9 (#11974) ([202b9b7](https://github.com/bitnami/charts/commit/202b9b7)), closes [#11974](https://github.com/bitnami/charts/issues/11974)
+
+## <small>10.0.8 (2022-08-16)</small>
+
+* [bitnami/zookeeper] Statefulset quorum auth value not set properly (#11764) ([f130594](https://github.com/bitnami/charts/commit/f130594)), closes [#11764](https://github.com/bitnami/charts/issues/11764)
+
+## <small>10.0.7 (2022-08-10)</small>
+
+* [bitnami/zookeeper] Fix quorum secret generation (#11692) ([824eef1](https://github.com/bitnami/charts/commit/824eef1)), closes [#11692](https://github.com/bitnami/charts/issues/11692)
+
+## <small>10.0.6 (2022-08-04)</small>
+
+* [bitnami/zookeeper] Release 10.0.6 updating components versions ([c5f76d3](https://github.com/bitnami/charts/commit/c5f76d3))
+
+## <small>10.0.5 (2022-08-03)</small>
+
+* [bitnami/zookeeper] Release 10.0.5 updating components versions ([ca3b0ea](https://github.com/bitnami/charts/commit/ca3b0ea))
+
+## <small>10.0.4 (2022-08-02)</small>
+
+* [bitnami/zookeeper] Release 10.0.4 updating components versions ([c04f32f](https://github.com/bitnami/charts/commit/c04f32f))
+
+## <small>10.0.3 (2022-07-30)</small>
+
+* [bitnami/*] Update URLs to point to the new bitnami/containers monorepo (#11352) ([d665af0](https://github.com/bitnami/charts/commit/d665af0)), closes [#11352](https://github.com/bitnami/charts/issues/11352)
+* [bitnami/zookeeper] Release 10.0.3 updating components versions ([3a7a10c](https://github.com/bitnami/charts/commit/3a7a10c))
+
+## <small>10.0.2 (2022-07-13)</small>
+
+* [bitnami/zookeeper] fix - service.headless.annitations  is inoperative when i  do not set the config ([9a6afc4](https://github.com/bitnami/charts/commit/9a6afc4)), closes [#11158](https://github.com/bitnami/charts/issues/11158)
+
+## <small>10.0.1 (2022-06-30)</small>
+
+* [bitnami/zookeeper] Release 10.0.1 updating components versions ([4f083fa](https://github.com/bitnami/charts/commit/4f083fa))
+
+## 10.0.0 (2022-06-14)
+
+* [bitnami/zookeeper] Major release 10: Rename client-server authentication parameters and add support ([e4b159a](https://github.com/bitnami/charts/commit/e4b159a)), closes [#10689](https://github.com/bitnami/charts/issues/10689)
+
+## <small>9.2.7 (2022-06-14)</small>
+
+* [bitnami/zookeeper] Release 9.2.7 updating components versions ([55139a3](https://github.com/bitnami/charts/commit/55139a3))
+
+## <small>9.2.6 (2022-06-13)</small>
+
+* [bitnami/zookeeper] Release 9.2.6 updating components versions ([085cba2](https://github.com/bitnami/charts/commit/085cba2))
+
+## <small>9.2.5 (2022-06-10)</small>
+
+* [bitnami/zookeeper] Release 9.2.5 updating components versions ([a0a8de7](https://github.com/bitnami/charts/commit/a0a8de7))
+
+## <small>9.2.4 (2022-06-07)</small>
+
+* [bitnami/*] Replace Kubeapps URL in READMEs (and kubeapps Chart.yaml) and remove BKPR references (#1 ([c6a7914](https://github.com/bitnami/charts/commit/c6a7914)), closes [#10600](https://github.com/bitnami/charts/issues/10600)
+* Fix tolerations and topologySpreadConstraints default values (#10649) ([e860095](https://github.com/bitnami/charts/commit/e860095)), closes [#10649](https://github.com/bitnami/charts/issues/10649)
+
+## <small>9.2.3 (2022-06-07)</small>
+
+* [bitnami/zookeeper] Release 9.2.3 updating components versions ([7973aea](https://github.com/bitnami/charts/commit/7973aea))
+
+## <small>9.2.2 (2022-06-02)</small>
+
+* Update Redis trademark references ([2cada87](https://github.com/bitnami/charts/commit/2cada87))
+
+## <small>9.2.1 (2022-06-01)</small>
+
+* [bitnami/several] Replace maintainers email by url (#10523) ([ff3cf61](https://github.com/bitnami/charts/commit/ff3cf61)), closes [#10523](https://github.com/bitnami/charts/issues/10523)
+
+## 9.2.0 (2022-05-26)
+
+* [bitnami/zookeeper] Add missing service parameter (#10425) ([f5d1dab](https://github.com/bitnami/charts/commit/f5d1dab)), closes [#10425](https://github.com/bitnami/charts/issues/10425)
+
+## <small>9.1.6 (2022-05-21)</small>
+
+* [bitnami/zookeeper] Release 9.1.6 updating components versions ([da2b12c](https://github.com/bitnami/charts/commit/da2b12c))
+
+## <small>9.1.5 (2022-05-20)</small>
+
+* [bitnami/zookeeper] Release 9.1.5 updating components versions ([7955674](https://github.com/bitnami/charts/commit/7955674))
+
+## <small>9.1.4 (2022-05-19)</small>
+
+* [bitnami/zookeeper] Release 9.1.4 updating components versions ([344aa96](https://github.com/bitnami/charts/commit/344aa96))
+
+## <small>9.1.3 (2022-05-18)</small>
+
+* [bitnami/zookeeper] Release 9.1.3 updating components versions ([29a67dd](https://github.com/bitnami/charts/commit/29a67dd))
+
+## <small>9.1.2 (2022-05-13)</small>
+
+* [bitnami/*] Remove old 'ci' files (#10171) ([5df30c4](https://github.com/bitnami/charts/commit/5df30c4)), closes [#10171](https://github.com/bitnami/charts/issues/10171)
+* [bitnami/*] Unify k8s directives separators (#10185) ([2650214](https://github.com/bitnami/charts/commit/2650214)), closes [#10185](https://github.com/bitnami/charts/issues/10185)
+
+## <small>9.1.1 (2022-04-25)</small>
+
+* [bitnami/zookeeper] Add chown for data dir, not only children (#9690) (#9884) ([f044fc9](https://github.com/bitnami/charts/commit/f044fc9)), closes [#9690](https://github.com/bitnami/charts/issues/9690) [#9884](https://github.com/bitnami/charts/issues/9884)
+
+## 9.1.0 (2022-04-22)
+
+* [bitnami/zookeeper] customize secrets keys to use SSL with cert-manager (#9679) ([86a0784](https://github.com/bitnami/charts/commit/86a0784)), closes [#9679](https://github.com/bitnami/charts/issues/9679)
+
+## <small>9.0.6 (2022-04-20)</small>
+
+* [bitnami/zookeeper] Release 9.0.6 updating components versions ([8137a6c](https://github.com/bitnami/charts/commit/8137a6c))
+
+## <small>9.0.5 (2022-04-19)</small>
+
+* [bitnami/zookeeper] Release 9.0.5 updating components versions ([0f6a03f](https://github.com/bitnami/charts/commit/0f6a03f))
+
+## <small>9.0.4 (2022-04-05)</small>
+
+* [bitnami/zookeeper] Release 9.0.4 updating components versions ([6629454](https://github.com/bitnami/charts/commit/6629454))
+
+## <small>9.0.3 (2022-04-02)</small>
+
+* [bitnami/zookeeper] Release 9.0.3 updating components versions ([1fdc120](https://github.com/bitnami/charts/commit/1fdc120))
+
+## <small>9.0.2 (2022-03-28)</small>
+
+* [bitnami/zookeeper] Release 9.0.2 updating components versions ([4be3ede](https://github.com/bitnami/charts/commit/4be3ede))
+
+## <small>9.0.1 (2022-03-27)</small>
+
+* [bitnami/zookeeper] Release 9.0.1 updating components versions ([a31c65d](https://github.com/bitnami/charts/commit/a31c65d))
+
+## 9.0.0 (2022-03-17)
+
+* [bitnami/zookeeper] MAJOR: Update to 3.8.0 (#9454) ([8e50551](https://github.com/bitnami/charts/commit/8e50551)), closes [#9454](https://github.com/bitnami/charts/issues/9454)
+
+## <small>8.1.2 (2022-03-16)</small>
+
+* [bitnami/zookeeper] Release 8.1.2 updating components versions ([841b10d](https://github.com/bitnami/charts/commit/841b10d))
+
+## <small>8.1.1 (2022-02-27)</small>
+
+* [bitnami/zookeeper] Release 8.1.1 updating components versions ([3c04c04](https://github.com/bitnami/charts/commit/3c04c04))
+
+## 8.1.0 (2022-02-24)
+
+* [bitnami/zookeeper] Add flag '-r' to xargs in volumePermissions init-container (#9138) ([cc3bbe2](https://github.com/bitnami/charts/commit/cc3bbe2)), closes [#9138](https://github.com/bitnami/charts/issues/9138)
+* Allow users to provide tls.key/tls.crt/ca.crt in a secret (#9151) ([c7339c1](https://github.com/bitnami/charts/commit/c7339c1)), closes [#9151](https://github.com/bitnami/charts/issues/9151)
+
+## <small>8.0.3 (2022-02-19)</small>
+
+* [bitnami/zookeeper] Release 8.0.3 updating components versions ([f8ee60b](https://github.com/bitnami/charts/commit/f8ee60b))
+
+## <small>8.0.2 (2022-02-17)</small>
+
+* [bitnami/zookeeper] Release 8.0.2 updating components versions ([9a44ee2](https://github.com/bitnami/charts/commit/9a44ee2))
+* Non utf8 chars (#8923) ([6ffd18f](https://github.com/bitnami/charts/commit/6ffd18f)), closes [#8923](https://github.com/bitnami/charts/issues/8923)
+
+## <small>8.0.1 (2022-01-20)</small>
+
+* [bitnami/*] Update READMEs (#8716) ([b9a9533](https://github.com/bitnami/charts/commit/b9a9533)), closes [#8716](https://github.com/bitnami/charts/issues/8716)
+* [bitnami/several] Change prerequisites (#8725) ([8d740c5](https://github.com/bitnami/charts/commit/8d740c5)), closes [#8725](https://github.com/bitnami/charts/issues/8725)
+
+## 8.0.0 (2022-01-18)
+
+* [bitnami/zookeeper] Chart standardized (#8623) ([dba767a](https://github.com/bitnami/charts/commit/dba767a)), closes [#8623](https://github.com/bitnami/charts/issues/8623)
+
+## <small>7.6.2 (2022-01-18)</small>
+
+* [bitnami/*] Readme automation (#8579) ([78d1938](https://github.com/bitnami/charts/commit/78d1938)), closes [#8579](https://github.com/bitnami/charts/issues/8579)
+* [bitnami/zookeeper] Release 7.6.2 updating components versions ([b3d69d5](https://github.com/bitnami/charts/commit/b3d69d5))
+
+## <small>7.6.1 (2022-01-11)</small>
+
+* [bitnami/zookeeper] Release 7.6.1 updating components versions ([708f0d4](https://github.com/bitnami/charts/commit/708f0d4))
+
+## 7.6.0 (2022-01-05)
+
+* [bitnami/several] Adapt templating format (#8562) ([8cad18a](https://github.com/bitnami/charts/commit/8cad18a)), closes [#8562](https://github.com/bitnami/charts/issues/8562)
+* [bitnami/several] Add license to the README ([05f7633](https://github.com/bitnami/charts/commit/05f7633))
+* [bitnami/several] Add license to the README ([32fb238](https://github.com/bitnami/charts/commit/32fb238))
+* [bitnami/several] Add license to the README ([b87c2f7](https://github.com/bitnami/charts/commit/b87c2f7))
+
+## <small>7.5.4 (2021-12-26)</small>
+
+* [bitnami/zookeeper] Release 7.5.4 updating components versions ([3a38fa1](https://github.com/bitnami/charts/commit/3a38fa1))
+
+## <small>7.5.3 (2021-12-17)</small>
+
+* [bitnami/zookeeper] Additional labels for metrics (#8448) ([945999a](https://github.com/bitnami/charts/commit/945999a)), closes [#8448](https://github.com/bitnami/charts/issues/8448)
+
+## <small>7.5.2 (2021-12-16)</small>
+
+* [bitnami/zookeeper] Add relabeling on servicemonitor and extraVolumeMounts evaluated as template (#8 ([cb65449](https://github.com/bitnami/charts/commit/cb65449)), closes [#8402](https://github.com/bitnami/charts/issues/8402)
+
+## <small>7.5.1 (2021-12-13)</small>
+
+* [bitnami/zookeeper] Fix securityContext reference after #8318 was merged (#8391) ([35c3398](https://github.com/bitnami/charts/commit/35c3398)), closes [#8318](https://github.com/bitnami/charts/issues/8318) [#8391](https://github.com/bitnami/charts/issues/8391)
+
+## 7.5.0 (2021-12-09)
+
+* [bitnami/zookeeper] Make it possible to customize the containers securityContext (#8318) ([a818e56](https://github.com/bitnami/charts/commit/a818e56)), closes [#8318](https://github.com/bitnami/charts/issues/8318)
+
+## <small>7.4.13 (2021-11-29)</small>
+
+* [bitnami/several] Regenerate README tables ([ac75243](https://github.com/bitnami/charts/commit/ac75243))
+* [bitnami/several] Replace HTTP by HTTPS when possible (#8259) ([eafb5bd](https://github.com/bitnami/charts/commit/eafb5bd)), closes [#8259](https://github.com/bitnami/charts/issues/8259)
+
+## <small>7.4.12 (2021-11-26)</small>
+
+* [bitnami/zookeeper] Release 7.4.12 updating components versions ([9fb2365](https://github.com/bitnami/charts/commit/9fb2365))
+
+## <small>7.4.11 (2021-11-03)</small>
+
+* fix: change zookeeper pdb version with apiVersion (#7983) ([50505f4](https://github.com/bitnami/charts/commit/50505f4)), closes [#7983](https://github.com/bitnami/charts/issues/7983)
+* [bitnami/several] Regenerate README tables ([412cf6a](https://github.com/bitnami/charts/commit/412cf6a))
+
+## <small>7.4.10 (2021-10-27)</small>
+
+* [bitnami/several] Regenerate README tables ([c82619f](https://github.com/bitnami/charts/commit/c82619f))
+* [bitnami/zookeeper] Release 7.4.10 updating components versions ([b5dfe89](https://github.com/bitnami/charts/commit/b5dfe89))
+
+## <small>7.4.9 (2021-10-25)</small>
+
+* [bitnami/zookeeper] Release 7.4.9 updating components versions ([be5e16f](https://github.com/bitnami/charts/commit/be5e16f))
+
+## <small>7.4.8 (2021-10-22)</small>
+
+* [bitnami/several] Add chart info to NOTES.txt (#7889) ([a6751cd](https://github.com/bitnami/charts/commit/a6751cd)), closes [#7889](https://github.com/bitnami/charts/issues/7889)
+
+## <small>7.4.7 (2021-10-19)</small>
+
+* [bitnami/several] Change pullPolicy for bitnami-shell image (#7852) ([9711a33](https://github.com/bitnami/charts/commit/9711a33)), closes [#7852](https://github.com/bitnami/charts/issues/7852)
+
+## <small>7.4.6 (2021-10-07)</small>
+
+* [bitnami/*] Fix service monitors selectors (#7720) ([1279593](https://github.com/bitnami/charts/commit/1279593)), closes [#7720](https://github.com/bitnami/charts/issues/7720)
+* [bitnami/several] Regenerate README tables ([ff170d1](https://github.com/bitnami/charts/commit/ff170d1))
+
+## <small>7.4.5 (2021-09-25)</small>
+
+* [bitnami/zookeeper] Release 7.4.5 updating components versions ([088d09f](https://github.com/bitnami/charts/commit/088d09f))
+
+## <small>7.4.4 (2021-09-24)</small>
+
+* [bitnami/*] Generate READMEs with new generator version (#7614) ([e5ab2e6](https://github.com/bitnami/charts/commit/e5ab2e6)), closes [#7614](https://github.com/bitnami/charts/issues/7614)
+* [bitnami/postgresql, zookeeper] Modify extravolumes and integrate sidecars (#7555) ([c4c4082](https://github.com/bitnami/charts/commit/c4c4082)), closes [#7555](https://github.com/bitnami/charts/issues/7555)
+
+## <small>7.4.3 (2021-09-03)</small>
+
+* [bitnami/several] Regenerate README tables ([da2513b](https://github.com/bitnami/charts/commit/da2513b))
+* [bitnami/zookeeper] Fix NetworkPolicy (#7398) ([74a039c](https://github.com/bitnami/charts/commit/74a039c)), closes [#7398](https://github.com/bitnami/charts/issues/7398)
+
+## <small>7.4.2 (2021-08-26)</small>
+
+* [bitnami/zookeeper] Release 7.4.2 updating components versions ([5340d0e](https://github.com/bitnami/charts/commit/5340d0e))
+
+## <small>7.4.1 (2021-08-25)</small>
+
+* [bitnami/zookeeper] Release 7.4.1 updating components versions ([71038bd](https://github.com/bitnami/charts/commit/71038bd))
+
+## 7.4.0 (2021-08-17)
+
+* [bitnami/several] Regenerate README tables ([6c107e8](https://github.com/bitnami/charts/commit/6c107e8))
+* [bitnami/zookeeper] Add containerPort (#7247) ([de311f0](https://github.com/bitnami/charts/commit/de311f0)), closes [#7247](https://github.com/bitnami/charts/issues/7247)
+
+## 7.3.0 (2021-08-11)
+
+* Added preAllocSize and snapCount options (#7183) ([e74750c](https://github.com/bitnami/charts/commit/e74750c)), closes [#7183](https://github.com/bitnami/charts/issues/7183)
+
+## 7.2.0 (2021-08-09)
+
+* Zookeeper topology (#7137) ([8623f7b](https://github.com/bitnami/charts/commit/8623f7b)), closes [#7137](https://github.com/bitnami/charts/issues/7137)
+
+## <small>7.1.2 (2021-08-04)</small>
+
+* [bitnami/several] Unify upgrading section ([baf2283](https://github.com/bitnami/charts/commit/baf2283))
+* [bitnami/zookeeper] Release 7.1.2 updating components versions ([df50db3](https://github.com/bitnami/charts/commit/df50db3))
+
+## <small>7.1.1 (2021-07-27)</small>
+
+* [bitnami/several] Bump version and update READMEs (#7069) ([6340bff](https://github.com/bitnami/charts/commit/6340bff)), closes [#7069](https://github.com/bitnami/charts/issues/7069)
+
+## 7.1.0 (2021-07-27)
+
+* [bitnami/several] Add diagnostic mode (#7012) ([f1344b0](https://github.com/bitnami/charts/commit/f1344b0)), closes [#7012](https://github.com/bitnami/charts/issues/7012)
+
+## <small>7.0.10 (2021-07-24)</small>
+
+* [bitnami/zookeeper] Release 7.0.10 updating components versions ([a5236e2](https://github.com/bitnami/charts/commit/a5236e2))
+
+## <small>7.0.9 (2021-07-21)</small>
+
+* [bitnami/*] Replace nil values (#6993) ([2be11a7](https://github.com/bitnami/charts/commit/2be11a7)), closes [#6993](https://github.com/bitnami/charts/issues/6993)
+
+## <small>7.0.8 (2021-07-16)</small>
+
+* [bitnami/*] Adapt values.yaml of common library, Tomcat, Wavefront and ZooKeeper charts (#6970) ([fb2693b](https://github.com/bitnami/charts/commit/fb2693b)), closes [#6970](https://github.com/bitnami/charts/issues/6970)
+
+## <small>7.0.7 (2021-07-09)</small>
+
+* apply common labels and annotations to PVC (#6898) ([b774fb7](https://github.com/bitnami/charts/commit/b774fb7)), closes [#6898](https://github.com/bitnami/charts/issues/6898)
+
+## <small>7.0.6 (2021-07-06)</small>
+
+* [bitnamti/zookeeper] Fix broken headless service annotations. (#6851) ([352eb00](https://github.com/bitnami/charts/commit/352eb00)), closes [#6851](https://github.com/bitnami/charts/issues/6851)
+
+## <small>7.0.5 (2021-07-05)</small>
+
+* [bitnami/zookeeper] Allow the use of the admin server to provide live… (#6478) ([c631461](https://github.com/bitnami/charts/commit/c631461)), closes [#6478](https://github.com/bitnami/charts/issues/6478)
+
+## <small>7.0.4 (2021-06-24)</small>
+
+* [bitnami/zookeeper] Add extra AltNames for localhost and headless service (#6737) ([9ea2d73](https://github.com/bitnami/charts/commit/9ea2d73)), closes [#6737](https://github.com/bitnami/charts/issues/6737)
+
+## <small>7.0.3 (2021-06-24)</small>
+
+* bitnami/zookeeper TLS enable for quorum added (#6742) ([30bbce8](https://github.com/bitnami/charts/commit/30bbce8)), closes [#6742](https://github.com/bitnami/charts/issues/6742)
+
+## <small>7.0.2 (2021-06-24)</small>
+
+* [bitnami/zookeeper] Release 7.0.2 updating components versions ([620b1a1](https://github.com/bitnami/charts/commit/620b1a1))
+
+## <small>7.0.1 (2021-06-21)</small>
+
+* [bitnami/zookeeper] Release 7.0.1 updating components versions ([d94c0dc](https://github.com/bitnami/charts/commit/d94c0dc))
+
+## 7.0.0 (2021-06-16)
+
+* [bitnami/zookeeper] Add support for autogenerated certs (#6532) ([40205f6](https://github.com/bitnami/charts/commit/40205f6)), closes [#6532](https://github.com/bitnami/charts/issues/6532)
+
+## 6.10.0 (2021-06-09)
+
+* [bitnami/zookeeper] Allow to specify a nodePort in zookeeper service (#6617) ([07168bb](https://github.com/bitnami/charts/commit/07168bb)), closes [#6617](https://github.com/bitnami/charts/issues/6617)
+
+## 6.9.0 (2021-06-08)
+
+* [bitnami/zookeeper] Add selector to pvc (#6505) ([a290ba8](https://github.com/bitnami/charts/commit/a290ba8)), closes [#6505](https://github.com/bitnami/charts/issues/6505)
+
+## 6.8.0 (2021-06-04)
+
+* [bitnami/zookeeper] add customLivenessProbe and customReadinessProbe (#6547) ([b95b366](https://github.com/bitnami/charts/commit/b95b366)), closes [#6547](https://github.com/bitnami/charts/issues/6547)
+
+## <small>6.7.4 (2021-06-02)</small>
+
+* [bitnami/zookeeper] Release 6.7.4 updating components versions ([0c13744](https://github.com/bitnami/charts/commit/0c13744))
+
+## <small>6.7.3 (2021-05-26)</small>
+
+* [bitnami/zookeeper] Release 6.7.3 updating components versions ([41bee22](https://github.com/bitnami/charts/commit/41bee22))
+
+## <small>6.7.2 (2021-04-26)</small>
+
+* [bitnami/zookeeper] Release 6.7.2 updating components versions ([1290a27](https://github.com/bitnami/charts/commit/1290a27))
+
+## <small>6.7.1 (2021-04-21)</small>
+
+* [bitnami/zookeeper] Updated Zookeeper README (#6158) ([ab0dbe4](https://github.com/bitnami/charts/commit/ab0dbe4)), closes [#6158](https://github.com/bitnami/charts/issues/6158)
+
+## 6.7.0 (2021-04-05)
+
+* Add automountServiceAccountToken field to the serviceaccount (#5996) ([8c2c4f0](https://github.com/bitnami/charts/commit/8c2c4f0)), closes [#5996](https://github.com/bitnami/charts/issues/5996)
+
+## 6.6.0 (2021-03-30)
+
+* [bitnami/zookeeper] Add new liveness/readiness probes to test TLS (#5944) ([dc22132](https://github.com/bitnami/charts/commit/dc22132)), closes [#5944](https://github.com/bitnami/charts/issues/5944)
+
+## <small>6.5.4 (2021-03-27)</small>
+
+* [bitnami/zookeeper] Release 6.5.4 updating components versions ([bdb1634](https://github.com/bitnami/charts/commit/bdb1634))
+
+## <small>6.5.3 (2021-03-25)</small>
+
+* [bitnami/zookeeper] Release 6.5.3 updating components versions ([fe13a2a](https://github.com/bitnami/charts/commit/fe13a2a))
+
+## <small>6.5.2 (2021-03-04)</small>
+
+* [bitnami/*] Remove minideb mentions (#5677) ([870bc4d](https://github.com/bitnami/charts/commit/870bc4d)), closes [#5677](https://github.com/bitnami/charts/issues/5677)
+
+## <small>6.5.1 (2021-02-23)</small>
+
+* [bitnami/zookeeper] Release 6.5.1 updating components versions ([c2ac165](https://github.com/bitnami/charts/commit/c2ac165))
+
+## 6.5.0 (2021-02-18)
+
+* [bitnami/*] Add notice regarding parameters immutability after chart installation (#4853) ([5f09573](https://github.com/bitnami/charts/commit/5f09573)), closes [#4853](https://github.com/bitnami/charts/issues/4853)
+* extra-list.yaml (#5502) ([b8e9836](https://github.com/bitnami/charts/commit/b8e9836)), closes [#5502](https://github.com/bitnami/charts/issues/5502)
+
+## 6.4.0 (2021-01-29)
+
+* [bitnami/zookeeper] Add hostAliases (#5321) ([bfbd24f](https://github.com/bitnami/charts/commit/bfbd24f)), closes [#5321](https://github.com/bitnami/charts/issues/5321)
+
+## <small>6.3.4 (2021-01-25)</small>
+
+* [bitnami/*] Unify icons in Chart.yaml and add missing fields (#5206) ([0462921](https://github.com/bitnami/charts/commit/0462921)), closes [#5206](https://github.com/bitnami/charts/issues/5206)
+
+## <small>6.3.3 (2021-01-24)</small>
+
+* [bitnami/zookeeper] Release 6.3.3 updating components versions ([41799f9](https://github.com/bitnami/charts/commit/41799f9))
+
+## <small>6.3.2 (2021-01-19)</small>
+
+* [bitnami/*] Change helm version in the prerequisites (#5090) ([c5e67a3](https://github.com/bitnami/charts/commit/c5e67a3)), closes [#5090](https://github.com/bitnami/charts/issues/5090)
+* [bitnami/zookeeper] Drop values-production.yaml support (#5135) ([7e98e1e](https://github.com/bitnami/charts/commit/7e98e1e)), closes [#5135](https://github.com/bitnami/charts/issues/5135)
+
+## <small>6.3.1 (2021-01-14)</small>
+
+* [bitnami/several] Add Redis trademark (#5023) ([dfa89b8](https://github.com/bitnami/charts/commit/dfa89b8)), closes [#5023](https://github.com/bitnami/charts/issues/5023)
+
+## 6.3.0 (2020-12-25)
+
+* [bitnami/zookeeper] feat: add initContianers (#4802) ([e19d329](https://github.com/bitnami/charts/commit/e19d329)), closes [#4802](https://github.com/bitnami/charts/issues/4802)
+
+## <small>6.2.1 (2020-12-18)</small>
+
+* [bitnami/zookeeper] Fix apache.tplValue (#4779) ([27f6f76](https://github.com/bitnami/charts/commit/27f6f76)), closes [#4779](https://github.com/bitnami/charts/issues/4779)
+
+## 6.2.0 (2020-12-17)
+
+* bitnami/zookeeper add minServerId variable (#4700) ([785a386](https://github.com/bitnami/charts/commit/785a386)), closes [#4700](https://github.com/bitnami/charts/issues/4700)
+
+## 6.1.0 (2020-12-16)
+
+* [bitnami/*] Affinity based on common presets (ix) (#4727) ([a0db323](https://github.com/bitnami/charts/commit/a0db323)), closes [#4727](https://github.com/bitnami/charts/issues/4727)
+
+## <small>6.0.2 (2020-12-14)</small>
+
+* [bitnami/*] fix typos (#4699) ([49adc63](https://github.com/bitnami/charts/commit/49adc63)), closes [#4699](https://github.com/bitnami/charts/issues/4699)
+* [bitnami/zookeeper] Release 6.0.2 updating components versions ([75b066f](https://github.com/bitnami/charts/commit/75b066f))
+
+## <small>6.0.1 (2020-12-11)</small>
+
+* [bitnami/zookeeper] Release 6.0.1 updating components versions ([124c4d9](https://github.com/bitnami/charts/commit/124c4d9))
+
+## 6.0.0 (2020-11-10)
+
+* [bitnami/*] Include link to Troubleshootin guide on README.md (#4136) ([c08a20e](https://github.com/bitnami/charts/commit/c08a20e)), closes [#4136](https://github.com/bitnami/charts/issues/4136)
+* [bitnami/zookeeper] Major version. Adapt Chart to apiVersion: v2 (#4261) ([b38b734](https://github.com/bitnami/charts/commit/b38b734)), closes [#4261](https://github.com/bitnami/charts/issues/4261)
+
+## 5.23.0 (2020-10-28)
+
+* [bitnami/zookeeper] Changes to add loadBalancerIP option to service (#4130) ([eff33a5](https://github.com/bitnami/charts/commit/eff33a5)), closes [#4130](https://github.com/bitnami/charts/issues/4130)
+
+## <small>5.22.2 (2020-10-21)</small>
+
+* [bitnami/zookeeper] Release 5.22.2 updating components versions ([d9a415e](https://github.com/bitnami/charts/commit/d9a415e))
+
+## <small>5.22.1 (2020-10-16)</small>
+
+* [binami/zookeeper] fix: remove wrong \ (#4039) ([68717b9](https://github.com/bitnami/charts/commit/68717b9)), closes [#4039](https://github.com/bitnami/charts/issues/4039)
+
+## 5.22.0 (2020-10-07)
+
+* [bitnami/zookeeper] allow for overriding namespace in zookeeper helm chart (#3881) ([01b1359](https://github.com/bitnami/charts/commit/01b1359)), closes [#3881](https://github.com/bitnami/charts/issues/3881)
+
+## <small>5.21.9 (2020-09-21)</small>
+
+* [bitnami/zookeeper] Release 5.21.9 updating components versions ([46d21fb](https://github.com/bitnami/charts/commit/46d21fb))
+
+## <small>5.21.8 (2020-09-10)</small>
+
+* [bitnami/zookeeper] Release 5.21.8 updating components versions ([686d6f4](https://github.com/bitnami/charts/commit/686d6f4))
+
+## <small>5.21.7 (2020-09-08)</small>
+
+* [bitnami/metrics-server] Add source repo (#3577) ([1ed12f9](https://github.com/bitnami/charts/commit/1ed12f9)), closes [#3577](https://github.com/bitnami/charts/issues/3577)
+* [bitnami/zookeeper] Override serviceAccount name when not creating one (#3587) ([963cc13](https://github.com/bitnami/charts/commit/963cc13)), closes [#3587](https://github.com/bitnami/charts/issues/3587)
+
+## <small>5.21.6 (2020-09-03)</small>
+
+* [bitnami/zookeeper] Release 5.21.6 updating components versions ([84298d2](https://github.com/bitnami/charts/commit/84298d2))
+
+## <small>5.21.5 (2020-08-07)</small>
+
+* [bitnami/zookeeper] Fix typo in zookeeper.tplValue usage for common labels and annotations (#3358) ([6f98e1d](https://github.com/bitnami/charts/commit/6f98e1d)), closes [#3358](https://github.com/bitnami/charts/issues/3358)
+
+## <small>5.21.4 (2020-08-04)</small>
+
+* fix redinessprobe wrong value ref (#3321) ([cf8f095](https://github.com/bitnami/charts/commit/cf8f095)), closes [#3321](https://github.com/bitnami/charts/issues/3321)
+
+## <small>5.21.3 (2020-08-04)</small>
+
+* [bitnami/zookeeper] Release 5.21.3 updating components versions ([2d394ac](https://github.com/bitnami/charts/commit/2d394ac))
+
+## <small>5.21.2 (2020-07-31)</small>
+
+* [bitnami/*] Fix TL;DR typo in READMEs (#3280) ([3d7ab40](https://github.com/bitnami/charts/commit/3d7ab40)), closes [#3280](https://github.com/bitnami/charts/issues/3280)
+* [bitnami/zookeeper] Add missing properties to production values (#3285) ([88eb837](https://github.com/bitnami/charts/commit/88eb837)), closes [#3285](https://github.com/bitnami/charts/issues/3285)
+
+## <small>5.21.1 (2020-07-29)</small>
+
+* [bitnami/zookeeper] Fix probes when using CentOS images (#3261) ([51fc89d](https://github.com/bitnami/charts/commit/51fc89d)), closes [#3261](https://github.com/bitnami/charts/issues/3261)
+
+## 5.21.0 (2020-07-28)
+
+* [bitnami/zookeeper] Metrics annotations through svc (#3251) ([3e06faf](https://github.com/bitnami/charts/commit/3e06faf)), closes [#3251](https://github.com/bitnami/charts/issues/3251)
+
+## 5.20.0 (2020-07-28)
+
+* [bitnami/zookeeper] Replace liveness and readiness probes with ZK commands (#3231) ([6222cc2](https://github.com/bitnami/charts/commit/6222cc2)), closes [#3231](https://github.com/bitnami/charts/issues/3231)
+
+## <small>5.19.1 (2020-07-22)</small>
+
+* [bitnami/zookeeper] Fix backwards incompatibility issue (#3175) ([fd27fd3](https://github.com/bitnami/charts/commit/fd27fd3)), closes [#3175](https://github.com/bitnami/charts/issues/3175)
+* [bitnami/zookeeper] Release 5.19.1 updating components versions ([41906ed](https://github.com/bitnami/charts/commit/41906ed))
+
+## 5.19.0 (2020-07-21)
+
+* [bitnami/zookeeper] Add custom labels/annotations parameters (#3173) ([478e565](https://github.com/bitnami/charts/commit/478e565)), closes [#3173](https://github.com/bitnami/charts/issues/3173)
+
+## 5.18.0 (2020-07-14)
+
+* [bitnami/all] Add categories (#3075) ([63bde06](https://github.com/bitnami/charts/commit/63bde06)), closes [#3075](https://github.com/bitnami/charts/issues/3075)
+* [bitnami/zookeeper] Made dataLogDir customizable. (#2994) ([8071c0c](https://github.com/bitnami/charts/commit/8071c0c)), closes [#2994](https://github.com/bitnami/charts/issues/2994)
+
+## <small>5.17.3 (2020-07-09)</small>
+
+* [bitnami/zookeeper] Release 5.17.3 updating components versions ([59fa1ff](https://github.com/bitnami/charts/commit/59fa1ff))
+
+## <small>5.17.2 (2020-07-01)</small>
+
+* [bitnami/zookeeper] Release 5.17.2 updating components versions ([cc6a84d](https://github.com/bitnami/charts/commit/cc6a84d))
+
+## <small>5.17.1 (2020-06-24)</small>
+
+* [bitnami/zookeeper] Release 5.17.1 updating components versions ([0d2f2cb](https://github.com/bitnami/charts/commit/0d2f2cb))
+
+## 5.17.0 (2020-06-19)
+
+* [bitnami/zookeeper] add schedulerName option (#2872) ([2d8b47c](https://github.com/bitnami/charts/commit/2d8b47c)), closes [#2872](https://github.com/bitnami/charts/issues/2872)
+
+## <small>5.16.3 (2020-06-18)</small>
+
+* [bitnami/zookeeper] Configure max session timeout as standard env var… (#2847) ([6452a6e](https://github.com/bitnami/charts/commit/6452a6e)), closes [#2847](https://github.com/bitnami/charts/issues/2847)
+
+## <small>5.16.2 (2020-06-18)</small>
+
+* [bitnami/zookeeper] Release 5.16.2 updating components versions ([f27906a](https://github.com/bitnami/charts/commit/f27906a))
+
+## <small>5.16.1 (2020-06-17)</small>
+
+* [bitnami/zookeeper] Release 5.16.1 updating components versions ([b3f3d33](https://github.com/bitnami/charts/commit/b3f3d33))
+
+## 5.16.0 (2020-06-05)
+
+* [bitnami/zookeeper] Add Prometheus Operator PrometheusRule support (#2703) ([29e70ae](https://github.com/bitnami/charts/commit/29e70ae)), closes [#2703](https://github.com/bitnami/charts/issues/2703)
+
+## <small>5.15.1 (2020-06-04)</small>
+
+* [bitnami/zookeeper] Release 5.15.1 updating components versions ([e9f8c2b](https://github.com/bitnami/charts/commit/e9f8c2b))
+
+## 5.15.0 (2020-06-02)
+
+* [bitnami/several] Fix trailing spaces to make helm lint work on all of them (#2705) ([bafba3f](https://github.com/bitnami/charts/commit/bafba3f)), closes [#2705](https://github.com/bitnami/charts/issues/2705)
+* [bitnami/zookeeper] Allow adding annotations to the services (#2701) ([f2692ad](https://github.com/bitnami/charts/commit/f2692ad)), closes [#2701](https://github.com/bitnami/charts/issues/2701)
+* [bitnami/zookeeper] Fix podAnnotations template rendering (#2662) ([5e6e64f](https://github.com/bitnami/charts/commit/5e6e64f)), closes [#2662](https://github.com/bitnami/charts/issues/2662)
+
+## <small>5.14.5 (2020-05-26)</small>
+
+* [bitnami/zookeeper] add egress rule into network policy for intra-node communication (#2596) ([e05e2f4](https://github.com/bitnami/charts/commit/e05e2f4)), closes [#2596](https://github.com/bitnami/charts/issues/2596)
+* [bitnami/zookeeper] Release 5.14.5 updating components versions ([e3cee60](https://github.com/bitnami/charts/commit/e3cee60))
+
+## <small>5.14.4 (2020-05-21)</small>
+
+* [bitnami/zookeeper] Release 5.14.4 updating components versions ([b35d9d3](https://github.com/bitnami/charts/commit/b35d9d3))
+* update bitnami/common to be compatible with helm v2.12+ (#2615) ([c7751eb](https://github.com/bitnami/charts/commit/c7751eb)), closes [#2615](https://github.com/bitnami/charts/issues/2615)
+
+## <small>5.14.3 (2020-05-08)</small>
+
+* [bitnami/zookeeper] Fix issue in ports (#2513) ([f91b42a](https://github.com/bitnami/charts/commit/f91b42a)), closes [#2513](https://github.com/bitnami/charts/issues/2513)
+* Fix Zookeeper Readme (#2486) ([3856cef](https://github.com/bitnami/charts/commit/3856cef)), closes [#2486](https://github.com/bitnami/charts/issues/2486)
+
+## <small>5.14.2 (2020-05-01)</small>
+
+* [bitnami/zookeeper] fix() typo (#2481) ([2562fbd](https://github.com/bitnami/charts/commit/2562fbd)), closes [#2481](https://github.com/bitnami/charts/issues/2481)
+
+## <small>5.14.1 (2020-04-30)</small>
+
+* [bitnami/zookeeper] Release 5.14.1 updating components versions ([1ae4f12](https://github.com/bitnami/charts/commit/1ae4f12))
+
+## 5.14.0 (2020-04-30)
+
+* [bitnami/zookeeper] feat(zookeeper) Added tls support for zookeeper (#2290) ([ef4381c](https://github.com/bitnami/charts/commit/ef4381c)), closes [#2290](https://github.com/bitnami/charts/issues/2290)
+
+## <small>5.13.2 (2020-04-29)</small>
+
+* [bitnami/zookeeper] Release 5.13.2 updating components versions ([4798f45](https://github.com/bitnami/charts/commit/4798f45))
+
+## <small>5.13.1 (2020-04-22)</small>
+
+* [bitnami/zookeeper] Istio service name convention. (#2332) ([e455621](https://github.com/bitnami/charts/commit/e455621)), closes [#2332](https://github.com/bitnami/charts/issues/2332)
+* [bitnami/zookeeper] Release 5.13.1 updating components versions ([58275e5](https://github.com/bitnami/charts/commit/58275e5))
+
+## 5.13.0 (2020-04-20)
+
+* [bitnami/zookeeper] add priorityClassName support (#2355) ([734910c](https://github.com/bitnami/charts/commit/734910c)), closes [#2355](https://github.com/bitnami/charts/issues/2355)
+
+## <small>5.12.2 (2020-04-20)</small>
+
+* [bitnami/zookeeper] Release 5.12.2 updating components versions ([16b7440](https://github.com/bitnami/charts/commit/16b7440))
+* [bitnami/zookeeper] ServiceMonitor does not discover prometheus target (#2341) ([a924e94](https://github.com/bitnami/charts/commit/a924e94)), closes [#2341](https://github.com/bitnami/charts/issues/2341)
+
+## <small>5.12.1 (2020-04-16)</small>
+
+* [bitnami/zookeeper] Release 5.12.1 updating components versions ([63cabe5](https://github.com/bitnami/charts/commit/63cabe5))
+
+## 5.12.0 (2020-04-16)
+
+* [bitnami/zookeeper] Introduced .Release.Namespace in objects meta (#2316) ([2c175bf](https://github.com/bitnami/charts/commit/2c175bf)), closes [#2316](https://github.com/bitnami/charts/issues/2316)
+
+## 5.11.0 (2020-04-10)
+
+* [bitnami/zookeeper] feat(zookeeper) added extra volume options to zookeeper chart (#2271) ([deb4983](https://github.com/bitnami/charts/commit/deb4983)), closes [#2271](https://github.com/bitnami/charts/issues/2271)
+
+## <small>5.10.1 (2020-04-09)</small>
+
+* [bitnami/zookeeper] Release 5.10.1 updating components versions ([28b1559](https://github.com/bitnami/charts/commit/28b1559))
+
+## 5.10.0 (2020-04-09)
+
+* [bitnami/zookeeper] Add podLabels to statefulset (#2257) ([cbad653](https://github.com/bitnami/charts/commit/cbad653)), closes [#2257](https://github.com/bitnami/charts/issues/2257)
+
+## 5.9.0 (2020-04-07)
+
+* [bitnami/zookeeper] add existingClaim support (#2238) ([9d03159](https://github.com/bitnami/charts/commit/9d03159)), closes [#2238](https://github.com/bitnami/charts/issues/2238)
+
+## <small>5.8.2 (2020-04-06)</small>
+
+* [bitnami/zookeeper] Release 5.8.2 updating components versions ([cbe62ec](https://github.com/bitnami/charts/commit/cbe62ec))
+
+## <small>5.8.1 (2020-04-06)</small>
+
+* [bitnami/zookeeper] Fix typo in README.md (#2234) ([41c2c83](https://github.com/bitnami/charts/commit/41c2c83)), closes [#2234](https://github.com/bitnami/charts/issues/2234)
+
+## 5.8.0 (2020-04-03)
+
+* [bitnami/zookeeper] Deprecate Prometheus exporter in favor of native endpoint (#2205) ([c4eff83](https://github.com/bitnami/charts/commit/c4eff83)), closes [#2205](https://github.com/bitnami/charts/issues/2205)
+
+## <small>5.7.2 (2020-03-26)</small>
+
+* [bitnami/zookeeper] Release 5.7.2 updating components versions ([901f120](https://github.com/bitnami/charts/commit/901f120))
+
+## <small>5.7.1 (2020-03-20)</small>
+
+* [bitnami/zookeeper] Release 5.7.1 updating components versions ([17c9ca0](https://github.com/bitnami/charts/commit/17c9ca0))
+
+## 5.7.0 (2020-03-20)
+
+* [bitnami/zookeeper] pod annotations (#2066) ([90edbc1](https://github.com/bitnami/charts/commit/90edbc1)), closes [#2066](https://github.com/bitnami/charts/issues/2066)
+
+## <small>5.6.3 (2020-03-12)</small>
+
+* [bitnami/zookeeper] Release 5.6.3 updating components versions ([9459a26](https://github.com/bitnami/charts/commit/9459a26))
+
+## <small>5.6.2 (2020-03-11)</small>
+
+* Move charts from upstreamed folder to bitnami (#2032) ([a0e44f7](https://github.com/bitnami/charts/commit/a0e44f7)), closes [#2032](https://github.com/bitnami/charts/issues/2032)
+
+## <small>5.6.1 (2020-03-10)</small>
+
+* [bitnami/zookeeper] Release 5.6.1 updating components versions ([ad58cc5](https://github.com/bitnami/charts/commit/ad58cc5))
+
+## 5.6.0 (2020-03-06)
+
+* [bitnami/zookeeper] Add template and parameters for configuring network policy (#2005) ([af5eadf](https://github.com/bitnami/charts/commit/af5eadf)), closes [#2005](https://github.com/bitnami/charts/issues/2005)
+
+## <small>5.5.1 (2020-02-27)</small>
+
+* [bitnami/zookeeper] Release 5.5.1 updating components versions ([eedc3ed](https://github.com/bitnami/charts/commit/eedc3ed))
+
+## 5.5.0 (2020-02-27)
+
+* bitnami/zookeeper: added varaibles for configure autopurge (#1984) ([685a979](https://github.com/bitnami/charts/commit/685a979)), closes [#1984](https://github.com/bitnami/charts/issues/1984)
+
+## <small>5.4.3 (2020-02-26)</small>
+
+* [bitnami/zookeeper] Release 5.4.3 updating components versions ([bbecf2e](https://github.com/bitnami/charts/commit/bbecf2e))
+
+## <small>5.4.2 (2020-02-14)</small>
+
+* [bitnami/several] Adapt READMEs and helpers to Helm 3 (#1911) ([40ee57c](https://github.com/bitnami/charts/commit/40ee57c)), closes [#1911](https://github.com/bitnami/charts/issues/1911)
+* [bitnami/zookeeper] Release 5.4.2 updating components versions ([2f602e6](https://github.com/bitnami/charts/commit/2f602e6))
+
+## <small>5.4.1 (2020-02-10)</small>
+
+* [bitnami/several] Replace stretch by buster in minideb secondary containers (#1900) ([678febc](https://github.com/bitnami/charts/commit/678febc)), closes [#1900](https://github.com/bitnami/charts/issues/1900)
+
+## 5.4.0 (2020-02-02)
+
+* Fix bump version 3 ([f35e96d](https://github.com/bitnami/charts/commit/f35e96d))
+
+## <small>5.3.6 (2020-02-02)</small>
+
+* adding an environment variable to make zookeeper listen on all ips (with default value false) ([a61d41f](https://github.com/bitnami/charts/commit/a61d41f))
+* fix bumping version ([ee5582d](https://github.com/bitnami/charts/commit/ee5582d))
+* Fixed README.md ([cb9d1fe](https://github.com/bitnami/charts/commit/cb9d1fe))
+* Update values files and bump version ([a63008c](https://github.com/bitnami/charts/commit/a63008c))
+
+## <small>5.3.5 (2020-01-30)</small>
+
+* [bitnami/zookeeper] Release 5.3.5 updating components versions ([e27d28a](https://github.com/bitnami/charts/commit/e27d28a))
+
+## <small>5.3.4 (2020-01-24)</small>
+
+* [bitnami/zookeeper] Release 5.3.4 updating components versions ([c066074](https://github.com/bitnami/charts/commit/c066074))
+
+## <small>5.3.3 (2020-01-14)</small>
+
+* [bitnami/zookeeper] Release 5.3.3 updating components versions ([feaffb9](https://github.com/bitnami/charts/commit/feaffb9))
+
+## <small>5.3.2 (2020-01-10)</small>
+
+* [bitnami/zookeeper] Release 5.3.2 updating components versions ([c7db1d4](https://github.com/bitnami/charts/commit/c7db1d4))
+
+## <small>5.3.1 (2020-01-03)</small>
+
+* [bitnami/zookeeper] fix metrics pod labels ([52e9e8c](https://github.com/bitnami/charts/commit/52e9e8c))
+* adding creating serviceAccount name to template ([3a43997](https://github.com/bitnami/charts/commit/3a43997))
+* fix typo in README.md ([ef0b620](https://github.com/bitnami/charts/commit/ef0b620))
+* Fixing indentation ([935db5c](https://github.com/bitnami/charts/commit/935db5c))
+* Unify comments ([67cfba8](https://github.com/bitnami/charts/commit/67cfba8))
+* Unify comments 2 ([91ed4aa](https://github.com/bitnami/charts/commit/91ed4aa))
+* Update bitnami/zookeeper/README.md ([0ea0e73](https://github.com/bitnami/charts/commit/0ea0e73))
+* Update bitnami/zookeeper/templates/serviceaccount.yaml ([942f57b](https://github.com/bitnami/charts/commit/942f57b))
+* Update bitnami/zookeeper/templates/statefulset.yaml ([cec58f2](https://github.com/bitnami/charts/commit/cec58f2))
+* Use template instead of include to be consistent ([924137e](https://github.com/bitnami/charts/commit/924137e))
+
+## 5.3.0 (2019-12-29)
+
+* [bitnami/zookeeper] Update components versions ([bff1786](https://github.com/bitnami/charts/commit/bff1786))
+* adding optional service account for zookeeper node ([7f1fc09](https://github.com/bitnami/charts/commit/7f1fc09))
+* Apply more suggestions ([d18a4fb](https://github.com/bitnami/charts/commit/d18a4fb))
+* Apply suggestions ([b0e06d1](https://github.com/bitnami/charts/commit/b0e06d1))
+* bump version and update README.md ([9519051](https://github.com/bitnami/charts/commit/9519051))
+
+## 5.2.0 (2019-11-26)
+
+* [bitnami/zookeeper] Lint chart and standardize ([1eb06b3](https://github.com/bitnami/charts/commit/1eb06b3))
+
+## <small>5.1.1 (2019-11-18)</small>
+
+* [bitnami/zookeeper] Release 5.1.1 updating components versions ([0392262](https://github.com/bitnami/charts/commit/0392262))
+
+## 5.1.0 (2019-10-25)
+
+* [bitnami/zookepper] adds servicemonitor support ([413151d](https://github.com/bitnami/charts/commit/413151d))
+
+## <small>5.0.7 (2019-10-24)</small>
+
+* [bitnami/zookeeper] Fix typo in Zookeeper readme ([fa1a055](https://github.com/bitnami/charts/commit/fa1a055))
+
+## <small>5.0.6 (2019-10-24)</small>
+
+* Fix links because of section renaming ([8e6fa3b](https://github.com/bitnami/charts/commit/8e6fa3b))
+
+## <small>5.0.5 (2019-10-23)</small>
+
+* Adapt README in charts (III) ([98eadc4](https://github.com/bitnami/charts/commit/98eadc4))
+
+## <small>5.0.4 (2019-10-19)</small>
+
+* [bitnami/zookeeper] Release 5.0.4 updating components versions ([c888904](https://github.com/bitnami/charts/commit/c888904))
+
+## <small>5.0.3 (2019-10-15)</small>
+
+* [bitnami/zookeeper] Update prerequisites ([1638b09](https://github.com/bitnami/charts/commit/1638b09))
+
+## <small>5.0.2 (2019-10-05)</small>
+
+* [bitnami/zookeeper] Release 5.0.2 updating components versions ([df9469d](https://github.com/bitnami/charts/commit/df9469d))
+
+## <small>5.0.1 (2019-09-20)</small>
+
+* [bitnami/*] Update apiVersion on sts, deployments, daemonsets and podsecuritypolicies ([4dfac07](https://github.com/bitnami/charts/commit/4dfac07))
+* Update tags ([94926ab](https://github.com/bitnami/charts/commit/94926ab))
+
+## 5.0.0 (2019-09-05)
+
+* Bump chart and tag versions ([369ed43](https://github.com/bitnami/charts/commit/369ed43))
+
+## <small>4.4.4 (2019-09-05)</small>
+
+* Update container entrypoint to make it compatible with bash logic ([d375b55](https://github.com/bitnami/charts/commit/d375b55))
+
+## <small>4.3.4 (2019-09-02)</small>
+
+* [bitnami/zookeeper] Release 4.3.4 updating components versions ([36bc5fc](https://github.com/bitnami/charts/commit/36bc5fc))
+* Use stretch instead of buster to be consistent ([decd85f](https://github.com/bitnami/charts/commit/decd85f))
+
+## <small>4.3.3 (2019-08-30)</small>
+
+* [bitnami/*] Use buster instead of latest as minideb tag and adapt sysctl ([921e811](https://github.com/bitnami/charts/commit/921e811))
+
+## <small>4.3.2 (2019-08-22)</small>
+
+* [bitnami/*] Fix 'storageClass' macros ([f41c193](https://github.com/bitnami/charts/commit/f41c193))
+
+## <small>4.3.1 (2019-08-21)</small>
+
+* Refactor StorageClass template to support old Helm versions ([1d7f3df](https://github.com/bitnami/charts/commit/1d7f3df))
+* Refactor storageClassTemplate ([1872215](https://github.com/bitnami/charts/commit/1872215))
+
+## 4.3.0 (2019-08-19)
+
+* Add global variable to set the storage class to all of the Hekm Charts ([cdb4bdc](https://github.com/bitnami/charts/commit/cdb4bdc))
+* Update charts versions ([9459dbb](https://github.com/bitnami/charts/commit/9459dbb))
+
+## <small>4.2.1 (2019-08-13)</small>
+
+* Update README.md ([0d5af7f](https://github.com/bitnami/charts/commit/0d5af7f))
+* Updated version numbers ([aa0294b](https://github.com/bitnami/charts/commit/aa0294b))
+
+## 4.2.0 (2019-08-12)
+
+* [bitnami/zookeeper] Use bitnami/zookeeper-exporter exporter image ([010685a](https://github.com/bitnami/charts/commit/010685a)), closes [#1344](https://github.com/bitnami/charts/issues/1344)
+
+## <small>4.1.1 (2019-07-30)</small>
+
+* Fix indentation ([c699e9f](https://github.com/bitnami/charts/commit/c699e9f))
+* Fix truncate comment in helpers ([cf4a7a3](https://github.com/bitnami/charts/commit/cf4a7a3))
+
+## 4.1.0 (2019-07-22)
+
+* Change Zookeeper ([64267e4](https://github.com/bitnami/charts/commit/64267e4))
+
+## 4.0.0 (2019-07-17)
+
+* Implement again #1283 changes but bumping the major version ([1ce079c](https://github.com/bitnami/charts/commit/1ce079c)), closes [#1283](https://github.com/bitnami/charts/issues/1283)
+
+## <small>3.0.8 (2019-07-17)</small>
+
+* Revert pull request #1283 ([8e5940a](https://github.com/bitnami/charts/commit/8e5940a)), closes [#1283](https://github.com/bitnami/charts/issues/1283)
+* Use name of the solution for the main container included in the pod ([d031dee](https://github.com/bitnami/charts/commit/d031dee))
+
+## <small>3.0.7 (2019-07-11)</small>
+
+* Standardize component.name & component.fullname functions ([775948e](https://github.com/bitnami/charts/commit/775948e))
+
+## <small>3.0.6 (2019-07-03)</small>
+
+* [bitnami/zookeeper] Fix Zookeeper metrics-deployment clusterDomain parameter ([7208fc7](https://github.com/bitnami/charts/commit/7208fc7))
+
+## <small>3.0.5 (2019-07-03)</small>
+
+* Change domain by clusterDomain ([4effe5c](https://github.com/bitnami/charts/commit/4effe5c))
+* Create template for cluster domain on Zookeeper ([9ee4ba0](https://github.com/bitnami/charts/commit/9ee4ba0))
+* Fix Zookeeper clusterDomain ([3520eca](https://github.com/bitnami/charts/commit/3520eca))
+* Update Zookeeper and Memcached READMEs ([afcd88a](https://github.com/bitnami/charts/commit/afcd88a))
+
+## <small>3.0.4 (2019-07-01)</small>
+
+* [bitnami/zookeeper] Release 3.0.4 updating components versions ([845016d](https://github.com/bitnami/charts/commit/845016d))
+* Changes in README ([7ac4ec0](https://github.com/bitnami/charts/commit/7ac4ec0))
+
+## <small>3.0.3 (2019-06-10)</small>
+
+* bitnami/zookeeper: update to 3.5.5 ([214fda3](https://github.com/bitnami/charts/commit/214fda3))
+* Bump version ([a672193](https://github.com/bitnami/charts/commit/a672193))
+
+## <small>3.0.2 (2019-06-10)</small>
+
+* Add command ([5e0cdcf](https://github.com/bitnami/charts/commit/5e0cdcf))
+* Use IfNotPresent as imagePullPolicy since we are using immutable tags ([53247da](https://github.com/bitnami/charts/commit/53247da))
+
+## <small>3.0.1 (2019-06-07)</small>
+
+* [bitnami/zookeeper] Unify and document production values ([5cc432c](https://github.com/bitnami/charts/commit/5cc432c))
+* Update appversion and image tag to do all the changes atomically ([7617249](https://github.com/bitnami/charts/commit/7617249))
+
+## 3.0.0 (2019-06-05)
+
+* bitnami/zookeeper - Upgrade notes for new version ([c57326e](https://github.com/bitnami/charts/commit/c57326e))
+
+## <small>2.2.4 (2019-05-29)</small>
+
+* Change syntax because of linter failing ([adfc357](https://github.com/bitnami/charts/commit/adfc357))
+* Fix https://github.com/helm/charts/pull/14199\#issuecomment-496883321 and support _sha256_ as an imm ([95957ea](https://github.com/bitnami/charts/commit/95957ea)), closes [#issuecomment-496883321](https://github.com/bitnami/charts/issues/issuecomment-496883321)
+* Use immutable tags in the main images ([17ca4f5](https://github.com/bitnami/charts/commit/17ca4f5))
+
+## <small>2.2.3 (2019-05-28)</small>
+
+* Prepare immutable tags ([f9093c1](https://github.com/bitnami/charts/commit/f9093c1))
+
+## <small>2.2.2 (2019-05-22)</small>
+
+* Add ZOO_LOG_LEVEL env var ([eba9fe2](https://github.com/bitnami/charts/commit/eba9fe2))
+* Clarify zookeeper serverUsers and serverPasswords input format ([411975a](https://github.com/bitnami/charts/commit/411975a))
+* Update README.md ([b3f6563](https://github.com/bitnami/charts/commit/b3f6563))
+* Update Zookeeper README to fix mistake ([168d6e7](https://github.com/bitnami/charts/commit/168d6e7))
+
+## <small>2.2.1 (2019-05-16)</small>
+
+* [bitnami/zookeeper] Add fullnameOverride ([2c3a003](https://github.com/bitnami/charts/commit/2c3a003))
+* Configure probes for metrics exporter ([0f82306](https://github.com/bitnami/charts/commit/0f82306))
+* Set ZooKeeper exporter connection timeout ([8c7209d](https://github.com/bitnami/charts/commit/8c7209d))
+* Switch metrics exporter image ([eb14061](https://github.com/bitnami/charts/commit/eb14061))
+
+## 2.1.0 (2019-05-08)
+
+* Publish DNS records for un-ready pods ([060f84e](https://github.com/bitnami/charts/commit/060f84e))
+
+## 2.0.0 (2019-05-07)
+
+* Add 'app.kubernetes.io/component' too ([5ba0d7f](https://github.com/bitnami/charts/commit/5ba0d7f))
+* Use official labels exclusively ([752c8f7](https://github.com/bitnami/charts/commit/752c8f7))
+
+## 1.8.0 (2019-05-07)
+
+* [bitnami/zookeeper] Fix labels + document metrics in README.md ([cf0d345](https://github.com/bitnami/charts/commit/cf0d345))
+
+## <small>1.7.1 (2019-05-07)</small>
+
+* Mount emptyDir for ZooKeeper ([ade41ae](https://github.com/bitnami/charts/commit/ade41ae))
+* Sync parameter explanation to production values ([70e3536](https://github.com/bitnami/charts/commit/70e3536))
+* Update values-production.yaml ([54478f6](https://github.com/bitnami/charts/commit/54478f6))
+* Update values.yaml ([04b5a7e](https://github.com/bitnami/charts/commit/04b5a7e))
+
+## 1.7.0 (2019-05-07)
+
+* Manage disruptions when using more than 1 replicas ([e1f9143](https://github.com/bitnami/charts/commit/e1f9143))
+
+## <small>1.6.1 (2019-04-25)</small>
+
+* Remove exporter pod from services ([20a77cf](https://github.com/bitnami/charts/commit/20a77cf))
+
+## 1.6.0 (2019-04-16)
+
+* Set metadata labels ([d85c73d](https://github.com/bitnami/charts/commit/d85c73d))
+
+## 1.5.0 (2019-04-08)
+
+* Add new kafka option. Add affinity for kafka and zookeeper ([10f0e71](https://github.com/bitnami/charts/commit/10f0e71))
+
+## <small>1.4.3 (2019-04-02)</small>
+
+* bitnami/zookeeper: update to 3.4.14 ([1cc0663](https://github.com/bitnami/charts/commit/1cc0663))
+
+## <small>1.4.2 (2019-03-18)</small>
+
+* Set rollingUpdate to null when updateStrategy is Recreate ([1a45bba](https://github.com/bitnami/charts/commit/1a45bba))
+* Use namespaces ([8c80056](https://github.com/bitnami/charts/commit/8c80056))
+
+## <small>1.4.1 (2019-03-14)</small>
+
+* Use global registry in secondary, metrics and other non-default images ([5d216bf](https://github.com/bitnami/charts/commit/5d216bf))
+
+## 1.4.0 (2019-03-12)
+
+* Fix typo ([5570067](https://github.com/bitnami/charts/commit/5570067))
+* Fix typo in helpers ([aea99a2](https://github.com/bitnami/charts/commit/aea99a2))
+* pullSecrets for production and metrics ([22d6e0b](https://github.com/bitnami/charts/commit/22d6e0b))
+
+## 1.3.0 (2019-03-11)
+
+* [bitnami/zookeeper] Add global imagePullSecrets to overwrite any other existing one ([3d5c427](https://github.com/bitnami/charts/commit/3d5c427))
+
+## <small>1.2.7 (2019-03-04)</small>
+
+* Add a metrics svc to be able to scrape with prometheus-operator ([ea9efbf](https://github.com/bitnami/charts/commit/ea9efbf))
+* Increase chart version for metrics svc ([da5186d](https://github.com/bitnami/charts/commit/da5186d))
+* Remove dependency on the zookeeper svc ([3128c01](https://github.com/bitnami/charts/commit/3128c01))
+
+## <small>1.2.6 (2019-03-01)</small>
+
+* Fix typo in statefulset.yaml ([f4606c8](https://github.com/bitnami/charts/commit/f4606c8))
+
+## <small>1.2.5 (2019-02-27)</small>
+
+* Add appiVersion to Chart.yaml ([08704a5](https://github.com/bitnami/charts/commit/08704a5))
+
+## <small>1.2.4 (2019-02-21)</small>
+
+* Update Chart.yaml ([5d77a80](https://github.com/bitnami/charts/commit/5d77a80))
+* Update README.md ([06ef802](https://github.com/bitnami/charts/commit/06ef802))
+
+## <small>1.2.3 (2019-02-07)</small>
+
+* Document the correct format for pullSecrets in READMEs ([9a2cf81](https://github.com/bitnami/charts/commit/9a2cf81))
+* Fix appVersion fields for some Chart.yaml files (#1048) ([697e18d](https://github.com/bitnami/charts/commit/697e18d)), closes [#1048](https://github.com/bitnami/charts/issues/1048)
+
+## <small>1.2.2 (2019-01-17)</small>
+
+* zookeeper: update to `3.4.13` ([f5b2a4f](https://github.com/bitnami/charts/commit/f5b2a4f))
+
+## <small>1.2.1 (2018-12-17)</small>
+
+* [bitnami/zookeeper] Only specify JVMFLAGS env var if they are provided ([f1eeba0](https://github.com/bitnami/charts/commit/f1eeba0))
+
+## 1.1.0 (2018-10-15)
+
+* [bitnami/zookeeper] Enable Zookeeper exporter ([ce3acad](https://github.com/bitnami/charts/commit/ce3acad))
+
+## <small>1.1.1 (2018-10-17)</small>
+
+* Add global registry option to Bitnami charts ([395ba08](https://github.com/bitnami/charts/commit/395ba08))
+* Apply some suggestions ([24706a6](https://github.com/bitnami/charts/commit/24706a6))
+* Bump versions ([0cfd3f4](https://github.com/bitnami/charts/commit/0cfd3f4))
+* Change logic to determine registry ([9ead294](https://github.com/bitnami/charts/commit/9ead294))
+* Check if global is set ([dec26e5](https://github.com/bitnami/charts/commit/dec26e5))
+* Fix typo ([93170ac](https://github.com/bitnami/charts/commit/93170ac))
+* Remove distro tags in charts ([427ac51](https://github.com/bitnami/charts/commit/427ac51))
+* Reword and update kafka dependencies ([be6cbed](https://github.com/bitnami/charts/commit/be6cbed))
+
+## 1.1.0 (2018-10-15)
+
+* [bitnami/zookeeper] Enable Zookeeper exporter ([ce3acad](https://github.com/bitnami/charts/commit/ce3acad))
+
+## <small>1.0.3 (2018-10-05)</small>
+
+* Add kubeapps text to charts READMEs ([2f6dc51](https://github.com/bitnami/charts/commit/2f6dc51))
+* Update statefulset.yaml ([79a78c5](https://github.com/bitnami/charts/commit/79a78c5))
+
+## <small>1.0.2 (2018-10-02)</small>
+
+* Add ) ([728466a](https://github.com/bitnami/charts/commit/728466a))
+* Fix go template inside go template ([a140313](https://github.com/bitnami/charts/commit/a140313))
+* Update Chart.yaml version ([223473b](https://github.com/bitnami/charts/commit/223473b))
+
+## <small>1.0.1 (2018-09-27)</small>
+
+* Improve getting LoadBalancer address in Bitnami charts NOTES.txt ([a641728](https://github.com/bitnami/charts/commit/a641728))
+
+## 1.0.0 (2018-09-21)
+
+* [bitnami/zookeeper] Fix chart not being upgradable ([b2d9a8a](https://github.com/bitnami/charts/commit/b2d9a8a))
+* Fix ports in README ([aec76e6](https://github.com/bitnami/charts/commit/aec76e6)), closes [#793](https://github.com/bitnami/charts/issues/793)
+
+## <small>0.0.7 (2018-09-05)</small>
+
+* Fix issue rendering zookeeper template ([8d07ced](https://github.com/bitnami/charts/commit/8d07ced))
+
+## <small>0.0.6 (2018-08-22)</small>
+
+* [bitnami/zookeeper] Fix Statefulset when Namespace is not default ([c189b9e](https://github.com/bitnami/charts/commit/c189b9e))
+
+## <small>0.0.5 (2018-08-06)</small>
+
+* Improve notes to access deployed services ([0071eb5](https://github.com/bitnami/charts/commit/0071eb5))
+
+## <small>0.0.4 (2018-07-31)</small>
+
+* Bump versions ([776b4b2](https://github.com/bitnami/charts/commit/776b4b2))
+
+## <small>0.0.3 (2018-07-31)</small>
+
+* Add missing release and charts labels in pods ([dfd13a2](https://github.com/bitnami/charts/commit/dfd13a2))
+* Add option to configure rollingUpdatePartition ([79dc6a7](https://github.com/bitnami/charts/commit/79dc6a7))
+* Delete unused servers value ([8ac33ea](https://github.com/bitnami/charts/commit/8ac33ea))
+* Fix versions ([5698a75](https://github.com/bitnami/charts/commit/5698a75))
+* zookeeper: bump chart appVersion to `3.4.12-debian-9` ([ba6f539](https://github.com/bitnami/charts/commit/ba6f539))
+* zookeeper: bump chart version to `0.0.3` ([e813f35](https://github.com/bitnami/charts/commit/e813f35))
+* zookeeper: update to `3.4.12-debian-9` ([2e597d2](https://github.com/bitnami/charts/commit/2e597d2))
+
+## <small>0.0.2 (2018-06-15)</small>
+
+* Add cluster capabilities to ZooKeeper chart ([7cb425a](https://github.com/bitnami/charts/commit/7cb425a))
+* Zookeeper cluster first version ([5f01505](https://github.com/bitnami/charts/commit/5f01505))
+
+## <small>0.0.1 (2018-06-13)</small>
+
+* Zookeeper chart ([35dfc58](https://github.com/bitnami/charts/commit/35dfc58))

--- a/bitnami/zookeeper/Chart.lock
+++ b/bitnami/zookeeper/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.19.2
-digest: sha256:e670e1075bfafffe040fae1158f1fa1f592585f394b48704ba137d2d083b1571
-generated: "2024-05-14T05:18:28.084306751Z"
+  version: 2.19.3
+digest: sha256:de997835d9ce9a9deefc2d70d8c62b11aa1d1a76ece9e86a83736ab9f930bf4d
+generated: "2024-05-21T14:50:16.487359193+02:00"

--- a/bitnami/zookeeper/Chart.yaml
+++ b/bitnami/zookeeper/Chart.yaml
@@ -28,4 +28,4 @@ maintainers:
 name: zookeeper
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/zookeeper
-version: 13.2.3
+version: 13.3.0

--- a/bitnami/zookeeper/templates/NOTES.txt
+++ b/bitnami/zookeeper/templates/NOTES.txt
@@ -75,3 +75,4 @@ To connect to your ZooKeeper server from outside the cluster execute the followi
 {{- include "zookeeper.validateValues" . }}
 {{- include "zookeeper.checkRollingTags" . }}
 {{- include "common.warnings.resources" (dict "sections" (list "" "tls" "volumePermissions") "context" $) }}
+{{- include "common.warnings.modifiedImages" (dict "images" (list .Values.image .Values.volumePermissions.image) "context" $) }}


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Replacing the original images that have been tested and verified when releasing the chart is a dangerous practice in terms of security, performance and available features. This PR updates the `NOTES.txt` file using the `common.warnings.modifiedImages` helper developed in https://github.com/bitnami/charts/pull/25952.


<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

Users are more aware of the risks of changing original images.
<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

n/a
<!-- Describe any known limitations with your change -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
