### PR TITLE
[bitnami/external-dns] Use different liveness/readiness probes

### DIFF
--- a/bitnami/external-dns/CHANGELOG.md
+++ b/bitnami/external-dns/CHANGELOG.md
@@ -1,1358 +1,1362 @@
 # Changelog
 
-## 7.5.1 (2024-05-22)
+## 7.5.2 (2024-05-24)
 
-* [bitnami/external-dns] PDB fixes ([#26292](https://github.com/bitnami/charts/pulls/26292))
+* [bitnami/external-dns] Use different liveness/readiness probes ([#26317](https://github.com/bitnami/charts/pull/26317))
+
+## <small>7.5.1 (2024-05-22)</small>
+
+* [bitnami/external-dns] PDB fixes (#26292) ([5e9d5eb](https://github.com/bitnami/charts/commit/5e9d5eb1e3008dc8fee50ec96c7f919c57fecf50)), closes [#26292](https://github.com/bitnami/charts/issues/26292)
 
 ## 7.5.0 (2024-05-21)
 
-* [bitnami/external-dns] feat: :sparkles: :lock: Add warning when original images are replaced (#26201 ([03f2cfd](https://github.com/bitnami/charts/commit/03f2cfd)), closes [#26201](https://github.com/bitnami/charts/issues/26201)
+* [bitnami/external-dns] feat: :sparkles: :lock: Add warning when original images are replaced (#26201 ([03f2cfd](https://github.com/bitnami/charts/commit/03f2cfdb73685bf514b64d5aec3893df77d11b0e)), closes [#26201](https://github.com/bitnami/charts/issues/26201)
 
 ## 7.4.0 (2024-05-21)
 
-* [bitnami/*] ci: :construction_worker: Add tag and changelog support (#25359) ([91c707c](https://github.com/bitnami/charts/commit/91c707c)), closes [#25359](https://github.com/bitnami/charts/issues/25359)
-* [bitnami/external-dns] PDB review (#25933) ([02b4f18](https://github.com/bitnami/charts/commit/02b4f18)), closes [#25933](https://github.com/bitnami/charts/issues/25933)
+* [bitnami/*] ci: :construction_worker: Add tag and changelog support (#25359) ([91c707c](https://github.com/bitnami/charts/commit/91c707c9e4e574725a09505d2d313fb93f1b4c0a)), closes [#25359](https://github.com/bitnami/charts/issues/25359)
+* [bitnami/external-dns] PDB review (#25933) ([02b4f18](https://github.com/bitnami/charts/commit/02b4f18746a6b7d21f311dca46e4bbe59c8e86e2)), closes [#25933](https://github.com/bitnami/charts/issues/25933)
 
 ## <small>7.3.4 (2024-05-18)</small>
 
-* [bitnami/external-dns] Release 7.3.4 updating components versions (#26012) ([47951be](https://github.com/bitnami/charts/commit/47951be)), closes [#26012](https://github.com/bitnami/charts/issues/26012)
+* [bitnami/external-dns] Release 7.3.4 updating components versions (#26012) ([47951be](https://github.com/bitnami/charts/commit/47951bee65fed62593199f36ffaadc80fbbaef6b)), closes [#26012](https://github.com/bitnami/charts/issues/26012)
 
 ## <small>7.3.3 (2024-05-17)</small>
 
-* [bitnami/external-dns] Release 7.3.3 (#25962) ([e6e63e9](https://github.com/bitnami/charts/commit/e6e63e9)), closes [#25962](https://github.com/bitnami/charts/issues/25962)
+* [bitnami/external-dns] Release 7.3.3 (#25962) ([e6e63e9](https://github.com/bitnami/charts/commit/e6e63e92110b642ead1f45325acfb3821cd95f70)), closes [#25962](https://github.com/bitnami/charts/issues/25962)
 
 ## <small>7.3.2 (2024-05-13)</small>
 
-* [bitnami/external-dns] Release 7.3.2 updating components versions (#25752) ([915353a](https://github.com/bitnami/charts/commit/915353a)), closes [#25752](https://github.com/bitnami/charts/issues/25752)
+* [bitnami/external-dns] Release 7.3.2 updating components versions (#25752) ([915353a](https://github.com/bitnami/charts/commit/915353a02a64559a7601b89325e0c328dbdd2c8c)), closes [#25752](https://github.com/bitnami/charts/issues/25752)
 
 ## <small>7.3.1 (2024-05-13)</small>
 
-* chore: templatize domain filters and exclusions (#25603) ([1b54f77](https://github.com/bitnami/charts/commit/1b54f77)), closes [#25603](https://github.com/bitnami/charts/issues/25603)
+* chore: templatize domain filters and exclusions (#25603) ([1b54f77](https://github.com/bitnami/charts/commit/1b54f7761a92caf942a8c34298791238630fec83)), closes [#25603](https://github.com/bitnami/charts/issues/25603)
 
 ## 7.3.0 (2024-05-08)
 
-* [bitnami/*] Change non-root and rolling-tags doc URLs (#25628) ([b067c94](https://github.com/bitnami/charts/commit/b067c94)), closes [#25628](https://github.com/bitnami/charts/issues/25628)
-* [bitnami/external-dns] Add aws.zoneMatchParent option (#25575) ([e337e96](https://github.com/bitnami/charts/commit/e337e96)), closes [#25575](https://github.com/bitnami/charts/issues/25575)
+* [bitnami/*] Change non-root and rolling-tags doc URLs (#25628) ([b067c94](https://github.com/bitnami/charts/commit/b067c94f6bcde427863c197fd355f0b5ba12ff5b)), closes [#25628](https://github.com/bitnami/charts/issues/25628)
+* [bitnami/external-dns] Add aws.zoneMatchParent option (#25575) ([e337e96](https://github.com/bitnami/charts/commit/e337e96146549cbeb47c9e9c91dd9687bd3e368d)), closes [#25575](https://github.com/bitnami/charts/issues/25575)
 
 ## <small>7.2.3 (2024-05-08)</small>
 
-* [bitnami/external-dns] Release 7.2.3 updating components versions (#25593) ([97199a6](https://github.com/bitnami/charts/commit/97199a6)), closes [#25593](https://github.com/bitnami/charts/issues/25593)
+* [bitnami/external-dns] Release 7.2.3 updating components versions (#25593) ([97199a6](https://github.com/bitnami/charts/commit/97199a66eb03f29aa09049fc201a4e01fad8a4ce)), closes [#25593](https://github.com/bitnami/charts/issues/25593)
 
 ## <small>7.2.2 (2024-05-07)</small>
 
-* [bitnami/*] Set new header/owner (#25558) ([8d1dc11](https://github.com/bitnami/charts/commit/8d1dc11)), closes [#25558](https://github.com/bitnami/charts/issues/25558)
-* [bitnami/external-dns] Release 7.2.2 updating components versions (#25585) ([ee82927](https://github.com/bitnami/charts/commit/ee82927)), closes [#25585](https://github.com/bitnami/charts/issues/25585)
+* [bitnami/*] Set new header/owner (#25558) ([8d1dc11](https://github.com/bitnami/charts/commit/8d1dc11f5fb30db6fba50c43d7af59d2f79deed3)), closes [#25558](https://github.com/bitnami/charts/issues/25558)
+* [bitnami/external-dns] Release 7.2.2 updating components versions (#25585) ([ee82927](https://github.com/bitnami/charts/commit/ee82927b1415247165137e297c55a5420cd727cd)), closes [#25585](https://github.com/bitnami/charts/issues/25585)
 
 ## <small>7.2.1 (2024-04-29)</small>
 
-* [bitnami/external-dns]Added the --cloudflare-dns-records-per-page option (#25420) ([628583f](https://github.com/bitnami/charts/commit/628583f)), closes [#25420](https://github.com/bitnami/charts/issues/25420)
-* [bitnami/multiple charts] Fix typo: "NetworkPolice" vs "NetworkPolicy" (#25348) ([6970c1b](https://github.com/bitnami/charts/commit/6970c1b)), closes [#25348](https://github.com/bitnami/charts/issues/25348)
-* Replace VMware by Broadcom copyright text (#25306) ([a5e4bd0](https://github.com/bitnami/charts/commit/a5e4bd0)), closes [#25306](https://github.com/bitnami/charts/issues/25306)
+* [bitnami/external-dns]Added the --cloudflare-dns-records-per-page option (#25420) ([628583f](https://github.com/bitnami/charts/commit/628583fa9e97a41a54031ee00b2bc6dca94a6568)), closes [#25420](https://github.com/bitnami/charts/issues/25420)
+* [bitnami/multiple charts] Fix typo: "NetworkPolice" vs "NetworkPolicy" (#25348) ([6970c1b](https://github.com/bitnami/charts/commit/6970c1ba245873506e73d459c6eac1e4919b778f)), closes [#25348](https://github.com/bitnami/charts/issues/25348)
+* Replace VMware by Broadcom copyright text (#25306) ([a5e4bd0](https://github.com/bitnami/charts/commit/a5e4bd0e35e419203793976a78d9d0a13de92c76)), closes [#25306](https://github.com/bitnami/charts/issues/25306)
 
 ## 7.2.0 (2024-04-15)
 
-* bitnami/external-dns Add support for OCI IAM instance principle and workload identity (#24708) ([43f3624](https://github.com/bitnami/charts/commit/43f3624)), closes [#24708](https://github.com/bitnami/charts/issues/24708)
+* bitnami/external-dns Add support for OCI IAM instance principle and workload identity (#24708) ([43f3624](https://github.com/bitnami/charts/commit/43f3624574f7fca3cf6e804a833017c28e4d7411)), closes [#24708](https://github.com/bitnami/charts/issues/24708)
 
 ## <small>7.1.2 (2024-04-05)</small>
 
-* [bitnami/external-dns] Release 7.1.2 updating components versions (#24941) ([bf0fa5f](https://github.com/bitnami/charts/commit/bf0fa5f)), closes [#24941](https://github.com/bitnami/charts/issues/24941)
+* [bitnami/external-dns] Release 7.1.2 updating components versions (#24941) ([bf0fa5f](https://github.com/bitnami/charts/commit/bf0fa5ff20b92fb5f449ea1ba99770aef053af41)), closes [#24941](https://github.com/bitnami/charts/issues/24941)
 
 ## <small>7.1.1 (2024-04-04)</small>
 
-* [bitnami/external-dns] Release 7.1.1 (#24879) ([461e4f6](https://github.com/bitnami/charts/commit/461e4f6)), closes [#24879](https://github.com/bitnami/charts/issues/24879)
-* Update resourcesPreset comments (#24467) ([92e3e8a](https://github.com/bitnami/charts/commit/92e3e8a)), closes [#24467](https://github.com/bitnami/charts/issues/24467)
+* [bitnami/external-dns] Release 7.1.1 (#24879) ([461e4f6](https://github.com/bitnami/charts/commit/461e4f6dc933b6185ff061a36df1e54a33588320)), closes [#24879](https://github.com/bitnami/charts/issues/24879)
+* Update resourcesPreset comments (#24467) ([92e3e8a](https://github.com/bitnami/charts/commit/92e3e8a507326d2a20a8f10ab3e7746a2ec5c554)), closes [#24467](https://github.com/bitnami/charts/issues/24467)
 
 ## 7.1.0 (2024-03-22)
 
-* [bitnami/external-dns] feat: add revisionHistoryLimit (#24525) ([73c549c](https://github.com/bitnami/charts/commit/73c549c)), closes [#24525](https://github.com/bitnami/charts/issues/24525)
+* [bitnami/external-dns] feat: add revisionHistoryLimit (#24525) ([73c549c](https://github.com/bitnami/charts/commit/73c549c15fcf5c4572e14746993ecdd92242b3ac)), closes [#24525](https://github.com/bitnami/charts/issues/24525)
 
 ## <small>7.0.2 (2024-03-21)</small>
 
-* [bitnami/external-dns] Release 7.0.2 (#24607) ([e06ec7a](https://github.com/bitnami/charts/commit/e06ec7a)), closes [#24607](https://github.com/bitnami/charts/issues/24607)
+* [bitnami/external-dns] Release 7.0.2 (#24607) ([e06ec7a](https://github.com/bitnami/charts/commit/e06ec7a52c0370c2ae7a737d08792e1de0a567b0)), closes [#24607](https://github.com/bitnami/charts/issues/24607)
 
 ## <small>7.0.1 (2024-03-21)</small>
 
-* [bitnami/external-dns] Fix boolean flag --pihole-tls-skip-verify (#24578) ([0c13f72](https://github.com/bitnami/charts/commit/0c13f72)), closes [#24578](https://github.com/bitnami/charts/issues/24578)
+* [bitnami/external-dns] Fix boolean flag --pihole-tls-skip-verify (#24578) ([0c13f72](https://github.com/bitnami/charts/commit/0c13f724036429d4d3d00ef2151c4821e097dd00)), closes [#24578](https://github.com/bitnami/charts/issues/24578)
 
 ## 7.0.0 (2024-03-18)
 
-* [bitnami/*] Reorder Chart sections (#24455) ([0cf4048](https://github.com/bitnami/charts/commit/0cf4048)), closes [#24455](https://github.com/bitnami/charts/issues/24455)
-* [bitnami/external-dns] feat!: :lock: :boom: Improve security defaults (#24325) ([47d68cc](https://github.com/bitnami/charts/commit/47d68cc)), closes [#24325](https://github.com/bitnami/charts/issues/24325)
+* [bitnami/*] Reorder Chart sections (#24455) ([0cf4048](https://github.com/bitnami/charts/commit/0cf4048e8743f70a9753d460655bd030cbff6824)), closes [#24455](https://github.com/bitnami/charts/issues/24455)
+* [bitnami/external-dns] feat!: :lock: :boom: Improve security defaults (#24325) ([47d68cc](https://github.com/bitnami/charts/commit/47d68cc5cea0fcf7c8471823ed5308b2b3595428)), closes [#24325](https://github.com/bitnami/charts/issues/24325)
 
 ## 6.38.0 (2024-03-15)
 
-* [bitnami/external-dns] feat: Add support for TXT record encryption (#23575) ([c9a12dd](https://github.com/bitnami/charts/commit/c9a12dd)), closes [#23575](https://github.com/bitnami/charts/issues/23575)
+* [bitnami/external-dns] feat: Add support for TXT record encryption (#23575) ([c9a12dd](https://github.com/bitnami/charts/commit/c9a12dd310691069f48ddcba64ee9ed00fb42824)), closes [#23575](https://github.com/bitnami/charts/issues/23575)
 
 ## 6.37.0 (2024-03-14)
 
-* [bitnami/external-dns] Allowing for customize dnsPolicy and dnsConfig for external-dns deployment (# ([4ce83be](https://github.com/bitnami/charts/commit/4ce83be)), closes [#24266](https://github.com/bitnami/charts/issues/24266)
+* [bitnami/external-dns] Allowing for customize dnsPolicy and dnsConfig for external-dns deployment (# ([4ce83be](https://github.com/bitnami/charts/commit/4ce83be155827e7e079cf078c131258d7f7c671d)), closes [#24266](https://github.com/bitnami/charts/issues/24266)
 
 ## <small>6.36.1 (2024-03-06)</small>
 
-* [bitnami/external-dns] Release 6.36.1 updating components versions (#24199) ([cfaf19e](https://github.com/bitnami/charts/commit/cfaf19e)), closes [#24199](https://github.com/bitnami/charts/issues/24199)
+* [bitnami/external-dns] Release 6.36.1 updating components versions (#24199) ([cfaf19e](https://github.com/bitnami/charts/commit/cfaf19ea1f7b055693e87008bb34e830d6f14ee8)), closes [#24199](https://github.com/bitnami/charts/issues/24199)
 
 ## 6.36.0 (2024-03-06)
 
-* [bitnami/external-dns] feat: :sparkles: :lock: Add automatic adaptation for Openshift restricted-v2  ([f5ac6f9](https://github.com/bitnami/charts/commit/f5ac6f9)), closes [#24080](https://github.com/bitnami/charts/issues/24080)
+* [bitnami/external-dns] feat: :sparkles: :lock: Add automatic adaptation for Openshift restricted-v2  ([f5ac6f9](https://github.com/bitnami/charts/commit/f5ac6f9ceca96edf0dafe9905c78b54d89ed5816)), closes [#24080](https://github.com/bitnami/charts/issues/24080)
 
 ## 6.35.0 (2024-02-27)
 
-* [bitnami/external-dns] feat: :sparkles: :lock: Add runAsGroup (#23890) ([8e3887b](https://github.com/bitnami/charts/commit/8e3887b)), closes [#23890](https://github.com/bitnami/charts/issues/23890)
+* [bitnami/external-dns] feat: :sparkles: :lock: Add runAsGroup (#23890) ([8e3887b](https://github.com/bitnami/charts/commit/8e3887bf81572f0af34b0b159da02533efb832ae)), closes [#23890](https://github.com/bitnami/charts/issues/23890)
 
 ## <small>6.34.2 (2024-02-21)</small>
 
-* [bitnami/external-dns] Release 6.34.2 updating components versions (#23750) ([96651f4](https://github.com/bitnami/charts/commit/96651f4)), closes [#23750](https://github.com/bitnami/charts/issues/23750)
+* [bitnami/external-dns] Release 6.34.2 updating components versions (#23750) ([96651f4](https://github.com/bitnami/charts/commit/96651f43deac7f4081446e856b48865b70d87400)), closes [#23750](https://github.com/bitnami/charts/issues/23750)
 
 ## <small>6.34.1 (2024-02-21)</small>
 
-* [bitnami/external-dns] Release 6.34.1 updating components versions (#23646) ([b838f7f](https://github.com/bitnami/charts/commit/b838f7f)), closes [#23646](https://github.com/bitnami/charts/issues/23646)
+* [bitnami/external-dns] Release 6.34.1 updating components versions (#23646) ([b838f7f](https://github.com/bitnami/charts/commit/b838f7f781e2d0859a3e24215abdba5a2bef8aa1)), closes [#23646](https://github.com/bitnami/charts/issues/23646)
 
 ## 6.34.0 (2024-02-20)
 
-* [bitnami/*] Bump all versions (#23602) ([b70ee2a](https://github.com/bitnami/charts/commit/b70ee2a)), closes [#23602](https://github.com/bitnami/charts/issues/23602)
+* [bitnami/*] Bump all versions (#23602) ([b70ee2a](https://github.com/bitnami/charts/commit/b70ee2a30e4dc256bf0ac52928fb2fa7a70f049b)), closes [#23602](https://github.com/bitnami/charts/issues/23602)
 
 ## 6.33.0 (2024-02-15)
 
-* [bitnami/external-dns] feat: :sparkles: :lock: Add resource preset support (#23447) ([df96ce8](https://github.com/bitnami/charts/commit/df96ce8)), closes [#23447](https://github.com/bitnami/charts/issues/23447)
+* [bitnami/external-dns] feat: :sparkles: :lock: Add resource preset support (#23447) ([df96ce8](https://github.com/bitnami/charts/commit/df96ce857360c31e2f1242d62c9dcc2c85e391a9)), closes [#23447](https://github.com/bitnami/charts/issues/23447)
 
 ## <small>6.32.1 (2024-02-09)</small>
 
-* [bitnami/external-dns] Release 6.32.1 updating components versions (#23362) ([afb7cea](https://github.com/bitnami/charts/commit/afb7cea)), closes [#23362](https://github.com/bitnami/charts/issues/23362)
+* [bitnami/external-dns] Release 6.32.1 updating components versions (#23362) ([afb7cea](https://github.com/bitnami/charts/commit/afb7cea17032961f0c772b3f98d27bb1eab6a4b5)), closes [#23362](https://github.com/bitnami/charts/issues/23362)
 
 ## 6.32.0 (2024-02-08)
 
-* [bitnami/external-dns] feat: :lock: Enable networkPolicy (#23285) ([c9676cb](https://github.com/bitnami/charts/commit/c9676cb)), closes [#23285](https://github.com/bitnami/charts/issues/23285)
+* [bitnami/external-dns] feat: :lock: Enable networkPolicy (#23285) ([c9676cb](https://github.com/bitnami/charts/commit/c9676cbc59c102292b172f6acf79819ce4fe4f16)), closes [#23285](https://github.com/bitnami/charts/issues/23285)
 
 ## <small>6.31.6 (2024-02-07)</small>
 
-* [bitnami/external-dns] Release 6.31.6 updating components versions (#23215) ([ca0878d](https://github.com/bitnami/charts/commit/ca0878d)), closes [#23215](https://github.com/bitnami/charts/issues/23215)
+* [bitnami/external-dns] Release 6.31.6 updating components versions (#23215) ([ca0878d](https://github.com/bitnami/charts/commit/ca0878d3c5a1adc14fccd79e167ac4cb1b5116e2)), closes [#23215](https://github.com/bitnami/charts/issues/23215)
 
 ## <small>6.31.5 (2024-02-02)</small>
 
-* [bitnami/external-dns] Release 6.31.5 updating components versions (#23060) ([9548713](https://github.com/bitnami/charts/commit/9548713)), closes [#23060](https://github.com/bitnami/charts/issues/23060)
+* [bitnami/external-dns] Release 6.31.5 updating components versions (#23060) ([9548713](https://github.com/bitnami/charts/commit/95487132e1276148f9a475a362b077f1823e89fd)), closes [#23060](https://github.com/bitnami/charts/issues/23060)
 
 ## <small>6.31.4 (2024-01-31)</small>
 
-* [bitnami/external-dns] Update CRDs and add headers for automatic update (#22886) ([d87ba5a](https://github.com/bitnami/charts/commit/d87ba5a)), closes [#22886](https://github.com/bitnami/charts/issues/22886)
+* [bitnami/external-dns] Update CRDs and add headers for automatic update (#22886) ([d87ba5a](https://github.com/bitnami/charts/commit/d87ba5acfd630c25459ad718b43b08f31dee6de4)), closes [#22886](https://github.com/bitnami/charts/issues/22886)
 
 ## <small>6.31.3 (2024-01-30)</small>
 
-* [bitnami/external-dns] Release 6.31.3 updating components versions (#22867) ([0c1d2c1](https://github.com/bitnami/charts/commit/0c1d2c1)), closes [#22867](https://github.com/bitnami/charts/issues/22867)
+* [bitnami/external-dns] Release 6.31.3 updating components versions (#22867) ([0c1d2c1](https://github.com/bitnami/charts/commit/0c1d2c1ed821857da43dd5f22a021bce1a01bd42)), closes [#22867](https://github.com/bitnami/charts/issues/22867)
 
 ## <small>6.31.2 (2024-01-27)</small>
 
-* [bitnami/external-dns] fix: :bug: Set seLinuxOptions to null for Openshift compatibility (#22585) ([99895d9](https://github.com/bitnami/charts/commit/99895d9)), closes [#22585](https://github.com/bitnami/charts/issues/22585)
-* [bitnami/external-dns] Release 6.31.2 updating components versions (#22790) ([7487874](https://github.com/bitnami/charts/commit/7487874)), closes [#22790](https://github.com/bitnami/charts/issues/22790)
+* [bitnami/external-dns] fix: :bug: Set seLinuxOptions to null for Openshift compatibility (#22585) ([99895d9](https://github.com/bitnami/charts/commit/99895d93e4e28b22ca812f317af53a6ae15edc58)), closes [#22585](https://github.com/bitnami/charts/issues/22585)
+* [bitnami/external-dns] Release 6.31.2 updating components versions (#22790) ([7487874](https://github.com/bitnami/charts/commit/748787489392a95e4284ac2fcd0782e345bfd171)), closes [#22790](https://github.com/bitnami/charts/issues/22790)
 
 ## <small>6.31.1 (2024-01-24)</small>
 
-* [bitnami/*] Move documentation sections from docs.bitnami.com back to the README (#22203) ([7564f36](https://github.com/bitnami/charts/commit/7564f36)), closes [#22203](https://github.com/bitnami/charts/issues/22203)
-* Fix mapping of pihole secret name (#22503) ([8532e73](https://github.com/bitnami/charts/commit/8532e73)), closes [#22503](https://github.com/bitnami/charts/issues/22503)
+* [bitnami/*] Move documentation sections from docs.bitnami.com back to the README (#22203) ([7564f36](https://github.com/bitnami/charts/commit/7564f36ca1e95ff30ee686652b7ab8690561a707)), closes [#22203](https://github.com/bitnami/charts/issues/22203)
+* Fix mapping of pihole secret name (#22503) ([8532e73](https://github.com/bitnami/charts/commit/8532e73c885cc73365fe648a75208bcb24777755)), closes [#22503](https://github.com/bitnami/charts/issues/22503)
 
 ## 6.31.0 (2024-01-19)
 
-* [bitnami/external-dns] fix: :lock: Move service-account token auto-mount to pod declaration (#22398) ([efca846](https://github.com/bitnami/charts/commit/efca846)), closes [#22398](https://github.com/bitnami/charts/issues/22398)
-* [bitnami/external-dns] Update CRDs and add source header (#22371) ([d59043c](https://github.com/bitnami/charts/commit/d59043c)), closes [#22371](https://github.com/bitnami/charts/issues/22371)
+* [bitnami/external-dns] fix: :lock: Move service-account token auto-mount to pod declaration (#22398) ([efca846](https://github.com/bitnami/charts/commit/efca846d99122a96a989c82a9acfdaf38bacbd52)), closes [#22398](https://github.com/bitnami/charts/issues/22398)
+* [bitnami/external-dns] Update CRDs and add source header (#22371) ([d59043c](https://github.com/bitnami/charts/commit/d59043c00a3365333d33443ed21fb06d23851b91)), closes [#22371](https://github.com/bitnami/charts/issues/22371)
 
 ## <small>6.30.1 (2024-01-18)</small>
 
-* [bitnami/external-dns] Release 6.30.1 updating components versions (#22269) ([a8b40f8](https://github.com/bitnami/charts/commit/a8b40f8)), closes [#22269](https://github.com/bitnami/charts/issues/22269)
+* [bitnami/external-dns] Release 6.30.1 updating components versions (#22269) ([a8b40f8](https://github.com/bitnami/charts/commit/a8b40f8d1dcbbf3ad1ac494beb6b44abe94a78e3)), closes [#22269](https://github.com/bitnami/charts/issues/22269)
 
 ## 6.30.0 (2024-01-16)
 
-* [bitnami/*] Fix ref links (in comments) (#21822) ([e4fa296](https://github.com/bitnami/charts/commit/e4fa296)), closes [#21822](https://github.com/bitnami/charts/issues/21822)
-* [bitnami/external-dns] fix: :lock: Improve podSecurityContext and containerSecurityContext with esse ([848b150](https://github.com/bitnami/charts/commit/848b150)), closes [#22116](https://github.com/bitnami/charts/issues/22116)
+* [bitnami/*] Fix ref links (in comments) (#21822) ([e4fa296](https://github.com/bitnami/charts/commit/e4fa296106b225cf8c82445727c675c7c725e380)), closes [#21822](https://github.com/bitnami/charts/issues/21822)
+* [bitnami/external-dns] fix: :lock: Improve podSecurityContext and containerSecurityContext with esse ([848b150](https://github.com/bitnami/charts/commit/848b150722564288a9600a00338db3b1132be2bd)), closes [#22116](https://github.com/bitnami/charts/issues/22116)
 
 ## <small>6.29.1 (2024-01-10)</small>
 
-* [bitnami/*] Fix docs.bitnami.com broken links (#21901) ([f35506d](https://github.com/bitnami/charts/commit/f35506d)), closes [#21901](https://github.com/bitnami/charts/issues/21901)
-* [bitnami/external-dns] Release 6.29.1 updating components versions (#21935) ([e994813](https://github.com/bitnami/charts/commit/e994813)), closes [#21935](https://github.com/bitnami/charts/issues/21935)
+* [bitnami/*] Fix docs.bitnami.com broken links (#21901) ([f35506d](https://github.com/bitnami/charts/commit/f35506d2dadee4f097986e7792df1f53ab215b5d)), closes [#21901](https://github.com/bitnami/charts/issues/21901)
+* [bitnami/external-dns] Release 6.29.1 updating components versions (#21935) ([e994813](https://github.com/bitnami/charts/commit/e994813032934fb59ddc033a253385d9bdc24df5)), closes [#21935](https://github.com/bitnami/charts/issues/21935)
 
 ## 6.29.0 (2024-01-08)
 
-* [bitnami/*] Update copyright: Year and company (#21815) ([6c4bf75](https://github.com/bitnami/charts/commit/6c4bf75)), closes [#21815](https://github.com/bitnami/charts/issues/21815)
-* [bitnami/external-dns] add pihole support (#21809) ([bb98b43](https://github.com/bitnami/charts/commit/bb98b43)), closes [#21809](https://github.com/bitnami/charts/issues/21809)
+* [bitnami/*] Update copyright: Year and company (#21815) ([6c4bf75](https://github.com/bitnami/charts/commit/6c4bf75dec58fc7c9aee9f089777b1a858c17d5b)), closes [#21815](https://github.com/bitnami/charts/issues/21815)
+* [bitnami/external-dns] add pihole support (#21809) ([bb98b43](https://github.com/bitnami/charts/commit/bb98b43256eb4479bbc2623835e6aca070daa6bb)), closes [#21809](https://github.com/bitnami/charts/issues/21809)
 
 ## <small>6.28.6 (2023-12-07)</small>
 
-* [bitnami/external-dns] Release 6.28.6 updating components versions (#21421) ([4bd5538](https://github.com/bitnami/charts/commit/4bd5538)), closes [#21421](https://github.com/bitnami/charts/issues/21421)
+* [bitnami/external-dns] Release 6.28.6 updating components versions (#21421) ([4bd5538](https://github.com/bitnami/charts/commit/4bd553887f02845db5cc6f0755a70260af7657e0)), closes [#21421](https://github.com/bitnami/charts/issues/21421)
 
 ## <small>6.28.5 (2023-11-21)</small>
 
-* [bitnami/*] Remove relative links to non-README sections, add verification for that and update TL;DR ([1103633](https://github.com/bitnami/charts/commit/1103633)), closes [#20967](https://github.com/bitnami/charts/issues/20967)
-* [bitnami/*] Rename solutions to "Bitnami package for ..." (#21038) ([b82f979](https://github.com/bitnami/charts/commit/b82f979)), closes [#21038](https://github.com/bitnami/charts/issues/21038)
-* [bitnami/external-dns] Release 6.28.5 updating components versions (#21111) ([597bfea](https://github.com/bitnami/charts/commit/597bfea)), closes [#21111](https://github.com/bitnami/charts/issues/21111)
+* [bitnami/*] Remove relative links to non-README sections, add verification for that and update TL;DR ([1103633](https://github.com/bitnami/charts/commit/11036334d82df0490aa4abdb591543cab6cf7d7f)), closes [#20967](https://github.com/bitnami/charts/issues/20967)
+* [bitnami/*] Rename solutions to "Bitnami package for ..." (#21038) ([b82f979](https://github.com/bitnami/charts/commit/b82f979e4fb63423fe6e2192c946d09d79c944fc)), closes [#21038](https://github.com/bitnami/charts/issues/21038)
+* [bitnami/external-dns] Release 6.28.5 updating components versions (#21111) ([597bfea](https://github.com/bitnami/charts/commit/597bfea5235fbc95b5a915d62bf916ba3cb4fad4)), closes [#21111](https://github.com/bitnami/charts/issues/21111)
 
 ## <small>6.28.4 (2023-11-08)</small>
 
-* [bitnami/external-dns] Release 6.28.4 updating components versions (#20689) ([83f5860](https://github.com/bitnami/charts/commit/83f5860)), closes [#20689](https://github.com/bitnami/charts/issues/20689)
+* [bitnami/external-dns] Release 6.28.4 updating components versions (#20689) ([83f5860](https://github.com/bitnami/charts/commit/83f58604316353ca30713cf274ee64d26b1a9f62)), closes [#20689](https://github.com/bitnami/charts/issues/20689)
 
 ## <small>6.28.3 (2023-11-08)</small>
 
-* [bitnami/external-dns] Release 6.28.3 updating components versions (#20681) ([7573bcb](https://github.com/bitnami/charts/commit/7573bcb)), closes [#20681](https://github.com/bitnami/charts/issues/20681)
+* [bitnami/external-dns] Release 6.28.3 updating components versions (#20681) ([7573bcb](https://github.com/bitnami/charts/commit/7573bcbba9b79c32352a2b4ce6373decaa7ad2d1)), closes [#20681](https://github.com/bitnami/charts/issues/20681)
 
 ## <small>6.28.2 (2023-11-07)</small>
 
-* [bitnami/external-dns] Release 6.28.2 updating components versions (#20670) ([faaba50](https://github.com/bitnami/charts/commit/faaba50)), closes [#20670](https://github.com/bitnami/charts/issues/20670)
+* [bitnami/external-dns] Release 6.28.2 updating components versions (#20670) ([faaba50](https://github.com/bitnami/charts/commit/faaba50b3c5b37121401c63368784c17212ebec1)), closes [#20670](https://github.com/bitnami/charts/issues/20670)
 
 ## <small>6.28.1 (2023-11-03)</small>
 
-* [bitnami/external-dns] Add Civo provider (#20205) ([9f20b9c](https://github.com/bitnami/charts/commit/9f20b9c)), closes [#20205](https://github.com/bitnami/charts/issues/20205)
+* [bitnami/external-dns] Add Civo provider (#20205) ([9f20b9c](https://github.com/bitnami/charts/commit/9f20b9ccf24fd8ad76a4133a5dcc9342628341fd)), closes [#20205](https://github.com/bitnami/charts/issues/20205)
 
 ## 6.28.0 (2023-10-31)
 
-* [bitnami/external-dns] feat: :sparkles: Add support for PSA restricted policy (#20426) ([9d98118](https://github.com/bitnami/charts/commit/9d98118)), closes [#20426](https://github.com/bitnami/charts/issues/20426)
+* [bitnami/external-dns] feat: :sparkles: Add support for PSA restricted policy (#20426) ([9d98118](https://github.com/bitnami/charts/commit/9d98118f63d15d9641ef2d5818afbffdfcc39003)), closes [#20426](https://github.com/bitnami/charts/issues/20426)
 
 ## 6.27.0 (2023-10-25)
 
-* [bitnami/*] Rename VMware Application Catalog (#20361) ([3acc734](https://github.com/bitnami/charts/commit/3acc734)), closes [#20361](https://github.com/bitnami/charts/issues/20361)
-* [bitnami/*] Skip image's tag in the README files of the Bitnami Charts (#19841) ([bb9a01b](https://github.com/bitnami/charts/commit/bb9a01b)), closes [#19841](https://github.com/bitnami/charts/issues/19841)
-* [bitnami/*] Standardize documentation (#19835) ([af5f753](https://github.com/bitnami/charts/commit/af5f753)), closes [#19835](https://github.com/bitnami/charts/issues/19835)
-* [bitnami/external-dns] ability to disable validation (#20001) ([9f757c4](https://github.com/bitnami/charts/commit/9f757c4)), closes [#20001](https://github.com/bitnami/charts/issues/20001)
+* [bitnami/*] Rename VMware Application Catalog (#20361) ([3acc734](https://github.com/bitnami/charts/commit/3acc73472beb6fb56c4d99f929061001205bc57e)), closes [#20361](https://github.com/bitnami/charts/issues/20361)
+* [bitnami/*] Skip image's tag in the README files of the Bitnami Charts (#19841) ([bb9a01b](https://github.com/bitnami/charts/commit/bb9a01b65911c87e48318db922cc05eb42785e42)), closes [#19841](https://github.com/bitnami/charts/issues/19841)
+* [bitnami/*] Standardize documentation (#19835) ([af5f753](https://github.com/bitnami/charts/commit/af5f7530c1bc8c5ded53a6c4f7b8f384ac1804f2)), closes [#19835](https://github.com/bitnami/charts/issues/19835)
+* [bitnami/external-dns] ability to disable validation (#20001) ([9f757c4](https://github.com/bitnami/charts/commit/9f757c4b2a01a8cb4a2161f667fd1b0beaa364f7)), closes [#20001](https://github.com/bitnami/charts/issues/20001)
 
 ## <small>6.26.5 (2023-10-11)</small>
 
-* [bitnami/external-dns] Release 6.26.5 (#20038) ([3975dfc](https://github.com/bitnami/charts/commit/3975dfc)), closes [#20038](https://github.com/bitnami/charts/issues/20038)
+* [bitnami/external-dns] Release 6.26.5 (#20038) ([3975dfc](https://github.com/bitnami/charts/commit/3975dfc79006e2b1d7a617a3f49bfcdf627c345d)), closes [#20038](https://github.com/bitnami/charts/issues/20038)
 
 ## <small>6.26.4 (2023-10-09)</small>
 
-* [bitnami/*] Update Helm charts prerequisites (#19745) ([eb755dd](https://github.com/bitnami/charts/commit/eb755dd)), closes [#19745](https://github.com/bitnami/charts/issues/19745)
-* [bitnami/external-dns] Release 6.26.4 (#19818) ([0fe284d](https://github.com/bitnami/charts/commit/0fe284d)), closes [#19818](https://github.com/bitnami/charts/issues/19818)
+* [bitnami/*] Update Helm charts prerequisites (#19745) ([eb755dd](https://github.com/bitnami/charts/commit/eb755dd36a4dd3cf6635be8e0598f9a7f4c4a554)), closes [#19745](https://github.com/bitnami/charts/issues/19745)
+* [bitnami/external-dns] Release 6.26.4 (#19818) ([0fe284d](https://github.com/bitnami/charts/commit/0fe284d3b21e8bc6b4f1867aea2ae43e8cd11603)), closes [#19818](https://github.com/bitnami/charts/issues/19818)
 
 ## <small>6.26.3 (2023-10-03)</small>
 
-* [bitnami/external-dns] Release 6.26.3 (#19701) ([c73f985](https://github.com/bitnami/charts/commit/c73f985)), closes [#19701](https://github.com/bitnami/charts/issues/19701)
+* [bitnami/external-dns] Release 6.26.3 (#19701) ([c73f985](https://github.com/bitnami/charts/commit/c73f9859e91360ce8d32db5e1c8668c62ccdb73e)), closes [#19701](https://github.com/bitnami/charts/issues/19701)
 
 ## <small>6.26.2 (2023-10-02)</small>
 
-* [bitnami/external-dns] Use common capabilities for PSP (#19626) ([c3177ed](https://github.com/bitnami/charts/commit/c3177ed)), closes [#19626](https://github.com/bitnami/charts/issues/19626)
+* [bitnami/external-dns] Use common capabilities for PSP (#19626) ([c3177ed](https://github.com/bitnami/charts/commit/c3177ed65ba18268988ceeed81274cde35ce99da)), closes [#19626](https://github.com/bitnami/charts/issues/19626)
 
 ## <small>6.26.1 (2023-09-18)</small>
 
-* [bitnami/external-dns] Release 6.26.1 (#19347) ([b24c53d](https://github.com/bitnami/charts/commit/b24c53d)), closes [#19347](https://github.com/bitnami/charts/issues/19347)
-* Revert "Autogenerate schema files (#19194)" (#19335) ([73d80be](https://github.com/bitnami/charts/commit/73d80be)), closes [#19194](https://github.com/bitnami/charts/issues/19194) [#19335](https://github.com/bitnami/charts/issues/19335)
+* [bitnami/external-dns] Release 6.26.1 (#19347) ([b24c53d](https://github.com/bitnami/charts/commit/b24c53decf3226fb75fe927836e3b700b71415b6)), closes [#19347](https://github.com/bitnami/charts/issues/19347)
+* Revert "Autogenerate schema files (#19194)" (#19335) ([73d80be](https://github.com/bitnami/charts/commit/73d80be525c88fb4b8a54451a55acd506e337062)), closes [#19194](https://github.com/bitnami/charts/issues/19194) [#19335](https://github.com/bitnami/charts/issues/19335)
 
 ## 6.26.0 (2023-09-13)
 
-* [bitnami/external-dns] Support dynamodb registry (#19190) ([8ef1893](https://github.com/bitnami/charts/commit/8ef1893)), closes [#19190](https://github.com/bitnami/charts/issues/19190)
+* [bitnami/external-dns] Support dynamodb registry (#19190) ([8ef1893](https://github.com/bitnami/charts/commit/8ef18933ea1ed3d5196a24b20133d91c52bb78f0)), closes [#19190](https://github.com/bitnami/charts/issues/19190)
 
 ## <small>6.25.1 (2023-09-13)</small>
 
-* [bitnami/external-dns] Add support for traefik ingressroutes in clust… (#19168) ([e03228e](https://github.com/bitnami/charts/commit/e03228e)), closes [#19168](https://github.com/bitnami/charts/issues/19168)
-* Autogenerate schema files (#19194) ([a2c2090](https://github.com/bitnami/charts/commit/a2c2090)), closes [#19194](https://github.com/bitnami/charts/issues/19194)
+* [bitnami/external-dns] Add support for traefik ingressroutes in clust… (#19168) ([e03228e](https://github.com/bitnami/charts/commit/e03228ecb4738d887b75dcb4fa88ea5f31e87bcc)), closes [#19168](https://github.com/bitnami/charts/issues/19168)
+* Autogenerate schema files (#19194) ([a2c2090](https://github.com/bitnami/charts/commit/a2c2090b5ac97f47b745c8028c6452bf99739772)), closes [#19194](https://github.com/bitnami/charts/issues/19194)
 
 ## 6.25.0 (2023-09-11)
 
-* feat: bitnami/external-dns: Support for Azure workload Identity (#19216) ([55885c5](https://github.com/bitnami/charts/commit/55885c5)), closes [#19216](https://github.com/bitnami/charts/issues/19216)
+* feat: bitnami/external-dns: Support for Azure workload Identity (#19216) ([55885c5](https://github.com/bitnami/charts/commit/55885c51838972f9ea4ff526be784bc9cd017589)), closes [#19216](https://github.com/bitnami/charts/issues/19216)
 
 ## <small>6.24.3 (2023-09-08)</small>
 
-* [bitnami/external-dns: Use merge helper]: (#19036) ([40264e2](https://github.com/bitnami/charts/commit/40264e2)), closes [#19036](https://github.com/bitnami/charts/issues/19036)
+* [bitnami/external-dns: Use merge helper]: (#19036) ([40264e2](https://github.com/bitnami/charts/commit/40264e240e17e2725a125bd3aef398274817cd6c)), closes [#19036](https://github.com/bitnami/charts/issues/19036)
 
 ## <small>6.24.2 (2023-09-06)</small>
 
-* [bitnami/external-dns] Release 6.24.2 (#19133) ([dd63249](https://github.com/bitnami/charts/commit/dd63249)), closes [#19133](https://github.com/bitnami/charts/issues/19133)
+* [bitnami/external-dns] Release 6.24.2 (#19133) ([dd63249](https://github.com/bitnami/charts/commit/dd63249a095ae64db76f0a72dfdb3ebfa367d805)), closes [#19133](https://github.com/bitnami/charts/issues/19133)
 
 ## <small>6.24.1 (2023-08-23)</small>
 
-* [bitnami/external-dns] Fix RFC2136 secret key name (#18768) ([42942c6](https://github.com/bitnami/charts/commit/42942c6)), closes [#18768](https://github.com/bitnami/charts/issues/18768)
+* [bitnami/external-dns] Fix RFC2136 secret key name (#18768) ([42942c6](https://github.com/bitnami/charts/commit/42942c6748b27b734e3336331a38ac111d2a6776)), closes [#18768](https://github.com/bitnami/charts/issues/18768)
 
 ## 6.24.0 (2023-08-23)
 
-* [bitnami/external-dns] Support for customizing standard labels (#18300) ([a0f8f0e](https://github.com/bitnami/charts/commit/a0f8f0e)), closes [#18300](https://github.com/bitnami/charts/issues/18300)
+* [bitnami/external-dns] Support for customizing standard labels (#18300) ([a0f8f0e](https://github.com/bitnami/charts/commit/a0f8f0ea81c60a0a915424184adfc031acf475f8)), closes [#18300](https://github.com/bitnami/charts/issues/18300)
 
 ## <small>6.23.6 (2023-08-19)</small>
 
-* [bitnami/external-dns] Release 6.23.6 (#18656) ([3767ede](https://github.com/bitnami/charts/commit/3767ede)), closes [#18656](https://github.com/bitnami/charts/issues/18656)
+* [bitnami/external-dns] Release 6.23.6 (#18656) ([3767ede](https://github.com/bitnami/charts/commit/3767ede1f81ba032b64e2bb039fef45b41b3f2b5)), closes [#18656](https://github.com/bitnami/charts/issues/18656)
 
 ## <small>6.23.5 (2023-08-17)</small>
 
-* [bitnami/external-dns] Release 6.23.5 updating components versions (#18514) ([6672ab4](https://github.com/bitnami/charts/commit/6672ab4)), closes [#18514](https://github.com/bitnami/charts/issues/18514)
+* [bitnami/external-dns] Release 6.23.5 updating components versions (#18514) ([6672ab4](https://github.com/bitnami/charts/commit/6672ab420d765964aa105fa46aa4c75c0c0c5024)), closes [#18514](https://github.com/bitnami/charts/issues/18514)
 
 ## <small>6.23.4 (2023-08-16)</small>
 
-* [bitnami/external-dns] Fix missing rfc2136.secretName secret key documentation (#17833) ([1937d35](https://github.com/bitnami/charts/commit/1937d35)), closes [#17833](https://github.com/bitnami/charts/issues/17833)
-* [bitnami/external-dns] Release 6.23.4 (#18453) ([5b24813](https://github.com/bitnami/charts/commit/5b24813)), closes [#18453](https://github.com/bitnami/charts/issues/18453)
+* [bitnami/external-dns] Fix missing rfc2136.secretName secret key documentation (#17833) ([1937d35](https://github.com/bitnami/charts/commit/1937d353126cadf81b1e6a19d71930bfb88116c9)), closes [#17833](https://github.com/bitnami/charts/issues/17833)
+* [bitnami/external-dns] Release 6.23.4 (#18453) ([5b24813](https://github.com/bitnami/charts/commit/5b24813ba55b06c3c228225370fe687d6d1b60d5)), closes [#18453](https://github.com/bitnami/charts/issues/18453)
 
 ## <small>6.23.3 (2023-08-09)</small>
 
-* [bitnami/external-dns] Support pod restarts when using gitops (#18059) ([347b13c](https://github.com/bitnami/charts/commit/347b13c)), closes [#18059](https://github.com/bitnami/charts/issues/18059)
+* [bitnami/external-dns] Support pod restarts when using gitops (#18059) ([347b13c](https://github.com/bitnami/charts/commit/347b13c2da46aca0790c09d2ca658fac0741996b)), closes [#18059](https://github.com/bitnami/charts/issues/18059)
 
 ## <small>6.23.2 (2023-08-08)</small>
 
-* [bitnami/external-dns] chore: :page_facing_up: Remove license in CRDs (#18278) ([f0c4330](https://github.com/bitnami/charts/commit/f0c4330)), closes [#18278](https://github.com/bitnami/charts/issues/18278)
+* [bitnami/external-dns] chore: :page_facing_up: Remove license in CRDs (#18278) ([f0c4330](https://github.com/bitnami/charts/commit/f0c4330381f7e5f335a08fa43166a4e3cf8e862d)), closes [#18278](https://github.com/bitnami/charts/issues/18278)
 
 ## <small>6.23.1 (2023-08-08)</small>
 
-* [bitnami/external-dns] chore: :truck: Move crd to templates/crds folder (#18250) ([e4b1f65](https://github.com/bitnami/charts/commit/e4b1f65)), closes [#18250](https://github.com/bitnami/charts/issues/18250)
+* [bitnami/external-dns] chore: :truck: Move crd to templates/crds folder (#18250) ([e4b1f65](https://github.com/bitnami/charts/commit/e4b1f654d2e7b085c2d8cd4da3f46ac50c893604)), closes [#18250](https://github.com/bitnami/charts/issues/18250)
 
 ## 6.23.0 (2023-08-08)
 
-* [bitnami/external-dns] Add support for externalName service (#18213) ([652af22](https://github.com/bitnami/charts/commit/652af22)), closes [#18213](https://github.com/bitnami/charts/issues/18213)
+* [bitnami/external-dns] Add support for externalName service (#18213) ([652af22](https://github.com/bitnami/charts/commit/652af22738ace87049be2bd14c7f722b32b4955c)), closes [#18213](https://github.com/bitnami/charts/issues/18213)
 
 ## 6.22.0 (2023-08-02)
 
-* Add value for filtering managed record types (#18067) ([d1a0958](https://github.com/bitnami/charts/commit/d1a0958)), closes [#18067](https://github.com/bitnami/charts/issues/18067)
+* Add value for filtering managed record types (#18067) ([d1a0958](https://github.com/bitnami/charts/commit/d1a095805e0b7176f52010d5dc07fb3094c8d9d9)), closes [#18067](https://github.com/bitnami/charts/issues/18067)
 
 ## <small>6.21.1 (2023-08-01)</small>
 
-* [bitnami/external-dns] tsig keyname as a variable (#18030) ([1dec242](https://github.com/bitnami/charts/commit/1dec242)), closes [#18030](https://github.com/bitnami/charts/issues/18030)
+* [bitnami/external-dns] tsig keyname as a variable (#18030) ([1dec242](https://github.com/bitnami/charts/commit/1dec242f3b22815eef05966e9537d46e3d447d52)), closes [#18030](https://github.com/bitnami/charts/issues/18030)
 
 ## 6.21.0 (2023-07-28)
 
-* Add value for filtering by IngressClass (#17506) ([25c088a](https://github.com/bitnami/charts/commit/25c088a)), closes [#17506](https://github.com/bitnami/charts/issues/17506)
+* Add value for filtering by IngressClass (#17506) ([25c088a](https://github.com/bitnami/charts/commit/25c088afc7897a497ec2a2cf1c25d23bd28a3745)), closes [#17506](https://github.com/bitnami/charts/issues/17506)
 
 ## <small>6.20.7 (2023-07-27)</small>
 
-* [bitnami/external-dns] Revert pr 17989 (#17990) ([e6fdaa2](https://github.com/bitnami/charts/commit/e6fdaa2)), closes [#17990](https://github.com/bitnami/charts/issues/17990)
+* [bitnami/external-dns] Revert pr 17989 (#17990) ([e6fdaa2](https://github.com/bitnami/charts/commit/e6fdaa25f40821e95eb18f3614f5c7f97c8b6e3e)), closes [#17990](https://github.com/bitnami/charts/issues/17990)
 
 ## <small>6.20.6 (2023-07-27)</small>
 
-* [bitnami/external-dns] Release 6.20.6 (#17989) ([b20aeb4](https://github.com/bitnami/charts/commit/b20aeb4)), closes [#17989](https://github.com/bitnami/charts/issues/17989)
+* [bitnami/external-dns] Release 6.20.6 (#17989) ([b20aeb4](https://github.com/bitnami/charts/commit/b20aeb404e4bf8f4f1d088ce40eeca4974c4bede)), closes [#17989](https://github.com/bitnami/charts/issues/17989)
 
 ## <small>6.20.5 (2023-07-26)</small>
 
-* [bitnami/external-dns] Release 6.20.5 (#17692) ([eff849e](https://github.com/bitnami/charts/commit/eff849e)), closes [#17692](https://github.com/bitnami/charts/issues/17692)
-* Add copyright header (#17300) ([da68be8](https://github.com/bitnami/charts/commit/da68be8)), closes [#17300](https://github.com/bitnami/charts/issues/17300)
-* Update charts readme (#17217) ([31b3c0a](https://github.com/bitnami/charts/commit/31b3c0a)), closes [#17217](https://github.com/bitnami/charts/issues/17217)
+* [bitnami/external-dns] Release 6.20.5 (#17692) ([eff849e](https://github.com/bitnami/charts/commit/eff849ed9b9ebb277f765477e8e2e7f321f04e3b)), closes [#17692](https://github.com/bitnami/charts/issues/17692)
+* Add copyright header (#17300) ([da68be8](https://github.com/bitnami/charts/commit/da68be8e951225133c7dfb572d5101ca3d61c5ae)), closes [#17300](https://github.com/bitnami/charts/issues/17300)
+* Update charts readme (#17217) ([31b3c0a](https://github.com/bitnami/charts/commit/31b3c0afd968ff4429107e34101f7509e6a0e913)), closes [#17217](https://github.com/bitnami/charts/issues/17217)
 
 ## <small>6.20.4 (2023-06-21)</small>
 
-* [bitnami/*] Change copyright section in READMEs (#17006) ([ef986a1](https://github.com/bitnami/charts/commit/ef986a1)), closes [#17006](https://github.com/bitnami/charts/issues/17006)
-* [bitnami/several] Change copyright section in READMEs (#16989) ([5b6a5cf](https://github.com/bitnami/charts/commit/5b6a5cf)), closes [#16989](https://github.com/bitnami/charts/issues/16989)
-* Fix errors (#17276) ([7a21b04](https://github.com/bitnami/charts/commit/7a21b04)), closes [#17276](https://github.com/bitnami/charts/issues/17276)
+* [bitnami/*] Change copyright section in READMEs (#17006) ([ef986a1](https://github.com/bitnami/charts/commit/ef986a1605241102b3dcafe9fd8089e6fc1201ad)), closes [#17006](https://github.com/bitnami/charts/issues/17006)
+* [bitnami/several] Change copyright section in READMEs (#16989) ([5b6a5cf](https://github.com/bitnami/charts/commit/5b6a5cfb7625a751848a2e5cd796bd7278f406ca)), closes [#16989](https://github.com/bitnami/charts/issues/16989)
+* Fix errors (#17276) ([7a21b04](https://github.com/bitnami/charts/commit/7a21b04507e74bb0ad095441fd1028f57bf381f7)), closes [#17276](https://github.com/bitnami/charts/issues/17276)
 
 ## <small>6.20.3 (2023-05-23)</small>
 
-* [bitnami/external-dns] add missing clusterrole permissions for gateway api (#16860) ([abc31a7](https://github.com/bitnami/charts/commit/abc31a7)), closes [#16860](https://github.com/bitnami/charts/issues/16860)
+* [bitnami/external-dns] add missing clusterrole permissions for gateway api (#16860) ([abc31a7](https://github.com/bitnami/charts/commit/abc31a77137becff5757000384118c75e4757410)), closes [#16860](https://github.com/bitnami/charts/issues/16860)
 
 ## <small>6.20.2 (2023-05-21)</small>
 
-* [bitnami/external-dns] Release 6.20.2 (#16763) ([2a61582](https://github.com/bitnami/charts/commit/2a61582)), closes [#16763](https://github.com/bitnami/charts/issues/16763)
+* [bitnami/external-dns] Release 6.20.2 (#16763) ([2a61582](https://github.com/bitnami/charts/commit/2a61582a4f955d4f175fc789cc184feb53c0cff2)), closes [#16763](https://github.com/bitnami/charts/issues/16763)
 
 ## <small>6.20.1 (2023-05-11)</small>
 
-* Add wording for enterprise page (#16560) ([8f22774](https://github.com/bitnami/charts/commit/8f22774)), closes [#16560](https://github.com/bitnami/charts/issues/16560)
-* Fix External DNS securityContext example (#16568) ([9588b32](https://github.com/bitnami/charts/commit/9588b32)), closes [#16568](https://github.com/bitnami/charts/issues/16568)
+* Add wording for enterprise page (#16560) ([8f22774](https://github.com/bitnami/charts/commit/8f2277440b976d52785ba9149762ad8620a73d1f)), closes [#16560](https://github.com/bitnami/charts/issues/16560)
+* Fix External DNS securityContext example (#16568) ([9588b32](https://github.com/bitnami/charts/commit/9588b32876a90c5ff736008a93c426e5307870bb)), closes [#16568](https://github.com/bitnami/charts/issues/16568)
 
 ## 6.20.0 (2023-05-09)
 
-* [bitnami/several] Adapt Chart.yaml to set desired OCI annotations (#16546) ([fc9b18f](https://github.com/bitnami/charts/commit/fc9b18f)), closes [#16546](https://github.com/bitnami/charts/issues/16546)
+* [bitnami/several] Adapt Chart.yaml to set desired OCI annotations (#16546) ([fc9b18f](https://github.com/bitnami/charts/commit/fc9b18f2e98805d4df629acbcde696f44f973344)), closes [#16546](https://github.com/bitnami/charts/issues/16546)
 
 ## <small>6.19.2 (2023-05-09)</small>
 
-* [bitnami/external-dns] Release 6.19.2 (#16458) ([6de909f](https://github.com/bitnami/charts/commit/6de909f)), closes [#16458](https://github.com/bitnami/charts/issues/16458)
+* [bitnami/external-dns] Release 6.19.2 (#16458) ([6de909f](https://github.com/bitnami/charts/commit/6de909f2a2fc6a45f5fdecc7cd511e205c6a11aa)), closes [#16458](https://github.com/bitnami/charts/issues/16458)
 
 ## <small>6.19.1 (2023-05-01)</small>
 
-* [bitnami/external-dns] Release 6.19.1 (#16292) ([97f7b2b](https://github.com/bitnami/charts/commit/97f7b2b)), closes [#16292](https://github.com/bitnami/charts/issues/16292)
+* [bitnami/external-dns] Release 6.19.1 (#16292) ([97f7b2b](https://github.com/bitnami/charts/commit/97f7b2bfcad77b887f18ef4068a756fc5d441336)), closes [#16292](https://github.com/bitnami/charts/issues/16292)
 
 ## 6.19.0 (2023-04-20)
 
-* [bitnami/*] Make Helm charts 100% OCI (#15998) ([8841510](https://github.com/bitnami/charts/commit/8841510)), closes [#15998](https://github.com/bitnami/charts/issues/15998)
+* [bitnami/*] Make Helm charts 100% OCI (#15998) ([8841510](https://github.com/bitnami/charts/commit/884151035efcbf2e1b3206e7def85511073fb57d)), closes [#15998](https://github.com/bitnami/charts/issues/15998)
 
 ## 6.18.0 (2023-04-14)
 
-* [bitnami/external-dns] add infoblox.nameRegex parameter (#16035) ([06102c8](https://github.com/bitnami/charts/commit/06102c8)), closes [#16035](https://github.com/bitnami/charts/issues/16035)
+* [bitnami/external-dns] add infoblox.nameRegex parameter (#16035) ([06102c8](https://github.com/bitnami/charts/commit/06102c8a0b0ab778857eb2338b19ff0cdd0ac166)), closes [#16035](https://github.com/bitnami/charts/issues/16035)
 
 ## 6.17.0 (2023-04-06)
 
-* [bitnami/external-dns] Add RBAC to support F5 VirtualServer external-dns source (#15804) ([7f55815](https://github.com/bitnami/charts/commit/7f55815)), closes [#15804](https://github.com/bitnami/charts/issues/15804)
-* [bitnami/external-dns] Bump chart version (#15968) ([e783031](https://github.com/bitnami/charts/commit/e783031)), closes [#15968](https://github.com/bitnami/charts/issues/15968)
+* [bitnami/external-dns] Add RBAC to support F5 VirtualServer external-dns source (#15804) ([7f55815](https://github.com/bitnami/charts/commit/7f55815b7a3e50bcf9ae90c18a72029b19da90bc)), closes [#15804](https://github.com/bitnami/charts/issues/15804)
+* [bitnami/external-dns] Bump chart version (#15968) ([e783031](https://github.com/bitnami/charts/commit/e783031ea4783ed968dc53e7d6571d41ef89b411)), closes [#15968](https://github.com/bitnami/charts/issues/15968)
 
 ## 6.16.0 (2023-04-03)
 
-* Add exoscale external dns values (#15837) ([8facec5](https://github.com/bitnami/charts/commit/8facec5)), closes [#15837](https://github.com/bitnami/charts/issues/15837)
+* Add exoscale external dns values (#15837) ([8facec5](https://github.com/bitnami/charts/commit/8facec56de443c548f498ddbac62658158da84ad)), closes [#15837](https://github.com/bitnami/charts/issues/15837)
 
 ## <small>6.15.1 (2023-04-01)</small>
 
-* [bitnami/external-dns] Release 6.15.1 (#15847) ([34f5acd](https://github.com/bitnami/charts/commit/34f5acd)), closes [#15847](https://github.com/bitnami/charts/issues/15847)
+* [bitnami/external-dns] Release 6.15.1 (#15847) ([34f5acd](https://github.com/bitnami/charts/commit/34f5acd734fe6ef9284f65ef48b1e2c22284d942)), closes [#15847](https://github.com/bitnami/charts/issues/15847)
 
 ## 6.15.0 (2023-03-28)
 
-* [bitnami/external-dns] Add support for Gateway API (#15465) ([f32c397](https://github.com/bitnami/charts/commit/f32c397)), closes [#15465](https://github.com/bitnami/charts/issues/15465)
+* [bitnami/external-dns] Add support for Gateway API (#15465) ([f32c397](https://github.com/bitnami/charts/commit/f32c397690142236f00a97a428eee10fe4893ab0)), closes [#15465](https://github.com/bitnami/charts/issues/15465)
 
 ## <small>6.14.5 (2023-03-28)</small>
 
-* [bitnami/external-dns] Release 6.14.5 (#15763) ([1a6df08](https://github.com/bitnami/charts/commit/1a6df08)), closes [#15763](https://github.com/bitnami/charts/issues/15763)
+* [bitnami/external-dns] Release 6.14.5 (#15763) ([1a6df08](https://github.com/bitnami/charts/commit/1a6df08bae0a983266bca88ada41e0633151a898)), closes [#15763](https://github.com/bitnami/charts/issues/15763)
 
 ## <small>6.14.4 (2023-03-18)</small>
 
-* [bitnami/external-dns] Release 6.14.4 (#15564) ([cc8b9ff](https://github.com/bitnami/charts/commit/cc8b9ff)), closes [#15564](https://github.com/bitnami/charts/issues/15564)
+* [bitnami/external-dns] Release 6.14.4 (#15564) ([cc8b9ff](https://github.com/bitnami/charts/commit/cc8b9ff539f1d5cb4bd66f3dc0dbfb7ee49afc88)), closes [#15564](https://github.com/bitnami/charts/issues/15564)
 
 ## <small>6.14.3 (2023-03-10)</small>
 
-* [bitnami/external-dns] fix image.digest (#15414) ([d16d6d9](https://github.com/bitnami/charts/commit/d16d6d9)), closes [#15414](https://github.com/bitnami/charts/issues/15414)
+* [bitnami/external-dns] fix image.digest (#15414) ([d16d6d9](https://github.com/bitnami/charts/commit/d16d6d9b6de04338d67d1b466793de4de7e72854)), closes [#15414](https://github.com/bitnami/charts/issues/15414)
 
 ## <small>6.14.2 (2023-03-08)</small>
 
-* [bitnami/charts] Apply linter to README files (#15357) ([0e29e60](https://github.com/bitnami/charts/commit/0e29e60)), closes [#15357](https://github.com/bitnami/charts/issues/15357)
-* [bitnami/external-dns] Release 6.14.2 (#15401) ([4530213](https://github.com/bitnami/charts/commit/4530213)), closes [#15401](https://github.com/bitnami/charts/issues/15401)
+* [bitnami/charts] Apply linter to README files (#15357) ([0e29e60](https://github.com/bitnami/charts/commit/0e29e600d3adc8b1b46e506eccb3decfab3b4e63)), closes [#15357](https://github.com/bitnami/charts/issues/15357)
+* [bitnami/external-dns] Release 6.14.2 (#15401) ([4530213](https://github.com/bitnami/charts/commit/45302130a7c916d9201442a5ec5163165bdcce44)), closes [#15401](https://github.com/bitnami/charts/issues/15401)
 
 ## <small>6.14.1 (2023-03-01)</small>
 
-* [bitnami/external-dns] Release 6.14.1 (#15239) ([d413edc](https://github.com/bitnami/charts/commit/d413edc)), closes [#15239](https://github.com/bitnami/charts/issues/15239)
+* [bitnami/external-dns] Release 6.14.1 (#15239) ([d413edc](https://github.com/bitnami/charts/commit/d413edc9bd423aa64a0c462be17d2e28b7b0b026)), closes [#15239](https://github.com/bitnami/charts/issues/15239)
 
 ## 6.14.0 (2023-02-20)
 
-* [bitnami/external-dns] Allow env variables to authenticate in AWS. (#14940) ([96b1887](https://github.com/bitnami/charts/commit/96b1887)), closes [#14940](https://github.com/bitnami/charts/issues/14940)
+* [bitnami/external-dns] Allow env variables to authenticate in AWS. (#14940) ([96b1887](https://github.com/bitnami/charts/commit/96b18873ffde02c34383b0bc66ce96e25a6a86d0)), closes [#14940](https://github.com/bitnami/charts/issues/14940)
 
 ## <small>6.13.4 (2023-02-17)</small>
 
-* [bitnami/*] Fix markdown linter issues (#14874) ([a51e0e8](https://github.com/bitnami/charts/commit/a51e0e8)), closes [#14874](https://github.com/bitnami/charts/issues/14874)
-* [bitnami/*] Fix markdown linter issues 2 (#14890) ([aa96572](https://github.com/bitnami/charts/commit/aa96572)), closes [#14890](https://github.com/bitnami/charts/issues/14890)
-* [bitnami/*] Remove unexpected extra spaces (#14873) ([c97c714](https://github.com/bitnami/charts/commit/c97c714)), closes [#14873](https://github.com/bitnami/charts/issues/14873)
-* [bitnami/external-dns] Release 6.13.4 (#14954) ([3614a90](https://github.com/bitnami/charts/commit/3614a90)), closes [#14954](https://github.com/bitnami/charts/issues/14954)
+* [bitnami/*] Fix markdown linter issues (#14874) ([a51e0e8](https://github.com/bitnami/charts/commit/a51e0e8d35495b907f3e70dd2f8e7c3bcbf4166a)), closes [#14874](https://github.com/bitnami/charts/issues/14874)
+* [bitnami/*] Fix markdown linter issues 2 (#14890) ([aa96572](https://github.com/bitnami/charts/commit/aa9657237ee8df4a46db0d7fdf8a23230dd6902a)), closes [#14890](https://github.com/bitnami/charts/issues/14890)
+* [bitnami/*] Remove unexpected extra spaces (#14873) ([c97c714](https://github.com/bitnami/charts/commit/c97c714887380d47eae7bfeff316bf01595ecd1d)), closes [#14873](https://github.com/bitnami/charts/issues/14873)
+* [bitnami/external-dns] Release 6.13.4 (#14954) ([3614a90](https://github.com/bitnami/charts/commit/3614a90c66c1f91419d9ccd6148f884d30578330)), closes [#14954](https://github.com/bitnami/charts/issues/14954)
 
 ## <small>6.13.3 (2023-02-13)</small>
 
-* [bitnami/*] Change copyright date (#14682) ([add4ec7](https://github.com/bitnami/charts/commit/add4ec7)), closes [#14682](https://github.com/bitnami/charts/issues/14682)
-* [bitnami/external-dns] Release 6.13.3 (#14857) ([59d1205](https://github.com/bitnami/charts/commit/59d1205)), closes [#14857](https://github.com/bitnami/charts/issues/14857)
+* [bitnami/*] Change copyright date (#14682) ([add4ec7](https://github.com/bitnami/charts/commit/add4ec701108ac36ed4de2dffbdf407a0d091067)), closes [#14682](https://github.com/bitnami/charts/issues/14682)
+* [bitnami/external-dns] Release 6.13.3 (#14857) ([59d1205](https://github.com/bitnami/charts/commit/59d12053e4daa10654a2f36146040ddb79d87e89)), closes [#14857](https://github.com/bitnami/charts/issues/14857)
 
 ## <small>6.13.2 (2023-01-31)</small>
 
-* [bitnami/*] Change licenses annotation format (#14377) ([0ab7608](https://github.com/bitnami/charts/commit/0ab7608)), closes [#14377](https://github.com/bitnami/charts/issues/14377)
-* [bitnami/*] Unify READMEs (#14472) ([2064fb8](https://github.com/bitnami/charts/commit/2064fb8)), closes [#14472](https://github.com/bitnami/charts/issues/14472)
-* [bitnami/external-dns] Don't regenerate self-signed certs on upgrade (#14619) ([8446587](https://github.com/bitnami/charts/commit/8446587)), closes [#14619](https://github.com/bitnami/charts/issues/14619)
+* [bitnami/*] Change licenses annotation format (#14377) ([0ab7608](https://github.com/bitnami/charts/commit/0ab760862c660fcc78cffadf8e1d8cdd70881473)), closes [#14377](https://github.com/bitnami/charts/issues/14377)
+* [bitnami/*] Unify READMEs (#14472) ([2064fb8](https://github.com/bitnami/charts/commit/2064fb8dcc78a845cdede8211af8c3cc52551161)), closes [#14472](https://github.com/bitnami/charts/issues/14472)
+* [bitnami/external-dns] Don't regenerate self-signed certs on upgrade (#14619) ([8446587](https://github.com/bitnami/charts/commit/84465878f9d846f443ee55515e0fef8523362418)), closes [#14619](https://github.com/bitnami/charts/issues/14619)
 
 ## <small>6.13.1 (2023-01-14)</small>
 
-* [bitnami/*] Add license annotation and remove obsolete engine parameter (#14293) ([da2a794](https://github.com/bitnami/charts/commit/da2a794)), closes [#14293](https://github.com/bitnami/charts/issues/14293)
-* [bitnami/external-dns] Release 6.13.1 (#14360) ([2188525](https://github.com/bitnami/charts/commit/2188525)), closes [#14360](https://github.com/bitnami/charts/issues/14360)
+* [bitnami/*] Add license annotation and remove obsolete engine parameter (#14293) ([da2a794](https://github.com/bitnami/charts/commit/da2a7943bae95b6e9b5b4ed972c15e990b69fdb0)), closes [#14293](https://github.com/bitnami/charts/issues/14293)
+* [bitnami/external-dns] Release 6.13.1 (#14360) ([2188525](https://github.com/bitnami/charts/commit/2188525dcda32a9f15bf3f659d63f15a002ccb87)), closes [#14360](https://github.com/bitnami/charts/issues/14360)
 
 ## 6.13.0 (2023-01-11)
 
-* [bitnami/external-dns] Add support for DaemonSet (#14080) ([f198be0](https://github.com/bitnami/charts/commit/f198be0)), closes [#14080](https://github.com/bitnami/charts/issues/14080)
+* [bitnami/external-dns] Add support for DaemonSet (#14080) ([f198be0](https://github.com/bitnami/charts/commit/f198be077f2b5abb633f36adeef9dc42b3cca6d4)), closes [#14080](https://github.com/bitnami/charts/issues/14080)
 
 ## <small>6.12.3 (2023-01-09)</small>
 
-* scaleway: remove useless defaultorganizationid parameter (#14159) ([03df18b](https://github.com/bitnami/charts/commit/03df18b)), closes [#14159](https://github.com/bitnami/charts/issues/14159)
+* scaleway: remove useless defaultorganizationid parameter (#14159) ([03df18b](https://github.com/bitnami/charts/commit/03df18b0ea897770e617efb6c8321513afbdc9a8)), closes [#14159](https://github.com/bitnami/charts/issues/14159)
 
 ## <small>6.12.2 (2022-12-19)</small>
 
-* [bitnami/external-dns] Release 6.12.2 (#14035) ([d6a59b5](https://github.com/bitnami/charts/commit/d6a59b5)), closes [#14035](https://github.com/bitnami/charts/issues/14035)
+* [bitnami/external-dns] Release 6.12.2 (#14035) ([d6a59b5](https://github.com/bitnami/charts/commit/d6a59b58973899418b588a2f9c2f0cc1e3e767ce)), closes [#14035](https://github.com/bitnami/charts/issues/14035)
 
 ## <small>6.12.1 (2022-11-19)</small>
 
-* [bitnami/external-dns] Release 6.12.1 (#13608) ([e0f7aa9](https://github.com/bitnami/charts/commit/e0f7aa9)), closes [#13608](https://github.com/bitnami/charts/issues/13608)
+* [bitnami/external-dns] Release 6.12.1 (#13608) ([e0f7aa9](https://github.com/bitnami/charts/commit/e0f7aa9728845240841d05510b9a113182de2fc4)), closes [#13608](https://github.com/bitnami/charts/issues/13608)
 
 ## 6.12.0 (2022-11-15)
 
-* [bitnami/external-dns] Add support for google provider batch change size (#13489) ([a676dfc](https://github.com/bitnami/charts/commit/a676dfc)), closes [#13489](https://github.com/bitnami/charts/issues/13489)
+* [bitnami/external-dns] Add support for google provider batch change size (#13489) ([a676dfc](https://github.com/bitnami/charts/commit/a676dfc79cf0e4f7c779cc939ad8d5d5aa09d9d5)), closes [#13489](https://github.com/bitnami/charts/issues/13489)
 
 ## <small>6.11.3 (2022-11-02)</small>
 
-* adjust the naming style for resources to make them not pass the length limit (#13277) ([320add1](https://github.com/bitnami/charts/commit/320add1)), closes [#13277](https://github.com/bitnami/charts/issues/13277)
+* adjust the naming style for resources to make them not pass the length limit (#13277) ([320add1](https://github.com/bitnami/charts/commit/320add1f95c41c7878cf955a691e4664a2f1e78b)), closes [#13277](https://github.com/bitnami/charts/issues/13277)
 
 ## <small>6.11.2 (2022-10-20)</small>
 
-* [bitnami/external-dns] Release 6.11.2 (#13059) ([a9db70e](https://github.com/bitnami/charts/commit/a9db70e)), closes [#13059](https://github.com/bitnami/charts/issues/13059)
+* [bitnami/external-dns] Release 6.11.2 (#13059) ([a9db70e](https://github.com/bitnami/charts/commit/a9db70e6ddcd23839952bdebc8d3b3072c56d853)), closes [#13059](https://github.com/bitnami/charts/issues/13059)
 
 ## <small>6.11.1 (2022-10-20)</small>
 
-* [bitnami/external-dns] Release 6.11.1 updating components versions (#13051) ([29e1c1d](https://github.com/bitnami/charts/commit/29e1c1d)), closes [#13051](https://github.com/bitnami/charts/issues/13051)
+* [bitnami/external-dns] Release 6.11.1 updating components versions (#13051) ([29e1c1d](https://github.com/bitnami/charts/commit/29e1c1dbf5e6808c21da0f552eb2103673ace54d)), closes [#13051](https://github.com/bitnami/charts/issues/13051)
 
 ## 6.11.0 (2022-10-20)
 
-* [bitname/external-dns] Support designate application credentials for external-dns (#12948) ([1be613b](https://github.com/bitnami/charts/commit/1be613b)), closes [#12948](https://github.com/bitnami/charts/issues/12948)
-* [bitnami/*] Use new default branch name in links (#12943) ([a529e02](https://github.com/bitnami/charts/commit/a529e02)), closes [#12943](https://github.com/bitnami/charts/issues/12943)
-* Generic README instructions related to the repo (#12792) ([3cf6b10](https://github.com/bitnami/charts/commit/3cf6b10)), closes [#12792](https://github.com/bitnami/charts/issues/12792)
+* [bitname/external-dns] Support designate application credentials for external-dns (#12948) ([1be613b](https://github.com/bitnami/charts/commit/1be613b2a8aa365917941c2d29f969a6b809502e)), closes [#12948](https://github.com/bitnami/charts/issues/12948)
+* [bitnami/*] Use new default branch name in links (#12943) ([a529e02](https://github.com/bitnami/charts/commit/a529e02597d49d944eba1eb0f190713293247176)), closes [#12943](https://github.com/bitnami/charts/issues/12943)
+* Generic README instructions related to the repo (#12792) ([3cf6b10](https://github.com/bitnami/charts/commit/3cf6b10e10e60df4b3e191d6b99aa99a9f597755)), closes [#12792](https://github.com/bitnami/charts/issues/12792)
 
 ## <small>6.10.2 (2022-10-04)</small>
 
-* [bitnami/external-dns] Use custom probes if given (#12495) ([78fe718](https://github.com/bitnami/charts/commit/78fe718)), closes [#12495](https://github.com/bitnami/charts/issues/12495) [#12354](https://github.com/bitnami/charts/issues/12354)
+* [bitnami/external-dns] Use custom probes if given (#12495) ([78fe718](https://github.com/bitnami/charts/commit/78fe718bd464f0bf516b9b420c10891cb178b515)), closes [#12495](https://github.com/bitnami/charts/issues/12495) [#12354](https://github.com/bitnami/charts/issues/12354)
 
 ## <small>6.10.1 (2022-09-28)</small>
 
-* [bitnami/external-dns] Release 6.10.1 (#12712) ([c42088c](https://github.com/bitnami/charts/commit/c42088c)), closes [#12712](https://github.com/bitnami/charts/issues/12712)
+* [bitnami/external-dns] Release 6.10.1 (#12712) ([c42088c](https://github.com/bitnami/charts/commit/c42088c942ce7bc5f7066861abf52d23046dbc70)), closes [#12712](https://github.com/bitnami/charts/issues/12712)
 
 ## 6.10.0 (2022-09-26)
 
-* [bitnami/external-dns] add PodMonitor to support Google Managed Prometheus (#12638) ([2235e5d](https://github.com/bitnami/charts/commit/2235e5d)), closes [#12638](https://github.com/bitnami/charts/issues/12638)
+* [bitnami/external-dns] add PodMonitor to support Google Managed Prometheus (#12638) ([2235e5d](https://github.com/bitnami/charts/commit/2235e5dbcf0afc4310b1eb3af3850fea4fcdb720)), closes [#12638](https://github.com/bitnami/charts/issues/12638)
 
 ## 6.9.0 (2022-09-16)
 
-* [bitnami/external-dns] Add support for Akamai provider (#12431) ([12e2a1d](https://github.com/bitnami/charts/commit/12e2a1d)), closes [#12431](https://github.com/bitnami/charts/issues/12431)
+* [bitnami/external-dns] Add support for Akamai provider (#12431) ([12e2a1d](https://github.com/bitnami/charts/commit/12e2a1d190bfa4bd4a700c8f6b5ae459251d4083)), closes [#12431](https://github.com/bitnami/charts/issues/12431)
 
 ## <small>6.8.2 (2022-09-08)</small>
 
-* [bitnami/external-dns] Release 6.8.2 (#12322) ([d98d277](https://github.com/bitnami/charts/commit/d98d277)), closes [#12322](https://github.com/bitnami/charts/issues/12322)
+* [bitnami/external-dns] Release 6.8.2 (#12322) ([d98d277](https://github.com/bitnami/charts/commit/d98d277e6403ca6acce0192a6077bd4cfb664191)), closes [#12322](https://github.com/bitnami/charts/issues/12322)
 
 ## <small>6.8.1 (2022-08-23)</small>
 
-* [bitnami/external-dns] Update Chart.lock (#12031) ([90af4d0](https://github.com/bitnami/charts/commit/90af4d0)), closes [#12031](https://github.com/bitnami/charts/issues/12031)
+* [bitnami/external-dns] Update Chart.lock (#12031) ([90af4d0](https://github.com/bitnami/charts/commit/90af4d0f30f73cafae2112f74ac525c71a1efcde)), closes [#12031](https://github.com/bitnami/charts/issues/12031)
 
 ## 6.8.0 (2022-08-22)
 
-* [bitnami/external-dns] Add support for image digest apart from tag (#11881) ([a28bf07](https://github.com/bitnami/charts/commit/a28bf07)), closes [#11881](https://github.com/bitnami/charts/issues/11881)
+* [bitnami/external-dns] Add support for image digest apart from tag (#11881) ([a28bf07](https://github.com/bitnami/charts/commit/a28bf071e625a75ba1972bc7e053696b1da8e99c)), closes [#11881](https://github.com/bitnami/charts/issues/11881)
 
 ## <small>6.7.5 (2022-08-09)</small>
 
-* [bitnami/external-dns] Release 6.7.5 (#11654) ([a81eb54](https://github.com/bitnami/charts/commit/a81eb54)), closes [#11654](https://github.com/bitnami/charts/issues/11654)
+* [bitnami/external-dns] Release 6.7.5 (#11654) ([a81eb54](https://github.com/bitnami/charts/commit/a81eb543828e98f226e7ddd15f0ba081edb7695b)), closes [#11654](https://github.com/bitnami/charts/issues/11654)
 
 ## <small>6.7.4 (2022-08-04)</small>
 
-* [bitnami/external-dns] Release 6.7.4 (#11574) ([0822c88](https://github.com/bitnami/charts/commit/0822c88)), closes [#11574](https://github.com/bitnami/charts/issues/11574)
+* [bitnami/external-dns] Release 6.7.4 (#11574) ([0822c88](https://github.com/bitnami/charts/commit/0822c882634c0c2cfe90d8cdef3b60230148b128)), closes [#11574](https://github.com/bitnami/charts/issues/11574)
 
 ## <small>6.7.3 (2022-08-03)</small>
 
-* [bitnami/external-dns] Release 6.7.3 (#11530) ([e130aeb](https://github.com/bitnami/charts/commit/e130aeb)), closes [#11530](https://github.com/bitnami/charts/issues/11530)
+* [bitnami/external-dns] Release 6.7.3 (#11530) ([e130aeb](https://github.com/bitnami/charts/commit/e130aeb046a23e5410068ac9baec047a5cfcaf2c)), closes [#11530](https://github.com/bitnami/charts/issues/11530)
 
 ## <small>6.7.2 (2022-07-27)</small>
 
-* [bitnami/*] Update URLs to point to the new bitnami/containers monorepo (#11352) ([d665af0](https://github.com/bitnami/charts/commit/d665af0)), closes [#11352](https://github.com/bitnami/charts/issues/11352)
-* [bitnami/external-dns] Release 6.7.2 (#11381) ([53ae3cb](https://github.com/bitnami/charts/commit/53ae3cb)), closes [#11381](https://github.com/bitnami/charts/issues/11381)
+* [bitnami/*] Update URLs to point to the new bitnami/containers monorepo (#11352) ([d665af0](https://github.com/bitnami/charts/commit/d665af0c708846192d8d5fb2f5f9ea65dd464ab0)), closes [#11352](https://github.com/bitnami/charts/issues/11352)
+* [bitnami/external-dns] Release 6.7.2 (#11381) ([53ae3cb](https://github.com/bitnami/charts/commit/53ae3cbe30800abb743ac0bb073abc34f894454f)), closes [#11381](https://github.com/bitnami/charts/issues/11381)
 
 ## <small>6.7.1 (2022-07-24)</small>
 
-* [bitnami/external-dns] Release 6.7.1 (#11327) ([1dcadee](https://github.com/bitnami/charts/commit/1dcadee)), closes [#11327](https://github.com/bitnami/charts/issues/11327)
+* [bitnami/external-dns] Release 6.7.1 (#11327) ([1dcadee](https://github.com/bitnami/charts/commit/1dcadee79ad22f754d234f4b7d95134c747bc472)), closes [#11327](https://github.com/bitnami/charts/issues/11327)
 
 ## 6.7.0 (2022-07-20)
 
-* [bitnami/external-dns] add support for custom serviceAccount.labels (#11251) ([c863b03](https://github.com/bitnami/charts/commit/c863b03)), closes [#11251](https://github.com/bitnami/charts/issues/11251)
+* [bitnami/external-dns] add support for custom serviceAccount.labels (#11251) ([c863b03](https://github.com/bitnami/charts/commit/c863b03390e16b9b802b9da638794816cd7e4259)), closes [#11251](https://github.com/bitnami/charts/issues/11251)
 
 ## <small>6.6.1 (2022-07-13)</small>
 
-* [bitnami/external-dns] Fix issue with psp-cluster-role (#11093) ([eba1da7](https://github.com/bitnami/charts/commit/eba1da7)), closes [#11093](https://github.com/bitnami/charts/issues/11093)
+* [bitnami/external-dns] Fix issue with psp-cluster-role (#11093) ([eba1da7](https://github.com/bitnami/charts/commit/eba1da7ca4988a705ef3f6718549b1931f10ae03)), closes [#11093](https://github.com/bitnami/charts/issues/11093)
 
 ## 6.6.0 (2022-07-05)
 
-* [bitnami/external-dns] Modify Cluster wide resources naming and add Helm Chart tests (#10679) ([de4f399](https://github.com/bitnami/charts/commit/de4f399)), closes [#10679](https://github.com/bitnami/charts/issues/10679)
+* [bitnami/external-dns] Modify Cluster wide resources naming and add Helm Chart tests (#10679) ([de4f399](https://github.com/bitnami/charts/commit/de4f3996ed7798f360e43a019afc7a36624bbafd)), closes [#10679](https://github.com/bitnami/charts/issues/10679)
 
 ## <small>6.5.7 (2022-06-30)</small>
 
-* [bitnami/external-dns] Release 6.5.7 updating components versions ([4344b85](https://github.com/bitnami/charts/commit/4344b85))
+* [bitnami/external-dns] Release 6.5.7 updating components versions ([4344b85](https://github.com/bitnami/charts/commit/4344b857ceed103453db040929a3a58fc3182676))
 
 ## <small>6.5.6 (2022-06-14)</small>
 
-* [bitnami/external-dns] Add missing commonLabels in some resources (#10739) ([9473832](https://github.com/bitnami/charts/commit/9473832)), closes [#10739](https://github.com/bitnami/charts/issues/10739)
+* [bitnami/external-dns] Add missing commonLabels in some resources (#10739) ([9473832](https://github.com/bitnami/charts/commit/94738321119299adb2777fe48ebf92ca51fb2dfd)), closes [#10739](https://github.com/bitnami/charts/issues/10739)
 
 ## <small>6.5.5 (2022-06-10)</small>
 
-* [bitnami/external-dns] Release 6.5.5 updating components versions ([df85df4](https://github.com/bitnami/charts/commit/df85df4))
+* [bitnami/external-dns] Release 6.5.5 updating components versions ([df85df4](https://github.com/bitnami/charts/commit/df85df4c0a45b82481a4d468cffef70b36be292e))
 
 ## <small>6.5.4 (2022-06-09)</small>
 
-* [bitnami/*] Replace Kubeapps URL in READMEs (and kubeapps Chart.yaml) and remove BKPR references (#1 ([c6a7914](https://github.com/bitnami/charts/commit/c6a7914)), closes [#10600](https://github.com/bitnami/charts/issues/10600)
-* [bitnami/external-dns] Allow watching release namespace without hardcoding it, when `clusterRole: tr ([312019f](https://github.com/bitnami/charts/commit/312019f)), closes [#10672](https://github.com/bitnami/charts/issues/10672)
+* [bitnami/*] Replace Kubeapps URL in READMEs (and kubeapps Chart.yaml) and remove BKPR references (#1 ([c6a7914](https://github.com/bitnami/charts/commit/c6a7914361e5aea6016fb45bf4d621edfd111d32)), closes [#10600](https://github.com/bitnami/charts/issues/10600)
+* [bitnami/external-dns] Allow watching release namespace without hardcoding it, when `clusterRole: tr ([312019f](https://github.com/bitnami/charts/commit/312019f01a15e0bfade1a53e618f5e02e2ddde15)), closes [#10672](https://github.com/bitnami/charts/issues/10672)
 
 ## <small>6.5.3 (2022-06-06)</small>
 
-* [bitnami/external-dns] Release 6.5.3 updating components versions ([dd9cfea](https://github.com/bitnami/charts/commit/dd9cfea))
+* [bitnami/external-dns] Release 6.5.3 updating components versions ([dd9cfea](https://github.com/bitnami/charts/commit/dd9cfea4538974a48d6335cf539626658277bc71))
 
 ## <small>6.5.2 (2022-06-01)</small>
 
-* [bitnami/several] Replace maintainers email by url (#10523) ([ff3cf61](https://github.com/bitnami/charts/commit/ff3cf61)), closes [#10523](https://github.com/bitnami/charts/issues/10523)
+* [bitnami/several] Replace maintainers email by url (#10523) ([ff3cf61](https://github.com/bitnami/charts/commit/ff3cf617a1680509b0f3855d17c4ccff7b29a0ff)), closes [#10523](https://github.com/bitnami/charts/issues/10523)
 
 ## <small>6.5.1 (2022-05-28)</small>
 
-* [bitnami/external-dns] Fix duplicated service type (#10469) ([9e9eaff](https://github.com/bitnami/charts/commit/9e9eaff)), closes [#10469](https://github.com/bitnami/charts/issues/10469)
+* [bitnami/external-dns] Fix duplicated service type (#10469) ([9e9eaff](https://github.com/bitnami/charts/commit/9e9eaff0a3ca7f1dc2784920face2e4d0fc350a7)), closes [#10469](https://github.com/bitnami/charts/issues/10469)
 
 ## 6.5.0 (2022-05-27)
 
-* [bitnami/external-dns] Add missing service parameter + fixes (#10408) ([475e4a0](https://github.com/bitnami/charts/commit/475e4a0)), closes [#10408](https://github.com/bitnami/charts/issues/10408)
+* [bitnami/external-dns] Add missing service parameter + fixes (#10408) ([475e4a0](https://github.com/bitnami/charts/commit/475e4a062daa01455dafe188d491b540e9fb8506)), closes [#10408](https://github.com/bitnami/charts/issues/10408)
 
 ## <small>6.4.6 (2022-05-27)</small>
 
-* [bitnami/external-dns] Release 6.4.6 updating components versions ([2e363a3](https://github.com/bitnami/charts/commit/2e363a3))
+* [bitnami/external-dns] Release 6.4.6 updating components versions ([2e363a3](https://github.com/bitnami/charts/commit/2e363a39815a39d5252e5277c4f1a912cb38ad6d))
 
 ## <small>6.4.5 (2022-05-26)</small>
 
-* [bitnami/external-dns] Fix YAML syntax (#10375) ([527568b](https://github.com/bitnami/charts/commit/527568b)), closes [#10375](https://github.com/bitnami/charts/issues/10375)
+* [bitnami/external-dns] Fix YAML syntax (#10375) ([527568b](https://github.com/bitnami/charts/commit/527568b2c9f327452e453d02fcaf9bc6e951e525)), closes [#10375](https://github.com/bitnami/charts/issues/10375)
 
 ## <small>6.4.4 (2022-05-21)</small>
 
-* [bitnami/external-dns] Release 6.4.4 updating components versions ([1f5894c](https://github.com/bitnami/charts/commit/1f5894c))
+* [bitnami/external-dns] Release 6.4.4 updating components versions ([1f5894c](https://github.com/bitnami/charts/commit/1f5894cda277019057bc43c7d640b843083583fe))
 
 ## <small>6.4.3 (2022-05-20)</small>
 
-* [bitnami/external-dns] Release 6.4.3 updating components versions ([7e3f392](https://github.com/bitnami/charts/commit/7e3f392))
+* [bitnami/external-dns] Release 6.4.3 updating components versions ([7e3f392](https://github.com/bitnami/charts/commit/7e3f392819c6807d78e11e829db3bbf3261808fc))
 
 ## <small>6.4.2 (2022-05-19)</small>
 
-* [bitnami/external-dns] Release 6.4.2 updating components versions ([9c60043](https://github.com/bitnami/charts/commit/9c60043))
+* [bitnami/external-dns] Release 6.4.2 updating components versions ([9c60043](https://github.com/bitnami/charts/commit/9c60043dc252ed9846ab1851e7029835035091a2))
 
 ## <small>6.4.1 (2022-05-18)</small>
 
-* [bitnami/external-dns] Release 6.4.1 updating components versions ([42c084a](https://github.com/bitnami/charts/commit/42c084a))
+* [bitnami/external-dns] Release 6.4.1 updating components versions ([42c084a](https://github.com/bitnami/charts/commit/42c084a38b640ad84d0ce72e0f62f006259e0b4a))
 
 ## 6.4.0 (2022-05-12)
 
-* [bitnami/external-dns] add template support for --aws-zones-cache-duration (#10007) ([e694170](https://github.com/bitnami/charts/commit/e694170)), closes [#10007](https://github.com/bitnami/charts/issues/10007)
+* [bitnami/external-dns] add template support for --aws-zones-cache-duration (#10007) ([e694170](https://github.com/bitnami/charts/commit/e694170b322fa13215571433707f53c014972c98)), closes [#10007](https://github.com/bitnami/charts/issues/10007)
 
 ## <small>6.3.1 (2022-05-12)</small>
 
-* [bitnami/external-dns] Add missing namespace metadata (#10122) ([7b97371](https://github.com/bitnami/charts/commit/7b97371)), closes [#10122](https://github.com/bitnami/charts/issues/10122)
+* [bitnami/external-dns] Add missing namespace metadata (#10122) ([7b97371](https://github.com/bitnami/charts/commit/7b97371801f3347a5ab49108c158b37a3909b408)), closes [#10122](https://github.com/bitnami/charts/issues/10122)
 
 ## 6.3.0 (2022-04-27)
 
-* [bitnami/external-dns] Add support for NS1 environment variable api key (#9906) ([3b8b888](https://github.com/bitnami/charts/commit/3b8b888)), closes [#9906](https://github.com/bitnami/charts/issues/9906)
+* [bitnami/external-dns] Add support for NS1 environment variable api key (#9906) ([3b8b888](https://github.com/bitnami/charts/commit/3b8b888ae6975152c3476f6d4dcdc93d6625bd56)), closes [#9906](https://github.com/bitnami/charts/issues/9906)
 
 ## <small>6.2.8 (2022-04-26)</small>
 
-* [bitnami/external-dns] Release 6.2.8 updating components versions ([4aceb5e](https://github.com/bitnami/charts/commit/4aceb5e))
-* [bitnami/external-dns]: fix: :bug: Set correct type to the oci.privateKey to avoid breaking the READ ([a9083c8](https://github.com/bitnami/charts/commit/a9083c8))
+* [bitnami/external-dns] Release 6.2.8 updating components versions ([4aceb5e](https://github.com/bitnami/charts/commit/4aceb5eade1e3d2857c25df829084a0f16af5054))
+* [bitnami/external-dns]: fix: :bug: Set correct type to the oci.privateKey to avoid breaking the READ ([a9083c8](https://github.com/bitnami/charts/commit/a9083c86660d8a11af9b65893ae942b21d49e62d))
 
 ## <small>6.2.7 (2022-04-20)</small>
 
-* [bitnami/external-dns]: fix: :bug: Remove unnecessary Azure validation (#9836) ([9d2e71d](https://github.com/bitnami/charts/commit/9d2e71d)), closes [#9836](https://github.com/bitnami/charts/issues/9836)
+* [bitnami/external-dns]: fix: :bug: Remove unnecessary Azure validation (#9836) ([9d2e71d](https://github.com/bitnami/charts/commit/9d2e71d64b6d192807b35a8a97911c11518d9615)), closes [#9836](https://github.com/bitnami/charts/issues/9836)
 
 ## <small>6.2.6 (2022-04-20)</small>
 
-* [bitnami/external-dns] Release 6.2.6 updating components versions ([f0333fd](https://github.com/bitnami/charts/commit/f0333fd))
+* [bitnami/external-dns] Release 6.2.6 updating components versions ([f0333fd](https://github.com/bitnami/charts/commit/f0333fd1c296a5ca3492c48919ec8fb19f1f9eb0))
 
 ## <small>6.2.5 (2022-04-19)</small>
 
-* [bitnami/external-dns] Release 6.2.5 updating components versions ([c689827](https://github.com/bitnami/charts/commit/c689827))
+* [bitnami/external-dns] Release 6.2.5 updating components versions ([c689827](https://github.com/bitnami/charts/commit/c6898275e6c9bb61591b3bdf2da444eb8ebef060))
 
 ## <small>6.2.4 (2022-04-02)</small>
 
-* [bitnami/external-dns] Release 6.2.4 updating components versions ([9413cf8](https://github.com/bitnami/charts/commit/9413cf8))
+* [bitnami/external-dns] Release 6.2.4 updating components versions ([9413cf8](https://github.com/bitnami/charts/commit/9413cf846ff3d73e7ed98c3bf98725fe859d3ca3))
 
 ## <small>6.2.3 (2022-03-27)</small>
 
-* [bitnami/external-dns] Release 6.2.3 updating components versions ([5d64831](https://github.com/bitnami/charts/commit/5d64831))
+* [bitnami/external-dns] Release 6.2.3 updating components versions ([5d64831](https://github.com/bitnami/charts/commit/5d6483100b91effe2b0f23b71fa6c729926c6c7c))
 
 ## <small>6.2.2 (2022-03-23)</small>
 
-* [bitnami/external-dns] Release 6.2.2 updating components versions ([353aa5a](https://github.com/bitnami/charts/commit/353aa5a))
+* [bitnami/external-dns] Release 6.2.2 updating components versions ([353aa5a](https://github.com/bitnami/charts/commit/353aa5a152ebb8a3ecf0d79023f4f601a4d80bc0))
 
 ## <small>6.2.1 (2022-03-16)</small>
 
-* [bitnami/external-dns] Release 6.2.1 updating components versions ([3b68441](https://github.com/bitnami/charts/commit/3b68441))
+* [bitnami/external-dns] Release 6.2.1 updating components versions ([3b68441](https://github.com/bitnami/charts/commit/3b684416893c6459e4c9e4ea07bba4f4b11d0b96))
 
 ## 6.2.0 (2022-03-15)
 
-* [bitnami/external-dns] Add support for OCI (#9334) ([4827eab](https://github.com/bitnami/charts/commit/4827eab)), closes [#9334](https://github.com/bitnami/charts/issues/9334)
+* [bitnami/external-dns] Add support for OCI (#9334) ([4827eab](https://github.com/bitnami/charts/commit/4827eab5fa07caaea4b534a2eb19637c708a1ba7)), closes [#9334](https://github.com/bitnami/charts/issues/9334)
 
 ## <small>6.1.8 (2022-03-02)</small>
 
-* fix trailing whitespace (#9252) ([b011568](https://github.com/bitnami/charts/commit/b011568)), closes [#9252](https://github.com/bitnami/charts/issues/9252)
+* fix trailing whitespace (#9252) ([b011568](https://github.com/bitnami/charts/commit/b01156839f50dc3ffe5739b60a8312cd7362f4da)), closes [#9252](https://github.com/bitnami/charts/issues/9252)
 
 ## <small>6.1.7 (2022-02-27)</small>
 
-* [bitnami/external-dns] Release 6.1.7 updating components versions ([33a45d8](https://github.com/bitnami/charts/commit/33a45d8))
+* [bitnami/external-dns] Release 6.1.7 updating components versions ([33a45d8](https://github.com/bitnami/charts/commit/33a45d84ee9e41ec89d057a191a6588467dc5669))
 
 ## <small>6.1.6 (2022-02-21)</small>
 
-* [bitnami/external-dns] Do not hardcode PDB apiVersion (#9095) ([ab576d5](https://github.com/bitnami/charts/commit/ab576d5)), closes [#9095](https://github.com/bitnami/charts/issues/9095)
+* [bitnami/external-dns] Do not hardcode PDB apiVersion (#9095) ([ab576d5](https://github.com/bitnami/charts/commit/ab576d548056953aed01a1de81ccd3dacaeb273f)), closes [#9095](https://github.com/bitnami/charts/issues/9095)
 
 ## <small>6.1.5 (2022-02-10)</small>
 
-* [bitnami/external-dns] Release 6.1.5 updating components versions ([11c90d6](https://github.com/bitnami/charts/commit/11c90d6))
-* Non utf8 chars (#8923) ([6ffd18f](https://github.com/bitnami/charts/commit/6ffd18f)), closes [#8923](https://github.com/bitnami/charts/issues/8923)
+* [bitnami/external-dns] Release 6.1.5 updating components versions ([11c90d6](https://github.com/bitnami/charts/commit/11c90d6d609001a4c6b0fcc112068097eedc1aa5))
+* Non utf8 chars (#8923) ([6ffd18f](https://github.com/bitnami/charts/commit/6ffd18fbbdf10e94ea1a90cf5b84ef610ac2a72d)), closes [#8923](https://github.com/bitnami/charts/issues/8923)
 
 ## <small>6.1.4 (2022-02-04)</small>
 
-* fix: add commonAnnotations to deployment (#8904) ([6dd78cf](https://github.com/bitnami/charts/commit/6dd78cf)), closes [#8904](https://github.com/bitnami/charts/issues/8904)
+* fix: add commonAnnotations to deployment (#8904) ([6dd78cf](https://github.com/bitnami/charts/commit/6dd78cf00a3a1604afb3fc1263d6e5eb028a5882)), closes [#8904](https://github.com/bitnami/charts/issues/8904)
 
 ## <small>6.1.3 (2022-01-31)</small>
 
-* [bitnami/external-dns] Fix deployment error on AKS with MSI. (refs bitnami#8822) (#8823) ([ea05887](https://github.com/bitnami/charts/commit/ea05887)), closes [bitnami#8822](https://github.com/bitnami/issues/8822) [#8823](https://github.com/bitnami/charts/issues/8823) [bitnami#8822](https://github.com/bitnami/issues/8822)
+* [bitnami/external-dns] Fix deployment error on AKS with MSI. (refs bitnami#8822) (#8823) ([ea05887](https://github.com/bitnami/charts/commit/ea058878f327d64ce71700b600a6ad966adf0a54)), closes [bitnami#8822](https://github.com/bitnami/issues/8822) [#8823](https://github.com/bitnami/charts/issues/8823) [bitnami#8822](https://github.com/bitnami/issues/8822)
 
 ## <small>6.1.2 (2022-01-20)</small>
 
-* [bitnami/*] Readme automation (#8579) ([78d1938](https://github.com/bitnami/charts/commit/78d1938)), closes [#8579](https://github.com/bitnami/charts/issues/8579)
-* [bitnami/*] Update READMEs (#8716) ([b9a9533](https://github.com/bitnami/charts/commit/b9a9533)), closes [#8716](https://github.com/bitnami/charts/issues/8716)
-* [bitnami/several] Change prerequisites (#8725) ([8d740c5](https://github.com/bitnami/charts/commit/8d740c5)), closes [#8725](https://github.com/bitnami/charts/issues/8725)
+* [bitnami/*] Readme automation (#8579) ([78d1938](https://github.com/bitnami/charts/commit/78d193831c900d178198491ffd08fa2217a64ecd)), closes [#8579](https://github.com/bitnami/charts/issues/8579)
+* [bitnami/*] Update READMEs (#8716) ([b9a9533](https://github.com/bitnami/charts/commit/b9a953337590eb2979453385874a267bacf50936)), closes [#8716](https://github.com/bitnami/charts/issues/8716)
+* [bitnami/several] Change prerequisites (#8725) ([8d740c5](https://github.com/bitnami/charts/commit/8d740c566cfdb7e2d933c40128b4e919fce953a5)), closes [#8725](https://github.com/bitnami/charts/issues/8725)
 
 ## <small>6.1.1 (2022-01-11)</small>
 
-* [bitnami/external-dns] Release 6.1.1 updating components versions ([a63ccde](https://github.com/bitnami/charts/commit/a63ccde))
+* [bitnami/external-dns] Release 6.1.1 updating components versions ([a63ccde](https://github.com/bitnami/charts/commit/a63ccdeb0798678ada861057c66647476a59af5a))
 
 ## 6.1.0 (2022-01-05)
 
-* [bitnami/several] Adapt templating format (#8562) ([8cad18a](https://github.com/bitnami/charts/commit/8cad18a)), closes [#8562](https://github.com/bitnami/charts/issues/8562)
-* [bitnami/several] Add license to the README ([05f7633](https://github.com/bitnami/charts/commit/05f7633))
-* [bitnami/several] Add license to the README ([32fb238](https://github.com/bitnami/charts/commit/32fb238))
-* [bitnami/several] Add license to the README ([b87c2f7](https://github.com/bitnami/charts/commit/b87c2f7))
+* [bitnami/several] Adapt templating format (#8562) ([8cad18a](https://github.com/bitnami/charts/commit/8cad18aed9966a6f0208e5ad6cee46cb217f47ab)), closes [#8562](https://github.com/bitnami/charts/issues/8562)
+* [bitnami/several] Add license to the README ([05f7633](https://github.com/bitnami/charts/commit/05f763372501d596e57db713dd53ff4ff3027cc4))
+* [bitnami/several] Add license to the README ([32fb238](https://github.com/bitnami/charts/commit/32fb238e60a0affc6debd3142eaa3c3d9089ec2a))
+* [bitnami/several] Add license to the README ([b87c2f7](https://github.com/bitnami/charts/commit/b87c2f7899d48a8b02c506765e6ae82937e9ba3f))
 
 ## <small>6.0.2 (2021-12-13)</small>
 
-* [bitnami/external-dns] Release 6.0.2 updating components versions ([1f5896f](https://github.com/bitnami/charts/commit/1f5896f))
+* [bitnami/external-dns] Release 6.0.2 updating components versions ([1f5896f](https://github.com/bitnami/charts/commit/1f5896fcd33fef307cb87e86231a347262dae500))
 
 ## <small>6.0.1 (2021-12-13)</small>
 
-* [external-dns] Fix duplicated variable in values.yaml (#8385) ([c98cd88](https://github.com/bitnami/charts/commit/c98cd88)), closes [#8385](https://github.com/bitnami/charts/issues/8385)
+* [external-dns] Fix duplicated variable in values.yaml (#8385) ([c98cd88](https://github.com/bitnami/charts/commit/c98cd88e0fbf84fe5da3a4d5ceca807c882220b5)), closes [#8385](https://github.com/bitnami/charts/issues/8385)
 
 ## 6.0.0 (2021-12-10)
 
-* [bitnami/dokuwiki, external-dns] Standardizations (#7659) ([e71fe1f](https://github.com/bitnami/charts/commit/e71fe1f)), closes [#7659](https://github.com/bitnami/charts/issues/7659)
+* [bitnami/dokuwiki, external-dns] Standardizations (#7659) ([e71fe1f](https://github.com/bitnami/charts/commit/e71fe1fc5ce643a66f2a1cb80880430893741f35)), closes [#7659](https://github.com/bitnami/charts/issues/7659)
 
 ## 5.6.0 (2021-12-09)
 
-* [bitnami/external-dns] Add value for controlling Google zone visibility (#8278) ([8188013](https://github.com/bitnami/charts/commit/8188013)), closes [#8278](https://github.com/bitnami/charts/issues/8278)
-* state correct version (#8260) ([e5d2e7d](https://github.com/bitnami/charts/commit/e5d2e7d)), closes [#8260](https://github.com/bitnami/charts/issues/8260) [/github.com/kubernetes-sigs/external-dns/issues/2168#issuecomment-947841020](https://github.com//github.com/kubernetes-sigs/external-dns/issues/2168/issues/issuecomment-947841020)
+* [bitnami/external-dns] Add value for controlling Google zone visibility (#8278) ([8188013](https://github.com/bitnami/charts/commit/8188013219f3182d838286ff145f49aa1f393a61)), closes [#8278](https://github.com/bitnami/charts/issues/8278)
+* state correct version (#8260) ([e5d2e7d](https://github.com/bitnami/charts/commit/e5d2e7db1cfb96ac7e04bf4af9c1d20734cf7cb4)), closes [#8260](https://github.com/bitnami/charts/issues/8260) [/github.com/kubernetes-sigs/external-dns/issues/2168#issuecomment-947841020](https://github.com//github.com/kubernetes-sigs/external-dns/issues/2168/issues/issuecomment-947841020)
 
 ## <small>5.5.2 (2021-11-29)</small>
 
-* [bitnami/several] Regenerate README tables ([ac75243](https://github.com/bitnami/charts/commit/ac75243))
-* [bitnami/several] Replace HTTP by HTTPS when possible (#8259) ([eafb5bd](https://github.com/bitnami/charts/commit/eafb5bd)), closes [#8259](https://github.com/bitnami/charts/issues/8259)
+* [bitnami/several] Regenerate README tables ([ac75243](https://github.com/bitnami/charts/commit/ac752431b90e935d0a4dbfef70dc44f24f3d3dd2))
+* [bitnami/several] Replace HTTP by HTTPS when possible (#8259) ([eafb5bd](https://github.com/bitnami/charts/commit/eafb5bd5a2cc3aaf04fc1e8ebedd73f420d76864)), closes [#8259](https://github.com/bitnami/charts/issues/8259)
 
 ## <small>5.5.1 (2021-11-26)</small>
 
-* [bitnami/external-dns] Release 5.5.1 updating components versions ([cc1a55e](https://github.com/bitnami/charts/commit/cc1a55e))
-* [bitnami/several] Regenerate README tables ([7b091c0](https://github.com/bitnami/charts/commit/7b091c0))
+* [bitnami/external-dns] Release 5.5.1 updating components versions ([cc1a55e](https://github.com/bitnami/charts/commit/cc1a55e71af5de6d371f30e207da3224809ff144))
+* [bitnami/several] Regenerate README tables ([7b091c0](https://github.com/bitnami/charts/commit/7b091c0808ef00425c404cb97fe73c0578ccf1a3))
 
 ## 5.5.0 (2021-11-18)
 
-* [bitnami/external-dns] add labelFilter to options for external-dns (#8153) ([f4d028c](https://github.com/bitnami/charts/commit/f4d028c)), closes [#8153](https://github.com/bitnami/charts/issues/8153)
+* [bitnami/external-dns] add labelFilter to options for external-dns (#8153) ([f4d028c](https://github.com/bitnami/charts/commit/f4d028cbac5d7bd862b13a574d9f35b92679f563)), closes [#8153](https://github.com/bitnami/charts/issues/8153)
 
 ## <small>5.4.16 (2021-11-17)</small>
 
-* [bitnami/several] Add extraDeploy feature to the pending charts (#8164) ([d812a24](https://github.com/bitnami/charts/commit/d812a24)), closes [#8164](https://github.com/bitnami/charts/issues/8164)
+* [bitnami/several] Add extraDeploy feature to the pending charts (#8164) ([d812a24](https://github.com/bitnami/charts/commit/d812a243cb1bba69c67ac22cfce1f7999848ef74)), closes [#8164](https://github.com/bitnami/charts/issues/8164)
 
 ## <small>5.4.15 (2021-10-27)</small>
 
-* [bitnami/*] Fix backticks in values.yaml that affects READMEs (#7946) ([d5b610c](https://github.com/bitnami/charts/commit/d5b610c)), closes [#7946](https://github.com/bitnami/charts/issues/7946)
-* [bitnami/*] Mark PodSecurityPolicy resources as deprecated (#7948) ([5cac753](https://github.com/bitnami/charts/commit/5cac753)), closes [#7948](https://github.com/bitnami/charts/issues/7948)
-* [bitnami/several] Regenerate README tables ([412cf6a](https://github.com/bitnami/charts/commit/412cf6a))
+* [bitnami/*] Fix backticks in values.yaml that affects READMEs (#7946) ([d5b610c](https://github.com/bitnami/charts/commit/d5b610c0306af7c9d3f85e1fa1604a111240e4f7)), closes [#7946](https://github.com/bitnami/charts/issues/7946)
+* [bitnami/*] Mark PodSecurityPolicy resources as deprecated (#7948) ([5cac753](https://github.com/bitnami/charts/commit/5cac7539dcb6c3baef06ed6676bfa99c16fdb5fe)), closes [#7948](https://github.com/bitnami/charts/issues/7948)
+* [bitnami/several] Regenerate README tables ([412cf6a](https://github.com/bitnami/charts/commit/412cf6a513cb0c03444a6e7811c6f27193239a10))
 
 ## <small>5.4.14 (2021-10-27)</small>
 
-* [bitnami/external-dns] Release 5.4.14 updating components versions ([3e5734a](https://github.com/bitnami/charts/commit/3e5734a))
-* [bitnami/several] Regenerate README tables ([c82619f](https://github.com/bitnami/charts/commit/c82619f))
+* [bitnami/external-dns] Release 5.4.14 updating components versions ([3e5734a](https://github.com/bitnami/charts/commit/3e5734a215fc045395dc5e39959e22155d1baf9f))
+* [bitnami/several] Regenerate README tables ([c82619f](https://github.com/bitnami/charts/commit/c82619f4141cd18e1b6079fdd84eb5b7bb47d819))
 
 ## <small>5.4.13 (2021-10-22)</small>
 
-* [bitnami/several] Add chart info to NOTES.txt (#7889) ([a6751cd](https://github.com/bitnami/charts/commit/a6751cd)), closes [#7889](https://github.com/bitnami/charts/issues/7889)
+* [bitnami/several] Add chart info to NOTES.txt (#7889) ([a6751cd](https://github.com/bitnami/charts/commit/a6751cdd33c461fabbc459fbea6f219ec64ab6b2)), closes [#7889](https://github.com/bitnami/charts/issues/7889)
 
 ## <small>5.4.12 (2021-10-22)</small>
 
-* [bitnami/external-dns] Release 5.4.12 updating components versions ([400a7e2](https://github.com/bitnami/charts/commit/400a7e2))
+* [bitnami/external-dns] Release 5.4.12 updating components versions ([400a7e2](https://github.com/bitnami/charts/commit/400a7e22c9b64321109e84163e9d950e05e40f2f))
 
 ## <small>5.4.11 (2021-10-13)</small>
 
-* [bitnami/external-dns] Update Chart.yaml (#7788) ([50401a6](https://github.com/bitnami/charts/commit/50401a6)), closes [#7788](https://github.com/bitnami/charts/issues/7788)
+* [bitnami/external-dns] Update Chart.yaml (#7788) ([50401a6](https://github.com/bitnami/charts/commit/50401a670db84dfb0513e398482ca4212cc8907e)), closes [#7788](https://github.com/bitnami/charts/issues/7788)
 
 ## <small>5.4.10 (2021-10-07)</small>
 
-* [bitnami/*] Fix service monitors selectors (#7720) ([1279593](https://github.com/bitnami/charts/commit/1279593)), closes [#7720](https://github.com/bitnami/charts/issues/7720)
-* [bitnami/several] Regenerate README tables ([a678bc7](https://github.com/bitnami/charts/commit/a678bc7))
+* [bitnami/*] Fix service monitors selectors (#7720) ([1279593](https://github.com/bitnami/charts/commit/1279593765044df99902bfee8dcfaeb60e95f125)), closes [#7720](https://github.com/bitnami/charts/issues/7720)
+* [bitnami/several] Regenerate README tables ([a678bc7](https://github.com/bitnami/charts/commit/a678bc7ba8f35e8e9735b23d136aeeff7c4db1d2))
 
 ## <small>5.4.9 (2021-10-06)</small>
 
-* [bitnami/external-dns] Release 5.4.9 updating components versions ([a07a97b](https://github.com/bitnami/charts/commit/a07a97b))
-* [bitnami/several] Regenerate README tables ([ff170d1](https://github.com/bitnami/charts/commit/ff170d1))
+* [bitnami/external-dns] Release 5.4.9 updating components versions ([a07a97b](https://github.com/bitnami/charts/commit/a07a97b9b58ce53c4d6b28e818625ea1864eb740))
+* [bitnami/several] Regenerate README tables ([ff170d1](https://github.com/bitnami/charts/commit/ff170d10f8aa6dae0f1e5c3f7d1c69fcec96b731))
 
 ## <small>5.4.8 (2021-09-25)</small>
 
-* [bitnami/external-dns] Release 5.4.8 updating components versions ([dbc2c61](https://github.com/bitnami/charts/commit/dbc2c61))
+* [bitnami/external-dns] Release 5.4.8 updating components versions ([dbc2c61](https://github.com/bitnami/charts/commit/dbc2c613f01d08413483b99487c8bfe34bdf9d51))
 
 ## <small>5.4.7 (2021-09-13)</small>
 
-* Fix transip SecretVolumeSource (#7463) ([0ba7d76](https://github.com/bitnami/charts/commit/0ba7d76)), closes [#7463](https://github.com/bitnami/charts/issues/7463) [/v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#secretvolumesource-v1](https://github.com//v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18//issues/secretvolumesource-v1)
+* Fix transip SecretVolumeSource (#7463) ([0ba7d76](https://github.com/bitnami/charts/commit/0ba7d761ff79cfb0581c88b10a632304f9f10b29)), closes [#7463](https://github.com/bitnami/charts/issues/7463) [/v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#secretvolumesource-v1](https://github.com//v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18//issues/secretvolumesource-v1)
 
 ## <small>5.4.6 (2021-09-10)</small>
 
-* [bitnami/external-dns] Fix typo in parameters section (#7455) ([e308e4e](https://github.com/bitnami/charts/commit/e308e4e)), closes [#7455](https://github.com/bitnami/charts/issues/7455)
+* [bitnami/external-dns] Fix typo in parameters section (#7455) ([e308e4e](https://github.com/bitnami/charts/commit/e308e4ed9083a4067b9fe1231191ab1b3d317350)), closes [#7455](https://github.com/bitnami/charts/issues/7455)
 
 ## <small>5.4.5 (2021-09-03)</small>
 
-* [bitnami/external-dns] Allow empty value for zoneType filter ([818a29d](https://github.com/bitnami/charts/commit/818a29d)), closes [/github.com/kubernetes-sigs/external-dns/blob/master/provider/zone_type_filter.go#L42](https://github.com//github.com/kubernetes-sigs/external-dns/blob/master/provider/zone_type_filter.go/issues/L42)
-* [bitnami/several] Regenerate README tables ([64d5d74](https://github.com/bitnami/charts/commit/64d5d74))
+* [bitnami/external-dns] Allow empty value for zoneType filter ([818a29d](https://github.com/bitnami/charts/commit/818a29d764e3cd64456a067cb134b4754ed214bd)), closes [/github.com/kubernetes-sigs/external-dns/blob/master/provider/zone_type_filter.go#L42](https://github.com//github.com/kubernetes-sigs/external-dns/blob/master/provider/zone_type_filter.go/issues/L42)
+* [bitnami/several] Regenerate README tables ([64d5d74](https://github.com/bitnami/charts/commit/64d5d747b84299ca9f63ea8a586b13870abe31a6))
 
 ## <small>5.4.4 (2021-08-26)</small>
 
-* [bitnami/external-dns] Release 5.4.4 updating components versions ([2204885](https://github.com/bitnami/charts/commit/2204885))
-* [bitnami/several] Regenerate README tables ([da2513b](https://github.com/bitnami/charts/commit/da2513b))
+* [bitnami/external-dns] Release 5.4.4 updating components versions ([2204885](https://github.com/bitnami/charts/commit/22048859728cdb037bcfd6721f5ab3d0dd5cfdcd))
+* [bitnami/several] Regenerate README tables ([da2513b](https://github.com/bitnami/charts/commit/da2513bf0a33819f3b1151d387c631a9ffdb03e2))
 
 ## <small>5.4.3 (2021-08-26)</small>
 
-* [bitnami/external-dns] Revert customCAHostPath change (#7320) ([c521ccc](https://github.com/bitnami/charts/commit/c521ccc)), closes [#7320](https://github.com/bitnami/charts/issues/7320)
+* [bitnami/external-dns] Revert customCAHostPath change (#7320) ([c521ccc](https://github.com/bitnami/charts/commit/c521ccc7ef85ee8d0fbe4905d66dd49d4fa187ab)), closes [#7320](https://github.com/bitnami/charts/issues/7320)
 
 ## <small>5.4.2 (2021-08-25)</small>
 
-* [bitnami/external-dns] Release 5.4.2 updating components versions ([010bb10](https://github.com/bitnami/charts/commit/010bb10))
-* [bitnami/several] Regenerate README tables ([6c9124f](https://github.com/bitnami/charts/commit/6c9124f))
+* [bitnami/external-dns] Release 5.4.2 updating components versions ([010bb10](https://github.com/bitnami/charts/commit/010bb107bb89bf5ab1cd1cc7df197fc8221f9ca1))
+* [bitnami/several] Regenerate README tables ([6c9124f](https://github.com/bitnami/charts/commit/6c9124f79491aa65f53a87c1ed598b47ffa8b411))
 
 ## <small>5.4.1 (2021-08-16)</small>
 
-* [bitnami/external-dns] Adds namespace entries to several templates (#7213) ([75d06bd](https://github.com/bitnami/charts/commit/75d06bd)), closes [#7213](https://github.com/bitnami/charts/issues/7213) [#7210](https://github.com/bitnami/charts/issues/7210)
-* [bitnami/several] Regenerate README tables ([6c107e8](https://github.com/bitnami/charts/commit/6c107e8))
+* [bitnami/external-dns] Adds namespace entries to several templates (#7213) ([75d06bd](https://github.com/bitnami/charts/commit/75d06bd589d18b98567bfaf40be061a5191e9be8)), closes [#7213](https://github.com/bitnami/charts/issues/7213) [#7210](https://github.com/bitnami/charts/issues/7210)
+* [bitnami/several] Regenerate README tables ([6c107e8](https://github.com/bitnami/charts/commit/6c107e835d6caf8db2e8b17dcd48c5971637e013))
 
 ## 5.4.0 (2021-08-11)
 
-* [bitnami/external-dns] rfc2136 provider can now be configured to use Kerberos authentication (#7128) ([86b94d8](https://github.com/bitnami/charts/commit/86b94d8)), closes [#7128](https://github.com/bitnami/charts/issues/7128)
+* [bitnami/external-dns] rfc2136 provider can now be configured to use Kerberos authentication (#7128) ([86b94d8](https://github.com/bitnami/charts/commit/86b94d8a596c03c51e663c50f66dacb76a40ea86)), closes [#7128](https://github.com/bitnami/charts/issues/7128)
 
 ## 5.3.0 (2021-08-06)
 
-* Add permissions to manage Kong's TCPIngress resources (#6711) ([48b3460](https://github.com/bitnami/charts/commit/48b3460)), closes [#6711](https://github.com/bitnami/charts/issues/6711)
+* Add permissions to manage Kong's TCPIngress resources (#6711) ([48b3460](https://github.com/bitnami/charts/commit/48b346039fab466014d059c62cb3f36a334bcd8a)), closes [#6711](https://github.com/bitnami/charts/issues/6711)
 
 ## <small>5.2.4 (2021-08-05)</small>
 
-* [bitnami/external-dns] Release 5.2.4 updating components versions ([787622d](https://github.com/bitnami/charts/commit/787622d))
+* [bitnami/external-dns] Release 5.2.4 updating components versions ([787622d](https://github.com/bitnami/charts/commit/787622d4d79b48ed01a1139358646e0362b3804a))
 
 ## <small>5.2.3 (2021-08-03)</small>
 
-* [bitnami/external-dns] Release 5.2.3 updating components versions ([9a73a4e](https://github.com/bitnami/charts/commit/9a73a4e))
-* [bitnami/several] Unify upgrading section ([baf2283](https://github.com/bitnami/charts/commit/baf2283))
+* [bitnami/external-dns] Release 5.2.3 updating components versions ([9a73a4e](https://github.com/bitnami/charts/commit/9a73a4edec0bb0678ccf99dda2f5ce8973cc32b6))
+* [bitnami/several] Unify upgrading section ([baf2283](https://github.com/bitnami/charts/commit/baf228384acec844e777485bb1597fb3a62c1faf))
 
 ## <small>5.2.2 (2021-07-27)</small>
 
-* [bitnami/several] Fix default values and regenerate README (#7024) ([4c86733](https://github.com/bitnami/charts/commit/4c86733)), closes [#7024](https://github.com/bitnami/charts/issues/7024)
+* [bitnami/several] Fix default values and regenerate README (#7024) ([4c86733](https://github.com/bitnami/charts/commit/4c867335c5c9c5aba041868df16ebb8f64ac68bd)), closes [#7024](https://github.com/bitnami/charts/issues/7024)
 
 ## <small>5.2.1 (2021-07-19)</small>
 
-* [bitnami/*] Adapt values.yaml of Elasticsearch, etcd and external-dns charts (#6822) ([a5d80d6](https://github.com/bitnami/charts/commit/a5d80d6)), closes [#6822](https://github.com/bitnami/charts/issues/6822)
+* [bitnami/*] Adapt values.yaml of Elasticsearch, etcd and external-dns charts (#6822) ([a5d80d6](https://github.com/bitnami/charts/commit/a5d80d61b044023eb41d0dd187fe71a16515ab2d)), closes [#6822](https://github.com/bitnami/charts/issues/6822)
 
 ## 5.2.0 (2021-07-16)
 
-* [bitnami/external-dns] Add  regexDomainFilter and regexDomainExclusion parameters (#6972) ([50e0539](https://github.com/bitnami/charts/commit/50e0539)), closes [#6972](https://github.com/bitnami/charts/issues/6972)
+* [bitnami/external-dns] Add  regexDomainFilter and regexDomainExclusion parameters (#6972) ([50e0539](https://github.com/bitnami/charts/commit/50e053997088203baf9061b67012dfd027fe1dbb)), closes [#6972](https://github.com/bitnami/charts/issues/6972)
 
 ## <small>5.1.4 (2021-07-04)</small>
 
-* [bitnami/external-dns] Document google.serviceAccountKey as optional (#6756) ([311b9bb](https://github.com/bitnami/charts/commit/311b9bb)), closes [#6756](https://github.com/bitnami/charts/issues/6756)
-* [bitnami/external-dns] Release 5.1.4 updating components versions ([c8be135](https://github.com/bitnami/charts/commit/c8be135))
+* [bitnami/external-dns] Document google.serviceAccountKey as optional (#6756) ([311b9bb](https://github.com/bitnami/charts/commit/311b9bba4f728e8b5663636a1c1266e4df659f38)), closes [#6756](https://github.com/bitnami/charts/issues/6756)
+* [bitnami/external-dns] Release 5.1.4 updating components versions ([c8be135](https://github.com/bitnami/charts/commit/c8be13598e756f87c0c3005eef5db90cdb6bec92))
 
 ## <small>5.1.3 (2021-06-24)</small>
 
-* [bitnami/external-dns] Remove deprecated variables for Azure Private DNS (#6744) ([0bd5264](https://github.com/bitnami/charts/commit/0bd5264)), closes [#6744](https://github.com/bitnami/charts/issues/6744)
+* [bitnami/external-dns] Remove deprecated variables for Azure Private DNS (#6744) ([0bd5264](https://github.com/bitnami/charts/commit/0bd52649e99bfae03e004efb9bbf2808cc504398)), closes [#6744](https://github.com/bitnami/charts/issues/6744)
 
 ## <small>5.1.2 (2021-06-23)</small>
 
-* Add Infoblox Max Results Option (#6725) ([7243258](https://github.com/bitnami/charts/commit/7243258)), closes [#6725](https://github.com/bitnami/charts/issues/6725)
+* Add Infoblox Max Results Option (#6725) ([7243258](https://github.com/bitnami/charts/commit/7243258988a7a52c7b499990f97665928cbda58e)), closes [#6725](https://github.com/bitnami/charts/issues/6725)
 
 ## <small>5.1.1 (2021-06-16)</small>
 
-* [bitnami/external-dns] update azure private dns provider (#6657) ([16598fa](https://github.com/bitnami/charts/commit/16598fa)), closes [#6657](https://github.com/bitnami/charts/issues/6657) [#6607](https://github.com/bitnami/charts/issues/6607) [#6608](https://github.com/bitnami/charts/issues/6608)
+* [bitnami/external-dns] update azure private dns provider (#6657) ([16598fa](https://github.com/bitnami/charts/commit/16598faadab4ed555402fcc24ebe4fe185b82fc4)), closes [#6657](https://github.com/bitnami/charts/issues/6657) [#6607](https://github.com/bitnami/charts/issues/6607) [#6608](https://github.com/bitnami/charts/issues/6608)
 
 ## 5.1.0 (2021-06-14)
 
-* [bitnami/external-dns] Add support for autogenerated certs (#6607) ([c92eb7b](https://github.com/bitnami/charts/commit/c92eb7b)), closes [#6607](https://github.com/bitnami/charts/issues/6607)
+* [bitnami/external-dns] Add support for autogenerated certs (#6607) ([c92eb7b](https://github.com/bitnami/charts/commit/c92eb7bda702a5789883a0570c3de0ef0e60f149)), closes [#6607](https://github.com/bitnami/charts/issues/6607)
 
 ## <small>5.0.4 (2021-06-10)</small>
 
-* ns1 ttl (#6623) ([2b3f4c9](https://github.com/bitnami/charts/commit/2b3f4c9)), closes [#6623](https://github.com/bitnami/charts/issues/6623)
+* ns1 ttl (#6623) ([2b3f4c9](https://github.com/bitnami/charts/commit/2b3f4c9b4a0db3bebdfc36ca6c333b7850a58311)), closes [#6623](https://github.com/bitnami/charts/issues/6623)
 
 ## <small>5.0.3 (2021-06-04)</small>
 
-* [bitnami/external-dns] Release 5.0.3 updating components versions ([00be16b](https://github.com/bitnami/charts/commit/00be16b))
+* [bitnami/external-dns] Release 5.0.3 updating components versions ([00be16b](https://github.com/bitnami/charts/commit/00be16bf4dd8101022bd0cd64ebcd08c8c6b3eb7))
 
 ## <small>5.0.2 (2021-05-28)</small>
 
-* [bitnami/external-dns] Include readinessProbe and livenessProbe just in case that there are defined  ([9984aa6](https://github.com/bitnami/charts/commit/9984aa6)), closes [#6481](https://github.com/bitnami/charts/issues/6481)
+* [bitnami/external-dns] Include readinessProbe and livenessProbe just in case that there are defined  ([9984aa6](https://github.com/bitnami/charts/commit/9984aa6ba5c3f29e6503d2ccb4339f0997d8aec5)), closes [#6481](https://github.com/bitnami/charts/issues/6481)
 
 ## <small>5.0.1 (2021-05-27)</small>
 
-* [bitnami/external-dns] fix: allow to pass OwnerId for non-txt registry type in external-dns chart (# ([d516d27](https://github.com/bitnami/charts/commit/d516d27)), closes [#6466](https://github.com/bitnami/charts/issues/6466)
-* [bitnami/external-dns] values.yaml docs missing policy (#6361) ([cc3a414](https://github.com/bitnami/charts/commit/cc3a414)), closes [#6361](https://github.com/bitnami/charts/issues/6361)
+* [bitnami/external-dns] fix: allow to pass OwnerId for non-txt registry type in external-dns chart (# ([d516d27](https://github.com/bitnami/charts/commit/d516d27267eb1b3389a7c63803b00db10f228616)), closes [#6466](https://github.com/bitnami/charts/issues/6466)
+* [bitnami/external-dns] values.yaml docs missing policy (#6361) ([cc3a414](https://github.com/bitnami/charts/commit/cc3a4149e89b650234bb9b09f365588a5ef7e67c)), closes [#6361](https://github.com/bitnami/charts/issues/6361)
 
 ## 5.0.0 (2021-05-06)
 
-* [bitnami/external-dns] Update CRDs api version (#6294) ([77bda99](https://github.com/bitnami/charts/commit/77bda99)), closes [#6294](https://github.com/bitnami/charts/issues/6294)
+* [bitnami/external-dns] Update CRDs api version (#6294) ([77bda99](https://github.com/bitnami/charts/commit/77bda9977595971ca16ad5ff4c125714f3d79ebf)), closes [#6294](https://github.com/bitnami/charts/issues/6294)
 
 ## <small>4.12.3 (2021-05-04)</small>
 
-* [bitnami/external-dns] Release 4.12.3 updating components versions ([c43d714](https://github.com/bitnami/charts/commit/c43d714))
+* [bitnami/external-dns] Release 4.12.3 updating components versions ([c43d714](https://github.com/bitnami/charts/commit/c43d714188842276ebc4b3c83195cac1fa9f88f4))
 
 ## <small>4.12.2 (2021-04-30)</small>
 
-* Feat: Provider: OVH - Use existing Secret (#6255) ([faa70aa](https://github.com/bitnami/charts/commit/faa70aa)), closes [#6255](https://github.com/bitnami/charts/issues/6255)
+* Feat: Provider: OVH - Use existing Secret (#6255) ([faa70aa](https://github.com/bitnami/charts/commit/faa70aa4b1d9c22aff597596e18c03d3abf1dd41)), closes [#6255](https://github.com/bitnami/charts/issues/6255)
 
 ## <small>4.11.2 (2021-04-29)</small>
 
-* [bitnami/external-dns] Fix typo in service name template (#6248) ([a7a4671](https://github.com/bitnami/charts/commit/a7a4671)), closes [#6248](https://github.com/bitnami/charts/issues/6248)
+* [bitnami/external-dns] Fix typo in service name template (#6248) ([a7a4671](https://github.com/bitnami/charts/commit/a7a4671ccaa3cd4317b6f69fccedfdcdd0768fe4)), closes [#6248](https://github.com/bitnami/charts/issues/6248)
 
 ## <small>4.11.1 (2021-04-23)</small>
 
-* [bitnami/external-dns] Release 4.11.1 updating components versions ([1f0ff4b](https://github.com/bitnami/charts/commit/1f0ff4b))
+* [bitnami/external-dns] Release 4.11.1 updating components versions ([1f0ff4b](https://github.com/bitnami/charts/commit/1f0ff4b46a99155089b2bd19e9c0c2acad2069cc))
 
 ## 4.11.0 (2021-04-14)
 
-* [bitnami/external-dns] Add support to configure a txtSuffix (#6098) ([33785f6](https://github.com/bitnami/charts/commit/33785f6)), closes [#6098](https://github.com/bitnami/charts/issues/6098)
+* [bitnami/external-dns] Add support to configure a txtSuffix (#6098) ([33785f6](https://github.com/bitnami/charts/commit/33785f648402785b85284229c299a1db79aec591)), closes [#6098](https://github.com/bitnami/charts/issues/6098)
 
 ## 4.10.0 (2021-04-09)
 
-* [bitnami/external-dns] Allow the use of a predefined secret by specifying a secretName for the rfc21 ([8d2a4ad](https://github.com/bitnami/charts/commit/8d2a4ad)), closes [#6057](https://github.com/bitnami/charts/issues/6057)
+* [bitnami/external-dns] Allow the use of a predefined secret by specifying a secretName for the rfc21 ([8d2a4ad](https://github.com/bitnami/charts/commit/8d2a4ade3a4bdb44add9ec74d8938a6eb86d6891)), closes [#6057](https://github.com/bitnami/charts/issues/6057)
 
 ## <small>4.9.4 (2021-03-30)</small>
 
-* bitnami/extern-dns (#5937) ([34a05eb](https://github.com/bitnami/charts/commit/34a05eb)), closes [#5937](https://github.com/bitnami/charts/issues/5937)
+* bitnami/extern-dns (#5937) ([34a05eb](https://github.com/bitnami/charts/commit/34a05ebcdeaff557c13b68830e57741e4942b10f)), closes [#5937](https://github.com/bitnami/charts/issues/5937)
 
 ## <small>4.9.3 (2021-03-24)</small>
 
-* [bitnami/external-dns] Release 4.9.3 updating components versions ([6ed718f](https://github.com/bitnami/charts/commit/6ed718f))
-* [bitnami/external-dns] Set namespace variable when not creating cluster role (#5808) ([68cb8c1](https://github.com/bitnami/charts/commit/68cb8c1)), closes [#5808](https://github.com/bitnami/charts/issues/5808)
+* [bitnami/external-dns] Release 4.9.3 updating components versions ([6ed718f](https://github.com/bitnami/charts/commit/6ed718fdee2cd7cd69363686613a4353f43e4ebf))
+* [bitnami/external-dns] Set namespace variable when not creating cluster role (#5808) ([68cb8c1](https://github.com/bitnami/charts/commit/68cb8c10287c0faae02fc42ee979945ca491fcaf)), closes [#5808](https://github.com/bitnami/charts/issues/5808)
 
 ## <small>4.9.2 (2021-03-22)</small>
 
-* [bitnami/external-dns]fix: update alibaba config (#5854) ([a65441d](https://github.com/bitnami/charts/commit/a65441d)), closes [#5854](https://github.com/bitnami/charts/issues/5854)
+* [bitnami/external-dns]fix: update alibaba config (#5854) ([a65441d](https://github.com/bitnami/charts/commit/a65441d094a815c4fcbc7041982cd1fba94d4035)), closes [#5854](https://github.com/bitnami/charts/issues/5854)
 
 ## <small>4.9.1 (2021-03-15)</small>
 
-* [bitnami/external-dns] Release 4.9.1 updating components versions ([c1cc890](https://github.com/bitnami/charts/commit/c1cc890))
+* [bitnami/external-dns] Release 4.9.1 updating components versions ([c1cc890](https://github.com/bitnami/charts/commit/c1cc8901ae54f4e4f5451ee2c304afa3a8218ffc))
 
 ## 4.9.0 (2021-03-08)
 
-* [bitnami/external-dns] Added Openshift Routes support (#5632) ([9508ea9](https://github.com/bitnami/charts/commit/9508ea9)), closes [#5632](https://github.com/bitnami/charts/issues/5632)
+* [bitnami/external-dns] Added Openshift Routes support (#5632) ([9508ea9](https://github.com/bitnami/charts/commit/9508ea9afe9bb3ef18464ceb62d9f8f5c2d5edc1)), closes [#5632](https://github.com/bitnami/charts/issues/5632)
 
 ## <small>4.8.6 (2021-03-03)</small>
 
-* Allow specifying automountServiceAccountToken (#5629) ([f067cc8](https://github.com/bitnami/charts/commit/f067cc8)), closes [#5629](https://github.com/bitnami/charts/issues/5629)
+* Allow specifying automountServiceAccountToken (#5629) ([f067cc8](https://github.com/bitnami/charts/commit/f067cc8d2697644f5170f1fe57771c212caef611)), closes [#5629](https://github.com/bitnami/charts/issues/5629)
 
 ## <small>4.8.5 (2021-03-02)</small>
 
-* Allow release to specify namespace for install (#5631) ([2ee43e5](https://github.com/bitnami/charts/commit/2ee43e5)), closes [#5631](https://github.com/bitnami/charts/issues/5631)
+* Allow release to specify namespace for install (#5631) ([2ee43e5](https://github.com/bitnami/charts/commit/2ee43e504e9a614a788446f593b5259b1815900f)), closes [#5631](https://github.com/bitnami/charts/issues/5631)
 
 ## <small>4.8.4 (2021-02-25)</small>
 
-* Fix external dns chart docs (#5609) ([dead24c](https://github.com/bitnami/charts/commit/dead24c)), closes [#5609](https://github.com/bitnami/charts/issues/5609)
+* Fix external dns chart docs (#5609) ([dead24c](https://github.com/bitnami/charts/commit/dead24c3ab2545f8fc82c4f17a3373450bcd8d0e)), closes [#5609](https://github.com/bitnami/charts/issues/5609)
 
 ## <small>4.8.3 (2021-02-22)</small>
 
-* [bitnami/*] Use common macro to define RBAC apiVersion (#5585) ([71fb99f](https://github.com/bitnami/charts/commit/71fb99f)), closes [#5585](https://github.com/bitnami/charts/issues/5585)
+* [bitnami/*] Use common macro to define RBAC apiVersion (#5585) ([71fb99f](https://github.com/bitnami/charts/commit/71fb99f541e971b1daafaa20ffb7d18b153b8d60)), closes [#5585](https://github.com/bitnami/charts/issues/5585)
 
 ## <small>4.8.2 (2021-02-22)</small>
 
-* [bitnami/external-dns] Ambassador RBAC Rules (#5565) ([ce6efde](https://github.com/bitnami/charts/commit/ce6efde)), closes [#5565](https://github.com/bitnami/charts/issues/5565)
+* [bitnami/external-dns] Ambassador RBAC Rules (#5565) ([ce6efde](https://github.com/bitnami/charts/commit/ce6efde097df11770db3685cb9197615dc3c8abf)), closes [#5565](https://github.com/bitnami/charts/issues/5565)
 
 ## <small>4.8.1 (2021-02-19)</small>
 
-* external-dns: add gloo-proxy rbac rules (#5553) ([8acd0a7](https://github.com/bitnami/charts/commit/8acd0a7)), closes [#5553](https://github.com/bitnami/charts/issues/5553)
+* external-dns: add gloo-proxy rbac rules (#5553) ([8acd0a7](https://github.com/bitnami/charts/commit/8acd0a700f795513bf1d200b8839a28c89b8b6f7)), closes [#5553](https://github.com/bitnami/charts/issues/5553)
 
 ## 4.8.0 (2021-02-18)
 
-* [bitnami/external-dns] Add pdb  (#5484) ([95ec95e](https://github.com/bitnami/charts/commit/95ec95e)), closes [#5484](https://github.com/bitnami/charts/issues/5484)
-* [bitnami/external-dns] add zone-name-filter (#5529) ([1a6d4a4](https://github.com/bitnami/charts/commit/1a6d4a4)), closes [#5529](https://github.com/bitnami/charts/issues/5529)
+* [bitnami/external-dns] Add pdb  (#5484) ([95ec95e](https://github.com/bitnami/charts/commit/95ec95e0e727adb7b01fbafad5b55a97106744a4)), closes [#5484](https://github.com/bitnami/charts/issues/5484)
+* [bitnami/external-dns] add zone-name-filter (#5529) ([1a6d4a4](https://github.com/bitnami/charts/commit/1a6d4a483c4cefb18a1120bcf4600b9eb5af8c4c)), closes [#5529](https://github.com/bitnami/charts/issues/5529)
 
 ## 4.7.0 (2021-02-16)
 
-* [bitnami/external-dns] Add msi user assigned managed identity (#5477) ([f112d71](https://github.com/bitnami/charts/commit/f112d71)), closes [#5477](https://github.com/bitnami/charts/issues/5477)
+* [bitnami/external-dns] Add msi user assigned managed identity (#5477) ([f112d71](https://github.com/bitnami/charts/commit/f112d71048e4fc3a8330f6b92fdb922fee0091ce)), closes [#5477](https://github.com/bitnami/charts/issues/5477)
 
 ## <small>4.6.1 (2021-02-13)</small>
 
-* [bitnami/external-dns] Release 4.6.1 updating components versions ([aeccd84](https://github.com/bitnami/charts/commit/aeccd84))
+* [bitnami/external-dns] Release 4.6.1 updating components versions ([aeccd84](https://github.com/bitnami/charts/commit/aeccd842375c1fd3f5f25b24bcd5f9f8eb5981fb))
 
 ## 4.6.0 (2021-01-28)
 
-* [bitnami/external-dns] Add hostAliases (#5239) ([a8482c7](https://github.com/bitnami/charts/commit/a8482c7)), closes [#5239](https://github.com/bitnami/charts/issues/5239)
+* [bitnami/external-dns] Add hostAliases (#5239) ([a8482c7](https://github.com/bitnami/charts/commit/a8482c7d535a60e4830a3a8f32b7a1d97edce2ae)), closes [#5239](https://github.com/bitnami/charts/issues/5239)
 
 ## <small>4.5.5 (2021-01-25)</small>
 
-* [bitnami/*] Unify icons in Chart.yaml and add missing fields (#5206) ([0462921](https://github.com/bitnami/charts/commit/0462921)), closes [#5206](https://github.com/bitnami/charts/issues/5206)
+* [bitnami/*] Unify icons in Chart.yaml and add missing fields (#5206) ([0462921](https://github.com/bitnami/charts/commit/0462921418ca8d54308b7466197a6d53ffae4628)), closes [#5206](https://github.com/bitnami/charts/issues/5206)
 
 ## <small>4.5.4 (2021-01-19)</small>
 
-* [bitnami/*] Change helm version in the prerequisites (#5090) ([c5e67a3](https://github.com/bitnami/charts/commit/c5e67a3)), closes [#5090](https://github.com/bitnami/charts/issues/5090)
-* [bitnami/external-dns] Drop values-production.yaml support (#5104) ([916e679](https://github.com/bitnami/charts/commit/916e679)), closes [#5104](https://github.com/bitnami/charts/issues/5104)
+* [bitnami/*] Change helm version in the prerequisites (#5090) ([c5e67a3](https://github.com/bitnami/charts/commit/c5e67a388743cbee28439d2cabca27884b9daf97)), closes [#5090](https://github.com/bitnami/charts/issues/5090)
+* [bitnami/external-dns] Drop values-production.yaml support (#5104) ([916e679](https://github.com/bitnami/charts/commit/916e679bb57f18b564ebf30e04a28ddb5666c2ec)), closes [#5104](https://github.com/bitnami/charts/issues/5104)
 
 ## <small>4.5.3 (2021-01-14)</small>
 
-* [bitnami/external-dns] Release 4.5.3 updating components versions ([7db6b65](https://github.com/bitnami/charts/commit/7db6b65))
+* [bitnami/external-dns] Release 4.5.3 updating components versions ([7db6b65](https://github.com/bitnami/charts/commit/7db6b65bb5be4aaa0532873aef750d062667192b))
 
 ## <small>4.5.2 (2021-01-13)</small>
 
-* [bitnami/external-dns] IRSA docs added (#4682) ([28e6e6f](https://github.com/bitnami/charts/commit/28e6e6f)), closes [#4682](https://github.com/bitnami/charts/issues/4682)
+* [bitnami/external-dns] IRSA docs added (#4682) ([28e6e6f](https://github.com/bitnami/charts/commit/28e6e6f257faa489b2c2708bb0a2c30cdb21a1bb)), closes [#4682](https://github.com/bitnami/charts/issues/4682)
 
 ## <small>4.5.1 (2021-01-11)</small>
 
-* [bitnami/external-dns] Release 4.5.1 updating components versions ([e404b88](https://github.com/bitnami/charts/commit/e404b88))
+* [bitnami/external-dns] Release 4.5.1 updating components versions ([e404b88](https://github.com/bitnami/charts/commit/e404b88709f77b3d000cc68d1c6f3939e52bb14c))
 
 ## 4.5.0 (2020-12-18)
 
-* [bitnami/external-dns] Add secretAnnotations value (#4745) ([bbab0dc](https://github.com/bitnami/charts/commit/bbab0dc)), closes [#4745](https://github.com/bitnami/charts/issues/4745)
+* [bitnami/external-dns] Add secretAnnotations value (#4745) ([bbab0dc](https://github.com/bitnami/charts/commit/bbab0dc5d108d59fa90c7d7e3b94e17f8345e421)), closes [#4745](https://github.com/bitnami/charts/issues/4745)
 
 ## <small>4.4.3 (2020-12-12)</small>
 
-* [bitnami/external-dns] Release 4.4.3 updating components versions ([55e40b0](https://github.com/bitnami/charts/commit/55e40b0))
+* [bitnami/external-dns] Release 4.4.3 updating components versions ([55e40b0](https://github.com/bitnami/charts/commit/55e40b0e46a9d484e3e042fad9c25f6a0dd507d8))
 
 ## <small>4.4.2 (2020-12-11)</small>
 
-* [bitnami/*] Update dependencies (#4694) ([2826c12](https://github.com/bitnami/charts/commit/2826c12)), closes [#4694](https://github.com/bitnami/charts/issues/4694)
+* [bitnami/*] Update dependencies (#4694) ([2826c12](https://github.com/bitnami/charts/commit/2826c125b42505f28431301e3c1bbe5366e47a01)), closes [#4694](https://github.com/bitnami/charts/issues/4694)
 
 ## <small>4.4.1 (2020-12-08)</small>
 
-* [bitnami/external-dns] Release 4.4.1 updating components versions ([6cc2050](https://github.com/bitnami/charts/commit/6cc2050))
+* [bitnami/external-dns] Release 4.4.1 updating components versions ([6cc2050](https://github.com/bitnami/charts/commit/6cc205084b75c8dab0ca44692e7b12d8e606fd60))
 
 ## 4.4.0 (2020-12-08)
 
-* feat: add service.enabled helm value (#4632) ([6a9bbfb](https://github.com/bitnami/charts/commit/6a9bbfb)), closes [#4632](https://github.com/bitnami/charts/issues/4632)
+* feat: add service.enabled helm value (#4632) ([6a9bbfb](https://github.com/bitnami/charts/commit/6a9bbfbd05175167b0120d48dbc3de0d8b22ee27)), closes [#4632](https://github.com/bitnami/charts/issues/4632)
 
 ## <small>4.3.1 (2020-11-26)</small>
 
-* [bitnami/external-dns] Fix typos (#4496) ([f300b2a](https://github.com/bitnami/charts/commit/f300b2a)), closes [#4496](https://github.com/bitnami/charts/issues/4496)
+* [bitnami/external-dns] Fix typos (#4496) ([f300b2a](https://github.com/bitnami/charts/commit/f300b2a92425b38ae394fb6fda97c7242acac0a7)), closes [#4496](https://github.com/bitnami/charts/issues/4496)
 
 ## 4.3.0 (2020-11-25)
 
-* [bitnami/*] Affinity based on common presets (ii) (#4472) ([934259f](https://github.com/bitnami/charts/commit/934259f)), closes [#4472](https://github.com/bitnami/charts/issues/4472)
+* [bitnami/*] Affinity based on common presets (ii) (#4472) ([934259f](https://github.com/bitnami/charts/commit/934259f78127c53c747dfff5e5df9f67738ec79c)), closes [#4472](https://github.com/bitnami/charts/issues/4472)
 
 ## 4.2.0 (2020-11-24)
 
-* [bitnami/external-dns] add Linode provider token support (#4080) ([e2a48a6](https://github.com/bitnami/charts/commit/e2a48a6)), closes [#4080](https://github.com/bitnami/charts/issues/4080)
+* [bitnami/external-dns] add Linode provider token support (#4080) ([e2a48a6](https://github.com/bitnami/charts/commit/e2a48a6671f64ad9c798694f3f28b4ef325f6b6e)), closes [#4080](https://github.com/bitnami/charts/issues/4080)
 
 ## 4.1.0 (2020-11-23)
 
-* [bitnami/external-dns] Add hetzner as provider (#4424) ([08ebe0b](https://github.com/bitnami/charts/commit/08ebe0b)), closes [#4424](https://github.com/bitnami/charts/issues/4424)
+* [bitnami/external-dns] Add hetzner as provider (#4424) ([08ebe0b](https://github.com/bitnami/charts/commit/08ebe0b361a867d9e6225abd2042913c483bfb6c)), closes [#4424](https://github.com/bitnami/charts/issues/4424)
 
 ## 4.0.0 (2020-11-11)
 
-* [bitnami/external-dns] Major version. Adapt Chart to apiVersion: v2 (#4284) ([0a4a240](https://github.com/bitnami/charts/commit/0a4a240)), closes [#4284](https://github.com/bitnami/charts/issues/4284)
+* [bitnami/external-dns] Major version. Adapt Chart to apiVersion: v2 (#4284) ([0a4a240](https://github.com/bitnami/charts/commit/0a4a240b75c7e9643de4ec9aa4d8e48568a5617c)), closes [#4284](https://github.com/bitnami/charts/issues/4284)
 
 ## 3.7.0 (2020-11-06)
 
-* [bitnami/external-dns] support for Scaleway DNS provider (#4224) ([731a029](https://github.com/bitnami/charts/commit/731a029)), closes [#4224](https://github.com/bitnami/charts/issues/4224)
+* [bitnami/external-dns] support for Scaleway DNS provider (#4224) ([731a029](https://github.com/bitnami/charts/commit/731a0291575a6211b76e2be5a4df443b649b3628)), closes [#4224](https://github.com/bitnami/charts/issues/4224)
 
 ## 3.6.0 (2020-11-05)
 
-* [bitnami/external-dns] add support for aws-api-retries arg (#4199) ([9c9f173](https://github.com/bitnami/charts/commit/9c9f173)), closes [#4199](https://github.com/bitnami/charts/issues/4199)
+* [bitnami/external-dns] add support for aws-api-retries arg (#4199) ([9c9f173](https://github.com/bitnami/charts/commit/9c9f173e7879f87a2eceadc80c066f0bb99e164f)), closes [#4199](https://github.com/bitnami/charts/issues/4199)
 
 ## <small>3.5.1 (2020-10-30)</small>
 
-* [bitnami/*] Include link to Troubleshootin guide on README.md (#4136) ([c08a20e](https://github.com/bitnami/charts/commit/c08a20e)), closes [#4136](https://github.com/bitnami/charts/issues/4136)
-* [bitnami/external-dns] Release 3.5.1 updating components versions ([bef1863](https://github.com/bitnami/charts/commit/bef1863))
+* [bitnami/*] Include link to Troubleshootin guide on README.md (#4136) ([c08a20e](https://github.com/bitnami/charts/commit/c08a20e3db004215383004ff023a73fcc2522e72)), closes [#4136](https://github.com/bitnami/charts/issues/4136)
+* [bitnami/external-dns] Release 3.5.1 updating components versions ([bef1863](https://github.com/bitnami/charts/commit/bef1863ac1f0c0204575b953a023fdec10533cb5))
 
 ## 3.5.0 (2020-10-28)
 
-* [bitnami/external-dns] Adding infoblox existing secret support (#4119) ([9e5c873](https://github.com/bitnami/charts/commit/9e5c873)), closes [#4119](https://github.com/bitnami/charts/issues/4119)
+* [bitnami/external-dns] Adding infoblox existing secret support (#4119) ([9e5c873](https://github.com/bitnami/charts/commit/9e5c8739f8cd30b3a7b301f1b72f8569b4b818a4)), closes [#4119](https://github.com/bitnami/charts/issues/4119)
 
 ## <small>3.4.9 (2020-10-19)</small>
 
-* [bitnami/external-dns] fix: pods annotations wrong indentation (#4037) ([d80b5e1](https://github.com/bitnami/charts/commit/d80b5e1)), closes [#4037](https://github.com/bitnami/charts/issues/4037)
+* [bitnami/external-dns] fix: pods annotations wrong indentation (#4037) ([d80b5e1](https://github.com/bitnami/charts/commit/d80b5e19e6b6bca3d0190fae8dada5b3f71d296d)), closes [#4037](https://github.com/bitnami/charts/issues/4037)
 
 ## <small>3.4.8 (2020-10-16)</small>
 
-* [bitnami/external-dns] Allow ARNs from AWS China to validate properly (#4021) ([e78476f](https://github.com/bitnami/charts/commit/e78476f)), closes [#4021](https://github.com/bitnami/charts/issues/4021)
+* [bitnami/external-dns] Allow ARNs from AWS China to validate properly (#4021) ([e78476f](https://github.com/bitnami/charts/commit/e78476f544db9a605ee22bf8549416a523fde5a3)), closes [#4021](https://github.com/bitnami/charts/issues/4021)
 
 ## <small>3.4.7 (2020-10-16)</small>
 
-* Add to the clusterrole, der. (#4031) ([9230292](https://github.com/bitnami/charts/commit/9230292)), closes [#4031](https://github.com/bitnami/charts/issues/4031)
+* Add to the clusterrole, der. (#4031) ([9230292](https://github.com/bitnami/charts/commit/923029254a5eb2fbccd678135c1acfa4ac04f150)), closes [#4031](https://github.com/bitnami/charts/issues/4031)
 
 ## <small>3.4.6 (2020-10-08)</small>
 
-* [bitnami/external-dns] Add ability to monitor contour entries added in 0.7.4 (#3941) ([0966de9](https://github.com/bitnami/charts/commit/0966de9)), closes [#3941](https://github.com/bitnami/charts/issues/3941)
+* [bitnami/external-dns] Add ability to monitor contour entries added in 0.7.4 (#3941) ([0966de9](https://github.com/bitnami/charts/commit/0966de9fb6f693aea277d1c79fd8f43c3e65b897)), closes [#3941](https://github.com/bitnami/charts/issues/3941)
 
 ## <small>3.4.5 (2020-10-06)</small>
 
-* [bitnami/external-dns] Support configuring service labels (#3917) ([41d917a](https://github.com/bitnami/charts/commit/41d917a)), closes [#3917](https://github.com/bitnami/charts/issues/3917)
+* [bitnami/external-dns] Support configuring service labels (#3917) ([41d917a](https://github.com/bitnami/charts/commit/41d917aba5946d290580c96afb295b9b9207dc59)), closes [#3917](https://github.com/bitnami/charts/issues/3917)
 
 ## <small>3.4.4 (2020-10-02)</small>
 
-* [bitnami/external-dns] Fix Azure validations to support azure.json from hostPath (#3846) ([37e3599](https://github.com/bitnami/charts/commit/37e3599)), closes [#3846](https://github.com/bitnami/charts/issues/3846)
+* [bitnami/external-dns] Fix Azure validations to support azure.json from hostPath (#3846) ([37e3599](https://github.com/bitnami/charts/commit/37e3599bd079871e636da756ba7e64989e3d15cb)), closes [#3846](https://github.com/bitnami/charts/issues/3846)
 
 ## <small>3.4.3 (2020-09-30)</small>
 
-* [bitnami/external-dns] Release 3.4.3 updating components versions ([868ef68](https://github.com/bitnami/charts/commit/868ef68))
+* [bitnami/external-dns] Release 3.4.3 updating components versions ([868ef68](https://github.com/bitnami/charts/commit/868ef68c96a2297c2db4080f6797d45544378bce))
 
 ## <small>3.4.2 (2020-09-25)</small>
 
-* Allow ARNs from AWS Gov-Cloud in values.yaml (#3770) ([5193cea](https://github.com/bitnami/charts/commit/5193cea)), closes [#3770](https://github.com/bitnami/charts/issues/3770)
+* Allow ARNs from AWS Gov-Cloud in values.yaml (#3770) ([5193cea](https://github.com/bitnami/charts/commit/5193cea7d18feade98ef428834540828407c3dee)), closes [#3770](https://github.com/bitnami/charts/issues/3770)
 
 ## <small>3.4.1 (2020-09-21)</small>
 
-* [bitnami/external-dns] Release 3.4.1 updating components versions ([522cab2](https://github.com/bitnami/charts/commit/522cab2))
+* [bitnami/external-dns] Release 3.4.1 updating components versions ([522cab2](https://github.com/bitnami/charts/commit/522cab24c86e353799bf2ebce98dd136d7b85395))
 
 ## 3.4.0 (2020-09-08)
 
-* [bitnami/external-dns] readme typo fix (#3602) ([8f9b408](https://github.com/bitnami/charts/commit/8f9b408)), closes [#3602](https://github.com/bitnami/charts/issues/3602)
-* [bitnami/external-dns] support role for namespace instead of clusterrole (#3593) ([6d08ad2](https://github.com/bitnami/charts/commit/6d08ad2)), closes [#3593](https://github.com/bitnami/charts/issues/3593)
+* [bitnami/external-dns] readme typo fix (#3602) ([8f9b408](https://github.com/bitnami/charts/commit/8f9b408951df46ca30cab143bf8fc7a607bb9511)), closes [#3602](https://github.com/bitnami/charts/issues/3602)
+* [bitnami/external-dns] support role for namespace instead of clusterrole (#3593) ([6d08ad2](https://github.com/bitnami/charts/commit/6d08ad27b757932d1f1de00d6e745183792e0728)), closes [#3593](https://github.com/bitnami/charts/issues/3593)
 
 ## <small>3.3.1 (2020-09-04)</small>
 
-* [bitnami/external-dns] Release 3.3.1 updating components versions ([964551a](https://github.com/bitnami/charts/commit/964551a))
-* [bitnami/metrics-server] Add source repo (#3577) ([1ed12f9](https://github.com/bitnami/charts/commit/1ed12f9)), closes [#3577](https://github.com/bitnami/charts/issues/3577)
+* [bitnami/external-dns] Release 3.3.1 updating components versions ([964551a](https://github.com/bitnami/charts/commit/964551a1a165decf566429699b78d8428543fb24))
+* [bitnami/metrics-server] Add source repo (#3577) ([1ed12f9](https://github.com/bitnami/charts/commit/1ed12f96af75322b46afdb2b3d9907c11b13f765)), closes [#3577](https://github.com/bitnami/charts/issues/3577)
 
 ## 3.3.0 (2020-09-03)
 
-* [bitnami/external-dns] only create clusterrole if not limited to namespace (#3412) ([4b0d529](https://github.com/bitnami/charts/commit/4b0d529)), closes [#3412](https://github.com/bitnami/charts/issues/3412)
-* external-dns infoblox provider additional parameter (#3397) ([be5b30d](https://github.com/bitnami/charts/commit/be5b30d)), closes [#3397](https://github.com/bitnami/charts/issues/3397)
-* Revert "[bitnami/external-dns] only create clusterrole if not limited to namespace (#3412)" (#3592) ([f461a0c](https://github.com/bitnami/charts/commit/f461a0c)), closes [#3412](https://github.com/bitnami/charts/issues/3412) [#3592](https://github.com/bitnami/charts/issues/3592)
+* [bitnami/external-dns] only create clusterrole if not limited to namespace (#3412) ([4b0d529](https://github.com/bitnami/charts/commit/4b0d529aebe2c1d1d013c2863f0c312ee4d89a9e)), closes [#3412](https://github.com/bitnami/charts/issues/3412)
+* external-dns infoblox provider additional parameter (#3397) ([be5b30d](https://github.com/bitnami/charts/commit/be5b30d4b65794d63d36449fc6e8a912bdccbdda)), closes [#3397](https://github.com/bitnami/charts/issues/3397)
+* Revert "[bitnami/external-dns] only create clusterrole if not limited to namespace (#3412)" (#3592) ([f461a0c](https://github.com/bitnami/charts/commit/f461a0c024384296e76cbc2f5051424773ae6e56)), closes [#3412](https://github.com/bitnami/charts/issues/3412) [#3592](https://github.com/bitnami/charts/issues/3592)
 
 ## <small>3.2.6 (2020-08-05)</small>
 
-* [bitnami/*] Fix TL;DR typo in READMEs (#3280) ([3d7ab40](https://github.com/bitnami/charts/commit/3d7ab40)), closes [#3280](https://github.com/bitnami/charts/issues/3280)
-* [bitnami/external-dns] Fix MSI for azure-private-dns provider (#3232) ([5c799cc](https://github.com/bitnami/charts/commit/5c799cc)), closes [#3232](https://github.com/bitnami/charts/issues/3232)
-* [bitnami/external-dns] Release 3.2.6 updating components versions ([80f79de](https://github.com/bitnami/charts/commit/80f79de))
+* [bitnami/*] Fix TL;DR typo in READMEs (#3280) ([3d7ab40](https://github.com/bitnami/charts/commit/3d7ab406fecd64f1af25f53e7d27f03ec95b29a4)), closes [#3280](https://github.com/bitnami/charts/issues/3280)
+* [bitnami/external-dns] Fix MSI for azure-private-dns provider (#3232) ([5c799cc](https://github.com/bitnami/charts/commit/5c799cc633ca92d65de279519ec02a375548f3b7)), closes [#3232](https://github.com/bitnami/charts/issues/3232)
+* [bitnami/external-dns] Release 3.2.6 updating components versions ([80f79de](https://github.com/bitnami/charts/commit/80f79de9982afabc471e97f89c2f0852471b34e7))
 
 ## <small>3.2.5 (2020-07-28)</small>
 
-* Add VirtualService support for istio (#3216) ([98c115c](https://github.com/bitnami/charts/commit/98c115c)), closes [#3216](https://github.com/bitnami/charts/issues/3216)
+* Add VirtualService support for istio (#3216) ([98c115c](https://github.com/bitnami/charts/commit/98c115cad63c7405f2ad1241dbd668e34e3a3f98)), closes [#3216](https://github.com/bitnami/charts/issues/3216)
 
 ## <small>3.2.4 (2020-07-23)</small>
 
-* [bitnami/all] Add categories (#3075) ([63bde06](https://github.com/bitnami/charts/commit/63bde06)), closes [#3075](https://github.com/bitnami/charts/issues/3075)
-* [bitnami/external-dns] Release 3.2.4 updating components versions ([a0d9242](https://github.com/bitnami/charts/commit/a0d9242))
+* [bitnami/all] Add categories (#3075) ([63bde06](https://github.com/bitnami/charts/commit/63bde066b87a140fab52264d0522401ab3d63509)), closes [#3075](https://github.com/bitnami/charts/issues/3075)
+* [bitnami/external-dns] Release 3.2.4 updating components versions ([a0d9242](https://github.com/bitnami/charts/commit/a0d9242d3aa21296ffe0584e5eda478bcc961ea7))
 
 ## <small>3.2.3 (2020-06-24)</small>
 
-* [bitnami/external-dns] Release 3.2.3 updating components versions ([4b333ee](https://github.com/bitnami/charts/commit/4b333ee))
+* [bitnami/external-dns] Release 3.2.3 updating components versions ([4b333ee](https://github.com/bitnami/charts/commit/4b333ee2610bd77090da0beb2f6088cd19e4f51f))
 
 ## <small>3.2.2 (2020-06-23)</small>
 
-* [bitnami/external-dns] Fix/setting pdns api key (#2718) ([c606938](https://github.com/bitnami/charts/commit/c606938)), closes [#2718](https://github.com/bitnami/charts/issues/2718)
+* [bitnami/external-dns] Fix/setting pdns api key (#2718) ([c606938](https://github.com/bitnami/charts/commit/c606938f87cac4225f994dc1ca9af5d4cd43923a)), closes [#2718](https://github.com/bitnami/charts/issues/2718)
 
 ## <small>3.2.1 (2020-06-16)</small>
 
-* [bitnami/external-dns] allow gcp project autodetection (#2841) ([57a608e](https://github.com/bitnami/charts/commit/57a608e)), closes [#2841](https://github.com/bitnami/charts/issues/2841)
+* [bitnami/external-dns] allow gcp project autodetection (#2841) ([57a608e](https://github.com/bitnami/charts/commit/57a608e741492e36b47a778daa11c65b8c38b295)), closes [#2841](https://github.com/bitnami/charts/issues/2841)
 
 ## 3.2.0 (2020-06-08)
 
-* [bitnami/external-dns] Support --exclude-domains flags (#2766) ([38fe265](https://github.com/bitnami/charts/commit/38fe265)), closes [#2766](https://github.com/bitnami/charts/issues/2766)
+* [bitnami/external-dns] Support --exclude-domains flags (#2766) ([38fe265](https://github.com/bitnami/charts/commit/38fe26573c97fdcefd43c65595725da36c2020ad)), closes [#2766](https://github.com/bitnami/charts/issues/2766)
 
 ## <small>3.1.2 (2020-06-08)</small>
 
-* [bitnami/external-dns] Fix cloudflare env vars (#2755) ([bb63ebb](https://github.com/bitnami/charts/commit/bb63ebb)), closes [#2755](https://github.com/bitnami/charts/issues/2755)
+* [bitnami/external-dns] Fix cloudflare env vars (#2755) ([bb63ebb](https://github.com/bitnami/charts/commit/bb63ebb107c76122db902fc779353ed6ba73aa6b)), closes [#2755](https://github.com/bitnami/charts/issues/2755)
 
 ## <small>3.1.1 (2020-06-03)</small>
 
-* [bitnami/external-dns] Release 3.1.1 updating components versions ([e71ef41](https://github.com/bitnami/charts/commit/e71ef41))
+* [bitnami/external-dns] Release 3.1.1 updating components versions ([e71ef41](https://github.com/bitnami/charts/commit/e71ef41f7ba1354823a56e274b16f698956fd755))
 
 ## 3.1.0 (2020-05-27)
 
-* [bitnami/external-dns] Support RFC2136 minTTL (#2651) ([5cd2cd0](https://github.com/bitnami/charts/commit/5cd2cd0)), closes [#2651](https://github.com/bitnami/charts/issues/2651)
-* Correct serviceAccountAnnotations upgrade docs (#2629) ([8fc88de](https://github.com/bitnami/charts/commit/8fc88de)), closes [#2629](https://github.com/bitnami/charts/issues/2629)
+* [bitnami/external-dns] Support RFC2136 minTTL (#2651) ([5cd2cd0](https://github.com/bitnami/charts/commit/5cd2cd009185033b577a788661d711f3c9a67b88)), closes [#2651](https://github.com/bitnami/charts/issues/2651)
+* Correct serviceAccountAnnotations upgrade docs (#2629) ([8fc88de](https://github.com/bitnami/charts/commit/8fc88de6c0ace34f72429a790e25101892b571c1)), closes [#2629](https://github.com/bitnami/charts/issues/2629)
 
 ## <small>3.0.2 (2020-05-21)</small>
 
-* [bitnami/external-dns] Add zalando routegroups to cluster role (#2630) ([14a03dc](https://github.com/bitnami/charts/commit/14a03dc)), closes [#2630](https://github.com/bitnami/charts/issues/2630)
-* update bitnami/common to be compatible with helm v2.12+ (#2615) ([c7751eb](https://github.com/bitnami/charts/commit/c7751eb)), closes [#2615](https://github.com/bitnami/charts/issues/2615)
+* [bitnami/external-dns] Add zalando routegroups to cluster role (#2630) ([14a03dc](https://github.com/bitnami/charts/commit/14a03dc8eb5c03e4f9388b19a1c0ab043a140869)), closes [#2630](https://github.com/bitnami/charts/issues/2630)
+* update bitnami/common to be compatible with helm v2.12+ (#2615) ([c7751eb](https://github.com/bitnami/charts/commit/c7751eb5764e468e1854b58a1b8491d2b13e0a4a)), closes [#2615](https://github.com/bitnami/charts/issues/2615)
 
 ## <small>3.0.1 (2020-05-15)</small>
 
-* [bitnami/external-dns] Fix Email for Cloudflare (#2586) ([3ea5449](https://github.com/bitnami/charts/commit/3ea5449)), closes [#2586](https://github.com/bitnami/charts/issues/2586)
+* [bitnami/external-dns] Fix Email for Cloudflare (#2586) ([3ea5449](https://github.com/bitnami/charts/commit/3ea544973c284a7290ebb79eef25800ae868140c)), closes [#2586](https://github.com/bitnami/charts/issues/2586)
 
 ## 3.0.0 (2020-05-15)
 
-* [bitnami/external-dns:] Follow Helm rbac best practices (#2589) ([943a73d](https://github.com/bitnami/charts/commit/943a73d)), closes [#2589](https://github.com/bitnami/charts/issues/2589)
+* [bitnami/external-dns:] Follow Helm rbac best practices (#2589) ([943a73d](https://github.com/bitnami/charts/commit/943a73da406c3ee1e549316ffbe3428171841fe4)), closes [#2589](https://github.com/bitnami/charts/issues/2589)
 
 ## <small>2.24.1 (2020-05-14)</small>
 
-* [bitnami/external-dns] Add secretName for PowerDNS (#2451) ([da0048b](https://github.com/bitnami/charts/commit/da0048b)), closes [#2451](https://github.com/bitnami/charts/issues/2451) [#2447](https://github.com/bitnami/charts/issues/2447)
+* [bitnami/external-dns] Add secretName for PowerDNS (#2451) ([da0048b](https://github.com/bitnami/charts/commit/da0048b4729697ac15e1da4797fb92b27cae98dd)), closes [#2451](https://github.com/bitnami/charts/issues/2451) [#2447](https://github.com/bitnami/charts/issues/2447)
 
 ## 2.24.0 (2020-05-13)
 
-* [bitnami/external-dns] add alibaba cloud configuration parameters (#2566) ([9ac2540](https://github.com/bitnami/charts/commit/9ac2540)), closes [#2566](https://github.com/bitnami/charts/issues/2566)
+* [bitnami/external-dns] add alibaba cloud configuration parameters (#2566) ([9ac2540](https://github.com/bitnami/charts/commit/9ac254036b72d644d8eee50b0c2dc532ab6179ab)), closes [#2566](https://github.com/bitnami/charts/issues/2566)
 
 ## <small>2.22.4 (2020-05-12)</small>
 
-* [bitnami/external-dns] Release 2.22.4 updating components versions ([7c6b379](https://github.com/bitnami/charts/commit/7c6b379))
+* [bitnami/external-dns] Release 2.22.4 updating components versions ([7c6b379](https://github.com/bitnami/charts/commit/7c6b37957b00e7bd4661b851ed3661da8e76e6a9))
 
 ## <small>2.22.3 (2020-05-12)</small>
 
-* [bitnami/external-dns] Release 2.22.3 updating components versions ([627b472](https://github.com/bitnami/charts/commit/627b472))
+* [bitnami/external-dns] Release 2.22.3 updating components versions ([627b472](https://github.com/bitnami/charts/commit/627b472b5dc7782458ffad937d1d2f4875add867))
 
 ## <small>2.22.2 (2020-05-12)</small>
 
-* [bitnami/external-dns] Fix Cloudflare existing secret (#2572) ([d0f8e11](https://github.com/bitnami/charts/commit/d0f8e11)), closes [#2572](https://github.com/bitnami/charts/issues/2572)
+* [bitnami/external-dns] Fix Cloudflare existing secret (#2572) ([d0f8e11](https://github.com/bitnami/charts/commit/d0f8e11c5209877118975acd823cf00349207bab)), closes [#2572](https://github.com/bitnami/charts/issues/2572)
 
 ## <small>2.22.1 (2020-04-30)</small>
 
-* [bitnami/external-dns] fix: correct new line on external-dns extraVolumes (#2422) ([364f797](https://github.com/bitnami/charts/commit/364f797)), closes [#2422](https://github.com/bitnami/charts/issues/2422)
+* [bitnami/external-dns] fix: correct new line on external-dns extraVolumes (#2422) ([364f797](https://github.com/bitnami/charts/commit/364f7972b8b4258e1dfd7c1ea866285dd3ffdc3a)), closes [#2422](https://github.com/bitnami/charts/issues/2422)
 
 ## 2.22.0 (2020-04-29)
 
-* [bitnami/external-dns] support vinyldns configuration (#2440) ([1196640](https://github.com/bitnami/charts/commit/1196640)), closes [#2440](https://github.com/bitnami/charts/issues/2440)
+* [bitnami/external-dns] support vinyldns configuration (#2440) ([1196640](https://github.com/bitnami/charts/commit/1196640dcc648939e5c19c479d65d36739b53d7e)), closes [#2440](https://github.com/bitnami/charts/issues/2440)
 
 ## <small>2.21.2 (2020-04-22)</small>
 
-* [bitnami/external-dns] Release 2.21.2 updating components versions ([dfecd01](https://github.com/bitnami/charts/commit/dfecd01))
+* [bitnami/external-dns] Release 2.21.2 updating components versions ([dfecd01](https://github.com/bitnami/charts/commit/dfecd012926cbd71d90038ccf3fa087c7461bb71))
 
 ## <small>2.21.1 (2020-04-21)</small>
 
-* [bitnami/external-dns] Remove old istio-ingress-gateway references (#2359) ([2ad4468](https://github.com/bitnami/charts/commit/2ad4468)), closes [#2359](https://github.com/bitnami/charts/issues/2359)
+* [bitnami/external-dns] Remove old istio-ingress-gateway references (#2359) ([2ad4468](https://github.com/bitnami/charts/commit/2ad44688f00899084a51d235c1f65b338d05429c)), closes [#2359](https://github.com/bitnami/charts/issues/2359)
 
 ## 2.21.0 (2020-04-16)
 
-* [bitnami/external-dns] add parameters for OVH authentication (#2293) ([301eda6](https://github.com/bitnami/charts/commit/301eda6)), closes [#2293](https://github.com/bitnami/charts/issues/2293)
+* [bitnami/external-dns] add parameters for OVH authentication (#2293) ([301eda6](https://github.com/bitnami/charts/commit/301eda6dedaa95a570e760a901c6497859fb592a)), closes [#2293](https://github.com/bitnami/charts/issues/2293)
 
 ## <small>2.20.15 (2020-04-16)</small>
 
-* [bitnami/external-dns] Release 2.20.15 updating components versions ([5e85aaf](https://github.com/bitnami/charts/commit/5e85aaf))
+* [bitnami/external-dns] Release 2.20.15 updating components versions ([5e85aaf](https://github.com/bitnami/charts/commit/5e85aafbccf22ae46997d056238d76420473148d))
 
 ## <small>2.20.14 (2020-04-15)</small>
 
-* [bitnami/external-dns] Release 2.20.14 updating components versions ([84b64f5](https://github.com/bitnami/charts/commit/84b64f5))
+* [bitnami/external-dns] Release 2.20.14 updating components versions ([84b64f5](https://github.com/bitnami/charts/commit/84b64f582958af2055587249f4e70dad421e5e2e))
 
 ## <small>2.20.13 (2020-04-15)</small>
 
-* [bitnami/external-dns] Release 2.20.13 updating components versions ([64f90f1](https://github.com/bitnami/charts/commit/64f90f1))
+* [bitnami/external-dns] Release 2.20.13 updating components versions ([64f90f1](https://github.com/bitnami/charts/commit/64f90f1fd6f9f982298954212954af3fa89e8c14))
 
 ## <small>2.20.12 (2020-04-13)</small>
 
-* [bitnami/external-dns] azure secrets set in env by secretKeyRef (#2258) ([e446ccc](https://github.com/bitnami/charts/commit/e446ccc)), closes [#2258](https://github.com/bitnami/charts/issues/2258)
-* Fix typo (#2246) ([abce027](https://github.com/bitnami/charts/commit/abce027)), closes [#2246](https://github.com/bitnami/charts/issues/2246)
+* [bitnami/external-dns] azure secrets set in env by secretKeyRef (#2258) ([e446ccc](https://github.com/bitnami/charts/commit/e446ccc4ceab31fd42b7c1eb4597ed0879bfa715)), closes [#2258](https://github.com/bitnami/charts/issues/2258)
+* Fix typo (#2246) ([abce027](https://github.com/bitnami/charts/commit/abce027eb6e1ba067037a7fa0750c9a0ad445ba5)), closes [#2246](https://github.com/bitnami/charts/issues/2246)
 
 ## <small>2.20.11 (2020-04-03)</small>
 
-*  [bitnami/external-dns] Fix markdown errors in README.md (#2208) ([556b602](https://github.com/bitnami/charts/commit/556b602)), closes [#2208](https://github.com/bitnami/charts/issues/2208)
+*  [bitnami/external-dns] Fix markdown errors in README.md (#2208) ([556b602](https://github.com/bitnami/charts/commit/556b6028e199626d728366359526342fd4621e49)), closes [#2208](https://github.com/bitnami/charts/issues/2208)
 
 ## <small>2.20.10 (2020-03-27)</small>
 
-* [bitnami/external-dns] Fix issue on SA (#2151) ([9858866](https://github.com/bitnami/charts/commit/9858866)), closes [#2151](https://github.com/bitnami/charts/issues/2151)
+* [bitnami/external-dns] Fix issue on SA (#2151) ([9858866](https://github.com/bitnami/charts/commit/9858866ad650a951d8c595d51b1ca80b4f8c6625)), closes [#2151](https://github.com/bitnami/charts/issues/2151)
 
 ## <small>2.20.9 (2020-03-27)</small>
 
-* [bitnami/external-dns] Remove unnecessary lines (#2148) ([1ccfd16](https://github.com/bitnami/charts/commit/1ccfd16)), closes [#2148](https://github.com/bitnami/charts/issues/2148)
+* [bitnami/external-dns] Remove unnecessary lines (#2148) ([1ccfd16](https://github.com/bitnami/charts/commit/1ccfd16c64b3da5a11d23f8b7255f9ff7201d5ff)), closes [#2148](https://github.com/bitnami/charts/issues/2148)
 
 ## <small>2.20.8 (2020-03-26)</small>
 
-* [bitnami/external-dns] reuse existing service account  (#2088) ([11ee48e](https://github.com/bitnami/charts/commit/11ee48e)), closes [#2088](https://github.com/bitnami/charts/issues/2088)
+* [bitnami/external-dns] reuse existing service account  (#2088) ([11ee48e](https://github.com/bitnami/charts/commit/11ee48ee38160447ec5616116d93b8f339eecf7c)), closes [#2088](https://github.com/bitnami/charts/issues/2088)
 
 ## <small>2.20.7 (2020-03-26)</small>
 
-* [bitnami/external-dns] Release 2.20.7 updating components versions ([23c6742](https://github.com/bitnami/charts/commit/23c6742))
+* [bitnami/external-dns] Release 2.20.7 updating components versions ([23c6742](https://github.com/bitnami/charts/commit/23c674245d4127d710279f671e3b6b0b8b24f32c))
 
 ## <small>2.20.6 (2020-03-20)</small>
 
-* [bitnami/external-dns] Release 2.20.6 updating components versions ([402665b](https://github.com/bitnami/charts/commit/402665b))
+* [bitnami/external-dns] Release 2.20.6 updating components versions ([402665b](https://github.com/bitnami/charts/commit/402665bb4df2b7aca3090f2b0e4e181c0583154d))
 
 ## <small>2.20.5 (2020-03-12)</small>
 
-* [bitnami/external-dns] Release 2.20.5 updating components versions ([2b37f7d](https://github.com/bitnami/charts/commit/2b37f7d))
-* adding endpoints resource permissions (#2035) ([97af92a](https://github.com/bitnami/charts/commit/97af92a)), closes [#2035](https://github.com/bitnami/charts/issues/2035) [kubernetes-sigs/external-dns#1005](https://github.com/kubernetes-sigs/external-dns/issues/1005)
+* [bitnami/external-dns] Release 2.20.5 updating components versions ([2b37f7d](https://github.com/bitnami/charts/commit/2b37f7d999427a578b0384c8d16e99d592976ec9))
+* adding endpoints resource permissions (#2035) ([97af92a](https://github.com/bitnami/charts/commit/97af92a390de3742199153841ad1764125bb1bce)), closes [#2035](https://github.com/bitnami/charts/issues/2035) [kubernetes-sigs/external-dns#1005](https://github.com/kubernetes-sigs/external-dns/issues/1005)
 
 ## <small>2.20.4 (2020-03-11)</small>
 
-* [bitnami/external-dns] Release 2.20.4 updating components versions ([9eca03c](https://github.com/bitnami/charts/commit/9eca03c))
+* [bitnami/external-dns] Release 2.20.4 updating components versions ([9eca03c](https://github.com/bitnami/charts/commit/9eca03cb2f4b9d4a5b7e877711f810f9151ea2a3))
 
 ## <small>2.20.3 (2020-03-11)</small>
 
-* [bitnami/external-dns] Remove chart since we're using the one synced from 'helm/charts' repo ([52bb8d2](https://github.com/bitnami/charts/commit/52bb8d2))
-* Changes in README ([7ac4ec0](https://github.com/bitnami/charts/commit/7ac4ec0))
-* Move charts from upstreamed folder to bitnami (#2032) ([a0e44f7](https://github.com/bitnami/charts/commit/a0e44f7)), closes [#2032](https://github.com/bitnami/charts/issues/2032)
+* [bitnami/external-dns] Remove chart since we're using the one synced from 'helm/charts' repo ([52bb8d2](https://github.com/bitnami/charts/commit/52bb8d29aaf890e9e916271434974c578fd04df9))
+* Changes in README ([7ac4ec0](https://github.com/bitnami/charts/commit/7ac4ec09a0113aae7d39173f52fb11c55f27cde5))
+* Move charts from upstreamed folder to bitnami (#2032) ([a0e44f7](https://github.com/bitnami/charts/commit/a0e44f7d6a10b8b5643186130ea420887cb72c7c)), closes [#2032](https://github.com/bitnami/charts/issues/2032)
 
 ## <small>1.5.9 (2019-06-10)</small>
 
-* bitnami/external-dns: update to 0.5.14 ([ca25f1a](https://github.com/bitnami/charts/commit/ca25f1a))
-* Bump version ([a672193](https://github.com/bitnami/charts/commit/a672193))
+* bitnami/external-dns: update to 0.5.14 ([ca25f1a](https://github.com/bitnami/charts/commit/ca25f1ae5f43d973bd80f88511a941d9d055eccf))
+* Bump version ([a672193](https://github.com/bitnami/charts/commit/a67219387480695cdd7e4dd2a7f5443ed8093a11))
 
 ## <small>1.5.8 (2019-06-10)</small>
 
-* Add command ([50e7559](https://github.com/bitnami/charts/commit/50e7559))
-* Use IfNotPresent as imagePullPolicy since we are using immutable tags ([53247da](https://github.com/bitnami/charts/commit/53247da))
+* Add command ([50e7559](https://github.com/bitnami/charts/commit/50e7559f77b740778fc2fdf8d65bb0d6d095a6e9))
+* Use IfNotPresent as imagePullPolicy since we are using immutable tags ([53247da](https://github.com/bitnami/charts/commit/53247da385b3bed19f02505b059591869893ecbb))
 
 ## <small>1.5.7 (2019-06-07)</small>
 
-* [bitnami/external-dns] Unify and document production values ([14be718](https://github.com/bitnami/charts/commit/14be718))
+* [bitnami/external-dns] Unify and document production values ([14be718](https://github.com/bitnami/charts/commit/14be71816fa39291b6abdbd8560d99c4f48c76cc))
 
 ## <small>1.5.6 (2019-05-29)</small>
 
-* Change syntax because of linter failing ([adfc357](https://github.com/bitnami/charts/commit/adfc357))
-* Fix https://github.com/helm/charts/pull/14199\#issuecomment-496883321 and support _sha256_ as an imm ([95957ea](https://github.com/bitnami/charts/commit/95957ea)), closes [#issuecomment-496883321](https://github.com/bitnami/charts/issues/issuecomment-496883321)
-* Use immutable tags in the main images ([17ca4f5](https://github.com/bitnami/charts/commit/17ca4f5))
+* Change syntax because of linter failing ([adfc357](https://github.com/bitnami/charts/commit/adfc35728c2a8a9def9e1897b3772d64df621354))
+* Fix https://github.com/helm/charts/pull/14199\#issuecomment-496883321 and support _sha256_ as an imm ([95957ea](https://github.com/bitnami/charts/commit/95957ea6430f28ec3593053afb0bfccb75703c79)), closes [#issuecomment-496883321](https://github.com/bitnami/charts/issues/issuecomment-496883321)
+* Use immutable tags in the main images ([17ca4f5](https://github.com/bitnami/charts/commit/17ca4f5c91da33da03f9e2d411fe5e004e825c4d))
 
 ## <small>1.5.5 (2019-05-28)</small>
 
-* Prepare immutable tags ([f9093c1](https://github.com/bitnami/charts/commit/f9093c1))
+* Prepare immutable tags ([f9093c1](https://github.com/bitnami/charts/commit/f9093c1aaa9cde25a042c3d62f7873385447cbf7))
 
 ## <small>1.5.4 (2019-05-14)</small>
 
-* bitnami/external-dns: update to 0.5.14 ([46a488d](https://github.com/bitnami/charts/commit/46a488d))
+* bitnami/external-dns: update to 0.5.14 ([46a488d](https://github.com/bitnami/charts/commit/46a488d847c7d355eea395231350c71222ef7d51))
 
 ## <small>1.5.3 (2019-04-24)</small>
 
-* bitnami/external-dns: update to 0.5.13 ([4730ade](https://github.com/bitnami/charts/commit/4730ade))
+* bitnami/external-dns: update to 0.5.13 ([4730ade](https://github.com/bitnami/charts/commit/4730adef7bc22158d4c991110e96c1a5be3126bb))
 
 ## <small>1.5.2 (2019-03-26)</small>
 
-* bitnami/external-dns: update to 0.5.12 ([ee79a18](https://github.com/bitnami/charts/commit/ee79a18))
+* bitnami/external-dns: update to 0.5.12 ([ee79a18](https://github.com/bitnami/charts/commit/ee79a18877c9212c9535006d51b93688fa7d18f1))
 
 ## <small>1.5.1 (2019-03-18)</small>
 
-* Remove pullSecrets for metrics without image in the helpers ([195f2ed](https://github.com/bitnami/charts/commit/195f2ed))
+* Remove pullSecrets for metrics without image in the helpers ([195f2ed](https://github.com/bitnami/charts/commit/195f2ed80f7f656d512dc476f54894681101e0f1))
 
 ## 1.5.0 (2019-03-12)
 
-* Fix typo ([5b596a2](https://github.com/bitnami/charts/commit/5b596a2))
-* Fix typo in helpers ([e731646](https://github.com/bitnami/charts/commit/e731646))
-* pullSecrets for production and metrics ([22d6e0b](https://github.com/bitnami/charts/commit/22d6e0b))
+* Fix typo ([5b596a2](https://github.com/bitnami/charts/commit/5b596a252b85bee5a9c75a4db01c62e48526a37d))
+* Fix typo in helpers ([e731646](https://github.com/bitnami/charts/commit/e7316462395e2774594798489941535ac1f77df4))
+* pullSecrets for production and metrics ([22d6e0b](https://github.com/bitnami/charts/commit/22d6e0b546ec6b222cc444ea3c02fd25d6f31dce))
 
 ## 1.4.0 (2019-03-11)
 
-* [bitnami/external-dns] Add global imagePullSecrets to overwrite any other existing one ([6bae8b8](https://github.com/bitnami/charts/commit/6bae8b8))
+* [bitnami/external-dns] Add global imagePullSecrets to overwrite any other existing one ([6bae8b8](https://github.com/bitnami/charts/commit/6bae8b8b511cf33841086bcb9fce6cb115f6e1bd))
 
 ## <small>1.3.5 (2019-02-27)</small>
 
-* Add appiVersion to Chart.yaml ([08704a5](https://github.com/bitnami/charts/commit/08704a5))
+* Add appiVersion to Chart.yaml ([08704a5](https://github.com/bitnami/charts/commit/08704a55fa287f8da2e680344163b65863959329))
 
 ## <small>1.3.4 (2019-02-21)</small>
 
-* Update Chart.yaml ([6bbe4d4](https://github.com/bitnami/charts/commit/6bbe4d4))
-* Update README.md ([dc32965](https://github.com/bitnami/charts/commit/dc32965))
+* Update Chart.yaml ([6bbe4d4](https://github.com/bitnami/charts/commit/6bbe4d417170bf2ca79c02670776bfdfc7451c95))
+* Update README.md ([dc32965](https://github.com/bitnami/charts/commit/dc32965f52874a2910321a7609d6023089ad94ea))
 
 ## <small>1.3.3 (2019-02-11)</small>
 
-* bitnami/external-dns: update to 0.5.11 ([df69e7f](https://github.com/bitnami/charts/commit/df69e7f))
+* bitnami/external-dns: update to 0.5.11 ([df69e7f](https://github.com/bitnami/charts/commit/df69e7f22e14cc58c19156f284bfe32d87c79a0a))
 
 ## <small>1.3.2 (2019-02-07)</small>
 
-* Document the correct format for pullSecrets in READMEs ([9a2cf81](https://github.com/bitnami/charts/commit/9a2cf81))
-* Fix appVersion fields for some Chart.yaml files (#1048) ([697e18d](https://github.com/bitnami/charts/commit/697e18d)), closes [#1048](https://github.com/bitnami/charts/issues/1048)
+* Document the correct format for pullSecrets in READMEs ([9a2cf81](https://github.com/bitnami/charts/commit/9a2cf81399905b7b3190bbc35a8d554f94014ce8))
+* Fix appVersion fields for some Chart.yaml files (#1048) ([697e18d](https://github.com/bitnami/charts/commit/697e18d3f9a878f7789404e6aed7516501c8ee22)), closes [#1048](https://github.com/bitnami/charts/issues/1048)
 
 ## <small>1.3.1 (2019-01-28)</small>
 
-* external-dns: update to `0.5.10` ([c8ce108](https://github.com/bitnami/charts/commit/c8ce108))
+* external-dns: update to `0.5.10` ([c8ce108](https://github.com/bitnami/charts/commit/c8ce108cd22ea9cb0130e09738b2e47cfd783b48))
 
 ## 1.3.0 (2018-12-17)
 
-* external-dns: only set google specific config if they are not empty ([3b2c665](https://github.com/bitnami/charts/commit/3b2c665))
+* external-dns: only set google specific config if they are not empty ([3b2c665](https://github.com/bitnami/charts/commit/3b2c665cc5cec92b2c208cb8a44eadcfbca48972))
 
 ## <small>1.2.3 (2018-12-17)</small>
 
-* Fix external-dns maintainers name ([bac3666](https://github.com/bitnami/charts/commit/bac3666))
+* Fix external-dns maintainers name ([bac3666](https://github.com/bitnami/charts/commit/bac3666e055ddd1a80fad68c84f2c38eeb634653))
 
 ## <small>1.2.2 (2018-12-12)</small>
 
-* Bump chart version for external-dns to 1.2.2 ([52309bf](https://github.com/bitnami/charts/commit/52309bf))
-* Fix indentation in external-dns deployment ([4434b20](https://github.com/bitnami/charts/commit/4434b20))
+* Bump chart version for external-dns to 1.2.2 ([52309bf](https://github.com/bitnami/charts/commit/52309bfb9e58b767cfc1eb4eacb44a87fa53f80d))
+* Fix indentation in external-dns deployment ([4434b20](https://github.com/bitnami/charts/commit/4434b201b2a2cc2110e0aaaa1fe589e4a0c75c2d))
 
 ## <small>1.2.1 (2018-11-28)</small>
 
-* external-dns: bump chart appVersion to `0.5.9` ([6565ad4](https://github.com/bitnami/charts/commit/6565ad4))
-* external-dns: bump chart version to `1.2.1` ([9edb6ea](https://github.com/bitnami/charts/commit/9edb6ea))
-* external-dns: update to `0.5.9` ([d51ebdc](https://github.com/bitnami/charts/commit/d51ebdc))
+* external-dns: bump chart appVersion to `0.5.9` ([6565ad4](https://github.com/bitnami/charts/commit/6565ad473a22acb2bfe794935d926f4e7d7affea))
+* external-dns: bump chart version to `1.2.1` ([9edb6ea](https://github.com/bitnami/charts/commit/9edb6ea38dcf88af49ccd4d5b411ac2e10d7ae71))
+* external-dns: update to `0.5.9` ([d51ebdc](https://github.com/bitnami/charts/commit/d51ebdcfb79fc1e6b1a782c370b6493bf9c348f4))
 
 ## 1.1.0 (2018-10-15)
 
-* [bitnami/external-dns] Add metrics handling ([31117b2](https://github.com/bitnami/charts/commit/31117b2))
+* [bitnami/external-dns] Add metrics handling ([31117b2](https://github.com/bitnami/charts/commit/31117b278af09651bc0b3cc43a892bfe26110e9778af09651bc0b3cc43a892bfe26110e97))
 
 ## <small>1.1.2 (2018-11-16)</small>
 
-* [bitnami/external-dns] Add instructions to install ExternalDN on AWS ([217f2f0](https://github.com/bitnami/charts/commit/217f2f0))
-* Bump versions ([0cfd3f4](https://github.com/bitnami/charts/commit/0cfd3f4))
+* [bitnami/external-dns] Add instructions to install ExternalDN on AWS ([217f2f0](https://github.com/bitnami/charts/commit/217f2f03a237d1b228241755df3369e1a1370a65))
+* Bump versions ([0cfd3f4](https://github.com/bitnami/charts/commit/0cfd3f421533a532c90438afa287bf46aa10413e))
 
 ## <small>1.1.1 (2018-10-17)</small>
 
-* Add global registry option to Bitnami charts ([395ba08](https://github.com/bitnami/charts/commit/395ba08))
-* Apply some suggestions ([24706a6](https://github.com/bitnami/charts/commit/24706a6))
-* Change logic to determine registry ([9ead294](https://github.com/bitnami/charts/commit/9ead294))
-* Check if global is set ([dec26e5](https://github.com/bitnami/charts/commit/dec26e5))
-* external-dns: bump chart appVersion to `0.5.8` ([8bf1ae0](https://github.com/bitnami/charts/commit/8bf1ae0))
-* external-dns: bump chart version to `1.1.1` ([f129be5](https://github.com/bitnami/charts/commit/f129be5))
-* external-dns: update to `0.5.8` ([01c51c0](https://github.com/bitnami/charts/commit/01c51c0))
-* Fix typo ([93170ac](https://github.com/bitnami/charts/commit/93170ac))
-* Reword and update kafka dependencies ([be6cbed](https://github.com/bitnami/charts/commit/be6cbed))
+* Add global registry option to Bitnami charts ([395ba08](https://github.com/bitnami/charts/commit/395ba08e2bc14ef28a0cae1fada97ed6cf2e777d))
+* Apply some suggestions ([24706a6](https://github.com/bitnami/charts/commit/24706a6163b75700c705f3021bb37790f95423c9))
+* Change logic to determine registry ([9ead294](https://github.com/bitnami/charts/commit/9ead294d5705f2646e8d3b70e14129d23c07bf8a))
+* Check if global is set ([dec26e5](https://github.com/bitnami/charts/commit/dec26e5d0b982905dde2a55fdf2285a7781a64cc))
+* external-dns: bump chart appVersion to `0.5.8` ([8bf1ae0](https://github.com/bitnami/charts/commit/8bf1ae05d078311d36b27e295ae74cf8e52b4024))
+* external-dns: bump chart version to `1.1.1` ([f129be5](https://github.com/bitnami/charts/commit/f129be574af77e99a0d0093bf422e6ce6e2c286c))
+* external-dns: update to `0.5.8` ([01c51c0](https://github.com/bitnami/charts/commit/01c51c0e4c050c8ec3d79f88fa2cec81aa50e3b3))
+* Fix typo ([93170ac](https://github.com/bitnami/charts/commit/93170acc16e842e55aff7b7d944f7fbe025eee91))
+* Reword and update kafka dependencies ([be6cbed](https://github.com/bitnami/charts/commit/be6cbedd27cea4c5c0e30ce70c9790c27ca1a0ec))
 
 ## 1.1.0 (2018-10-15)
 
-* [bitnami/external-dns] Add metrics handling ([31117b2](https://github.com/bitnami/charts/commit/31117b2))
+* [bitnami/external-dns] Add metrics handling ([31117b2](https://github.com/bitnami/charts/commit/31117b278af09651bc0b3cc43a892bfe26110e9778af09651bc0b3cc43a892bfe26110e97))
 
 ## <small>1.0.4 (2018-10-05)</small>
 
-* Add kubeapps text to charts READMEs ([2f6dc51](https://github.com/bitnami/charts/commit/2f6dc51))
-* Bump external-dns version ([ffd8070](https://github.com/bitnami/charts/commit/ffd8070))
+* Add kubeapps text to charts READMEs ([2f6dc51](https://github.com/bitnami/charts/commit/2f6dc51ce6307d57bd8c20e929da23dd2adf22d5))
+* Bump external-dns version ([ffd8070](https://github.com/bitnami/charts/commit/ffd80705c0a214dd8321e9ce49466fa97bde2531))
 
 ## <small>1.0.3 (2018-10-05)</small>
 
-* external-dns: bump chart appVersion to `0.5.7` ([1b03f4c](https://github.com/bitnami/charts/commit/1b03f4c))
-* external-dns: bump chart version to `1.0.3` ([ee72a61](https://github.com/bitnami/charts/commit/ee72a61))
-* external-dns: update to `0.5.7-debian-9` ([8126059](https://github.com/bitnami/charts/commit/8126059))
+* external-dns: bump chart appVersion to `0.5.7` ([1b03f4c](https://github.com/bitnami/charts/commit/1b03f4c436b1890dcaceca8fb98d113bfa3e0f6c))
+* external-dns: bump chart version to `1.0.3` ([ee72a61](https://github.com/bitnami/charts/commit/ee72a618426337e2c8a9e0d60d9852add1d07783))
+* external-dns: update to `0.5.7-debian-9` ([8126059](https://github.com/bitnami/charts/commit/8126059d5c7b1c4f250dd6d901aabd7bce1ae6b3))
 
 ## <small>1.0.2 (2018-09-28)</small>
 
-* Fix indentation issue ([4715c70](https://github.com/bitnami/charts/commit/4715c70))
+* Fix indentation issue ([4715c70](https://github.com/bitnami/charts/commit/4715c707b5a0e0f8301ee8cdcfc21aead5ba67d7))
 
 ## <small>1.0.1 (2018-09-28)</small>
 
-* [bitnami/external-dns] Fixes for external-dns chart ([89c0201](https://github.com/bitnami/charts/commit/89c0201))
+* [bitnami/external-dns] Fixes for external-dns chart ([89c0201](https://github.com/bitnami/charts/commit/89c0201796641909aeab612869ad593d5a13012c))
 
 ## 1.0.0 (2018-09-21)
 
-* [bitnami/external-dns] Fix chart not being upgradable ([7c33e2c](https://github.com/bitnami/charts/commit/7c33e2c))
-* Add accepted values for 'switch' parameters ([5736eb3](https://github.com/bitnami/charts/commit/5736eb3))
-* External dns chart (continuing @juan131 work PR #715) ([16704b0](https://github.com/bitnami/charts/commit/16704b0)), closes [#715](https://github.com/bitnami/charts/issues/715)
-* Use 'helm upgrade' command to fix already installed charts ([d5a6b71](https://github.com/bitnami/charts/commit/d5a6b71))
+* [bitnami/external-dns] Fix chart not being upgradable ([7c33e2c](https://github.com/bitnami/charts/commit/7c33e2cf49d18ef0944a5a0cce02b6689b13a7f1))
+* Add accepted values for 'switch' parameters ([5736eb3](https://github.com/bitnami/charts/commit/5736eb3b6de56b7762a4b91385c630ebed80c1f1))
+* External dns chart (continuing @juan131 work PR #715) ([16704b0](https://github.com/bitnami/charts/commit/16704b0d5413e87195c9531a2382ff0454f21d7e)), closes [#715](https://github.com/bitnami/charts/issues/715)
+* Use 'helm upgrade' command to fix already installed charts ([d5a6b71](https://github.com/bitnami/charts/commit/d5a6b7167460da62b0ea568a10ebb0b6f053f130))
 
 ## <small>0.0.1 (2018-07-19)</small>
 
-* Add new chart: ExternalDNS ([5bc9faf](https://github.com/bitnami/charts/commit/5bc9faf))
+* Add new chart: ExternalDNS ([5bc9faf](https://github.com/bitnami/charts/commit/5bc9faf65498bfc0fdac911d8e0f3115a2689851))

--- a/bitnami/external-dns/Chart.yaml
+++ b/bitnami/external-dns/Chart.yaml
@@ -28,4 +28,4 @@ maintainers:
 name: external-dns
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/external-dns
-version: 7.5.1
+version: 7.5.2

--- a/bitnami/external-dns/templates/dep-ds.yaml
+++ b/bitnami/external-dns/templates/dep-ds.yaml
@@ -712,8 +712,7 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.livenessProbe.enabled }}
           livenessProbe:
-            httpGet:
-              path: /healthz
+            tcpSocket:
               port: http
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}


### PR DESCRIPTION
### Description of the change
This PR aims to use different liveness/readiness probes to improve overall security and avoid unnecessary container restarts. [More info](https://github.com/zegl/kube-score/blob/master/README_PROBES.md).

### Benefits

Increase availability and resilience.

### Possible drawbacks

N/A

### Applicable issues

- fixes #

### Additional information

- Related to #23537

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- ~[X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)~
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
