### PR TITLE
[bitnami/flink] Use different liveness/readiness probes

### DIFF
--- a/bitnami/flink/CHANGELOG.md
+++ b/bitnami/flink/CHANGELOG.md
@@ -1,220 +1,225 @@
 # Changelog
 
+## 1.2.1 (2024-05-23)
+
+* [bitnami/flink] Use different liveness/readiness probes ([#26316](https://github.com/bitnami/charts/pull/26316))
+
 ## 1.2.0 (2024-05-21)
 
-* [bitnami/flink] feat: :sparkles: :lock: Add warning when original images are replaced ([#26203](https://github.com/bitnami/charts/pulls/26203))
+* [bitnami/*] ci: :construction_worker: Add tag and changelog support (#25359) ([91c707c](https://github.com/bitnami/charts/commit/91c707c9e4e574725a09505d2d313fb93f1b4c0a)), closes [#25359](https://github.com/bitnami/charts/issues/25359)
+* [bitnami/flink] feat: :sparkles: :lock: Add warning when original images are replaced (#26203) ([85acf85](https://github.com/bitnami/charts/commit/85acf8586edbd2ddbad591a8d550fd3066662b01)), closes [#26203](https://github.com/bitnami/charts/issues/26203)
 
 ## <small>1.1.3 (2024-05-18)</small>
 
-* [bitnami/flink] Release 1.1.3 updating components versions (#26013) ([e9d6acf](https://github.com/bitnami/charts/commit/e9d6acf)), closes [#26013](https://github.com/bitnami/charts/issues/26013)
+* [bitnami/flink] Release 1.1.3 updating components versions (#26013) ([e9d6acf](https://github.com/bitnami/charts/commit/e9d6acfe436493e13afeb4657a02e0d2e57ac22c)), closes [#26013](https://github.com/bitnami/charts/issues/26013)
 
 ## <small>1.1.2 (2024-05-13)</small>
 
-* [bitnami/*] Change non-root and rolling-tags doc URLs (#25628) ([b067c94](https://github.com/bitnami/charts/commit/b067c94)), closes [#25628](https://github.com/bitnami/charts/issues/25628)
-* [bitnami/*] Set new header/owner (#25558) ([8d1dc11](https://github.com/bitnami/charts/commit/8d1dc11)), closes [#25558](https://github.com/bitnami/charts/issues/25558)
-* [bitnami/flink] Release 1.1.2 updating components versions (#25753) ([360dda8](https://github.com/bitnami/charts/commit/360dda8)), closes [#25753](https://github.com/bitnami/charts/issues/25753)
+* [bitnami/*] Change non-root and rolling-tags doc URLs (#25628) ([b067c94](https://github.com/bitnami/charts/commit/b067c94f6bcde427863c197fd355f0b5ba12ff5b)), closes [#25628](https://github.com/bitnami/charts/issues/25628)
+* [bitnami/*] Set new header/owner (#25558) ([8d1dc11](https://github.com/bitnami/charts/commit/8d1dc11f5fb30db6fba50c43d7af59d2f79deed3)), closes [#25558](https://github.com/bitnami/charts/issues/25558)
+* [bitnami/flink] Release 1.1.2 updating components versions (#25753) ([360dda8](https://github.com/bitnami/charts/commit/360dda87888a47755f352a45437c1b59d817b35c)), closes [#25753](https://github.com/bitnami/charts/issues/25753)
 
 ## <small>1.1.1 (2024-04-29)</small>
 
-* [bitnami/flink] Release 1.1.1 updating components versions (#25448) ([ec7d04e](https://github.com/bitnami/charts/commit/ec7d04e)), closes [#25448](https://github.com/bitnami/charts/issues/25448)
+* [bitnami/flink] Release 1.1.1 updating components versions (#25448) ([ec7d04e](https://github.com/bitnami/charts/commit/ec7d04e1398076e0ec2dedd2d8a695d8e8a728f6)), closes [#25448](https://github.com/bitnami/charts/issues/25448)
 
 ## 1.1.0 (2024-04-25)
 
-* [bitnami/flink] Improve service ports & network policies (#25350) ([4237bb6](https://github.com/bitnami/charts/commit/4237bb6)), closes [#25350](https://github.com/bitnami/charts/issues/25350)
-* [bitnami/multiple charts] Fix typo: "NetworkPolice" vs "NetworkPolicy" (#25348) ([6970c1b](https://github.com/bitnami/charts/commit/6970c1b)), closes [#25348](https://github.com/bitnami/charts/issues/25348)
-* Replace VMware by Broadcom copyright text (#25306) ([a5e4bd0](https://github.com/bitnami/charts/commit/a5e4bd0)), closes [#25306](https://github.com/bitnami/charts/issues/25306)
+* [bitnami/flink] Improve service ports & network policies (#25350) ([4237bb6](https://github.com/bitnami/charts/commit/4237bb61d9c249880d759934caff6e845a175345)), closes [#25350](https://github.com/bitnami/charts/issues/25350)
+* [bitnami/multiple charts] Fix typo: "NetworkPolice" vs "NetworkPolicy" (#25348) ([6970c1b](https://github.com/bitnami/charts/commit/6970c1ba245873506e73d459c6eac1e4919b778f)), closes [#25348](https://github.com/bitnami/charts/issues/25348)
+* Replace VMware by Broadcom copyright text (#25306) ([a5e4bd0](https://github.com/bitnami/charts/commit/a5e4bd0e35e419203793976a78d9d0a13de92c76)), closes [#25306](https://github.com/bitnami/charts/issues/25306)
 
 ## <small>1.0.2 (2024-04-22)</small>
 
-* [bitnami/flink] Ensure data port is set in configuration (#25169) ([fa9eda1](https://github.com/bitnami/charts/commit/fa9eda1)), closes [#25169](https://github.com/bitnami/charts/issues/25169)
-* Update resourcesPreset comments (#24467) ([92e3e8a](https://github.com/bitnami/charts/commit/92e3e8a)), closes [#24467](https://github.com/bitnami/charts/issues/24467)
+* [bitnami/flink] Ensure data port is set in configuration (#25169) ([fa9eda1](https://github.com/bitnami/charts/commit/fa9eda14602a666824f6204cf5a398a21a04953d)), closes [#25169](https://github.com/bitnami/charts/issues/25169)
+* Update resourcesPreset comments (#24467) ([92e3e8a](https://github.com/bitnami/charts/commit/92e3e8a507326d2a20a8f10ab3e7746a2ec5c554)), closes [#24467](https://github.com/bitnami/charts/issues/24467)
 
 ## <small>1.0.1 (2024-03-20)</small>
 
-* [bitnami/flink] Release 1.0.1 updating components versions (#24571) ([3a09c26](https://github.com/bitnami/charts/commit/3a09c26)), closes [#24571](https://github.com/bitnami/charts/issues/24571)
+* [bitnami/flink] Release 1.0.1 updating components versions (#24571) ([3a09c26](https://github.com/bitnami/charts/commit/3a09c26856a8b1771eb59de496e3ff35d94466b7)), closes [#24571](https://github.com/bitnami/charts/issues/24571)
 
 ## 1.0.0 (2024-03-18)
 
-* [bitnami/*] Reorder Chart sections (#24455) ([0cf4048](https://github.com/bitnami/charts/commit/0cf4048)), closes [#24455](https://github.com/bitnami/charts/issues/24455)
-* [bitnami/flink] feat!: :lock: :boom: Improve security defaults (#24326) ([d7cf5f7](https://github.com/bitnami/charts/commit/d7cf5f7)), closes [#24326](https://github.com/bitnami/charts/issues/24326)
+* [bitnami/*] Reorder Chart sections (#24455) ([0cf4048](https://github.com/bitnami/charts/commit/0cf4048e8743f70a9753d460655bd030cbff6824)), closes [#24455](https://github.com/bitnami/charts/issues/24455)
+* [bitnami/flink] feat!: :lock: :boom: Improve security defaults (#24326) ([d7cf5f7](https://github.com/bitnami/charts/commit/d7cf5f7b18d961b0e5fd2197011f8dbdffd11194)), closes [#24326](https://github.com/bitnami/charts/issues/24326)
 
 ## 0.13.0 (2024-03-08)
 
-* [bitnami/flink] feat: :sparkles: :lock: Add support for readOnlyRootFilesystem (#24198) ([74ab25e](https://github.com/bitnami/charts/commit/74ab25e)), closes [#24198](https://github.com/bitnami/charts/issues/24198)
+* [bitnami/flink] feat: :sparkles: :lock: Add support for readOnlyRootFilesystem (#24198) ([74ab25e](https://github.com/bitnami/charts/commit/74ab25e80b579ca9dff116ea0f7281b2c6fd72df)), closes [#24198](https://github.com/bitnami/charts/issues/24198)
 
 ## 0.12.0 (2024-03-06)
 
-* [bitnami/flink] feat: :sparkles: :lock: Add automatic adaptation for Openshift restricted-v2 SCC (#2 ([dce33d9](https://github.com/bitnami/charts/commit/dce33d9)), closes [#24081](https://github.com/bitnami/charts/issues/24081)
+* [bitnami/flink] feat: :sparkles: :lock: Add automatic adaptation for Openshift restricted-v2 SCC (#2 ([dce33d9](https://github.com/bitnami/charts/commit/dce33d9c59d19574be0d4f84f55ce6ca966c9e32)), closes [#24081](https://github.com/bitnami/charts/issues/24081)
 
 ## 0.11.0 (2024-03-05)
 
-* [bitnami/flink] Taskmanager to use a statefulset (#23904) ([50e8c6d](https://github.com/bitnami/charts/commit/50e8c6d)), closes [#23904](https://github.com/bitnami/charts/issues/23904)
+* [bitnami/flink] Taskmanager to use a statefulset (#23904) ([50e8c6d](https://github.com/bitnami/charts/commit/50e8c6dacf8ddf43db1919427a17f7ba074c6aaa)), closes [#23904](https://github.com/bitnami/charts/issues/23904)
 
 ## <small>0.10.2 (2024-02-21)</small>
 
-* [bitnami/flink] Release 0.10.2 updating components versions (#23768) ([045b1d8](https://github.com/bitnami/charts/commit/045b1d8)), closes [#23768](https://github.com/bitnami/charts/issues/23768)
+* [bitnami/flink] Release 0.10.2 updating components versions (#23768) ([045b1d8](https://github.com/bitnami/charts/commit/045b1d8385697feaa24d4020481b8dd1b2ad3ef8)), closes [#23768](https://github.com/bitnami/charts/issues/23768)
 
 ## <small>0.10.1 (2024-02-21)</small>
 
-* [bitnami/flink] Release 0.10.1 updating components versions (#23704) ([838cf89](https://github.com/bitnami/charts/commit/838cf89)), closes [#23704](https://github.com/bitnami/charts/issues/23704)
+* [bitnami/flink] Release 0.10.1 updating components versions (#23704) ([838cf89](https://github.com/bitnami/charts/commit/838cf89e4956b8f661c9bb7791fdbcd8484be121)), closes [#23704](https://github.com/bitnami/charts/issues/23704)
 
 ## 0.10.0 (2024-02-20)
 
-* [bitnami/*] Bump all versions (#23602) ([b70ee2a](https://github.com/bitnami/charts/commit/b70ee2a)), closes [#23602](https://github.com/bitnami/charts/issues/23602)
+* [bitnami/*] Bump all versions (#23602) ([b70ee2a](https://github.com/bitnami/charts/commit/b70ee2a30e4dc256bf0ac52928fb2fa7a70f049b)), closes [#23602](https://github.com/bitnami/charts/issues/23602)
 
 ## 0.9.0 (2024-02-16)
 
-* [bitnami/flink] feat: :sparkles: :lock: Add resource preset support (#23448) ([23fbdaf](https://github.com/bitnami/charts/commit/23fbdaf)), closes [#23448](https://github.com/bitnami/charts/issues/23448)
+* [bitnami/flink] feat: :sparkles: :lock: Add resource preset support (#23448) ([23fbdaf](https://github.com/bitnami/charts/commit/23fbdaf9dd6641de91aa198ec707828cc2428df2)), closes [#23448](https://github.com/bitnami/charts/issues/23448)
 
 ## 0.8.0 (2024-02-07)
 
-* [bitnami/flink] feat: :lock: Enable networkPolicy (#23284) ([9c4b59f](https://github.com/bitnami/charts/commit/9c4b59f)), closes [#23284](https://github.com/bitnami/charts/issues/23284)
+* [bitnami/flink] feat: :lock: Enable networkPolicy (#23284) ([9c4b59f](https://github.com/bitnami/charts/commit/9c4b59f02a2a07b44f2a18372a26913a2dd9b16b)), closes [#23284](https://github.com/bitnami/charts/issues/23284)
 
 ## <small>0.7.4 (2024-02-05)</small>
 
-* [bitnami/flink] Release 0.7.4 (#22927) ([d3cfa5b](https://github.com/bitnami/charts/commit/d3cfa5b)), closes [#22927](https://github.com/bitnami/charts/issues/22927)
+* [bitnami/flink] Release 0.7.4 (#22927) ([d3cfa5b](https://github.com/bitnami/charts/commit/d3cfa5bc89d09347c8c7faab3da055a96b885b6e)), closes [#22927](https://github.com/bitnami/charts/issues/22927)
 
 ## <small>0.7.3 (2024-01-30)</small>
 
-* [bitnami/flink] Release 0.7.3 updating components versions (#22841) ([0eff7ba](https://github.com/bitnami/charts/commit/0eff7ba)), closes [#22841](https://github.com/bitnami/charts/issues/22841)
+* [bitnami/flink] Release 0.7.3 updating components versions (#22841) ([0eff7ba](https://github.com/bitnami/charts/commit/0eff7ba1969ffe5d475a11ae64337189074c70bc)), closes [#22841](https://github.com/bitnami/charts/issues/22841)
 
 ## <small>0.7.2 (2024-01-27)</small>
 
-* [bitnami/*] Move documentation sections from docs.bitnami.com back to the README (#22203) ([7564f36](https://github.com/bitnami/charts/commit/7564f36)), closes [#22203](https://github.com/bitnami/charts/issues/22203)
-* [bitnami/flink] Release 0.7.2 updating components versions (#22775) ([c98f119](https://github.com/bitnami/charts/commit/c98f119)), closes [#22775](https://github.com/bitnami/charts/issues/22775)
+* [bitnami/*] Move documentation sections from docs.bitnami.com back to the README (#22203) ([7564f36](https://github.com/bitnami/charts/commit/7564f36ca1e95ff30ee686652b7ab8690561a707)), closes [#22203](https://github.com/bitnami/charts/issues/22203)
+* [bitnami/flink] Release 0.7.2 updating components versions (#22775) ([c98f119](https://github.com/bitnami/charts/commit/c98f1195195689c75abf7b9176a55d55500af958)), closes [#22775](https://github.com/bitnami/charts/issues/22775)
 
 ## <small>0.7.1 (2024-01-24)</small>
 
-* [bitnami/flink] fix: :bug: Set seLinuxOptions to null for Openshift compatibility (#22586) ([ac47595](https://github.com/bitnami/charts/commit/ac47595)), closes [#22586](https://github.com/bitnami/charts/issues/22586)
+* [bitnami/flink] fix: :bug: Set seLinuxOptions to null for Openshift compatibility (#22586) ([ac47595](https://github.com/bitnami/charts/commit/ac47595c78051430ea37ff7206620a3803ac6b0e)), closes [#22586](https://github.com/bitnami/charts/issues/22586)
 
 ## 0.7.0 (2024-01-22)
 
-* [bitnami/flink] fix: :lock: Move service-account token auto-mount to pod declaration (#22483) ([af53d3c](https://github.com/bitnami/charts/commit/af53d3c)), closes [#22483](https://github.com/bitnami/charts/issues/22483)
+* [bitnami/flink] fix: :lock: Move service-account token auto-mount to pod declaration (#22483) ([af53d3c](https://github.com/bitnami/charts/commit/af53d3c48cd13d58f6e3d14de82ab19bba4d1adb)), closes [#22483](https://github.com/bitnami/charts/issues/22483)
 
 ## <small>0.6.1 (2024-01-18)</small>
 
-* [bitnami/flink] Release 0.6.1 updating components versions (#22347) ([291134b](https://github.com/bitnami/charts/commit/291134b)), closes [#22347](https://github.com/bitnami/charts/issues/22347)
+* [bitnami/flink] Release 0.6.1 updating components versions (#22347) ([291134b](https://github.com/bitnami/charts/commit/291134b3868ab1694a7f2b093ea71d5174e51ef5)), closes [#22347](https://github.com/bitnami/charts/issues/22347)
 
 ## 0.6.0 (2024-01-16)
 
-* [bitnami/flink] fix: :lock: Improve podSecurityContext and containerSecurityContext with essential s ([39f0e8a](https://github.com/bitnami/charts/commit/39f0e8a)), closes [#22117](https://github.com/bitnami/charts/issues/22117)
+* [bitnami/flink] fix: :lock: Improve podSecurityContext and containerSecurityContext with essential s ([39f0e8a](https://github.com/bitnami/charts/commit/39f0e8a10eadd21ab2c05fceea4a0e4045569ea3)), closes [#22117](https://github.com/bitnami/charts/issues/22117)
 
 ## <small>0.5.4 (2024-01-15)</small>
 
-* [bitnami/*] Fix docs.bitnami.com broken links (#21901) ([f35506d](https://github.com/bitnami/charts/commit/f35506d)), closes [#21901](https://github.com/bitnami/charts/issues/21901)
-* [bitnami/*] Fix ref links (in comments) (#21822) ([e4fa296](https://github.com/bitnami/charts/commit/e4fa296)), closes [#21822](https://github.com/bitnami/charts/issues/21822)
-* [bitnami/*] Update copyright: Year and company (#21815) ([6c4bf75](https://github.com/bitnami/charts/commit/6c4bf75)), closes [#21815](https://github.com/bitnami/charts/issues/21815)
-* [bitnami/flink] fix: :lock: Do not automount the service account token unless necessary (#22039) ([8577e38](https://github.com/bitnami/charts/commit/8577e38)), closes [#22039](https://github.com/bitnami/charts/issues/22039)
+* [bitnami/*] Fix docs.bitnami.com broken links (#21901) ([f35506d](https://github.com/bitnami/charts/commit/f35506d2dadee4f097986e7792df1f53ab215b5d)), closes [#21901](https://github.com/bitnami/charts/issues/21901)
+* [bitnami/*] Fix ref links (in comments) (#21822) ([e4fa296](https://github.com/bitnami/charts/commit/e4fa296106b225cf8c82445727c675c7c725e380)), closes [#21822](https://github.com/bitnami/charts/issues/21822)
+* [bitnami/*] Update copyright: Year and company (#21815) ([6c4bf75](https://github.com/bitnami/charts/commit/6c4bf75dec58fc7c9aee9f089777b1a858c17d5b)), closes [#21815](https://github.com/bitnami/charts/issues/21815)
+* [bitnami/flink] fix: :lock: Do not automount the service account token unless necessary (#22039) ([8577e38](https://github.com/bitnami/charts/commit/8577e389e4f01dc3a537f299ddda660886af13a2)), closes [#22039](https://github.com/bitnami/charts/issues/22039)
 
 ## <small>0.5.3 (2023-12-31)</small>
 
-* [bitnami/flink] Release 0.5.3 updating components versions (#21802) ([ac4be37](https://github.com/bitnami/charts/commit/ac4be37)), closes [#21802](https://github.com/bitnami/charts/issues/21802)
+* [bitnami/flink] Release 0.5.3 updating components versions (#21802) ([ac4be37](https://github.com/bitnami/charts/commit/ac4be3731363fe52a098ac5bdd7a79e7be819dc7)), closes [#21802](https://github.com/bitnami/charts/issues/21802)
 
 ## <small>0.5.2 (2023-11-21)</small>
 
-* [bitnami/*] Rename solutions to "Bitnami package for ..." (#21038) ([b82f979](https://github.com/bitnami/charts/commit/b82f979)), closes [#21038](https://github.com/bitnami/charts/issues/21038)
-* [bitnami/flink] Release 0.5.2 updating components versions (#21114) ([1c57b8e](https://github.com/bitnami/charts/commit/1c57b8e)), closes [#21114](https://github.com/bitnami/charts/issues/21114)
+* [bitnami/*] Rename solutions to "Bitnami package for ..." (#21038) ([b82f979](https://github.com/bitnami/charts/commit/b82f979e4fb63423fe6e2192c946d09d79c944fc)), closes [#21038](https://github.com/bitnami/charts/issues/21038)
+* [bitnami/flink] Release 0.5.2 updating components versions (#21114) ([1c57b8e](https://github.com/bitnami/charts/commit/1c57b8e88d3b0ef36a11c3349ba68e6f3bceefa7)), closes [#21114](https://github.com/bitnami/charts/issues/21114)
 
 ## <small>0.5.1 (2023-11-20)</small>
 
-* [bitnami/*] Remove relative links to non-README sections, add verification for that and update TL;DR ([1103633](https://github.com/bitnami/charts/commit/1103633)), closes [#20967](https://github.com/bitnami/charts/issues/20967)
-* [bitnami/flink] Release 0.5.1 (#21011) ([268b61c](https://github.com/bitnami/charts/commit/268b61c)), closes [#21011](https://github.com/bitnami/charts/issues/21011)
+* [bitnami/*] Remove relative links to non-README sections, add verification for that and update TL;DR ([1103633](https://github.com/bitnami/charts/commit/11036334d82df0490aa4abdb591543cab6cf7d7f)), closes [#20967](https://github.com/bitnami/charts/issues/20967)
+* [bitnami/flink] Release 0.5.1 (#21011) ([268b61c](https://github.com/bitnami/charts/commit/268b61c41a16bf22e17c935bdf043ebb678daefb)), closes [#21011](https://github.com/bitnami/charts/issues/21011)
 
 ## 0.5.0 (2023-10-31)
 
-* [bitnami/flink] feat: :sparkles: Add support for PSA restricted policy (#20427) ([dd6a83c](https://github.com/bitnami/charts/commit/dd6a83c)), closes [#20427](https://github.com/bitnami/charts/issues/20427)
+* [bitnami/flink] feat: :sparkles: Add support for PSA restricted policy (#20427) ([dd6a83c](https://github.com/bitnami/charts/commit/dd6a83c37cf63aaf9c81f0df0b480c1e619768dd)), closes [#20427](https://github.com/bitnami/charts/issues/20427)
 
 ## <small>0.4.6 (2023-10-24)</small>
 
-* [bitnami/*] Rename VMware Application Catalog (#20361) ([3acc734](https://github.com/bitnami/charts/commit/3acc734)), closes [#20361](https://github.com/bitnami/charts/issues/20361)
-* [bitnami/*] Skip image's tag in the README files of the Bitnami Charts (#19841) ([bb9a01b](https://github.com/bitnami/charts/commit/bb9a01b)), closes [#19841](https://github.com/bitnami/charts/issues/19841)
-* [bitnami/*] Standardize documentation (#19835) ([af5f753](https://github.com/bitnami/charts/commit/af5f753)), closes [#19835](https://github.com/bitnami/charts/issues/19835)
-* [bitnami/flink] Release 0.4.6 updating components versions (#20392) ([8e79ebd](https://github.com/bitnami/charts/commit/8e79ebd)), closes [#20392](https://github.com/bitnami/charts/issues/20392)
+* [bitnami/*] Rename VMware Application Catalog (#20361) ([3acc734](https://github.com/bitnami/charts/commit/3acc73472beb6fb56c4d99f929061001205bc57e)), closes [#20361](https://github.com/bitnami/charts/issues/20361)
+* [bitnami/*] Skip image's tag in the README files of the Bitnami Charts (#19841) ([bb9a01b](https://github.com/bitnami/charts/commit/bb9a01b65911c87e48318db922cc05eb42785e42)), closes [#19841](https://github.com/bitnami/charts/issues/19841)
+* [bitnami/*] Standardize documentation (#19835) ([af5f753](https://github.com/bitnami/charts/commit/af5f7530c1bc8c5ded53a6c4f7b8f384ac1804f2)), closes [#19835](https://github.com/bitnami/charts/issues/19835)
+* [bitnami/flink] Release 0.4.6 updating components versions (#20392) ([8e79ebd](https://github.com/bitnami/charts/commit/8e79ebd7e1b61ad55f677bbfdd38448f5c562cf2)), closes [#20392](https://github.com/bitnami/charts/issues/20392)
 
 ## <small>0.4.5 (2023-10-12)</small>
 
-* [bitnami/flink] Release 0.4.5 updating components versions (#20129) ([a29934a](https://github.com/bitnami/charts/commit/a29934a)), closes [#20129](https://github.com/bitnami/charts/issues/20129)
+* [bitnami/flink] Release 0.4.5 updating components versions (#20129) ([a29934a](https://github.com/bitnami/charts/commit/a29934a6779b24860e1c2acc27271de5b1c28a96)), closes [#20129](https://github.com/bitnami/charts/issues/20129)
 
 ## <small>0.4.4 (2023-10-12)</small>
 
-* [bitnami/*] Update Helm charts prerequisites (#19745) ([eb755dd](https://github.com/bitnami/charts/commit/eb755dd)), closes [#19745](https://github.com/bitnami/charts/issues/19745)
-* [bitnami/flink] Release 0.4.4 (#20115) ([5a652d7](https://github.com/bitnami/charts/commit/5a652d7)), closes [#20115](https://github.com/bitnami/charts/issues/20115)
+* [bitnami/*] Update Helm charts prerequisites (#19745) ([eb755dd](https://github.com/bitnami/charts/commit/eb755dd36a4dd3cf6635be8e0598f9a7f4c4a554)), closes [#19745](https://github.com/bitnami/charts/issues/19745)
+* [bitnami/flink] Release 0.4.4 (#20115) ([5a652d7](https://github.com/bitnami/charts/commit/5a652d73ae198a0a0459e11845a369a99781ffd1)), closes [#20115](https://github.com/bitnami/charts/issues/20115)
 
 ## <small>0.4.3 (2023-10-02)</small>
 
-* [bitnami/flink] Fix pullSecrets and extraVolumeMounts (#19675) ([575e1b9](https://github.com/bitnami/charts/commit/575e1b9)), closes [#19675](https://github.com/bitnami/charts/issues/19675)
+* [bitnami/flink] Fix pullSecrets and extraVolumeMounts (#19675) ([575e1b9](https://github.com/bitnami/charts/commit/575e1b9322a85613fe57c6370426e8bdf8c8c268)), closes [#19675](https://github.com/bitnami/charts/issues/19675)
 
 ## <small>0.4.2 (2023-09-18)</small>
 
-* [bitnami/flink] Release 0.4.2 (#19357) ([d0cb50e](https://github.com/bitnami/charts/commit/d0cb50e)), closes [#19357](https://github.com/bitnami/charts/issues/19357)
-* Autogenerate schema files (#19194) ([a2c2090](https://github.com/bitnami/charts/commit/a2c2090)), closes [#19194](https://github.com/bitnami/charts/issues/19194)
-* Revert "Autogenerate schema files (#19194)" (#19335) ([73d80be](https://github.com/bitnami/charts/commit/73d80be)), closes [#19194](https://github.com/bitnami/charts/issues/19194) [#19335](https://github.com/bitnami/charts/issues/19335)
+* [bitnami/flink] Release 0.4.2 (#19357) ([d0cb50e](https://github.com/bitnami/charts/commit/d0cb50e308d24f6661e6a6b9b868678bde5fa6ce)), closes [#19357](https://github.com/bitnami/charts/issues/19357)
+* Autogenerate schema files (#19194) ([a2c2090](https://github.com/bitnami/charts/commit/a2c2090b5ac97f47b745c8028c6452bf99739772)), closes [#19194](https://github.com/bitnami/charts/issues/19194)
+* Revert "Autogenerate schema files (#19194)" (#19335) ([73d80be](https://github.com/bitnami/charts/commit/73d80be525c88fb4b8a54451a55acd506e337062)), closes [#19194](https://github.com/bitnami/charts/issues/19194) [#19335](https://github.com/bitnami/charts/issues/19335)
 
 ## <small>0.4.1 (2023-09-06)</small>
 
-* [bitnami/flink: Use merge helper]: (#19037) ([a8c93e5](https://github.com/bitnami/charts/commit/a8c93e5)), closes [#19037](https://github.com/bitnami/charts/issues/19037)
+* [bitnami/flink: Use merge helper]: (#19037) ([a8c93e5](https://github.com/bitnami/charts/commit/a8c93e588d93aa7161fa5474126a13b26692da56)), closes [#19037](https://github.com/bitnami/charts/issues/19037)
 
 ## 0.4.0 (2023-08-22)
 
-* [bitnami/flink] Support for customizing standard labels (#18299) ([ad24bd1](https://github.com/bitnami/charts/commit/ad24bd1)), closes [#18299](https://github.com/bitnami/charts/issues/18299)
+* [bitnami/flink] Support for customizing standard labels (#18299) ([ad24bd1](https://github.com/bitnami/charts/commit/ad24bd128b25cc3c153def7e7db61c489447451f)), closes [#18299](https://github.com/bitnami/charts/issues/18299)
 
 ## <small>0.3.8 (2023-08-19)</small>
 
-* [bitnami/flink] Release 0.3.8 (#18658) ([034aefd](https://github.com/bitnami/charts/commit/034aefd)), closes [#18658](https://github.com/bitnami/charts/issues/18658)
+* [bitnami/flink] Release 0.3.8 (#18658) ([034aefd](https://github.com/bitnami/charts/commit/034aefd426e2017bd45b5a1a150cfe22013ac967)), closes [#18658](https://github.com/bitnami/charts/issues/18658)
 
 ## <small>0.3.7 (2023-08-17)</small>
 
-* [bitnami/flink] Release 0.3.7 (#18515) ([9785d4a](https://github.com/bitnami/charts/commit/9785d4a)), closes [#18515](https://github.com/bitnami/charts/issues/18515)
+* [bitnami/flink] Release 0.3.7 (#18515) ([9785d4a](https://github.com/bitnami/charts/commit/9785d4ad4ecdd97f1af06e1170533b1d616e8149)), closes [#18515](https://github.com/bitnami/charts/issues/18515)
 
 ## <small>0.3.6 (2023-07-26)</small>
 
-* [bitnami/flink] Release 0.3.6 (#17983) ([eb2886c](https://github.com/bitnami/charts/commit/eb2886c)), closes [#17983](https://github.com/bitnami/charts/issues/17983)
+* [bitnami/flink] Release 0.3.6 (#17983) ([eb2886c](https://github.com/bitnami/charts/commit/eb2886c65857aac9e18b356f59e00d92a918e98a)), closes [#17983](https://github.com/bitnami/charts/issues/17983)
 
 ## <small>0.3.5 (2023-07-19)</small>
 
-* [bitnami/flink] Release 0.3.5 (#17777) ([4f2dffb](https://github.com/bitnami/charts/commit/4f2dffb)), closes [#17777](https://github.com/bitnami/charts/issues/17777)
+* [bitnami/flink] Release 0.3.5 (#17777) ([4f2dffb](https://github.com/bitnami/charts/commit/4f2dffbe1e5bbe5a60c9b7ecf5358c1c7a796354)), closes [#17777](https://github.com/bitnami/charts/issues/17777)
 
 ## <small>0.3.4 (2023-07-13)</small>
 
-* [bitnami/flink] Release 0 (#17595) ([3edfc0b](https://github.com/bitnami/charts/commit/3edfc0b)), closes [#17595](https://github.com/bitnami/charts/issues/17595)
-* Add copyright header (#17300) ([da68be8](https://github.com/bitnami/charts/commit/da68be8)), closes [#17300](https://github.com/bitnami/charts/issues/17300)
+* [bitnami/flink] Release 0 (#17595) ([3edfc0b](https://github.com/bitnami/charts/commit/3edfc0b007e2ba3abd952f5f4a1c8038e8d23870)), closes [#17595](https://github.com/bitnami/charts/issues/17595)
+* Add copyright header (#17300) ([da68be8](https://github.com/bitnami/charts/commit/da68be8e951225133c7dfb572d5101ca3d61c5ae)), closes [#17300](https://github.com/bitnami/charts/issues/17300)
 
 ## <small>0.3.3 (2023-06-25)</small>
 
-* [bitnami/*] Change copyright section in READMEs (#17006) ([ef986a1](https://github.com/bitnami/charts/commit/ef986a1)), closes [#17006](https://github.com/bitnami/charts/issues/17006)
-* [bitnami/flink] Release 0.3.3 (#17342) ([97cc438](https://github.com/bitnami/charts/commit/97cc438)), closes [#17342](https://github.com/bitnami/charts/issues/17342)
-* [bitnami/several] Change copyright section in READMEs (#16989) ([5b6a5cf](https://github.com/bitnami/charts/commit/5b6a5cf)), closes [#16989](https://github.com/bitnami/charts/issues/16989)
-* Update charts readme (#17217) ([31b3c0a](https://github.com/bitnami/charts/commit/31b3c0a)), closes [#17217](https://github.com/bitnami/charts/issues/17217)
+* [bitnami/*] Change copyright section in READMEs (#17006) ([ef986a1](https://github.com/bitnami/charts/commit/ef986a1605241102b3dcafe9fd8089e6fc1201ad)), closes [#17006](https://github.com/bitnami/charts/issues/17006)
+* [bitnami/flink] Release 0.3.3 (#17342) ([97cc438](https://github.com/bitnami/charts/commit/97cc438d91fd0ae8c059c28a50d5399c2c89d649)), closes [#17342](https://github.com/bitnami/charts/issues/17342)
+* [bitnami/several] Change copyright section in READMEs (#16989) ([5b6a5cf](https://github.com/bitnami/charts/commit/5b6a5cfb7625a751848a2e5cd796bd7278f406ca)), closes [#16989](https://github.com/bitnami/charts/issues/16989)
+* Update charts readme (#17217) ([31b3c0a](https://github.com/bitnami/charts/commit/31b3c0afd968ff4429107e34101f7509e6a0e913)), closes [#17217](https://github.com/bitnami/charts/issues/17217)
 
 ## <small>0.3.2 (2023-05-26)</small>
 
-* [bitnami/flink] Release 0.3.2 updating components versions (#16926) ([4dc7a1c](https://github.com/bitnami/charts/commit/4dc7a1c)), closes [#16926](https://github.com/bitnami/charts/issues/16926)
+* [bitnami/flink] Release 0.3.2 updating components versions (#16926) ([4dc7a1c](https://github.com/bitnami/charts/commit/4dc7a1c70798070e6b1ba10a8cec6f28178dc62c)), closes [#16926](https://github.com/bitnami/charts/issues/16926)
 
 ## <small>0.3.1 (2023-05-26)</small>
 
-* [bitnami/flink] Release 0.3.1 updating components versions (#16924) ([dee7f0a](https://github.com/bitnami/charts/commit/dee7f0a)), closes [#16924](https://github.com/bitnami/charts/issues/16924)
-* Add wording for enterprise page (#16560) ([8f22774](https://github.com/bitnami/charts/commit/8f22774)), closes [#16560](https://github.com/bitnami/charts/issues/16560)
+* [bitnami/flink] Release 0.3.1 updating components versions (#16924) ([dee7f0a](https://github.com/bitnami/charts/commit/dee7f0a1d064f3fedcc9f78e3757de400c61dfde)), closes [#16924](https://github.com/bitnami/charts/issues/16924)
+* Add wording for enterprise page (#16560) ([8f22774](https://github.com/bitnami/charts/commit/8f2277440b976d52785ba9149762ad8620a73d1f)), closes [#16560](https://github.com/bitnami/charts/issues/16560)
 
 ## 0.3.0 (2023-05-09)
 
-* [bitnami/several] Adapt Chart.yaml to set desired OCI annotations (#16546) ([fc9b18f](https://github.com/bitnami/charts/commit/fc9b18f)), closes [#16546](https://github.com/bitnami/charts/issues/16546)
+* [bitnami/several] Adapt Chart.yaml to set desired OCI annotations (#16546) ([fc9b18f](https://github.com/bitnami/charts/commit/fc9b18f2e98805d4df629acbcde696f44f973344)), closes [#16546](https://github.com/bitnami/charts/issues/16546)
 
 ## <small>0.2.1 (2023-05-09)</small>
 
-* [bitnami/flink] Release 0.2.1 (#16506) ([7c6b674](https://github.com/bitnami/charts/commit/7c6b674)), closes [#16506](https://github.com/bitnami/charts/issues/16506)
+* [bitnami/flink] Release 0.2.1 (#16506) ([7c6b674](https://github.com/bitnami/charts/commit/7c6b6741cad164cb9a7b619b51d9143680210a97)), closes [#16506](https://github.com/bitnami/charts/issues/16506)
 
 ## 0.2.0 (2023-04-20)
 
-* [bitnami/*] Make Helm charts 100% OCI (#15998) ([8841510](https://github.com/bitnami/charts/commit/8841510)), closes [#15998](https://github.com/bitnami/charts/issues/15998)
+* [bitnami/*] Make Helm charts 100% OCI (#15998) ([8841510](https://github.com/bitnami/charts/commit/884151035efcbf2e1b3206e7def85511073fb57d)), closes [#15998](https://github.com/bitnami/charts/issues/15998)
 
 ## <small>0.1.2 (2023-04-12)</small>
 
-* [bitnami/flink] Release 0.1.2 updating components versions ([231c884](https://github.com/bitnami/charts/commit/231c884))
+* [bitnami/flink] Release 0.1.2 updating components versions ([231c884](https://github.com/bitnami/charts/commit/231c884a54cb71678956f2d8b9a68c9872bd3c26))
 
 ## <small>0.1.1 (2023-04-05)</small>
 
-* [bitnami/flink] Release 0.1.1 updating components versions ([ff1bd0f](https://github.com/bitnami/charts/commit/ff1bd0f))
+* [bitnami/flink] Release 0.1.1 updating components versions ([ff1bd0f](https://github.com/bitnami/charts/commit/ff1bd0fd1ef405418a1ed5711512072c099d6bcd))
 
 ## 0.1.0 (2023-04-05)
 
-* [bitnami/flink] Add Apache Flink chart (#14879) ([f05c7a6](https://github.com/bitnami/charts/commit/f05c7a6)), closes [#14879](https://github.com/bitnami/charts/issues/14879) [#15510](https://github.com/bitnami/charts/issues/15510)
+* [bitnami/flink] Add Apache Flink chart (#14879) ([f05c7a6](https://github.com/bitnami/charts/commit/f05c7a6045576b506cf57533cfde8b386c7a97ad)), closes [#14879](https://github.com/bitnami/charts/issues/14879) [#15510](https://github.com/bitnami/charts/issues/15510)

--- a/bitnami/flink/Chart.yaml
+++ b/bitnami/flink/Chart.yaml
@@ -28,4 +28,4 @@ maintainers:
 name: flink
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/flink
-version: 1.2.0
+version: 1.2.1

--- a/bitnami/flink/templates/jobmanager/deployment.yaml
+++ b/bitnami/flink/templates/jobmanager/deployment.yaml
@@ -139,8 +139,11 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.jobmanager.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.jobmanager.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.jobmanager.livenessProbe "enabled") "context" $) | nindent 12 }}
-            tcpSocket:
-              port: rpc
+            exec:
+              command:
+              - pgrep
+              - -f
+              - jobmanager
           {{- end }}
           {{- if .Values.jobmanager.customReadinessProbe }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.jobmanager.customReadinessProbe "context" $) | nindent 12 }}

--- a/bitnami/flink/templates/taskmanager/statefulset.yaml
+++ b/bitnami/flink/templates/taskmanager/statefulset.yaml
@@ -147,8 +147,11 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.taskmanager.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.taskmanager.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.taskmanager.livenessProbe "enabled") "context" $) | nindent 12 }}
-            tcpSocket:
-              port: rpc
+            exec:
+              command:
+              - pgrep
+              - -f
+              - taskmanager
           {{- end }}
           {{- if .Values.taskmanager.customReadinessProbe }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.taskmanager.customReadinessProbe "context" $) | nindent 12 }}


### PR DESCRIPTION
### Description of the change
This PR aims to use different liveness/readiness probes to improve overall security and avoid unnecessary container restarts. [More info](https://github.com/zegl/kube-score/blob/master/README_PROBES.md).

### Benefits

Increase availability and resilience.

### Possible drawbacks

N/A

### Applicable issues

- fixes #

### Additional information

- Related to #23537

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- ~[X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)~
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
