### PR TITLE
[bitnami/metallb] Use different liveness/readiness probes

### DIFF
--- a/bitnami/metallb/CHANGELOG.md
+++ b/bitnami/metallb/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
+## 6.2.1 (2024-05-21)
+
+* [bitnami/metallb] Use different liveness/readiness probes ([#26293](https://github.com/bitnami/charts/pulls/26293))
+
 ## 6.2.0 (2024-05-21)
 
-* [bitnami/metallb] feat: :sparkles: :lock: Add warning when original images are replaced ([#26242](https://github.com/bitnami/charts/pulls/26242))
+* [bitnami/*] ci: :construction_worker: Add tag and changelog support (#25359) ([91c707c](https://github.com/bitnami/charts/commit/91c707c)), closes [#25359](https://github.com/bitnami/charts/issues/25359)
+* [bitnami/metallb] feat: :sparkles: :lock: Add warning when original images are replaced (#26242) ([0e2b32c](https://github.com/bitnami/charts/commit/0e2b32c)), closes [#26242](https://github.com/bitnami/charts/issues/26242)
 
 ## <small>6.1.7 (2024-05-18)</small>
 

--- a/bitnami/metallb/Chart.lock
+++ b/bitnami/metallb/Chart.lock
@@ -4,4 +4,3 @@ dependencies:
   version: 2.19.3
 digest: sha256:de997835d9ce9a9deefc2d70d8c62b11aa1d1a76ece9e86a83736ab9f930bf4d
 generated: "2024-05-21T14:11:40.819394606+02:00"
-

--- a/bitnami/metallb/Chart.lock
+++ b/bitnami/metallb/Chart.lock
@@ -4,3 +4,4 @@ dependencies:
   version: 2.19.3
 digest: sha256:de997835d9ce9a9deefc2d70d8c62b11aa1d1a76ece9e86a83736ab9f930bf4d
 generated: "2024-05-21T14:11:40.819394606+02:00"
+

--- a/bitnami/metallb/Chart.yaml
+++ b/bitnami/metallb/Chart.yaml
@@ -36,4 +36,3 @@ name: metallb
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/metallb
 version: 6.2.1
-

--- a/bitnami/metallb/Chart.yaml
+++ b/bitnami/metallb/Chart.yaml
@@ -35,4 +35,5 @@ maintainers:
 name: metallb
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/metallb
-version: 6.2.0
+version: 6.2.1
+

--- a/bitnami/metallb/templates/controller/deployment.yaml
+++ b/bitnami/metallb/templates/controller/deployment.yaml
@@ -150,8 +150,7 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.controller.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.controller.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.controller.livenessProbe "enabled") "context" $) | nindent 12 }}
-            httpGet:
-              path: /metrics
+            tcpSocket:
               port: metrics
           {{- end }}
           {{- if .Values.controller.customReadinessProbe }}

--- a/bitnami/metallb/templates/speaker/daemonset.yaml
+++ b/bitnami/metallb/templates/speaker/daemonset.yaml
@@ -181,8 +181,7 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.speaker.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.speaker.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.speaker.livenessProbe "enabled") "context" $) | nindent 12 }}
-            httpGet:
-              path: /metrics
+            tcpSocket:
               port: metrics
           {{- end }}
           {{- if .Values.speaker.customReadinessProbe }}
@@ -311,8 +310,7 @@ spec:
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.speaker.frr.customReadinessProbe "context" $) | nindent 12 }}
           {{- else if .Values.speaker.frr.readinessProbe.enabled }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.speaker.frr.readinessProbe "enabled") "context" $) | nindent 12 }}
-            httpGet:
-              path: /livez
+            tcpSocket:
               port: {{ .Values.speaker.frr.containerPorts.metrics }}
           {{- end }}
           {{- if .Values.speaker.frr.customStartupProbe }}


### PR DESCRIPTION
### Description of the change
This PR aims to use different liveness/readiness probes to improve overall security and avoid unnecessary container restarts. [More info](https://github.com/zegl/kube-score/blob/master/README_PROBES.md).

### Benefits

Increase availability and resilience.

### Possible drawbacks

N/A

### Applicable issues

- fixes #

### Additional information

- Related to #23537

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- ~[X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)~
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
