### PR TITLE
[bitnami/influxdb] Use different liveness/readiness probes

### DIFF
--- a/bitnami/influxdb/CHANGELOG.md
+++ b/bitnami/influxdb/CHANGELOG.md
@@ -1,1073 +1,1078 @@
 # Changelog
 
+## 6.1.1 (2024-05-22)
+
+* [bitnami/influxdb] Use different liveness/readiness probes ([#26303](https://github.com/bitnami/charts/pull/26303))
+
 ## 6.1.0 (2024-05-21)
 
-* [bitnami/influxdb] feat: :sparkles: :lock: Add warning when original images are replaced ([#26217](https://github.com/bitnami/charts/pulls/26217))
+* [bitnami/*] ci: :construction_worker: Add tag and changelog support (#25359) ([91c707c](https://github.com/bitnami/charts/commit/91c707c9e4e574725a09505d2d313fb93f1b4c0a)), closes [#25359](https://github.com/bitnami/charts/issues/25359)
+* [bitnami/influxdb] feat: :sparkles: :lock: Add warning when original images are replaced (#26217) ([8b7d329](https://github.com/bitnami/charts/commit/8b7d3296895e55f03de637164037d2b5a70b39f2)), closes [#26217](https://github.com/bitnami/charts/issues/26217)
 
 ## <small>6.0.13 (2024-05-18)</small>
 
-* [bitnami/influxdb] Release 6.0.13 updating components versions (#26024) ([74ebf9b](https://github.com/bitnami/charts/commit/74ebf9b)), closes [#26024](https://github.com/bitnami/charts/issues/26024)
+* [bitnami/influxdb] Release 6.0.13 updating components versions (#26024) ([74ebf9b](https://github.com/bitnami/charts/commit/74ebf9b9c9c717aa6620b8e7eb74ed28c4eb45b9)), closes [#26024](https://github.com/bitnami/charts/issues/26024)
 
 ## <small>6.0.12 (2024-05-14)</small>
 
-* [bitnami/influxdb] Release 6.0.12 updating components versions (#25836) ([e8f4c27](https://github.com/bitnami/charts/commit/e8f4c27)), closes [#25836](https://github.com/bitnami/charts/issues/25836)
+* [bitnami/influxdb] Release 6.0.12 updating components versions (#25836) ([e8f4c27](https://github.com/bitnami/charts/commit/e8f4c270da9ce1e31093d8a7fbc61ea25ce08ca6)), closes [#25836](https://github.com/bitnami/charts/issues/25836)
 
 ## <small>6.0.11 (2024-05-08)</small>
 
-* [bitnami/*] Change non-root and rolling-tags doc URLs (#25628) ([b067c94](https://github.com/bitnami/charts/commit/b067c94)), closes [#25628](https://github.com/bitnami/charts/issues/25628)
-* [bitnami/influxdb] Release 6.0.11 (#25640) ([081ffe9](https://github.com/bitnami/charts/commit/081ffe9)), closes [#25640](https://github.com/bitnami/charts/issues/25640)
+* [bitnami/*] Change non-root and rolling-tags doc URLs (#25628) ([b067c94](https://github.com/bitnami/charts/commit/b067c94f6bcde427863c197fd355f0b5ba12ff5b)), closes [#25628](https://github.com/bitnami/charts/issues/25628)
+* [bitnami/influxdb] Release 6.0.11 (#25640) ([081ffe9](https://github.com/bitnami/charts/commit/081ffe9dd70c8fccd308552d3b6335cc25c98909)), closes [#25640](https://github.com/bitnami/charts/issues/25640)
 
 ## <small>6.0.10 (2024-05-08)</small>
 
-* [bitnami/*] Set new header/owner (#25558) ([8d1dc11](https://github.com/bitnami/charts/commit/8d1dc11)), closes [#25558](https://github.com/bitnami/charts/issues/25558)
-* [bitnami/influxdb] Release 6.0.10 updating components versions (#25606) ([027e4ba](https://github.com/bitnami/charts/commit/027e4ba)), closes [#25606](https://github.com/bitnami/charts/issues/25606)
+* [bitnami/*] Set new header/owner (#25558) ([8d1dc11](https://github.com/bitnami/charts/commit/8d1dc11f5fb30db6fba50c43d7af59d2f79deed3)), closes [#25558](https://github.com/bitnami/charts/issues/25558)
+* [bitnami/influxdb] Release 6.0.10 updating components versions (#25606) ([027e4ba](https://github.com/bitnami/charts/commit/027e4bad2d9232f70324c06f3f3304d89e8b6c49)), closes [#25606](https://github.com/bitnami/charts/issues/25606)
 
 ## <small>6.0.9 (2024-04-29)</small>
 
-* [bitnami/multiple charts] Fix typo: "NetworkPolice" vs "NetworkPolicy" (#25348) ([6970c1b](https://github.com/bitnami/charts/commit/6970c1b)), closes [#25348](https://github.com/bitnami/charts/issues/25348)
-* Fix typo in influxdb template (#25429) ([7f863f3](https://github.com/bitnami/charts/commit/7f863f3)), closes [#25429](https://github.com/bitnami/charts/issues/25429)
-* Replace VMware by Broadcom copyright text (#25306) ([a5e4bd0](https://github.com/bitnami/charts/commit/a5e4bd0)), closes [#25306](https://github.com/bitnami/charts/issues/25306)
+* [bitnami/multiple charts] Fix typo: "NetworkPolice" vs "NetworkPolicy" (#25348) ([6970c1b](https://github.com/bitnami/charts/commit/6970c1ba245873506e73d459c6eac1e4919b778f)), closes [#25348](https://github.com/bitnami/charts/issues/25348)
+* Fix typo in influxdb template (#25429) ([7f863f3](https://github.com/bitnami/charts/commit/7f863f3fa4ec96aad75baee5b81302e3adf812e5)), closes [#25429](https://github.com/bitnami/charts/issues/25429)
+* Replace VMware by Broadcom copyright text (#25306) ([a5e4bd0](https://github.com/bitnami/charts/commit/a5e4bd0e35e419203793976a78d9d0a13de92c76)), closes [#25306](https://github.com/bitnami/charts/issues/25306)
 
 ## <small>6.0.8 (2024-04-16)</small>
 
-* [bitnami/influxdb] Release 6.0.8 updating components versions (#25193) ([278ee93](https://github.com/bitnami/charts/commit/278ee93)), closes [#25193](https://github.com/bitnami/charts/issues/25193)
+* [bitnami/influxdb] Release 6.0.8 updating components versions (#25193) ([278ee93](https://github.com/bitnami/charts/commit/278ee9317931c23ff8a5a5a2fc7c1b40d7216be6)), closes [#25193](https://github.com/bitnami/charts/issues/25193)
 
 ## <small>6.0.7 (2024-04-16)</small>
 
-* [bitnami/influxdb] Release 6.0.7 updating components versions (#25185) ([6bafb34](https://github.com/bitnami/charts/commit/6bafb34)), closes [#25185](https://github.com/bitnami/charts/issues/25185)
+* [bitnami/influxdb] Release 6.0.7 updating components versions (#25185) ([6bafb34](https://github.com/bitnami/charts/commit/6bafb34766752cc51081b95c3db98a7e63fe7b5f)), closes [#25185](https://github.com/bitnami/charts/issues/25185)
 
 ## <small>6.0.6 (2024-04-13)</small>
 
-* [bitnami/influxdb] Release 6.0.6 updating components versions (#25161) ([326a23e](https://github.com/bitnami/charts/commit/326a23e)), closes [#25161](https://github.com/bitnami/charts/issues/25161)
+* [bitnami/influxdb] Release 6.0.6 updating components versions (#25161) ([326a23e](https://github.com/bitnami/charts/commit/326a23ece1363ce21ba4beccc5cf2d5e99cd0bce)), closes [#25161](https://github.com/bitnami/charts/issues/25161)
 
 ## <small>6.0.5 (2024-04-05)</small>
 
-* [bitnami/influxdb] Release 6.0.5 updating components versions (#24953) ([419e7d6](https://github.com/bitnami/charts/commit/419e7d6)), closes [#24953](https://github.com/bitnami/charts/issues/24953)
+* [bitnami/influxdb] Release 6.0.5 updating components versions (#24953) ([419e7d6](https://github.com/bitnami/charts/commit/419e7d669ef3b529cd2b2a6dcf04cb13c430b924)), closes [#24953](https://github.com/bitnami/charts/issues/24953)
 
 ## <small>6.0.4 (2024-04-04)</small>
 
-* [bitnami/*] Reorder Chart sections (#24455) ([0cf4048](https://github.com/bitnami/charts/commit/0cf4048)), closes [#24455](https://github.com/bitnami/charts/issues/24455)
-* [bitnami/influxdb] Release 6.0.4 (#24887) ([55c3c38](https://github.com/bitnami/charts/commit/55c3c38)), closes [#24887](https://github.com/bitnami/charts/issues/24887)
-* Update resourcesPreset comments (#24467) ([92e3e8a](https://github.com/bitnami/charts/commit/92e3e8a)), closes [#24467](https://github.com/bitnami/charts/issues/24467)
+* [bitnami/*] Reorder Chart sections (#24455) ([0cf4048](https://github.com/bitnami/charts/commit/0cf4048e8743f70a9753d460655bd030cbff6824)), closes [#24455](https://github.com/bitnami/charts/issues/24455)
+* [bitnami/influxdb] Release 6.0.4 (#24887) ([55c3c38](https://github.com/bitnami/charts/commit/55c3c38ecbed24cb8abb30b586fcd3a9382826ca)), closes [#24887](https://github.com/bitnami/charts/issues/24887)
+* Update resourcesPreset comments (#24467) ([92e3e8a](https://github.com/bitnami/charts/commit/92e3e8a507326d2a20a8f10ab3e7746a2ec5c554)), closes [#24467](https://github.com/bitnami/charts/issues/24467)
 
 ## <small>6.0.3 (2024-03-15)</small>
 
-* [bitnami/influxdb] feat: add imagePullSecrets to backup (#24451) ([91b7e4b](https://github.com/bitnami/charts/commit/91b7e4b)), closes [#24451](https://github.com/bitnami/charts/issues/24451)
+* [bitnami/influxdb] feat: add imagePullSecrets to backup (#24451) ([91b7e4b](https://github.com/bitnami/charts/commit/91b7e4bdf9c6dda6ec1dc6a951064aa7dc2c8496)), closes [#24451](https://github.com/bitnami/charts/issues/24451)
 
 ## <small>6.0.2 (2024-03-14)</small>
 
-* fix: use right indent (#24444) ([47f8b5c](https://github.com/bitnami/charts/commit/47f8b5c)), closes [#24444](https://github.com/bitnami/charts/issues/24444)
+* fix: use right indent (#24444) ([47f8b5c](https://github.com/bitnami/charts/commit/47f8b5cea491d8eae0a999e0b8f8424b872c96e9)), closes [#24444](https://github.com/bitnami/charts/issues/24444)
 
 ## <small>6.0.1 (2024-03-13)</small>
 
-* [bitnami/influxdb] resources, aws cli cache and service account for the backup part in the helm char ([cac05b0](https://github.com/bitnami/charts/commit/cac05b0)), closes [#24361](https://github.com/bitnami/charts/issues/24361) [#24324](https://github.com/bitnami/charts/issues/24324) [#24324](https://github.com/bitnami/charts/issues/24324) [#24324](https://github.com/bitnami/charts/issues/24324) [#24324](https://github.com/bitnami/charts/issues/24324)
+* [bitnami/influxdb] resources, aws cli cache and service account for the backup part in the helm char ([cac05b0](https://github.com/bitnami/charts/commit/cac05b0b4c77c1bac7db739c0ff360f5d9f28050)), closes [#24361](https://github.com/bitnami/charts/issues/24361) [#24324](https://github.com/bitnami/charts/issues/24324) [#24324](https://github.com/bitnami/charts/issues/24324) [#24324](https://github.com/bitnami/charts/issues/24324) [#24324](https://github.com/bitnami/charts/issues/24324)
 
 ## 6.0.0 (2024-03-13)
 
-* [bitnami/influxdb] feat!: :lock: :boom: Improve security defaults (#24342) ([2ed668a](https://github.com/bitnami/charts/commit/2ed668a)), closes [#24342](https://github.com/bitnami/charts/issues/24342)
+* [bitnami/influxdb] feat!: :lock: :boom: Improve security defaults (#24342) ([2ed668a](https://github.com/bitnami/charts/commit/2ed668a7fe832a39a250c559b3d5578c71084844)), closes [#24342](https://github.com/bitnami/charts/issues/24342)
 
 ## <small>5.18.1 (2024-03-06)</small>
 
-* [bitnami/influxdb] Release 5.18.1 updating components versions (#24207) ([a83dd8e](https://github.com/bitnami/charts/commit/a83dd8e)), closes [#24207](https://github.com/bitnami/charts/issues/24207)
+* [bitnami/influxdb] Release 5.18.1 updating components versions (#24207) ([a83dd8e](https://github.com/bitnami/charts/commit/a83dd8e3f741e667781d9247ce05015c340ccaf8)), closes [#24207](https://github.com/bitnami/charts/issues/24207)
 
 ## 5.18.0 (2024-03-06)
 
-* [bitnami/influxdb] feat: :sparkles: :lock: Add automatic adaptation for Openshift restricted-v2 SCC  ([c21a5db](https://github.com/bitnami/charts/commit/c21a5db)), closes [#24094](https://github.com/bitnami/charts/issues/24094)
+* [bitnami/influxdb] feat: :sparkles: :lock: Add automatic adaptation for Openshift restricted-v2 SCC  ([c21a5db](https://github.com/bitnami/charts/commit/c21a5db68de06470f1a977a54f09ba7f2694c786)), closes [#24094](https://github.com/bitnami/charts/issues/24094)
 
 ## <small>5.17.1 (2024-02-26)</small>
 
-* [bitnami/influxdb] Remove duplicate mountpath in influxdb deployment (#23897) ([9da1f99](https://github.com/bitnami/charts/commit/9da1f99)), closes [#23897](https://github.com/bitnami/charts/issues/23897)
+* [bitnami/influxdb] Remove duplicate mountpath in influxdb deployment (#23897) ([9da1f99](https://github.com/bitnami/charts/commit/9da1f9979d1735f6deaa08928f58f20165e078e2)), closes [#23897](https://github.com/bitnami/charts/issues/23897)
 
 ## 5.17.0 (2024-02-22)
 
-* [bitnami/influxdb] feat: :sparkles: :lock: Add readOnlyRootFilesystem support (#23609) ([16264cf](https://github.com/bitnami/charts/commit/16264cf)), closes [#23609](https://github.com/bitnami/charts/issues/23609)
+* [bitnami/influxdb] feat: :sparkles: :lock: Add readOnlyRootFilesystem support (#23609) ([16264cf](https://github.com/bitnami/charts/commit/16264cf1c32a8cfb4d3bd3b4a8a83d4eff0dcf5f)), closes [#23609](https://github.com/bitnami/charts/issues/23609)
 
 ## <small>5.16.3 (2024-02-21)</small>
 
-* [bitnami/influxdb] Release 5.16.3 updating components versions (#23764) ([0f8391a](https://github.com/bitnami/charts/commit/0f8391a)), closes [#23764](https://github.com/bitnami/charts/issues/23764)
+* [bitnami/influxdb] Release 5.16.3 updating components versions (#23764) ([0f8391a](https://github.com/bitnami/charts/commit/0f8391a24ef86db8f5bf0d3ab1d2ab3ecadf4024)), closes [#23764](https://github.com/bitnami/charts/issues/23764)
 
 ## <small>5.16.2 (2024-02-21)</small>
 
-* [bitnami/influxdb] Release 5.16.2 updating components versions (#23661) ([2fe5ace](https://github.com/bitnami/charts/commit/2fe5ace)), closes [#23661](https://github.com/bitnami/charts/issues/23661)
+* [bitnami/influxdb] Release 5.16.2 updating components versions (#23661) ([2fe5ace](https://github.com/bitnami/charts/commit/2fe5ace21fe411cef5ab6d255f445faf28cabb56)), closes [#23661](https://github.com/bitnami/charts/issues/23661)
 
 ## <small>5.16.1 (2024-02-21)</small>
 
-* [bitnami/influxdb] Fix a bug when backup.enabled is true (#23598) ([33cb0d3](https://github.com/bitnami/charts/commit/33cb0d3)), closes [#23598](https://github.com/bitnami/charts/issues/23598)
+* [bitnami/influxdb] Fix a bug when backup.enabled is true (#23598) ([33cb0d3](https://github.com/bitnami/charts/commit/33cb0d399abe7792c5ad42beabbaf7a199aad666)), closes [#23598](https://github.com/bitnami/charts/issues/23598)
 
 ## 5.16.0 (2024-02-20)
 
-* [bitnami/*] Bump all versions (#23602) ([b70ee2a](https://github.com/bitnami/charts/commit/b70ee2a)), closes [#23602](https://github.com/bitnami/charts/issues/23602)
+* [bitnami/*] Bump all versions (#23602) ([b70ee2a](https://github.com/bitnami/charts/commit/b70ee2a30e4dc256bf0ac52928fb2fa7a70f049b)), closes [#23602](https://github.com/bitnami/charts/issues/23602)
 
 ## 5.15.0 (2024-02-16)
 
-* [bitnami/influxdb] feat: :sparkles: :lock: Add resource preset support (#23462) ([7322226](https://github.com/bitnami/charts/commit/7322226)), closes [#23462](https://github.com/bitnami/charts/issues/23462)
+* [bitnami/influxdb] feat: :sparkles: :lock: Add resource preset support (#23462) ([7322226](https://github.com/bitnami/charts/commit/7322226d2f598f9a17f4fc036216703e7b5f2bd3)), closes [#23462](https://github.com/bitnami/charts/issues/23462)
 
 ## <small>5.14.2 (2024-02-07)</small>
 
-* [bitnami/influxdb] Release 5.14.2 updating components versions (#23293) ([488df67](https://github.com/bitnami/charts/commit/488df67)), closes [#23293](https://github.com/bitnami/charts/issues/23293)
+* [bitnami/influxdb] Release 5.14.2 updating components versions (#23293) ([488df67](https://github.com/bitnami/charts/commit/488df670f9611e2ea9274e19cbbcdaba158404b7)), closes [#23293](https://github.com/bitnami/charts/issues/23293)
 
 ## <small>5.14.1 (2024-02-07)</small>
 
-* [bitnami/influxdb] Release 5.14.1 updating components versions (#23234) ([8088626](https://github.com/bitnami/charts/commit/8088626)), closes [#23234](https://github.com/bitnami/charts/issues/23234)
+* [bitnami/influxdb] Release 5.14.1 updating components versions (#23234) ([8088626](https://github.com/bitnami/charts/commit/8088626f72a387d000acbe8eb57bbc4b69d02f32)), closes [#23234](https://github.com/bitnami/charts/issues/23234)
 
 ## 5.14.0 (2024-02-07)
 
-* [bitnami/influxdb] feat: :lock: Enable networkPolicy (#23203) ([5273f71](https://github.com/bitnami/charts/commit/5273f71)), closes [#23203](https://github.com/bitnami/charts/issues/23203)
+* [bitnami/influxdb] feat: :lock: Enable networkPolicy (#23203) ([5273f71](https://github.com/bitnami/charts/commit/5273f71d3140f47069d8bea1cfb18c2447550242)), closes [#23203](https://github.com/bitnami/charts/issues/23203)
 
 ## <small>5.13.6 (2024-02-02)</small>
 
-* [bitnami/influxdb] Release 5.13.6 updating components versions (#23081) ([f6a1364](https://github.com/bitnami/charts/commit/f6a1364)), closes [#23081](https://github.com/bitnami/charts/issues/23081)
+* [bitnami/influxdb] Release 5.13.6 updating components versions (#23081) ([f6a1364](https://github.com/bitnami/charts/commit/f6a1364d83627d2f7a3ff0a03440d8b2d9ae4544)), closes [#23081](https://github.com/bitnami/charts/issues/23081)
 
 ## <small>5.13.5 (2024-01-30)</small>
 
-* [bitnami/influxdb] Release 5.13.5 updating components versions (#22929) ([e1359f7](https://github.com/bitnami/charts/commit/e1359f7)), closes [#22929](https://github.com/bitnami/charts/issues/22929)
+* [bitnami/influxdb] Release 5.13.5 updating components versions (#22929) ([e1359f7](https://github.com/bitnami/charts/commit/e1359f7b27e49aee32fe09c97046020015bf9f91)), closes [#22929](https://github.com/bitnami/charts/issues/22929)
 
 ## <small>5.13.4 (2024-01-30)</small>
 
-* [bitnami/influxdb] Release 5.13.4 updating components versions (#22912) ([89d05eb](https://github.com/bitnami/charts/commit/89d05eb)), closes [#22912](https://github.com/bitnami/charts/issues/22912)
+* [bitnami/influxdb] Release 5.13.4 updating components versions (#22912) ([89d05eb](https://github.com/bitnami/charts/commit/89d05eb2686b9c29306de88d6a0b60291e97214c)), closes [#22912](https://github.com/bitnami/charts/issues/22912)
 
 ## <small>5.13.3 (2024-01-30)</small>
 
-* [bitnami/influxdb] Release 5.13.3 updating components versions (#22849) ([a0e9fde](https://github.com/bitnami/charts/commit/a0e9fde)), closes [#22849](https://github.com/bitnami/charts/issues/22849)
+* [bitnami/influxdb] Release 5.13.3 updating components versions (#22849) ([a0e9fde](https://github.com/bitnami/charts/commit/a0e9fdedabba6e4e15e1c9597f42dcd27aef96b6)), closes [#22849](https://github.com/bitnami/charts/issues/22849)
 
 ## <small>5.13.2 (2024-01-27)</small>
 
-* [bitnami/*] Move documentation sections from docs.bitnami.com back to the README (#22203) ([7564f36](https://github.com/bitnami/charts/commit/7564f36)), closes [#22203](https://github.com/bitnami/charts/issues/22203)
-* [bitnami/influxdb] Release 5.13.2 updating components versions (#22798) ([6ecc0c7](https://github.com/bitnami/charts/commit/6ecc0c7)), closes [#22798](https://github.com/bitnami/charts/issues/22798)
+* [bitnami/*] Move documentation sections from docs.bitnami.com back to the README (#22203) ([7564f36](https://github.com/bitnami/charts/commit/7564f36ca1e95ff30ee686652b7ab8690561a707)), closes [#22203](https://github.com/bitnami/charts/issues/22203)
+* [bitnami/influxdb] Release 5.13.2 updating components versions (#22798) ([6ecc0c7](https://github.com/bitnami/charts/commit/6ecc0c7d50e7d881112ff11b642a475920eb9ad4)), closes [#22798](https://github.com/bitnami/charts/issues/22798)
 
 ## <small>5.13.1 (2024-01-24)</small>
 
-* [bitnami/influxdb] fix: :bug: Set seLinuxOptions to null for Openshift compatibility (#22599) ([4d07616](https://github.com/bitnami/charts/commit/4d07616)), closes [#22599](https://github.com/bitnami/charts/issues/22599)
+* [bitnami/influxdb] fix: :bug: Set seLinuxOptions to null for Openshift compatibility (#22599) ([4d07616](https://github.com/bitnami/charts/commit/4d07616fe94b58cfaea748add65c2b70d9f818a3)), closes [#22599](https://github.com/bitnami/charts/issues/22599)
 
 ## 5.13.0 (2024-01-19)
 
-* [bitnami/influxdb] fix: :lock: Move service-account token auto-mount to pod declaration (#22412) ([cb8e6f6](https://github.com/bitnami/charts/commit/cb8e6f6)), closes [#22412](https://github.com/bitnami/charts/issues/22412)
+* [bitnami/influxdb] fix: :lock: Move service-account token auto-mount to pod declaration (#22412) ([cb8e6f6](https://github.com/bitnami/charts/commit/cb8e6f68e9039489b16436ac0d60d9f2aad64083)), closes [#22412](https://github.com/bitnami/charts/issues/22412)
 
 ## <small>5.12.1 (2024-01-18)</small>
 
-* [bitnami/influxdb] Release 5.12.1 updating components versions (#22280) ([4c0d5b1](https://github.com/bitnami/charts/commit/4c0d5b1)), closes [#22280](https://github.com/bitnami/charts/issues/22280)
+* [bitnami/influxdb] Release 5.12.1 updating components versions (#22280) ([4c0d5b1](https://github.com/bitnami/charts/commit/4c0d5b10b2133d0ea2107e8150468b5217ded33e)), closes [#22280](https://github.com/bitnami/charts/issues/22280)
 
 ## 5.12.0 (2024-01-16)
 
-* [bitnami/influxdb] fix: :lock: Improve podSecurityContext and containerSecurityContext with essentia ([db1eb99](https://github.com/bitnami/charts/commit/db1eb99)), closes [#22130](https://github.com/bitnami/charts/issues/22130)
+* [bitnami/influxdb] fix: :lock: Improve podSecurityContext and containerSecurityContext with essentia ([db1eb99](https://github.com/bitnami/charts/commit/db1eb9989098cbb7cc48945c03c7c4cb6020f9a3)), closes [#22130](https://github.com/bitnami/charts/issues/22130)
 
 ## <small>5.11.4 (2024-01-15)</small>
 
-* [bitnami/*] Fix ref links (in comments) (#21822) ([e4fa296](https://github.com/bitnami/charts/commit/e4fa296)), closes [#21822](https://github.com/bitnami/charts/issues/21822)
-* [bitnami/influxdb] fix: :lock: Do not automount the service account token unless necessary (#22045) ([73d5d4f](https://github.com/bitnami/charts/commit/73d5d4f)), closes [#22045](https://github.com/bitnami/charts/issues/22045)
+* [bitnami/*] Fix ref links (in comments) (#21822) ([e4fa296](https://github.com/bitnami/charts/commit/e4fa296106b225cf8c82445727c675c7c725e380)), closes [#21822](https://github.com/bitnami/charts/issues/21822)
+* [bitnami/influxdb] fix: :lock: Do not automount the service account token unless necessary (#22045) ([73d5d4f](https://github.com/bitnami/charts/commit/73d5d4ff27e574c2c27c8b15a0a5533336174093)), closes [#22045](https://github.com/bitnami/charts/issues/22045)
 
 ## <small>5.11.3 (2024-01-10)</small>
 
-* [bitnami/*] Fix docs.bitnami.com broken links (#21901) ([f35506d](https://github.com/bitnami/charts/commit/f35506d)), closes [#21901](https://github.com/bitnami/charts/issues/21901)
-* [bitnami/influxdb] Release 5.11.3 updating components versions (#21945) ([10c6457](https://github.com/bitnami/charts/commit/10c6457)), closes [#21945](https://github.com/bitnami/charts/issues/21945)
+* [bitnami/*] Fix docs.bitnami.com broken links (#21901) ([f35506d](https://github.com/bitnami/charts/commit/f35506d2dadee4f097986e7792df1f53ab215b5d)), closes [#21901](https://github.com/bitnami/charts/issues/21901)
+* [bitnami/influxdb] Release 5.11.3 updating components versions (#21945) ([10c6457](https://github.com/bitnami/charts/commit/10c6457b934012c8ca7b0c29a71cf1d54fd0dd01)), closes [#21945](https://github.com/bitnami/charts/issues/21945)
 
 ## <small>5.11.2 (2024-01-05)</small>
 
-* [bitnami/*] Update copyright: Year and company (#21815) ([6c4bf75](https://github.com/bitnami/charts/commit/6c4bf75)), closes [#21815](https://github.com/bitnami/charts/issues/21815)
-* [bitnami/influxdb] Release 5.11.2 updating components versions (#21867) ([41b0e9d](https://github.com/bitnami/charts/commit/41b0e9d)), closes [#21867](https://github.com/bitnami/charts/issues/21867)
+* [bitnami/*] Update copyright: Year and company (#21815) ([6c4bf75](https://github.com/bitnami/charts/commit/6c4bf75dec58fc7c9aee9f089777b1a858c17d5b)), closes [#21815](https://github.com/bitnami/charts/issues/21815)
+* [bitnami/influxdb] Release 5.11.2 updating components versions (#21867) ([41b0e9d](https://github.com/bitnami/charts/commit/41b0e9d6bd5e128cb35e6a18cfc74b8701bd573e)), closes [#21867](https://github.com/bitnami/charts/issues/21867)
 
 ## <small>5.11.1 (2023-12-07)</small>
 
-* [bitnami/influxdb] Release 5.11.1 updating components versions (#21465) ([ff96ff6](https://github.com/bitnami/charts/commit/ff96ff6)), closes [#21465](https://github.com/bitnami/charts/issues/21465)
+* [bitnami/influxdb] Release 5.11.1 updating components versions (#21465) ([ff96ff6](https://github.com/bitnami/charts/commit/ff96ff60a4add055591e032a215043e3827589f2)), closes [#21465](https://github.com/bitnami/charts/issues/21465)
 
 ## 5.11.0 (2023-12-05)
 
-* [bitnami/*] Remove relative links to non-README sections, add verification for that and update TL;DR ([1103633](https://github.com/bitnami/charts/commit/1103633)), closes [#20967](https://github.com/bitnami/charts/issues/20967)
-* [bitnami/influxdb] Add support custom endpoint s3 for backups (#21211) ([6e2af96](https://github.com/bitnami/charts/commit/6e2af96)), closes [#21211](https://github.com/bitnami/charts/issues/21211)
+* [bitnami/*] Remove relative links to non-README sections, add verification for that and update TL;DR ([1103633](https://github.com/bitnami/charts/commit/11036334d82df0490aa4abdb591543cab6cf7d7f)), closes [#20967](https://github.com/bitnami/charts/issues/20967)
+* [bitnami/influxdb] Add support custom endpoint s3 for backups (#21211) ([6e2af96](https://github.com/bitnami/charts/commit/6e2af9626fe7c0a8e83ed2defc785c7a03938bdd)), closes [#21211](https://github.com/bitnami/charts/issues/21211)
 
 ## <small>5.10.2 (2023-11-08)</small>
 
-* [bitnami/influxdb] Release 5.10.2 updating components versions (#20806) ([803f0a5](https://github.com/bitnami/charts/commit/803f0a5)), closes [#20806](https://github.com/bitnami/charts/issues/20806)
+* [bitnami/influxdb] Release 5.10.2 updating components versions (#20806) ([803f0a5](https://github.com/bitnami/charts/commit/803f0a58cb063e59823e3b0030f80bd96efa86af)), closes [#20806](https://github.com/bitnami/charts/issues/20806)
 
 ## <small>5.10.1 (2023-11-08)</small>
 
-* [bitnami/influxdb] Release 5.10.1 updating components versions (#20740) ([4a4bf5c](https://github.com/bitnami/charts/commit/4a4bf5c)), closes [#20740](https://github.com/bitnami/charts/issues/20740)
+* [bitnami/influxdb] Release 5.10.1 updating components versions (#20740) ([4a4bf5c](https://github.com/bitnami/charts/commit/4a4bf5c7534934c1b76a948f5708070181b8ea23)), closes [#20740](https://github.com/bitnami/charts/issues/20740)
 
 ## 5.10.0 (2023-10-31)
 
-* [bitnami/*] Rename VMware Application Catalog (#20361) ([3acc734](https://github.com/bitnami/charts/commit/3acc734)), closes [#20361](https://github.com/bitnami/charts/issues/20361)
-* [bitnami/*] Skip image's tag in the README files of the Bitnami Charts (#19841) ([bb9a01b](https://github.com/bitnami/charts/commit/bb9a01b)), closes [#19841](https://github.com/bitnami/charts/issues/19841)
-* [bitnami/*] Standardize documentation (#19835) ([af5f753](https://github.com/bitnami/charts/commit/af5f753)), closes [#19835](https://github.com/bitnami/charts/issues/19835)
-* [bitnami/influxdb] feat: :sparkles: Add support for PSA restricted policy (#20451) ([0f4486f](https://github.com/bitnami/charts/commit/0f4486f)), closes [#20451](https://github.com/bitnami/charts/issues/20451)
+* [bitnami/*] Rename VMware Application Catalog (#20361) ([3acc734](https://github.com/bitnami/charts/commit/3acc73472beb6fb56c4d99f929061001205bc57e)), closes [#20361](https://github.com/bitnami/charts/issues/20361)
+* [bitnami/*] Skip image's tag in the README files of the Bitnami Charts (#19841) ([bb9a01b](https://github.com/bitnami/charts/commit/bb9a01b65911c87e48318db922cc05eb42785e42)), closes [#19841](https://github.com/bitnami/charts/issues/19841)
+* [bitnami/*] Standardize documentation (#19835) ([af5f753](https://github.com/bitnami/charts/commit/af5f7530c1bc8c5ded53a6c4f7b8f384ac1804f2)), closes [#19835](https://github.com/bitnami/charts/issues/19835)
+* [bitnami/influxdb] feat: :sparkles: Add support for PSA restricted policy (#20451) ([0f4486f](https://github.com/bitnami/charts/commit/0f4486fde9035bd7a05a62f3f6156af7d94c3064)), closes [#20451](https://github.com/bitnami/charts/issues/20451)
 
 ## <small>5.9.11 (2023-10-17)</small>
 
-* [bitnami/influxdb] Release 5.9.11 (#20290) ([cac8e1b](https://github.com/bitnami/charts/commit/cac8e1b)), closes [#20290](https://github.com/bitnami/charts/issues/20290)
+* [bitnami/influxdb] Release 5.9.11 (#20290) ([cac8e1b](https://github.com/bitnami/charts/commit/cac8e1bda2010277aaf44be9bec875b2ecbe6dcf)), closes [#20290](https://github.com/bitnami/charts/issues/20290)
 
 ## <small>5.9.10 (2023-10-17)</small>
 
-* [bitnami/influxdb] Release 5.9.10 (#20269) ([960d944](https://github.com/bitnami/charts/commit/960d944)), closes [#20269](https://github.com/bitnami/charts/issues/20269)
+* [bitnami/influxdb] Release 5.9.10 (#20269) ([960d944](https://github.com/bitnami/charts/commit/960d944b4d2e0f541eeaed7c23a8c40bde2d725c)), closes [#20269](https://github.com/bitnami/charts/issues/20269)
 
 ## <small>5.9.9 (2023-10-12)</small>
 
-* [bitnami/influxdb] Release 5.9.9 (#20138) ([a55d6a9](https://github.com/bitnami/charts/commit/a55d6a9)), closes [#20138](https://github.com/bitnami/charts/issues/20138)
+* [bitnami/influxdb] Release 5.9.9 (#20138) ([a55d6a9](https://github.com/bitnami/charts/commit/a55d6a9cdba1122ae4346ec646119ec47fbbfe92)), closes [#20138](https://github.com/bitnami/charts/issues/20138)
 
 ## <small>5.9.8 (2023-10-11)</small>
 
-* [bitnami/influxdb] Release 5.9.8 (#20044) ([8419598](https://github.com/bitnami/charts/commit/8419598)), closes [#20044](https://github.com/bitnami/charts/issues/20044)
+* [bitnami/influxdb] Release 5.9.8 (#20044) ([8419598](https://github.com/bitnami/charts/commit/8419598b4e155f45a794d9c3c950343da57207a6)), closes [#20044](https://github.com/bitnami/charts/issues/20044)
 
 ## <small>5.9.7 (2023-10-09)</small>
 
-* [bitnami/influxdb] Release 5.9.7 (#19915) ([3f99c1c](https://github.com/bitnami/charts/commit/3f99c1c)), closes [#19915](https://github.com/bitnami/charts/issues/19915)
+* [bitnami/influxdb] Release 5.9.7 (#19915) ([3f99c1c](https://github.com/bitnami/charts/commit/3f99c1cd4e5a8520f6248dfee3e53ca99b6d7c8f)), closes [#19915](https://github.com/bitnami/charts/issues/19915)
 
 ## <small>5.9.6 (2023-10-09)</small>
 
-* [bitnami/*] Update Helm charts prerequisites (#19745) ([eb755dd](https://github.com/bitnami/charts/commit/eb755dd)), closes [#19745](https://github.com/bitnami/charts/issues/19745)
-* [bitnami/influxdb] Release 5.9.6 (#19854) ([b7f6837](https://github.com/bitnami/charts/commit/b7f6837)), closes [#19854](https://github.com/bitnami/charts/issues/19854)
+* [bitnami/*] Update Helm charts prerequisites (#19745) ([eb755dd](https://github.com/bitnami/charts/commit/eb755dd36a4dd3cf6635be8e0598f9a7f4c4a554)), closes [#19745](https://github.com/bitnami/charts/issues/19745)
+* [bitnami/influxdb] Release 5.9.6 (#19854) ([b7f6837](https://github.com/bitnami/charts/commit/b7f6837f336a2be007e94ffa0bdc175dde716b6c)), closes [#19854](https://github.com/bitnami/charts/issues/19854)
 
 ## <small>5.9.5 (2023-10-03)</small>
 
-* [bitnami/influxdb] Release 5.9.5 (#19716) ([bb3969e](https://github.com/bitnami/charts/commit/bb3969e)), closes [#19716](https://github.com/bitnami/charts/issues/19716)
+* [bitnami/influxdb] Release 5.9.5 (#19716) ([bb3969e](https://github.com/bitnami/charts/commit/bb3969efc93a9228db1fed35196ffeff547255a2)), closes [#19716](https://github.com/bitnami/charts/issues/19716)
 
 ## <small>5.9.4 (2023-10-02)</small>
 
-* [bitnami/influxdb] Use common capabilities for PSP (#19628) ([2bde39f](https://github.com/bitnami/charts/commit/2bde39f)), closes [#19628](https://github.com/bitnami/charts/issues/19628)
-* Autogenerate schema files (#19194) ([a2c2090](https://github.com/bitnami/charts/commit/a2c2090)), closes [#19194](https://github.com/bitnami/charts/issues/19194)
-* Revert "Autogenerate schema files (#19194)" (#19335) ([73d80be](https://github.com/bitnami/charts/commit/73d80be)), closes [#19194](https://github.com/bitnami/charts/issues/19194) [#19335](https://github.com/bitnami/charts/issues/19335)
+* [bitnami/influxdb] Use common capabilities for PSP (#19628) ([2bde39f](https://github.com/bitnami/charts/commit/2bde39f8fc5b90948468cf7b0c5d9e322a6e6c70)), closes [#19628](https://github.com/bitnami/charts/issues/19628)
+* Autogenerate schema files (#19194) ([a2c2090](https://github.com/bitnami/charts/commit/a2c2090b5ac97f47b745c8028c6452bf99739772)), closes [#19194](https://github.com/bitnami/charts/issues/19194)
+* Revert "Autogenerate schema files (#19194)" (#19335) ([73d80be](https://github.com/bitnami/charts/commit/73d80be525c88fb4b8a54451a55acd506e337062)), closes [#19194](https://github.com/bitnami/charts/issues/19194) [#19335](https://github.com/bitnami/charts/issues/19335)
 
 ## <small>5.9.3 (2023-09-07)</small>
 
-* [bitnami/influxdb: Use merge helper]: (#19050) ([36c4748](https://github.com/bitnami/charts/commit/36c4748)), closes [#19050](https://github.com/bitnami/charts/issues/19050)
+* [bitnami/influxdb: Use merge helper]: (#19050) ([36c4748](https://github.com/bitnami/charts/commit/36c4748ec61c1eaaf630d3df61e6d25f44483e05)), closes [#19050](https://github.com/bitnami/charts/issues/19050)
 
 ## <small>5.9.2 (2023-09-06)</small>
 
-* [bitnami/influxdb] Release 5.9.2 (#19150) ([76b79a1](https://github.com/bitnami/charts/commit/76b79a1)), closes [#19150](https://github.com/bitnami/charts/issues/19150)
+* [bitnami/influxdb] Release 5.9.2 (#19150) ([76b79a1](https://github.com/bitnami/charts/commit/76b79a10f6455d6db68731876c8b2a00e03e4107)), closes [#19150](https://github.com/bitnami/charts/issues/19150)
 
 ## <small>5.9.1 (2023-08-28)</small>
 
-* [bitnami/influxdb] test: :white_check_mark: Add persistence test (#18788) ([cb87cfd](https://github.com/bitnami/charts/commit/cb87cfd)), closes [#18788](https://github.com/bitnami/charts/issues/18788)
+* [bitnami/influxdb] test: :white_check_mark: Add persistence test (#18788) ([cb87cfd](https://github.com/bitnami/charts/commit/cb87cfd4a92b6bdc3921fa2c6b5711b08e026ccf)), closes [#18788](https://github.com/bitnami/charts/issues/18788)
 
 ## 5.9.0 (2023-08-23)
 
-* [bitnami/influxdb] Support for customizing standard labels (#18307) ([a779aeb](https://github.com/bitnami/charts/commit/a779aeb)), closes [#18307](https://github.com/bitnami/charts/issues/18307)
+* [bitnami/influxdb] Support for customizing standard labels (#18307) ([a779aeb](https://github.com/bitnami/charts/commit/a779aebd02f2ba67672490162b01c9497e1273aa)), closes [#18307](https://github.com/bitnami/charts/issues/18307)
 
 ## <small>5.8.3 (2023-08-19)</small>
 
-* [bitnami/influxdb] Release 5.8.3 (#18668) ([955c323](https://github.com/bitnami/charts/commit/955c323)), closes [#18668](https://github.com/bitnami/charts/issues/18668)
+* [bitnami/influxdb] Release 5.8.3 (#18668) ([955c323](https://github.com/bitnami/charts/commit/955c323117719fa4c0865bf98d65b2e4108a2ff3)), closes [#18668](https://github.com/bitnami/charts/issues/18668)
 
 ## <small>5.8.2 (2023-08-17)</small>
 
-* [bitnami/influxdb] Release 5.8.2 (#18525) ([26a9160](https://github.com/bitnami/charts/commit/26a9160)), closes [#18525](https://github.com/bitnami/charts/issues/18525)
+* [bitnami/influxdb] Release 5.8.2 (#18525) ([26a9160](https://github.com/bitnami/charts/commit/26a91601ea1b90660507374689ca56dfe4fc1c51)), closes [#18525](https://github.com/bitnami/charts/issues/18525)
 
 ## <small>5.8.1 (2023-07-31)</small>
 
-* [bitnami/influxdb] include namespace in port forward command (#17950) ([63aba51](https://github.com/bitnami/charts/commit/63aba51)), closes [#17950](https://github.com/bitnami/charts/issues/17950)
+* [bitnami/influxdb] include namespace in port forward command (#17950) ([63aba51](https://github.com/bitnami/charts/commit/63aba51f260ed2f0ac3d018e14445e28907aa4d6)), closes [#17950](https://github.com/bitnami/charts/issues/17950)
 
 ## 5.8.0 (2023-07-26)
 
-* [bitnami/influxdb] Set some additional pod security restrictions (#17291) ([8abab18](https://github.com/bitnami/charts/commit/8abab18)), closes [#17291](https://github.com/bitnami/charts/issues/17291)
+* [bitnami/influxdb] Set some additional pod security restrictions (#17291) ([8abab18](https://github.com/bitnami/charts/commit/8abab1872e25cf84409ac22fd4c4e03cb9c39698)), closes [#17291](https://github.com/bitnami/charts/issues/17291)
 
 ## <small>5.7.3 (2023-07-25)</small>
 
-* [bitnami/influxdb] Release 5.7.3 (#17902) ([abe9242](https://github.com/bitnami/charts/commit/abe9242)), closes [#17902](https://github.com/bitnami/charts/issues/17902)
+* [bitnami/influxdb] Release 5.7.3 (#17902) ([abe9242](https://github.com/bitnami/charts/commit/abe9242f3fe2b991f515b203d9748fe0eea662cf)), closes [#17902](https://github.com/bitnami/charts/issues/17902)
 
 ## <small>5.7.2 (2023-07-15)</small>
 
-* [bitnami/influxdb] Release 5 (#17604) ([7b6e3e4](https://github.com/bitnami/charts/commit/7b6e3e4)), closes [#17604](https://github.com/bitnami/charts/issues/17604)
+* [bitnami/influxdb] Release 5 (#17604) ([7b6e3e4](https://github.com/bitnami/charts/commit/7b6e3e4683c75cce8e400bcc57da40e2413e2290)), closes [#17604](https://github.com/bitnami/charts/issues/17604)
 
 ## <small>5.7.1 (2023-07-06)</small>
 
-* [bitnami/influxdb] Fixup storage class templating for PVC (#17434) ([c94ada3](https://github.com/bitnami/charts/commit/c94ada3)), closes [#17434](https://github.com/bitnami/charts/issues/17434)
-* Add copyright header (#17300) ([da68be8](https://github.com/bitnami/charts/commit/da68be8)), closes [#17300](https://github.com/bitnami/charts/issues/17300)
+* [bitnami/influxdb] Fixup storage class templating for PVC (#17434) ([c94ada3](https://github.com/bitnami/charts/commit/c94ada3bf1e7cfd1911688d76afccb55b545594b)), closes [#17434](https://github.com/bitnami/charts/issues/17434)
+* Add copyright header (#17300) ([da68be8](https://github.com/bitnami/charts/commit/da68be8e951225133c7dfb572d5101ca3d61c5ae)), closes [#17300](https://github.com/bitnami/charts/issues/17300)
 
 ## 5.7.0 (2023-06-26)
 
-* [bitnami/influxdb] Add possibility to specify labels for ServiceMonitor (#17325) ([825360f](https://github.com/bitnami/charts/commit/825360f)), closes [#17325](https://github.com/bitnami/charts/issues/17325)
-* Update charts readme (#17217) ([31b3c0a](https://github.com/bitnami/charts/commit/31b3c0a)), closes [#17217](https://github.com/bitnami/charts/issues/17217)
+* [bitnami/influxdb] Add possibility to specify labels for ServiceMonitor (#17325) ([825360f](https://github.com/bitnami/charts/commit/825360fa2e954cc46156ed0f6d439fe85f7b0a36)), closes [#17325](https://github.com/bitnami/charts/issues/17325)
+* Update charts readme (#17217) ([31b3c0a](https://github.com/bitnami/charts/commit/31b3c0afd968ff4429107e34101f7509e6a0e913)), closes [#17217](https://github.com/bitnami/charts/issues/17217)
 
 ## <small>5.6.2 (2023-06-20)</small>
 
-* [bitnami/*] Change copyright section in READMEs (#17006) ([ef986a1](https://github.com/bitnami/charts/commit/ef986a1)), closes [#17006](https://github.com/bitnami/charts/issues/17006)
-* [bitnami/influxdb] Release 5.6.2 (#17210) ([5dae3cf](https://github.com/bitnami/charts/commit/5dae3cf)), closes [#17210](https://github.com/bitnami/charts/issues/17210)
-* [bitnami/several] Change copyright section in READMEs (#16989) ([5b6a5cf](https://github.com/bitnami/charts/commit/5b6a5cf)), closes [#16989](https://github.com/bitnami/charts/issues/16989)
+* [bitnami/*] Change copyright section in READMEs (#17006) ([ef986a1](https://github.com/bitnami/charts/commit/ef986a1605241102b3dcafe9fd8089e6fc1201ad)), closes [#17006](https://github.com/bitnami/charts/issues/17006)
+* [bitnami/influxdb] Release 5.6.2 (#17210) ([5dae3cf](https://github.com/bitnami/charts/commit/5dae3cfe3b10839de028d26eebf51754ef815d80)), closes [#17210](https://github.com/bitnami/charts/issues/17210)
+* [bitnami/several] Change copyright section in READMEs (#16989) ([5b6a5cf](https://github.com/bitnami/charts/commit/5b6a5cfb7625a751848a2e5cd796bd7278f406ca)), closes [#16989](https://github.com/bitnami/charts/issues/16989)
 
 ## <small>5.6.1 (2023-05-21)</small>
 
-* [bitnami/influxdb] Release 5.6.1 (#16770) ([898b9aa](https://github.com/bitnami/charts/commit/898b9aa)), closes [#16770](https://github.com/bitnami/charts/issues/16770)
-* Add wording for enterprise page (#16560) ([8f22774](https://github.com/bitnami/charts/commit/8f22774)), closes [#16560](https://github.com/bitnami/charts/issues/16560)
+* [bitnami/influxdb] Release 5.6.1 (#16770) ([898b9aa](https://github.com/bitnami/charts/commit/898b9aad43b229bc899961793d2479c3e73a2ee6)), closes [#16770](https://github.com/bitnami/charts/issues/16770)
+* Add wording for enterprise page (#16560) ([8f22774](https://github.com/bitnami/charts/commit/8f2277440b976d52785ba9149762ad8620a73d1f)), closes [#16560](https://github.com/bitnami/charts/issues/16560)
 
 ## 5.6.0 (2023-05-09)
 
-* [bitnami/several] Adapt Chart.yaml to set desired OCI annotations (#16546) ([fc9b18f](https://github.com/bitnami/charts/commit/fc9b18f)), closes [#16546](https://github.com/bitnami/charts/issues/16546)
+* [bitnami/several] Adapt Chart.yaml to set desired OCI annotations (#16546) ([fc9b18f](https://github.com/bitnami/charts/commit/fc9b18f2e98805d4df629acbcde696f44f973344)), closes [#16546](https://github.com/bitnami/charts/issues/16546)
 
 ## <small>5.5.2 (2023-05-09)</small>
 
-* [bitnami/influxdb] Release 5.5.2 (#16513) ([a8d1907](https://github.com/bitnami/charts/commit/a8d1907)), closes [#16513](https://github.com/bitnami/charts/issues/16513)
+* [bitnami/influxdb] Release 5.5.2 (#16513) ([a8d1907](https://github.com/bitnami/charts/commit/a8d19075c2f92b414548aa2a772f6a5ab21c7f8d)), closes [#16513](https://github.com/bitnami/charts/issues/16513)
 
 ## <small>5.5.1 (2023-04-29)</small>
 
-* [bitnami/influxdb] Release 5.5.1 (#16281) ([9c3090c](https://github.com/bitnami/charts/commit/9c3090c)), closes [#16281](https://github.com/bitnami/charts/issues/16281)
-* [bitnami/influxdb] Seperate unrelated parameters (#16122) ([57b75a4](https://github.com/bitnami/charts/commit/57b75a4)), closes [#16122](https://github.com/bitnami/charts/issues/16122)
+* [bitnami/influxdb] Release 5.5.1 (#16281) ([9c3090c](https://github.com/bitnami/charts/commit/9c3090cee06fa6a88c590dee90e7bb99a271d644)), closes [#16281](https://github.com/bitnami/charts/issues/16281)
+* [bitnami/influxdb] Seperate unrelated parameters (#16122) ([57b75a4](https://github.com/bitnami/charts/commit/57b75a41660c7ba5a9b6c164b79e989edbc91f17)), closes [#16122](https://github.com/bitnami/charts/issues/16122)
 
 ## 5.5.0 (2023-04-20)
 
-* [bitnami/*] Make Helm charts 100% OCI (#15998) ([8841510](https://github.com/bitnami/charts/commit/8841510)), closes [#15998](https://github.com/bitnami/charts/issues/15998)
+* [bitnami/*] Make Helm charts 100% OCI (#15998) ([8841510](https://github.com/bitnami/charts/commit/884151035efcbf2e1b3206e7def85511073fb57d)), closes [#15998](https://github.com/bitnami/charts/issues/15998)
 
 ## <small>5.4.23 (2023-04-18)</small>
 
-* [bitnami/influxdb] Release 5.4.23 (#16106) ([0e4320e](https://github.com/bitnami/charts/commit/0e4320e)), closes [#16106](https://github.com/bitnami/charts/issues/16106)
+* [bitnami/influxdb] Release 5.4.23 (#16106) ([0e4320e](https://github.com/bitnami/charts/commit/0e4320e757d40e441853a9b8ccdb159bf9c9c9d4)), closes [#16106](https://github.com/bitnami/charts/issues/16106)
 
 ## <small>5.4.22 (2023-04-17)</small>
 
-* [bitnami/influxdb] Release 5.4.22 (#16096) ([9c64146](https://github.com/bitnami/charts/commit/9c64146)), closes [#16096](https://github.com/bitnami/charts/issues/16096)
+* [bitnami/influxdb] Release 5.4.22 (#16096) ([9c64146](https://github.com/bitnami/charts/commit/9c64146cd84b7f043023376649185c683f736672)), closes [#16096](https://github.com/bitnami/charts/issues/16096)
 
 ## <small>5.4.21 (2023-04-11)</small>
 
-* [bitnami/influxdb] Expose admin bucket retention (#16006) ([76f8965](https://github.com/bitnami/charts/commit/76f8965)), closes [#16006](https://github.com/bitnami/charts/issues/16006)
+* [bitnami/influxdb] Expose admin bucket retention (#16006) ([76f8965](https://github.com/bitnami/charts/commit/76f89651b3778947e0a4834ccaf9c9fea6f90fca)), closes [#16006](https://github.com/bitnami/charts/issues/16006)
 
 ## <small>5.4.20 (2023-04-01)</small>
 
-* [bitnami/influxdb] Release 5.4.20 (#15853) ([aff0a5d](https://github.com/bitnami/charts/commit/aff0a5d)), closes [#15853](https://github.com/bitnami/charts/issues/15853)
+* [bitnami/influxdb] Release 5.4.20 (#15853) ([aff0a5d](https://github.com/bitnami/charts/commit/aff0a5d5c613003b330822b28c43b992122ea135)), closes [#15853](https://github.com/bitnami/charts/issues/15853)
 
 ## <small>5.4.19 (2023-03-22)</small>
 
-* [bitnami/influxdb] fix servicemonitor and service labels (#15660) ([4e45762](https://github.com/bitnami/charts/commit/4e45762)), closes [#15660](https://github.com/bitnami/charts/issues/15660)
+* [bitnami/influxdb] fix servicemonitor and service labels (#15660) ([4e45762](https://github.com/bitnami/charts/commit/4e45762025495f2571692d5d3e2026cc9a540bdc)), closes [#15660](https://github.com/bitnami/charts/issues/15660)
 
 ## <small>5.4.18 (2023-03-19)</small>
 
-* [bitnami/charts] Apply linter to README files (#15357) ([0e29e60](https://github.com/bitnami/charts/commit/0e29e60)), closes [#15357](https://github.com/bitnami/charts/issues/15357)
-* [bitnami/influxdb] Release 5.4.18 (#15592) ([8f3f4c4](https://github.com/bitnami/charts/commit/8f3f4c4)), closes [#15592](https://github.com/bitnami/charts/issues/15592)
+* [bitnami/charts] Apply linter to README files (#15357) ([0e29e60](https://github.com/bitnami/charts/commit/0e29e600d3adc8b1b46e506eccb3decfab3b4e63)), closes [#15357](https://github.com/bitnami/charts/issues/15357)
+* [bitnami/influxdb] Release 5.4.18 (#15592) ([8f3f4c4](https://github.com/bitnami/charts/commit/8f3f4c4a3276530709fe32e562990b7159e9f25a)), closes [#15592](https://github.com/bitnami/charts/issues/15592)
 
 ## <small>5.4.17 (2023-03-01)</small>
 
-* [bitnami/influxdb] Release 5.4.17 (#15205) ([c514b8c](https://github.com/bitnami/charts/commit/c514b8c)), closes [#15205](https://github.com/bitnami/charts/issues/15205)
+* [bitnami/influxdb] Release 5.4.17 (#15205) ([c514b8c](https://github.com/bitnami/charts/commit/c514b8c003cae48402adee8044ef502a800ec14c)), closes [#15205](https://github.com/bitnami/charts/issues/15205)
 
 ## <small>5.4.16 (2023-02-17)</small>
 
-* [bitnami/*] Change copyright date (#14682) ([add4ec7](https://github.com/bitnami/charts/commit/add4ec7)), closes [#14682](https://github.com/bitnami/charts/issues/14682)
-* [bitnami/*] Fix markdown linter issues (#14874) ([a51e0e8](https://github.com/bitnami/charts/commit/a51e0e8)), closes [#14874](https://github.com/bitnami/charts/issues/14874)
-* [bitnami/*] Fix markdown linter issues 2 (#14890) ([aa96572](https://github.com/bitnami/charts/commit/aa96572)), closes [#14890](https://github.com/bitnami/charts/issues/14890)
-* [bitnami/*] Remove unexpected extra spaces (#14873) ([c97c714](https://github.com/bitnami/charts/commit/c97c714)), closes [#14873](https://github.com/bitnami/charts/issues/14873)
-* [bitnami/influxdb] Release 5.4.16 (#14982) ([c634b61](https://github.com/bitnami/charts/commit/c634b61)), closes [#14982](https://github.com/bitnami/charts/issues/14982)
+* [bitnami/*] Change copyright date (#14682) ([add4ec7](https://github.com/bitnami/charts/commit/add4ec701108ac36ed4de2dffbdf407a0d091067)), closes [#14682](https://github.com/bitnami/charts/issues/14682)
+* [bitnami/*] Fix markdown linter issues (#14874) ([a51e0e8](https://github.com/bitnami/charts/commit/a51e0e8d35495b907f3e70dd2f8e7c3bcbf4166a)), closes [#14874](https://github.com/bitnami/charts/issues/14874)
+* [bitnami/*] Fix markdown linter issues 2 (#14890) ([aa96572](https://github.com/bitnami/charts/commit/aa9657237ee8df4a46db0d7fdf8a23230dd6902a)), closes [#14890](https://github.com/bitnami/charts/issues/14890)
+* [bitnami/*] Remove unexpected extra spaces (#14873) ([c97c714](https://github.com/bitnami/charts/commit/c97c714887380d47eae7bfeff316bf01595ecd1d)), closes [#14873](https://github.com/bitnami/charts/issues/14873)
+* [bitnami/influxdb] Release 5.4.16 (#14982) ([c634b61](https://github.com/bitnami/charts/commit/c634b6174f79d1f1169398890557638bfcd0bd98)), closes [#14982](https://github.com/bitnami/charts/issues/14982)
 
 ## <small>5.4.15 (2023-01-28)</small>
 
-* [bitnami/*] Add license annotation and remove obsolete engine parameter (#14293) ([da2a794](https://github.com/bitnami/charts/commit/da2a794)), closes [#14293](https://github.com/bitnami/charts/issues/14293)
-* [bitnami/*] Change licenses annotation format (#14377) ([0ab7608](https://github.com/bitnami/charts/commit/0ab7608)), closes [#14377](https://github.com/bitnami/charts/issues/14377)
-* [bitnami/*] Unify READMEs (#14472) ([2064fb8](https://github.com/bitnami/charts/commit/2064fb8)), closes [#14472](https://github.com/bitnami/charts/issues/14472)
-* [bitnami/influxdb] Release 5.4.15 (#14582) ([830f09d](https://github.com/bitnami/charts/commit/830f09d)), closes [#14582](https://github.com/bitnami/charts/issues/14582)
+* [bitnami/*] Add license annotation and remove obsolete engine parameter (#14293) ([da2a794](https://github.com/bitnami/charts/commit/da2a7943bae95b6e9b5b4ed972c15e990b69fdb0)), closes [#14293](https://github.com/bitnami/charts/issues/14293)
+* [bitnami/*] Change licenses annotation format (#14377) ([0ab7608](https://github.com/bitnami/charts/commit/0ab760862c660fcc78cffadf8e1d8cdd70881473)), closes [#14377](https://github.com/bitnami/charts/issues/14377)
+* [bitnami/*] Unify READMEs (#14472) ([2064fb8](https://github.com/bitnami/charts/commit/2064fb8dcc78a845cdede8211af8c3cc52551161)), closes [#14472](https://github.com/bitnami/charts/issues/14472)
+* [bitnami/influxdb] Release 5.4.15 (#14582) ([830f09d](https://github.com/bitnami/charts/commit/830f09d659e6f9ea3699be4a251671f5712766ac)), closes [#14582](https://github.com/bitnami/charts/issues/14582)
 
 ## <small>5.4.14 (2022-12-29)</small>
 
-* [bitnami/influxdb] Release 5.4.14 (#14131) ([dc148e4](https://github.com/bitnami/charts/commit/dc148e4)), closes [#14131](https://github.com/bitnami/charts/issues/14131)
+* [bitnami/influxdb] Release 5.4.14 (#14131) ([dc148e4](https://github.com/bitnami/charts/commit/dc148e4ac0f2ccaea80a4566f73fddc8b4011356)), closes [#14131](https://github.com/bitnami/charts/issues/14131)
 
 ## <small>5.4.13 (2022-12-16)</small>
 
-* [bitnami/influxdb] Release 5.4.13 (#13986) ([1458675](https://github.com/bitnami/charts/commit/1458675)), closes [#13986](https://github.com/bitnami/charts/issues/13986)
+* [bitnami/influxdb] Release 5.4.13 (#13986) ([1458675](https://github.com/bitnami/charts/commit/1458675c8b3f38c0173adbfb6d37678304841a51)), closes [#13986](https://github.com/bitnami/charts/issues/13986)
 
 ## <small>5.4.12 (2022-12-14)</small>
 
-* [bitnami/influxdb] Release 5.4.12 (#13957) ([3dd3906](https://github.com/bitnami/charts/commit/3dd3906)), closes [#13957](https://github.com/bitnami/charts/issues/13957)
+* [bitnami/influxdb] Release 5.4.12 (#13957) ([3dd3906](https://github.com/bitnami/charts/commit/3dd3906955e7f8d0bb87b2d9ff66820c090a42eb)), closes [#13957](https://github.com/bitnami/charts/issues/13957)
 
 ## <small>5.4.11 (2022-11-17)</small>
 
-* [bitnami/influxdb] Release 5.4.11 updating components versions (#13566) ([6610d6d](https://github.com/bitnami/charts/commit/6610d6d)), closes [#13566](https://github.com/bitnami/charts/issues/13566)
+* [bitnami/influxdb] Release 5.4.11 updating components versions (#13566) ([6610d6d](https://github.com/bitnami/charts/commit/6610d6d87365112d7d30bdc6af146ecf5e48d58b)), closes [#13566](https://github.com/bitnami/charts/issues/13566)
 
 ## <small>5.4.10 (2022-11-04)</small>
 
-* [bitnami/influxdb] Release 5.4.10 (#13294) ([85a67e0](https://github.com/bitnami/charts/commit/85a67e0)), closes [#13294](https://github.com/bitnami/charts/issues/13294)
+* [bitnami/influxdb] Release 5.4.10 (#13294) ([85a67e0](https://github.com/bitnami/charts/commit/85a67e0a06593211c1f5acec861685415807a124)), closes [#13294](https://github.com/bitnami/charts/issues/13294)
 
 ## <small>5.4.9 (2022-10-31)</small>
 
-* fix apiversion hardcode for cronjob (#13112) ([f946a7f](https://github.com/bitnami/charts/commit/f946a7f)), closes [#13112](https://github.com/bitnami/charts/issues/13112)
+* fix apiversion hardcode for cronjob (#13112) ([f946a7f](https://github.com/bitnami/charts/commit/f946a7fa2c5fa7899b40292fed92f76a34fea7cd)), closes [#13112](https://github.com/bitnami/charts/issues/13112)
 
 ## <small>5.4.8 (2022-10-24)</small>
 
-* [bitnami/influxdb] Release 5.4.8 (#13108) ([8e050df](https://github.com/bitnami/charts/commit/8e050df)), closes [#13108](https://github.com/bitnami/charts/issues/13108)
-* remove deprecated param (#13069) ([f624476](https://github.com/bitnami/charts/commit/f624476)), closes [#13069](https://github.com/bitnami/charts/issues/13069)
+* [bitnami/influxdb] Release 5.4.8 (#13108) ([8e050df](https://github.com/bitnami/charts/commit/8e050dfe7b8412f314c6696a562b5b09d144375a)), closes [#13108](https://github.com/bitnami/charts/issues/13108)
+* remove deprecated param (#13069) ([f624476](https://github.com/bitnami/charts/commit/f6244767060a728dfe5e86d55d540c835a9972b7)), closes [#13069](https://github.com/bitnami/charts/issues/13069)
 
 ## <small>5.4.7 (2022-10-21)</small>
 
-* [bitnami/*] Use new default branch name in links (#12943) ([a529e02](https://github.com/bitnami/charts/commit/a529e02)), closes [#12943](https://github.com/bitnami/charts/issues/12943)
-* [bitnami/influxdb] Release 5.4.7 (#13085) ([b3b36fc](https://github.com/bitnami/charts/commit/b3b36fc)), closes [#13085](https://github.com/bitnami/charts/issues/13085)
-* Generic README instructions related to the repo (#12792) ([3cf6b10](https://github.com/bitnami/charts/commit/3cf6b10)), closes [#12792](https://github.com/bitnami/charts/issues/12792)
+* [bitnami/*] Use new default branch name in links (#12943) ([a529e02](https://github.com/bitnami/charts/commit/a529e02597d49d944eba1eb0f190713293247176)), closes [#12943](https://github.com/bitnami/charts/issues/12943)
+* [bitnami/influxdb] Release 5.4.7 (#13085) ([b3b36fc](https://github.com/bitnami/charts/commit/b3b36fcb003d267fd8fe5eceaa6b4e81e8611d4b)), closes [#13085](https://github.com/bitnami/charts/issues/13085)
+* Generic README instructions related to the repo (#12792) ([3cf6b10](https://github.com/bitnami/charts/commit/3cf6b10e10e60df4b3e191d6b99aa99a9f597755)), closes [#12792](https://github.com/bitnami/charts/issues/12792)
 
 ## <small>5.4.6 (2022-09-27)</small>
 
-* [bitnami/influxdb] Add chown for data dir, not only children (#12648) ([74c134c](https://github.com/bitnami/charts/commit/74c134c)), closes [#12648](https://github.com/bitnami/charts/issues/12648)
+* [bitnami/influxdb] Add chown for data dir, not only children (#12648) ([74c134c](https://github.com/bitnami/charts/commit/74c134cc61a106741a9033daac7e7d3e9bb13684)), closes [#12648](https://github.com/bitnami/charts/issues/12648)
 
 ## <small>5.4.5 (2022-09-21)</small>
 
-* [bitnami/influxdb] Release 5.4.5 (#12625) ([6807bb0](https://github.com/bitnami/charts/commit/6807bb0)), closes [#12625](https://github.com/bitnami/charts/issues/12625)
+* [bitnami/influxdb] Release 5.4.5 (#12625) ([6807bb0](https://github.com/bitnami/charts/commit/6807bb083eb1dfaf366b3c267c41e93f7be61794)), closes [#12625](https://github.com/bitnami/charts/issues/12625)
 
 ## <small>5.4.4 (2022-09-21)</small>
 
-* [bitnami/influxdb] Release 5.4.4 (#12620) ([62eefaa](https://github.com/bitnami/charts/commit/62eefaa)), closes [#12620](https://github.com/bitnami/charts/issues/12620)
+* [bitnami/influxdb] Release 5.4.4 (#12620) ([62eefaa](https://github.com/bitnami/charts/commit/62eefaab633007028bfd1497174a0c8bbb9460b2)), closes [#12620](https://github.com/bitnami/charts/issues/12620)
 
 ## <small>5.4.3 (2022-09-20)</small>
 
-* [bitnami/influxdb] Use custom probes if given (#12505) ([dcc900f](https://github.com/bitnami/charts/commit/dcc900f)), closes [#12505](https://github.com/bitnami/charts/issues/12505) [#12354](https://github.com/bitnami/charts/issues/12354)
+* [bitnami/influxdb] Use custom probes if given (#12505) ([dcc900f](https://github.com/bitnami/charts/commit/dcc900f951211ca39f17745e701822d787441e90)), closes [#12505](https://github.com/bitnami/charts/issues/12505) [#12354](https://github.com/bitnami/charts/issues/12354)
 
 ## <small>5.4.2 (2022-09-12)</small>
 
-* [bitnami/influxdb] Release 5.4.2 (#12370) ([5240419](https://github.com/bitnami/charts/commit/5240419)), closes [#12370](https://github.com/bitnami/charts/issues/12370)
+* [bitnami/influxdb] Release 5.4.2 (#12370) ([5240419](https://github.com/bitnami/charts/commit/5240419290f1283d298d85ae2964ddcb2cfbe0fb)), closes [#12370](https://github.com/bitnami/charts/issues/12370)
 
 ## <small>5.4.1 (2022-08-23)</small>
 
-* [bitnami/influxdb] Update Chart.lock (#12057) ([f718096](https://github.com/bitnami/charts/commit/f718096)), closes [#12057](https://github.com/bitnami/charts/issues/12057)
+* [bitnami/influxdb] Update Chart.lock (#12057) ([f718096](https://github.com/bitnami/charts/commit/f71809630f447d7e4156c643fb5ce8e5a56471e0)), closes [#12057](https://github.com/bitnami/charts/issues/12057)
 
 ## 5.4.0 (2022-08-22)
 
-* [bitnami/influxdb] Add support for image digest apart from tag (#11887) ([1de9293](https://github.com/bitnami/charts/commit/1de9293)), closes [#11887](https://github.com/bitnami/charts/issues/11887)
+* [bitnami/influxdb] Add support for image digest apart from tag (#11887) ([1de9293](https://github.com/bitnami/charts/commit/1de92933e60b260e745341062ea2edaf280620f7)), closes [#11887](https://github.com/bitnami/charts/issues/11887)
 
 ## <small>5.3.12 (2022-08-19)</small>
 
-* [bitnami/influxdb] Release 5.3.12 updating components versions ([85ef007](https://github.com/bitnami/charts/commit/85ef007))
+* [bitnami/influxdb] Release 5.3.12 updating components versions ([85ef007](https://github.com/bitnami/charts/commit/85ef00766f2c44587bcde0d611a7bc359baaa09b))
 
 ## <small>5.3.11 (2022-08-09)</small>
 
-* [bitnami/influxdb] Release 5.3.11 updating components versions ([492ceaa](https://github.com/bitnami/charts/commit/492ceaa))
+* [bitnami/influxdb] Release 5.3.11 updating components versions ([492ceaa](https://github.com/bitnami/charts/commit/492ceaa35e52cc22227afa726ce871257d28d2fb))
 
 ## <small>5.3.10 (2022-08-04)</small>
 
-* [bitnami/influxdb] Release 5.3.10 updating components versions ([aed1001](https://github.com/bitnami/charts/commit/aed1001))
+* [bitnami/influxdb] Release 5.3.10 updating components versions ([aed1001](https://github.com/bitnami/charts/commit/aed10010ef85b46690e648c15c30107298f2f75e))
 
 ## <small>5.3.9 (2022-08-04)</small>
 
-* [bitnami/influxdb] Release 5.3.9 updating components versions ([cedacf8](https://github.com/bitnami/charts/commit/cedacf8))
+* [bitnami/influxdb] Release 5.3.9 updating components versions ([cedacf8](https://github.com/bitnami/charts/commit/cedacf8cbb85a84b87dfee893b025cab892e8276))
 
 ## <small>5.3.8 (2022-08-02)</small>
 
-* [bitnami/*] Update URLs to point to the new bitnami/containers monorepo (#11352) ([d665af0](https://github.com/bitnami/charts/commit/d665af0)), closes [#11352](https://github.com/bitnami/charts/issues/11352)
-* [bitnami/influxdb] Release 5.3.8 updating components versions ([c885c70](https://github.com/bitnami/charts/commit/c885c70))
+* [bitnami/*] Update URLs to point to the new bitnami/containers monorepo (#11352) ([d665af0](https://github.com/bitnami/charts/commit/d665af0c708846192d8d5fb2f5f9ea65dd464ab0)), closes [#11352](https://github.com/bitnami/charts/issues/11352)
+* [bitnami/influxdb] Release 5.3.8 updating components versions ([c885c70](https://github.com/bitnami/charts/commit/c885c70539f8a6d29e46ac44d1fc039ab4a76e8b))
 
 ## <small>5.3.7 (2022-07-04)</small>
 
-* [bitnami/influxdb] Release 5.3.7 updating components versions ([31efccb](https://github.com/bitnami/charts/commit/31efccb))
+* [bitnami/influxdb] Release 5.3.7 updating components versions ([31efccb](https://github.com/bitnami/charts/commit/31efccb1bd136c6aabcfa22b34a4caca6e0e1eb3))
 
 ## <small>5.3.6 (2022-06-30)</small>
 
-* [bitnami/influxdb] Release 5.3.6 updating components versions ([f6db496](https://github.com/bitnami/charts/commit/f6db496))
+* [bitnami/influxdb] Release 5.3.6 updating components versions ([f6db496](https://github.com/bitnami/charts/commit/f6db4965b9d5fd9de562908c01d8cc5e3faaa9ab))
 
 ## <small>5.3.5 (2022-06-21)</small>
 
-* [bitnami/influxdb] Release 5.3.5 updating components versions ([5df164c](https://github.com/bitnami/charts/commit/5df164c))
+* [bitnami/influxdb] Release 5.3.5 updating components versions ([5df164c](https://github.com/bitnami/charts/commit/5df164c1c4cf147a0052295f35d63e5566fcb695))
 
 ## <small>5.3.4 (2022-06-10)</small>
 
-* [bitnami/*] Replace Kubeapps URL in READMEs (and kubeapps Chart.yaml) and remove BKPR references (#1 ([c6a7914](https://github.com/bitnami/charts/commit/c6a7914)), closes [#10600](https://github.com/bitnami/charts/issues/10600)
-* [bitnami/influxdb] Release 5.3.4 updating components versions ([30cabd9](https://github.com/bitnami/charts/commit/30cabd9))
+* [bitnami/*] Replace Kubeapps URL in READMEs (and kubeapps Chart.yaml) and remove BKPR references (#1 ([c6a7914](https://github.com/bitnami/charts/commit/c6a7914361e5aea6016fb45bf4d621edfd111d32)), closes [#10600](https://github.com/bitnami/charts/issues/10600)
+* [bitnami/influxdb] Release 5.3.4 updating components versions ([30cabd9](https://github.com/bitnami/charts/commit/30cabd9695621e363d308de4f76f3f49ff7a6900))
 
 ## <small>5.3.3 (2022-06-06)</small>
 
-* [bitnami/influxdb] Release 5.3.3 updating components versions ([892df74](https://github.com/bitnami/charts/commit/892df74))
+* [bitnami/influxdb] Release 5.3.3 updating components versions ([892df74](https://github.com/bitnami/charts/commit/892df7428ebd4e1c35687fe410fa8bb56ff107c7))
 
 ## <small>5.3.2 (2022-06-01)</small>
 
-* [bitnami/several] Replace maintainers email by url (#10523) ([ff3cf61](https://github.com/bitnami/charts/commit/ff3cf61)), closes [#10523](https://github.com/bitnami/charts/issues/10523)
+* [bitnami/several] Replace maintainers email by url (#10523) ([ff3cf61](https://github.com/bitnami/charts/commit/ff3cf617a1680509b0f3855d17c4ccff7b29a0ff)), closes [#10523](https://github.com/bitnami/charts/issues/10523)
 
 ## <small>5.3.1 (2022-05-30)</small>
 
-* [bitnami/several] Replace base64 --decode with base64 -d (#10495) ([099286a](https://github.com/bitnami/charts/commit/099286a)), closes [#10495](https://github.com/bitnami/charts/issues/10495)
+* [bitnami/several] Replace base64 --decode with base64 -d (#10495) ([099286a](https://github.com/bitnami/charts/commit/099286ae7a87784cf809df0b64ab24f7ff0144c8)), closes [#10495](https://github.com/bitnami/charts/issues/10495)
 
 ## 5.3.0 (2022-05-23)
 
-* [bitnami/influxdb] Add missing serviceAccount.* parameters (#10338) ([6a4f754](https://github.com/bitnami/charts/commit/6a4f754)), closes [#10338](https://github.com/bitnami/charts/issues/10338)
+* [bitnami/influxdb] Add missing serviceAccount.* parameters (#10338) ([6a4f754](https://github.com/bitnami/charts/commit/6a4f7546937d24cf2ac4842317093cd50c5697f4)), closes [#10338](https://github.com/bitnami/charts/issues/10338)
 
 ## <small>5.2.4 (2022-05-21)</small>
 
-* [bitnami/influxdb] Release 5.2.4 updating components versions ([fb42c68](https://github.com/bitnami/charts/commit/fb42c68))
+* [bitnami/influxdb] Release 5.2.4 updating components versions ([fb42c68](https://github.com/bitnami/charts/commit/fb42c688539128bf5f295595bcd053072e28b1b6))
 
 ## <small>5.2.3 (2022-05-20)</small>
 
-* [bitnami/influxdb] Release 5.2.3 updating components versions ([1110257](https://github.com/bitnami/charts/commit/1110257))
+* [bitnami/influxdb] Release 5.2.3 updating components versions ([1110257](https://github.com/bitnami/charts/commit/11102570cf76eadf388fe353b1e25a11be03fefd))
 
 ## <small>5.2.2 (2022-05-19)</small>
 
-* [bitnami/influxdb] Release 5.2.2 updating components versions ([fbab810](https://github.com/bitnami/charts/commit/fbab810))
+* [bitnami/influxdb] Release 5.2.2 updating components versions ([fbab810](https://github.com/bitnami/charts/commit/fbab810f29bc19efd6a09d1c86f198303acd735b))
 
 ## <small>5.2.1 (2022-05-18)</small>
 
-* [bitnami/influxdb] Release 5.2.1 updating components versions ([439526d](https://github.com/bitnami/charts/commit/439526d))
+* [bitnami/influxdb] Release 5.2.1 updating components versions ([439526d](https://github.com/bitnami/charts/commit/439526d0d9a496e385a5a3b7d3e99c6e75633209))
 
 ## 5.2.0 (2022-05-16)
 
-* [bitnami/*] add ingress extraRules feature (#10253) ([0f6cbb9](https://github.com/bitnami/charts/commit/0f6cbb9)), closes [#10253](https://github.com/bitnami/charts/issues/10253)
+* [bitnami/*] add ingress extraRules feature (#10253) ([0f6cbb9](https://github.com/bitnami/charts/commit/0f6cbb9099b0e56685cc1d36ba50340f3d7278a1)), closes [#10253](https://github.com/bitnami/charts/issues/10253)
 
 ## <small>5.1.2 (2022-05-13)</small>
 
-* [bitnami/*] Unify k8s directives separators (#10185) ([2650214](https://github.com/bitnami/charts/commit/2650214)), closes [#10185](https://github.com/bitnami/charts/issues/10185)
+* [bitnami/*] Unify k8s directives separators (#10185) ([2650214](https://github.com/bitnami/charts/commit/26502141d146ca3bdfb3bf744fcdec8ca5cece44)), closes [#10185](https://github.com/bitnami/charts/issues/10185)
 
 ## <small>5.1.1 (2022-05-12)</small>
 
-* [bitnami/influxdb] Add missing namespace metadata (#10125) ([5a13c4a](https://github.com/bitnami/charts/commit/5a13c4a)), closes [#10125](https://github.com/bitnami/charts/issues/10125)
+* [bitnami/influxdb] Add missing namespace metadata (#10125) ([5a13c4a](https://github.com/bitnami/charts/commit/5a13c4adb10ef89035a6b43a8d49ebef689a4d8d)), closes [#10125](https://github.com/bitnami/charts/issues/10125)
 
 ## 5.1.0 (2022-05-09)
 
-* [bitnami/influxdb] Fix issue in initContainer and remove influxdb folder in templates (#10088) ([9b6b8f4](https://github.com/bitnami/charts/commit/9b6b8f4)), closes [#10088](https://github.com/bitnami/charts/issues/10088)
+* [bitnami/influxdb] Fix issue in initContainer and remove influxdb folder in templates (#10088) ([9b6b8f4](https://github.com/bitnami/charts/commit/9b6b8f403e44ff25bf8c075782b8ef4708959231)), closes [#10088](https://github.com/bitnami/charts/issues/10088)
 
 ## 5.0.0 (2022-05-06)
 
-* [bitnami/influxdb] Remove influxdb-relay subcomponent (#9981) ([5708766](https://github.com/bitnami/charts/commit/5708766)), closes [#9981](https://github.com/bitnami/charts/issues/9981)
+* [bitnami/influxdb] Remove influxdb-relay subcomponent (#9981) ([5708766](https://github.com/bitnami/charts/commit/5708766e1ded392a416387b6bf6e74df6b3c14a0)), closes [#9981](https://github.com/bitnami/charts/issues/9981)
 
 ## <small>4.0.12 (2022-04-20)</small>
 
-* [bitnami/influxdb] Release 4.0.12 updating components versions ([9024be1](https://github.com/bitnami/charts/commit/9024be1))
+* [bitnami/influxdb] Release 4.0.12 updating components versions ([9024be1](https://github.com/bitnami/charts/commit/9024be1a30e7b7bf3e846e36e52a725fee962ab7))
 
 ## <small>4.0.11 (2022-04-19)</small>
 
-* [bitnami/influxdb] Release 4.0.11 updating components versions ([aa27456](https://github.com/bitnami/charts/commit/aa27456))
+* [bitnami/influxdb] Release 4.0.11 updating components versions ([aa27456](https://github.com/bitnami/charts/commit/aa2745683b8ec87fe9293dc71312976cc680d4c5))
 
 ## <small>4.0.10 (2022-04-11)</small>
 
-* [bitnami/influxdb] Release 4.0.10 updating components versions ([5c1dad3](https://github.com/bitnami/charts/commit/5c1dad3))
+* [bitnami/influxdb] Release 4.0.10 updating components versions ([5c1dad3](https://github.com/bitnami/charts/commit/5c1dad3c5eaa04e445ef70fbe5547f074b784925))
 
 ## <small>4.0.9 (2022-04-07)</small>
 
-* [bitnami/influxdb] Release 4.0.9 updating components versions ([9f9619e](https://github.com/bitnami/charts/commit/9f9619e))
+* [bitnami/influxdb] Release 4.0.9 updating components versions ([9f9619e](https://github.com/bitnami/charts/commit/9f9619eb919fe68763f602c1d6cbd1c752ae21c0))
 
 ## <small>4.0.8 (2022-04-03)</small>
 
-* [bitnami/influxdb] Release 4.0.8 updating components versions ([5fb3eec](https://github.com/bitnami/charts/commit/5fb3eec))
+* [bitnami/influxdb] Release 4.0.8 updating components versions ([5fb3eec](https://github.com/bitnami/charts/commit/5fb3eec81700752e4e0c6a3218a56871401c5625))
 
 ## <small>4.0.7 (2022-04-02)</small>
 
-* [bitnami/influxdb] Release 4.0.7 updating components versions ([f284b34](https://github.com/bitnami/charts/commit/f284b34))
+* [bitnami/influxdb] Release 4.0.7 updating components versions ([f284b34](https://github.com/bitnami/charts/commit/f284b34e843e2b226ff3b364dcf61b40ac6d5dbc))
 
 ## <small>4.0.6 (2022-03-30)</small>
 
-* fix notes (#9617) ([f99b98f](https://github.com/bitnami/charts/commit/f99b98f)), closes [#9617](https://github.com/bitnami/charts/issues/9617)
+* fix notes (#9617) ([f99b98f](https://github.com/bitnami/charts/commit/f99b98f11077344640c75f5509438937b4ba41c6)), closes [#9617](https://github.com/bitnami/charts/issues/9617)
 
 ## <small>4.0.5 (2022-03-28)</small>
 
-* [bitnami/influxdb] Release 4.0.5 updating components versions ([aa356d2](https://github.com/bitnami/charts/commit/aa356d2))
+* [bitnami/influxdb] Release 4.0.5 updating components versions ([aa356d2](https://github.com/bitnami/charts/commit/aa356d2990121867ac05766ddf7e031df9baa044))
 
 ## <small>4.0.4 (2022-03-27)</small>
 
-* [bitnami/influxdb] Release 4.0.4 updating components versions ([a461bf8](https://github.com/bitnami/charts/commit/a461bf8))
+* [bitnami/influxdb] Release 4.0.4 updating components versions ([a461bf8](https://github.com/bitnami/charts/commit/a461bf8ee0002635e52aa304c1f0e00ff32ea39e))
 
 ## <small>4.0.3 (2022-03-17)</small>
 
-* [bitnami/influxdb] Release 4.0.3 updating components versions ([e4ae909](https://github.com/bitnami/charts/commit/e4ae909))
+* [bitnami/influxdb] Release 4.0.3 updating components versions ([e4ae909](https://github.com/bitnami/charts/commit/e4ae9098a8662e8cc27945c0568e562758f31563))
 
 ## <small>4.0.2 (2022-03-16)</small>
 
-* [bitnami/influxdb] Release 4.0.2 updating components versions ([5549f6d](https://github.com/bitnami/charts/commit/5549f6d))
+* [bitnami/influxdb] Release 4.0.2 updating components versions ([5549f6d](https://github.com/bitnami/charts/commit/5549f6de027aa270d595cf0b8b3c8c824e623556))
 
 ## <small>4.0.1 (2022-03-10)</small>
 
-* feat: tls hostname template support (#9359) ([8fce9d0](https://github.com/bitnami/charts/commit/8fce9d0)), closes [#9359](https://github.com/bitnami/charts/issues/9359)
-* [bitnami/*] Fix non utf8 characters (#9347) ([0cec8a8](https://github.com/bitnami/charts/commit/0cec8a8)), closes [#9347](https://github.com/bitnami/charts/issues/9347)
+* feat: tls hostname template support (#9359) ([8fce9d0](https://github.com/bitnami/charts/commit/8fce9d0bd6420892bbf9708fbff48465dd64bbe8)), closes [#9359](https://github.com/bitnami/charts/issues/9359)
+* [bitnami/*] Fix non utf8 characters (#9347) ([0cec8a8](https://github.com/bitnami/charts/commit/0cec8a8d30b8f1ca85febe9acc342522d5b18850)), closes [#9347](https://github.com/bitnami/charts/issues/9347)
 
 ## 4.0.0 (2022-03-03)
 
-* bitnami/influxdb remove InfluxDB logic for branch 1 (#9275) ([80a3946](https://github.com/bitnami/charts/commit/80a3946)), closes [#9275](https://github.com/bitnami/charts/issues/9275)
+* bitnami/influxdb remove InfluxDB logic for branch 1 (#9275) ([80a3946](https://github.com/bitnami/charts/commit/80a3946ce402da3fb8e0235e7995c01f0a6da03c)), closes [#9275](https://github.com/bitnami/charts/issues/9275)
 
 ## <small>3.0.6 (2022-02-27)</small>
 
-* [bitnami/influxdb] Release 3.0.6 updating components versions ([d1c0f79](https://github.com/bitnami/charts/commit/d1c0f79))
+* [bitnami/influxdb] Release 3.0.6 updating components versions ([d1c0f79](https://github.com/bitnami/charts/commit/d1c0f790f9ee4d71379ed46e5f3d50862a8fb390))
 
 ## <small>3.0.5 (2022-02-25)</small>
 
-* [bitnami/influxdb] influx CLI command issues (#9202) ([03672b1](https://github.com/bitnami/charts/commit/03672b1)), closes [#9202](https://github.com/bitnami/charts/issues/9202)
+* [bitnami/influxdb] influx CLI command issues (#9202) ([03672b1](https://github.com/bitnami/charts/commit/03672b183027afe3c033c802db903b5ffb841e07)), closes [#9202](https://github.com/bitnami/charts/issues/9202)
 
 ## <small>3.0.4 (2022-02-22)</small>
 
-* [bitnami/influxdb] Add flag '-r' to xargs in volumePermissions init-container (#9133) ([d776194](https://github.com/bitnami/charts/commit/d776194)), closes [#9133](https://github.com/bitnami/charts/issues/9133)
-* [bitnami/influxdb] Release 3.0.4 updating components versions ([1e88dad](https://github.com/bitnami/charts/commit/1e88dad))
+* [bitnami/influxdb] Add flag '-r' to xargs in volumePermissions init-container (#9133) ([d776194](https://github.com/bitnami/charts/commit/d77619404012be7a73d632c2eac62d3048c32d9e)), closes [#9133](https://github.com/bitnami/charts/issues/9133)
+* [bitnami/influxdb] Release 3.0.4 updating components versions ([1e88dad](https://github.com/bitnami/charts/commit/1e88dad162e8112198bd0894f0b34f54181bcf58))
 
 ## <small>3.0.3 (2022-02-20)</small>
 
-* [bitnami/influxdb] Release 3.0.3 updating components versions ([7b9e049](https://github.com/bitnami/charts/commit/7b9e049))
-* Non utf8 chars (#8923) ([6ffd18f](https://github.com/bitnami/charts/commit/6ffd18f)), closes [#8923](https://github.com/bitnami/charts/issues/8923)
+* [bitnami/influxdb] Release 3.0.3 updating components versions ([7b9e049](https://github.com/bitnami/charts/commit/7b9e04954eafb0828ad5f930e8325083a820b506))
+* Non utf8 chars (#8923) ([6ffd18f](https://github.com/bitnami/charts/commit/6ffd18fbbdf10e94ea1a90cf5b84ef610ac2a72d)), closes [#8923](https://github.com/bitnami/charts/issues/8923)
 
 ## <small>3.0.2 (2022-01-20)</small>
 
-* [bitnami/influxdb] Release 3.0.2 updating components versions ([1fc82ce](https://github.com/bitnami/charts/commit/1fc82ce))
+* [bitnami/influxdb] Release 3.0.2 updating components versions ([1fc82ce](https://github.com/bitnami/charts/commit/1fc82ce1763a873590299af1ca918160d3e9be4c))
 
 ## <small>3.0.1 (2022-01-20)</small>
 
-* [bitnami/several] Change prerequisites (#8725) ([8d740c5](https://github.com/bitnami/charts/commit/8d740c5)), closes [#8725](https://github.com/bitnami/charts/issues/8725)
+* [bitnami/several] Change prerequisites (#8725) ([8d740c5](https://github.com/bitnami/charts/commit/8d740c566cfdb7e2d933c40128b4e919fce953a5)), closes [#8725](https://github.com/bitnami/charts/issues/8725)
 
 ## 3.0.0 (2022-01-19)
 
-* [bitnami/influxdb] Chart standardized (#7497) ([f73c06a](https://github.com/bitnami/charts/commit/f73c06a)), closes [#7497](https://github.com/bitnami/charts/issues/7497)
+* [bitnami/influxdb] Chart standardized (#7497) ([f73c06a](https://github.com/bitnami/charts/commit/f73c06a295b96b893e30953dc1768eca3f8b910f)), closes [#7497](https://github.com/bitnami/charts/issues/7497)
 
 ## <small>2.6.2 (2022-01-19)</small>
 
-* [bitnami/influxdb] Release 2.6.2 updating components versions ([ad4b802](https://github.com/bitnami/charts/commit/ad4b802))
+* [bitnami/influxdb] Release 2.6.2 updating components versions ([ad4b802](https://github.com/bitnami/charts/commit/ad4b802daf11d8c35f48284f69bea35442b8cea2))
 
 ## <small>2.6.1 (2022-01-18)</small>
 
-* [bitnami/*] Readme automation (#8579) ([78d1938](https://github.com/bitnami/charts/commit/78d1938)), closes [#8579](https://github.com/bitnami/charts/issues/8579)
-* [bitnami/influxdb] Release 2.6.1 updating components versions ([24a225e](https://github.com/bitnami/charts/commit/24a225e))
+* [bitnami/*] Readme automation (#8579) ([78d1938](https://github.com/bitnami/charts/commit/78d193831c900d178198491ffd08fa2217a64ecd)), closes [#8579](https://github.com/bitnami/charts/issues/8579)
+* [bitnami/influxdb] Release 2.6.1 updating components versions ([24a225e](https://github.com/bitnami/charts/commit/24a225e82724275fa15f77dc553946e9a42fd9aa))
 
 ## 2.6.0 (2022-01-12)
 
-* [bitnami/influxdb] Add aws backup upload provider (#8613) ([80f08d7](https://github.com/bitnami/charts/commit/80f08d7)), closes [#8613](https://github.com/bitnami/charts/issues/8613)
+* [bitnami/influxdb] Add aws backup upload provider (#8613) ([80f08d7](https://github.com/bitnami/charts/commit/80f08d777c43baa2160e470c592e66732e320e6c)), closes [#8613](https://github.com/bitnami/charts/issues/8613)
 
 ## <small>2.5.1 (2022-01-11)</small>
 
-* [bitnami/influxdb] Release 2.5.1 updating components versions ([7d59dcf](https://github.com/bitnami/charts/commit/7d59dcf))
+* [bitnami/influxdb] Release 2.5.1 updating components versions ([7d59dcf](https://github.com/bitnami/charts/commit/7d59dcf7af59d3eb9906c0db8093c4b2d8b71fa4))
 
 ## 2.5.0 (2022-01-05)
 
-* [bitnami/several] Adapt templating format (#8562) ([8cad18a](https://github.com/bitnami/charts/commit/8cad18a)), closes [#8562](https://github.com/bitnami/charts/issues/8562)
-* [bitnami/several] Add license to the README ([05f7633](https://github.com/bitnami/charts/commit/05f7633))
-* [bitnami/several] Add license to the README ([32fb238](https://github.com/bitnami/charts/commit/32fb238))
-* [bitnami/several] Add license to the README ([b87c2f7](https://github.com/bitnami/charts/commit/b87c2f7))
+* [bitnami/several] Adapt templating format (#8562) ([8cad18a](https://github.com/bitnami/charts/commit/8cad18aed9966a6f0208e5ad6cee46cb217f47ab)), closes [#8562](https://github.com/bitnami/charts/issues/8562)
+* [bitnami/several] Add license to the README ([05f7633](https://github.com/bitnami/charts/commit/05f763372501d596e57db713dd53ff4ff3027cc4))
+* [bitnami/several] Add license to the README ([32fb238](https://github.com/bitnami/charts/commit/32fb238e60a0affc6debd3142eaa3c3d9089ec2a))
+* [bitnami/several] Add license to the README ([b87c2f7](https://github.com/bitnami/charts/commit/b87c2f7899d48a8b02c506765e6ae82937e9ba3f))
 
 ## <small>2.4.6 (2021-12-29)</small>
 
-* [bitnami/influxdb] Release 2.4.6 updating components versions ([45ba9b2](https://github.com/bitnami/charts/commit/45ba9b2))
+* [bitnami/influxdb] Release 2.4.6 updating components versions ([45ba9b2](https://github.com/bitnami/charts/commit/45ba9b2da78be11d3b17878c51f8c56287289af5))
 
 ## <small>2.4.5 (2021-12-14)</small>
 
-* [bitnami/influxdb] Changed ownership of /bitnami/influxdb to prevent custom init script initializati ([c48d1c4](https://github.com/bitnami/charts/commit/c48d1c4)), closes [#8376](https://github.com/bitnami/charts/issues/8376)
+* [bitnami/influxdb] Changed ownership of /bitnami/influxdb to prevent custom init script initializati ([c48d1c4](https://github.com/bitnami/charts/commit/c48d1c43b941e4852abd13c47be56801b8b0b46e)), closes [#8376](https://github.com/bitnami/charts/issues/8376)
 
 ## <small>2.4.4 (2021-12-09)</small>
 
-* [bitnami/cassandra,etcd,influxdb,metallb,mysql,postgresql,postgresql-ha,redis] Align networkpolicy   ([0404b1a](https://github.com/bitnami/charts/commit/0404b1a)), closes [#8336](https://github.com/bitnami/charts/issues/8336)
-* [bitnami/several] Regenerate README tables ([8150149](https://github.com/bitnami/charts/commit/8150149))
+* [bitnami/cassandra,etcd,influxdb,metallb,mysql,postgresql,postgresql-ha,redis] Align networkpolicy   ([0404b1a](https://github.com/bitnami/charts/commit/0404b1aa52a4514eee06143a7ce85307f16af6d3)), closes [#8336](https://github.com/bitnami/charts/issues/8336)
+* [bitnami/several] Regenerate README tables ([8150149](https://github.com/bitnami/charts/commit/8150149f0bb746e86ff0029fc375d43775bdf15a))
 
 ## <small>2.4.3 (2021-11-29)</small>
 
-* [bitnami/influxdb] Fix probes (#8268) ([468a830](https://github.com/bitnami/charts/commit/468a830)), closes [#8268](https://github.com/bitnami/charts/issues/8268)
+* [bitnami/influxdb] Fix probes (#8268) ([468a830](https://github.com/bitnami/charts/commit/468a830e1e3b448daa3cff4faa47ba6bdf1e6817)), closes [#8268](https://github.com/bitnami/charts/issues/8268)
 
 ## <small>2.4.2 (2021-11-29)</small>
 
-* [bitnami/several] Regenerate README tables ([7b091c0](https://github.com/bitnami/charts/commit/7b091c0))
-* [bitnami/several] Replace HTTP by HTTPS when possible (#8259) ([eafb5bd](https://github.com/bitnami/charts/commit/eafb5bd)), closes [#8259](https://github.com/bitnami/charts/issues/8259)
+* [bitnami/several] Regenerate README tables ([7b091c0](https://github.com/bitnami/charts/commit/7b091c0808ef00425c404cb97fe73c0578ccf1a3))
+* [bitnami/several] Replace HTTP by HTTPS when possible (#8259) ([eafb5bd](https://github.com/bitnami/charts/commit/eafb5bd5a2cc3aaf04fc1e8ebedd73f420d76864)), closes [#8259](https://github.com/bitnami/charts/issues/8259)
 
 ## <small>2.4.1 (2021-11-17)</small>
 
-* [bitnami/influxdb] Release 2.4.1 updating components versions ([e365681](https://github.com/bitnami/charts/commit/e365681))
+* [bitnami/influxdb] Release 2.4.1 updating components versions ([e365681](https://github.com/bitnami/charts/commit/e365681777d9dd5edafdcf226b2ae6f9f4dc1819))
 
 ## 2.4.0 (2021-11-16)
 
-* [bitnami/influxdb] Added PSP for volume permissions in hardened cluster (#8124) ([03d1297](https://github.com/bitnami/charts/commit/03d1297)), closes [#8124](https://github.com/bitnami/charts/issues/8124)
-* [bitnami/several] Regenerate README tables ([412cf6a](https://github.com/bitnami/charts/commit/412cf6a))
+* [bitnami/influxdb] Added PSP for volume permissions in hardened cluster (#8124) ([03d1297](https://github.com/bitnami/charts/commit/03d1297fd4fae79b95034378918208f6c55dd900)), closes [#8124](https://github.com/bitnami/charts/issues/8124)
+* [bitnami/several] Regenerate README tables ([412cf6a](https://github.com/bitnami/charts/commit/412cf6a513cb0c03444a6e7811c6f27193239a10))
 
 ## <small>2.3.18 (2021-10-27)</small>
 
-* [bitnami/influxdb] Release 2.3.18 updating components versions ([c539b2b](https://github.com/bitnami/charts/commit/c539b2b))
+* [bitnami/influxdb] Release 2.3.18 updating components versions ([c539b2b](https://github.com/bitnami/charts/commit/c539b2b6e788dc8d5b432136aa020108c9bc808f))
 
 ## <small>2.3.17 (2021-10-22)</small>
 
-* [bitnami/several] Add chart info to NOTES.txt (#7889) ([a6751cd](https://github.com/bitnami/charts/commit/a6751cd)), closes [#7889](https://github.com/bitnami/charts/issues/7889)
+* [bitnami/several] Add chart info to NOTES.txt (#7889) ([a6751cd](https://github.com/bitnami/charts/commit/a6751cdd33c461fabbc459fbea6f219ec64ab6b2)), closes [#7889](https://github.com/bitnami/charts/issues/7889)
 
 ## <small>2.3.16 (2021-10-19)</small>
 
-* [bitnami/several] Change pullPolicy for bitnami-shell image (#7852) ([9711a33](https://github.com/bitnami/charts/commit/9711a33)), closes [#7852](https://github.com/bitnami/charts/issues/7852)
+* [bitnami/several] Change pullPolicy for bitnami-shell image (#7852) ([9711a33](https://github.com/bitnami/charts/commit/9711a33c6eec72ea79143c4b7574dbe6a148d6b2)), closes [#7852](https://github.com/bitnami/charts/issues/7852)
 
 ## <small>2.3.15 (2021-10-07)</small>
 
-* [bitnami/*] Fix service monitors selectors (#7720) ([1279593](https://github.com/bitnami/charts/commit/1279593)), closes [#7720](https://github.com/bitnami/charts/issues/7720)
-* [bitnami/several] Regenerate README tables ([cdcf8c1](https://github.com/bitnami/charts/commit/cdcf8c1))
+* [bitnami/*] Fix service monitors selectors (#7720) ([1279593](https://github.com/bitnami/charts/commit/1279593765044df99902bfee8dcfaeb60e95f125)), closes [#7720](https://github.com/bitnami/charts/issues/7720)
+* [bitnami/several] Regenerate README tables ([cdcf8c1](https://github.com/bitnami/charts/commit/cdcf8c1407a9a23b93fadf513be21ca1f9c7c056))
 
 ## <small>2.3.14 (2021-10-05)</small>
 
-* [bitnami/influxdb] Release 2.3.14 updating components versions ([4b0b0d4](https://github.com/bitnami/charts/commit/4b0b0d4))
-* [bitnami/several] Regenerate README tables ([7815b73](https://github.com/bitnami/charts/commit/7815b73))
+* [bitnami/influxdb] Release 2.3.14 updating components versions ([4b0b0d4](https://github.com/bitnami/charts/commit/4b0b0d4cb971421c2d4483c5187769c4fdaad7bf))
+* [bitnami/several] Regenerate README tables ([7815b73](https://github.com/bitnami/charts/commit/7815b7364052724bf1e75de96bcb0b41834e05df))
 
 ## <small>2.3.13 (2021-10-01)</small>
 
-* [bitnami/influxdb] extrahosts creates the same paths as hostname (#7654) ([0b46c43](https://github.com/bitnami/charts/commit/0b46c43)), closes [#7654](https://github.com/bitnami/charts/issues/7654) [/github.com/bitnami/charts/blob/31f75b5950840b3939c65360a781bc1d66b9e9d2/bitnami/influxdb/Chart.yaml#L27](https://github.com//github.com/bitnami/charts/blob/31f75b5950840b3939c65360a781bc1d66b9e9d2/bitnami/influxdb/Chart.yaml/issues/L27)
-* [bitnami/several] Regenerate README tables ([c3367d9](https://github.com/bitnami/charts/commit/c3367d9))
+* [bitnami/influxdb] extrahosts creates the same paths as hostname (#7654) ([0b46c43](https://github.com/bitnami/charts/commit/0b46c43c141f21eeab971db035a66be16bbb2354)), closes [#7654](https://github.com/bitnami/charts/issues/7654) [/github.com/bitnami/charts/blob/31f75b5950840b3939c65360a781bc1d66b9e9d2/bitnami/influxdb/Chart.yaml#L27](https://github.com//github.com/bitnami/charts/blob/31f75b5950840b3939c65360a781bc1d66b9e9d2/bitnami/influxdb/Chart.yaml/issues/L27)
+* [bitnami/several] Regenerate README tables ([c3367d9](https://github.com/bitnami/charts/commit/c3367d910710aece8db3ece72554597fce871ae1))
 
 ## <small>2.3.12 (2021-10-01)</small>
 
-* [bitnami/*] Drop support for deprecated cert-manager annotation (#7582) ([a081792](https://github.com/bitnami/charts/commit/a081792)), closes [#7582](https://github.com/bitnami/charts/issues/7582)
+* [bitnami/*] Drop support for deprecated cert-manager annotation (#7582) ([a081792](https://github.com/bitnami/charts/commit/a08179293543f063e5de966a9976ca967161de7b)), closes [#7582](https://github.com/bitnami/charts/issues/7582)
 
 ## <small>2.3.11 (2021-09-30)</small>
 
-* [bitnami/influxdb] Release 2.3.11 updating components versions ([3105de7](https://github.com/bitnami/charts/commit/3105de7))
-* [bitnami/several] Regenerate README tables ([ff170d1](https://github.com/bitnami/charts/commit/ff170d1))
+* [bitnami/influxdb] Release 2.3.11 updating components versions ([3105de7](https://github.com/bitnami/charts/commit/3105de7623e61ff2e3e55a15c6a2572cc024b5ad))
+* [bitnami/several] Regenerate README tables ([ff170d1](https://github.com/bitnami/charts/commit/ff170d10f8aa6dae0f1e5c3f7d1c69fcec96b731))
 
 ## <small>2.3.10 (2021-09-25)</small>
 
-* [bitnami/*] Generate READMEs with new generator version (#7614) ([e5ab2e6](https://github.com/bitnami/charts/commit/e5ab2e6)), closes [#7614](https://github.com/bitnami/charts/issues/7614)
-* [bitnami/influxdb] Release 2.3.10 updating components versions ([78fd42a](https://github.com/bitnami/charts/commit/78fd42a))
-* [bitnami/several] Regenerate README tables ([64d5d74](https://github.com/bitnami/charts/commit/64d5d74))
+* [bitnami/*] Generate READMEs with new generator version (#7614) ([e5ab2e6](https://github.com/bitnami/charts/commit/e5ab2e6ecdd6bce800863f154cda524ff9f6c117)), closes [#7614](https://github.com/bitnami/charts/issues/7614)
+* [bitnami/influxdb] Release 2.3.10 updating components versions ([78fd42a](https://github.com/bitnami/charts/commit/78fd42aa426ddf5f73e44bcdfc79c5222fbeb07c))
+* [bitnami/several] Regenerate README tables ([64d5d74](https://github.com/bitnami/charts/commit/64d5d747b84299ca9f63ea8a586b13870abe31a6))
 
 ## <small>2.3.9 (2021-08-27)</small>
 
-* [bitnami/influxdb] Fix cronjob's emptyDir indentation (#7338) ([dc89896](https://github.com/bitnami/charts/commit/dc89896)), closes [#7338](https://github.com/bitnami/charts/issues/7338)
+* [bitnami/influxdb] Fix cronjob's emptyDir indentation (#7338) ([dc89896](https://github.com/bitnami/charts/commit/dc898960869494e7cab50ad6ccd3d44a13d922df)), closes [#7338](https://github.com/bitnami/charts/issues/7338)
 
 ## <small>2.3.8 (2021-08-26)</small>
 
-* [bitnami/influxdb] Release 2.3.8 updating components versions ([da705d5](https://github.com/bitnami/charts/commit/da705d5))
-* [bitnami/several] Regenerate README tables ([da2513b](https://github.com/bitnami/charts/commit/da2513b))
+* [bitnami/influxdb] Release 2.3.8 updating components versions ([da705d5](https://github.com/bitnami/charts/commit/da705d525a1e4b58564592e465aaa53b9b0932ba))
+* [bitnami/several] Regenerate README tables ([da2513b](https://github.com/bitnami/charts/commit/da2513bf0a33819f3b1151d387c631a9ffdb03e2))
 
 ## <small>2.3.7 (2021-08-26)</small>
 
-* [bitnami/influxdb] Release 2.3.7 updating components versions ([9e4e622](https://github.com/bitnami/charts/commit/9e4e622))
-* [bitnami/several] Regenerate README tables ([6c9124f](https://github.com/bitnami/charts/commit/6c9124f))
+* [bitnami/influxdb] Release 2.3.7 updating components versions ([9e4e622](https://github.com/bitnami/charts/commit/9e4e622638aba04e32f3d590a0372ed6c3bb93a9))
+* [bitnami/several] Regenerate README tables ([6c9124f](https://github.com/bitnami/charts/commit/6c9124f79491aa65f53a87c1ed598b47ffa8b411))
 
 ## <small>2.3.6 (2021-08-13)</small>
 
-* [bitnami/influxdb] Release 2.3.6 updating components versions ([32e0b9e](https://github.com/bitnami/charts/commit/32e0b9e))
-* [bitnami/several] Regenerate README tables ([6c107e8](https://github.com/bitnami/charts/commit/6c107e8))
+* [bitnami/influxdb] Release 2.3.6 updating components versions ([32e0b9e](https://github.com/bitnami/charts/commit/32e0b9ea1206b601d22e202aa3af4f3cdc191c43))
+* [bitnami/several] Regenerate README tables ([6c107e8](https://github.com/bitnami/charts/commit/6c107e835d6caf8db2e8b17dcd48c5971637e013))
 
 ## <small>2.3.5 (2021-08-06)</small>
 
-* [bitnami/influxdb] Fix ingress path (#7141) ([d87e719](https://github.com/bitnami/charts/commit/d87e719)), closes [#7141](https://github.com/bitnami/charts/issues/7141)
+* [bitnami/influxdb] Fix ingress path (#7141) ([d87e719](https://github.com/bitnami/charts/commit/d87e719467546b4ce9b54cb14ee0ac2dd29539c9)), closes [#7141](https://github.com/bitnami/charts/issues/7141)
 
 ## <small>2.3.4 (2021-08-04)</small>
 
-* [bitnami/influxdb] Release 2.3.4 updating components versions ([bf34873](https://github.com/bitnami/charts/commit/bf34873))
+* [bitnami/influxdb] Release 2.3.4 updating components versions ([bf34873](https://github.com/bitnami/charts/commit/bf34873270dce3ae7dab0b33005abcb403d38a72))
 
 ## <small>2.3.3 (2021-07-30)</small>
 
-* [bitnami/several] Fix default values when using `foo: |` (#7092) ([fe91297](https://github.com/bitnami/charts/commit/fe91297)), closes [#7092](https://github.com/bitnami/charts/issues/7092)
+* [bitnami/several] Fix default values when using `foo: |` (#7092) ([fe91297](https://github.com/bitnami/charts/commit/fe91297fdf3f6c74aee31c423912e4ac19b55c94)), closes [#7092](https://github.com/bitnami/charts/issues/7092)
 
 ## <small>2.3.2 (2021-07-27)</small>
 
-* [bitnami/several] Bump version and update READMEs (#7069) ([6340bff](https://github.com/bitnami/charts/commit/6340bff)), closes [#7069](https://github.com/bitnami/charts/issues/7069)
+* [bitnami/several] Bump version and update READMEs (#7069) ([6340bff](https://github.com/bitnami/charts/commit/6340bff66f93c8c797bda3ca0842e4bf770059f1)), closes [#7069](https://github.com/bitnami/charts/issues/7069)
 
 ## <small>2.3.1 (2021-07-27)</small>
 
-* [bitnami/several] Fix default values and regenerate README (#7024) ([4c86733](https://github.com/bitnami/charts/commit/4c86733)), closes [#7024](https://github.com/bitnami/charts/issues/7024)
-* Replace <sup> strings with &trade; in the README files (#7066) ([d298b49](https://github.com/bitnami/charts/commit/d298b49)), closes [#7066](https://github.com/bitnami/charts/issues/7066)
+* [bitnami/several] Fix default values and regenerate README (#7024) ([4c86733](https://github.com/bitnami/charts/commit/4c867335c5c9c5aba041868df16ebb8f64ac68bd)), closes [#7024](https://github.com/bitnami/charts/issues/7024)
+* Replace <sup> strings with &trade; in the README files (#7066) ([d298b49](https://github.com/bitnami/charts/commit/d298b4996da33c9580c2594e6dc8ad665dd0ebab)), closes [#7066](https://github.com/bitnami/charts/issues/7066)
 
 ## 2.3.0 (2021-07-27)
 
-* [bitnami/several] Add diagnostic mode (#7012) ([f1344b0](https://github.com/bitnami/charts/commit/f1344b0)), closes [#7012](https://github.com/bitnami/charts/issues/7012)
+* [bitnami/several] Add diagnostic mode (#7012) ([f1344b0](https://github.com/bitnami/charts/commit/f1344b0361c5a93bf971d08f0fc64d3c8588cbf9)), closes [#7012](https://github.com/bitnami/charts/issues/7012)
 
 ## <small>2.2.14 (2021-07-22)</small>
 
-* [bitnami/influxdb] Release 2.2.14 updating components versions ([907669f](https://github.com/bitnami/charts/commit/907669f))
+* [bitnami/influxdb] Release 2.2.14 updating components versions ([907669f](https://github.com/bitnami/charts/commit/907669f327d7b320119ae87b1fad539d26860eca))
 
 ## <small>2.2.13 (2021-07-21)</small>
 
-* [bitnami/influxdb] Release 2.2.13 updating components versions ([0cb7c1a](https://github.com/bitnami/charts/commit/0cb7c1a))
+* [bitnami/influxdb] Release 2.2.13 updating components versions ([0cb7c1a](https://github.com/bitnami/charts/commit/0cb7c1a7a6fda0837fa0120cf5fc15720d19a50c))
 
 ## <small>2.2.12 (2021-07-16)</small>
 
-* [bitnami/*] Adapt values.yaml of harbor, influxdb and jasperreports charts (#6832) ([7f89370](https://github.com/bitnami/charts/commit/7f89370)), closes [#6832](https://github.com/bitnami/charts/issues/6832)
+* [bitnami/*] Adapt values.yaml of harbor, influxdb and jasperreports charts (#6832) ([7f89370](https://github.com/bitnami/charts/commit/7f893700445e6abf8bcf1c7d5b824196f3df359b)), closes [#6832](https://github.com/bitnami/charts/issues/6832)
 
 ## <small>2.2.11 (2021-07-02)</small>
 
-* [bitnami/influxdb] Fix indentation generating backup cronjob (#6817) ([eaf4749](https://github.com/bitnami/charts/commit/eaf4749)), closes [#6817](https://github.com/bitnami/charts/issues/6817)
+* [bitnami/influxdb] Fix indentation generating backup cronjob (#6817) ([eaf4749](https://github.com/bitnami/charts/commit/eaf474947cca6fb455249aad80714a7bf8293956)), closes [#6817](https://github.com/bitnami/charts/issues/6817)
 
 ## <small>2.2.10 (2021-06-29)</small>
 
-* [bitnami/influxdb] - add nodeSelector, affinity and tolerations to the backup container(s) (#6778) ([3baa4dd](https://github.com/bitnami/charts/commit/3baa4dd)), closes [#6778](https://github.com/bitnami/charts/issues/6778) [#6765](https://github.com/bitnami/charts/issues/6765)
+* [bitnami/influxdb] - add nodeSelector, affinity and tolerations to the backup container(s) (#6778) ([3baa4dd](https://github.com/bitnami/charts/commit/3baa4ddf90906335ea6253d5cd02a3a8774e5773)), closes [#6778](https://github.com/bitnami/charts/issues/6778) [#6765](https://github.com/bitnami/charts/issues/6765)
 
 ## <small>2.2.9 (2021-06-25)</small>
 
-* Add commonLabels to pod spec (#6759) ([c7448d8](https://github.com/bitnami/charts/commit/c7448d8)), closes [#6759](https://github.com/bitnami/charts/issues/6759)
+* Add commonLabels to pod spec (#6759) ([c7448d8](https://github.com/bitnami/charts/commit/c7448d86e552029d53b5094a7c8b5cd18ab8020d)), closes [#6759](https://github.com/bitnami/charts/issues/6759)
 
 ## <small>2.2.8 (2021-06-21)</small>
 
-* [bitnami/influxdb] Release 2.2.8 updating components versions ([7727ba2](https://github.com/bitnami/charts/commit/7727ba2))
+* [bitnami/influxdb] Release 2.2.8 updating components versions ([7727ba2](https://github.com/bitnami/charts/commit/7727ba281ff889957f26aabfd8187c7629e18b75))
 
 ## <small>2.2.7 (2021-06-19)</small>
 
-* [bitnami/influxdb] Release 2.2.7 updating components versions ([2d5dc18](https://github.com/bitnami/charts/commit/2d5dc18))
+* [bitnami/influxdb] Release 2.2.7 updating components versions ([2d5dc18](https://github.com/bitnami/charts/commit/2d5dc18fe5bb44898fd029ec4e61181fd5ef3b38))
 
 ## <small>2.2.6 (2021-05-28)</small>
 
-* [bitnami/influxdb] Release 2.2.6 updating components versions ([34bc3b6](https://github.com/bitnami/charts/commit/34bc3b6))
+* [bitnami/influxdb] Release 2.2.6 updating components versions ([34bc3b6](https://github.com/bitnami/charts/commit/34bc3b6628f01b1d113a03f3cf048a8a0fea1bf1))
 
 ## <small>2.2.5 (2021-05-24)</small>
 
-* [bitnami/influxdb] Release 2.2.5 updating components versions ([fb5364a](https://github.com/bitnami/charts/commit/fb5364a))
+* [bitnami/influxdb] Release 2.2.5 updating components versions ([fb5364a](https://github.com/bitnami/charts/commit/fb5364ab7d305f865b0969d8c7655d09828bc21e))
 
 ## <small>2.2.4 (2021-05-23)</small>
 
-* [bitnami/influxdb] Release 2.2.4 updating components versions ([e21392e](https://github.com/bitnami/charts/commit/e21392e))
+* [bitnami/influxdb] Release 2.2.4 updating components versions ([e21392e](https://github.com/bitnami/charts/commit/e21392ea737201b2f0d531cbf358f63cbeb91409))
 
 ## <small>2.2.3 (2021-05-19)</small>
 
-* [bitnami/influxdb] Fix Backup (influxdb-backup-dummy-container) (#6404) ([1e8e275](https://github.com/bitnami/charts/commit/1e8e275)), closes [#6404](https://github.com/bitnami/charts/issues/6404)
+* [bitnami/influxdb] Fix Backup (influxdb-backup-dummy-container) (#6404) ([1e8e275](https://github.com/bitnami/charts/commit/1e8e275b85abfc1f64c35053bdd18883eef75945)), closes [#6404](https://github.com/bitnami/charts/issues/6404)
 
 ## <small>2.2.2 (2021-04-29)</small>
 
-* [bitnami/influxdb] Release 2.2.2 updating components versions ([e8a21d0](https://github.com/bitnami/charts/commit/e8a21d0))
-* Update README.md (#6230) ([a561b11](https://github.com/bitnami/charts/commit/a561b11)), closes [#6230](https://github.com/bitnami/charts/issues/6230)
+* [bitnami/influxdb] Release 2.2.2 updating components versions ([e8a21d0](https://github.com/bitnami/charts/commit/e8a21d0b2daef6d4846bf1511ac225fe85707fe1))
+* Update README.md (#6230) ([a561b11](https://github.com/bitnami/charts/commit/a561b11f6abe3c64a3b9defddb5e73da3bcf5a14)), closes [#6230](https://github.com/bitnami/charts/issues/6230)
 
 ## <small>2.2.1 (2021-04-21)</small>
 
-* [bitnami/influxdb] Release 2.2.1 updating components versions ([419e439](https://github.com/bitnami/charts/commit/419e439))
+* [bitnami/influxdb] Release 2.2.1 updating components versions ([419e439](https://github.com/bitnami/charts/commit/419e439660530630132b99ceac05b6029a2024fd))
 
 ## 2.2.0 (2021-03-25)
 
-* [bitnami/influxdb] Add sessionaffinity capability (#5900) ([452e5e9](https://github.com/bitnami/charts/commit/452e5e9)), closes [#5900](https://github.com/bitnami/charts/issues/5900)
+* [bitnami/influxdb] Add sessionaffinity capability (#5900) ([452e5e9](https://github.com/bitnami/charts/commit/452e5e94661beaf255a25c2783c394b91fbe737a)), closes [#5900](https://github.com/bitnami/charts/issues/5900)
 
 ## 2.1.0 (2021-03-22)
 
-* bitnami/influxdb: Adding collectd listener option (#5851) ([7dc3f29](https://github.com/bitnami/charts/commit/7dc3f29)), closes [#5851](https://github.com/bitnami/charts/issues/5851)
+* bitnami/influxdb: Adding collectd listener option (#5851) ([7dc3f29](https://github.com/bitnami/charts/commit/7dc3f29d7abfeabcb614af63e03e923a6dfa5bc4)), closes [#5851](https://github.com/bitnami/charts/issues/5851)
 
 ## <small>2.0.6 (2021-03-16)</small>
 
-* [bitnami/influxdb] Release 2.0.6 updating components versions ([74f8cbd](https://github.com/bitnami/charts/commit/74f8cbd))
+* [bitnami/influxdb] Release 2.0.6 updating components versions ([74f8cbd](https://github.com/bitnami/charts/commit/74f8cbd3ac13487039d4dd1e46cfb3a0ae8bc5c0))
 
 ## <small>2.0.5 (2021-03-08)</small>
 
-* [bitnami/influxdb] Fix typo in ingress.yaml (#5703) ([d22e787](https://github.com/bitnami/charts/commit/d22e787)), closes [#5703](https://github.com/bitnami/charts/issues/5703)
+* [bitnami/influxdb] Fix typo in ingress.yaml (#5703) ([d22e787](https://github.com/bitnami/charts/commit/d22e787700b53417b8acf41f44ca9b119edd5d29)), closes [#5703](https://github.com/bitnami/charts/issues/5703)
 
 ## <small>2.0.4 (2021-03-04)</small>
 
-* [bitnami/*] Remove minideb mentions (#5677) ([870bc4d](https://github.com/bitnami/charts/commit/870bc4d)), closes [#5677](https://github.com/bitnami/charts/issues/5677)
+* [bitnami/*] Remove minideb mentions (#5677) ([870bc4d](https://github.com/bitnami/charts/commit/870bc4dba1fc3aa55dd157da6687b25e8d352206)), closes [#5677](https://github.com/bitnami/charts/issues/5677)
 
 ## <small>2.0.3 (2021-02-14)</small>
 
-* [bitnami/*] Add notice regarding parameters immutability after chart installation (#4853) ([5f09573](https://github.com/bitnami/charts/commit/5f09573)), closes [#4853](https://github.com/bitnami/charts/issues/4853)
-* [bitnami/influxdb] Release 2.0.3 updating components versions ([16b0448](https://github.com/bitnami/charts/commit/16b0448))
-* [bitnami/several] Monthly trademark review (#5375) ([307a73d](https://github.com/bitnami/charts/commit/307a73d)), closes [#5375](https://github.com/bitnami/charts/issues/5375)
+* [bitnami/*] Add notice regarding parameters immutability after chart installation (#4853) ([5f09573](https://github.com/bitnami/charts/commit/5f095734f92555dec7cd0e3ee961f315eac170ff)), closes [#4853](https://github.com/bitnami/charts/issues/4853)
+* [bitnami/influxdb] Release 2.0.3 updating components versions ([16b0448](https://github.com/bitnami/charts/commit/16b0448fe29543c7892cedddfb3591f339b22485))
+* [bitnami/several] Monthly trademark review (#5375) ([307a73d](https://github.com/bitnami/charts/commit/307a73dcca857e4b567113113142c68b6eaf85e0)), closes [#5375](https://github.com/bitnami/charts/issues/5375)
 
 ## <small>2.0.2 (2021-02-01)</small>
 
-* [bitnami/influxdb] fix: add check for auth.admin.token when upgrade (#5356) ([3981afa](https://github.com/bitnami/charts/commit/3981afa)), closes [#5356](https://github.com/bitnami/charts/issues/5356)
+* [bitnami/influxdb] fix: add check for auth.admin.token when upgrade (#5356) ([3981afa](https://github.com/bitnami/charts/commit/3981afa5f19a79abbecb40060b5fbe69412a65f1)), closes [#5356](https://github.com/bitnami/charts/issues/5356)
 
 ## <small>2.0.1 (2021-01-29)</small>
 
-* [bitnami/influxdb] Release 2.0.1 updating components versions ([2187bb4](https://github.com/bitnami/charts/commit/2187bb4))
+* [bitnami/influxdb] Release 2.0.1 updating components versions ([2187bb4](https://github.com/bitnami/charts/commit/2187bb4c34591c0a24228c542a9f9400a43b174c))
 
 ## 2.0.0 (2021-01-28)
 
-* [bitnami/influxdb] MAJOR: adapt the chart to use InfluxDB 2.0 (#5097) ([8d1f38a](https://github.com/bitnami/charts/commit/8d1f38a)), closes [#5097](https://github.com/bitnami/charts/issues/5097)
+* [bitnami/influxdb] MAJOR: adapt the chart to use InfluxDB 2.0 (#5097) ([8d1f38a](https://github.com/bitnami/charts/commit/8d1f38aa8d72864db6c3557083575139555259fe)), closes [#5097](https://github.com/bitnami/charts/issues/5097)
 
 ## <small>1.1.9 (2021-01-19)</small>
 
-* [bitnami/*] Change helm version in the prerequisites (#5090) ([c5e67a3](https://github.com/bitnami/charts/commit/c5e67a3)), closes [#5090](https://github.com/bitnami/charts/issues/5090)
-* [bitnami/influxdb] Drop values-production.yaml support (#5108) ([67be850](https://github.com/bitnami/charts/commit/67be850)), closes [#5108](https://github.com/bitnami/charts/issues/5108)
+* [bitnami/*] Change helm version in the prerequisites (#5090) ([c5e67a3](https://github.com/bitnami/charts/commit/c5e67a388743cbee28439d2cabca27884b9daf97)), closes [#5090](https://github.com/bitnami/charts/issues/5090)
+* [bitnami/influxdb] Drop values-production.yaml support (#5108) ([67be850](https://github.com/bitnami/charts/commit/67be85057198bcdf4a17fdbd067018a7cbb7b7c4)), closes [#5108](https://github.com/bitnami/charts/issues/5108)
 
 ## <small>1.1.8 (2021-01-10)</small>
 
-* [bitnami/influxdb] Release 1.1.8 updating components versions ([3f2b19a](https://github.com/bitnami/charts/commit/3f2b19a))
+* [bitnami/influxdb] Release 1.1.8 updating components versions ([3f2b19a](https://github.com/bitnami/charts/commit/3f2b19ad2743d28828b5c217b2b682e0db57be75))
 
 ## <small>1.1.7 (2021-01-07)</small>
 
-* [bitnami/influxdb] Add trademark in non-readme files and unify format (#4903) ([211cd1d](https://github.com/bitnami/charts/commit/211cd1d)), closes [#4903](https://github.com/bitnami/charts/issues/4903)
+* [bitnami/influxdb] Add trademark in non-readme files and unify format (#4903) ([211cd1d](https://github.com/bitnami/charts/commit/211cd1d747ebd329e2b266ba4cc8ae92c8cee01b)), closes [#4903](https://github.com/bitnami/charts/issues/4903)
 
 ## <small>1.1.6 (2020-12-22)</small>
 
-* [bitnami/influxdb] Fixes relay command influxdb (#4817) ([84213fa](https://github.com/bitnami/charts/commit/84213fa)), closes [#4817](https://github.com/bitnami/charts/issues/4817)
+* [bitnami/influxdb] Fixes relay command influxdb (#4817) ([84213fa](https://github.com/bitnami/charts/commit/84213fabb2d534c3adfbfe361dae19723b118932)), closes [#4817](https://github.com/bitnami/charts/issues/4817)
 
 ## <small>1.1.5 (2020-12-18)</small>
 
-* [bitnami/*] fix typos (#4699) ([49adc63](https://github.com/bitnami/charts/commit/49adc63)), closes [#4699](https://github.com/bitnami/charts/issues/4699)
-* [bitnami/influxdb] Re-order ingress rules to be compatible with ALB ingress controller (#4771) ([49d3a2c](https://github.com/bitnami/charts/commit/49d3a2c)), closes [#4771](https://github.com/bitnami/charts/issues/4771)
+* [bitnami/*] fix typos (#4699) ([49adc63](https://github.com/bitnami/charts/commit/49adc63b672da976c55af2e077aa5648a357b77f)), closes [#4699](https://github.com/bitnami/charts/issues/4699)
+* [bitnami/influxdb] Re-order ingress rules to be compatible with ALB ingress controller (#4771) ([49d3a2c](https://github.com/bitnami/charts/commit/49d3a2c055f191751e508c5ff99127998091bb28)), closes [#4771](https://github.com/bitnami/charts/issues/4771)
 
 ## <small>1.1.4 (2020-12-11)</small>
 
-* [bitnami/*] Update dependencies (#4694) ([2826c12](https://github.com/bitnami/charts/commit/2826c12)), closes [#4694](https://github.com/bitnami/charts/issues/4694)
+* [bitnami/*] Update dependencies (#4694) ([2826c12](https://github.com/bitnami/charts/commit/2826c125b42505f28431301e3c1bbe5366e47a01)), closes [#4694](https://github.com/bitnami/charts/issues/4694)
 
 ## <small>1.1.3 (2020-12-11)</small>
 
-* [bitnami/influxdb] Release 1.1.3 updating components versions ([163c4c0](https://github.com/bitnami/charts/commit/163c4c0))
+* [bitnami/influxdb] Release 1.1.3 updating components versions ([163c4c0](https://github.com/bitnami/charts/commit/163c4c052c2cab37e999fbb5e3b2fc0caa1315bf))
 
 ## <small>1.1.2 (2020-12-07)</small>
 
-* [bitnami/influxdb] Fixes and cosmetics (#4620) ([fcf680b](https://github.com/bitnami/charts/commit/fcf680b)), closes [#4620](https://github.com/bitnami/charts/issues/4620)
+* [bitnami/influxdb] Fixes and cosmetics (#4620) ([fcf680b](https://github.com/bitnami/charts/commit/fcf680b003e2844709e4766c3de8154068061769)), closes [#4620](https://github.com/bitnami/charts/issues/4620)
 
 ## <small>1.1.1 (2020-12-03)</small>
 
-* [bitnami/influxdb] Fix affinity template function call (#4579) ([8de2e56](https://github.com/bitnami/charts/commit/8de2e56)), closes [#4579](https://github.com/bitnami/charts/issues/4579)
+* [bitnami/influxdb] Fix affinity template function call (#4579) ([8de2e56](https://github.com/bitnami/charts/commit/8de2e56c9d6f305e81180748a0b1388ff62dd225)), closes [#4579](https://github.com/bitnami/charts/issues/4579)
 
 ## 1.1.0 (2020-11-25)
 
-* [bitnami/*] Affinity based on common presets (ii) (#4472) ([934259f](https://github.com/bitnami/charts/commit/934259f)), closes [#4472](https://github.com/bitnami/charts/issues/4472)
+* [bitnami/*] Affinity based on common presets (ii) (#4472) ([934259f](https://github.com/bitnami/charts/commit/934259f78127c53c747dfff5e5df9f67738ec79c)), closes [#4472](https://github.com/bitnami/charts/issues/4472)
 
 ## 1.0.0 (2020-11-11)
 
-* [bitnami/influxdb] Major version. Adapt Chart to apiVersion: v2 (#4281) ([e1769b3](https://github.com/bitnami/charts/commit/e1769b3)), closes [#4281](https://github.com/bitnami/charts/issues/4281)
+* [bitnami/influxdb] Major version. Adapt Chart to apiVersion: v2 (#4281) ([e1769b3](https://github.com/bitnami/charts/commit/e1769b36a7f3998191dd804021b5204b1e1c1364)), closes [#4281](https://github.com/bitnami/charts/issues/4281)
 
 ## <small>0.6.11 (2020-10-31)</small>
 
-* [bitnami/*] Include link to Troubleshootin guide on README.md (#4136) ([c08a20e](https://github.com/bitnami/charts/commit/c08a20e)), closes [#4136](https://github.com/bitnami/charts/issues/4136)
-* [bitnami/influxdb] Release 0.6.11 updating components versions ([56ba499](https://github.com/bitnami/charts/commit/56ba499))
+* [bitnami/*] Include link to Troubleshootin guide on README.md (#4136) ([c08a20e](https://github.com/bitnami/charts/commit/c08a20e3db004215383004ff023a73fcc2522e72)), closes [#4136](https://github.com/bitnami/charts/issues/4136)
+* [bitnami/influxdb] Release 0.6.11 updating components versions ([56ba499](https://github.com/bitnami/charts/commit/56ba499f7b1e24d65dd7830be8485a337449335a))
 
 ## <small>0.6.10 (2020-10-27)</small>
 
-* [bitnami/influxdb] Set proper ingress apiVersion (#4097) ([99a01fc](https://github.com/bitnami/charts/commit/99a01fc)), closes [#4097](https://github.com/bitnami/charts/issues/4097)
+* [bitnami/influxdb] Set proper ingress apiVersion (#4097) ([99a01fc](https://github.com/bitnami/charts/commit/99a01fcb1e101a2c98047cf9393cbfec60e6389a)), closes [#4097](https://github.com/bitnami/charts/issues/4097)
 
 ## <small>0.6.9 (2020-10-06)</small>
 
-* bitnami/influxdb not starting chown: missing operand after #3863 (#3903) ([661c0db](https://github.com/bitnami/charts/commit/661c0db)), closes [#3863](https://github.com/bitnami/charts/issues/3863) [#3903](https://github.com/bitnami/charts/issues/3903) [#3863](https://github.com/bitnami/charts/issues/3863) [#3863](https://github.com/bitnami/charts/issues/3863)
+* bitnami/influxdb not starting chown: missing operand after #3863 (#3903) ([661c0db](https://github.com/bitnami/charts/commit/661c0db7a0a8c09ff6d0c0ba6a9c7766da95670e)), closes [#3863](https://github.com/bitnami/charts/issues/3863) [#3903](https://github.com/bitnami/charts/issues/3903) [#3863](https://github.com/bitnami/charts/issues/3863) [#3863](https://github.com/bitnami/charts/issues/3863)
 
 ## <small>0.6.8 (2020-10-01)</small>
 
-* [bitnami/influxdb] Release 0.6.8 updating components versions ([92b4efa](https://github.com/bitnami/charts/commit/92b4efa))
+* [bitnami/influxdb] Release 0.6.8 updating components versions ([92b4efa](https://github.com/bitnami/charts/commit/92b4efa46bc295422cdf7f41785c137e293fada4))
 
 ## <small>0.6.7 (2020-09-21)</small>
 
-* [bitnami/influxdb] Release 0.6.7 updating components versions ([bc6eb11](https://github.com/bitnami/charts/commit/bc6eb11))
+* [bitnami/influxdb] Release 0.6.7 updating components versions ([bc6eb11](https://github.com/bitnami/charts/commit/bc6eb11ca56d6913dd2e9495ff15dd18573500e3))
 
 ## <small>0.6.6 (2020-09-04)</small>
 
-* [bitnami/influxdb] Release 0.6.6 updating components versions ([4fb90d9](https://github.com/bitnami/charts/commit/4fb90d9))
-* [bitnami/metrics-server] Add source repo (#3577) ([1ed12f9](https://github.com/bitnami/charts/commit/1ed12f9)), closes [#3577](https://github.com/bitnami/charts/issues/3577)
+* [bitnami/influxdb] Release 0.6.6 updating components versions ([4fb90d9](https://github.com/bitnami/charts/commit/4fb90d9cb717a072918a20874a517df37f2612d0))
+* [bitnami/metrics-server] Add source repo (#3577) ([1ed12f9](https://github.com/bitnami/charts/commit/1ed12f96af75322b46afdb2b3d9907c11b13f765)), closes [#3577](https://github.com/bitnami/charts/issues/3577)
 
 ## <small>0.6.5 (2020-08-07)</small>
 
-* [bitnami/influxdb] Fix indentation for ServiceMonitor namespaceSelector (#3355) ([ded57e2](https://github.com/bitnami/charts/commit/ded57e2)), closes [#3355](https://github.com/bitnami/charts/issues/3355)
+* [bitnami/influxdb] Fix indentation for ServiceMonitor namespaceSelector (#3355) ([ded57e2](https://github.com/bitnami/charts/commit/ded57e24c85965578208e8462908b94122d96bc5)), closes [#3355](https://github.com/bitnami/charts/issues/3355)
 
 ## <small>0.6.4 (2020-08-05)</small>
 
-* [bitnami/*] Fix TL;DR typo in READMEs (#3280) ([3d7ab40](https://github.com/bitnami/charts/commit/3d7ab40)), closes [#3280](https://github.com/bitnami/charts/issues/3280)
-* [bitnami/influxdb] Release 0.6.4 updating components versions ([b6c7cba](https://github.com/bitnami/charts/commit/b6c7cba))
+* [bitnami/*] Fix TL;DR typo in READMEs (#3280) ([3d7ab40](https://github.com/bitnami/charts/commit/3d7ab406fecd64f1af25f53e7d27f03ec95b29a4)), closes [#3280](https://github.com/bitnami/charts/issues/3280)
+* [bitnami/influxdb] Release 0.6.4 updating components versions ([b6c7cba](https://github.com/bitnami/charts/commit/b6c7cba10b8c53c0b591a1cefda236e7afa9b9be))
 
 ## <small>0.6.3 (2020-07-29)</small>
 
-* [bitnami/influxdb] Remove duplicated volume declaration when using existingClaim (#3145) ([cab37bb](https://github.com/bitnami/charts/commit/cab37bb)), closes [#3145](https://github.com/bitnami/charts/issues/3145)
-* Fix podAnnotations in cronjob (#3254) ([4aeed91](https://github.com/bitnami/charts/commit/4aeed91)), closes [#3254](https://github.com/bitnami/charts/issues/3254)
+* [bitnami/influxdb] Remove duplicated volume declaration when using existingClaim (#3145) ([cab37bb](https://github.com/bitnami/charts/commit/cab37bb32235f0a74c0ef7f7dbe5a7a7425ee3fe)), closes [#3145](https://github.com/bitnami/charts/issues/3145)
+* Fix podAnnotations in cronjob (#3254) ([4aeed91](https://github.com/bitnami/charts/commit/4aeed91a43cadce6b15bee96a816629b3ae5a49e)), closes [#3254](https://github.com/bitnami/charts/issues/3254)
 
 ## <small>0.6.2 (2020-07-17)</small>
 
-* [bitnami/influxdb] Release 0.6.2 updating components versions ([9d94737](https://github.com/bitnami/charts/commit/9d94737))
+* [bitnami/influxdb] Release 0.6.2 updating components versions ([9d94737](https://github.com/bitnami/charts/commit/9d947371af26b0bbd95853af9aaf0731c59c31ce))
 
 ## <small>0.6.1 (2020-07-17)</small>
 
-* [bitnami/influxdb] Fix podManagementPolicy value name (#3143) ([c11db37](https://github.com/bitnami/charts/commit/c11db37)), closes [#3143](https://github.com/bitnami/charts/issues/3143)
+* [bitnami/influxdb] Fix podManagementPolicy value name (#3143) ([c11db37](https://github.com/bitnami/charts/commit/c11db37c6563cd4ce009be4af1cacffbfb2711df)), closes [#3143](https://github.com/bitnami/charts/issues/3143)
 
 ## 0.6.0 (2020-07-17)
 
-* [bitnami/influxdb] Add Pod Management Policy in StatefulSet + Docs (#3142) ([7491db3](https://github.com/bitnami/charts/commit/7491db3)), closes [#3142](https://github.com/bitnami/charts/issues/3142)
+* [bitnami/influxdb] Add Pod Management Policy in StatefulSet + Docs (#3142) ([7491db3](https://github.com/bitnami/charts/commit/7491db3060d32eaa13e4fa85940d5a1b17ddb35a)), closes [#3142](https://github.com/bitnami/charts/issues/3142)
 
 ## <small>0.5.4 (2020-07-13)</small>
 
-* [bitnami/all] Add categories (#3075) ([63bde06](https://github.com/bitnami/charts/commit/63bde06)), closes [#3075](https://github.com/bitnami/charts/issues/3075)
-* [bitnami/influxdb] Release 0.5.4 updating components versions ([e1a2de1](https://github.com/bitnami/charts/commit/e1a2de1))
+* [bitnami/all] Add categories (#3075) ([63bde06](https://github.com/bitnami/charts/commit/63bde066b87a140fab52264d0522401ab3d63509)), closes [#3075](https://github.com/bitnami/charts/issues/3075)
+* [bitnami/influxdb] Release 0.5.4 updating components versions ([e1a2de1](https://github.com/bitnami/charts/commit/e1a2de1ab0902d8eb94968c213b4af79984ac935))
 
 ## <small>0.5.3 (2020-06-18)</small>
 
-* [bitnami/influxdb] Release 0.5.3 updating components versions ([5916f78](https://github.com/bitnami/charts/commit/5916f78))
+* [bitnami/influxdb] Release 0.5.3 updating components versions ([5916f78](https://github.com/bitnami/charts/commit/5916f788da9cfa187110eb7dc92f102640178747))
 
 ## <small>0.5.2 (2020-06-17)</small>
 
-* [bitnami/influxdb] Release 0.5.2 updating components versions ([6ef7bcd](https://github.com/bitnami/charts/commit/6ef7bcd))
+* [bitnami/influxdb] Release 0.5.2 updating components versions ([6ef7bcd](https://github.com/bitnami/charts/commit/6ef7bcde81395854bf408d04f065ce93931d8cd8))
 
 ## <small>0.5.1 (2020-06-03)</small>
 
-* [bitnami/influxdb] Add trademark information to InfluxDB (#2739) ([6614e3f](https://github.com/bitnami/charts/commit/6614e3f)), closes [#2739](https://github.com/bitnami/charts/issues/2739)
+* [bitnami/influxdb] Add trademark information to InfluxDB (#2739) ([6614e3f](https://github.com/bitnami/charts/commit/6614e3f1946b225383af2482a751eeee00cea307)), closes [#2739](https://github.com/bitnami/charts/issues/2739)
 
 ## 0.5.0 (2020-06-01)
 
-* [bitnami/influxdb] make more flexible when using volumePermissions (#2417) ([9a8c169](https://github.com/bitnami/charts/commit/9a8c169)), closes [#2417](https://github.com/bitnami/charts/issues/2417)
-* [bitnami/several] Fix trailing spaces to make helm lint work on all of them (#2705) ([bafba3f](https://github.com/bitnami/charts/commit/bafba3f)), closes [#2705](https://github.com/bitnami/charts/issues/2705)
+* [bitnami/influxdb] make more flexible when using volumePermissions (#2417) ([9a8c169](https://github.com/bitnami/charts/commit/9a8c169e19685f739e3708a2453a72f033ddb823)), closes [#2417](https://github.com/bitnami/charts/issues/2417)
+* [bitnami/several] Fix trailing spaces to make helm lint work on all of them (#2705) ([bafba3f](https://github.com/bitnami/charts/commit/bafba3fc8b8949897ad2d99d437bd8fc975223e4)), closes [#2705](https://github.com/bitnami/charts/issues/2705)
 
 ## <small>0.4.8 (2020-05-22)</small>
 
-* [bitnami/influxdb] Release 0.4.8 updating components versions ([10a6b6c](https://github.com/bitnami/charts/commit/10a6b6c))
-* update bitnami/common to be compatible with helm v2.12+ (#2615) ([c7751eb](https://github.com/bitnami/charts/commit/c7751eb)), closes [#2615](https://github.com/bitnami/charts/issues/2615)
+* [bitnami/influxdb] Release 0.4.8 updating components versions ([10a6b6c](https://github.com/bitnami/charts/commit/10a6b6c11c74b7ca0e468e72832ef10f67a8a9a4))
+* update bitnami/common to be compatible with helm v2.12+ (#2615) ([c7751eb](https://github.com/bitnami/charts/commit/c7751eb5764e468e1854b58a1b8491d2b13e0a4a)), closes [#2615](https://github.com/bitnami/charts/issues/2615)
 
 ## <small>0.4.7 (2020-04-22)</small>
 
-* [bitnami/influxdb] Release 0.4.7 updating components versions ([e0d5d83](https://github.com/bitnami/charts/commit/e0d5d83))
+* [bitnami/influxdb] Release 0.4.7 updating components versions ([e0d5d83](https://github.com/bitnami/charts/commit/e0d5d839c3427436c693bbb43224516544d2c6a1))
 
 ## <small>0.4.6 (2020-04-16)</small>
 
-* [bitnami/influxdb] .Values.initdbScripts does not exist and doesn't create the Config Map properly ( ([94d2891](https://github.com/bitnami/charts/commit/94d2891)), closes [#2270](https://github.com/bitnami/charts/issues/2270)
-* [bitnami/influxdb] Release 0.4.6 updating components versions ([cb40e83](https://github.com/bitnami/charts/commit/cb40e83))
+* [bitnami/influxdb] .Values.initdbScripts does not exist and doesn't create the Config Map properly ( ([94d2891](https://github.com/bitnami/charts/commit/94d2891793b0133ac5968a871beead0f1e048a00)), closes [#2270](https://github.com/bitnami/charts/issues/2270)
+* [bitnami/influxdb] Release 0.4.6 updating components versions ([cb40e83](https://github.com/bitnami/charts/commit/cb40e8374c998291689e83e4e267ce304a7ae847))
 
 ## <small>0.4.5 (2020-04-12)</small>
 
-* [bitnami/influxdb] Release 0.4.5 updating components versions ([310d4aa](https://github.com/bitnami/charts/commit/310d4aa))
+* [bitnami/influxdb] Release 0.4.5 updating components versions ([310d4aa](https://github.com/bitnami/charts/commit/310d4aa78e1c24f0be2e5b04deb8e18ad8fa83f5))
 
 ## <small>0.4.4 (2020-04-07)</small>
 
-* Indluxdb init container (#2206) ([1db1712](https://github.com/bitnami/charts/commit/1db1712)), closes [#2206](https://github.com/bitnami/charts/issues/2206)
+* Indluxdb init container (#2206) ([1db1712](https://github.com/bitnami/charts/commit/1db1712baa5f6e08e7a3f28cf8b28d4352302a4c)), closes [#2206](https://github.com/bitnami/charts/issues/2206)
 
 ## <small>0.4.3 (2020-03-26)</small>
 
-* [bitnami/influxdb] Release 0.4.3 updating components versions ([ff5825e](https://github.com/bitnami/charts/commit/ff5825e))
+* [bitnami/influxdb] Release 0.4.3 updating components versions ([ff5825e](https://github.com/bitnami/charts/commit/ff5825e9d6a630f9ecce7389fb47ff6ad830f512))
 
 ## <small>0.4.2 (2020-03-24)</small>
 
-* [bitnami/influxdb] Release 0.4.2 updating components versions ([027bae0](https://github.com/bitnami/charts/commit/027bae0))
+* [bitnami/influxdb] Release 0.4.2 updating components versions ([027bae0](https://github.com/bitnami/charts/commit/027bae0b03eb3faf0e20233fa2247c2d6c05985a))
 
 ## <small>0.4.1 (2020-03-19)</small>
 
-* [bitnami/influxdb] Release 0.4.1 updating components versions ([89e914e](https://github.com/bitnami/charts/commit/89e914e))
+* [bitnami/influxdb] Release 0.4.1 updating components versions ([89e914e](https://github.com/bitnami/charts/commit/89e914ee8e843180cb7fc58861914a01464d4a92))
 
 ## 0.4.0 (2020-03-18)
 
-* [bitnami/influxdb] added backup funtion & some refactoring (#1962) ([47162ee](https://github.com/bitnami/charts/commit/47162ee)), closes [#1962](https://github.com/bitnami/charts/issues/1962)
-* Bump chart version. Follow-up of #1962 (#2082) ([2c39122](https://github.com/bitnami/charts/commit/2c39122)), closes [#1962](https://github.com/bitnami/charts/issues/1962) [#2082](https://github.com/bitnami/charts/issues/2082) [#1962](https://github.com/bitnami/charts/issues/1962)
+* [bitnami/influxdb] added backup funtion & some refactoring (#1962) ([47162ee](https://github.com/bitnami/charts/commit/47162eea9388033b62096cdae468415b48e9278b)), closes [#1962](https://github.com/bitnami/charts/issues/1962)
+* Bump chart version. Follow-up of #1962 (#2082) ([2c39122](https://github.com/bitnami/charts/commit/2c39122e56ab4535d7550a1cdada23405bc4d312)), closes [#1962](https://github.com/bitnami/charts/issues/1962) [#2082](https://github.com/bitnami/charts/issues/2082) [#1962](https://github.com/bitnami/charts/issues/1962)
 
 ## <small>0.3.9 (2020-03-12)</small>
 
-* [bitnami/influxdb] Release 0.3.9 updating components versions ([946b7ca](https://github.com/bitnami/charts/commit/946b7ca))
+* [bitnami/influxdb] Release 0.3.9 updating components versions ([946b7ca](https://github.com/bitnami/charts/commit/946b7cacf7350d844fb5350669930a4ecaeeeee9))
 
 ## <small>0.3.8 (2020-03-11)</small>
 
-* Move charts from upstreamed folder to bitnami (#2032) ([a0e44f7](https://github.com/bitnami/charts/commit/a0e44f7)), closes [#2032](https://github.com/bitnami/charts/issues/2032)
+* Move charts from upstreamed folder to bitnami (#2032) ([a0e44f7](https://github.com/bitnami/charts/commit/a0e44f7d6a10b8b5643186130ea420887cb72c7c)), closes [#2032](https://github.com/bitnami/charts/issues/2032)
 
 ## <small>0.3.7 (2020-02-26)</small>
 
-* [bitnami/influxdb] Release 0.3.7 updating components versions ([15ce4c5](https://github.com/bitnami/charts/commit/15ce4c5))
-* [bitnami/several] Adapt READMEs and helpers to Helm 3 (#1911) ([40ee57c](https://github.com/bitnami/charts/commit/40ee57c)), closes [#1911](https://github.com/bitnami/charts/issues/1911)
+* [bitnami/influxdb] Release 0.3.7 updating components versions ([15ce4c5](https://github.com/bitnami/charts/commit/15ce4c546384468dfc84be0a387deb2f4dde39a7))
+* [bitnami/several] Adapt READMEs and helpers to Helm 3 (#1911) ([40ee57c](https://github.com/bitnami/charts/commit/40ee57cf5164717357e1627b55bf25f59c40fbd1)), closes [#1911](https://github.com/bitnami/charts/issues/1911)
 
 ## <small>0.3.6 (2020-02-10)</small>
 
-* [bitnami/several] Replace stretch by buster in minideb secondary containers (#1900) ([678febc](https://github.com/bitnami/charts/commit/678febc)), closes [#1900](https://github.com/bitnami/charts/issues/1900)
+* [bitnami/several] Replace stretch by buster in minideb secondary containers (#1900) ([678febc](https://github.com/bitnami/charts/commit/678febc237594606f2505ba98c651a8ab8f484ab)), closes [#1900](https://github.com/bitnami/charts/issues/1900)
 
 ## <small>0.3.5 (2020-02-07)</small>
 
-* [bitnami/influxdb] Release 0.3.5 updating components versions ([7dc013e](https://github.com/bitnami/charts/commit/7dc013e))
+* [bitnami/influxdb] Release 0.3.5 updating components versions ([7dc013e](https://github.com/bitnami/charts/commit/7dc013e9a0979e83674034f6b76e9a214bade0f7))
 
 ## <small>0.3.4 (2020-01-24)</small>
 
-* [bitnami/influxdb] Release 0.3.4 updating components versions ([1cdbad6](https://github.com/bitnami/charts/commit/1cdbad6))
+* [bitnami/influxdb] Release 0.3.4 updating components versions ([1cdbad6](https://github.com/bitnami/charts/commit/1cdbad62d0d7baa51e2c2bc1b1135a7c58d8ac03))
 
 ## <small>0.3.3 (2020-01-14)</small>
 
-* [bitnami/influxdb] Release 0.3.3 updating components versions ([7c49e2f](https://github.com/bitnami/charts/commit/7c49e2f))
+* [bitnami/influxdb] Release 0.3.3 updating components versions ([7c49e2f](https://github.com/bitnami/charts/commit/7c49e2ff62724fa7271ae6bac823a0e262c1b77c))
 
 ## <small>0.3.2 (2020-01-10)</small>
 
-* [bitnami/influxdb] Release 0.3.2 updating components versions ([f254507](https://github.com/bitnami/charts/commit/f254507))
+* [bitnami/influxdb] Release 0.3.2 updating components versions ([f254507](https://github.com/bitnami/charts/commit/f2545079cf290747b6b4c2cb2fdd13433acb8918))
 
 ## <small>0.3.1 (2019-12-24)</small>
 
-* [bitnami/influxdb] use the POD_IP in health checks ([6b8ee1e](https://github.com/bitnami/charts/commit/6b8ee1e))
+* [bitnami/influxdb] use the POD_IP in health checks ([6b8ee1e](https://github.com/bitnami/charts/commit/6b8ee1ee873872d9c5d75583da3b9bf2f4ef7360))
 
 ## 0.3.0 (2019-12-16)
 
-* [bitnami/influxdb] configure update strategy for deployments ([39ef693](https://github.com/bitnami/charts/commit/39ef693))
+* [bitnami/influxdb] configure update strategy for deployments ([39ef693](https://github.com/bitnami/charts/commit/39ef693cd27d4e0e812c20d3eba3ed99123777ab))
 
 ## <small>0.2.5 (2019-12-05)</small>
 
-* [bitnami/influxdb] Increase default values for timeoutSeconds/periodSeconds on probes ([e5b64dc](https://github.com/bitnami/charts/commit/e5b64dc))
+* [bitnami/influxdb] Increase default values for timeoutSeconds/periodSeconds on probes ([e5b64dc](https://github.com/bitnami/charts/commit/e5b64dcb8ece6efbe5447d7276dc06e5c0a35f6d))
 
 ## <small>0.2.4 (2019-12-05)</small>
 
-* [bitnami/influxdb] replicaCount is ignored on relay deployment ([ca03401](https://github.com/bitnami/charts/commit/ca03401))
+* [bitnami/influxdb] replicaCount is ignored on relay deployment ([ca03401](https://github.com/bitnami/charts/commit/ca034017b9e648421279c8e0e23f1f786a943ea1))
 
 ## <small>0.2.3 (2019-11-21)</small>
 
-* [bitnami/influxdb] Allow use custom ports ([6a34034](https://github.com/bitnami/charts/commit/6a34034))
-* Different ports for service and container ([46652cd](https://github.com/bitnami/charts/commit/46652cd))
-* Fix hard antiAffinity indentation ([c388867](https://github.com/bitnami/charts/commit/c388867))
-* Use the proper port ([947feca](https://github.com/bitnami/charts/commit/947feca))
+* [bitnami/influxdb] Allow use custom ports ([6a34034](https://github.com/bitnami/charts/commit/6a340347cb53ca18d3fff829f1251e178639c93c))
+* Different ports for service and container ([46652cd](https://github.com/bitnami/charts/commit/46652cdd858bd292a102df67023c808323abeca5))
+* Fix hard antiAffinity indentation ([c388867](https://github.com/bitnami/charts/commit/c38886797b1f997ed1e538bfa27ec446b117c5c1))
+* Use the proper port ([947feca](https://github.com/bitnami/charts/commit/947feca0e2b4e4155d28567ac77b508594b32218))
 
 ## <small>0.2.2 (2019-11-20)</small>
 
-* [bitnami/influxdb] Lint chart ([50d77a5](https://github.com/bitnami/charts/commit/50d77a5))
-* [bitnami/influxdb] Update components versions ([cf5f72a](https://github.com/bitnami/charts/commit/cf5f72a))
-* Increase version ([f141b04](https://github.com/bitnami/charts/commit/f141b04))
+* [bitnami/influxdb] Lint chart ([50d77a5](https://github.com/bitnami/charts/commit/50d77a5f9137fa79182ff136caf099e7b2eb2f42))
+* [bitnami/influxdb] Update components versions ([cf5f72a](https://github.com/bitnami/charts/commit/cf5f72adeea19ba75c46cfef6e9b76effdcb59b1))
+* Increase version ([f141b04](https://github.com/bitnami/charts/commit/f141b0437a5bc0f89a87246341908aec98a2bbdf))
 
 ## <small>0.2.1 (2019-11-15)</small>
 
-* [bitnami/influxdb] Fix timeouts on readiness/liveness probes ([b9e8fe8](https://github.com/bitnami/charts/commit/b9e8fe8))
-* [bitnami/influxdb] Update components versions ([7090222](https://github.com/bitnami/charts/commit/7090222))
-* Increase version ([8fa79d4](https://github.com/bitnami/charts/commit/8fa79d4))
+* [bitnami/influxdb] Fix timeouts on readiness/liveness probes ([b9e8fe8](https://github.com/bitnami/charts/commit/b9e8fe89f21c20ba78e6507b4c8842bf51238d3d))
+* [bitnami/influxdb] Update components versions ([7090222](https://github.com/bitnami/charts/commit/70902226831eba0c417f12f401ab6c1befd68511))
+* Increase version ([8fa79d4](https://github.com/bitnami/charts/commit/8fa79d4612f0938f718ad742f2aa02dbe7e92339))
 
 ## 0.2.0 (2019-10-25)
 
-* [bitnami/influxdb] add servicemonitor support ([eadc656](https://github.com/bitnami/charts/commit/eadc656))
+* [bitnami/influxdb] add servicemonitor support ([eadc656](https://github.com/bitnami/charts/commit/eadc656f550e4d6b68dfc7000ca01c50ebcf0a2d))
 
 ## <small>0.1.3 (2019-10-24)</small>
 
-* Fix links because of section renaming ([8e6fa3b](https://github.com/bitnami/charts/commit/8e6fa3b))
+* Fix links because of section renaming ([8e6fa3b](https://github.com/bitnami/charts/commit/8e6fa3bf7e3198954b6af507cf143fd4870c1c33))
 
 ## <small>0.1.2 (2019-10-23)</small>
 
-* Adapt README in charts (II) ([4705a98](https://github.com/bitnami/charts/commit/4705a98))
+* Adapt README in charts (II) ([4705a98](https://github.com/bitnami/charts/commit/4705a98e346aae7e784ee27cd8c58d0f8e8411f3))
 
 ## <small>0.1.1 (2019-10-17)</small>
 
-* [bitnami/influxdb] Release 0.1.1 updating components versions ([ab1060d](https://github.com/bitnami/charts/commit/ab1060d))
-* [bitnami/influxdb] Update components versions ([7016f0e](https://github.com/bitnami/charts/commit/7016f0e))
-* [bitnami/influxdb] Update prerequisites ([8d45927](https://github.com/bitnami/charts/commit/8d45927))
-* Add Prometheus service for InfluxDB metrics ([64eacba](https://github.com/bitnami/charts/commit/64eacba))
-* Address suggestion in the review ([7181329](https://github.com/bitnami/charts/commit/7181329))
-* Apply corrections from review ([aecf0d8](https://github.com/bitnami/charts/commit/aecf0d8))
-* Headless service should only be created in ha architecture ([f7cbac1](https://github.com/bitnami/charts/commit/f7cbac1))
+* [bitnami/influxdb] Release 0.1.1 updating components versions ([ab1060d](https://github.com/bitnami/charts/commit/ab1060dba04fcbfc7548f850738d27a2d1d4fd15))
+* [bitnami/influxdb] Update components versions ([7016f0e](https://github.com/bitnami/charts/commit/7016f0e552a34ae8fac11bb4855a1fbdb7cdd6c8))
+* [bitnami/influxdb] Update prerequisites ([8d45927](https://github.com/bitnami/charts/commit/8d45927bfff8e8727940a85fb13c191d0cd8fdc1))
+* Add Prometheus service for InfluxDB metrics ([64eacba](https://github.com/bitnami/charts/commit/64eacba6a5f600810a5f82641e4f628ce07c8af6))
+* Address suggestion in the review ([7181329](https://github.com/bitnami/charts/commit/7181329467f2289f16a2673e9691bf850681f8e7))
+* Apply corrections from review ([aecf0d8](https://github.com/bitnami/charts/commit/aecf0d81d05178a144eba0f16f086254abc3d6b4))
+* Headless service should only be created in ha architecture ([f7cbac1](https://github.com/bitnami/charts/commit/f7cbac12754bce7155e9435599d604aa78878335))
 
 ## 0.1.0 (2019-10-03)
 
-* Add new InfluxDB chart ([8d4da16](https://github.com/bitnami/charts/commit/8d4da16))
+* Add new InfluxDB chart ([8d4da16](https://github.com/bitnami/charts/commit/8d4da16f0efdc7f9ae7d5382020b7faf1c084b6c))

--- a/bitnami/influxdb/Chart.yaml
+++ b/bitnami/influxdb/Chart.yaml
@@ -37,4 +37,4 @@ maintainers:
 name: influxdb
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/influxdb
-version: 6.1.0
+version: 6.1.1

--- a/bitnami/influxdb/templates/deployment.yaml
+++ b/bitnami/influxdb/templates/deployment.yaml
@@ -254,21 +254,9 @@ spec:
           {{- else if .Values.influxdb.livenessProbe.enabled }}
           {{- $livenessTimeout := sub (int .Values.influxdb.livenessProbe.timeoutSeconds) 1 }}
           livenessProbe: {{- omit .Values.influxdb.livenessProbe "enabled" | toYaml | nindent 12 }}
-            exec:
-              command:
-                - bash
-                - -c
-                - |
-                  . /opt/bitnami/scripts/libinfluxdb.sh
-
-                  influxdb_env
-
-                  {{- if .Values.auth.enabled }}
-                  export INFLUX_USERNAME="$INFLUXDB_ADMIN_USER"
-                  export INFLUX_PASSWORD="$INFLUXDB_ADMIN_USER_PASSWORD"
-                  {{- end }}
-
-                  timeout {{ $livenessTimeout }}s influx ping --host http://$POD_IP:{{ .Values.influxdb.containerPorts.http }}
+            httpGet:
+              port: http
+              path: /
           {{- end }}
           {{- if .Values.influxdb.customReadinessProbe }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.influxdb.customReadinessProbe "context" $) | nindent 12 }}


### PR DESCRIPTION
### Description of the change
This PR aims to use different liveness/readiness probes to improve overall security and avoid unnecessary container restarts. [More info](https://github.com/zegl/kube-score/blob/master/README_PROBES.md).

### Benefits

Increase availability and resilience.

### Possible drawbacks

N/A

### Applicable issues

- fixes #

### Additional information

- Related to #23537

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- ~[X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)~
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
