### PR TITLE
[bitnami/memcached] Use different liveness/readiness probes

### DIFF
--- a/bitnami/memcached/CHANGELOG.md
+++ b/bitnami/memcached/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
+## 7.4.1 (2024-05-21)
+
+* [bitnami/memcached] Use different liveness/readiness probes ([#26295](https://github.com/bitnami/charts/pulls/26295))
+
 ## 7.4.0 (2024-05-21)
 
-* [bitnami/memcached] feat: :sparkles: :lock: Add warning when original images are replaced ([#26241](https://github.com/bitnami/charts/pulls/26241))
+* [bitnami/*] ci: :construction_worker: Add tag and changelog support (#25359) ([91c707c](https://github.com/bitnami/charts/commit/91c707c)), closes [#25359](https://github.com/bitnami/charts/issues/25359)
+* [bitnami/memcached] feat: :sparkles: :lock: Add warning when original images are replaced (#26241) ([778b421](https://github.com/bitnami/charts/commit/778b421)), closes [#26241](https://github.com/bitnami/charts/issues/26241)
 
 ## 7.3.0 (2024-05-20)
 

--- a/bitnami/memcached/Chart.lock
+++ b/bitnami/memcached/Chart.lock
@@ -4,3 +4,4 @@ dependencies:
   version: 2.19.3
 digest: sha256:de997835d9ce9a9deefc2d70d8c62b11aa1d1a76ece9e86a83736ab9f930bf4d
 generated: "2024-05-21T14:10:49.696069263+02:00"
+

--- a/bitnami/memcached/Chart.yaml
+++ b/bitnami/memcached/Chart.yaml
@@ -31,4 +31,4 @@ maintainers:
 name: memcached
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/memcached
-version: 7.4.0
+version: 7.4.1

--- a/bitnami/memcached/templates/deployment.yaml
+++ b/bitnami/memcached/templates/deployment.yaml
@@ -127,8 +127,10 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.livenessProbe "enabled") "context" $) | nindent 12 }}
-            tcpSocket:
-              port: memcache
+            exec:
+              command:
+                - pgrep
+                - memcached
           {{- end }}
           {{- if .Values.customReadinessProbe }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customReadinessProbe "context" $) | nindent 12 }}
@@ -178,8 +180,7 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.metrics.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.metrics.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.metrics.livenessProbe "enabled") "context" $) | nindent 12 }}
-            httpGet:
-              path: /metrics
+            tcpSocket:
               port: {{ .Values.metrics.containerPorts.metrics }}
           {{- end }}
           {{- if .Values.metrics.customReadinessProbe }}

--- a/bitnami/memcached/templates/statefulset.yaml
+++ b/bitnami/memcached/templates/statefulset.yaml
@@ -166,8 +166,10 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.livenessProbe "enabled") "context" $) | nindent 12 }}
-            tcpSocket:
-              port: memcache
+            exec:
+              command:
+                - pgrep
+                - memcached
           {{- end }}
           {{- if .Values.customReadinessProbe }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customReadinessProbe "context" $) | nindent 12 }}
@@ -231,8 +233,7 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.metrics.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.metrics.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.metrics.livenessProbe "enabled") "context" $) | nindent 12 }}
-            httpGet:
-              path: /metrics
+            tcpSocket:
               port: {{ .Values.metrics.containerPorts.metrics }}
           {{- end }}
           {{- if .Values.metrics.customReadinessProbe }}


### PR DESCRIPTION
### Description of the change
This PR aims to use different liveness/readiness probes to improve overall security and avoid unnecessary container restarts. [More info](https://github.com/zegl/kube-score/blob/master/README_PROBES.md).

### Benefits

Increase availability and resilience.

### Possible drawbacks

N/A

### Applicable issues

- fixes #

### Additional information

- Related to #23537

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- ~[X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)~
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
