### PR TITLE
[bitnami/keycloak] Use different liveness/readiness probes

### DIFF
--- a/bitnami/keycloak/CHANGELOG.md
+++ b/bitnami/keycloak/CHANGELOG.md
@@ -1,8 +1,14 @@
 # Changelog
 
+## 21.3.1 (2024-05-22)
+
+* [bitnami/keycloak] Use different liveness/readiness probes ([#26318](https://github.com/bitnami/charts/pulls/26318))
+
 ## 21.3.0 (2024-05-21)
 
-* [bitnami/keycloak] feat: :sparkles: :lock: Add warning when original images are replaced ([#26225](https://github.com/bitnami/charts/pulls/26225))
+* [bitnami/*] ci: :construction_worker: Add tag and changelog support (#25359) ([91c707c](https://github.com/bitnami/charts/commit/91c707c)), closes [#25359](https://github.com/bitnami/charts/issues/25359)
+* [bitnami/keycloak] feat: :sparkles: :lock: Add warning when original images are replaced (#26225) ([095e689](https://github.com/bitnami/charts/commit/095e689)), closes [#26225](https://github.com/bitnami/charts/issues/26225)
+* Update README.md (#25996) ([d04084c](https://github.com/bitnami/charts/commit/d04084c)), closes [#25996](https://github.com/bitnami/charts/issues/25996)
 
 ## <small>21.2.2 (2024-05-18)</small>
 

--- a/bitnami/keycloak/Chart.lock
+++ b/bitnami/keycloak/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: postgresql
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 15.3.5
+  version: 15.4.0
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 2.19.3
-digest: sha256:733f900df591c9175c755b21213ed83c02a011517e70120f4e00aa28b12397e2
-generated: "2024-05-21T13:56:34.464070813+02:00"
+digest: sha256:aef3ad652bf811a804846abc0c8355ab57e2cd668e2f28788a1ef93c0f333977
+generated: "2024-05-22T11:20:57.892466+02:00"

--- a/bitnami/keycloak/Chart.yaml
+++ b/bitnami/keycloak/Chart.yaml
@@ -33,4 +33,4 @@ maintainers:
 name: keycloak
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/keycloak
-version: 21.3.0
+version: 21.3.1

--- a/bitnami/keycloak/templates/statefulset.yaml
+++ b/bitnami/keycloak/templates/statefulset.yaml
@@ -267,8 +267,7 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.livenessProbe.enabled }}
           livenessProbe: {{- omit .Values.livenessProbe "enabled" | toYaml | nindent 12 }}
-            httpGet:
-              path: {{ .Values.httpRelativePath }}
+            tcpSocket:
               port: http
           {{- end }}
           {{- if .Values.customReadinessProbe }}


### PR DESCRIPTION
### Description of the change
This PR aims to use different liveness/readiness probes to improve overall security and avoid unnecessary container restarts. [More info](https://github.com/zegl/kube-score/blob/master/README_PROBES.md).

### Benefits

Increase availability and resilience.

### Possible drawbacks

N/A

### Applicable issues

- fixes #

### Additional information

- Related to #23537

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- ~[X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)~
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
