### PR TITLE
[bitnami/fluentd] Use different liveness/readiness probes

### DIFF
--- a/bitnami/fluentd/CHANGELOG.md
+++ b/bitnami/fluentd/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
+## 6.3.1 (2024-05-22)
+
+* [bitnami/fluentd] Use different liveness/readiness probes ([#26311](https://github.com/bitnami/charts/pulls/26311))
+
 ## 6.3.0 (2024-05-21)
 
-* [bitnami/fluentd] feat: :sparkles: :lock: Add warning when original images are replaced ([#26205](https://github.com/bitnami/charts/pulls/26205))
+* [bitnami/*] ci: :construction_worker: Add tag and changelog support (#25359) ([91c707c](https://github.com/bitnami/charts/commit/91c707c)), closes [#25359](https://github.com/bitnami/charts/issues/25359)
+* [bitnami/fluentd] feat: :sparkles: :lock: Add warning when original images are replaced (#26205) ([929a4c8](https://github.com/bitnami/charts/commit/929a4c8)), closes [#26205](https://github.com/bitnami/charts/issues/26205)
 
 ## <small>6.2.3 (2024-05-18)</small>
 

--- a/bitnami/fluentd/Chart.yaml
+++ b/bitnami/fluentd/Chart.yaml
@@ -30,4 +30,4 @@ maintainers:
 name: fluentd
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/fluentd
-version: 6.3.0
+version: 6.3.1

--- a/bitnami/fluentd/templates/aggregator-statefulset.yaml
+++ b/bitnami/fluentd/templates/aggregator-statefulset.yaml
@@ -222,8 +222,7 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.aggregator.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.aggregator.livenessProbe.enabled }}
           livenessProbe:
-            httpGet:
-              path: {{ .Values.aggregator.livenessProbe.httpGet.path }}
+            tcpSocket:
               port: {{ .Values.aggregator.livenessProbe.httpGet.port }}
             initialDelaySeconds: {{ .Values.aggregator.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.aggregator.livenessProbe.periodSeconds }}

--- a/bitnami/fluentd/templates/forwarder-daemonset.yaml
+++ b/bitnami/fluentd/templates/forwarder-daemonset.yaml
@@ -214,8 +214,7 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.forwarder.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.forwarder.livenessProbe.enabled }}
           livenessProbe:
-            httpGet:
-              path: {{ .Values.forwarder.livenessProbe.httpGet.path }}
+            tcpSocket:
               port: {{ .Values.forwarder.livenessProbe.httpGet.port }}
             initialDelaySeconds: {{ .Values.forwarder.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.forwarder.livenessProbe.periodSeconds }}


### PR DESCRIPTION
### Description of the change
This PR aims to use different liveness/readiness probes to improve overall security and avoid unnecessary container restarts. [More info](https://github.com/zegl/kube-score/blob/master/README_PROBES.md).

### Benefits

Increase availability and resilience.

### Possible drawbacks

N/A

### Applicable issues

- fixes #

### Additional information

- Related to #23537

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- ~[X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)~
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
