### PR TITLE
[bitnami/sealed-secrets] Use different liveness/readiness probes

### DIFF
--- a/bitnami/sealed-secrets/CHANGELOG.md
+++ b/bitnami/sealed-secrets/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
+## 2.2.1 (2024-05-21)
+
+* [bitnami/sealed-secrets] Use different liveness/readiness probes ([#26299](https://github.com/bitnami/charts/pulls/26299))
+
 ## 2.2.0 (2024-05-21)
 
-* [bitnami/sealed-secrets] feat: :sparkles: :lock: Add warning when original images are replaced ([#26275](https://github.com/bitnami/charts/pulls/26275))
+* [bitnami/*] ci: :construction_worker: Add tag and changelog support (#25359) ([91c707c](https://github.com/bitnami/charts/commit/91c707c)), closes [#25359](https://github.com/bitnami/charts/issues/25359)
+* [bitnami/sealed-secrets] feat: :sparkles: :lock: Add warning when original images are replaced (#262 ([89f973b](https://github.com/bitnami/charts/commit/89f973b)), closes [#26275](https://github.com/bitnami/charts/issues/26275)
 
 ## <small>2.1.4 (2024-05-18)</small>
 

--- a/bitnami/sealed-secrets/Chart.lock
+++ b/bitnami/sealed-secrets/Chart.lock
@@ -4,3 +4,4 @@ dependencies:
   version: 2.19.3
 digest: sha256:de997835d9ce9a9deefc2d70d8c62b11aa1d1a76ece9e86a83736ab9f930bf4d
 generated: "2024-05-21T14:38:20.275147838+02:00"
+

--- a/bitnami/sealed-secrets/Chart.yaml
+++ b/bitnami/sealed-secrets/Chart.yaml
@@ -29,4 +29,5 @@ name: sealed-secrets
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/sealed-secrets
 - https://github.com/bitnami-labs/sealed-secrets
-version: 2.2.0
+version: 2.2.1
+

--- a/bitnami/sealed-secrets/templates/deployment.yaml
+++ b/bitnami/sealed-secrets/templates/deployment.yaml
@@ -175,8 +175,7 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.livenessProbe "enabled") "context" $) | nindent 12 }}
-            httpGet:
-              path: /healthz
+            tcpSocket:
               port: http
           {{- end }}
           {{- if .Values.customReadinessProbe }}


### PR DESCRIPTION
### Description of the change
This PR aims to use different liveness/readiness probes to improve overall security and avoid unnecessary container restarts. [More info](https://github.com/zegl/kube-score/blob/master/README_PROBES.md).

### Benefits

Increase availability and resilience.

### Possible drawbacks

N/A

### Applicable issues

- fixes #

### Additional information

- Related to #23537

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- ~[X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)~
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
