### PR TITLE
[bitnami/seaweedfs] fix: adapt pod security context to openshift

### DIFF
--- a/bitnami/seaweedfs/CHANGELOG.md
+++ b/bitnami/seaweedfs/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
+## 0.2.1 (2024-05-21)
+
+* [bitnami/seaweedfs] fix: adapt pod security context to openshift ([#26294](https://github.com/bitnami/charts/pulls/26294))
+
 ## 0.2.0 (2024-05-21)
 
-* [bitnami/seaweedfs] feat: :sparkles: :lock: Add warning when original images are replaced ([#26276](https://github.com/bitnami/charts/pulls/26276))
+* [bitnami/*] ci: :construction_worker: Add tag and changelog support (#25359) ([91c707c](https://github.com/bitnami/charts/commit/91c707c)), closes [#25359](https://github.com/bitnami/charts/issues/25359)
+* [bitnami/seaweedfs] feat: :sparkles: :lock: Add warning when original images are replaced (#26276) ([0f63987](https://github.com/bitnami/charts/commit/0f63987)), closes [#26276](https://github.com/bitnami/charts/issues/26276)
 
 ## <small>0.1.7 (2024-05-18)</small>
 

--- a/bitnami/seaweedfs/Chart.yaml
+++ b/bitnami/seaweedfs/Chart.yaml
@@ -39,4 +39,4 @@ maintainers:
 name: seaweedfs
 sources:
 - https://github.com/bitnami/containers/tree/main/bitnami/seaweedfs
-version: 0.2.0
+version: 0.2.1

--- a/bitnami/seaweedfs/templates/filer/statefulset.yaml
+++ b/bitnami/seaweedfs/templates/filer/statefulset.yaml
@@ -79,7 +79,7 @@ spec:
       topologySpreadConstraints: {{- include "common.tplvalues.render" (dict "value" .Values.filer.topologySpreadConstraints "context" .) | nindent 8 }}
       {{- end }}
       {{- if .Values.filer.podSecurityContext.enabled }}
-      securityContext: {{- omit .Values.filer.podSecurityContext "enabled" | toYaml | nindent 8 }}
+      securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.filer.podSecurityContext "context" $) | nindent 8 }}
       {{- end }}
       {{- if .Values.filer.terminationGracePeriodSeconds }}
       terminationGracePeriodSeconds: {{ .Values.filer.terminationGracePeriodSeconds }}

--- a/bitnami/seaweedfs/templates/master/statefulset.yaml
+++ b/bitnami/seaweedfs/templates/master/statefulset.yaml
@@ -78,7 +78,7 @@ spec:
       topologySpreadConstraints: {{- include "common.tplvalues.render" (dict "value" .Values.master.topologySpreadConstraints "context" .) | nindent 8 }}
       {{- end }}
       {{- if .Values.master.podSecurityContext.enabled }}
-      securityContext: {{- omit .Values.master.podSecurityContext "enabled" | toYaml | nindent 8 }}
+      securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.master.podSecurityContext "context" $) | nindent 8 }}
       {{- end }}
       {{- if .Values.master.terminationGracePeriodSeconds }}
       terminationGracePeriodSeconds: {{ .Values.master.terminationGracePeriodSeconds }}

--- a/bitnami/seaweedfs/templates/s3/deployment.yaml
+++ b/bitnami/seaweedfs/templates/s3/deployment.yaml
@@ -77,7 +77,7 @@ spec:
       topologySpreadConstraints: {{- include "common.tplvalues.render" (dict "value" .Values.s3.topologySpreadConstraints "context" .) | nindent 8 }}
       {{- end }}
       {{- if .Values.s3.podSecurityContext.enabled }}
-      securityContext: {{- omit .Values.s3.podSecurityContext "enabled" | toYaml | nindent 8 }}
+      securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.s3.podSecurityContext "context" $) | nindent 8 }}
       {{- end }}
       {{- if .Values.s3.terminationGracePeriodSeconds }}
       terminationGracePeriodSeconds: {{ .Values.s3.terminationGracePeriodSeconds }}

--- a/bitnami/seaweedfs/templates/volume/statefulset.yaml
+++ b/bitnami/seaweedfs/templates/volume/statefulset.yaml
@@ -78,7 +78,7 @@ spec:
       topologySpreadConstraints: {{- include "common.tplvalues.render" (dict "value" .Values.volume.topologySpreadConstraints "context" .) | nindent 8 }}
       {{- end }}
       {{- if .Values.volume.podSecurityContext.enabled }}
-      securityContext: {{- omit .Values.volume.podSecurityContext "enabled" | toYaml | nindent 8 }}
+      securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.volume.podSecurityContext "context" $) | nindent 8 }}
       {{- end }}
       {{- if .Values.volume.terminationGracePeriodSeconds }}
       terminationGracePeriodSeconds: {{ .Values.volume.terminationGracePeriodSeconds }}

--- a/bitnami/seaweedfs/templates/webadv/deployment.yaml
+++ b/bitnami/seaweedfs/templates/webadv/deployment.yaml
@@ -74,7 +74,7 @@ spec:
       topologySpreadConstraints: {{- include "common.tplvalues.render" (dict "value" .Values.webdav.topologySpreadConstraints "context" .) | nindent 8 }}
       {{- end }}
       {{- if .Values.webdav.podSecurityContext.enabled }}
-      securityContext: {{- omit .Values.webdav.podSecurityContext "enabled" | toYaml | nindent 8 }}
+      securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.webdav.podSecurityContext "context" $) | nindent 8 }}
       {{- end }}
       {{- if .Values.webdav.terminationGracePeriodSeconds }}
       terminationGracePeriodSeconds: {{ .Values.webdav.terminationGracePeriodSeconds }}


### PR DESCRIPTION
### Description of the change
Use the `renderSecurityContext` helper to render the `podSecurityContext`. 

### Benefits
It works with the `auto` compatibility parameter for Openshift.

### Checklist
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
