### PR TITLE
[bitnami/apache] Fix htdocs with readOnlyRootFilesystem

### DIFF
--- a/bitnami/apache/CHANGELOG.md
+++ b/bitnami/apache/CHANGELOG.md
@@ -1,0 +1,1231 @@
+# Changelog
+
+## 11.1.1 (2024-05-21)
+
+* [bitnami/apache] Fix htdocs with readOnlyRootFilesystem ([#26304](https://github.com/bitnami/charts/pulls/26304))
+
+## <small>11.0.6 (2024-05-17)</small>
+
+* [bitnami/apache] Release 11.0.6 updating components versions (#25997) ([8df9c0d](https://github.com/bitnami/charts/commit/8df9c0d)), closes [#25997](https://github.com/bitnami/charts/issues/25997)
+
+## <small>11.0.5 (2024-05-15)</small>
+
+* [bitnami/apache] Reverts #25862 (#25924) ([57341b4](https://github.com/bitnami/charts/commit/57341b4)), closes [#25862](https://github.com/bitnami/charts/issues/25862) [#25924](https://github.com/bitnami/charts/issues/25924)
+
+## <small>11.0.4 (2024-05-15)</small>
+
+* [bitnami/apache] PDB review (#25862) ([aa65e09](https://github.com/bitnami/charts/commit/aa65e09)), closes [#25862](https://github.com/bitnami/charts/issues/25862)
+
+## <small>11.0.3 (2024-05-13)</small>
+
+* [bitnami/*] Change non-root and rolling-tags doc URLs (#25628) ([b067c94](https://github.com/bitnami/charts/commit/b067c94)), closes [#25628](https://github.com/bitnami/charts/issues/25628)
+* [bitnami/*] Set new header/owner (#25558) ([8d1dc11](https://github.com/bitnami/charts/commit/8d1dc11)), closes [#25558](https://github.com/bitnami/charts/issues/25558)
+* [bitnami/apache] Release 11.0.3 updating components versions (#25742) ([8c4205a](https://github.com/bitnami/charts/commit/8c4205a)), closes [#25742](https://github.com/bitnami/charts/issues/25742)
+* [bitnami/multiple charts] Fix typo: "NetworkPolice" vs "NetworkPolicy" (#25348) ([6970c1b](https://github.com/bitnami/charts/commit/6970c1b)), closes [#25348](https://github.com/bitnami/charts/issues/25348)
+* Replace VMware by Broadcom copyright text (#25306) ([a5e4bd0](https://github.com/bitnami/charts/commit/a5e4bd0)), closes [#25306](https://github.com/bitnami/charts/issues/25306)
+
+## <small>11.0.2 (2024-04-05)</small>
+
+* [bitnami/apache] Release 11.0.2 updating components versions (#24964) ([b9d9c34](https://github.com/bitnami/charts/commit/b9d9c34)), closes [#24964](https://github.com/bitnami/charts/issues/24964)
+
+## <small>11.0.1 (2024-04-04)</small>
+
+* [bitnami/*] Readme typos (#24852) ([532fcdc](https://github.com/bitnami/charts/commit/532fcdc)), closes [#24852](https://github.com/bitnami/charts/issues/24852)
+* [bitnami/apache] Release 11.0.1 updating components versions (#24897) ([d5ce536](https://github.com/bitnami/charts/commit/d5ce536)), closes [#24897](https://github.com/bitnami/charts/issues/24897)
+* Update resourcesPreset comments (#24467) ([92e3e8a](https://github.com/bitnami/charts/commit/92e3e8a)), closes [#24467](https://github.com/bitnami/charts/issues/24467)
+
+## 11.0.0 (2024-03-18)
+
+* [bitnami/*] Reorder Chart sections (#24455) ([0cf4048](https://github.com/bitnami/charts/commit/0cf4048)), closes [#24455](https://github.com/bitnami/charts/issues/24455)
+* [bitnami/apache] feat!: :lock: :boom: Improve security defaults (#24272) ([e1cac49](https://github.com/bitnami/charts/commit/e1cac49)), closes [#24272](https://github.com/bitnami/charts/issues/24272)
+
+## <small>10.9.2 (2024-03-15)</small>
+
+* [bitnami/apache] Set /app as safe directory when enabling gitSync (#24261) ([8f32ce1](https://github.com/bitnami/charts/commit/8f32ce1)), closes [#24261](https://github.com/bitnami/charts/issues/24261)
+
+## <small>10.9.1 (2024-03-08)</small>
+
+* [bitnami/apache] Release 10.9.1 updating components versions (#24287) ([774d324](https://github.com/bitnami/charts/commit/774d324)), closes [#24287](https://github.com/bitnami/charts/issues/24287)
+
+## 10.9.0 (2024-03-08)
+
+* [bitnami/apache] feat: :sparkles: :lock: Add networkPolicy (#24254) ([8c20107](https://github.com/bitnami/charts/commit/8c20107)), closes [#24254](https://github.com/bitnami/charts/issues/24254)
+
+## 10.8.0 (2024-03-06)
+
+* [bitnami/apache] feat: :sparkles: :lock: Add readOnlyRootFilesystem support (#24032) ([6b08891](https://github.com/bitnami/charts/commit/6b08891)), closes [#24032](https://github.com/bitnami/charts/issues/24032)
+
+## 10.7.0 (2024-03-05)
+
+* [bitnami/apache] feat: :sparkles: :lock: Add automatic adaptation for Openshift restricted-v2 SCC (# ([7db9c2e](https://github.com/bitnami/charts/commit/7db9c2e)), closes [#24059](https://github.com/bitnami/charts/issues/24059)
+
+## <small>10.6.2 (2024-02-21)</small>
+
+* [bitnami/apache] Release 10.6.2 updating components versions (#23737) ([4838d00](https://github.com/bitnami/charts/commit/4838d00)), closes [#23737](https://github.com/bitnami/charts/issues/23737)
+
+## <small>10.6.1 (2024-02-21)</small>
+
+* [bitnami/apache] feat: :sparkles: :lock: Add resource preset support (#23428) ([6eb5a56](https://github.com/bitnami/charts/commit/6eb5a56)), closes [#23428](https://github.com/bitnami/charts/issues/23428)
+* [bitnami/apache] Release 10.6.1 updating components versions (#23625) ([96b397b](https://github.com/bitnami/charts/commit/96b397b)), closes [#23625](https://github.com/bitnami/charts/issues/23625)
+
+## 10.6.0 (2024-02-20)
+
+* [bitnami/*] Bump all versions (#23602) ([b70ee2a](https://github.com/bitnami/charts/commit/b70ee2a)), closes [#23602](https://github.com/bitnami/charts/issues/23602)
+
+## <small>10.5.4 (2024-02-02)</small>
+
+* [bitnami/apache] Release 10.5.4 updating components versions (#23055) ([ed5a617](https://github.com/bitnami/charts/commit/ed5a617)), closes [#23055](https://github.com/bitnami/charts/issues/23055)
+
+## <small>10.5.3 (2024-02-01)</small>
+
+* [bitnami/apache] Release 10.5.3 updating components versions (#23003) ([7b8e581](https://github.com/bitnami/charts/commit/7b8e581)), closes [#23003](https://github.com/bitnami/charts/issues/23003)
+
+## <small>10.5.2 (2024-01-29)</small>
+
+* [bitnami/apache] Release 10.5.2 updating components versions (#22812) ([5fc5a38](https://github.com/bitnami/charts/commit/5fc5a38)), closes [#22812](https://github.com/bitnami/charts/issues/22812)
+
+## <small>10.5.1 (2024-01-26)</small>
+
+* [bitnami/apache] Release 10.5.1 updating components versions (#22764) ([02dd8d4](https://github.com/bitnami/charts/commit/02dd8d4)), closes [#22764](https://github.com/bitnami/charts/issues/22764)
+
+## 10.5.0 (2024-01-24)
+
+* [bitnami/*] Move documentation sections from docs.bitnami.com back to the README (#22203) ([7564f36](https://github.com/bitnami/charts/commit/7564f36)), closes [#22203](https://github.com/bitnami/charts/issues/22203)
+* [bitnami/apache] Revert Network Policies (#22688) ([ca419fa](https://github.com/bitnami/charts/commit/ca419fa)), closes [#22688](https://github.com/bitnami/charts/issues/22688)
+
+## <small>10.4.2 (2024-01-24)</small>
+
+* [bitnami/apache] fix: :bug: Set seLinuxOptions to null for Openshift compatibility (#22566) ([4ba97ba](https://github.com/bitnami/charts/commit/4ba97ba)), closes [#22566](https://github.com/bitnami/charts/issues/22566)
+
+## <small>10.4.1 (2024-01-22)</small>
+
+* [bitnami/apache] Release 10.4.1 updating components versions (#22543) ([ca4068f](https://github.com/bitnami/charts/commit/ca4068f)), closes [#22543](https://github.com/bitnami/charts/issues/22543)
+
+## 10.4.0 (2024-01-19)
+
+* [bitnami/apache] fix: :lock: Move service-account token auto-mount to pod declaration (#22478) ([f824fb5](https://github.com/bitnami/charts/commit/f824fb5)), closes [#22478](https://github.com/bitnami/charts/issues/22478)
+
+## <small>10.3.1 (2024-01-17)</small>
+
+* [bitnami/apache] fix: :lock: Improve podSecurityContext and containerSecurityContext with essential  ([4526f8d](https://github.com/bitnami/charts/commit/4526f8d)), closes [#22097](https://github.com/bitnami/charts/issues/22097)
+* [bitnami/apache] Release 10.3.1 updating components versions (#22257) ([eedc50b](https://github.com/bitnami/charts/commit/eedc50b)), closes [#22257](https://github.com/bitnami/charts/issues/22257)
+
+## 10.3.0 (2024-01-16)
+
+* [bitnami/apache] Add Network Policies (#22094) ([0dc5ba7](https://github.com/bitnami/charts/commit/0dc5ba7)), closes [#22094](https://github.com/bitnami/charts/issues/22094)
+
+## <small>10.2.5 (2024-01-16)</small>
+
+* [bitnami/*] Fix docs.bitnami.com broken links (#21901) ([f35506d](https://github.com/bitnami/charts/commit/f35506d)), closes [#21901](https://github.com/bitnami/charts/issues/21901)
+* [bitnami/*] Fix ref links (in comments) (#21822) ([e4fa296](https://github.com/bitnami/charts/commit/e4fa296)), closes [#21822](https://github.com/bitnami/charts/issues/21822)
+* [bitnami/*] Update copyright: Year and company (#21815) ([6c4bf75](https://github.com/bitnami/charts/commit/6c4bf75)), closes [#21815](https://github.com/bitnami/charts/issues/21815)
+* [bitnami/apache] Release 10.2.5 updating components versions (#22220) ([b01e121](https://github.com/bitnami/charts/commit/b01e121)), closes [#22220](https://github.com/bitnami/charts/issues/22220)
+
+## <small>10.2.4 (2023-12-07)</small>
+
+* [bitnami/apache] Release 10.2.4 updating components versions (#21449) ([dfb25ce](https://github.com/bitnami/charts/commit/dfb25ce)), closes [#21449](https://github.com/bitnami/charts/issues/21449)
+
+## <small>10.2.3 (2023-11-21)</small>
+
+* [bitnami/*] Remove relative links to non-README sections, add verification for that and update TL;DR ([1103633](https://github.com/bitnami/charts/commit/1103633)), closes [#20967](https://github.com/bitnami/charts/issues/20967)
+* [bitnami/*] Rename solutions to "Bitnami package for ..." (#21038) ([b82f979](https://github.com/bitnami/charts/commit/b82f979)), closes [#21038](https://github.com/bitnami/charts/issues/21038)
+* [bitnami/apache] Release 10.2.3 updating components versions (#21096) ([194ddc0](https://github.com/bitnami/charts/commit/194ddc0)), closes [#21096](https://github.com/bitnami/charts/issues/21096)
+
+## <small>10.2.2 (2023-11-16)</small>
+
+* [bitnami/apache] Release 10.2.2 updating components versions (#21005) ([05ab715](https://github.com/bitnami/charts/commit/05ab715)), closes [#21005](https://github.com/bitnami/charts/issues/21005)
+
+## <small>10.2.1 (2023-11-08)</small>
+
+* [bitnami/apache] Release 10.2.1 updating components versions (#20717) ([600fbbb](https://github.com/bitnami/charts/commit/600fbbb)), closes [#20717](https://github.com/bitnami/charts/issues/20717)
+
+## 10.2.0 (2023-10-25)
+
+* [bitnami/*] Rename VMware Application Catalog (#20361) ([3acc734](https://github.com/bitnami/charts/commit/3acc734)), closes [#20361](https://github.com/bitnami/charts/issues/20361)
+* [bitnami/*] Skip image's tag in the README files of the Bitnami Charts (#19841) ([bb9a01b](https://github.com/bitnami/charts/commit/bb9a01b)), closes [#19841](https://github.com/bitnami/charts/issues/19841)
+* [bitnami/*] Standardize documentation (#19835) ([af5f753](https://github.com/bitnami/charts/commit/af5f753)), closes [#19835](https://github.com/bitnami/charts/issues/19835)
+* [bitnami/apache] feat: :sparkles: Add support for PSA restricted policy (#20379) ([3ba463c](https://github.com/bitnami/charts/commit/3ba463c)), closes [#20379](https://github.com/bitnami/charts/issues/20379)
+
+## <small>10.1.6 (2023-10-19)</small>
+
+* [bitnami/apache] Release 10.1.6 (#20325) ([4a09e87](https://github.com/bitnami/charts/commit/4a09e87)), closes [#20325](https://github.com/bitnami/charts/issues/20325)
+
+## <small>10.1.5 (2023-10-12)</small>
+
+* [bitnami/apache] Release 10.1.5 (#20125) ([4786060](https://github.com/bitnami/charts/commit/4786060)), closes [#20125](https://github.com/bitnami/charts/issues/20125)
+
+## <small>10.1.4 (2023-10-08)</small>
+
+* [bitnami/*] Update Helm charts prerequisites (#19745) ([eb755dd](https://github.com/bitnami/charts/commit/eb755dd)), closes [#19745](https://github.com/bitnami/charts/issues/19745)
+* [bitnami/apache] bump bitnami/common (#19777) ([9a1316e](https://github.com/bitnami/charts/commit/9a1316e)), closes [#19777](https://github.com/bitnami/charts/issues/19777)
+
+## <small>10.1.3 (2023-10-04)</small>
+
+* [bitnami/apache] Release 10.1.3 (#19747) ([7055354](https://github.com/bitnami/charts/commit/7055354)), closes [#19747](https://github.com/bitnami/charts/issues/19747)
+* Revert "Autogenerate schema files (#19194)" (#19335) ([73d80be](https://github.com/bitnami/charts/commit/73d80be)), closes [#19194](https://github.com/bitnami/charts/issues/19194) [#19335](https://github.com/bitnami/charts/issues/19335)
+
+## <small>10.1.2 (2023-09-18)</small>
+
+* [bitnami/apache] Release 10.1.2 (#19332) ([13b5c01](https://github.com/bitnami/charts/commit/13b5c01)), closes [#19332](https://github.com/bitnami/charts/issues/19332)
+* Autogenerate schema files (#19194) ([a2c2090](https://github.com/bitnami/charts/commit/a2c2090)), closes [#19194](https://github.com/bitnami/charts/issues/19194)
+
+## <small>10.1.1 (2023-09-08)</small>
+
+* [bitnami/apache]: Use merge helper (#19019) ([72bd511](https://github.com/bitnami/charts/commit/72bd511)), closes [#19019](https://github.com/bitnami/charts/issues/19019)
+
+## 10.1.0 (2023-08-22)
+
+* [bitnami/apache] Support for customizing standard labels (#18291) ([8192243](https://github.com/bitnami/charts/commit/8192243)), closes [#18291](https://github.com/bitnami/charts/issues/18291)
+
+## <small>10.0.5 (2023-08-19)</small>
+
+* [bitnami/apache] Release 10.0.5 (#18643) ([09d8bdf](https://github.com/bitnami/charts/commit/09d8bdf)), closes [#18643](https://github.com/bitnami/charts/issues/18643)
+
+## <small>10.0.4 (2023-08-17)</small>
+
+* [bitnami/apache] Release 10.0.4 (#18496) ([5a185d9](https://github.com/bitnami/charts/commit/5a185d9)), closes [#18496](https://github.com/bitnami/charts/issues/18496)
+
+## <small>10.0.3 (2023-08-03)</small>
+
+* [bitnami/apache] Release 10.0.3 (#18156) ([121964f](https://github.com/bitnami/charts/commit/121964f)), closes [#18156](https://github.com/bitnami/charts/issues/18156)
+
+## <small>10.0.2 (2023-07-25)</small>
+
+* [bitnami/apache] Release 10.0.2 (#17910) ([dc65b4b](https://github.com/bitnami/charts/commit/dc65b4b)), closes [#17910](https://github.com/bitnami/charts/issues/17910)
+
+## <small>10.0.1 (2023-07-25)</small>
+
+* [bitnami/apache] Release 10.0.1 (#17854) ([7e44efb](https://github.com/bitnami/charts/commit/7e44efb)), closes [#17854](https://github.com/bitnami/charts/issues/17854)
+
+## 10.0.0 (2023-07-18)
+
+* [bitnami/apache] Rewrite Ingress TLS logic (#17124) ([8d539d5](https://github.com/bitnami/charts/commit/8d539d5)), closes [#17124](https://github.com/bitnami/charts/issues/17124)
+
+## <small>9.6.5 (2023-07-15)</small>
+
+* [bitnami/apache] Release 9.6.5 (#17636) ([c6410bc](https://github.com/bitnami/charts/commit/c6410bc)), closes [#17636](https://github.com/bitnami/charts/issues/17636)
+
+## <small>9.6.4 (2023-07-06)</small>
+
+* [bitnami/apache] Release 9.6.4 (#17508) ([39b01eb](https://github.com/bitnami/charts/commit/39b01eb)), closes [#17508](https://github.com/bitnami/charts/issues/17508)
+* Add copyright header (#17300) ([da68be8](https://github.com/bitnami/charts/commit/da68be8)), closes [#17300](https://github.com/bitnami/charts/issues/17300)
+* Update charts readme (#17217) ([31b3c0a](https://github.com/bitnami/charts/commit/31b3c0a)), closes [#17217](https://github.com/bitnami/charts/issues/17217)
+
+## <small>9.6.3 (2023-06-06)</small>
+
+* [bitnami/*] Change copyright section in READMEs (#17006) ([ef986a1](https://github.com/bitnami/charts/commit/ef986a1)), closes [#17006](https://github.com/bitnami/charts/issues/17006)
+* [bitnami/apache] Release 9.6.3 (#17045) ([5386aab](https://github.com/bitnami/charts/commit/5386aab)), closes [#17045](https://github.com/bitnami/charts/issues/17045)
+* [bitnami/several] Change copyright section in READMEs (#16989) ([5b6a5cf](https://github.com/bitnami/charts/commit/5b6a5cf)), closes [#16989](https://github.com/bitnami/charts/issues/16989)
+
+## <small>9.6.2 (2023-05-26)</small>
+
+* [bitnami/apache] Release 9.6.2 (#16931) ([ffc96e0](https://github.com/bitnami/charts/commit/ffc96e0)), closes [#16931](https://github.com/bitnami/charts/issues/16931)
+
+## <small>9.6.1 (2023-05-21)</small>
+
+* [bitnami/apache] Release 9.6.1 (#16753) ([5540bd7](https://github.com/bitnami/charts/commit/5540bd7)), closes [#16753](https://github.com/bitnami/charts/issues/16753)
+* Add wording for enterprise page (#16560) ([8f22774](https://github.com/bitnami/charts/commit/8f22774)), closes [#16560](https://github.com/bitnami/charts/issues/16560)
+
+## 9.6.0 (2023-05-09)
+
+* [bitnami/several] Adapt Chart.yaml to set desired OCI annotations (#16546) ([fc9b18f](https://github.com/bitnami/charts/commit/fc9b18f)), closes [#16546](https://github.com/bitnami/charts/issues/16546)
+
+## <small>9.5.3 (2023-05-09)</small>
+
+* [bitnami/apache] Release 9.5.3 (#16447) ([86f1ba7](https://github.com/bitnami/charts/commit/86f1ba7)), closes [#16447](https://github.com/bitnami/charts/issues/16447)
+
+## <small>9.5.2 (2023-04-26)</small>
+
+* [bitnami/apache] Release 9.5.2 (#16238) ([c1bb725](https://github.com/bitnami/charts/commit/c1bb725)), closes [#16238](https://github.com/bitnami/charts/issues/16238)
+
+## <small>9.5.1 (2023-04-25)</small>
+
+* [bitnami/apache] Release 9.5.1 (#16216) ([eb51484](https://github.com/bitnami/charts/commit/eb51484)), closes [#16216](https://github.com/bitnami/charts/issues/16216)
+
+## 9.5.0 (2023-04-25)
+
+* [bitnami/several] Revert changes done by mistake in Chart.yaml repo (#16211) ([3a60f4b](https://github.com/bitnami/charts/commit/3a60f4b)), closes [#16211](https://github.com/bitnami/charts/issues/16211)
+
+## <small>9.4.1 (2023-04-20)</small>
+
+* [bitnami/apache] Release 9.4.1 (#16140) ([09cbc73](https://github.com/bitnami/charts/commit/09cbc73)), closes [#16140](https://github.com/bitnami/charts/issues/16140)
+
+## 9.4.0 (2023-04-20)
+
+* [bitnami/*] Make Helm charts 100% OCI (#15998) ([8841510](https://github.com/bitnami/charts/commit/8841510)), closes [#15998](https://github.com/bitnami/charts/issues/15998)
+
+## <small>9.3.3 (2023-04-17)</small>
+
+* [bitnami/apache] Release 9.3.3 (#16100) ([01a3ba1](https://github.com/bitnami/charts/commit/01a3ba1)), closes [#16100](https://github.com/bitnami/charts/issues/16100)
+
+## <small>9.3.2 (2023-04-14)</small>
+
+* [bitnami/apache] Release 9.3.2 (#16070) ([34be12a](https://github.com/bitnami/charts/commit/34be12a)), closes [#16070](https://github.com/bitnami/charts/issues/16070)
+
+## <small>9.3.1 (2023-04-13)</small>
+
+* [bitnami/apache] Release 9.3.1 (#16041) ([7424cd8](https://github.com/bitnami/charts/commit/7424cd8)), closes [#16041](https://github.com/bitnami/charts/issues/16041)
+
+## 9.3.0 (2023-04-12)
+
+* [bitnami/apache] Allow setting deployment's revisionHistoryLimit (#16016) ([8527652](https://github.com/bitnami/charts/commit/8527652)), closes [#16016](https://github.com/bitnami/charts/issues/16016)
+
+## <small>9.2.23 (2023-04-06)</small>
+
+* [bitnami/apache] Release 9.2.23 (#15985) ([57ddf9d](https://github.com/bitnami/charts/commit/57ddf9d)), closes [#15985](https://github.com/bitnami/charts/issues/15985)
+
+## <small>9.2.22 (2023-04-05)</small>
+
+* [bitnami/apache] Release 9.2.22 (#15971) ([df2b151](https://github.com/bitnami/charts/commit/df2b151)), closes [#15971](https://github.com/bitnami/charts/issues/15971)
+
+## <small>9.2.21 (2023-04-01)</small>
+
+* [bitnami/apache] Release 9.2.21 (#15838) ([f16ff92](https://github.com/bitnami/charts/commit/f16ff92)), closes [#15838](https://github.com/bitnami/charts/issues/15838)
+
+## <small>9.2.20 (2023-03-30)</small>
+
+* [bitnami/apache] Release 9.2.20 (#15813) ([c59ca8d](https://github.com/bitnami/charts/commit/c59ca8d)), closes [#15813](https://github.com/bitnami/charts/issues/15813)
+
+## <small>9.2.19 (2023-03-18)</small>
+
+* [bitnami/apache] Release 9.2.19 (#15554) ([c0aadff](https://github.com/bitnami/charts/commit/c0aadff)), closes [#15554](https://github.com/bitnami/charts/issues/15554)
+
+## <small>9.2.18 (2023-03-08)</small>
+
+* [bitnami/apache] Release 9.2.18 (#15368) ([bf17cb7](https://github.com/bitnami/charts/commit/bf17cb7)), closes [#15368](https://github.com/bitnami/charts/issues/15368)
+* [bitnami/charts] Apply linter to README files (#15357) ([0e29e60](https://github.com/bitnami/charts/commit/0e29e60)), closes [#15357](https://github.com/bitnami/charts/issues/15357)
+
+## <small>9.2.17 (2023-03-01)</small>
+
+* [bitnami/apache] Release 9.2.17 (#15190) ([d24edc3](https://github.com/bitnami/charts/commit/d24edc3)), closes [#15190](https://github.com/bitnami/charts/issues/15190)
+
+## <small>9.2.16 (2023-02-17)</small>
+
+* [bitnami/*] Fix markdown linter issues (#14874) ([a51e0e8](https://github.com/bitnami/charts/commit/a51e0e8)), closes [#14874](https://github.com/bitnami/charts/issues/14874)
+* [bitnami/*] Fix markdown linter issues 2 (#14890) ([aa96572](https://github.com/bitnami/charts/commit/aa96572)), closes [#14890](https://github.com/bitnami/charts/issues/14890)
+* [bitnami/*] Remove unexpected extra spaces (#14873) ([c97c714](https://github.com/bitnami/charts/commit/c97c714)), closes [#14873](https://github.com/bitnami/charts/issues/14873)
+* [bitnami/apache] Release 9.2.16 (#14945) ([5a41df9](https://github.com/bitnami/charts/commit/5a41df9)), closes [#14945](https://github.com/bitnami/charts/issues/14945)
+
+## <small>9.2.15 (2023-02-02)</small>
+
+* [bitnami/apache] Release 9.2.15 (#14715) ([8446d44](https://github.com/bitnami/charts/commit/8446d44)), closes [#14715](https://github.com/bitnami/charts/issues/14715)
+
+## <small>9.2.14 (2023-02-01)</small>
+
+* [bitnami/apache] Release 9.2.14 (#14696) ([75498dd](https://github.com/bitnami/charts/commit/75498dd)), closes [#14696](https://github.com/bitnami/charts/issues/14696)
+
+## <small>9.2.13 (2023-02-01)</small>
+
+* [bitnami/apache] Release 9.2.13 (#14695) ([36816c3](https://github.com/bitnami/charts/commit/36816c3)), closes [#14695](https://github.com/bitnami/charts/issues/14695)
+
+## <small>9.2.12 (2023-01-31)</small>
+
+* [bitnami/*] Change copyright date (#14682) ([add4ec7](https://github.com/bitnami/charts/commit/add4ec7)), closes [#14682](https://github.com/bitnami/charts/issues/14682)
+* [bitnami/*] Unify READMEs (#14472) ([2064fb8](https://github.com/bitnami/charts/commit/2064fb8)), closes [#14472](https://github.com/bitnami/charts/issues/14472)
+* [bitnami/apache] Don't regenerate self-signed certs on upgrade (#14606) ([2cd37c3](https://github.com/bitnami/charts/commit/2cd37c3)), closes [#14606](https://github.com/bitnami/charts/issues/14606)
+
+## <small>9.2.11 (2023-01-17)</small>
+
+* [bitnami/*] Add license annotation and remove obsolete engine parameter (#14293) ([da2a794](https://github.com/bitnami/charts/commit/da2a794)), closes [#14293](https://github.com/bitnami/charts/issues/14293)
+* [bitnami/*] Change licenses annotation format (#14377) ([0ab7608](https://github.com/bitnami/charts/commit/0ab7608)), closes [#14377](https://github.com/bitnami/charts/issues/14377)
+* [bitnami/apache] Release 9.2.11 (#14403) ([e3ab251](https://github.com/bitnami/charts/commit/e3ab251)), closes [#14403](https://github.com/bitnami/charts/issues/14403)
+
+## <small>9.2.10 (2023-01-05)</small>
+
+* [bitnami/apache] Release 9.2.10 (#14188) ([c5f0745](https://github.com/bitnami/charts/commit/c5f0745)), closes [#14188](https://github.com/bitnami/charts/issues/14188)
+
+## <small>9.2.9 (2022-12-10)</small>
+
+* [bitnami/apache] Release 9.2.9 (#13890) ([7740349](https://github.com/bitnami/charts/commit/7740349)), closes [#13890](https://github.com/bitnami/charts/issues/13890)
+
+## <small>9.2.8 (2022-12-07)</small>
+
+* [bitnami/apache] Release 9.2.8 (#13861) ([f295091](https://github.com/bitnami/charts/commit/f295091)), closes [#13861](https://github.com/bitnami/charts/issues/13861)
+
+## <small>9.2.7 (2022-11-07)</small>
+
+* [bitnami/apache] Release 9.2.7 (#13379) ([a135c3b](https://github.com/bitnami/charts/commit/a135c3b)), closes [#13379](https://github.com/bitnami/charts/issues/13379)
+
+## <small>9.2.6 (2022-10-26)</small>
+
+* [bitnami/*] Use new default branch name in links (#12943) ([a529e02](https://github.com/bitnami/charts/commit/a529e02)), closes [#12943](https://github.com/bitnami/charts/issues/12943)
+* [bitnami/apache] Optimize annos (#13127) ([90e9d43](https://github.com/bitnami/charts/commit/90e9d43)), closes [#13127](https://github.com/bitnami/charts/issues/13127)
+
+## <small>9.2.5 (2022-10-08)</small>
+
+* [bitnami/apache] Release 9.2.5 (#12865) ([2d6f4e8](https://github.com/bitnami/charts/commit/2d6f4e8)), closes [#12865](https://github.com/bitnami/charts/issues/12865)
+* Generic README instructions related to the repo (#12792) ([3cf6b10](https://github.com/bitnami/charts/commit/3cf6b10)), closes [#12792](https://github.com/bitnami/charts/issues/12792)
+
+## <small>9.2.4 (2022-09-21)</small>
+
+* [bitnami/apache] Use custom probes if given (#12438) ([fce9049](https://github.com/bitnami/charts/commit/fce9049)), closes [#12438](https://github.com/bitnami/charts/issues/12438) [#12354](https://github.com/bitnami/charts/issues/12354)
+
+## <small>9.2.3 (2022-09-08)</small>
+
+* [bitnami/apache] Release 9.2.3 (#12326) ([01facfd](https://github.com/bitnami/charts/commit/01facfd)), closes [#12326](https://github.com/bitnami/charts/issues/12326)
+
+## <small>9.2.2 (2022-09-01)</small>
+
+* [bitnami/apache] Release 9.2.2 (#12247) ([b0952ad](https://github.com/bitnami/charts/commit/b0952ad)), closes [#12247](https://github.com/bitnami/charts/issues/12247)
+* adjust the naming style for resources name to make them not pass the length limit (#12203) ([4294bcf](https://github.com/bitnami/charts/commit/4294bcf)), closes [#12203](https://github.com/bitnami/charts/issues/12203)
+* Allow the charts containerPorts to be configured (#12137) ([0ce981c](https://github.com/bitnami/charts/commit/0ce981c)), closes [#12137](https://github.com/bitnami/charts/issues/12137)
+
+## <small>9.2.1 (2022-08-23)</small>
+
+* [bitnami/apache] Update Chart.lock (#12040) ([59fecbf](https://github.com/bitnami/charts/commit/59fecbf)), closes [#12040](https://github.com/bitnami/charts/issues/12040)
+
+## 9.2.0 (2022-08-22)
+
+* [bitnami/apache] Add support for image digest apart from tag (#11866) ([ec29e94](https://github.com/bitnami/charts/commit/ec29e94)), closes [#11866](https://github.com/bitnami/charts/issues/11866)
+
+## <small>9.1.18 (2022-08-09)</small>
+
+* [bitnami/apache] Release 9.1.18 updating components versions ([ddc011b](https://github.com/bitnami/charts/commit/ddc011b))
+
+## <small>9.1.17 (2022-08-08)</small>
+
+* [bitnami/apache] Release 9.1.17 updating components versions ([d73b95c](https://github.com/bitnami/charts/commit/d73b95c))
+
+## <small>9.1.16 (2022-08-04)</small>
+
+* [bitnami/apache] Release 9.1.16 updating components versions ([bb0ac6d](https://github.com/bitnami/charts/commit/bb0ac6d))
+
+## <small>9.1.15 (2022-08-03)</small>
+
+* [bitnami/apache] Release 9.1.15 updating components versions ([adf51c1](https://github.com/bitnami/charts/commit/adf51c1))
+
+## <small>9.1.14 (2022-08-02)</small>
+
+* [bitnami/*] Update URLs to point to the new bitnami/containers monorepo (#11352) ([d665af0](https://github.com/bitnami/charts/commit/d665af0)), closes [#11352](https://github.com/bitnami/charts/issues/11352)
+* [bitnami/apache] Release 9.1.14 updating components versions ([e4862b5](https://github.com/bitnami/charts/commit/e4862b5))
+
+## <small>9.1.13 (2022-07-04)</small>
+
+* [bitnami/apache] Release 9.1.13 updating components versions ([30e2773](https://github.com/bitnami/charts/commit/30e2773))
+
+## <small>9.1.12 (2022-06-30)</small>
+
+* [bitnami/apache] Release 9.1.12 updating components versions ([6da6dfe](https://github.com/bitnami/charts/commit/6da6dfe))
+
+## <small>9.1.11 (2022-06-10)</small>
+
+* [bitnami/apache] Release 9.1.11 updating components versions ([f685611](https://github.com/bitnami/charts/commit/f685611))
+
+## <small>9.1.10 (2022-06-08)</small>
+
+* [bitnami/*] Replace Kubeapps URL in READMEs (and kubeapps Chart.yaml) and remove BKPR references (#1 ([c6a7914](https://github.com/bitnami/charts/commit/c6a7914)), closes [#10600](https://github.com/bitnami/charts/issues/10600)
+* [bitnami/apache] Release 9.1.10 updating components versions ([7cbfade](https://github.com/bitnami/charts/commit/7cbfade))
+
+## <small>9.1.9 (2022-06-06)</small>
+
+* [bitnami/apache] Release 9.1.9 updating components versions ([0e33d68](https://github.com/bitnami/charts/commit/0e33d68))
+
+## <small>9.1.8 (2022-06-01)</small>
+
+* [bitnami/several] Replace maintainers email by url (#10523) ([ff3cf61](https://github.com/bitnami/charts/commit/ff3cf61)), closes [#10523](https://github.com/bitnami/charts/issues/10523)
+
+## <small>9.1.7 (2022-05-31)</small>
+
+* [bitnami/apache] Release 9.1.7 updating components versions ([2e2a282](https://github.com/bitnami/charts/commit/2e2a282))
+
+## <small>9.1.6 (2022-05-22)</small>
+
+* [bitnami/apache] Release 9.1.6 updating components versions ([71a4f3e](https://github.com/bitnami/charts/commit/71a4f3e))
+
+## <small>9.1.5 (2022-05-21)</small>
+
+* [bitnami/apache] Release 9.1.5 updating components versions ([7d7e216](https://github.com/bitnami/charts/commit/7d7e216))
+
+## <small>9.1.4 (2022-05-20)</small>
+
+* [bitnami/*] Fix HPA API version template usage (#10332) ([85ce7af](https://github.com/bitnami/charts/commit/85ce7af)), closes [#10332](https://github.com/bitnami/charts/issues/10332)
+
+## <small>9.1.3 (2022-05-20)</small>
+
+* [bitnami/apache] Release 9.1.3 updating components versions ([8370622](https://github.com/bitnami/charts/commit/8370622))
+
+## <small>9.1.2 (2022-05-18)</small>
+
+* [bitnami/apache] Fix probes not reading port from .Values (#10286) ([9103960](https://github.com/bitnami/charts/commit/9103960)), closes [#10286](https://github.com/bitnami/charts/issues/10286) [#1696](https://github.com/bitnami/charts/issues/1696)
+
+## <small>9.1.1 (2022-05-18)</small>
+
+* [bitnami/apache] Release 9.1.1 updating components versions ([8dafe79](https://github.com/bitnami/charts/commit/8dafe79))
+
+## 9.1.0 (2022-05-16)
+
+* [bitnami/*] add ingress extraRules feature (#10253) ([0f6cbb9](https://github.com/bitnami/charts/commit/0f6cbb9)), closes [#10253](https://github.com/bitnami/charts/issues/10253)
+
+## <small>9.0.19 (2022-05-14)</small>
+
+* [bitnami/*] Remove old 'ci' files (#10171) ([5df30c4](https://github.com/bitnami/charts/commit/5df30c4)), closes [#10171](https://github.com/bitnami/charts/issues/10171)
+* [bitnami/apache] Use the new helper for HPA API version (#10192) ([a2099a5](https://github.com/bitnami/charts/commit/a2099a5)), closes [#10192](https://github.com/bitnami/charts/issues/10192)
+
+## <small>9.0.18 (2022-05-11)</small>
+
+* [bitnami/apache] Add missing namespace metadata (#10097) ([b7953e1](https://github.com/bitnami/charts/commit/b7953e1)), closes [#10097](https://github.com/bitnami/charts/issues/10097)
+
+## <small>9.0.17 (2022-04-20)</small>
+
+* [bitnami/apache] Release 9.0.17 updating components versions ([79fd938](https://github.com/bitnami/charts/commit/79fd938))
+
+## <small>9.0.16 (2022-04-19)</small>
+
+* [bitnami/apache] Release 9.0.16 updating components versions ([4940dc5](https://github.com/bitnami/charts/commit/4940dc5))
+
+## <small>9.0.15 (2022-04-07)</small>
+
+* [bitnami/apache] Release 9.0.15 updating components versions ([5c10027](https://github.com/bitnami/charts/commit/5c10027))
+
+## <small>9.0.14 (2022-04-02)</small>
+
+* [bitnami/apache] Release 9.0.14 updating components versions ([d711087](https://github.com/bitnami/charts/commit/d711087))
+
+## <small>9.0.13 (2022-03-27)</small>
+
+* [bitnami/apache] Release 9.0.13 updating components versions ([13ab47a](https://github.com/bitnami/charts/commit/13ab47a))
+
+## <small>9.0.12 (2022-03-17)</small>
+
+* [bitnami/apache] Release 9.0.12 updating components versions ([5f42999](https://github.com/bitnami/charts/commit/5f42999))
+
+## <small>9.0.11 (2022-03-16)</small>
+
+* [bitnami/apache] Release 9.0.11 updating components versions ([e496e18](https://github.com/bitnami/charts/commit/e496e18))
+
+## <small>9.0.10 (2022-03-14)</small>
+
+* [bitnami/apache] Release 9.0.10 updating components versions ([d4b7e3b](https://github.com/bitnami/charts/commit/d4b7e3b))
+
+## <small>9.0.9 (2022-03-10)</small>
+
+* [bitnami/apache] Release 9.0.9 updating components versions ([6734ddd](https://github.com/bitnami/charts/commit/6734ddd))
+
+## <small>9.0.8 (2022-03-10)</small>
+
+* [bitnami/apache] Fix typo in parameter metadata ([0a7067d](https://github.com/bitnami/charts/commit/0a7067d))
+
+## <small>9.0.7 (2022-03-10)</small>
+
+* [bitnami/apache] Fix issue rendering metrics.*.additionalLabels (#9362) ([2c473a9](https://github.com/bitnami/charts/commit/2c473a9)), closes [#9362](https://github.com/bitnami/charts/issues/9362)
+
+## <small>9.0.6 (2022-02-27)</small>
+
+* [bitnami/apache] Release 9.0.6 updating components versions ([4f0c91d](https://github.com/bitnami/charts/commit/4f0c91d))
+
+## <small>9.0.5 (2022-02-24)</small>
+
+* [bitnami/apache] Release 9.0.5 updating components versions ([0061a62](https://github.com/bitnami/charts/commit/0061a62))
+
+## <small>9.0.4 (2022-02-23)</small>
+
+* [bitnami/apache] Release 9.0.4 updating components versions ([e527b2a](https://github.com/bitnami/charts/commit/e527b2a))
+
+## <small>9.0.3 (2022-02-19)</small>
+
+* [bitnami/apache] Release 9.0.3 updating components versions ([607727f](https://github.com/bitnami/charts/commit/607727f))
+
+## <small>9.0.2 (2022-02-13)</small>
+
+* [bitnami/apache] Release 9.0.2 updating components versions ([9f9b227](https://github.com/bitnami/charts/commit/9f9b227))
+* Non utf8 chars (#8923) ([6ffd18f](https://github.com/bitnami/charts/commit/6ffd18f)), closes [#8923](https://github.com/bitnami/charts/issues/8923)
+
+## <small>9.0.1 (2022-01-20)</small>
+
+* [bitnami/*] Readme automation (#8579) ([78d1938](https://github.com/bitnami/charts/commit/78d1938)), closes [#8579](https://github.com/bitnami/charts/issues/8579)
+* [bitnami/*] Update READMEs (#8716) ([b9a9533](https://github.com/bitnami/charts/commit/b9a9533)), closes [#8716](https://github.com/bitnami/charts/issues/8716)
+* [bitnami/several] Change prerequisites (#8725) ([8d740c5](https://github.com/bitnami/charts/commit/8d740c5)), closes [#8725](https://github.com/bitnami/charts/issues/8725)
+
+## 9.0.0 (2022-01-14)
+
+* [bitnami/apache] Chart standardized (#7491) ([6be033b](https://github.com/bitnami/charts/commit/6be033b)), closes [#7491](https://github.com/bitnami/charts/issues/7491)
+
+## <small>8.12.1 (2022-01-11)</small>
+
+* [bitnami/apache] Release 8.12.1 updating components versions ([2584539](https://github.com/bitnami/charts/commit/2584539))
+
+## 8.12.0 (2022-01-05)
+
+* [bitnami/several] Adapt templating format (#8562) ([8cad18a](https://github.com/bitnami/charts/commit/8cad18a)), closes [#8562](https://github.com/bitnami/charts/issues/8562)
+* [bitnami/several] Add license to the README ([05f7633](https://github.com/bitnami/charts/commit/05f7633))
+* [bitnami/several] Add license to the README ([32fb238](https://github.com/bitnami/charts/commit/32fb238))
+* [bitnami/several] Add license to the README ([b87c2f7](https://github.com/bitnami/charts/commit/b87c2f7))
+
+## <small>8.11.1 (2021-12-23)</small>
+
+* [bitnami/apache] Release 8.11.1 updating components versions ([53bd626](https://github.com/bitnami/charts/commit/53bd626))
+
+## 8.11.0 (2021-12-21)
+
+* [bitnami/apache]  Add podMonitor and prometheusRules (#8452) ([6fd5a46](https://github.com/bitnami/charts/commit/6fd5a46)), closes [#8452](https://github.com/bitnami/charts/issues/8452)
+
+## <small>8.10.2 (2021-12-20)</small>
+
+* [bitnami/apache] Release 8.10.2 updating components versions ([97a3834](https://github.com/bitnami/charts/commit/97a3834))
+
+## <small>8.10.1 (2021-12-14)</small>
+
+* [bitnami/apache] Release 8.10.1 updating components versions ([5c88fcd](https://github.com/bitnami/charts/commit/5c88fcd))
+
+## 8.10.0 (2021-12-09)
+
+* [bitnami/apache] Adds a switch to enable/disable the git-repo-syncer sidecar container… (#8332) ([8df6ebe](https://github.com/bitnami/charts/commit/8df6ebe)), closes [#8332](https://github.com/bitnami/charts/issues/8332)
+
+## <small>8.9.7 (2021-11-29)</small>
+
+* [bitnami/several] Replace HTTP by HTTPS when possible (#8259) ([eafb5bd](https://github.com/bitnami/charts/commit/eafb5bd)), closes [#8259](https://github.com/bitnami/charts/issues/8259)
+
+## <small>8.9.6 (2021-11-24)</small>
+
+* [bitnami/apache] Allow to move hidden directories (#8210) ([1136b1d](https://github.com/bitnami/charts/commit/1136b1d)), closes [#8210](https://github.com/bitnami/charts/issues/8210)
+* [bitnami/several] Regenerate README tables ([e8e4e6a](https://github.com/bitnami/charts/commit/e8e4e6a))
+
+## <small>8.9.5 (2021-11-21)</small>
+
+* [bitnami/apache] Release 8.9.5 updating components versions ([9f75ea8](https://github.com/bitnami/charts/commit/9f75ea8))
+
+## <small>8.9.4 (2021-11-20)</small>
+
+* [bitnami/apache] Release 8.9.4 updating components versions ([2fbebbb](https://github.com/bitnami/charts/commit/2fbebbb))
+* [bitnami/several] Regenerate README tables ([7b091c0](https://github.com/bitnami/charts/commit/7b091c0))
+
+## <small>8.9.3 (2021-11-17)</small>
+
+* [bitnami/apache] Release 8.9.3 updating components versions ([2580b0b](https://github.com/bitnami/charts/commit/2580b0b))
+
+## <small>8.9.2 (2021-11-11)</small>
+
+* [bitnami/apache] Fix clone htdocs when restart (#7970) ([df4fe38](https://github.com/bitnami/charts/commit/df4fe38)), closes [#7970](https://github.com/bitnami/charts/issues/7970)
+
+## <small>8.9.1 (2021-11-02)</small>
+
+* [bitnami/apache, bitnami/fluentd] Fix metadata used to generate README table (#8010) ([aecbb3b](https://github.com/bitnami/charts/commit/aecbb3b)), closes [#8010](https://github.com/bitnami/charts/issues/8010)
+* [bitnami/apache] Add tls secrets to match values example (#7989) ([d503216](https://github.com/bitnami/charts/commit/d503216)), closes [#7989](https://github.com/bitnami/charts/issues/7989)
+
+## 8.9.0 (2021-11-02)
+
+* [bitnami/apache] Add Autoscaling and Disruption Budget options (#7990) ([e0c07b1](https://github.com/bitnami/charts/commit/e0c07b1)), closes [#7990](https://github.com/bitnami/charts/issues/7990)
+* [bitnami/several] Regenerate README tables ([412cf6a](https://github.com/bitnami/charts/commit/412cf6a))
+
+## <small>8.8.6 (2021-10-26)</small>
+
+* [bitnami/apache] Release 8.8.6 updating components versions ([6d7a85d](https://github.com/bitnami/charts/commit/6d7a85d))
+
+## <small>8.8.5 (2021-10-22)</small>
+
+* [bitnami/several] Add chart info to NOTES.txt (#7889) ([a6751cd](https://github.com/bitnami/charts/commit/a6751cd)), closes [#7889](https://github.com/bitnami/charts/issues/7889)
+* [bitnami/several] Regenerate README tables ([9bead53](https://github.com/bitnami/charts/commit/9bead53))
+
+## <small>8.8.4 (2021-10-07)</small>
+
+* [bitnami/apache] Release 8.8.4 updating components versions ([8cbc517](https://github.com/bitnami/charts/commit/8cbc517))
+* [bitnami/several] Regenerate README tables ([cdcf8c1](https://github.com/bitnami/charts/commit/cdcf8c1))
+
+## <small>8.8.3 (2021-10-05)</small>
+
+* [bitnami/*] Revert changes in values.schemas.json (#7699) ([aaa314f](https://github.com/bitnami/charts/commit/aaa314f)), closes [#7699](https://github.com/bitnami/charts/issues/7699)
+
+## <small>8.8.2 (2021-10-05)</small>
+
+* [bitnami/apache] Release 8.8.2 updating components versions ([b4cf1a4](https://github.com/bitnami/charts/commit/b4cf1a4))
+
+## <small>8.8.1 (2021-10-01)</small>
+
+* [bitnami/*] Drop support for deprecated cert-manager annotation (#7582) ([a081792](https://github.com/bitnami/charts/commit/a081792)), closes [#7582](https://github.com/bitnami/charts/issues/7582)
+
+## 8.8.0 (2021-09-29)
+
+* [bitnami/apache,tomcat] add extraPodSpec (#7580) ([e3a8529](https://github.com/bitnami/charts/commit/e3a8529)), closes [#7580](https://github.com/bitnami/charts/issues/7580)
+* [bitnami/several] Regenerate README tables ([9d60bbd](https://github.com/bitnami/charts/commit/9d60bbd))
+
+## 8.7.0 (2021-09-27)
+
+* [bitnami/apache,postgresql,tomcat] add topologySpreadConstraints (#7598) ([557bfe9](https://github.com/bitnami/charts/commit/557bfe9)), closes [#7598](https://github.com/bitnami/charts/issues/7598)
+* [bitnami/several] Regenerate README tables ([003a0fb](https://github.com/bitnami/charts/commit/003a0fb))
+
+## <small>8.6.5 (2021-09-16)</small>
+
+* [bitnami/apache] Release 8.6.5 updating components versions ([7578c1b](https://github.com/bitnami/charts/commit/7578c1b))
+
+## <small>8.6.4 (2021-09-15)</small>
+
+* [bitnami/apache] Release 8.6.4 updating components versions ([4903073](https://github.com/bitnami/charts/commit/4903073))
+* [bitnami/several] Regenerate README tables ([64d5d74](https://github.com/bitnami/charts/commit/64d5d74))
+
+## <small>8.6.3 (2021-08-26)</small>
+
+* [bitnami/apache] Release 8.6.3 updating components versions ([da42550](https://github.com/bitnami/charts/commit/da42550))
+* [bitnami/several] Regenerate README tables ([da2513b](https://github.com/bitnami/charts/commit/da2513b))
+
+## <small>8.6.2 (2021-08-25)</small>
+
+* [bitnami/apache] Release 8.6.2 updating components versions ([5d59368](https://github.com/bitnami/charts/commit/5d59368))
+* [bitnami/several] Regenerate README tables ([6c9124f](https://github.com/bitnami/charts/commit/6c9124f))
+
+## <small>8.6.1 (2021-08-19)</small>
+
+* [bitnami/apache] Release 8.6.1 updating components versions ([320b9b6](https://github.com/bitnami/charts/commit/320b9b6))
+* [bitnami/several] Regenerate README tables ([6c107e8](https://github.com/bitnami/charts/commit/6c107e8))
+
+## 8.6.0 (2021-08-09)
+
+* [bitnami/apache] add support for IngressClassName (#7169) ([ff904d6](https://github.com/bitnami/charts/commit/ff904d6)), closes [#7169](https://github.com/bitnami/charts/issues/7169)
+
+## <small>8.5.11 (2021-08-04)</small>
+
+* [bitnami/apache] Release 8.5.11 updating components versions ([a26b35f](https://github.com/bitnami/charts/commit/a26b35f))
+
+## <small>8.5.10 (2021-07-22)</small>
+
+* [bitnami/several] Fix default values and regenerate README (#7023) ([c443ded](https://github.com/bitnami/charts/commit/c443ded)), closes [#7023](https://github.com/bitnami/charts/issues/7023)
+
+## <small>8.5.9 (2021-07-19)</small>
+
+* [bitnami/*] Adapt values.yaml of Apache, ASP.NET Core and Cassandra to readme-generator (#6751) ([cee2166](https://github.com/bitnami/charts/commit/cee2166)), closes [#6751](https://github.com/bitnami/charts/issues/6751)
+
+## <small>8.5.8 (2021-07-08)</small>
+
+* [bitnami/apache] Release 8.5.8 updating components versions ([ef6138d](https://github.com/bitnami/charts/commit/ef6138d))
+
+## <small>8.5.7 (2021-06-21)</small>
+
+* [bitnami/apache] Release 8.5.7 updating components versions ([7d15675](https://github.com/bitnami/charts/commit/7d15675))
+
+## <small>8.5.6 (2021-06-19)</small>
+
+* [bitnami/apache] Release 8.5.6 updating components versions ([42a4875](https://github.com/bitnami/charts/commit/42a4875))
+
+## <small>8.5.5 (2021-06-02)</small>
+
+* [bitnami/apache] Release 8.5.5 updating components versions ([958e9ac](https://github.com/bitnami/charts/commit/958e9ac))
+
+## <small>8.5.4 (2021-05-23)</small>
+
+* [bitnami/apache] Release 8.5.4 updating components versions ([e7a1f8e](https://github.com/bitnami/charts/commit/e7a1f8e))
+
+## <small>8.5.3 (2021-05-20)</small>
+
+* [bitnami/apache] Release 8.5.3 updating components versions ([50e7148](https://github.com/bitnami/charts/commit/50e7148))
+
+## <small>8.5.2 (2021-04-20)</small>
+
+* [bitnami/apache] Release 8.5.2 updating components versions ([9b0b5c0](https://github.com/bitnami/charts/commit/9b0b5c0))
+
+## <small>8.5.1 (2021-04-08)</small>
+
+* [bitnami/apache] fix service annotations (#6046) ([92ab847](https://github.com/bitnami/charts/commit/92ab847)), closes [#6046](https://github.com/bitnami/charts/issues/6046)
+
+## 8.5.0 (2021-04-07)
+
+* [bitnami/apache] port commonLabels, commonAnnotations & podLabels from other charts (#6037) ([01b7733](https://github.com/bitnami/charts/commit/01b7733)), closes [#6037](https://github.com/bitnami/charts/issues/6037)
+
+## <small>8.4.2 (2021-04-05)</small>
+
+* [bitnami/apache] Release 8.4.2 updating components versions ([554bd21](https://github.com/bitnami/charts/commit/554bd21))
+
+## <small>8.4.1 (2021-03-28)</small>
+
+* [bitnami/apache] Release 8.4.1 updating components versions ([3c2d896](https://github.com/bitnami/charts/commit/3c2d896))
+
+## 8.4.0 (2021-03-19)
+
+* [bitnami/*] Allow git ssh connections (#5814) ([c9adeff](https://github.com/bitnami/charts/commit/c9adeff)), closes [#5814](https://github.com/bitnami/charts/issues/5814)
+
+## <small>8.3.2 (2021-03-04)</small>
+
+* [bitnami/*] Remove minideb mentions (#5677) ([870bc4d](https://github.com/bitnami/charts/commit/870bc4d)), closes [#5677](https://github.com/bitnami/charts/issues/5677)
+
+## <small>8.3.1 (2021-02-26)</small>
+
+* [bitnami/apache] Release 8.3.1 updating components versions ([ac6741d](https://github.com/bitnami/charts/commit/ac6741d))
+
+## 8.3.0 (2021-02-18)
+
+* [bitnami/apache] Add extra-list.yaml & extra initContainers & sidecars (#5534) ([8f589f1](https://github.com/bitnami/charts/commit/8f589f1)), closes [#5534](https://github.com/bitnami/charts/issues/5534)
+
+## <small>8.2.3 (2021-01-27)</small>
+
+* [bitnami/apache] Release 8.2.3 updating components versions ([0ed3d19](https://github.com/bitnami/charts/commit/0ed3d19))
+
+## <small>8.2.2 (2021-01-27)</small>
+
+* [bitnami/apache] Release 8.2.2 updating components versions ([734ce3f](https://github.com/bitnami/charts/commit/734ce3f))
+
+## <small>8.2.1 (2021-01-27)</small>
+
+* Improves Apache/MySQL README files (#4994) ([e40c914](https://github.com/bitnami/charts/commit/e40c914)), closes [#4994](https://github.com/bitnami/charts/issues/4994)
+
+## 8.2.0 (2021-01-22)
+
+* [bitnami/*] Change helm version in the prerequisites (#5090) ([c5e67a3](https://github.com/bitnami/charts/commit/c5e67a3)), closes [#5090](https://github.com/bitnami/charts/issues/5090)
+* [bitnami/apache] Add hostAliases support (#5161) ([cc3e570](https://github.com/bitnami/charts/commit/cc3e570)), closes [#5161](https://github.com/bitnami/charts/issues/5161)
+
+## <small>8.1.1 (2021-01-04)</small>
+
+* [bitnami/apache] Release 8.1.1 updating components versions ([26ee9fc](https://github.com/bitnami/charts/commit/26ee9fc))
+
+## 8.1.0 (2020-12-31)
+
+* [bitnami/*] fix typos (#4699) ([49adc63](https://github.com/bitnami/charts/commit/49adc63)), closes [#4699](https://github.com/bitnami/charts/issues/4699)
+* [bitnami/*] Update ingress rules (batch 1) (#4870) ([2f3e2be](https://github.com/bitnami/charts/commit/2f3e2be)), closes [#4870](https://github.com/bitnami/charts/issues/4870)
+
+## <small>8.0.3 (2020-12-11)</small>
+
+* [bitnami/*] Update dependencies (#4694) ([2826c12](https://github.com/bitnami/charts/commit/2826c12)), closes [#4694](https://github.com/bitnami/charts/issues/4694)
+
+## <small>8.0.2 (2020-12-10)</small>
+
+* [bitnami/apache] Release 8.0.2 updating components versions ([1e44bbc](https://github.com/bitnami/charts/commit/1e44bbc))
+
+## <small>8.0.1 (2020-11-20)</small>
+
+* [bitnami/*] Expose the "service type" in the basic form for Kubeapps (#4445) ([cf3b3d3](https://github.com/bitnami/charts/commit/cf3b3d3)), closes [#4445](https://github.com/bitnami/charts/issues/4445)
+
+## 8.0.0 (2020-11-10)
+
+* [bitnami/*] Include link to Troubleshootin guide on README.md (#4136) ([c08a20e](https://github.com/bitnami/charts/commit/c08a20e)), closes [#4136](https://github.com/bitnami/charts/issues/4136)
+* [bitnami/apache] Major version. Adapt Chart to apiVersion: v2 (#4287) ([d90a33d](https://github.com/bitnami/charts/commit/d90a33d)), closes [#4287](https://github.com/bitnami/charts/issues/4287)
+
+## 7.6.0 (2020-10-23)
+
+* [bitnami/apache] feat: add extraEnvVars (#4083) ([1567840](https://github.com/bitnami/charts/commit/1567840)), closes [#4083](https://github.com/bitnami/charts/issues/4083)
+
+## <small>7.5.1 (2020-10-20)</small>
+
+* [bitnami/apache] Release 7.5.1 updating components versions ([a1df14f](https://github.com/bitnami/charts/commit/a1df14f))
+
+## 7.5.0 (2020-10-09)
+
+* [bitnami/apache] Add extra volume support (#3970) ([e6aee9c](https://github.com/bitnami/charts/commit/e6aee9c)), closes [#3970](https://github.com/bitnami/charts/issues/3970)
+
+## 7.4.0 (2020-09-24)
+
+* [bitnami/*] Affinity based on common presets (#3746) ([01884c7](https://github.com/bitnami/charts/commit/01884c7)), closes [#3746](https://github.com/bitnami/charts/issues/3746)
+
+## <small>7.3.26 (2020-09-21)</small>
+
+* [bitnami/apache] Release 7.3.26 updating components versions ([4ce1c62](https://github.com/bitnami/charts/commit/4ce1c62))
+
+## <small>7.3.25 (2020-09-07)</small>
+
+* [bitnami/apache] Release 7.3.25 updating components versions ([4144bfe](https://github.com/bitnami/charts/commit/4144bfe))
+* [bitnami/metrics-server] Add source repo (#3577) ([1ed12f9](https://github.com/bitnami/charts/commit/1ed12f9)), closes [#3577](https://github.com/bitnami/charts/issues/3577)
+
+## <small>7.3.24 (2020-08-14)</small>
+
+* [bitnami/apache] Add resources for git container (#3399) ([f3e8318](https://github.com/bitnami/charts/commit/f3e8318)), closes [#3399](https://github.com/bitnami/charts/issues/3399)
+
+## <small>7.3.23 (2020-08-07)</small>
+
+* [bitnami/apache] Release 7.3.23 updating components versions ([ad806b5](https://github.com/bitnami/charts/commit/ad806b5))
+
+## <small>7.3.22 (2020-08-07)</small>
+
+* [bitnami/apache] Release 7.3.22 updating components versions ([ed6ae89](https://github.com/bitnami/charts/commit/ed6ae89))
+
+## <small>7.3.21 (2020-08-05)</small>
+
+* [bitnami/*] Fix TL;DR typo in READMEs (#3280) ([3d7ab40](https://github.com/bitnami/charts/commit/3d7ab40)), closes [#3280](https://github.com/bitnami/charts/issues/3280)
+* [bitnami/apache] Release 7.3.21 updating components versions ([365fa4b](https://github.com/bitnami/charts/commit/365fa4b))
+
+## <small>7.3.20 (2020-07-24)</small>
+
+* [bitnami/all] Add categories (#3075) ([63bde06](https://github.com/bitnami/charts/commit/63bde06)), closes [#3075](https://github.com/bitnami/charts/issues/3075)
+* [bitnami/apache] Release 7.3.20 updating components versions ([37e4526](https://github.com/bitnami/charts/commit/37e4526))
+
+## <small>7.3.19 (2020-07-02)</small>
+
+* [bitnami/apache] Release 7.3.19 updating components versions ([ac1f8c4](https://github.com/bitnami/charts/commit/ac1f8c4))
+
+## <small>7.3.18 (2020-06-18)</small>
+
+* [bitnami/apache] Release 7.3.18 updating components versions ([0fbec7e](https://github.com/bitnami/charts/commit/0fbec7e))
+* [multiple charts] Update hidden properties in the different JSON schemas (#2871) ([4cff6ba](https://github.com/bitnami/charts/commit/4cff6ba)), closes [#2871](https://github.com/bitnami/charts/issues/2871)
+
+## <small>7.3.17 (2020-06-02)</small>
+
+* [bitnami/apache] Release 7.3.17 updating components versions ([aa1be0b](https://github.com/bitnami/charts/commit/aa1be0b))
+* Add support for helm lint and helm install in PRs via GH Actions (#2721) ([5ed97f0](https://github.com/bitnami/charts/commit/5ed97f0)), closes [#2721](https://github.com/bitnami/charts/issues/2721)
+
+## <small>7.3.16 (2020-05-22)</small>
+
+* [bitnami/apache] Release 7.3.16 updating components versions ([3d6600e](https://github.com/bitnami/charts/commit/3d6600e))
+* update bitnami/common to be compatible with helm v2.12+ (#2615) ([c7751eb](https://github.com/bitnami/charts/commit/c7751eb)), closes [#2615](https://github.com/bitnami/charts/issues/2615)
+
+## <small>7.3.15 (2020-04-22)</small>
+
+* [bitnami/apache] Release 7.3.15 updating components versions ([37de68b](https://github.com/bitnami/charts/commit/37de68b))
+
+## <small>7.3.14 (2020-04-16)</small>
+
+* [bitnami/apache] Release 7.3.14 updating components versions ([d2d1a57](https://github.com/bitnami/charts/commit/d2d1a57))
+
+## <small>7.3.13 (2020-04-10)</small>
+
+* [bitnami/apache] Change in the command of apache-exporter  (#2280) ([ccc69c8](https://github.com/bitnami/charts/commit/ccc69c8)), closes [#2280](https://github.com/bitnami/charts/issues/2280)
+
+## <small>7.3.12 (2020-04-06)</small>
+
+* [bitnami/apache] Release 7.3.12 updating components versions ([a7f4532](https://github.com/bitnami/charts/commit/a7f4532))
+
+## <small>7.3.11 (2020-03-26)</small>
+
+* [bitnami/apache] Release 7.3.11 updating components versions ([8ed692f](https://github.com/bitnami/charts/commit/8ed692f))
+
+## <small>7.3.10 (2020-03-20)</small>
+
+* [bitnami/apache] Release 7.3.10 updating components versions ([d0fef10](https://github.com/bitnami/charts/commit/d0fef10))
+
+## <small>7.3.9 (2020-03-11)</small>
+
+* [bitnami/apache] Release 7.3.9 updating components versions ([da70ce0](https://github.com/bitnami/charts/commit/da70ce0))
+
+## <small>7.3.8 (2020-03-11)</small>
+
+* Move charts from upstreamed folder to bitnami (#2032) ([a0e44f7](https://github.com/bitnami/charts/commit/a0e44f7)), closes [#2032](https://github.com/bitnami/charts/issues/2032)
+
+## <small>7.3.7 (2020-02-25)</small>
+
+* [bitnami/apache] Release 7.3.7 updating components versions ([792068a](https://github.com/bitnami/charts/commit/792068a))
+
+## <small>7.3.6 (2020-02-18)</small>
+
+* [bitnami/apache] Release 7.3.6 updating components versions ([7610af0](https://github.com/bitnami/charts/commit/7610af0))
+
+## <small>7.3.5 (2020-02-11)</small>
+
+* [bitnami/several] Adapt READMEs and helpers to Helm 3 (#1911) ([40ee57c](https://github.com/bitnami/charts/commit/40ee57c)), closes [#1911](https://github.com/bitnami/charts/issues/1911)
+
+## <small>7.3.4 (2020-01-24)</small>
+
+* [bitnami/apache] Release 7.3.4 updating components versions ([0745148](https://github.com/bitnami/charts/commit/0745148))
+
+## <small>7.3.3 (2020-01-14)</small>
+
+* [bitnami/apache] Release 7.3.3 updating components versions ([4d6e512](https://github.com/bitnami/charts/commit/4d6e512))
+
+## <small>7.3.2 (2020-01-10)</small>
+
+* [bitnami/apache] Release 7.3.2 updating components versions ([11dd716](https://github.com/bitnami/charts/commit/11dd716))
+
+## <small>7.3.1 (2019-12-19)</small>
+
+* add some useful information to NOTE.txt ([9892f73](https://github.com/bitnami/charts/commit/9892f73))
+* changed port back to http ([6a880cb](https://github.com/bitnami/charts/commit/6a880cb))
+* new parameter added to README.md ([0644674](https://github.com/bitnami/charts/commit/0644674))
+
+## 7.3.0 (2019-12-04)
+
+* minor version updated ([1c4baa0](https://github.com/bitnami/charts/commit/1c4baa0))
+
+## <small>7.2.15 (2019-12-03)</small>
+
+* adding port and path to probes ([fe95d6a](https://github.com/bitnami/charts/commit/fe95d6a))
+* minor version update ([70e3211](https://github.com/bitnami/charts/commit/70e3211))
+
+## <small>7.2.14 (2019-11-28)</small>
+
+* [bitnami/apache] Fix typo in values.schema.json ([65904a1](https://github.com/bitnami/charts/commit/65904a1))
+
+## <small>7.2.13 (2019-11-18)</small>
+
+* [bitnami/apache] Release 7.2.13 updating components versions ([c868e57](https://github.com/bitnami/charts/commit/c868e57))
+
+## <small>7.2.12 (2019-11-14)</small>
+
+* [bitnami/apache] Lint chart ([4103cdd](https://github.com/bitnami/charts/commit/4103cdd))
+* Bump chart version ([548de9f](https://github.com/bitnami/charts/commit/548de9f))
+
+## <small>7.2.5 (2019-11-07)</small>
+
+* [bitnami/apache] Lint chart ([8107113](https://github.com/bitnami/charts/commit/8107113))
+
+## <small>7.2.10 (2019-11-14)</small>
+
+* [bitnami/apache] Release 7.2.10 updating components versions ([096ee01](https://github.com/bitnami/charts/commit/096ee01))
+
+## <small>7.2.9 (2019-11-12)</small>
+
+* [bitnami/apache] Release 7.2.9 updating components versions ([c671d09](https://github.com/bitnami/charts/commit/c671d09))
+
+## <small>7.2.8 (2019-11-11)</small>
+
+* [bitnami/apache] Release 7.2.8 updating components versions ([e492c3f](https://github.com/bitnami/charts/commit/e492c3f))
+
+## <small>7.2.7 (2019-11-10)</small>
+
+* [bitnami/apache] Release 7.2.7 updating components versions ([918f214](https://github.com/bitnami/charts/commit/918f214))
+
+## <small>7.2.6 (2019-11-08)</small>
+
+* [bitnami/apache] Release 7.2.5 updating components versions ([5bf791f](https://github.com/bitnami/charts/commit/5bf791f))
+* [bitnami/apache] Release 7.2.6 updating components versions ([597e20e](https://github.com/bitnami/charts/commit/597e20e))
+
+## <small>7.2.5 (2019-11-07)</small>
+
+* [bitnami/apache] Lint chart ([8107113](https://github.com/bitnami/charts/commit/8107113))
+
+## <small>7.2.4 (2019-11-07)</small>
+
+* [bitnami/apache] Release 7.2.4 updating components versions ([6ff5c71](https://github.com/bitnami/charts/commit/6ff5c71))
+
+## <small>7.2.3 (2019-11-05)</small>
+
+* Update values.schema.json to reflect latest format ([f7664df](https://github.com/bitnami/charts/commit/f7664df))
+
+## <small>7.2.2 (2019-10-24)</small>
+
+* Add semicolon to TL;DR section to unify all READMEs ([23863cd](https://github.com/bitnami/charts/commit/23863cd))
+
+## <small>7.2.1 (2019-10-23)</small>
+
+* Adapt README in charts (I) ([eb80a7e](https://github.com/bitnami/charts/commit/eb80a7e))
+
+## 7.2.0 (2019-10-18)
+
+* [bitnami/apache] Update prerequisites ([8308bed](https://github.com/bitnami/charts/commit/8308bed))
+* Add JSON Schema to Apache chart ([f3f4af7](https://github.com/bitnami/charts/commit/f3f4af7))
+
+## <small>7.1.1 (2019-10-16)</small>
+
+* [bitnami/apache] Release 7.1.1 updating components versions ([2f203e0](https://github.com/bitnami/charts/commit/2f203e0))
+* Allow mounting files from files/ directory ([4a5cc44](https://github.com/bitnami/charts/commit/4a5cc44))
+
+## 7.1.0 (2019-10-04)
+
+* Allow mounting httpd.conf through a config map ([200ca88](https://github.com/bitnami/charts/commit/200ca88))
+
+## <small>7.0.3 (2019-10-03)</small>
+
+* [bitnami/*] Fix broken links to NGINX Ingress Annotations docs ([42a2f47](https://github.com/bitnami/charts/commit/42a2f47))
+
+## <small>7.0.2 (2019-09-26)</small>
+
+* [bitnami/apache] Release 7.0.2 updating components versions ([8e2cd12](https://github.com/bitnami/charts/commit/8e2cd12))
+
+## <small>7.0.1 (2019-09-20)</small>
+
+* [bitnami/*] Update apiVersion on sts, deployments, daemonsets and podsecuritypolicies ([4dfac07](https://github.com/bitnami/charts/commit/4dfac07))
+* [bitnami/apache] Update components versions ([ecd65ed](https://github.com/bitnami/charts/commit/ecd65ed))
+
+## 7.0.0 (2019-09-19)
+
+* Use Apache bash container ([da53cfa](https://github.com/bitnami/charts/commit/da53cfa))
+
+## 6.1.0 (2019-09-04)
+
+* Bump minor version ([10f1738](https://github.com/bitnami/charts/commit/10f1738))
+
+## <small>6.0.7 (2019-09-04)</small>
+
+* Add affinity to apache ([56bc5ea](https://github.com/bitnami/charts/commit/56bc5ea))
+
+## <small>6.0.6 (2019-09-02)</small>
+
+* [bitnami/apache] Release 6.0.6 updating components versions ([982fa15](https://github.com/bitnami/charts/commit/982fa15))
+
+## <small>6.0.5 (2019-08-30)</small>
+
+* [bitnami/apache] Release 6.0.5 updating components versions ([fd7f2cd](https://github.com/bitnami/charts/commit/fd7f2cd))
+
+## <small>6.0.4 (2019-08-30)</small>
+
+* [bitnami/apache] Release 6.0.4 updating components versions ([0f1e9de](https://github.com/bitnami/charts/commit/0f1e9de))
+
+## <small>6.0.3 (2019-08-15)</small>
+
+* [bitnami/apache] Release 6.0.3 updating components versions ([ec907ce](https://github.com/bitnami/charts/commit/ec907ce))
+
+## <small>6.0.2 (2019-08-13)</small>
+
+* Update README.md ([575d0b8](https://github.com/bitnami/charts/commit/575d0b8))
+* Update README.md ([9e220f7](https://github.com/bitnami/charts/commit/9e220f7))
+* Updated version numbers ([aa0294b](https://github.com/bitnami/charts/commit/aa0294b))
+
+## <small>6.0.1 (2019-08-12)</small>
+
+* [bitnami/apache] Allow custom htdocs ([4ddd3ca](https://github.com/bitnami/charts/commit/4ddd3ca))
+* [bitnami/apache] Allow mounting data ([5e32fdc](https://github.com/bitnami/charts/commit/5e32fdc))
+* [bitnami/apache] Release 6.0.1 updating components versions ([ef7f1be](https://github.com/bitnami/charts/commit/ef7f1be))
+* Add notable  changes ([899ab2b](https://github.com/bitnami/charts/commit/899ab2b))
+* Fix truncate comment in helpers ([cf4a7a3](https://github.com/bitnami/charts/commit/cf4a7a3))
+
+## <small>5.1.1 (2019-07-24)</small>
+
+* [bitnami/apache] Fix typo in the README.md (#1314) ([08cdeae](https://github.com/bitnami/charts/commit/08cdeae)), closes [#1314](https://github.com/bitnami/charts/issues/1314)
+
+## 5.1.0 (2019-07-24)
+
+* [bitnami/apache] Replace lusotycoon/apache-exporter with bitnami/apache-exporter (#1305) ([b0d506b](https://github.com/bitnami/charts/commit/b0d506b)), closes [#1305](https://github.com/bitnami/charts/issues/1305)
+* Implement again #1283 changes but bumping the major version ([1ce079c](https://github.com/bitnami/charts/commit/1ce079c)), closes [#1283](https://github.com/bitnami/charts/issues/1283)
+
+## <small>4.3.4 (2019-07-17)</small>
+
+* Revert pull request #1283 ([8e5940a](https://github.com/bitnami/charts/commit/8e5940a)), closes [#1283](https://github.com/bitnami/charts/issues/1283)
+* Undo breaking changes on labels ([ae05c77](https://github.com/bitnami/charts/commit/ae05c77))
+* Use name of the solution for the main container included in the pod ([d031dee](https://github.com/bitnami/charts/commit/d031dee))
+
+## <small>4.3.3 (2019-07-11)</small>
+
+* Changes in README ([7ac4ec0](https://github.com/bitnami/charts/commit/7ac4ec0))
+* Standardize component.name & component.fullname functions ([775948e](https://github.com/bitnami/charts/commit/775948e))
+
+## <small>4.3.2 (2019-06-10)</small>
+
+* bitnami/apache: update to 2.4.39 ([dd28a08](https://github.com/bitnami/charts/commit/dd28a08))
+* Bump version ([a672193](https://github.com/bitnami/charts/commit/a672193))
+
+## <small>4.3.1 (2019-06-10)</small>
+
+* Use IfNotPresent as imagePullPolicy since we are using immutable tags ([53247da](https://github.com/bitnami/charts/commit/53247da))
+
+## 4.3.0 (2019-05-30)
+
+* Remove apache volume ([c8b847a](https://github.com/bitnami/charts/commit/c8b847a))
+
+## <small>4.2.4 (2019-05-29)</small>
+
+* Change syntax because of linter failing ([adfc357](https://github.com/bitnami/charts/commit/adfc357))
+* Create NOTES.txt for apache and nginx ([f564ac1](https://github.com/bitnami/charts/commit/f564ac1))
+* Fix https://github.com/helm/charts/pull/14199\#issuecomment-496883321 and support _sha256_ as an imm ([95957ea](https://github.com/bitnami/charts/commit/95957ea)), closes [#issuecomment-496883321](https://github.com/bitnami/charts/issues/issuecomment-496883321)
+
+## <small>4.2.3 (2019-05-28)</small>
+
+* Prepare immutable tags ([f9093c1](https://github.com/bitnami/charts/commit/f9093c1))
+
+## <small>4.2.2 (2019-05-23)</small>
+
+* bitnami/apache: update to 2.4.39 ([4329e0f](https://github.com/bitnami/charts/commit/4329e0f))
+
+## <small>4.2.1 (2019-05-22)</small>
+
+* [bitnami/apache] Add ingress rules ([ab49ce8](https://github.com/bitnami/charts/commit/ab49ce8))
+* Apply suggestions ([303827f](https://github.com/bitnami/charts/commit/303827f))
+* bitnami/apache: update to 2.4.39 ([691f6a4](https://github.com/bitnami/charts/commit/691f6a4))
+
+## <small>4.1.2 (2019-04-02)</small>
+
+* bitnami/apache: update to 2.4.39 ([5f6a007](https://github.com/bitnami/charts/commit/5f6a007))
+* Use namespaces ([8c80056](https://github.com/bitnami/charts/commit/8c80056))
+
+## <small>4.1.1 (2019-03-14)</small>
+
+* [bitnami/apache] Fix typo in values.yaml comments ([60da668](https://github.com/bitnami/charts/commit/60da668))
+* Complete imageRegisty example ([9c9988e](https://github.com/bitnami/charts/commit/9c9988e))
+* Use global registry in secondary, metrics and other non-default images ([5d216bf](https://github.com/bitnami/charts/commit/5d216bf))
+
+## 4.1.0 (2019-03-07)
+
+* [bitnami/apache] Add global 'imagePullSecrets' to overwrite any other existing one ([b826c65](https://github.com/bitnami/charts/commit/b826c65))
+
+## <small>4.0.7 (2019-02-27)</small>
+
+* Add appiVersion to Chart.yaml ([08704a5](https://github.com/bitnami/charts/commit/08704a5))
+
+## <small>4.0.6 (2019-02-26)</small>
+
+* Fix Apache version ([7d64f01](https://github.com/bitnami/charts/commit/7d64f01))
+
+## <small>4.0.5 (2019-02-21)</small>
+
+* Update Chart.yaml ([2f9f96e](https://github.com/bitnami/charts/commit/2f9f96e))
+* Update README.md ([3ca4aa2](https://github.com/bitnami/charts/commit/3ca4aa2))
+
+## <small>4.0.4 (2019-02-07)</small>
+
+* Fix appVersion fields for some Chart.yaml files (#1048) ([697e18d](https://github.com/bitnami/charts/commit/697e18d)), closes [#1048](https://github.com/bitnami/charts/issues/1048)
+
+## <small>4.0.3 (2019-02-06)</small>
+
+* bitnami/apache: update to 2.4.40.test ([2756910](https://github.com/bitnami/charts/commit/2756910))
+
+## <small>4.0.2 (2019-02-06)</small>
+
+* Document the correct format for pullSecrets in READMEs ([9a2cf81](https://github.com/bitnami/charts/commit/9a2cf81))
+* apache: update to `2.4.38` ([989efaf](https://github.com/bitnami/charts/commit/989efaf))
+
+## <small>4.0.1 (2018-12-13)</small>
+
+* Add podAnnotations ([78310b4](https://github.com/bitnami/charts/commit/78310b4))
+* Add readme entry ([e7db1d3](https://github.com/bitnami/charts/commit/e7db1d3))
+* Change logos ([4e43cd4](https://github.com/bitnami/charts/commit/4e43cd4))
+
+## 2.2.0 (2018-10-29)
+
+* Fix port ([7c37ee1](https://github.com/bitnami/charts/commit/7c37ee1))
+
+## 3.0.0 (2018-11-21)
+
+* [bitnami/apache] Add service.type to values.yaml ([1de5d8b](https://github.com/bitnami/charts/commit/1de5d8b))
+
+## 2.2.0 (2018-10-29)
+
+* Fix port ([7c37ee1](https://github.com/bitnami/charts/commit/7c37ee1))
+
+## <small>2.1.2 (2018-10-23)</small>
+
+* apache: bump chart appVersion to `2.4.37` ([affe81a](https://github.com/bitnami/charts/commit/affe81a))
+* apache: bump chart version to `2.1.2` ([f5ec4d4](https://github.com/bitnami/charts/commit/f5ec4d4))
+* apache: update to `2.4.37` ([6a89554](https://github.com/bitnami/charts/commit/6a89554))
+
+## <small>2.1.1 (2018-10-17)</small>
+
+* Apply some suggestions ([24706a6](https://github.com/bitnami/charts/commit/24706a6))
+* Bump versions ([0cfd3f4](https://github.com/bitnami/charts/commit/0cfd3f4))
+* Change logic to determine registry ([9ead294](https://github.com/bitnami/charts/commit/9ead294))
+* Check if global is set ([dec26e5](https://github.com/bitnami/charts/commit/dec26e5))
+* Fix typo ([93170ac](https://github.com/bitnami/charts/commit/93170ac))
+* Remove distro tags in charts ([427ac51](https://github.com/bitnami/charts/commit/427ac51))
+* Reword and update kafka dependencies ([be6cbed](https://github.com/bitnami/charts/commit/be6cbed))
+
+## 2.1.0 (2018-10-11)
+
+* Add global registry option to Bitnami charts ([395ba08](https://github.com/bitnami/charts/commit/395ba08))
+
+## <small>2.0.2 (2018-10-05)</small>
+
+* Add kubeapps text to charts READMEs ([2f6dc51](https://github.com/bitnami/charts/commit/2f6dc51))
+
+## <small>2.0.1 (2018-09-24)</small>
+
+* apache: bump chart appVersion to `2.4.35` ([8f3e712](https://github.com/bitnami/charts/commit/8f3e712))
+* apache: bump chart version to `2.0.1` ([e9d931a](https://github.com/bitnami/charts/commit/e9d931a))
+* apache: update to `2.4.35-debian-9` ([202801e](https://github.com/bitnami/charts/commit/202801e))
+
+## 2.0.0 (2018-09-21)
+
+* [bitnami/apache] Fix chart not being upgradable ([c3a2454](https://github.com/bitnami/charts/commit/c3a2454))
+
+## 1.0.0 (2018-07-24)
+
+* Bump major version ([0edf8e8](https://github.com/bitnami/charts/commit/0edf8e8))
+
+## <small>0.3.15 (2018-07-24)</small>
+
+* Adapt apache chart to non-root ([ce72a7d](https://github.com/bitnami/charts/commit/ce72a7d))
+* Bump chart version ([302028c](https://github.com/bitnami/charts/commit/302028c))
+
+## <small>0.3.14 (2018-07-16)</small>
+
+* apache: bump chart appVersion to `2.4.34` ([637605e](https://github.com/bitnami/charts/commit/637605e))
+* apache: bump chart version to `0.3.14` ([1200f25](https://github.com/bitnami/charts/commit/1200f25))
+* apache: update to `2.4.34-debian-9` ([228462a](https://github.com/bitnami/charts/commit/228462a))
+
+## <small>0.3.13 (2018-07-06)</small>
+
+* apache: bump chart appVersion to `2.4.33-debian-9` ([a6d1062](https://github.com/bitnami/charts/commit/a6d1062))
+* apache: bump chart version to `0.3.13` ([41999ab](https://github.com/bitnami/charts/commit/41999ab))
+* apache: update to `2.4.33-debian-9` ([0717e61](https://github.com/bitnami/charts/commit/0717e61))
+
+## <small>0.3.12 (2018-05-30)</small>
+
+* bum chart version ([5e98822](https://github.com/bitnami/charts/commit/5e98822))
+* Fix imagePullPolicy for apache bitnami chart ([5ff6cd0](https://github.com/bitnami/charts/commit/5ff6cd0))
+
+## <small>0.3.11 (2018-04-13)</small>
+
+* Documentation fixes ([fdbcc57](https://github.com/bitnami/charts/commit/fdbcc57))
+
+## <small>0.3.10 (2018-04-13)</small>
+
+* Rename charts folders ([5413120](https://github.com/bitnami/charts/commit/5413120))

--- a/bitnami/apache/Chart.yaml
+++ b/bitnami/apache/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: apache
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/apache
-version: 11.1.0
+version: 11.1.1

--- a/bitnami/apache/templates/deployment.yaml
+++ b/bitnami/apache/templates/deployment.yaml
@@ -255,7 +255,7 @@ spec:
               subPath: app-tmp-dir
             {{- if (include "apache.useHtdocs" .) }}
             - name: htdocs
-              mountPath: /app
+              mountPath: /opt/bitnami/apache/htdocs
             {{- end }}
             {{- if or (.Files.Glob "files/vhosts/*.conf") (.Values.vhostsConfigMap) }}
             - name: vhosts


### PR DESCRIPTION
### Description of the change

Fixes an issue with apache, where deployment will fail when htdocs are mounted.

```
apache 09:12:49.11 INFO  ==> ** Starting Apache setup **
apache 09:12:49.22 INFO  ==> Mounting application files from '/app'
rm: cannot remove '/opt/bitnami/apache/htdocs/index.html': Read-only file system
```

This issue is caused by [this section](https://github.com/bitnami/containers/blob/553a1efd8556e38d226a19dd2d2535cf9b08e756/bitnami/apache/2.4/debian-12/rootfs/opt/bitnami/scripts/apache/setup.sh#L76-L80) of the image logic:

```
if ! is_dir_empty "/app"; then
    info "Mounting application files from '/app'"
    rm -rf "$APACHE_HTDOCS_DIR"
    ln -sf "/app" "$APACHE_HTDOCS_DIR"
fi
```

Mounting the htdocs at `/app` will attempt to remove `/opt/bitnami/apache/htdocs`, causing the above permission error.

### Possible drawbacks

This PR mounts the htdocs directly at `/opt/bitnami/apache/htdocs`, causing the `/app` folder to remain empty from now on.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #25669

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
