### PR TITLE
[bitnami/spring-cloud-dataflow] Use different liveness/readiness probes

### DIFF
--- a/bitnami/spring-cloud-dataflow/CHANGELOG.md
+++ b/bitnami/spring-cloud-dataflow/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
+## 28.1.1 (2024-05-21)
+
+* [bitnami/spring-cloud-dataflow] Use different liveness/readiness probes ([#26297](https://github.com/bitnami/charts/pulls/26297))
+
 ## 28.1.0 (2024-05-21)
 
-* [bitnami/spring-cloud-dataflow] feat: :sparkles: :lock: Add warning when original images are replaced ([#26280](https://github.com/bitnami/charts/pulls/26280))
+* [bitnami/*] ci: :construction_worker: Add tag and changelog support (#25359) ([91c707c](https://github.com/bitnami/charts/commit/91c707c)), closes [#25359](https://github.com/bitnami/charts/issues/25359)
+* [bitnami/spring-cloud-dataflow] feat: :sparkles: :lock: Add warning when original images are replace ([d9dfc42](https://github.com/bitnami/charts/commit/d9dfc42)), closes [#26280](https://github.com/bitnami/charts/issues/26280)
 
 ## <small>28.0.5 (2024-05-21)</small>
 

--- a/bitnami/spring-cloud-dataflow/Chart.lock
+++ b/bitnami/spring-cloud-dataflow/Chart.lock
@@ -7,9 +7,9 @@ dependencies:
   version: 18.0.6
 - name: kafka
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 28.2.6
+  version: 28.3.0
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 2.19.3
-digest: sha256:ea2592acf498ce398001886a6d1fe969c3073348d8756f87bd26b1a8e66efda5
-generated: "2024-05-21T14:42:04.070093679+02:00"
+digest: sha256:1a4745dba446b33a39c2b2332f8dd22f811b68d08b64ca155541001e046f6b31
+generated: "2024-05-21T17:56:24.121636+02:00"

--- a/bitnami/spring-cloud-dataflow/Chart.yaml
+++ b/bitnami/spring-cloud-dataflow/Chart.yaml
@@ -53,4 +53,5 @@ maintainers:
 name: spring-cloud-dataflow
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/spring-cloud-dataflow
-version: 28.1.0
+version: 28.1.1
+

--- a/bitnami/spring-cloud-dataflow/templates/prometheus-proxy/deployment.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/prometheus-proxy/deployment.yaml
@@ -114,8 +114,7 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.metrics.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.metrics.livenessProbe.enabled }}
           livenessProbe:
-            httpGet:
-              path: /actuator/health
+            tcpSocket:
               port: http
             initialDelaySeconds: {{ .Values.metrics.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.metrics.livenessProbe.periodSeconds }}

--- a/bitnami/spring-cloud-dataflow/templates/server/deployment.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/server/deployment.yaml
@@ -218,8 +218,7 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.server.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.server.livenessProbe.enabled }}
           livenessProbe:
-            httpGet:
-              path: /management/health
+            tcpSocket:
               port: http
             initialDelaySeconds: {{ .Values.server.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.server.livenessProbe.periodSeconds }}

--- a/bitnami/spring-cloud-dataflow/templates/skipper/deployment.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/skipper/deployment.yaml
@@ -179,8 +179,7 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.skipper.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.skipper.livenessProbe.enabled }}
           livenessProbe:
-            httpGet:
-              path: /actuator/health
+            tcpSocket:
               port: http
             initialDelaySeconds: {{ .Values.skipper.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.skipper.livenessProbe.periodSeconds }}


### PR DESCRIPTION
### Description of the change
This PR aims to use different liveness/readiness probes to improve overall security and avoid unnecessary container restarts. [More info](https://github.com/zegl/kube-score/blob/master/README_PROBES.md).

### Benefits

Increase availability and resilience.

### Possible drawbacks

N/A

### Applicable issues

- fixes #

### Additional information

- Related to #23537

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- ~[X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)~
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
