### PR TITLE
[bitnami/oauth2-proxy] Use different liveness/readiness probes

### DIFF
--- a/bitnami/oauth2-proxy/CHANGELOG.md
+++ b/bitnami/oauth2-proxy/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
+## 5.1.1 (2024-05-21)
+
+* [bitnami/oauth2-proxy] Use different liveness/readiness probes ([#26300](https://github.com/bitnami/charts/pulls/26300))
+
 ## 5.1.0 (2024-05-21)
 
-* [bitnami/oauth2-proxy] feat: :sparkles: :lock: Add warning when original images are replaced ([#26256](https://github.com/bitnami/charts/pulls/26256))
+* [bitnami/*] ci: :construction_worker: Add tag and changelog support (#25359) ([91c707c](https://github.com/bitnami/charts/commit/91c707c)), closes [#25359](https://github.com/bitnami/charts/issues/25359)
+* [bitnami/oauth2-proxy] feat: :sparkles: :lock: Add warning when original images are replaced (#26256 ([b3d7bf5](https://github.com/bitnami/charts/commit/b3d7bf5)), closes [#26256](https://github.com/bitnami/charts/issues/26256)
 
 ## <small>5.0.7 (2024-05-18)</small>
 

--- a/bitnami/oauth2-proxy/Chart.lock
+++ b/bitnami/oauth2-proxy/Chart.lock
@@ -1,9 +1,10 @@
 dependencies:
 - name: redis
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 19.3.4
+  version: 19.4.0
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 2.19.3
-digest: sha256:5ce9cb6d07186ecd09f2cb23b4fc76299f2958d52378988d6c74869483dc3caa
-generated: "2024-05-21T14:22:50.417078056+02:00"
+digest: sha256:1eccb87b8cb9b2ef3b9c78ae88907ca1063b3c49ae34f0b0bc76e2626417b246
+generated: "2024-05-21T17:06:43.601414+02:00"
+

--- a/bitnami/oauth2-proxy/Chart.yaml
+++ b/bitnami/oauth2-proxy/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: oauth2-proxy
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/oauth2-proxy
-version: 5.1.0
+version: 5.1.1

--- a/bitnami/oauth2-proxy/templates/deployment.yaml
+++ b/bitnami/oauth2-proxy/templates/deployment.yaml
@@ -212,10 +212,8 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.livenessProbe.enabled }}
           livenessProbe:
-            httpGet:
-              path: /ping
+            tcpSocket:
               port: http
-              scheme: HTTP
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}


### PR DESCRIPTION
### Description of the change
This PR aims to use different liveness/readiness probes to improve overall security and avoid unnecessary container restarts. [More info](https://github.com/zegl/kube-score/blob/master/README_PROBES.md).

### Benefits

Increase availability and resilience.

### Possible drawbacks

N/A

### Applicable issues

- fixes #

### Additional information

- Related to #23537

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- ~[X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)~
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
