### PR TITLE
[bitnami/spring-cloud-dataflow] Fix variables definition sensitive to Helm 'release-name'

### DIFF
--- a/bitnami/spring-cloud-dataflow/CHANGELOG.md
+++ b/bitnami/spring-cloud-dataflow/CHANGELOG.md
@@ -6,1025 +6,1025 @@
 
 ## <small>28.1.1 (2024-05-22)</small>
 
-* [bitnami/spring-cloud-dataflow] Use different liveness/readiness probes (#26297) ([a50e35e](https://github.com/bitnami/charts/commit/a50e35e)), closes [#26297](https://github.com/bitnami/charts/issues/26297)
+* [bitnami/spring-cloud-dataflow] Use different liveness/readiness probes (#26297) ([a50e35e](https://github.com/bitnami/charts/commit/a50e35e1a25b3b737ebd7ab5d7eb8e7456912bc3)), closes [#26297](https://github.com/bitnami/charts/issues/26297)
 
 ## 28.1.0 (2024-05-21)
 
-* [bitnami/*] ci: :construction_worker: Add tag and changelog support (#25359) ([91c707c](https://github.com/bitnami/charts/commit/91c707c)), closes [#25359](https://github.com/bitnami/charts/issues/25359)
-* [bitnami/spring-cloud-dataflow] feat: :sparkles: :lock: Add warning when original images are replace ([d9dfc42](https://github.com/bitnami/charts/commit/d9dfc42)), closes [#26280](https://github.com/bitnami/charts/issues/26280)
+* [bitnami/*] ci: :construction_worker: Add tag and changelog support (#25359) ([91c707c](https://github.com/bitnami/charts/commit/91c707c9e4e574725a09505d2d313fb93f1b4c0a)), closes [#25359](https://github.com/bitnami/charts/issues/25359)
+* [bitnami/spring-cloud-dataflow] feat: :sparkles: :lock: Add warning when original images are replace ([d9dfc42](https://github.com/bitnami/charts/commit/d9dfc428db4d8251a61f1f9f4f956fc0418b9de6)), closes [#26280](https://github.com/bitnami/charts/issues/26280)
 
 ## <small>28.0.5 (2024-05-21)</small>
 
-* [bitnami/spring-cloud-dataflow] Release 28.0.5 updating components versions (#26149) ([438b648](https://github.com/bitnami/charts/commit/438b648)), closes [#26149](https://github.com/bitnami/charts/issues/26149)
+* [bitnami/spring-cloud-dataflow] Release 28.0.5 updating components versions (#26149) ([438b648](https://github.com/bitnami/charts/commit/438b648262c313d21a5c16b952a158b40c7f0a84)), closes [#26149](https://github.com/bitnami/charts/issues/26149)
 
 ## <small>28.0.4 (2024-05-18)</small>
 
-* [bitnami/spring-cloud-dataflow] Release 28.0.4 updating components versions (#26080) ([ad43b40](https://github.com/bitnami/charts/commit/ad43b40)), closes [#26080](https://github.com/bitnami/charts/issues/26080)
+* [bitnami/spring-cloud-dataflow] Release 28.0.4 updating components versions (#26080) ([ad43b40](https://github.com/bitnami/charts/commit/ad43b40f0c121e1d25b5c10c9da1e71ae2ab9045)), closes [#26080](https://github.com/bitnami/charts/issues/26080)
 
 ## <small>28.0.3 (2024-05-14)</small>
 
-* [bitnami/*] Change non-root and rolling-tags doc URLs (#25628) ([b067c94](https://github.com/bitnami/charts/commit/b067c94)), closes [#25628](https://github.com/bitnami/charts/issues/25628)
-* [bitnami/*] Set new header/owner (#25558) ([8d1dc11](https://github.com/bitnami/charts/commit/8d1dc11)), closes [#25558](https://github.com/bitnami/charts/issues/25558)
-* [bitnami/spring-cloud-dataflow] Release 28.0.3 updating components versions (#25825) ([49abf05](https://github.com/bitnami/charts/commit/49abf05)), closes [#25825](https://github.com/bitnami/charts/issues/25825)
+* [bitnami/*] Change non-root and rolling-tags doc URLs (#25628) ([b067c94](https://github.com/bitnami/charts/commit/b067c94f6bcde427863c197fd355f0b5ba12ff5b)), closes [#25628](https://github.com/bitnami/charts/issues/25628)
+* [bitnami/*] Set new header/owner (#25558) ([8d1dc11](https://github.com/bitnami/charts/commit/8d1dc11f5fb30db6fba50c43d7af59d2f79deed3)), closes [#25558](https://github.com/bitnami/charts/issues/25558)
+* [bitnami/spring-cloud-dataflow] Release 28.0.3 updating components versions (#25825) ([49abf05](https://github.com/bitnami/charts/commit/49abf0531c78b33144a013b4eddc5162103aa818)), closes [#25825](https://github.com/bitnami/charts/issues/25825)
 
 ## <small>28.0.2 (2024-04-26)</small>
 
-* [bitnami/multiple charts] Fix typo: "NetworkPolice" vs "NetworkPolicy" (#25348) ([6970c1b](https://github.com/bitnami/charts/commit/6970c1b)), closes [#25348](https://github.com/bitnami/charts/issues/25348)
-* [bitnami/spring-cloud-dataflow] Release 28.0.2 updating components versions (#25414) ([181db2a](https://github.com/bitnami/charts/commit/181db2a)), closes [#25414](https://github.com/bitnami/charts/issues/25414)
-* Replace VMware by Broadcom copyright text (#25306) ([a5e4bd0](https://github.com/bitnami/charts/commit/a5e4bd0)), closes [#25306](https://github.com/bitnami/charts/issues/25306)
+* [bitnami/multiple charts] Fix typo: "NetworkPolice" vs "NetworkPolicy" (#25348) ([6970c1b](https://github.com/bitnami/charts/commit/6970c1ba245873506e73d459c6eac1e4919b778f)), closes [#25348](https://github.com/bitnami/charts/issues/25348)
+* [bitnami/spring-cloud-dataflow] Release 28.0.2 updating components versions (#25414) ([181db2a](https://github.com/bitnami/charts/commit/181db2a1019a51022c6195862069f1203fb9739f)), closes [#25414](https://github.com/bitnami/charts/issues/25414)
+* Replace VMware by Broadcom copyright text (#25306) ([a5e4bd0](https://github.com/bitnami/charts/commit/a5e4bd0e35e419203793976a78d9d0a13de92c76)), closes [#25306](https://github.com/bitnami/charts/issues/25306)
 
 ## <small>28.0.1 (2024-04-22)</small>
 
-* Remove Skipper ConfigMap and Secrets when Skipper is disabled (#25281) ([50b96b0](https://github.com/bitnami/charts/commit/50b96b0)), closes [#25281](https://github.com/bitnami/charts/issues/25281)
+* Remove Skipper ConfigMap and Secrets when Skipper is disabled (#25281) ([50b96b0](https://github.com/bitnami/charts/commit/50b96b0964330c7ba75260a3b3692ff561f7e1c4)), closes [#25281](https://github.com/bitnami/charts/issues/25281)
 
 ## 28.0.0 (2024-04-10)
 
-* [bitnami/spring-cloud-dataflow] Bump rabbitmq subchart (#25096) ([8b6790e](https://github.com/bitnami/charts/commit/8b6790e)), closes [#25096](https://github.com/bitnami/charts/issues/25096)
+* [bitnami/spring-cloud-dataflow] Bump rabbitmq subchart (#25096) ([8b6790e](https://github.com/bitnami/charts/commit/8b6790e107bc5c93ccb8fc1535166f191094fd12)), closes [#25096](https://github.com/bitnami/charts/issues/25096)
 
 ## <small>27.0.3 (2024-04-10)</small>
 
-* [bitnami/spring-cloud-dataflow] Release 27.0.3 updating components versions (#25092) ([b189fda](https://github.com/bitnami/charts/commit/b189fda)), closes [#25092](https://github.com/bitnami/charts/issues/25092)
+* [bitnami/spring-cloud-dataflow] Release 27.0.3 updating components versions (#25092) ([b189fda](https://github.com/bitnami/charts/commit/b189fdaadf598bf78328046df4975d52e9db9190)), closes [#25092](https://github.com/bitnami/charts/issues/25092)
 
 ## <small>27.0.2 (2024-04-05)</small>
 
-* [bitnami/spring-cloud-dataflow] Release 27.0.2 updating components versions (#25011) ([37fa3bb](https://github.com/bitnami/charts/commit/37fa3bb)), closes [#25011](https://github.com/bitnami/charts/issues/25011)
+* [bitnami/spring-cloud-dataflow] Release 27.0.2 updating components versions (#25011) ([37fa3bb](https://github.com/bitnami/charts/commit/37fa3bb6d29358466574a045adc796d73d4d4485)), closes [#25011](https://github.com/bitnami/charts/issues/25011)
 
 ## <small>27.0.1 (2024-04-03)</small>
 
-* [bitnami/*] Readme typos (#24852) ([532fcdc](https://github.com/bitnami/charts/commit/532fcdc)), closes [#24852](https://github.com/bitnami/charts/issues/24852)
-* feat:(dataflow) manage tls cert via existing secret (#24748) ([dd62c04](https://github.com/bitnami/charts/commit/dd62c04)), closes [#24748](https://github.com/bitnami/charts/issues/24748) [bitnami/charts#22973](https://github.com/bitnami/charts/issues/22973)
+* [bitnami/*] Readme typos (#24852) ([532fcdc](https://github.com/bitnami/charts/commit/532fcdc499cb67eccf0ade49ff1c02d3deb1d696)), closes [#24852](https://github.com/bitnami/charts/issues/24852)
+* feat:(dataflow) manage tls cert via existing secret (#24748) ([dd62c04](https://github.com/bitnami/charts/commit/dd62c04776102f90eb54a1f2cf1c901b03af6b3e)), closes [#24748](https://github.com/bitnami/charts/issues/24748) [bitnami/charts#22973](https://github.com/bitnami/charts/issues/22973)
 
 ## 27.0.0 (2024-04-03)
 
-* [bitnami/spring-cloud-dataflow] feat!: :lock: :boom: Improve security defaults (#24714) ([1a3c7bc](https://github.com/bitnami/charts/commit/1a3c7bc)), closes [#24714](https://github.com/bitnami/charts/issues/24714)
-* Update resourcesPreset comments (#24467) ([92e3e8a](https://github.com/bitnami/charts/commit/92e3e8a)), closes [#24467](https://github.com/bitnami/charts/issues/24467)
+* [bitnami/spring-cloud-dataflow] feat!: :lock: :boom: Improve security defaults (#24714) ([1a3c7bc](https://github.com/bitnami/charts/commit/1a3c7bc4526a7d6ea5363513c0c24788ffeb310a)), closes [#24714](https://github.com/bitnami/charts/issues/24714)
+* Update resourcesPreset comments (#24467) ([92e3e8a](https://github.com/bitnami/charts/commit/92e3e8a507326d2a20a8f10ab3e7746a2ec5c554)), closes [#24467](https://github.com/bitnami/charts/issues/24467)
 
 ## <small>26.13.2 (2024-04-02)</small>
 
-* [bitnami/spring-cloud-dataflow] Release 26.13.2 updating components versions (#24801) ([4e9999a](https://github.com/bitnami/charts/commit/4e9999a)), closes [#24801](https://github.com/bitnami/charts/issues/24801)
+* [bitnami/spring-cloud-dataflow] Release 26.13.2 updating components versions (#24801) ([4e9999a](https://github.com/bitnami/charts/commit/4e9999a87bf1e005ea8b6bca155293b28bbad94a)), closes [#24801](https://github.com/bitnami/charts/issues/24801)
 
 ## <small>26.13.1 (2024-03-26)</small>
 
-* bitnami/spring-cloud-dataflow Fix for #24575, undefined variable error while running spring cl… (#24 ([3c472c6](https://github.com/bitnami/charts/commit/3c472c6)), closes [#24575](https://github.com/bitnami/charts/issues/24575) [#24611](https://github.com/bitnami/charts/issues/24611)
+* bitnami/spring-cloud-dataflow Fix for #24575, undefined variable error while running spring cl… (#24 ([3c472c6](https://github.com/bitnami/charts/commit/3c472c6c3cb529f51d4bad84093fec4bbe1d4fe8)), closes [#24575](https://github.com/bitnami/charts/issues/24575) [#24611](https://github.com/bitnami/charts/issues/24611)
 
 ## 26.13.0 (2024-03-20)
 
-* [bitnami/spring-cloud-dataflow] Add externalEgress support (#24576) ([19d385a](https://github.com/bitnami/charts/commit/19d385a)), closes [#24576](https://github.com/bitnami/charts/issues/24576)
+* [bitnami/spring-cloud-dataflow] Add externalEgress support (#24576) ([19d385a](https://github.com/bitnami/charts/commit/19d385aae7fc62c79299d9e8447d65e5e8173e04)), closes [#24576](https://github.com/bitnami/charts/issues/24576)
 
 ## 26.12.0 (2024-03-18)
 
-* [bitnami/*] Reorder Chart sections (#24455) ([0cf4048](https://github.com/bitnami/charts/commit/0cf4048)), closes [#24455](https://github.com/bitnami/charts/issues/24455)
-* [bitnami/spring-cloud-dataflow] Address external RabbitMQ inconsistencies (#24493) ([7496823](https://github.com/bitnami/charts/commit/7496823)), closes [#24493](https://github.com/bitnami/charts/issues/24493)
+* [bitnami/*] Reorder Chart sections (#24455) ([0cf4048](https://github.com/bitnami/charts/commit/0cf4048e8743f70a9753d460655bd030cbff6824)), closes [#24455](https://github.com/bitnami/charts/issues/24455)
+* [bitnami/spring-cloud-dataflow] Address external RabbitMQ inconsistencies (#24493) ([7496823](https://github.com/bitnami/charts/commit/74968235d901aaf1b039d1b8228c9e9daa8fef41)), closes [#24493](https://github.com/bitnami/charts/issues/24493)
 
 ## 26.11.0 (2024-03-13)
 
-* [bitnami/spring-cloud-dataflow] Add support for using different external db credentials for Dataflow ([06783d2](https://github.com/bitnami/charts/commit/06783d2)), closes [#24386](https://github.com/bitnami/charts/issues/24386)
+* [bitnami/spring-cloud-dataflow] Add support for using different external db credentials for Dataflow ([06783d2](https://github.com/bitnami/charts/commit/06783d238d2e14b2e381c2e027d05c13b679cb7e)), closes [#24386](https://github.com/bitnami/charts/issues/24386)
 
 ## 26.10.0 (2024-03-05)
 
-* [bitnami/spring-cloud-dataflow] feat: :sparkles: :lock: Add automatic adaptation for Openshift restr ([1a1a1ba](https://github.com/bitnami/charts/commit/1a1a1ba)), closes [#24157](https://github.com/bitnami/charts/issues/24157)
+* [bitnami/spring-cloud-dataflow] feat: :sparkles: :lock: Add automatic adaptation for Openshift restr ([1a1a1ba](https://github.com/bitnami/charts/commit/1a1a1ba2f8dbc017a9eb082f1200da23e5ebc796)), closes [#24157](https://github.com/bitnami/charts/issues/24157)
 
 ## 26.9.0 (2024-03-05)
 
-* [bitnami/spring-cloud-dataflow] feat: :sparkles: :lock: Add readOnlyRootFilesystem support (#23994) ([88b5090](https://github.com/bitnami/charts/commit/88b5090)), closes [#23994](https://github.com/bitnami/charts/issues/23994)
+* [bitnami/spring-cloud-dataflow] feat: :sparkles: :lock: Add readOnlyRootFilesystem support (#23994) ([88b5090](https://github.com/bitnami/charts/commit/88b5090a494639d29db958ab6b421b2920145460)), closes [#23994](https://github.com/bitnami/charts/issues/23994)
 
 ## <small>26.8.3 (2024-03-04)</small>
 
-* [bitnami/spring-cloud-dataflow] Release 26.8.3 updating components versions (#24047) ([80ef3b5](https://github.com/bitnami/charts/commit/80ef3b5)), closes [#24047](https://github.com/bitnami/charts/issues/24047)
+* [bitnami/spring-cloud-dataflow] Release 26.8.3 updating components versions (#24047) ([80ef3b5](https://github.com/bitnami/charts/commit/80ef3b567b812b4a141d3072bed74e06cd72d7c3)), closes [#24047](https://github.com/bitnami/charts/issues/24047)
 
 ## <small>26.8.2 (2024-02-29)</small>
 
-* Fix Spring Cloud Dataflow Server OAuth2 Configuration Generalization (#23958) ([dd929f1](https://github.com/bitnami/charts/commit/dd929f1)), closes [#23958](https://github.com/bitnami/charts/issues/23958)
+* Fix Spring Cloud Dataflow Server OAuth2 Configuration Generalization (#23958) ([dd929f1](https://github.com/bitnami/charts/commit/dd929f1fa2e6453f9fdede3c78117be91f7d3996)), closes [#23958](https://github.com/bitnami/charts/issues/23958)
 
 ## <small>26.8.1 (2024-02-27)</small>
 
-* [bitnami/spring-cloud-dataflow] fix: :bug: Add missing coalesce in metrics networkPolicy (#23937) ([0e302eb](https://github.com/bitnami/charts/commit/0e302eb)), closes [#23937](https://github.com/bitnami/charts/issues/23937)
+* [bitnami/spring-cloud-dataflow] fix: :bug: Add missing coalesce in metrics networkPolicy (#23937) ([0e302eb](https://github.com/bitnami/charts/commit/0e302eb5bae3a291922dde3c19326b957125da95)), closes [#23937](https://github.com/bitnami/charts/issues/23937)
 
 ## 26.8.0 (2024-02-26)
 
-* Feature Spring CLoud Dataflow Security (#23900) ([2dc0a59](https://github.com/bitnami/charts/commit/2dc0a59)), closes [#23900](https://github.com/bitnami/charts/issues/23900)
+* Feature Spring CLoud Dataflow Security (#23900) ([2dc0a59](https://github.com/bitnami/charts/commit/2dc0a59efc050d2f41b778f30412c215c31abde2)), closes [#23900](https://github.com/bitnami/charts/issues/23900)
 
 ## <small>26.7.1 (2024-02-22)</small>
 
-* [bitnami/spring-cloud-dataflow] Release 26.7.1 updating components versions (#23854) ([7d00b68](https://github.com/bitnami/charts/commit/7d00b68)), closes [#23854](https://github.com/bitnami/charts/issues/23854)
+* [bitnami/spring-cloud-dataflow] Release 26.7.1 updating components versions (#23854) ([7d00b68](https://github.com/bitnami/charts/commit/7d00b68ddf5e950667e1349fface6cee07cb7ccf)), closes [#23854](https://github.com/bitnami/charts/issues/23854)
 
 ## 26.7.0 (2024-02-20)
 
-* [bitnami/*] Bump all versions (#23602) ([b70ee2a](https://github.com/bitnami/charts/commit/b70ee2a)), closes [#23602](https://github.com/bitnami/charts/issues/23602)
+* [bitnami/*] Bump all versions (#23602) ([b70ee2a](https://github.com/bitnami/charts/commit/b70ee2a30e4dc256bf0ac52928fb2fa7a70f049b)), closes [#23602](https://github.com/bitnami/charts/issues/23602)
 
 ## 26.6.0 (2024-02-16)
 
-* [bitnami/spring-cloud-dataflow] feat: :sparkles: :lock: Add resource preset support (#23524) ([51c49c6](https://github.com/bitnami/charts/commit/51c49c6)), closes [#23524](https://github.com/bitnami/charts/issues/23524)
+* [bitnami/spring-cloud-dataflow] feat: :sparkles: :lock: Add resource preset support (#23524) ([51c49c6](https://github.com/bitnami/charts/commit/51c49c6ebe4f284dfc4e7d73cab7eb05eac25ac3)), closes [#23524](https://github.com/bitnami/charts/issues/23524)
 
 ## <small>26.5.4 (2024-02-15)</small>
 
-* [bitnami/spring-cloud-dataflow] Fixing disabling skipper networkPolicy creation (#23412) ([9f9b01e](https://github.com/bitnami/charts/commit/9f9b01e)), closes [#23412](https://github.com/bitnami/charts/issues/23412)
+* [bitnami/spring-cloud-dataflow] Fixing disabling skipper networkPolicy creation (#23412) ([9f9b01e](https://github.com/bitnami/charts/commit/9f9b01e0020eb0693cb62d0c47ab1ae720c5d766)), closes [#23412](https://github.com/bitnami/charts/issues/23412)
 
 ## <small>26.5.3 (2024-02-03)</small>
 
-* [bitnami/spring-cloud-dataflow] Release 26.5.3 updating components versions (#23142) ([39859c9](https://github.com/bitnami/charts/commit/39859c9)), closes [#23142](https://github.com/bitnami/charts/issues/23142)
+* [bitnami/spring-cloud-dataflow] Release 26.5.3 updating components versions (#23142) ([39859c9](https://github.com/bitnami/charts/commit/39859c913e3f9d0eaca8c80a60f778b86add7b4b)), closes [#23142](https://github.com/bitnami/charts/issues/23142)
 
 ## <small>26.5.2 (2024-02-02)</small>
 
-* [bitnami/spring-cloud-dataflow] Release 26.5.2 updating components versions (#23051) ([5abcd37](https://github.com/bitnami/charts/commit/5abcd37)), closes [#23051](https://github.com/bitnami/charts/issues/23051)
+* [bitnami/spring-cloud-dataflow] Release 26.5.2 updating components versions (#23051) ([5abcd37](https://github.com/bitnami/charts/commit/5abcd376aafd98311d3f3b295ddc73c8979c0e2d)), closes [#23051](https://github.com/bitnami/charts/issues/23051)
 
 ## <small>26.5.1 (2024-01-31)</small>
 
-* [bitnami/spring-cloud-dataflow] Add jdbc parameter value for MariaDB (#22887) ([e6542e9](https://github.com/bitnami/charts/commit/e6542e9)), closes [#22887](https://github.com/bitnami/charts/issues/22887)
+* [bitnami/spring-cloud-dataflow] Add jdbc parameter value for MariaDB (#22887) ([e6542e9](https://github.com/bitnami/charts/commit/e6542e9fc033fe835fb26a60d98396be9eb817f3)), closes [#22887](https://github.com/bitnami/charts/issues/22887)
 
 ## 26.5.0 (2024-01-30)
 
-* [bitnami/spring-cloud-dataflow] feat: :recycle: :lock: Refactor and enable NetworkPolicy by default  ([d5fed68](https://github.com/bitnami/charts/commit/d5fed68)), closes [#22718](https://github.com/bitnami/charts/issues/22718)
+* [bitnami/spring-cloud-dataflow] feat: :recycle: :lock: Refactor and enable NetworkPolicy by default  ([d5fed68](https://github.com/bitnami/charts/commit/d5fed68112b58bb0b0b38f08725939faefc097a8)), closes [#22718](https://github.com/bitnami/charts/issues/22718)
 
 ## <small>26.4.1 (2024-01-25)</small>
 
-* [bitnami/*] Move documentation sections from docs.bitnami.com back to the README (#22203) ([7564f36](https://github.com/bitnami/charts/commit/7564f36)), closes [#22203](https://github.com/bitnami/charts/issues/22203)
-* [bitnami/spring-cloud-dataflow] fix: :bug: Set seLinuxOptions to null for Openshift compatibility (# ([99fdeea](https://github.com/bitnami/charts/commit/99fdeea)), closes [#22661](https://github.com/bitnami/charts/issues/22661)
+* [bitnami/*] Move documentation sections from docs.bitnami.com back to the README (#22203) ([7564f36](https://github.com/bitnami/charts/commit/7564f36ca1e95ff30ee686652b7ab8690561a707)), closes [#22203](https://github.com/bitnami/charts/issues/22203)
+* [bitnami/spring-cloud-dataflow] fix: :bug: Set seLinuxOptions to null for Openshift compatibility (# ([99fdeea](https://github.com/bitnami/charts/commit/99fdeeae5d8c8d1ca5b0df9eb9c033ffc9febeda)), closes [#22661](https://github.com/bitnami/charts/issues/22661)
 
 ## 26.4.0 (2024-01-19)
 
-* [bitnami/spring-cloud-dataflow] fix: :lock: Move service-account token auto-mount to pod declaration ([18506b8](https://github.com/bitnami/charts/commit/18506b8)), closes [#22463](https://github.com/bitnami/charts/issues/22463)
+* [bitnami/spring-cloud-dataflow] fix: :lock: Move service-account token auto-mount to pod declaration ([18506b8](https://github.com/bitnami/charts/commit/18506b8a92d914c054082f2112cdb5005aab2873)), closes [#22463](https://github.com/bitnami/charts/issues/22463)
 
 ## <small>26.3.1 (2024-01-18)</small>
 
-* [bitnami/spring-cloud-dataflow] Release 26.3.1 updating components versions (#22355) ([58d7f05](https://github.com/bitnami/charts/commit/58d7f05)), closes [#22355](https://github.com/bitnami/charts/issues/22355)
+* [bitnami/spring-cloud-dataflow] Release 26.3.1 updating components versions (#22355) ([58d7f05](https://github.com/bitnami/charts/commit/58d7f05dc586ab8ff28334b08b272786980adf4f)), closes [#22355](https://github.com/bitnami/charts/issues/22355)
 
 ## 26.3.0 (2024-01-17)
 
-* [bitnami/spring-cloud-dataflow] fix: :lock: Improve podSecurityContext and containerSecurityContext  ([8f398d3](https://github.com/bitnami/charts/commit/8f398d3)), closes [#22192](https://github.com/bitnami/charts/issues/22192)
+* [bitnami/spring-cloud-dataflow] fix: :lock: Improve podSecurityContext and containerSecurityContext  ([8f398d3](https://github.com/bitnami/charts/commit/8f398d38e880cb5fc612c2c79d0c460da34eea48)), closes [#22192](https://github.com/bitnami/charts/issues/22192)
 
 ## <small>26.2.3 (2024-01-16)</small>
 
-* [bitnami/spring-cloud-dataflow] Release 26.2.3 updating components versions (#22236) ([d5007f8](https://github.com/bitnami/charts/commit/d5007f8)), closes [#22236](https://github.com/bitnami/charts/issues/22236)
+* [bitnami/spring-cloud-dataflow] Release 26.2.3 updating components versions (#22236) ([d5007f8](https://github.com/bitnami/charts/commit/d5007f8334d2cbd4e5b99fa8d4417a1179e36483)), closes [#22236](https://github.com/bitnami/charts/issues/22236)
 
 ## <small>26.2.2 (2024-01-16)</small>
 
-* [bitnami/spring-cloud-dataflow] Release 26.2.2 updating components versions (#22230) ([16bc6a0](https://github.com/bitnami/charts/commit/16bc6a0)), closes [#22230](https://github.com/bitnami/charts/issues/22230)
+* [bitnami/spring-cloud-dataflow] Release 26.2.2 updating components versions (#22230) ([16bc6a0](https://github.com/bitnami/charts/commit/16bc6a060e059a6417b9377ff33e9b3d2b6019c2)), closes [#22230](https://github.com/bitnami/charts/issues/22230)
 
 ## <small>26.2.1 (2024-01-11)</small>
 
-* [bitnami/*] Fix docs.bitnami.com broken links (#21901) ([f35506d](https://github.com/bitnami/charts/commit/f35506d)), closes [#21901](https://github.com/bitnami/charts/issues/21901)
-* [bitnami/*] Fix ref links (in comments) (#21822) ([e4fa296](https://github.com/bitnami/charts/commit/e4fa296)), closes [#21822](https://github.com/bitnami/charts/issues/21822)
-* [bitnami/*] Update copyright: Year and company (#21815) ([6c4bf75](https://github.com/bitnami/charts/commit/6c4bf75)), closes [#21815](https://github.com/bitnami/charts/issues/21815)
-* [bitnami/spring-cloud-dataflow] Release 26.2.1 updating components versions (#22005) ([f70f274](https://github.com/bitnami/charts/commit/f70f274)), closes [#22005](https://github.com/bitnami/charts/issues/22005)
+* [bitnami/*] Fix docs.bitnami.com broken links (#21901) ([f35506d](https://github.com/bitnami/charts/commit/f35506d2dadee4f097986e7792df1f53ab215b5d)), closes [#21901](https://github.com/bitnami/charts/issues/21901)
+* [bitnami/*] Fix ref links (in comments) (#21822) ([e4fa296](https://github.com/bitnami/charts/commit/e4fa296106b225cf8c82445727c675c7c725e380)), closes [#21822](https://github.com/bitnami/charts/issues/21822)
+* [bitnami/*] Update copyright: Year and company (#21815) ([6c4bf75](https://github.com/bitnami/charts/commit/6c4bf75dec58fc7c9aee9f089777b1a858c17d5b)), closes [#21815](https://github.com/bitnami/charts/issues/21815)
+* [bitnami/spring-cloud-dataflow] Release 26.2.1 updating components versions (#22005) ([f70f274](https://github.com/bitnami/charts/commit/f70f2741a936b1b6cebfb73ee227e5e216bafaf5)), closes [#22005](https://github.com/bitnami/charts/issues/22005)
 
 ## 26.2.0 (2023-12-26)
 
-* [bitnami/scdf] Add securityContext to init containers (#21758) ([424d16d](https://github.com/bitnami/charts/commit/424d16d)), closes [#21758](https://github.com/bitnami/charts/issues/21758)
+* [bitnami/scdf] Add securityContext to init containers (#21758) ([424d16d](https://github.com/bitnami/charts/commit/424d16d3a45a4bfe8dcd913873b04c0ce7e0789e)), closes [#21758](https://github.com/bitnami/charts/issues/21758)
 
 ## <small>26.1.1 (2023-12-22)</small>
 
-* [bitnami/spring-cloud-dataflow] Release 26.1.1 updating components versions (#21739) ([f7b16cf](https://github.com/bitnami/charts/commit/f7b16cf)), closes [#21739](https://github.com/bitnami/charts/issues/21739)
+* [bitnami/spring-cloud-dataflow] Release 26.1.1 updating components versions (#21739) ([f7b16cf](https://github.com/bitnami/charts/commit/f7b16cf06b6e2a4b25fb518f1012c523bd1ec41c)), closes [#21739](https://github.com/bitnami/charts/issues/21739)
 
 ## 26.1.0 (2023-12-22)
 
-* [bitnami/spring-cloud-dataflow] feat: :sparkles: Add missing health checks (#21644) ([c78b6dd](https://github.com/bitnami/charts/commit/c78b6dd)), closes [#21644](https://github.com/bitnami/charts/issues/21644)
+* [bitnami/spring-cloud-dataflow] feat: :sparkles: Add missing health checks (#21644) ([c78b6dd](https://github.com/bitnami/charts/commit/c78b6dd109261d44948d6af02b7363f0fb9ef664)), closes [#21644](https://github.com/bitnami/charts/issues/21644)
 
 ## 26.0.0 (2023-12-20)
 
-* [bitnami/spring-cloud-dataflow] Upgrade MariaDB 11.2 (#21697) ([0285378](https://github.com/bitnami/charts/commit/0285378)), closes [#21697](https://github.com/bitnami/charts/issues/21697)
+* [bitnami/spring-cloud-dataflow] Upgrade MariaDB 11.2 (#21697) ([0285378](https://github.com/bitnami/charts/commit/0285378769f2e1bebb4e9ceaea919f2c4fa0711a)), closes [#21697](https://github.com/bitnami/charts/issues/21697)
 
 ## <small>25.1.4 (2023-12-20)</small>
 
-* [bitnami/spring-cloud-dataflow] Release 25.1.4 updating components versions (#21678) ([8903bfa](https://github.com/bitnami/charts/commit/8903bfa)), closes [#21678](https://github.com/bitnami/charts/issues/21678)
+* [bitnami/spring-cloud-dataflow] Release 25.1.4 updating components versions (#21678) ([8903bfa](https://github.com/bitnami/charts/commit/8903bfac35159d55f2d54f16303e7bb66614d4c0)), closes [#21678](https://github.com/bitnami/charts/issues/21678)
 
 ## <small>25.1.3 (2023-11-21)</small>
 
-* [bitnami/*] Remove relative links to non-README sections, add verification for that and update TL;DR ([1103633](https://github.com/bitnami/charts/commit/1103633)), closes [#20967](https://github.com/bitnami/charts/issues/20967)
-* [bitnami/*] Rename solutions to "Bitnami package for ..." (#21038) ([b82f979](https://github.com/bitnami/charts/commit/b82f979)), closes [#21038](https://github.com/bitnami/charts/issues/21038)
-* [bitnami/spring-cloud-dataflow] Release 25.1.3 updating components versions (#21177) ([5c8c0fa](https://github.com/bitnami/charts/commit/5c8c0fa)), closes [#21177](https://github.com/bitnami/charts/issues/21177)
+* [bitnami/*] Remove relative links to non-README sections, add verification for that and update TL;DR ([1103633](https://github.com/bitnami/charts/commit/11036334d82df0490aa4abdb591543cab6cf7d7f)), closes [#20967](https://github.com/bitnami/charts/issues/20967)
+* [bitnami/*] Rename solutions to "Bitnami package for ..." (#21038) ([b82f979](https://github.com/bitnami/charts/commit/b82f979e4fb63423fe6e2192c946d09d79c944fc)), closes [#21038](https://github.com/bitnami/charts/issues/21038)
+* [bitnami/spring-cloud-dataflow] Release 25.1.3 updating components versions (#21177) ([5c8c0fa](https://github.com/bitnami/charts/commit/5c8c0fa530ef6c7b2452fad1f4c7391088cf5fbf)), closes [#21177](https://github.com/bitnami/charts/issues/21177)
 
 ## <small>25.1.2 (2023-11-08)</small>
 
-* [bitnami/spring-cloud-dataflow] Release 25.1.2 updating components versions (#20787) ([609a2bc](https://github.com/bitnami/charts/commit/609a2bc)), closes [#20787](https://github.com/bitnami/charts/issues/20787)
+* [bitnami/spring-cloud-dataflow] Release 25.1.2 updating components versions (#20787) ([609a2bc](https://github.com/bitnami/charts/commit/609a2bcf1f5abf757da2ac7b6c44dbb9666adf80)), closes [#20787](https://github.com/bitnami/charts/issues/20787)
 
 ## <small>25.1.1 (2023-11-07)</small>
 
-* [bitnami/spring-cloud-dataflow] Release 25.1.1 updating components versions (#20657) ([1c7be14](https://github.com/bitnami/charts/commit/1c7be14)), closes [#20657](https://github.com/bitnami/charts/issues/20657)
+* [bitnami/spring-cloud-dataflow] Release 25.1.1 updating components versions (#20657) ([1c7be14](https://github.com/bitnami/charts/commit/1c7be146e4a5311c59fb164ba82bd9845d2e2cf9)), closes [#20657](https://github.com/bitnami/charts/issues/20657)
 
 ## 25.1.0 (2023-11-06)
 
-* [bitnami/*] Rename VMware Application Catalog (#20361) ([3acc734](https://github.com/bitnami/charts/commit/3acc734)), closes [#20361](https://github.com/bitnami/charts/issues/20361)
-* [bitnami/*] Skip image's tag in the README files of the Bitnami Charts (#19841) ([bb9a01b](https://github.com/bitnami/charts/commit/bb9a01b)), closes [#19841](https://github.com/bitnami/charts/issues/19841)
-* [bitnami/*] Standardize documentation (#19835) ([af5f753](https://github.com/bitnami/charts/commit/af5f753)), closes [#19835](https://github.com/bitnami/charts/issues/19835)
-* [bitnami/spring-cloud-dataflow] feat: :sparkles: Add support for PSA restricted policy (#20549) ([a92dc64](https://github.com/bitnami/charts/commit/a92dc64)), closes [#20549](https://github.com/bitnami/charts/issues/20549)
+* [bitnami/*] Rename VMware Application Catalog (#20361) ([3acc734](https://github.com/bitnami/charts/commit/3acc73472beb6fb56c4d99f929061001205bc57e)), closes [#20361](https://github.com/bitnami/charts/issues/20361)
+* [bitnami/*] Skip image's tag in the README files of the Bitnami Charts (#19841) ([bb9a01b](https://github.com/bitnami/charts/commit/bb9a01b65911c87e48318db922cc05eb42785e42)), closes [#19841](https://github.com/bitnami/charts/issues/19841)
+* [bitnami/*] Standardize documentation (#19835) ([af5f753](https://github.com/bitnami/charts/commit/af5f7530c1bc8c5ded53a6c4f7b8f384ac1804f2)), closes [#19835](https://github.com/bitnami/charts/issues/19835)
+* [bitnami/spring-cloud-dataflow] feat: :sparkles: Add support for PSA restricted policy (#20549) ([a92dc64](https://github.com/bitnami/charts/commit/a92dc6497556e3990d08f611e33fb9572bf20511)), closes [#20549](https://github.com/bitnami/charts/issues/20549)
 
 ## 25.0.0 (2023-10-17)
 
-* [bitnami/spring-cloud-dataflow] Update kafka to 26.x.x (#20275) ([e3a693c](https://github.com/bitnami/charts/commit/e3a693c)), closes [#20275](https://github.com/bitnami/charts/issues/20275)
+* [bitnami/spring-cloud-dataflow] Update kafka to 26.x.x (#20275) ([e3a693c](https://github.com/bitnami/charts/commit/e3a693cc13682f5614d07da2a32f68f81ff5c3fb)), closes [#20275](https://github.com/bitnami/charts/issues/20275)
 
 ## <small>24.0.3 (2023-10-16)</small>
 
-* [bitnami/spring-cloud-dataflow] Release 24.0.3 (#20260) ([8b2e3bd](https://github.com/bitnami/charts/commit/8b2e3bd)), closes [#20260](https://github.com/bitnami/charts/issues/20260)
+* [bitnami/spring-cloud-dataflow] Release 24.0.3 (#20260) ([8b2e3bd](https://github.com/bitnami/charts/commit/8b2e3bd8ded9630344f0f013cdbceaf60c5456cb)), closes [#20260](https://github.com/bitnami/charts/issues/20260)
 
 ## <small>24.0.2 (2023-10-13)</small>
 
-* [bitnami/spring-cloud-dataflow] Release 24.0.2 (#20217) ([6a0cbd5](https://github.com/bitnami/charts/commit/6a0cbd5)), closes [#20217](https://github.com/bitnami/charts/issues/20217)
+* [bitnami/spring-cloud-dataflow] Release 24.0.2 (#20217) ([6a0cbd5](https://github.com/bitnami/charts/commit/6a0cbd5d607d2507f3a676a2fda894362c0dc684)), closes [#20217](https://github.com/bitnami/charts/issues/20217)
 
 ## <small>24.0.1 (2023-10-11)</small>
 
-* [bitnami/spring-cloud-dataflow] Release 24.0.1 (#20051) ([f4cb422](https://github.com/bitnami/charts/commit/f4cb422)), closes [#20051](https://github.com/bitnami/charts/issues/20051)
+* [bitnami/spring-cloud-dataflow] Release 24.0.1 (#20051) ([f4cb422](https://github.com/bitnami/charts/commit/f4cb422df940d3b8ba4742ad734451e163c32869)), closes [#20051](https://github.com/bitnami/charts/issues/20051)
 
 ## 24.0.0 (2023-10-11)
 
-* [bitnami/*] Update Helm charts prerequisites (#19745) ([eb755dd](https://github.com/bitnami/charts/commit/eb755dd)), closes [#19745](https://github.com/bitnami/charts/issues/19745)
-* [bitnami/spring-cloud-dataflow] Update MariaDB to 14.x.x (#20010) ([ce0cfb0](https://github.com/bitnami/charts/commit/ce0cfb0)), closes [#20010](https://github.com/bitnami/charts/issues/20010)
+* [bitnami/*] Update Helm charts prerequisites (#19745) ([eb755dd](https://github.com/bitnami/charts/commit/eb755dd36a4dd3cf6635be8e0598f9a7f4c4a554)), closes [#19745](https://github.com/bitnami/charts/issues/19745)
+* [bitnami/spring-cloud-dataflow] Update MariaDB to 14.x.x (#20010) ([ce0cfb0](https://github.com/bitnami/charts/commit/ce0cfb092b6d702cd36ca2ec684a4110814c5a30)), closes [#20010](https://github.com/bitnami/charts/issues/20010)
 
 ## <small>23.1.4 (2023-09-27)</small>
 
-* [bitnami/spring-cloud-dataflow] Release 23.1.4 (#19585) ([b7076f8](https://github.com/bitnami/charts/commit/b7076f8)), closes [#19585](https://github.com/bitnami/charts/issues/19585)
+* [bitnami/spring-cloud-dataflow] Release 23.1.4 (#19585) ([b7076f8](https://github.com/bitnami/charts/commit/b7076f80a24f4afa38fb40d5afc8658a9499e323)), closes [#19585](https://github.com/bitnami/charts/issues/19585)
 
 ## <small>23.1.3 (2023-09-20)</small>
 
-* [bitnami/spring-cloud-dataflow] Use different app.kubernetes.io/version label on subcomponents (#193 ([1a624f4](https://github.com/bitnami/charts/commit/1a624f4)), closes [#19354](https://github.com/bitnami/charts/issues/19354)
+* [bitnami/spring-cloud-dataflow] Use different app.kubernetes.io/version label on subcomponents (#193 ([1a624f4](https://github.com/bitnami/charts/commit/1a624f42baa5c22665de493cd2a0ac58dca77c78)), closes [#19354](https://github.com/bitnami/charts/issues/19354)
 
 ## <small>23.1.2 (2023-09-20)</small>
 
-* [bitnami/*] Update readme files (#19277) ([e56aeb2](https://github.com/bitnami/charts/commit/e56aeb2)), closes [#19277](https://github.com/bitnami/charts/issues/19277)
-* [bitnami/spring-cloud-dataflow] Release 23.1.2 (#19413) ([494edd2](https://github.com/bitnami/charts/commit/494edd2)), closes [#19413](https://github.com/bitnami/charts/issues/19413)
-* Autogenerate schema files (#19194) ([a2c2090](https://github.com/bitnami/charts/commit/a2c2090)), closes [#19194](https://github.com/bitnami/charts/issues/19194)
-* Revert "Autogenerate schema files (#19194)" (#19335) ([73d80be](https://github.com/bitnami/charts/commit/73d80be)), closes [#19194](https://github.com/bitnami/charts/issues/19194) [#19335](https://github.com/bitnami/charts/issues/19335)
+* [bitnami/*] Update readme files (#19277) ([e56aeb2](https://github.com/bitnami/charts/commit/e56aeb2fbfbf5b6e42375db48cc7ae1ef1c3a823)), closes [#19277](https://github.com/bitnami/charts/issues/19277)
+* [bitnami/spring-cloud-dataflow] Release 23.1.2 (#19413) ([494edd2](https://github.com/bitnami/charts/commit/494edd2b5bc081ffec83edabc5ee8e2fe30555d8)), closes [#19413](https://github.com/bitnami/charts/issues/19413)
+* Autogenerate schema files (#19194) ([a2c2090](https://github.com/bitnami/charts/commit/a2c2090b5ac97f47b745c8028c6452bf99739772)), closes [#19194](https://github.com/bitnami/charts/issues/19194)
+* Revert "Autogenerate schema files (#19194)" (#19335) ([73d80be](https://github.com/bitnami/charts/commit/73d80be525c88fb4b8a54451a55acd506e337062)), closes [#19194](https://github.com/bitnami/charts/issues/19194) [#19335](https://github.com/bitnami/charts/issues/19335)
 
 ## <small>23.1.1 (2023-09-07)</small>
 
-* [bitnami/spring-cloud-dataflow: Use merge helper]: (#19109) ([8574d46](https://github.com/bitnami/charts/commit/8574d46)), closes [#19109](https://github.com/bitnami/charts/issues/19109)
+* [bitnami/spring-cloud-dataflow: Use merge helper]: (#19109) ([8574d46](https://github.com/bitnami/charts/commit/8574d46894e48254a8c36c2235edfa3c438f7d23)), closes [#19109](https://github.com/bitnami/charts/issues/19109)
 
 ## 23.1.0 (2023-08-29)
 
-* [bitnami/spring-cloud-dataflow] Support for customizing standard labels (#18749) ([c98c66e](https://github.com/bitnami/charts/commit/c98c66e)), closes [#18749](https://github.com/bitnami/charts/issues/18749)
+* [bitnami/spring-cloud-dataflow] Support for customizing standard labels (#18749) ([c98c66e](https://github.com/bitnami/charts/commit/c98c66e4517cd5e29751d0c3a9aeee649c1ef32b)), closes [#18749](https://github.com/bitnami/charts/issues/18749)
 
 ## 23.0.0 (2023-08-25)
 
-* [bitnami/spring-cloud-dataflow] Update Kafka subchart 25.0.0 (#18854) ([259a2ad](https://github.com/bitnami/charts/commit/259a2ad)), closes [#18854](https://github.com/bitnami/charts/issues/18854)
+* [bitnami/spring-cloud-dataflow] Update Kafka subchart 25.0.0 (#18854) ([259a2ad](https://github.com/bitnami/charts/commit/259a2ad53e6b4c7de741acd2b003c38b96cf44ae)), closes [#18854](https://github.com/bitnami/charts/issues/18854)
 
 ## <small>22.0.3 (2023-08-21)</small>
 
-* [bitnami/spring-cloud-dataflow] Release 22.0.3 (#18721) ([bce5545](https://github.com/bitnami/charts/commit/bce5545)), closes [#18721](https://github.com/bitnami/charts/issues/18721)
+* [bitnami/spring-cloud-dataflow] Release 22.0.3 (#18721) ([bce5545](https://github.com/bitnami/charts/commit/bce55456d9de347ad6bb46f08be7da8803a3ed82)), closes [#18721](https://github.com/bitnami/charts/issues/18721)
 
 ## <small>22.0.2 (2023-08-18)</small>
 
-* [bitnami/spring-cloud-dataflow] Release 22.0.2 (#18633) ([032f011](https://github.com/bitnami/charts/commit/032f011)), closes [#18633](https://github.com/bitnami/charts/issues/18633)
+* [bitnami/spring-cloud-dataflow] Release 22.0.2 (#18633) ([032f011](https://github.com/bitnami/charts/commit/032f0114d63f45e52811374e93172517ab16eee3)), closes [#18633](https://github.com/bitnami/charts/issues/18633)
 
 ## <small>22.0.1 (2023-08-17)</small>
 
-* [bitnami/spring-cloud-dataflow] Release 22.0.1 (#18595) ([a5c9c2d](https://github.com/bitnami/charts/commit/a5c9c2d)), closes [#18595](https://github.com/bitnami/charts/issues/18595)
+* [bitnami/spring-cloud-dataflow] Release 22.0.1 (#18595) ([a5c9c2d](https://github.com/bitnami/charts/commit/a5c9c2d5b789697fd2e9666dd7f875cfcbdf41c1)), closes [#18595](https://github.com/bitnami/charts/issues/18595)
 
 ## 22.0.0 (2023-08-04)
 
-* [bitnami/spring-cloud-dataflow] Update Kafka subchart 24.0.0 (#18185) ([fe830e8](https://github.com/bitnami/charts/commit/fe830e8)), closes [#18185](https://github.com/bitnami/charts/issues/18185)
+* [bitnami/spring-cloud-dataflow] Update Kafka subchart 24.0.0 (#18185) ([fe830e8](https://github.com/bitnami/charts/commit/fe830e8d8cfeecef0a101733f7432a46986bd38e)), closes [#18185](https://github.com/bitnami/charts/issues/18185)
 
 ## <small>21.0.1 (2023-08-02)</small>
 
-* [bitnami/spring-cloud-dataflow] Release 21.0.1 (#18138) ([5c73193](https://github.com/bitnami/charts/commit/5c73193)), closes [#18138](https://github.com/bitnami/charts/issues/18138)
+* [bitnami/spring-cloud-dataflow] Release 21.0.1 (#18138) ([5c73193](https://github.com/bitnami/charts/commit/5c73193c9e3481ef4fc794d355348ff718e0b5dc)), closes [#18138](https://github.com/bitnami/charts/issues/18138)
 
 ## 21.0.0 (2023-08-02)
 
-* [bitnami/spring-cloud-dataflow] Update dependencies (#18117) ([db1f24e](https://github.com/bitnami/charts/commit/db1f24e)), closes [#18117](https://github.com/bitnami/charts/issues/18117)
+* [bitnami/spring-cloud-dataflow] Update dependencies (#18117) ([db1f24e](https://github.com/bitnami/charts/commit/db1f24e0de18d38cd9481a5c14530ce64c4f2bf5)), closes [#18117](https://github.com/bitnami/charts/issues/18117)
 
 ## 20.0.0 (2023-06-30)
 
-* [bitnami/spring-cloud-dataflow] Update Kafka version (#17401) ([43089df](https://github.com/bitnami/charts/commit/43089df)), closes [#17401](https://github.com/bitnami/charts/issues/17401)
-* Add copyright header (#17300) ([da68be8](https://github.com/bitnami/charts/commit/da68be8)), closes [#17300](https://github.com/bitnami/charts/issues/17300)
-* Update charts readme (#17217) ([31b3c0a](https://github.com/bitnami/charts/commit/31b3c0a)), closes [#17217](https://github.com/bitnami/charts/issues/17217)
+* [bitnami/spring-cloud-dataflow] Update Kafka version (#17401) ([43089df](https://github.com/bitnami/charts/commit/43089df7e9c00101fb053916334861ebe7a89d59)), closes [#17401](https://github.com/bitnami/charts/issues/17401)
+* Add copyright header (#17300) ([da68be8](https://github.com/bitnami/charts/commit/da68be8e951225133c7dfb572d5101ca3d61c5ae)), closes [#17300](https://github.com/bitnami/charts/issues/17300)
+* Update charts readme (#17217) ([31b3c0a](https://github.com/bitnami/charts/commit/31b3c0afd968ff4429107e34101f7509e6a0e913)), closes [#17217](https://github.com/bitnami/charts/issues/17217)
 
 ## <small>19.0.1 (2023-06-20)</small>
 
-* [bitnami/spring-cloud-dataflow] Fix issue 17117 - Unable to mount volumes on Tasks (#17149) ([0be63b3](https://github.com/bitnami/charts/commit/0be63b3)), closes [#17149](https://github.com/bitnami/charts/issues/17149)
+* [bitnami/spring-cloud-dataflow] Fix issue 17117 - Unable to mount volumes on Tasks (#17149) ([0be63b3](https://github.com/bitnami/charts/commit/0be63b30ff7929451fd5578cc6f8d79fb081afbd)), closes [#17149](https://github.com/bitnami/charts/issues/17149)
 
 ## 19.0.0 (2023-06-12)
 
-* [bitnami/*] Change copyright section in READMEs (#17006) ([ef986a1](https://github.com/bitnami/charts/commit/ef986a1)), closes [#17006](https://github.com/bitnami/charts/issues/17006)
-* [bitnami/several] Change copyright section in READMEs (#16989) ([5b6a5cf](https://github.com/bitnami/charts/commit/5b6a5cf)), closes [#16989](https://github.com/bitnami/charts/issues/16989)
-* [bitnami/spring-cloud-dataflow] Bump rabbitmq dependency (#17086) ([aad5b54](https://github.com/bitnami/charts/commit/aad5b54)), closes [#17086](https://github.com/bitnami/charts/issues/17086)
+* [bitnami/*] Change copyright section in READMEs (#17006) ([ef986a1](https://github.com/bitnami/charts/commit/ef986a1605241102b3dcafe9fd8089e6fc1201ad)), closes [#17006](https://github.com/bitnami/charts/issues/17006)
+* [bitnami/several] Change copyright section in READMEs (#16989) ([5b6a5cf](https://github.com/bitnami/charts/commit/5b6a5cfb7625a751848a2e5cd796bd7278f406ca)), closes [#16989](https://github.com/bitnami/charts/issues/16989)
+* [bitnami/spring-cloud-dataflow] Bump rabbitmq dependency (#17086) ([aad5b54](https://github.com/bitnami/charts/commit/aad5b54ac6a8105ddbac4c8628a2aff1b839fc29)), closes [#17086](https://github.com/bitnami/charts/issues/17086)
 
 ## <small>18.1.1 (2023-05-12)</small>
 
-* [bitnami/spring-cloud-dataflow] Release 18.1.1 (#16625) ([824fe21](https://github.com/bitnami/charts/commit/824fe21)), closes [#16625](https://github.com/bitnami/charts/issues/16625)
-* Add wording for enterprise page (#16560) ([8f22774](https://github.com/bitnami/charts/commit/8f22774)), closes [#16560](https://github.com/bitnami/charts/issues/16560)
+* [bitnami/spring-cloud-dataflow] Release 18.1.1 (#16625) ([824fe21](https://github.com/bitnami/charts/commit/824fe2117a02ccc0d5e9ab1bb017ebf2f14b72b7)), closes [#16625](https://github.com/bitnami/charts/issues/16625)
+* Add wording for enterprise page (#16560) ([8f22774](https://github.com/bitnami/charts/commit/8f2277440b976d52785ba9149762ad8620a73d1f)), closes [#16560](https://github.com/bitnami/charts/issues/16560)
 
 ## 18.1.0 (2023-05-09)
 
-* [bitnami/several] Adapt Chart.yaml to set desired OCI annotations (#16546) ([fc9b18f](https://github.com/bitnami/charts/commit/fc9b18f)), closes [#16546](https://github.com/bitnami/charts/issues/16546)
+* [bitnami/several] Adapt Chart.yaml to set desired OCI annotations (#16546) ([fc9b18f](https://github.com/bitnami/charts/commit/fc9b18f2e98805d4df629acbcde696f44f973344)), closes [#16546](https://github.com/bitnami/charts/issues/16546)
 
 ## <small>18.0.3 (2023-05-09)</small>
 
-* [bitnami/spring-cloud-dataflow] Release 18.0.3 (#16549) ([a1e74dc](https://github.com/bitnami/charts/commit/a1e74dc)), closes [#16549](https://github.com/bitnami/charts/issues/16549)
+* [bitnami/spring-cloud-dataflow] Release 18.0.3 (#16549) ([a1e74dc](https://github.com/bitnami/charts/commit/a1e74dc368c37b1b0705cedc9056971a501a1e42)), closes [#16549](https://github.com/bitnami/charts/issues/16549)
 
 ## <small>18.0.2 (2023-05-09)</small>
 
-* [bitnami/spring-cloud-dataflow] Release 18.0.2 (#16507) ([e0607ee](https://github.com/bitnami/charts/commit/e0607ee)), closes [#16507](https://github.com/bitnami/charts/issues/16507)
+* [bitnami/spring-cloud-dataflow] Release 18.0.2 (#16507) ([e0607ee](https://github.com/bitnami/charts/commit/e0607ee415471e66dbdbf05fe07729c1720e99d4)), closes [#16507](https://github.com/bitnami/charts/issues/16507)
 
 ## <small>18.0.1 (2023-05-01)</small>
 
-* [bitnami/spring-cloud-dataflow] Release 18.0.1 (#16316) ([b797e6c](https://github.com/bitnami/charts/commit/b797e6c)), closes [#16316](https://github.com/bitnami/charts/issues/16316)
+* [bitnami/spring-cloud-dataflow] Release 18.0.1 (#16316) ([b797e6c](https://github.com/bitnami/charts/commit/b797e6cdd6d74fbee220ac1ad371a1953fa5e54b)), closes [#16316](https://github.com/bitnami/charts/issues/16316)
 
 ## 18.0.0 (2023-04-24)
 
-* [bitnami/spring-cloud-dataflow] Update dependencies (#16192) ([0d83765](https://github.com/bitnami/charts/commit/0d83765)), closes [#16192](https://github.com/bitnami/charts/issues/16192)
+* [bitnami/spring-cloud-dataflow] Update dependencies (#16192) ([0d83765](https://github.com/bitnami/charts/commit/0d8376593706be9905dd50ea8305a115b831fb63)), closes [#16192](https://github.com/bitnami/charts/issues/16192)
 
 ## 17.0.0 (2023-04-21)
 
-* [bitnami/spring-cloud-dataflow] Upgrade MariaDB to version 10.11 (#16167) ([9c21bfe](https://github.com/bitnami/charts/commit/9c21bfe)), closes [#16167](https://github.com/bitnami/charts/issues/16167)
+* [bitnami/spring-cloud-dataflow] Upgrade MariaDB to version 10.11 (#16167) ([9c21bfe](https://github.com/bitnami/charts/commit/9c21bfefc806b3808747c819c83d8187ff7af71f)), closes [#16167](https://github.com/bitnami/charts/issues/16167)
 
 ## 16.1.0 (2023-04-20)
 
-* [bitnami/*] Make Helm charts 100% OCI (#15998) ([8841510](https://github.com/bitnami/charts/commit/8841510)), closes [#15998](https://github.com/bitnami/charts/issues/15998)
-* Fix the example of using an external database (spring-cloud-dataflow) (#15988) ([997cb0f](https://github.com/bitnami/charts/commit/997cb0f)), closes [#15988](https://github.com/bitnami/charts/issues/15988)
+* [bitnami/*] Make Helm charts 100% OCI (#15998) ([8841510](https://github.com/bitnami/charts/commit/884151035efcbf2e1b3206e7def85511073fb57d)), closes [#15998](https://github.com/bitnami/charts/issues/15998)
+* Fix the example of using an external database (spring-cloud-dataflow) (#15988) ([997cb0f](https://github.com/bitnami/charts/commit/997cb0ffa6ea76d60e30b3645227c3c48ba0b679)), closes [#15988](https://github.com/bitnami/charts/issues/15988)
 
 ## <small>16.0.2 (2023-04-01)</small>
 
-* [bitnami/spring-cloud-dataflow] Release 16.0.2 (#15912) ([ed9d3d1](https://github.com/bitnami/charts/commit/ed9d3d1)), closes [#15912](https://github.com/bitnami/charts/issues/15912)
+* [bitnami/spring-cloud-dataflow] Release 16.0.2 (#15912) ([ed9d3d1](https://github.com/bitnami/charts/commit/ed9d3d11163e5aa1f8efb552e5fe94c0eb92b1ea)), closes [#15912](https://github.com/bitnami/charts/issues/15912)
 
 ## <small>16.0.1 (2023-03-19)</small>
 
-* [bitnami/spring-cloud-dataflow] Release 16.0.1 (#15616) ([dac3d39](https://github.com/bitnami/charts/commit/dac3d39)), closes [#15616](https://github.com/bitnami/charts/issues/15616)
+* [bitnami/spring-cloud-dataflow] Release 16.0.1 (#15616) ([dac3d39](https://github.com/bitnami/charts/commit/dac3d39a2e24e8f691983504ba4c63ea52acc726)), closes [#15616](https://github.com/bitnami/charts/issues/15616)
 
 ## 16.0.0 (2023-03-17)
 
-* [bitnami/several] Fix README linter issues ([6a9cdaa](https://github.com/bitnami/charts/commit/6a9cdaa))
-* [bitnami/spring-cloud-dataflow] bump kafka dependency (#15539) ([9ac4ad9](https://github.com/bitnami/charts/commit/9ac4ad9)), closes [#15539](https://github.com/bitnami/charts/issues/15539)
+* [bitnami/several] Fix README linter issues ([6a9cdaa](https://github.com/bitnami/charts/commit/6a9cdaab638f21729cf56a7138a6d250f61d5723))
+* [bitnami/spring-cloud-dataflow] bump kafka dependency (#15539) ([9ac4ad9](https://github.com/bitnami/charts/commit/9ac4ad9c8fa5efeb94fcf3e31558abb615193ce5)), closes [#15539](https://github.com/bitnami/charts/issues/15539)
 
 ## <small>15.0.6 (2023-03-08)</small>
 
-* [bitnami/charts] Apply linter to README files (#15357) ([0e29e60](https://github.com/bitnami/charts/commit/0e29e60)), closes [#15357](https://github.com/bitnami/charts/issues/15357)
-* [bitnami/spring-cloud-dataflow] Release 15.0.6 (#15399) ([d21f226](https://github.com/bitnami/charts/commit/d21f226)), closes [#15399](https://github.com/bitnami/charts/issues/15399)
+* [bitnami/charts] Apply linter to README files (#15357) ([0e29e60](https://github.com/bitnami/charts/commit/0e29e600d3adc8b1b46e506eccb3decfab3b4e63)), closes [#15357](https://github.com/bitnami/charts/issues/15357)
+* [bitnami/spring-cloud-dataflow] Release 15.0.6 (#15399) ([d21f226](https://github.com/bitnami/charts/commit/d21f226585f3e426255af8be093e1f0dac8fef3f)), closes [#15399](https://github.com/bitnami/charts/issues/15399)
 
 ## <small>15.0.5 (2023-03-01)</small>
 
-* [bitnami/*] Fix markdown linter issues (#14874) ([a51e0e8](https://github.com/bitnami/charts/commit/a51e0e8)), closes [#14874](https://github.com/bitnami/charts/issues/14874)
-* [bitnami/*] Fix markdown linter issues 2 (#14890) ([aa96572](https://github.com/bitnami/charts/commit/aa96572)), closes [#14890](https://github.com/bitnami/charts/issues/14890)
-* [bitnami/*] Remove unexpected extra spaces (#14873) ([c97c714](https://github.com/bitnami/charts/commit/c97c714)), closes [#14873](https://github.com/bitnami/charts/issues/14873)
-* [bitnami/spring-cloud-dataflow] Release 15.0.5 (#15253) ([9ffaa28](https://github.com/bitnami/charts/commit/9ffaa28)), closes [#15253](https://github.com/bitnami/charts/issues/15253)
+* [bitnami/*] Fix markdown linter issues (#14874) ([a51e0e8](https://github.com/bitnami/charts/commit/a51e0e8d35495b907f3e70dd2f8e7c3bcbf4166a)), closes [#14874](https://github.com/bitnami/charts/issues/14874)
+* [bitnami/*] Fix markdown linter issues 2 (#14890) ([aa96572](https://github.com/bitnami/charts/commit/aa9657237ee8df4a46db0d7fdf8a23230dd6902a)), closes [#14890](https://github.com/bitnami/charts/issues/14890)
+* [bitnami/*] Remove unexpected extra spaces (#14873) ([c97c714](https://github.com/bitnami/charts/commit/c97c714887380d47eae7bfeff316bf01595ecd1d)), closes [#14873](https://github.com/bitnami/charts/issues/14873)
+* [bitnami/spring-cloud-dataflow] Release 15.0.5 (#15253) ([9ffaa28](https://github.com/bitnami/charts/commit/9ffaa2850522af2edb191eca66619dccc8d5d27a)), closes [#15253](https://github.com/bitnami/charts/issues/15253)
 
 ## <small>15.0.4 (2023-02-13)</small>
 
-* [bitnami/*] Change copyright date (#14682) ([add4ec7](https://github.com/bitnami/charts/commit/add4ec7)), closes [#14682](https://github.com/bitnami/charts/issues/14682)
-* [bitnami/spring-cloud-dataflow] Release 15.0.4 (#14858) ([4d34e19](https://github.com/bitnami/charts/commit/4d34e19)), closes [#14858](https://github.com/bitnami/charts/issues/14858)
+* [bitnami/*] Change copyright date (#14682) ([add4ec7](https://github.com/bitnami/charts/commit/add4ec701108ac36ed4de2dffbdf407a0d091067)), closes [#14682](https://github.com/bitnami/charts/issues/14682)
+* [bitnami/spring-cloud-dataflow] Release 15.0.4 (#14858) ([4d34e19](https://github.com/bitnami/charts/commit/4d34e19635a15161652b8fe7862681c5ff2df62b)), closes [#14858](https://github.com/bitnami/charts/issues/14858)
 
 ## <small>15.0.3 (2023-01-31)</small>
 
-* [bitnami/spring-cloud-dataflow] Don't regenerate self-signed certs on upgrade (#14663) ([26df891](https://github.com/bitnami/charts/commit/26df891)), closes [#14663](https://github.com/bitnami/charts/issues/14663)
+* [bitnami/spring-cloud-dataflow] Don't regenerate self-signed certs on upgrade (#14663) ([26df891](https://github.com/bitnami/charts/commit/26df8914a8732ec5f6361b1c31f8ef30bf7d22d3)), closes [#14663](https://github.com/bitnami/charts/issues/14663)
 
 ## <small>15.0.2 (2023-01-23)</small>
 
-* [bitnami/*] Add license annotation and remove obsolete engine parameter (#14293) ([da2a794](https://github.com/bitnami/charts/commit/da2a794)), closes [#14293](https://github.com/bitnami/charts/issues/14293)
-* [bitnami/*] Change licenses annotation format (#14377) ([0ab7608](https://github.com/bitnami/charts/commit/0ab7608)), closes [#14377](https://github.com/bitnami/charts/issues/14377)
-* [bitnami/*] Unify READMEs (#14472) ([2064fb8](https://github.com/bitnami/charts/commit/2064fb8)), closes [#14472](https://github.com/bitnami/charts/issues/14472)
-* [bitnami/spring-cloud-dataflow] Release 15.0.2 (#14358) ([8eedbf4](https://github.com/bitnami/charts/commit/8eedbf4)), closes [#14358](https://github.com/bitnami/charts/issues/14358)
+* [bitnami/*] Add license annotation and remove obsolete engine parameter (#14293) ([da2a794](https://github.com/bitnami/charts/commit/da2a7943bae95b6e9b5b4ed972c15e990b69fdb0)), closes [#14293](https://github.com/bitnami/charts/issues/14293)
+* [bitnami/*] Change licenses annotation format (#14377) ([0ab7608](https://github.com/bitnami/charts/commit/0ab760862c660fcc78cffadf8e1d8cdd70881473)), closes [#14377](https://github.com/bitnami/charts/issues/14377)
+* [bitnami/*] Unify READMEs (#14472) ([2064fb8](https://github.com/bitnami/charts/commit/2064fb8dcc78a845cdede8211af8c3cc52551161)), closes [#14472](https://github.com/bitnami/charts/issues/14472)
+* [bitnami/spring-cloud-dataflow] Release 15.0.2 (#14358) ([8eedbf4](https://github.com/bitnami/charts/commit/8eedbf4027b88f6f9f4d42ebc896dcbdce4c26d0)), closes [#14358](https://github.com/bitnami/charts/issues/14358)
 
 ## <small>15.0.1 (2022-12-14)</small>
 
-* [bitnami/spring-cloud-dataflow] Release 15.0.1 (#13950) ([95cf0f3](https://github.com/bitnami/charts/commit/95cf0f3)), closes [#13950](https://github.com/bitnami/charts/issues/13950)
+* [bitnami/spring-cloud-dataflow] Release 15.0.1 (#13950) ([95cf0f3](https://github.com/bitnami/charts/commit/95cf0f344fd506e46192fb03b807e95a8befa7bb)), closes [#13950](https://github.com/bitnami/charts/issues/13950)
 
 ## 15.0.0 (2022-12-06)
 
-* [bitnami/spring-cloud-dataflow] Kafka subchart update (#13842) ([deb8dc3](https://github.com/bitnami/charts/commit/deb8dc3)), closes [#13842](https://github.com/bitnami/charts/issues/13842)
+* [bitnami/spring-cloud-dataflow] Kafka subchart update (#13842) ([deb8dc3](https://github.com/bitnami/charts/commit/deb8dc39d7081904c84220ad34269ead691e1129)), closes [#13842](https://github.com/bitnami/charts/issues/13842)
 
 ## <small>14.0.2 (2022-11-14)</small>
 
-* [bitnami/spring-cloud-dataflow] Release 14.0.2 (#13500) ([32502aa](https://github.com/bitnami/charts/commit/32502aa)), closes [#13500](https://github.com/bitnami/charts/issues/13500)
+* [bitnami/spring-cloud-dataflow] Release 14.0.2 (#13500) ([32502aa](https://github.com/bitnami/charts/commit/32502aa81a72be1ffbdab2af3656f0cde1223095)), closes [#13500](https://github.com/bitnami/charts/issues/13500)
 
 ## <small>14.0.1 (2022-10-26)</small>
 
-* [bitnami/*] Use new default branch name in links (#12943) ([a529e02](https://github.com/bitnami/charts/commit/a529e02)), closes [#12943](https://github.com/bitnami/charts/issues/12943)
-* [bitnami/spring-cloud-dataflow] Update subchart dependencies (#13157) ([4d469c5](https://github.com/bitnami/charts/commit/4d469c5)), closes [#13157](https://github.com/bitnami/charts/issues/13157)
-* Rename the main branch of Bitnami Charts from master to another more inclusive term (#13000) ([05d666f](https://github.com/bitnami/charts/commit/05d666f)), closes [#13000](https://github.com/bitnami/charts/issues/13000)
+* [bitnami/*] Use new default branch name in links (#12943) ([a529e02](https://github.com/bitnami/charts/commit/a529e02597d49d944eba1eb0f190713293247176)), closes [#12943](https://github.com/bitnami/charts/issues/12943)
+* [bitnami/spring-cloud-dataflow] Update subchart dependencies (#13157) ([4d469c5](https://github.com/bitnami/charts/commit/4d469c55185648fd9aeddf2f1c173d6cd7b70015)), closes [#13157](https://github.com/bitnami/charts/issues/13157)
+* Rename the main branch of Bitnami Charts from master to another more inclusive term (#13000) ([05d666f](https://github.com/bitnami/charts/commit/05d666f5ea353cd6fdedd4358b9943cd356dfd5b)), closes [#13000](https://github.com/bitnami/charts/issues/13000)
 
 ## 14.0.0 (2022-10-17)
 
-* [bitnami/spring-cloud-dataflow] Update dependencies (#12972) ([f9a3f43](https://github.com/bitnami/charts/commit/f9a3f43)), closes [#12972](https://github.com/bitnami/charts/issues/12972)
+* [bitnami/spring-cloud-dataflow] Update dependencies (#12972) ([f9a3f43](https://github.com/bitnami/charts/commit/f9a3f431bf055bddce5f34ff91140c83b26e6bff)), closes [#12972](https://github.com/bitnami/charts/issues/12972)
 
 ## <small>13.0.1 (2022-10-15)</small>
 
-* [bitnami/spring-cloud-dataflow] Release 13.0.1 (#12964) ([23f8a9d](https://github.com/bitnami/charts/commit/23f8a9d)), closes [#12964](https://github.com/bitnami/charts/issues/12964)
+* [bitnami/spring-cloud-dataflow] Release 13.0.1 (#12964) ([23f8a9d](https://github.com/bitnami/charts/commit/23f8a9d7bc13114fbb70fbe45c50a96b7e2a2381)), closes [#12964](https://github.com/bitnami/charts/issues/12964)
 
 ## 13.0.0 (2022-10-11)
 
-* [bitnami/spring-cloud-dataflow] Update dependencies (#12897) ([e2819a8](https://github.com/bitnami/charts/commit/e2819a8)), closes [#12897](https://github.com/bitnami/charts/issues/12897)
-* Generic README instructions related to the repo (#12792) ([3cf6b10](https://github.com/bitnami/charts/commit/3cf6b10)), closes [#12792](https://github.com/bitnami/charts/issues/12792)
+* [bitnami/spring-cloud-dataflow] Update dependencies (#12897) ([e2819a8](https://github.com/bitnami/charts/commit/e2819a803fc177d38971c002726483763ff45faa)), closes [#12897](https://github.com/bitnami/charts/issues/12897)
+* Generic README instructions related to the repo (#12792) ([3cf6b10](https://github.com/bitnami/charts/commit/3cf6b10e10e60df4b3e191d6b99aa99a9f597755)), closes [#12792](https://github.com/bitnami/charts/issues/12792)
 
 ## <small>12.1.7 (2022-09-19)</small>
 
-* [bitnami/spring-cloud-dataflow] Use custom probes if given (#12560) ([40e7f3f](https://github.com/bitnami/charts/commit/40e7f3f)), closes [#12560](https://github.com/bitnami/charts/issues/12560) [#12354](https://github.com/bitnami/charts/issues/12354)
+* [bitnami/spring-cloud-dataflow] Use custom probes if given (#12560) ([40e7f3f](https://github.com/bitnami/charts/commit/40e7f3f7d2919ad381cc6752b8044376f7fcb066)), closes [#12560](https://github.com/bitnami/charts/issues/12560) [#12354](https://github.com/bitnami/charts/issues/12354)
 
 ## <small>12.1.6 (2022-09-15)</small>
 
-* [bitnami/spring-cloud-dataflow] Release 12.1.6 (#12432) ([dca6d4a](https://github.com/bitnami/charts/commit/dca6d4a)), closes [#12432](https://github.com/bitnami/charts/issues/12432)
+* [bitnami/spring-cloud-dataflow] Release 12.1.6 (#12432) ([dca6d4a](https://github.com/bitnami/charts/commit/dca6d4a91f683f095a5d0adc0ed0960496ea37bf)), closes [#12432](https://github.com/bitnami/charts/issues/12432)
 
 ## <small>12.1.5 (2022-09-03)</small>
 
-* [bitnami/spring-cloud-dataflow] Release 12.1.5 (#12272) ([970a995](https://github.com/bitnami/charts/commit/970a995)), closes [#12272](https://github.com/bitnami/charts/issues/12272)
+* [bitnami/spring-cloud-dataflow] Release 12.1.5 (#12272) ([970a995](https://github.com/bitnami/charts/commit/970a9959ed984822d709874fb54769804fb60dee)), closes [#12272](https://github.com/bitnami/charts/issues/12272)
 
 ## <small>12.1.4 (2022-08-24)</small>
 
-* [bitnami/spring-cloud-dataflow] Update Chart.lock (#12130) ([056260e](https://github.com/bitnami/charts/commit/056260e)), closes [#12130](https://github.com/bitnami/charts/issues/12130)
+* [bitnami/spring-cloud-dataflow] Update Chart.lock (#12130) ([056260e](https://github.com/bitnami/charts/commit/056260e46829b95bf0805c0b77650c4596eecb57)), closes [#12130](https://github.com/bitnami/charts/issues/12130)
 
 ## <small>12.1.3 (2022-08-23)</small>
 
-* [bitnami/spring-cloud-dataflow] Update Chart.lock (#12109) ([b3af5cf](https://github.com/bitnami/charts/commit/b3af5cf)), closes [#12109](https://github.com/bitnami/charts/issues/12109)
+* [bitnami/spring-cloud-dataflow] Update Chart.lock (#12109) ([b3af5cf](https://github.com/bitnami/charts/commit/b3af5cf7978ace89462798b6baf2e46a29db7a37)), closes [#12109](https://github.com/bitnami/charts/issues/12109)
 
 ## <small>12.1.2 (2022-08-22)</small>
 
-* [bitnami/spring-cloud-dataflow] Update Chart.lock (#11998) ([4776364](https://github.com/bitnami/charts/commit/4776364)), closes [#11998](https://github.com/bitnami/charts/issues/11998)
+* [bitnami/spring-cloud-dataflow] Update Chart.lock (#11998) ([4776364](https://github.com/bitnami/charts/commit/4776364209e7b52adcb9b9ed5bdf54d41728747b)), closes [#11998](https://github.com/bitnami/charts/issues/11998)
 
 ## <small>12.1.1 (2022-08-22)</small>
 
-* [bitnami/spring-cloud-dataflow] Update Chart.lock (#11980) ([a6beb02](https://github.com/bitnami/charts/commit/a6beb02)), closes [#11980](https://github.com/bitnami/charts/issues/11980)
+* [bitnami/spring-cloud-dataflow] Update Chart.lock (#11980) ([a6beb02](https://github.com/bitnami/charts/commit/a6beb02bc896e065e9575b30299342fce4aabd6d)), closes [#11980](https://github.com/bitnami/charts/issues/11980)
 
 ## 12.1.0 (2022-08-22)
 
-* [bitnami/spring-cloud-dataflow] Add support for image digest apart from tag (#11958) ([1f5f7fc](https://github.com/bitnami/charts/commit/1f5f7fc)), closes [#11958](https://github.com/bitnami/charts/issues/11958)
+* [bitnami/spring-cloud-dataflow] Add support for image digest apart from tag (#11958) ([1f5f7fc](https://github.com/bitnami/charts/commit/1f5f7fc4ddebc1589d0dce7ec5dff7b350cd1009)), closes [#11958](https://github.com/bitnami/charts/issues/11958)
 
 ## <small>12.0.7 (2022-08-04)</small>
 
-* [bitnami/spring-cloud-dataflow] Release 12.0.7 (#11599) ([46193bd](https://github.com/bitnami/charts/commit/46193bd)), closes [#11599](https://github.com/bitnami/charts/issues/11599)
+* [bitnami/spring-cloud-dataflow] Release 12.0.7 (#11599) ([46193bd](https://github.com/bitnami/charts/commit/46193bd4cd96021d1485d580461e7ae72801db8a)), closes [#11599](https://github.com/bitnami/charts/issues/11599)
 
 ## <small>12.0.6 (2022-08-03)</small>
 
-* [bitnami/spring-cloud-dataflow] Release 12.0.6 (#11547) ([2dd31cc](https://github.com/bitnami/charts/commit/2dd31cc)), closes [#11547](https://github.com/bitnami/charts/issues/11547)
+* [bitnami/spring-cloud-dataflow] Release 12.0.6 (#11547) ([2dd31cc](https://github.com/bitnami/charts/commit/2dd31cc2e2298160067b9b36687ccb640a0f75ed)), closes [#11547](https://github.com/bitnami/charts/issues/11547)
 
 ## <small>12.0.5 (2022-07-30)</small>
 
-* [bitnami/*] Update URLs to point to the new bitnami/containers monorepo (#11352) ([d665af0](https://github.com/bitnami/charts/commit/d665af0)), closes [#11352](https://github.com/bitnami/charts/issues/11352)
-* [bitnami/spring-cloud-dataflow] Release 12.0.5 (#11436) ([11644ea](https://github.com/bitnami/charts/commit/11644ea)), closes [#11436](https://github.com/bitnami/charts/issues/11436)
+* [bitnami/*] Update URLs to point to the new bitnami/containers monorepo (#11352) ([d665af0](https://github.com/bitnami/charts/commit/d665af0c708846192d8d5fb2f5f9ea65dd464ab0)), closes [#11352](https://github.com/bitnami/charts/issues/11352)
+* [bitnami/spring-cloud-dataflow] Release 12.0.5 (#11436) ([11644ea](https://github.com/bitnami/charts/commit/11644ea0296839a94f3ca47c36cdcf9cd25306d9)), closes [#11436](https://github.com/bitnami/charts/issues/11436)
 
 ## <small>12.0.4 (2022-07-19)</small>
 
-* [bitnami/spring-cloud-dataflow] use common tpl function instead of toYaml (#11191) ([be7cd82](https://github.com/bitnami/charts/commit/be7cd82)), closes [#11191](https://github.com/bitnami/charts/issues/11191)
+* [bitnami/spring-cloud-dataflow] use common tpl function instead of toYaml (#11191) ([be7cd82](https://github.com/bitnami/charts/commit/be7cd822860191aa7688aa44d736d0d1e4b2e226)), closes [#11191](https://github.com/bitnami/charts/issues/11191)
 
 ## <small>12.0.3 (2022-07-11)</small>
 
-* [bitnami/spring-cloud-dataflow] Apply server.containerPort as documented. (#10823) ([7649bc0](https://github.com/bitnami/charts/commit/7649bc0)), closes [#10823](https://github.com/bitnami/charts/issues/10823) [#10301](https://github.com/bitnami/charts/issues/10301)
+* [bitnami/spring-cloud-dataflow] Apply server.containerPort as documented. (#10823) ([7649bc0](https://github.com/bitnami/charts/commit/7649bc00bbba7c00324f8b66abf22a3e67d86db4)), closes [#10823](https://github.com/bitnami/charts/issues/10823) [#10301](https://github.com/bitnami/charts/issues/10301)
 
 ## <small>12.0.2 (2022-06-30)</small>
 
-* [bitnami/spring-cloud-dataflow] Fix README.md upgrading header + typos (#10813) ([28dff25](https://github.com/bitnami/charts/commit/28dff25)), closes [#10813](https://github.com/bitnami/charts/issues/10813)
-* [bitnami/spring-cloud-dataflow] Release 12.0.2 (#10950) ([e7e17a2](https://github.com/bitnami/charts/commit/e7e17a2)), closes [#10950](https://github.com/bitnami/charts/issues/10950)
+* [bitnami/spring-cloud-dataflow] Fix README.md upgrading header + typos (#10813) ([28dff25](https://github.com/bitnami/charts/commit/28dff2596d1198a68fd565b868fb9e86c8625bca)), closes [#10813](https://github.com/bitnami/charts/issues/10813)
+* [bitnami/spring-cloud-dataflow] Release 12.0.2 (#10950) ([e7e17a2](https://github.com/bitnami/charts/commit/e7e17a29ecc05a08bc959aa65895fe484bd7ad2a)), closes [#10950](https://github.com/bitnami/charts/issues/10950)
 
 ## <small>12.0.1 (2022-06-20)</small>
 
-* Update helpers to ensure scdf.rabbitmq.port is assigned a default value if not in values.yaml (#1044 ([a5c9600](https://github.com/bitnami/charts/commit/a5c9600)), closes [#10448](https://github.com/bitnami/charts/issues/10448) [#10446](https://github.com/bitnami/charts/issues/10446)
+* Update helpers to ensure scdf.rabbitmq.port is assigned a default value if not in values.yaml (#1044 ([a5c9600](https://github.com/bitnami/charts/commit/a5c96004152a74a8e234756d5b2bd352c985e9aa)), closes [#10448](https://github.com/bitnami/charts/issues/10448) [#10446](https://github.com/bitnami/charts/issues/10446)
 
 ## 12.0.0 (2022-06-16)
 
-* [bitnami/spring-cloud-dataflow] Update Kafka subchart (#10772) ([e72127d](https://github.com/bitnami/charts/commit/e72127d)), closes [#10772](https://github.com/bitnami/charts/issues/10772)
+* [bitnami/spring-cloud-dataflow] Update Kafka subchart (#10772) ([e72127d](https://github.com/bitnami/charts/commit/e72127d8562276d6dbb68b54add8c75539459fd1)), closes [#10772](https://github.com/bitnami/charts/issues/10772)
 
 ## <small>11.0.4 (2022-06-10)</small>
 
-* [bitnami/spring-cloud-dataflow] Release 11.0.4 updating components versions ([b7e1fa1](https://github.com/bitnami/charts/commit/b7e1fa1))
+* [bitnami/spring-cloud-dataflow] Release 11.0.4 updating components versions ([b7e1fa1](https://github.com/bitnami/charts/commit/b7e1fa17613eb0a7fdf775e60ec719cf75ec6dcb))
 
 ## <small>11.0.3 (2022-06-07)</small>
 
-* [bitnami/*] Replace Kubeapps URL in READMEs (and kubeapps Chart.yaml) and remove BKPR references (#1 ([c6a7914](https://github.com/bitnami/charts/commit/c6a7914)), closes [#10600](https://github.com/bitnami/charts/issues/10600)
-* Fix tolerations and topologySpreadConstraints default values (#10619) ([b1ed7d2](https://github.com/bitnami/charts/commit/b1ed7d2)), closes [#10619](https://github.com/bitnami/charts/issues/10619)
+* [bitnami/*] Replace Kubeapps URL in READMEs (and kubeapps Chart.yaml) and remove BKPR references (#1 ([c6a7914](https://github.com/bitnami/charts/commit/c6a7914361e5aea6016fb45bf4d621edfd111d32)), closes [#10600](https://github.com/bitnami/charts/issues/10600)
+* Fix tolerations and topologySpreadConstraints default values (#10619) ([b1ed7d2](https://github.com/bitnami/charts/commit/b1ed7d2703a4c20a7202ce2e01ce353b47fb3f48)), closes [#10619](https://github.com/bitnami/charts/issues/10619)
 
 ## <small>11.0.2 (2022-06-07)</small>
 
-* [bitnami/spring-cloud-dataflow] Release 11.0.2 updating components versions ([80ebd6e](https://github.com/bitnami/charts/commit/80ebd6e))
+* [bitnami/spring-cloud-dataflow] Release 11.0.2 updating components versions ([80ebd6e](https://github.com/bitnami/charts/commit/80ebd6e7d12a9a85fb96ed8e2d0655b377c545b7))
 
 ## <small>11.0.1 (2022-06-01)</small>
 
-* [bitnami/several] Replace maintainers email by url (#10523) ([ff3cf61](https://github.com/bitnami/charts/commit/ff3cf61)), closes [#10523](https://github.com/bitnami/charts/issues/10523)
+* [bitnami/several] Replace maintainers email by url (#10523) ([ff3cf61](https://github.com/bitnami/charts/commit/ff3cf617a1680509b0f3855d17c4ccff7b29a0ff)), closes [#10523](https://github.com/bitnami/charts/issues/10523)
 
 ## 11.0.0 (2022-05-31)
 
-* [bitnami/spring-cloud-dataflow]: feat!: Bump RabbitMQ subchart (#10459) ([ad846a0](https://github.com/bitnami/charts/commit/ad846a0)), closes [#10459](https://github.com/bitnami/charts/issues/10459)
+* [bitnami/spring-cloud-dataflow]: feat!: Bump RabbitMQ subchart (#10459) ([ad846a0](https://github.com/bitnami/charts/commit/ad846a0e15a24b52fd73108d87db65b200ad107c)), closes [#10459](https://github.com/bitnami/charts/issues/10459)
 
 ## <small>10.0.2 (2022-05-30)</small>
 
-* [bitnami/several] Replace base64 --decode with base64 -d (#10495) ([099286a](https://github.com/bitnami/charts/commit/099286a)), closes [#10495](https://github.com/bitnami/charts/issues/10495)
+* [bitnami/several] Replace base64 --decode with base64 -d (#10495) ([099286a](https://github.com/bitnami/charts/commit/099286ae7a87784cf809df0b64ab24f7ff0144c8)), closes [#10495](https://github.com/bitnami/charts/issues/10495)
 
 ## <small>10.0.1 (2022-05-26)</small>
 
-* [bitnami/spring-cloud-dataflow] Release 10.0.1 updating components versions ([9278379](https://github.com/bitnami/charts/commit/9278379))
+* [bitnami/spring-cloud-dataflow] Release 10.0.1 updating components versions ([9278379](https://github.com/bitnami/charts/commit/927837960ea61069c1cb76697c07ed069b8e4b8d))
 
 ## 10.0.0 (2022-05-25)
 
-* Update kafka dependency for spring-cloud-dataflow (#10394) ([3a2955d](https://github.com/bitnami/charts/commit/3a2955d)), closes [#10394](https://github.com/bitnami/charts/issues/10394)
+* Update kafka dependency for spring-cloud-dataflow (#10394) ([3a2955d](https://github.com/bitnami/charts/commit/3a2955da4c372a385b6154395413ee1307bce862)), closes [#10394](https://github.com/bitnami/charts/issues/10394)
 
 ## <small>9.1.3 (2022-05-24)</small>
 
-* [bitnami/spring-cloud-dataflow] Use the new helper for HPA API version (#10213) ([8b813f6](https://github.com/bitnami/charts/commit/8b813f6)), closes [#10213](https://github.com/bitnami/charts/issues/10213)
+* [bitnami/spring-cloud-dataflow] Use the new helper for HPA API version (#10213) ([8b813f6](https://github.com/bitnami/charts/commit/8b813f692c95444add3bf5a8878d29640a6397ae)), closes [#10213](https://github.com/bitnami/charts/issues/10213)
 
 ## <small>9.1.2 (2022-05-22)</small>
 
-* [bitnami/spring-cloud-dataflow] Release 9.1.2 updating components versions ([b1bfb6e](https://github.com/bitnami/charts/commit/b1bfb6e))
+* [bitnami/spring-cloud-dataflow] Release 9.1.2 updating components versions ([b1bfb6e](https://github.com/bitnami/charts/commit/b1bfb6e352e7d6236892326e190e6f86d5147607))
 
 ## <small>9.1.1 (2022-05-18)</small>
 
-* [bitnami/spring-cloud-dataflow] Release 9.1.1 updating components versions ([3e4e29e](https://github.com/bitnami/charts/commit/3e4e29e))
+* [bitnami/spring-cloud-dataflow] Release 9.1.1 updating components versions ([3e4e29e](https://github.com/bitnami/charts/commit/3e4e29e2683efdf2dd96d4fe1f70a274329c0d1a))
 
 ## 9.1.0 (2022-05-16)
 
-* [bitnami/*] add ingress extraRules feature (#10253) ([0f6cbb9](https://github.com/bitnami/charts/commit/0f6cbb9)), closes [#10253](https://github.com/bitnami/charts/issues/10253)
+* [bitnami/*] add ingress extraRules feature (#10253) ([0f6cbb9](https://github.com/bitnami/charts/commit/0f6cbb9099b0e56685cc1d36ba50340f3d7278a1)), closes [#10253](https://github.com/bitnami/charts/issues/10253)
 
 ## 9.0.0 (2022-05-04)
 
-* [bitnami/spring-cloud-dataflow] Update RabbitMQ subchart (#10024) ([00da763](https://github.com/bitnami/charts/commit/00da763)), closes [#10024](https://github.com/bitnami/charts/issues/10024)
+* [bitnami/spring-cloud-dataflow] Update RabbitMQ subchart (#10024) ([00da763](https://github.com/bitnami/charts/commit/00da76316782bb72c5781f44a6315bc40eb96b62)), closes [#10024](https://github.com/bitnami/charts/issues/10024)
 
 ## <small>8.0.1 (2022-04-22)</small>
 
-* [bitnami/spring-cloud-dataflow] Release 8.0.1 updating components versions ([58f8a19](https://github.com/bitnami/charts/commit/58f8a19))
+* [bitnami/spring-cloud-dataflow] Release 8.0.1 updating components versions ([58f8a19](https://github.com/bitnami/charts/commit/58f8a19cfb10c58c5c30878b31447a237057b999))
 
 ## 8.0.0 (2022-04-21)
 
-* [bitnami/spring-cloud-dataflow] feat!: :arrow_up: Bump MariaDB version to 10.6 (#9860) ([3d2cd15](https://github.com/bitnami/charts/commit/3d2cd15)), closes [#9860](https://github.com/bitnami/charts/issues/9860)
+* [bitnami/spring-cloud-dataflow] feat!: :arrow_up: Bump MariaDB version to 10.6 (#9860) ([3d2cd15](https://github.com/bitnami/charts/commit/3d2cd15b6e6abfdd1c61804e07ac1a7a04bb6e10)), closes [#9860](https://github.com/bitnami/charts/issues/9860)
 
 ## <small>7.0.6 (2022-04-19)</small>
 
-* [bitnami/spring-cloud-dataflow] Release 7.0.6 updating components versions ([5caf93e](https://github.com/bitnami/charts/commit/5caf93e))
+* [bitnami/spring-cloud-dataflow] Release 7.0.6 updating components versions ([5caf93e](https://github.com/bitnami/charts/commit/5caf93e5dd8e9356c146dfb34810a444a6ce7906))
 
 ## <small>7.0.5 (2022-04-08)</small>
 
-* [bitnami/spring-cloud-dataflow] Release 7.0.5 updating components versions ([14d91e2](https://github.com/bitnami/charts/commit/14d91e2))
+* [bitnami/spring-cloud-dataflow] Release 7.0.5 updating components versions ([14d91e2](https://github.com/bitnami/charts/commit/14d91e2bed2e4328434c45f301628987f53e43ec))
 
 ## <small>7.0.4 (2022-04-06)</small>
 
-* [bitnami/spring-cloud-dataflow] Release 7.0.4 updating components versions ([764695e](https://github.com/bitnami/charts/commit/764695e))
+* [bitnami/spring-cloud-dataflow] Release 7.0.4 updating components versions ([764695e](https://github.com/bitnami/charts/commit/764695e98efba813a4c5346328f5c2c44dc96ed7))
 
 ## <small>7.0.3 (2022-04-03)</small>
 
-* [bitnami/spring-cloud-dataflow] Release 7.0.3 updating components versions ([8a54bec](https://github.com/bitnami/charts/commit/8a54bec))
+* [bitnami/spring-cloud-dataflow] Release 7.0.3 updating components versions ([8a54bec](https://github.com/bitnami/charts/commit/8a54bec15526f3005a3d8fd6565f853b3b915413))
 
 ## <small>7.0.2 (2022-04-02)</small>
 
-* [bitnami/spring-cloud-dataflow] Release 7.0.2 updating components versions ([cb288db](https://github.com/bitnami/charts/commit/cb288db))
+* [bitnami/spring-cloud-dataflow] Release 7.0.2 updating components versions ([cb288db](https://github.com/bitnami/charts/commit/cb288db65e01abf00631020c8d1e1e0b2066ad1a))
 
 ## <small>7.0.1 (2022-03-29)</small>
 
-* [bitnami/spring-cloud-dataflow] Release 7.0.1 updating components versions ([b29bdab](https://github.com/bitnami/charts/commit/b29bdab))
+* [bitnami/spring-cloud-dataflow] Release 7.0.1 updating components versions ([b29bdab](https://github.com/bitnami/charts/commit/b29bdab1bf35e554eac1c5200f81a76a85c9614b))
 
 ## 7.0.0 (2022-03-28)
 
-* [bitnami/spring-cloud-dataflow] Update kafka (#9577) ([9aecc4a](https://github.com/bitnami/charts/commit/9aecc4a)), closes [#9577](https://github.com/bitnami/charts/issues/9577)
+* [bitnami/spring-cloud-dataflow] Update kafka (#9577) ([9aecc4a](https://github.com/bitnami/charts/commit/9aecc4abe8190550fca7dc4887d13031f5a036dc)), closes [#9577](https://github.com/bitnami/charts/issues/9577)
 
 ## <small>6.0.9 (2022-03-28)</small>
 
-* [bitnami/spring-cloud-dataflow] Release 6.0.9 updating components versions ([856e23a](https://github.com/bitnami/charts/commit/856e23a))
+* [bitnami/spring-cloud-dataflow] Release 6.0.9 updating components versions ([856e23a](https://github.com/bitnami/charts/commit/856e23aa57a883f0d6dd411e6e42402acedc6e56))
 
 ## <small>6.0.8 (2022-03-27)</small>
 
-* [bitnami/spring-cloud-dataflow] Release 6.0.8 updating components versions ([93f6735](https://github.com/bitnami/charts/commit/93f6735))
+* [bitnami/spring-cloud-dataflow] Release 6.0.8 updating components versions ([93f6735](https://github.com/bitnami/charts/commit/93f6735303c4d223da354fe4d8d4a8073af5db8a))
 
 ## <small>6.0.7 (2022-03-25)</small>
 
-* [bitnami/spring-cloud-dataflow] Release 6.0.7 updating components versions ([9341046](https://github.com/bitnami/charts/commit/9341046))
+* [bitnami/spring-cloud-dataflow] Release 6.0.7 updating components versions ([9341046](https://github.com/bitnami/charts/commit/9341046970fdcf49f884694182c94692b1663586))
 
 ## <small>6.0.6 (2022-03-25)</small>
 
-* Add missing entryPointStyle so that entrypoint may be configured for SCDF tasks (#9516) ([c041b64](https://github.com/bitnami/charts/commit/c041b64)), closes [#9516](https://github.com/bitnami/charts/issues/9516)
+* Add missing entryPointStyle so that entrypoint may be configured for SCDF tasks (#9516) ([c041b64](https://github.com/bitnami/charts/commit/c041b641f17cbe0cf61528decc3f1cca4f4e243a)), closes [#9516](https://github.com/bitnami/charts/issues/9516)
 
 ## <small>6.0.5 (2022-03-18)</small>
 
-* [bitnami/spring-cloud-dataflow] Release 6.0.5 updating components versions ([66b47b7](https://github.com/bitnami/charts/commit/66b47b7))
+* [bitnami/spring-cloud-dataflow] Release 6.0.5 updating components versions ([66b47b7](https://github.com/bitnami/charts/commit/66b47b7773c11197476f5b191ed3217fb97ec89b))
 
 ## <small>6.0.4 (2022-03-17)</small>
 
-* [bitnami/spring-cloud-dataflow] Release 6.0.4 updating components versions ([61ca765](https://github.com/bitnami/charts/commit/61ca765))
+* [bitnami/spring-cloud-dataflow] Release 6.0.4 updating components versions ([61ca765](https://github.com/bitnami/charts/commit/61ca765fd3de6983d33e43e66bada3047021b69c))
 
 ## <small>6.0.3 (2022-03-16)</small>
 
-* [bitnami/spring-cloud-dataflow] Release 6.0.3 updating components versions ([16c5d58](https://github.com/bitnami/charts/commit/16c5d58))
+* [bitnami/spring-cloud-dataflow] Release 6.0.3 updating components versions ([16c5d58](https://github.com/bitnami/charts/commit/16c5d589c975213d1b5ec40656eb715455da9f9d))
 
 ## <small>6.0.2 (2022-03-15)</small>
 
-* [bitnami/spring-cloud-dataflow] Added entryPointStyle and imagePullPo… (#9409) ([a7f8057](https://github.com/bitnami/charts/commit/a7f8057)), closes [#9409](https://github.com/bitnami/charts/issues/9409)
+* [bitnami/spring-cloud-dataflow] Added entryPointStyle and imagePullPo… (#9409) ([a7f8057](https://github.com/bitnami/charts/commit/a7f805734f45eda6def0d5e1fa82473791427e85)), closes [#9409](https://github.com/bitnami/charts/issues/9409)
 
 ## <small>6.0.1 (2022-03-15)</small>
 
-* bitnami/spring-cloud-dataflow: deployer.podSecurityContext can be switched off without warnings (#94 ([39159dd](https://github.com/bitnami/charts/commit/39159dd)), closes [#9405](https://github.com/bitnami/charts/issues/9405)
+* bitnami/spring-cloud-dataflow: deployer.podSecurityContext can be switched off without warnings (#94 ([39159dd](https://github.com/bitnami/charts/commit/39159ddeb17d962ffd1e37f3f015308f2af8ea78)), closes [#9405](https://github.com/bitnami/charts/issues/9405)
 
 ## 6.0.0 (2022-03-07)
 
-* [bitnami/spring-cloud-dataflow] Bump Kafka subchart (#9316) ([fb82bb1](https://github.com/bitnami/charts/commit/fb82bb1)), closes [#9316](https://github.com/bitnami/charts/issues/9316)
+* [bitnami/spring-cloud-dataflow] Bump Kafka subchart (#9316) ([fb82bb1](https://github.com/bitnami/charts/commit/fb82bb1fb025b51828bc85dda5f44de6f6e4157d)), closes [#9316](https://github.com/bitnami/charts/issues/9316)
 
 ## <small>5.2.3 (2022-03-04)</small>
 
-* [bitnami/several] Reorder subcharts (#9299) ([a041f6b](https://github.com/bitnami/charts/commit/a041f6b)), closes [#9299](https://github.com/bitnami/charts/issues/9299)
+* [bitnami/several] Reorder subcharts (#9299) ([a041f6b](https://github.com/bitnami/charts/commit/a041f6b0ff2dea82b3d030cb99454cede94dbc9a)), closes [#9299](https://github.com/bitnami/charts/issues/9299)
 
 ## <small>5.2.2 (2022-02-27)</small>
 
-* [bitnami/spring-cloud-dataflow] Release 5.2.2 updating components versions ([a6b8819](https://github.com/bitnami/charts/commit/a6b8819))
+* [bitnami/spring-cloud-dataflow] Release 5.2.2 updating components versions ([a6b8819](https://github.com/bitnami/charts/commit/a6b88193c0dcbc67133e4434733a6b343857b406))
 
 ## <small>5.2.1 (2022-02-21)</small>
 
-* [bitnami/spring-cloud-dataflow] Do not hardcode PDB apiVersion (#9117) ([9446ea3](https://github.com/bitnami/charts/commit/9446ea3)), closes [#9117](https://github.com/bitnami/charts/issues/9117)
+* [bitnami/spring-cloud-dataflow] Do not hardcode PDB apiVersion (#9117) ([9446ea3](https://github.com/bitnami/charts/commit/9446ea37ddd984bf5176eaad712157b058fc2935)), closes [#9117](https://github.com/bitnami/charts/issues/9117)
 
 ## 5.2.0 (2022-02-11)
 
-* Add common application properties configuration (#8982) ([5aa0fb2](https://github.com/bitnami/charts/commit/5aa0fb2)), closes [#8982](https://github.com/bitnami/charts/issues/8982)
+* Add common application properties configuration (#8982) ([5aa0fb2](https://github.com/bitnami/charts/commit/5aa0fb23aa5e7d4d95a4641692b8d4e717f14143)), closes [#8982](https://github.com/bitnami/charts/issues/8982)
 
 ## <small>5.1.1 (2022-02-09)</small>
 
-* [bitnami/spring-cloud-dataflow] Release 5.1.1 updating components versions ([4b3b9e4](https://github.com/bitnami/charts/commit/4b3b9e4))
+* [bitnami/spring-cloud-dataflow] Release 5.1.1 updating components versions ([4b3b9e4](https://github.com/bitnami/charts/commit/4b3b9e43afb10bf81d1d08804f8ba6bbd72729c2))
 
 ## 5.1.0 (2022-02-01)
 
-* [bitnami/spring-cloud-dataflow] enable deployer secretRefs (#8842) ([f392ed0](https://github.com/bitnami/charts/commit/f392ed0)), closes [#8842](https://github.com/bitnami/charts/issues/8842)
+* [bitnami/spring-cloud-dataflow] enable deployer secretRefs (#8842) ([f392ed0](https://github.com/bitnami/charts/commit/f392ed0715f31f5ed78eae15a5b4da490e9ebb8e)), closes [#8842](https://github.com/bitnami/charts/issues/8842)
 
 ## <small>5.0.5 (2022-01-21)</small>
 
-* [bitnami/spring-cloud-dataflow] Release 5.0.5 updating components versions ([0c14b78](https://github.com/bitnami/charts/commit/0c14b78))
+* [bitnami/spring-cloud-dataflow] Release 5.0.5 updating components versions ([0c14b78](https://github.com/bitnami/charts/commit/0c14b7811be7420d799bfae4dde1da1cd39f3cdc))
 
 ## <small>5.0.4 (2022-01-20)</small>
 
-* [bitnami/*] Update READMEs (#8716) ([b9a9533](https://github.com/bitnami/charts/commit/b9a9533)), closes [#8716](https://github.com/bitnami/charts/issues/8716)
-* [bitnami/several] Change prerequisites (#8725) ([8d740c5](https://github.com/bitnami/charts/commit/8d740c5)), closes [#8725](https://github.com/bitnami/charts/issues/8725)
+* [bitnami/*] Update READMEs (#8716) ([b9a9533](https://github.com/bitnami/charts/commit/b9a953337590eb2979453385874a267bacf50936)), closes [#8716](https://github.com/bitnami/charts/issues/8716)
+* [bitnami/several] Change prerequisites (#8725) ([8d740c5](https://github.com/bitnami/charts/commit/8d740c566cfdb7e2d933c40128b4e919fce953a5)), closes [#8725](https://github.com/bitnami/charts/issues/8725)
 
 ## <small>5.0.3 (2022-01-18)</small>
 
-* [bitnami/*] Readme automation (#8579) ([78d1938](https://github.com/bitnami/charts/commit/78d1938)), closes [#8579](https://github.com/bitnami/charts/issues/8579)
-* Fix metrics (#8695) ([e71d38e](https://github.com/bitnami/charts/commit/e71d38e)), closes [#8695](https://github.com/bitnami/charts/issues/8695)
+* [bitnami/*] Readme automation (#8579) ([78d1938](https://github.com/bitnami/charts/commit/78d193831c900d178198491ffd08fa2217a64ecd)), closes [#8579](https://github.com/bitnami/charts/issues/8579)
+* Fix metrics (#8695) ([e71d38e](https://github.com/bitnami/charts/commit/e71d38ea4e4d98ec7ab032bcf6cf7e9dfb904129)), closes [#8695](https://github.com/bitnami/charts/issues/8695)
 
 ## <small>5.0.2 (2022-01-17)</small>
 
-* [bitnami/spring-cloud-dataflow] Remove dollar prompt from command examples in README (#8631) ([4a8d223](https://github.com/bitnami/charts/commit/4a8d223)), closes [#8631](https://github.com/bitnami/charts/issues/8631)
+* [bitnami/spring-cloud-dataflow] Remove dollar prompt from command examples in README (#8631) ([4a8d223](https://github.com/bitnami/charts/commit/4a8d223a91d55b17620588c7e511493842985221)), closes [#8631](https://github.com/bitnami/charts/issues/8631)
 
 ## <small>5.0.1 (2022-01-10)</small>
 
-* [bitnami/spring-cloud-dataflow] Add deployer.imagePullSecrets property (#8597) ([8fae03e](https://github.com/bitnami/charts/commit/8fae03e)), closes [#8597](https://github.com/bitnami/charts/issues/8597)
+* [bitnami/spring-cloud-dataflow] Add deployer.imagePullSecrets property (#8597) ([8fae03e](https://github.com/bitnami/charts/commit/8fae03e02f010d0d99c1c0aec414ff6b75ac7ac9)), closes [#8597](https://github.com/bitnami/charts/issues/8597)
 
 ## 5.0.0 (2022-01-04)
 
-* [bitnami/several] Add license to the README ([05f7633](https://github.com/bitnami/charts/commit/05f7633))
-* [bitnami/several] Add license to the README ([32fb238](https://github.com/bitnami/charts/commit/32fb238))
-* [bitnami/several] Add license to the README ([b87c2f7](https://github.com/bitnami/charts/commit/b87c2f7))
-* [bitnami/spring-cloud-dataflow] Chart standardized (#8524) ([43029d4](https://github.com/bitnami/charts/commit/43029d4)), closes [#8524](https://github.com/bitnami/charts/issues/8524)
+* [bitnami/several] Add license to the README ([05f7633](https://github.com/bitnami/charts/commit/05f763372501d596e57db713dd53ff4ff3027cc4))
+* [bitnami/several] Add license to the README ([32fb238](https://github.com/bitnami/charts/commit/32fb238e60a0affc6debd3142eaa3c3d9089ec2a))
+* [bitnami/several] Add license to the README ([b87c2f7](https://github.com/bitnami/charts/commit/b87c2f7899d48a8b02c506765e6ae82937e9ba3f))
+* [bitnami/spring-cloud-dataflow] Chart standardized (#8524) ([43029d4](https://github.com/bitnami/charts/commit/43029d4470dd3b66623d90150f56ce6791dcb801)), closes [#8524](https://github.com/bitnami/charts/issues/8524)
 
 ## <small>4.2.5 (2021-12-29)</small>
 
-* [bitnami/spring-cloud-dataflow] Release 4.2.5 updating components versions ([2e0f260](https://github.com/bitnami/charts/commit/2e0f260))
+* [bitnami/spring-cloud-dataflow] Release 4.2.5 updating components versions ([2e0f260](https://github.com/bitnami/charts/commit/2e0f2600ed7860ae7e8f2e57712498ed22b59d9a))
 
 ## <small>4.2.4 (2021-12-28)</small>
 
-* [bitnami/spring-cloud-dataflow] Release 4.2.4 updating components versions ([e99f8e8](https://github.com/bitnami/charts/commit/e99f8e8))
+* [bitnami/spring-cloud-dataflow] Release 4.2.4 updating components versions ([e99f8e8](https://github.com/bitnami/charts/commit/e99f8e8d62fdef4360d8cf5ae62f9bb42b483c2c))
 
 ## <small>4.2.3 (2021-12-24)</small>
 
-* [bitnami/several] Regenerate README tables ([8150149](https://github.com/bitnami/charts/commit/8150149))
-* [bitnami/spring-cloud-dataflow] Allow multiple external kafka nodes (#8488) ([e7dc50a](https://github.com/bitnami/charts/commit/e7dc50a)), closes [#8488](https://github.com/bitnami/charts/issues/8488)
+* [bitnami/several] Regenerate README tables ([8150149](https://github.com/bitnami/charts/commit/8150149f0bb746e86ff0029fc375d43775bdf15a))
+* [bitnami/spring-cloud-dataflow] Allow multiple external kafka nodes (#8488) ([e7dc50a](https://github.com/bitnami/charts/commit/e7dc50a96d738da1d00549084f7cbd40023c6186)), closes [#8488](https://github.com/bitnami/charts/issues/8488)
 
 ## <small>4.2.2 (2021-11-29)</small>
 
-* [bitnami/several] Replace HTTP by HTTPS when possible (#8259) ([eafb5bd](https://github.com/bitnami/charts/commit/eafb5bd)), closes [#8259](https://github.com/bitnami/charts/issues/8259)
+* [bitnami/several] Replace HTTP by HTTPS when possible (#8259) ([eafb5bd](https://github.com/bitnami/charts/commit/eafb5bd5a2cc3aaf04fc1e8ebedd73f420d76864)), closes [#8259](https://github.com/bitnami/charts/issues/8259)
 
 ## <small>4.2.1 (2021-11-28)</small>
 
-* [bitnami/several] Regenerate README tables ([ac75243](https://github.com/bitnami/charts/commit/ac75243))
-* [bitnami/spring-cloud-dataflow] Release 4.2.1 updating components versions ([d8ecdf4](https://github.com/bitnami/charts/commit/d8ecdf4))
+* [bitnami/several] Regenerate README tables ([ac75243](https://github.com/bitnami/charts/commit/ac752431b90e935d0a4dbfef70dc44f24f3d3dd2))
+* [bitnami/spring-cloud-dataflow] Release 4.2.1 updating components versions ([d8ecdf4](https://github.com/bitnami/charts/commit/d8ecdf4a36c6d9dbca724bc19773f2ae72eb77d3))
 
 ## 4.2.0 (2021-11-25)
 
-* [bitnami/spring-cloud-dataflow] Add new variable .Values.server.configuration.defaultSpringApplicati ([dcae1c3](https://github.com/bitnami/charts/commit/dcae1c3)), closes [#8228](https://github.com/bitnami/charts/issues/8228)
+* [bitnami/spring-cloud-dataflow] Add new variable .Values.server.configuration.defaultSpringApplicati ([dcae1c3](https://github.com/bitnami/charts/commit/dcae1c34117358c7f0c36d99c083d612e170ae19)), closes [#8228](https://github.com/bitnami/charts/issues/8228)
 
 ## <small>4.1.6 (2021-11-19)</small>
 
-* [bitnami/several] Regenerate README tables ([3cefed3](https://github.com/bitnami/charts/commit/3cefed3))
-* Add undocumented parameter in values.yaml (#8188) ([605f6f2](https://github.com/bitnami/charts/commit/605f6f2)), closes [#8188](https://github.com/bitnami/charts/issues/8188)
+* [bitnami/several] Regenerate README tables ([3cefed3](https://github.com/bitnami/charts/commit/3cefed3ef961fbd7596242b1165bcfa229a9cadb))
+* Add undocumented parameter in values.yaml (#8188) ([605f6f2](https://github.com/bitnami/charts/commit/605f6f287d36bb7dd3eddeb2bcb6c55d72a620d1)), closes [#8188](https://github.com/bitnami/charts/issues/8188)
 
 ## <small>4.1.5 (2021-10-28)</small>
 
-* [bitnami/several] Regenerate README tables ([412cf6a](https://github.com/bitnami/charts/commit/412cf6a))
-* [bitnami/spring-cloud-dataflow] Release 4.1.5 updating components versions ([ffae081](https://github.com/bitnami/charts/commit/ffae081))
+* [bitnami/several] Regenerate README tables ([412cf6a](https://github.com/bitnami/charts/commit/412cf6a513cb0c03444a6e7811c6f27193239a10))
+* [bitnami/spring-cloud-dataflow] Release 4.1.5 updating components versions ([ffae081](https://github.com/bitnami/charts/commit/ffae08192aa002e0f00234c9e688b85d26b0f5d9))
 
 ## <small>4.1.4 (2021-10-27)</small>
 
-* [bitnami/spring-cloud-dataflow] Release 4.1.4 updating components versions ([b98b483](https://github.com/bitnami/charts/commit/b98b483))
+* [bitnami/spring-cloud-dataflow] Release 4.1.4 updating components versions ([b98b483](https://github.com/bitnami/charts/commit/b98b4836c93b8ef9661c4776a5c58d0cd5381f3f))
 
 ## <small>4.1.3 (2021-10-22)</small>
 
-* [bitnami/*] Generate READMEs (#7790) ([0833a8c](https://github.com/bitnami/charts/commit/0833a8c)), closes [#7790](https://github.com/bitnami/charts/issues/7790)
-* [bitnami/several] Add chart info to NOTES.txt (#7889) ([a6751cd](https://github.com/bitnami/charts/commit/a6751cd)), closes [#7889](https://github.com/bitnami/charts/issues/7889)
+* [bitnami/*] Generate READMEs (#7790) ([0833a8c](https://github.com/bitnami/charts/commit/0833a8c16300d68abf6030639c3479d8fb031e25)), closes [#7790](https://github.com/bitnami/charts/issues/7790)
+* [bitnami/several] Add chart info to NOTES.txt (#7889) ([a6751cd](https://github.com/bitnami/charts/commit/a6751cdd33c461fabbc459fbea6f219ec64ab6b2)), closes [#7889](https://github.com/bitnami/charts/issues/7889)
 
 ## <small>4.1.2 (2021-10-12)</small>
 
-* [bitnami/spring-cloud-dataflow] Release 4.1.2 updating components versions ([f011a8c](https://github.com/bitnami/charts/commit/f011a8c))
+* [bitnami/spring-cloud-dataflow] Release 4.1.2 updating components versions ([f011a8c](https://github.com/bitnami/charts/commit/f011a8cca2e7920f16289154d05c3ce8a2a332d3))
 
 ## <small>4.1.1 (2021-10-01)</small>
 
-* [bitnami/*] Drop support for deprecated cert-manager annotation (#7646) ([4297b79](https://github.com/bitnami/charts/commit/4297b79)), closes [#7646](https://github.com/bitnami/charts/issues/7646)
-* [bitnami/several] Regenerate README tables ([79eac44](https://github.com/bitnami/charts/commit/79eac44))
+* [bitnami/*] Drop support for deprecated cert-manager annotation (#7646) ([4297b79](https://github.com/bitnami/charts/commit/4297b792e48fba9c7c3b8fed447a856632c61201)), closes [#7646](https://github.com/bitnami/charts/issues/7646)
+* [bitnami/several] Regenerate README tables ([79eac44](https://github.com/bitnami/charts/commit/79eac4490bf5d0abe582920d9662a892c9666870))
 
 ## 4.1.0 (2021-09-22)
 
-* [bitnami/spring-cloud-dataflow] - 7541 Add spring.flyway.enabled configuration (#7570) ([9de0e60](https://github.com/bitnami/charts/commit/9de0e60)), closes [#7570](https://github.com/bitnami/charts/issues/7570)
+* [bitnami/spring-cloud-dataflow] - 7541 Add spring.flyway.enabled configuration (#7570) ([9de0e60](https://github.com/bitnami/charts/commit/9de0e60206f62b0530481622bb296fd09162918d)), closes [#7570](https://github.com/bitnami/charts/issues/7570)
 
 ## <small>4.0.4 (2021-09-22)</small>
 
-* [bitnami/several] Regenerate README tables ([64d5d74](https://github.com/bitnami/charts/commit/64d5d74))
-* [bitnami/spring-cloud-dataflow] 7539 - add spring cloud task closecontext enabled (#7567) ([cb5e060](https://github.com/bitnami/charts/commit/cb5e060)), closes [#7567](https://github.com/bitnami/charts/issues/7567)
+* [bitnami/several] Regenerate README tables ([64d5d74](https://github.com/bitnami/charts/commit/64d5d747b84299ca9f63ea8a586b13870abe31a6))
+* [bitnami/spring-cloud-dataflow] 7539 - add spring cloud task closecontext enabled (#7567) ([cb5e060](https://github.com/bitnami/charts/commit/cb5e060704478a50d968e3bf895f05bbf5b2a1e1)), closes [#7567](https://github.com/bitnami/charts/issues/7567)
 
 ## <small>4.0.3 (2021-08-30)</small>
 
-* [bitnami/several] Regenerate README tables ([da2513b](https://github.com/bitnami/charts/commit/da2513b))
-* [bitnami/spring-cloud-dataflow] Release 4.0.3 updating components versions ([7f2c221](https://github.com/bitnami/charts/commit/7f2c221))
+* [bitnami/several] Regenerate README tables ([da2513b](https://github.com/bitnami/charts/commit/da2513bf0a33819f3b1151d387c631a9ffdb03e2))
+* [bitnami/spring-cloud-dataflow] Release 4.0.3 updating components versions ([7f2c221](https://github.com/bitnami/charts/commit/7f2c2213e1bc6136b726073f733910ee82c212de))
 
 ## <small>4.0.2 (2021-08-25)</small>
 
-* [bitnami/several] Regenerate README tables ([6c107e8](https://github.com/bitnami/charts/commit/6c107e8))
-* [bitnami/spring-cloud-dataflow] Release 4.0.2 updating components versions ([9b39318](https://github.com/bitnami/charts/commit/9b39318))
+* [bitnami/several] Regenerate README tables ([6c107e8](https://github.com/bitnami/charts/commit/6c107e835d6caf8db2e8b17dcd48c5971637e013))
+* [bitnami/spring-cloud-dataflow] Release 4.0.2 updating components versions ([9b39318](https://github.com/bitnami/charts/commit/9b3931887e92eebf69d45c9b100bcd7e8c7a7e43))
 
 ## <small>4.0.1 (2021-08-02)</small>
 
-* [bitnami/spring-cloud-dataflow] Release 4.0.1 updating components versions ([9d34180](https://github.com/bitnami/charts/commit/9d34180))
+* [bitnami/spring-cloud-dataflow] Release 4.0.1 updating components versions ([9d34180](https://github.com/bitnami/charts/commit/9d3418044d09d4af5771f4538c676d990313a215))
 
 ## 4.0.0 (2021-08-02)
 
-* [bitnami/several] Upadte READMEs ([eb3c291](https://github.com/bitnami/charts/commit/eb3c291))
-* [bitnami/several] Use the latest major version in subcharts (#7117) ([3c1c105](https://github.com/bitnami/charts/commit/3c1c105)), closes [#7117](https://github.com/bitnami/charts/issues/7117)
+* [bitnami/several] Upadte READMEs ([eb3c291](https://github.com/bitnami/charts/commit/eb3c2916be233280f2226d9cdceb57b08ab4a23b))
+* [bitnami/several] Use the latest major version in subcharts (#7117) ([3c1c105](https://github.com/bitnami/charts/commit/3c1c105ce61d24a81e34bf7be5250bfe07068efb)), closes [#7117](https://github.com/bitnami/charts/issues/7117)
 
 ## <small>3.0.3 (2021-07-26)</small>
 
-* [bitnami/spring-cloud-dataflow] Release 3.0.3 updating components versions ([4ecb582](https://github.com/bitnami/charts/commit/4ecb582))
+* [bitnami/spring-cloud-dataflow] Release 3.0.3 updating components versions ([4ecb582](https://github.com/bitnami/charts/commit/4ecb582b1563e17a34509b99af1cdd8c389b5eb9))
 
 ## <small>3.0.2 (2021-07-21)</small>
 
-* [bitnami/*] Replace nil values (#6993) ([2be11a7](https://github.com/bitnami/charts/commit/2be11a7)), closes [#6993](https://github.com/bitnami/charts/issues/6993)
+* [bitnami/*] Replace nil values (#6993) ([2be11a7](https://github.com/bitnami/charts/commit/2be11a70b92a01603c1f079eeaff4b00dc4796d6)), closes [#6993](https://github.com/bitnami/charts/issues/6993)
 
 ## <small>3.0.1 (2021-07-15)</small>
 
-* [bitnami/*] Adapt values.yaml of Spark, Spring Cloud Data Flow and SuiteCRM charts (#6951) ([647d72d](https://github.com/bitnami/charts/commit/647d72d)), closes [#6951](https://github.com/bitnami/charts/issues/6951)
+* [bitnami/*] Adapt values.yaml of Spark, Spring Cloud Data Flow and SuiteCRM charts (#6951) ([647d72d](https://github.com/bitnami/charts/commit/647d72d3b1714cc82c22451bb0dc9088abc0f52a)), closes [#6951](https://github.com/bitnami/charts/issues/6951)
 
 ## 3.0.0 (2021-07-12)
 
-* [bitnami/*] Update subchart dependencies (#6922) ([bba410f](https://github.com/bitnami/charts/commit/bba410f)), closes [#6922](https://github.com/bitnami/charts/issues/6922)
+* [bitnami/*] Update subchart dependencies (#6922) ([bba410f](https://github.com/bitnami/charts/commit/bba410f5d365ec216c01883650bbbab3816c023c)), closes [#6922](https://github.com/bitnami/charts/issues/6922)
 
 ## <small>2.11.4 (2021-06-26)</small>
 
-* [bitnami/spring-cloud-dataflow] Release 2.11.4 updating components versions ([cb22673](https://github.com/bitnami/charts/commit/cb22673))
+* [bitnami/spring-cloud-dataflow] Release 2.11.4 updating components versions ([cb22673](https://github.com/bitnami/charts/commit/cb22673b63a063732af6a6ad59b73990daeb62d3))
 
 ## <small>2.11.3 (2021-06-24)</small>
 
-* [bitnami/spring-cloud-dataflow] Release 2.11.3 updating components versions ([d93f4df](https://github.com/bitnami/charts/commit/d93f4df))
+* [bitnami/spring-cloud-dataflow] Release 2.11.3 updating components versions ([d93f4df](https://github.com/bitnami/charts/commit/d93f4dfd1951308a698225fb2b3f72bef7b0e439))
 
 ## <small>2.11.2 (2021-06-19)</small>
 
-* [bitnami/spring-cloud-dataflow] Release 2.11.2 updating components versions ([8cc06e7](https://github.com/bitnami/charts/commit/8cc06e7))
+* [bitnami/spring-cloud-dataflow] Release 2.11.2 updating components versions ([8cc06e7](https://github.com/bitnami/charts/commit/8cc06e725d6d57c22c35f3b3bb7fbb8c28561454))
 
 ## <small>2.11.1 (2021-05-23)</small>
 
-* [bitnami/spring-cloud-dataflow] Release 2.11.1 updating components versions ([ac60c39](https://github.com/bitnami/charts/commit/ac60c39))
+* [bitnami/spring-cloud-dataflow] Release 2.11.1 updating components versions ([ac60c39](https://github.com/bitnami/charts/commit/ac60c39ef38a31f7986424465e3576f44dca4c59))
 
 ## 2.11.0 (2021-05-20)
 
-* [bitnami/*] Update Kubectl container version (#6420) ([dad6d38](https://github.com/bitnami/charts/commit/dad6d38)), closes [#6420](https://github.com/bitnami/charts/issues/6420)
+* [bitnami/*] Update Kubectl container version (#6420) ([dad6d38](https://github.com/bitnami/charts/commit/dad6d3857f54132e32b5860cd454129bc8b781fe)), closes [#6420](https://github.com/bitnami/charts/issues/6420)
 
 ## <small>2.10.3 (2021-05-03)</small>
 
-* [bitnami/spring-cloud-dataflow] Release 2.10.3 updating components versions ([c350e1c](https://github.com/bitnami/charts/commit/c350e1c))
+* [bitnami/spring-cloud-dataflow] Release 2.10.3 updating components versions ([c350e1c](https://github.com/bitnami/charts/commit/c350e1c8123e9efc4fa53801ccd0241db4983a53))
 
 ## <small>2.10.2 (2021-04-30)</small>
 
-* Fix typos in several README files (#6252) ([fd16565](https://github.com/bitnami/charts/commit/fd16565)), closes [#6252](https://github.com/bitnami/charts/issues/6252)
+* Fix typos in several README files (#6252) ([fd16565](https://github.com/bitnami/charts/commit/fd1656587a007ac9b8e9d895f6b99607fb225f7c)), closes [#6252](https://github.com/bitnami/charts/issues/6252)
 
 ## <small>2.10.1 (2021-04-03)</small>
 
-* [bitnami/spring-cloud-dataflow] Release 2.10.1 updating components versions ([5bbc176](https://github.com/bitnami/charts/commit/5bbc176))
+* [bitnami/spring-cloud-dataflow] Release 2.10.1 updating components versions ([5bbc176](https://github.com/bitnami/charts/commit/5bbc176e515af558e5cf94f73973505820f980c7))
 
 ## 2.10.0 (2021-03-18)
 
-* [bitnami/spring-cloud-dataflow] Add more configuration options for prometheus proxy (#5827) ([49a3d17](https://github.com/bitnami/charts/commit/49a3d17)), closes [#5827](https://github.com/bitnami/charts/issues/5827)
+* [bitnami/spring-cloud-dataflow] Add more configuration options for prometheus proxy (#5827) ([49a3d17](https://github.com/bitnami/charts/commit/49a3d17ba11ac8af9e576f556c2ddb8d884426ce)), closes [#5827](https://github.com/bitnami/charts/issues/5827)
 
 ## <small>2.9.1 (2021-03-18)</small>
 
-* [bitnami/spring-cloud-dataflow]: rabbitmq passwordErrors only if rabbitmq is used (#5781) (#5819) ([8a1c00f](https://github.com/bitnami/charts/commit/8a1c00f)), closes [#5781](https://github.com/bitnami/charts/issues/5781) [#5819](https://github.com/bitnami/charts/issues/5819)
+* [bitnami/spring-cloud-dataflow]: rabbitmq passwordErrors only if rabbitmq is used (#5781) (#5819) ([8a1c00f](https://github.com/bitnami/charts/commit/8a1c00f879f5e72980b044ad820e89729185055c)), closes [#5781](https://github.com/bitnami/charts/issues/5781) [#5819](https://github.com/bitnami/charts/issues/5819)
 
 ## 2.9.0 (2021-03-17)
 
-* [bitnami/spring-cloud-dataflow] Add more configuration options for prometheus proxy (#5807) ([8bfd73a](https://github.com/bitnami/charts/commit/8bfd73a)), closes [#5807](https://github.com/bitnami/charts/issues/5807)
+* [bitnami/spring-cloud-dataflow] Add more configuration options for prometheus proxy (#5807) ([8bfd73a](https://github.com/bitnami/charts/commit/8bfd73aad2b7ab1cbc1f1e86d1cdbd55f316f39b)), closes [#5807](https://github.com/bitnami/charts/issues/5807)
 
 ## 2.8.0 (2021-03-08)
 
-* [bitnami/scdf] General improvements (#5719) ([3f7ed3f](https://github.com/bitnami/charts/commit/3f7ed3f)), closes [#5719](https://github.com/bitnami/charts/issues/5719)
+* [bitnami/scdf] General improvements (#5719) ([3f7ed3f](https://github.com/bitnami/charts/commit/3f7ed3f9f511b630bbe6add49790040a1aefc46a)), closes [#5719](https://github.com/bitnami/charts/issues/5719)
 
 ## <small>2.7.5 (2021-03-04)</small>
 
-* [bitnami/spring-cloud-dataflow] Release 2.7.5 updating components versions ([9db0f63](https://github.com/bitnami/charts/commit/9db0f63))
-* Update README.md (#5611) ([91f6bea](https://github.com/bitnami/charts/commit/91f6bea)), closes [#5611](https://github.com/bitnami/charts/issues/5611)
+* [bitnami/spring-cloud-dataflow] Release 2.7.5 updating components versions ([9db0f63](https://github.com/bitnami/charts/commit/9db0f63bae3f5d9bcd2e53d9c3ea6023ff7b5ef1))
+* Update README.md (#5611) ([91f6bea](https://github.com/bitnami/charts/commit/91f6bea605482a159d5927446457811205c05566)), closes [#5611](https://github.com/bitnami/charts/issues/5611)
 
 ## <small>2.7.4 (2021-02-22)</small>
 
-* [bitnami/*] Use common macro to define RBAC apiVersion (#5585) ([71fb99f](https://github.com/bitnami/charts/commit/71fb99f)), closes [#5585](https://github.com/bitnami/charts/issues/5585)
+* [bitnami/*] Use common macro to define RBAC apiVersion (#5585) ([71fb99f](https://github.com/bitnami/charts/commit/71fb99f541e971b1daafaa20ffb7d18b153b8d60)), closes [#5585](https://github.com/bitnami/charts/issues/5585)
 
 ## <small>2.7.3 (2021-02-11)</small>
 
-* fix skipper extraVolumes and extraVolumeMounts improperly pointing at server (#5460) ([d292695](https://github.com/bitnami/charts/commit/d292695)), closes [#5460](https://github.com/bitnami/charts/issues/5460)
+* fix skipper extraVolumes and extraVolumeMounts improperly pointing at server (#5460) ([d292695](https://github.com/bitnami/charts/commit/d2926952b68911ae864786174673183822d9cc60)), closes [#5460](https://github.com/bitnami/charts/issues/5460)
 
 ## <small>2.7.2 (2021-02-10)</small>
 
-* [bitnami/spring-cloud-dataflow] Scdf proxy configuration (#5399) ([21f4bad](https://github.com/bitnami/charts/commit/21f4bad)), closes [#5399](https://github.com/bitnami/charts/issues/5399)
+* [bitnami/spring-cloud-dataflow] Scdf proxy configuration (#5399) ([21f4bad](https://github.com/bitnami/charts/commit/21f4bad58c879a819e96a30109b665df4c29c26a)), closes [#5399](https://github.com/bitnami/charts/issues/5399)
 
 ## <small>2.7.1 (2021-02-02)</small>
 
-* [bitnami/spring-cloud-dataflow] Release 2.7.1 updating components versions ([847dd24](https://github.com/bitnami/charts/commit/847dd24))
+* [bitnami/spring-cloud-dataflow] Release 2.7.1 updating components versions ([847dd24](https://github.com/bitnami/charts/commit/847dd24c8df2fad881cabbf90e630373e3a0b0cd))
 
 ## 2.7.0 (2021-02-01)
 
-* [bitnami/spring-cloud-dataflow] External Kafka support (#5293) ([b789ef0](https://github.com/bitnami/charts/commit/b789ef0)), closes [#5293](https://github.com/bitnami/charts/issues/5293)
+* [bitnami/spring-cloud-dataflow] External Kafka support (#5293) ([b789ef0](https://github.com/bitnami/charts/commit/b789ef04adc3112d5b437fe3ad62ad3852968039)), closes [#5293](https://github.com/bitnami/charts/issues/5293)
 
 ## <small>2.6.1 (2021-01-31)</small>
 
-* [bitnami/spring-cloud-dataflow] Release 2.6.1 updating components versions ([93b5a23](https://github.com/bitnami/charts/commit/93b5a23))
+* [bitnami/spring-cloud-dataflow] Release 2.6.1 updating components versions ([93b5a23](https://github.com/bitnami/charts/commit/93b5a23ec90bd6040fcde45cd2706e4b5f68bb7f))
 
 ## 2.6.0 (2021-01-28)
 
-* [bitnami/spring-cloud-dataflow] Add hostAliases (#5309) ([40ba37d](https://github.com/bitnami/charts/commit/40ba37d)), closes [#5309](https://github.com/bitnami/charts/issues/5309)
+* [bitnami/spring-cloud-dataflow] Add hostAliases (#5309) ([40ba37d](https://github.com/bitnami/charts/commit/40ba37da944ce809a8cb3cb736ef3787a6a84db6)), closes [#5309](https://github.com/bitnami/charts/issues/5309)
 
 ## <small>2.5.4 (2021-01-26)</small>
 
-* [bitnami/spring-cloud-dataflow] Add metrics resources to README.md (#5234) ([9402569](https://github.com/bitnami/charts/commit/9402569)), closes [#5234](https://github.com/bitnami/charts/issues/5234)
+* [bitnami/spring-cloud-dataflow] Add metrics resources to README.md (#5234) ([9402569](https://github.com/bitnami/charts/commit/94025694ebea092dde8cb3c6b58fc0ec4e69effd)), closes [#5234](https://github.com/bitnami/charts/issues/5234)
 
 ## <small>2.5.3 (2021-01-25)</small>
 
-* [bitnami/*] Unify icons in Chart.yaml and add missing fields (#5206) ([0462921](https://github.com/bitnami/charts/commit/0462921)), closes [#5206](https://github.com/bitnami/charts/issues/5206)
+* [bitnami/*] Unify icons in Chart.yaml and add missing fields (#5206) ([0462921](https://github.com/bitnami/charts/commit/0462921418ca8d54308b7466197a6d53ffae4628)), closes [#5206](https://github.com/bitnami/charts/issues/5206)
 
 ## <small>2.5.2 (2021-01-19)</small>
 
-* [bitnami/*] Change helm version in the prerequisites (#5090) ([c5e67a3](https://github.com/bitnami/charts/commit/c5e67a3)), closes [#5090](https://github.com/bitnami/charts/issues/5090)
-* [bitnami/spring-cloud-dataflow] Drop values-production.yaml support (#5132) ([c8ba41c](https://github.com/bitnami/charts/commit/c8ba41c)), closes [#5132](https://github.com/bitnami/charts/issues/5132)
+* [bitnami/*] Change helm version in the prerequisites (#5090) ([c5e67a3](https://github.com/bitnami/charts/commit/c5e67a388743cbee28439d2cabca27884b9daf97)), closes [#5090](https://github.com/bitnami/charts/issues/5090)
+* [bitnami/spring-cloud-dataflow] Drop values-production.yaml support (#5132) ([c8ba41c](https://github.com/bitnami/charts/commit/c8ba41c38d4690b28a40d253872e63d3da1c6346)), closes [#5132](https://github.com/bitnami/charts/issues/5132)
 
 ## <small>2.5.1 (2021-01-18)</small>
 
-* [bitnami/spring-cloud-dataflow] Fix of missing `extraDeploy` template. (#5044) ([3035aac](https://github.com/bitnami/charts/commit/3035aac)), closes [#5044](https://github.com/bitnami/charts/issues/5044)
+* [bitnami/spring-cloud-dataflow] Fix of missing `extraDeploy` template. (#5044) ([3035aac](https://github.com/bitnami/charts/commit/3035aacae5fe8019ebe4c7838c84dbb8c540abbb)), closes [#5044](https://github.com/bitnami/charts/issues/5044)
 
 ## 2.5.0 (2021-01-14)
 
-* [bitnami/spring-cloud-dataflow] Add common annotations and labels and adapt ingress to k8s 1.20 (#50 ([4ec6e4c](https://github.com/bitnami/charts/commit/4ec6e4c)), closes [#5011](https://github.com/bitnami/charts/issues/5011)
+* [bitnami/spring-cloud-dataflow] Add common annotations and labels and adapt ingress to k8s 1.20 (#50 ([4ec6e4c](https://github.com/bitnami/charts/commit/4ec6e4c9ea8a2a8c1e359af63d8f1842b53520db)), closes [#5011](https://github.com/bitnami/charts/issues/5011)
 
 ## <small>2.4.2 (2021-01-03)</small>
 
-* [bitnami/spring-cloud-dataflow] Release 2.4.2 updating components versions ([658f76a](https://github.com/bitnami/charts/commit/658f76a))
+* [bitnami/spring-cloud-dataflow] Release 2.4.2 updating components versions ([658f76a](https://github.com/bitnami/charts/commit/658f76a9d3628d67067acc88d501b52f36c11e78))
 
 ## <small>2.4.1 (2020-12-22)</small>
 
-* [bitnami/spring-cloud-dataflow] externalDatabase.existingPasswordKey value (#4807) ([2f4b094](https://github.com/bitnami/charts/commit/2f4b094)), closes [#4807](https://github.com/bitnami/charts/issues/4807)
+* [bitnami/spring-cloud-dataflow] externalDatabase.existingPasswordKey value (#4807) ([2f4b094](https://github.com/bitnami/charts/commit/2f4b0942e1a9df0d915435934db9c3ba0dcc6dd1)), closes [#4807](https://github.com/bitnami/charts/issues/4807)
 
 ## 2.4.0 (2020-12-17)
 
-* [bitnami/spring-cloud-dataflow] Update SCDF metrics configuration for… (#4752) ([9976ee8](https://github.com/bitnami/charts/commit/9976ee8)), closes [#4752](https://github.com/bitnami/charts/issues/4752)
+* [bitnami/spring-cloud-dataflow] Update SCDF metrics configuration for… (#4752) ([9976ee8](https://github.com/bitnami/charts/commit/9976ee849b96d8571963da2ad9a68d388ec504ab)), closes [#4752](https://github.com/bitnami/charts/issues/4752)
 
 ## 2.3.0 (2020-12-15)
 
-* [bitnami/*] Affinity based on common presets (viii) (#4721) ([950ac9c](https://github.com/bitnami/charts/commit/950ac9c)), closes [#4721](https://github.com/bitnami/charts/issues/4721)
-* [bitnami/*] fix typos (#4699) ([49adc63](https://github.com/bitnami/charts/commit/49adc63)), closes [#4699](https://github.com/bitnami/charts/issues/4699)
+* [bitnami/*] Affinity based on common presets (viii) (#4721) ([950ac9c](https://github.com/bitnami/charts/commit/950ac9cd4d3914b7ffe7966b75876f416e479883)), closes [#4721](https://github.com/bitnami/charts/issues/4721)
+* [bitnami/*] fix typos (#4699) ([49adc63](https://github.com/bitnami/charts/commit/49adc63b672da976c55af2e077aa5648a357b77f)), closes [#4699](https://github.com/bitnami/charts/issues/4699)
 
 ## <small>2.2.1 (2020-12-11)</small>
 
-* [bitnami/*] Update dependencies (#4694) ([2826c12](https://github.com/bitnami/charts/commit/2826c12)), closes [#4694](https://github.com/bitnami/charts/issues/4694)
+* [bitnami/*] Update dependencies (#4694) ([2826c12](https://github.com/bitnami/charts/commit/2826c125b42505f28431301e3c1bbe5366e47a01)), closes [#4694](https://github.com/bitnami/charts/issues/4694)
 
 ## 2.2.0 (2020-12-04)
 
-* [bitnami/spring-cloud-dataflow] feat: move composedtak env var to the next version (#4603) ([a530487](https://github.com/bitnami/charts/commit/a530487)), closes [#4603](https://github.com/bitnami/charts/issues/4603)
+* [bitnami/spring-cloud-dataflow] feat: move composedtak env var to the next version (#4603) ([a530487](https://github.com/bitnami/charts/commit/a530487328253c59e4fce81f794ca87f68d96afa)), closes [#4603](https://github.com/bitnami/charts/issues/4603)
 
 ## 2.1.0 (2020-12-01)
 
-* [bitnami/spring-cloud-dataflow] Support extraVolume and extraVolumeMounts (#4550) ([beaaf12](https://github.com/bitnami/charts/commit/beaaf12)), closes [#4550](https://github.com/bitnami/charts/issues/4550) [#4534](https://github.com/bitnami/charts/issues/4534)
+* [bitnami/spring-cloud-dataflow] Support extraVolume and extraVolumeMounts (#4550) ([beaaf12](https://github.com/bitnami/charts/commit/beaaf129536ef28b3b52d8fda3ed8d4992751701)), closes [#4550](https://github.com/bitnami/charts/issues/4550) [#4534](https://github.com/bitnami/charts/issues/4534)
 
 ## <small>2.0.2 (2020-11-30)</small>
 
-* [bitnami/spring-cloud-dataflow] Release 2.0.2 updating components versions ([3f6054c](https://github.com/bitnami/charts/commit/3f6054c))
+* [bitnami/spring-cloud-dataflow] Release 2.0.2 updating components versions ([3f6054c](https://github.com/bitnami/charts/commit/3f6054c1c9633d0aa78d15d2a3e3ea009c35940f))
 
 ## <small>2.0.1 (2020-11-20)</small>
 
-* [bitnami/*] Expose the "service type" in the basic form for Kubeapps (#4445) ([cf3b3d3](https://github.com/bitnami/charts/commit/cf3b3d3)), closes [#4445](https://github.com/bitnami/charts/issues/4445)
+* [bitnami/*] Expose the "service type" in the basic form for Kubeapps (#4445) ([cf3b3d3](https://github.com/bitnami/charts/commit/cf3b3d3def5931883df8054806edcea9b8339c50)), closes [#4445](https://github.com/bitnami/charts/issues/4445)
 
 ## 2.0.0 (2020-11-12)
 
-* [bitnami/spring-cloud-dataflow] Major version. Adapt Chart to apiVersion: v2 (#4321) ([36de430](https://github.com/bitnami/charts/commit/36de430)), closes [#4321](https://github.com/bitnami/charts/issues/4321)
+* [bitnami/spring-cloud-dataflow] Major version. Adapt Chart to apiVersion: v2 (#4321) ([36de430](https://github.com/bitnami/charts/commit/36de430cd1a5d4638a3b75ca43c352935ef2e7ad)), closes [#4321](https://github.com/bitnami/charts/issues/4321)
 
 ## <small>1.2.1 (2020-10-29)</small>
 
-* [bitnami/*] Include link to Troubleshootin guide on README.md (#4136) ([c08a20e](https://github.com/bitnami/charts/commit/c08a20e)), closes [#4136](https://github.com/bitnami/charts/issues/4136)
-* [bitnami/spring-cloud-dataflow] Release 1.2.1 updating components versions ([a129eb9](https://github.com/bitnami/charts/commit/a129eb9))
+* [bitnami/*] Include link to Troubleshootin guide on README.md (#4136) ([c08a20e](https://github.com/bitnami/charts/commit/c08a20e3db004215383004ff023a73fcc2522e72)), closes [#4136](https://github.com/bitnami/charts/issues/4136)
+* [bitnami/spring-cloud-dataflow] Release 1.2.1 updating components versions ([a129eb9](https://github.com/bitnami/charts/commit/a129eb99321896b1523783534b884923cc6eb672))
 
 ## 1.2.0 (2020-10-14)
 
-* [bitnami/spring-cloud-dataflow] Fixes external database config (#3961) ([1829257](https://github.com/bitnami/charts/commit/1829257)), closes [#3961](https://github.com/bitnami/charts/issues/3961)
+* [bitnami/spring-cloud-dataflow] Fixes external database config (#3961) ([1829257](https://github.com/bitnami/charts/commit/182925783b9cdd5ffada63c3949588256f464280)), closes [#3961](https://github.com/bitnami/charts/issues/3961)
 
 ## 1.1.0 (2020-10-13)
 
-* [bitnami/spring-cloud-dataflow] feat: configure deployer podSecurityContext (#3994) ([9ba580d](https://github.com/bitnami/charts/commit/9ba580d)), closes [#3994](https://github.com/bitnami/charts/issues/3994)
+* [bitnami/spring-cloud-dataflow] feat: configure deployer podSecurityContext (#3994) ([9ba580d](https://github.com/bitnami/charts/commit/9ba580d0244112c0bec3d2ce64576a578335cafb)), closes [#3994](https://github.com/bitnami/charts/issues/3994)
 
 ## 1.0.0 (2020-10-09)
 
-* [bitnami/spring-cloud-dataflow] NEW MAJOR: bumb mariadb dependency (#3935) ([9e37c94](https://github.com/bitnami/charts/commit/9e37c94)), closes [#3935](https://github.com/bitnami/charts/issues/3935)
+* [bitnami/spring-cloud-dataflow] NEW MAJOR: bumb mariadb dependency (#3935) ([9e37c94](https://github.com/bitnami/charts/commit/9e37c94c5ff5ba7f554dc07efbeb9af946ceee75)), closes [#3935](https://github.com/bitnami/charts/issues/3935)
 
 ## <small>0.7.4 (2020-09-29)</small>
 
-* [bitnami/spring-cloud-dataflow] Release 0.7.4 updating components versions ([54b1595](https://github.com/bitnami/charts/commit/54b1595))
+* [bitnami/spring-cloud-dataflow] Release 0.7.4 updating components versions ([54b1595](https://github.com/bitnami/charts/commit/54b15950e16c15ae9653d126d4a1b9cab859caa4))
 
 ## <small>0.7.3 (2020-09-22)</small>
 
-* [bitnami/spring-cloud-dataflow] Release 0.7.3 updating components versions ([2870d04](https://github.com/bitnami/charts/commit/2870d04))
+* [bitnami/spring-cloud-dataflow] Release 0.7.3 updating components versions ([2870d04](https://github.com/bitnami/charts/commit/2870d04226ca6fde669d15d1d0e10899f0295919))
 
 ## <small>0.7.2 (2020-09-20)</small>
 
-* [bitnami/spring-cloud-dataflow] Release 0.7.2 updating components versions ([79e8ce2](https://github.com/bitnami/charts/commit/79e8ce2))
+* [bitnami/spring-cloud-dataflow] Release 0.7.2 updating components versions ([79e8ce2](https://github.com/bitnami/charts/commit/79e8ce217d803d2f6d81bd394b220b755546902f))
 
 ## <small>0.7.1 (2020-09-11)</small>
 
-* illegal number syntax: "-" in NOTES.txt (#3654) ([6572fc2](https://github.com/bitnami/charts/commit/6572fc2)), closes [#3654](https://github.com/bitnami/charts/issues/3654)
+* illegal number syntax: "-" in NOTES.txt (#3654) ([6572fc2](https://github.com/bitnami/charts/commit/6572fc28019bc64c3459ac5b0768839333808283)), closes [#3654](https://github.com/bitnami/charts/issues/3654)
 
 ## 0.7.0 (2020-09-10)
 
-* [bitnami/metrics-server] Add source repo (#3577) ([1ed12f9](https://github.com/bitnami/charts/commit/1ed12f9)), closes [#3577](https://github.com/bitnami/charts/issues/3577)
-* [bitnami/spring-cloud-dataflow] feat: add composed task runner image (#3623) ([ce5e1e9](https://github.com/bitnami/charts/commit/ce5e1e9)), closes [#3623](https://github.com/bitnami/charts/issues/3623)
+* [bitnami/metrics-server] Add source repo (#3577) ([1ed12f9](https://github.com/bitnami/charts/commit/1ed12f96af75322b46afdb2b3d9907c11b13f765)), closes [#3577](https://github.com/bitnami/charts/issues/3577)
+* [bitnami/spring-cloud-dataflow] feat: add composed task runner image (#3623) ([ce5e1e9](https://github.com/bitnami/charts/commit/ce5e1e9062ea471c83082d43422a13db1544ccc8)), closes [#3623](https://github.com/bitnami/charts/issues/3623)
 
 ## <small>0.6.2 (2020-08-21)</small>
 
-* [bitnami/spring-cloud-dataflow] Release 0.6.2 updating components versions ([571717b](https://github.com/bitnami/charts/commit/571717b))
+* [bitnami/spring-cloud-dataflow] Release 0.6.2 updating components versions ([571717b](https://github.com/bitnami/charts/commit/571717b1d9047b1a21b2d5c65de724fa7b499545))
 
 ## <small>0.6.1 (2020-08-20)</small>
 
-* [bitnami/spring-cloud-dataflow] Release 0.6.1 updating components versions ([421e732](https://github.com/bitnami/charts/commit/421e732))
+* [bitnami/spring-cloud-dataflow] Release 0.6.1 updating components versions ([421e732](https://github.com/bitnami/charts/commit/421e732e2ecdd48668b8037093db30423cb9b091))
 
 ## 0.6.0 (2020-08-13)
 
-* [bitnami/*] Use common helps for upgrade password errors (#3335) ([079f5bd](https://github.com/bitnami/charts/commit/079f5bd)), closes [#3335](https://github.com/bitnami/charts/issues/3335)
+* [bitnami/*] Use common helps for upgrade password errors (#3335) ([079f5bd](https://github.com/bitnami/charts/commit/079f5bd6ec59bb058216d6a931449b895517c789)), closes [#3335](https://github.com/bitnami/charts/issues/3335)
 
 ## 0.5.0 (2020-08-12)
 
-* [bitnami/spring-cloud-dataflow] feat: add url to grafana (#3401) ([e084d30](https://github.com/bitnami/charts/commit/e084d30)), closes [#3401](https://github.com/bitnami/charts/issues/3401)
+* [bitnami/spring-cloud-dataflow] feat: add url to grafana (#3401) ([e084d30](https://github.com/bitnami/charts/commit/e084d30ed740946932b6056d55d47d7c6bd26969)), closes [#3401](https://github.com/bitnami/charts/issues/3401)
 
 ## <small>0.4.3 (2020-08-10)</small>
 
-* [bitnami/spring-cloud-dataflow] Release 0.4.3 updating components versions ([a7a0c7e](https://github.com/bitnami/charts/commit/a7a0c7e))
+* [bitnami/spring-cloud-dataflow] Release 0.4.3 updating components versions ([a7a0c7e](https://github.com/bitnami/charts/commit/a7a0c7e799081cfc754bb90be51d4fb483934311))
 
 ## <small>0.4.2 (2020-08-07)</small>
 
-* [bitnami/spring-cloud-dataflow] Release 0.4.2 updating components versions ([189cc9b](https://github.com/bitnami/charts/commit/189cc9b))
+* [bitnami/spring-cloud-dataflow] Release 0.4.2 updating components versions ([189cc9b](https://github.com/bitnami/charts/commit/189cc9b2795719113cda49a4eb16376e5a90623b))
 
 ## <small>0.4.1 (2020-08-06)</small>
 
-* [bitnami/*] Fix TL;DR typo in READMEs (#3280) ([3d7ab40](https://github.com/bitnami/charts/commit/3d7ab40)), closes [#3280](https://github.com/bitnami/charts/issues/3280)
-* [bitnami/spring-cloud-dataflow] Release 0.4.1 updating components versions ([9bafbe0](https://github.com/bitnami/charts/commit/9bafbe0))
+* [bitnami/*] Fix TL;DR typo in READMEs (#3280) ([3d7ab40](https://github.com/bitnami/charts/commit/3d7ab406fecd64f1af25f53e7d27f03ec95b29a4)), closes [#3280](https://github.com/bitnami/charts/issues/3280)
+* [bitnami/spring-cloud-dataflow] Release 0.4.1 updating components versions ([9bafbe0](https://github.com/bitnami/charts/commit/9bafbe0ff18583505e3b78a6418277075bbafe22))
 
 ## 0.4.0 (2020-07-22)
 
-* [bitnami/spring-cloud-dataflow] Added ability to configure volumeMounts, volumes and environmentVari ([b74d81d](https://github.com/bitnami/charts/commit/b74d81d)), closes [#3180](https://github.com/bitnami/charts/issues/3180)
+* [bitnami/spring-cloud-dataflow] Added ability to configure volumeMounts, volumes and environmentVari ([b74d81d](https://github.com/bitnami/charts/commit/b74d81d404358c945b4b66b1149c374a3d47eaf6)), closes [#3180](https://github.com/bitnami/charts/issues/3180)
 
 ## 0.3.0 (2020-07-21)
 
-* [bitnami/spring-cloud-dataflow] Add parameters to configure dataflow deployer properties and possibi ([9e97f55](https://github.com/bitnami/charts/commit/9e97f55)), closes [#3162](https://github.com/bitnami/charts/issues/3162)
+* [bitnami/spring-cloud-dataflow] Add parameters to configure dataflow deployer properties and possibi ([9e97f55](https://github.com/bitnami/charts/commit/9e97f55c43f6a1d03d41122201b8f0c6a1939213)), closes [#3162](https://github.com/bitnami/charts/issues/3162)
 
 ## <small>0.2.9 (2020-07-17)</small>
 
-* [bitnami/spring-cloud-dataflow] Release 0.2.9 updating components versions ([e8b2bed](https://github.com/bitnami/charts/commit/e8b2bed))
+* [bitnami/spring-cloud-dataflow] Release 0.2.9 updating components versions ([e8b2bed](https://github.com/bitnami/charts/commit/e8b2bed173d95d0ac4c57729cb1607611778f78d))
 
 ## <small>0.2.8 (2020-07-15)</small>
 
-* [bitnami/spring-cloud-dataflow] Use .Release.Name in env vars for kafka (#3102) ([f0227ad](https://github.com/bitnami/charts/commit/f0227ad)), closes [#3102](https://github.com/bitnami/charts/issues/3102)
+* [bitnami/spring-cloud-dataflow] Use .Release.Name in env vars for kafka (#3102) ([f0227ad](https://github.com/bitnami/charts/commit/f0227adb5ee3253f2050eeea7f8240b0f522e2b0)), closes [#3102](https://github.com/bitnami/charts/issues/3102)
 
 ## <small>0.2.7 (2020-07-11)</small>
 
-* [bitnami/spring-cloud-dataflow] Release 0.2.7 updating components versions ([d43ead8](https://github.com/bitnami/charts/commit/d43ead8))
+* [bitnami/spring-cloud-dataflow] Release 0.2.7 updating components versions ([d43ead8](https://github.com/bitnami/charts/commit/d43ead811211fa1ef18b2164b306b1d39e274c4d))
 
 ## <small>0.2.6 (2020-07-10)</small>
 
-* [bitnami/all] Add categories (#3075) ([63bde06](https://github.com/bitnami/charts/commit/63bde06)), closes [#3075](https://github.com/bitnami/charts/issues/3075)
-* [bitnami/spring-cloud-dataflow] Release 0.2.6 updating components versions ([fa7ec08](https://github.com/bitnami/charts/commit/fa7ec08))
+* [bitnami/all] Add categories (#3075) ([63bde06](https://github.com/bitnami/charts/commit/63bde066b87a140fab52264d0522401ab3d63509)), closes [#3075](https://github.com/bitnami/charts/issues/3075)
+* [bitnami/spring-cloud-dataflow] Release 0.2.6 updating components versions ([fa7ec08](https://github.com/bitnami/charts/commit/fa7ec0845f52aea2d3f59bee1bec3d7e5608ad5e))
 
 ## <small>0.2.5 (2020-07-08)</small>
 
-* [bitnami/spring-cloud-dataflow] Release 0.2.5 updating components versions ([9c41451](https://github.com/bitnami/charts/commit/9c41451))
+* [bitnami/spring-cloud-dataflow] Release 0.2.5 updating components versions ([9c41451](https://github.com/bitnami/charts/commit/9c41451f5e1c9238d43200bbf55a75b5b2df829d))
 
 ## <small>0.2.4 (2020-07-08)</small>
 
-* [bitnami/spring-cloud-dataflow] fix dataflow icon URL (#3063) ([9cbb7cb](https://github.com/bitnami/charts/commit/9cbb7cb)), closes [#3063](https://github.com/bitnami/charts/issues/3063)
+* [bitnami/spring-cloud-dataflow] fix dataflow icon URL (#3063) ([9cbb7cb](https://github.com/bitnami/charts/commit/9cbb7cb38f4830b331bbfb063ff328b3e63096ca)), closes [#3063](https://github.com/bitnami/charts/issues/3063)
 
 ## <small>0.2.3 (2020-07-07)</small>
 
-* [bitnami/spring-cloud-dataflow] Release 0.2.3 updating components versions ([970bc7a](https://github.com/bitnami/charts/commit/970bc7a))
+* [bitnami/spring-cloud-dataflow] Release 0.2.3 updating components versions ([970bc7a](https://github.com/bitnami/charts/commit/970bc7ad183d8e7d32f9b66e564ba055b517a7a1))
 
 ## <small>0.2.2 (2020-07-07)</small>
 
-* Trim blank lines for better formatting of configmaps (#3039) ([230aef0](https://github.com/bitnami/charts/commit/230aef0)), closes [#3039](https://github.com/bitnami/charts/issues/3039)
+* Trim blank lines for better formatting of configmaps (#3039) ([230aef0](https://github.com/bitnami/charts/commit/230aef0b1d33289bbc4a12f52c2d501487d0c5ce)), closes [#3039](https://github.com/bitnami/charts/issues/3039)
 
 ## <small>0.2.1 (2020-07-06)</small>
 
-* [bitnami/spring-cloud-dataflow] Release 0.2.1 updating components versions ([76055de](https://github.com/bitnami/charts/commit/76055de))
+* [bitnami/spring-cloud-dataflow] Release 0.2.1 updating components versions ([76055de](https://github.com/bitnami/charts/commit/76055de5b2d77a780dc57cbaf1bf5d799670f2b6))
 
 ## 0.2.0 (2020-07-06)
 
-* [bitnami/spring-cloud-data-flow] Fixes and improvements (#2945) ([f49b5a1](https://github.com/bitnami/charts/commit/f49b5a1)), closes [#2945](https://github.com/bitnami/charts/issues/2945)
+* [bitnami/spring-cloud-data-flow] Fixes and improvements (#2945) ([f49b5a1](https://github.com/bitnami/charts/commit/f49b5a1ade1a892916037ab8f6a0636c1de13255)), closes [#2945](https://github.com/bitnami/charts/issues/2945)
 
 ## <small>0.1.4 (2020-07-03)</small>
 
-* [bitnami/spring-cloud-dataflow] Release 0.1.4 updating components versions ([b4f1b43](https://github.com/bitnami/charts/commit/b4f1b43))
+* [bitnami/spring-cloud-dataflow] Release 0.1.4 updating components versions ([b4f1b43](https://github.com/bitnami/charts/commit/b4f1b43f88028cc45f0b2f84bf5a501d6a0b1bef))
 
 ## <small>0.1.3 (2020-07-03)</small>
 
-* [bitnami/spring-cloud-dataflow] Remove trailing spaces (#3010) ([b1b9a7d](https://github.com/bitnami/charts/commit/b1b9a7d)), closes [#3010](https://github.com/bitnami/charts/issues/3010)
+* [bitnami/spring-cloud-dataflow] Remove trailing spaces (#3010) ([b1b9a7d](https://github.com/bitnami/charts/commit/b1b9a7d2ea10a889068b143bc2e5e367f38207b2)), closes [#3010](https://github.com/bitnami/charts/issues/3010)
 
 ## <small>0.1.2 (2020-06-25)</small>
 
-* [bitnami/spring-cloud-dataflow] Release 0.1.2 updating components versions ([7eca7d7](https://github.com/bitnami/charts/commit/7eca7d7))
-* Update description ([2ac7191](https://github.com/bitnami/charts/commit/2ac7191))
+* [bitnami/spring-cloud-dataflow] Release 0.1.2 updating components versions ([7eca7d7](https://github.com/bitnami/charts/commit/7eca7d72581cb6f1c785b5922902901b39786ee6))
+* Update description ([2ac7191](https://github.com/bitnami/charts/commit/2ac7191be35571592888ba5c0ef163290f8f5b4e))
 
 ## <small>0.1.1 (2020-06-23)</small>
 
-* [bitnami/spring-cloud-dataflow] Release 0.1.1 updating components versions ([5b2d9e6](https://github.com/bitnami/charts/commit/5b2d9e6))
+* [bitnami/spring-cloud-dataflow] Release 0.1.1 updating components versions ([5b2d9e6](https://github.com/bitnami/charts/commit/5b2d9e6b06b9433319ba988de67f1f56a6ff2c3e))
 
 ## 0.1.0 (2020-06-23)
 
-* Add new chart: Spring Cloud Data Flow (#2747) ([ac39354](https://github.com/bitnami/charts/commit/ac39354)), closes [#2747](https://github.com/bitnami/charts/issues/2747)
+* Add new chart: Spring Cloud Data Flow (#2747) ([ac39354](https://github.com/bitnami/charts/commit/ac39354958978c37a80b18409789420b32e84f83)), closes [#2747](https://github.com/bitnami/charts/issues/2747)

--- a/bitnami/spring-cloud-dataflow/CHANGELOG.md
+++ b/bitnami/spring-cloud-dataflow/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 28.1.1 (2024-05-21)
+## 28.1.2 (2024-05-22)
 
-* [bitnami/spring-cloud-dataflow] Use different liveness/readiness probes ([#26297](https://github.com/bitnami/charts/pulls/26297))
+* [bitnami/spring-cloud-dataflow] Fix variables definition sensitive to Helm 'release-name' ([#26315](https://github.com/bitnami/charts/pulls/26315))
+
+## <small>28.1.1 (2024-05-22)</small>
+
+* [bitnami/spring-cloud-dataflow] Use different liveness/readiness probes (#26297) ([a50e35e](https://github.com/bitnami/charts/commit/a50e35e)), closes [#26297](https://github.com/bitnami/charts/issues/26297)
 
 ## 28.1.0 (2024-05-21)
 

--- a/bitnami/spring-cloud-dataflow/Chart.yaml
+++ b/bitnami/spring-cloud-dataflow/Chart.yaml
@@ -53,5 +53,5 @@ maintainers:
 name: spring-cloud-dataflow
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/spring-cloud-dataflow
-version: 28.1.1
+version: 28.1.2
 

--- a/bitnami/spring-cloud-dataflow/templates/skipper/configmap.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/skipper/configmap.yaml
@@ -61,8 +61,8 @@ data:
                       {{- end }}
                     {{- else if .Values.kafka.enabled }}
                     environmentVariables:
-                      - SPRING_CLOUD_STREAM_KAFKA_BINDER_BROKERS=${{ printf "{" }}{{ .Release.Name }}_KAFKA_SERVICE_HOST}:${{ printf "{" }}{{ .Release.Name }}_KAFKA_SERVICE_PORT}
-                      - SPRING_CLOUD_STREAM_KAFKA_BINDER_ZK_NODES=${{ printf "{" }}{{ .Release.Name }}_ZOOKEEPER_SERVICE_HOST}:${{ printf "{" }}{{ .Release.Name }}_ZOOKEEPER_SERVICE_PORT}
+                      - SPRING_CLOUD_STREAM_KAFKA_BINDER_BROKERS=${{ printf "{" }}{{ regexReplaceAll "\\W+" (upper .Release.Name) "_" }}_KAFKA_SERVICE_HOST}:${{ printf "{" }}{{ regexReplaceAll "\\W+" (upper .Release.Name) "_" }}_KAFKA_SERVICE_PORT}
+                      - SPRING_CLOUD_STREAM_KAFKA_BINDER_ZK_NODES=${{ printf "{" }}{{ regexReplaceAll "\\W+" (upper .Release.Name) "_" }}_ZOOKEEPER_SERVICE_HOST}:${{ printf "{" }}{{ regexReplaceAll "\\W+" (upper .Release.Name) "_" }}_ZOOKEEPER_SERVICE_PORT}
                       {{- if $environmentVariables }}
                       {{- $environmentVariables | nindent 22 }}
                       {{- end }}


### PR DESCRIPTION
Wrong variables definition in the skipper's ConfigMap. The variables are sensitive to 'release-name' provided with Heml installation command. This fix issue reported with ticket [[issues/26169](https://github.com/bitnami/charts/issues/26169)].

### Description of the change

This fix the definition of following application variables, declared with wrong values.
- SPRING_CLOUD_STREAM_KAFKA_BINDER_BROKERS 
- SPRING_CLOUD_STREAM_KAFKA_BINDER_ZK_NODES

Fixes https://github.com/bitnami/charts/issues/26169

### Benefits

With this fix is possible to install Spring-Cloud-Dataflow using Helm 'release-name' that contain dash char ('-'). 

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)