### PR TITLE
[bitnami/jaeger] Use different liveness/readiness probes

### DIFF
--- a/bitnami/jaeger/CHANGELOG.md
+++ b/bitnami/jaeger/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
+## 2.2.1 (2024-05-21)
+
+* [bitnami/jaeger] Use different liveness/readiness probes ([#26302](https://github.com/bitnami/charts/pulls/26302))
+
 ## 2.2.0 (2024-05-21)
 
-* [bitnami/jaeger] feat: :sparkles: :lock: Add warning when original images are replaced ([#26218](https://github.com/bitnami/charts/pulls/26218))
+* [bitnami/*] ci: :construction_worker: Add tag and changelog support (#25359) ([91c707c](https://github.com/bitnami/charts/commit/91c707c)), closes [#25359](https://github.com/bitnami/charts/issues/25359)
+* [bitnami/jaeger] feat: :sparkles: :lock: Add warning when original images are replaced (#26218) ([7f61fc9](https://github.com/bitnami/charts/commit/7f61fc9)), closes [#26218](https://github.com/bitnami/charts/issues/26218)
 
 ## <small>2.1.5 (2024-05-18)</small>
 

--- a/bitnami/jaeger/Chart.lock
+++ b/bitnami/jaeger/Chart.lock
@@ -7,3 +7,4 @@ dependencies:
   version: 11.1.8
 digest: sha256:123d8cb5c93612a3ed37efad416ff9d527a8282ff4a48fcb76ee99926f0535b3
 generated: "2024-05-21T13:50:37.577123443+02:00"
+

--- a/bitnami/jaeger/Chart.yaml
+++ b/bitnami/jaeger/Chart.yaml
@@ -34,4 +34,5 @@ maintainers:
 name: jaeger
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/jaeger
-version: 2.2.0
+version: 2.2.1
+

--- a/bitnami/jaeger/templates/agent/deployment.yaml
+++ b/bitnami/jaeger/templates/agent/deployment.yaml
@@ -156,8 +156,7 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.agent.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.agent.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.agent.livenessProbe "enabled") "context" $) | nindent 12 }}
-            httpGet:
-              path: /
+            tcpSocket:
               port: admin
           {{- end }}
           {{- if .Values.agent.customReadinessProbe }}

--- a/bitnami/jaeger/templates/collector/deployment.yaml
+++ b/bitnami/jaeger/templates/collector/deployment.yaml
@@ -155,8 +155,7 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.collector.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.collector.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.collector.livenessProbe "enabled") "context" $) | nindent 12 }}
-            httpGet:
-              path: /
+            tcpSocket:
               port: admin
           {{- end }}
           {{- if .Values.collector.customReadinessProbe }}

--- a/bitnami/jaeger/templates/query/deployment.yaml
+++ b/bitnami/jaeger/templates/query/deployment.yaml
@@ -141,8 +141,7 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.query.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.query.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.query.livenessProbe "enabled") "context" $) | nindent 12 }}
-            httpGet:
-              path: /
+            tcpSocket:
               port: admin
           {{- end }}
           {{- if .Values.query.customReadinessProbe }}


### PR DESCRIPTION
### Description of the change
This PR aims to use different liveness/readiness probes to improve overall security and avoid unnecessary container restarts. [More info](https://github.com/zegl/kube-score/blob/master/README_PROBES.md).

### Benefits

Increase availability and resilience.

### Possible drawbacks

N/A

### Applicable issues

- fixes #

### Additional information

- Related to #23537

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- ~[X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)~
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
