### PR TITLE
[bitnami/nats] Use different liveness/readiness probes

### DIFF
--- a/bitnami/nats/CHANGELOG.md
+++ b/bitnami/nats/CHANGELOG.md
@@ -1,902 +1,906 @@
 # Changelog
 
-## 8.2.1 (2024-05-22)
+## 8.2.2 (2024-05-23)
 
-* [bitnami/nats] Release 8.2.1 ([#26312](https://github.com/bitnami/charts/pulls/26312))
+* [bitnami/nats] Use different liveness/readiness probes ([#26320](https://github.com/bitnami/charts/pull/26320))
+
+## <small>8.2.1 (2024-05-22)</small>
+
+* [bitnami/nats] Release 8.2.1 (#26312) ([b3f7c11](https://github.com/bitnami/charts/commit/b3f7c11fdea90235231ecb2ac919ee4bef71f728)), closes [#26312](https://github.com/bitnami/charts/issues/26312)
 
 ## 8.2.0 (2024-05-21)
 
-* [bitnami/nats] feat: :sparkles: :lock: Add warning when original images are replaced (#26252) ([a1f466b](https://github.com/bitnami/charts/commit/a1f466b)), closes [#26252](https://github.com/bitnami/charts/issues/26252)
+* [bitnami/nats] feat: :sparkles: :lock: Add warning when original images are replaced (#26252) ([a1f466b](https://github.com/bitnami/charts/commit/a1f466b9681b2a7bcb9f40a2fbc1e586020dcb42)), closes [#26252](https://github.com/bitnami/charts/issues/26252)
 
 ## 8.1.0 (2024-05-21)
 
-* [bitnami/*] ci: :construction_worker: Add tag and changelog support (#25359) ([91c707c](https://github.com/bitnami/charts/commit/91c707c)), closes [#25359](https://github.com/bitnami/charts/issues/25359)
-* [bitnami/nats] PDB review (#26158) ([41d2121](https://github.com/bitnami/charts/commit/41d2121)), closes [#26158](https://github.com/bitnami/charts/issues/26158)
+* [bitnami/*] ci: :construction_worker: Add tag and changelog support (#25359) ([91c707c](https://github.com/bitnami/charts/commit/91c707c9e4e574725a09505d2d313fb93f1b4c0a)), closes [#25359](https://github.com/bitnami/charts/issues/25359)
+* [bitnami/nats] PDB review (#26158) ([41d2121](https://github.com/bitnami/charts/commit/41d212196f5c6ff15e8265ca8f307f4c28269e61)), closes [#26158](https://github.com/bitnami/charts/issues/26158)
 
 ## <small>8.0.8 (2024-05-18)</small>
 
-* [bitnami/nats] Release 8.0.8 updating components versions (#26053) ([0caf8a5](https://github.com/bitnami/charts/commit/0caf8a5)), closes [#26053](https://github.com/bitnami/charts/issues/26053)
+* [bitnami/nats] Release 8.0.8 updating components versions (#26053) ([0caf8a5](https://github.com/bitnami/charts/commit/0caf8a598c6ec59df9b91d618e44fea1a7c4a4b1)), closes [#26053](https://github.com/bitnami/charts/issues/26053)
 
 ## <small>8.0.7 (2024-05-17)</small>
 
-* [bitnami/nats] Release 8.0.7 updating components versions (#25959) ([5cf7111](https://github.com/bitnami/charts/commit/5cf7111)), closes [#25959](https://github.com/bitnami/charts/issues/25959)
+* [bitnami/nats] Release 8.0.7 updating components versions (#25959) ([5cf7111](https://github.com/bitnami/charts/commit/5cf7111337a0ae91c20b68594b9de125413427c6)), closes [#25959](https://github.com/bitnami/charts/issues/25959)
 
 ## <small>8.0.6 (2024-05-14)</small>
 
-* [bitnami/*] Change non-root and rolling-tags doc URLs (#25628) ([b067c94](https://github.com/bitnami/charts/commit/b067c94)), closes [#25628](https://github.com/bitnami/charts/issues/25628)
-* [bitnami/nats] Release 8.0.6 updating components versions (#25799) ([507342c](https://github.com/bitnami/charts/commit/507342c)), closes [#25799](https://github.com/bitnami/charts/issues/25799)
+* [bitnami/*] Change non-root and rolling-tags doc URLs (#25628) ([b067c94](https://github.com/bitnami/charts/commit/b067c94f6bcde427863c197fd355f0b5ba12ff5b)), closes [#25628](https://github.com/bitnami/charts/issues/25628)
+* [bitnami/nats] Release 8.0.6 updating components versions (#25799) ([507342c](https://github.com/bitnami/charts/commit/507342c176ee9a4253b8c96c71e09b57439eaa24)), closes [#25799](https://github.com/bitnami/charts/issues/25799)
 
 ## <small>8.0.5 (2024-05-08)</small>
 
-* [bitnami/*] Set new header/owner (#25558) ([8d1dc11](https://github.com/bitnami/charts/commit/8d1dc11)), closes [#25558](https://github.com/bitnami/charts/issues/25558)
-* [bitnami/nats] Release 8.0.5 updating components versions (#25612) ([f3feda6](https://github.com/bitnami/charts/commit/f3feda6)), closes [#25612](https://github.com/bitnami/charts/issues/25612)
-* Replace VMware by Broadcom copyright text (#25306) ([a5e4bd0](https://github.com/bitnami/charts/commit/a5e4bd0)), closes [#25306](https://github.com/bitnami/charts/issues/25306)
+* [bitnami/*] Set new header/owner (#25558) ([8d1dc11](https://github.com/bitnami/charts/commit/8d1dc11f5fb30db6fba50c43d7af59d2f79deed3)), closes [#25558](https://github.com/bitnami/charts/issues/25558)
+* [bitnami/nats] Release 8.0.5 updating components versions (#25612) ([f3feda6](https://github.com/bitnami/charts/commit/f3feda6a9e737094c02f9cf4d03d85f488d7b4d6)), closes [#25612](https://github.com/bitnami/charts/issues/25612)
+* Replace VMware by Broadcom copyright text (#25306) ([a5e4bd0](https://github.com/bitnami/charts/commit/a5e4bd0e35e419203793976a78d9d0a13de92c76)), closes [#25306](https://github.com/bitnami/charts/issues/25306)
 
 ## <small>8.0.4 (2024-04-12)</small>
 
-* [bitnami/nats] Release 8.0.4 updating components versions (#25148) ([f9970a7](https://github.com/bitnami/charts/commit/f9970a7)), closes [#25148](https://github.com/bitnami/charts/issues/25148)
+* [bitnami/nats] Release 8.0.4 updating components versions (#25148) ([f9970a7](https://github.com/bitnami/charts/commit/f9970a79ac7b20b399950f700561653d8ac25f32)), closes [#25148](https://github.com/bitnami/charts/issues/25148)
 
 ## <small>8.0.3 (2024-04-05)</small>
 
-* [bitnami/nats] Release 8.0.3 updating components versions (#24958) ([30ce05e](https://github.com/bitnami/charts/commit/30ce05e)), closes [#24958](https://github.com/bitnami/charts/issues/24958)
+* [bitnami/nats] Release 8.0.3 updating components versions (#24958) ([30ce05e](https://github.com/bitnami/charts/commit/30ce05e1a75bec6e3215be211f02850db59e3eb0)), closes [#24958](https://github.com/bitnami/charts/issues/24958)
 
 ## <small>8.0.2 (2024-04-04)</small>
 
-* [bitnami/*] Readme typos (#24852) ([532fcdc](https://github.com/bitnami/charts/commit/532fcdc)), closes [#24852](https://github.com/bitnami/charts/issues/24852)
-* [bitnami/nats] Release 8.0.2 updating components versions (#24905) ([a934fe6](https://github.com/bitnami/charts/commit/a934fe6)), closes [#24905](https://github.com/bitnami/charts/issues/24905)
+* [bitnami/*] Readme typos (#24852) ([532fcdc](https://github.com/bitnami/charts/commit/532fcdc499cb67eccf0ade49ff1c02d3deb1d696)), closes [#24852](https://github.com/bitnami/charts/issues/24852)
+* [bitnami/nats] Release 8.0.2 updating components versions (#24905) ([a934fe6](https://github.com/bitnami/charts/commit/a934fe68dd12d95727af382face95c885b5d8be6)), closes [#24905](https://github.com/bitnami/charts/issues/24905)
 
 ## <small>8.0.1 (2024-04-03)</small>
 
-* [bitnami/nats] Fix readiness probe endpoint (#24360) (#24466) ([6afae9c](https://github.com/bitnami/charts/commit/6afae9c)), closes [#24360](https://github.com/bitnami/charts/issues/24360) [#24466](https://github.com/bitnami/charts/issues/24466) [#24360](https://github.com/bitnami/charts/issues/24360)
-* [bitnami/several] Fix comment mentioning Keycloak (#24661) ([641c546](https://github.com/bitnami/charts/commit/641c546)), closes [#24661](https://github.com/bitnami/charts/issues/24661)
-* Update resourcesPreset comments (#24467) ([92e3e8a](https://github.com/bitnami/charts/commit/92e3e8a)), closes [#24467](https://github.com/bitnami/charts/issues/24467)
+* [bitnami/nats] Fix readiness probe endpoint (#24360) (#24466) ([6afae9c](https://github.com/bitnami/charts/commit/6afae9ca699542bd9a5a5dc53009cdc7c00a5859)), closes [#24360](https://github.com/bitnami/charts/issues/24360) [#24466](https://github.com/bitnami/charts/issues/24466) [#24360](https://github.com/bitnami/charts/issues/24360)
+* [bitnami/several] Fix comment mentioning Keycloak (#24661) ([641c546](https://github.com/bitnami/charts/commit/641c5468069de826c12d1e7c825807cf68b4ee96)), closes [#24661](https://github.com/bitnami/charts/issues/24661)
+* Update resourcesPreset comments (#24467) ([92e3e8a](https://github.com/bitnami/charts/commit/92e3e8a507326d2a20a8f10ab3e7746a2ec5c554)), closes [#24467](https://github.com/bitnami/charts/issues/24467)
 
 ## 8.0.0 (2024-03-18)
 
-* [bitnami/*] Reorder Chart sections (#24455) ([0cf4048](https://github.com/bitnami/charts/commit/0cf4048)), closes [#24455](https://github.com/bitnami/charts/issues/24455)
-* [bitnami/nats] feat!: 🔒 💥 Improve security defaults (#24372) ([640c4a8](https://github.com/bitnami/charts/commit/640c4a8)), closes [#24372](https://github.com/bitnami/charts/issues/24372)
+* [bitnami/*] Reorder Chart sections (#24455) ([0cf4048](https://github.com/bitnami/charts/commit/0cf4048e8743f70a9753d460655bd030cbff6824)), closes [#24455](https://github.com/bitnami/charts/issues/24455)
+* [bitnami/nats] feat!: 🔒 💥 Improve security defaults (#24372) ([640c4a8](https://github.com/bitnami/charts/commit/640c4a8d7c4f002c1a307bc74f2fc26b069832a1)), closes [#24372](https://github.com/bitnami/charts/issues/24372)
 
 ## <small>7.18.1 (2024-03-13)</small>
 
-* [bitnami/nats] Release 7.18.1 updating components versions (#24381) ([6595302](https://github.com/bitnami/charts/commit/6595302)), closes [#24381](https://github.com/bitnami/charts/issues/24381)
+* [bitnami/nats] Release 7.18.1 updating components versions (#24381) ([6595302](https://github.com/bitnami/charts/commit/65953028438a799a6dd2bf900705281dd3002cd3)), closes [#24381](https://github.com/bitnami/charts/issues/24381)
 
 ## 7.18.0 (2024-03-08)
 
-* [bitnami/nats] feat: :sparkles: :lock: Add automatic adaptation for Openshift restricted-v2 SCC (#24 ([aa5778e](https://github.com/bitnami/charts/commit/aa5778e)), closes [#24129](https://github.com/bitnami/charts/issues/24129)
+* [bitnami/nats] feat: :sparkles: :lock: Add automatic adaptation for Openshift restricted-v2 SCC (#24 ([aa5778e](https://github.com/bitnami/charts/commit/aa5778e7e52058fd9c8b82581f713f05077db407)), closes [#24129](https://github.com/bitnami/charts/issues/24129)
 
 ## <small>7.17.3 (2024-03-06)</small>
 
-* [bitnami/nats] Release 7.17.3 updating components versions (#24224) ([a7beda8](https://github.com/bitnami/charts/commit/a7beda8)), closes [#24224](https://github.com/bitnami/charts/issues/24224)
+* [bitnami/nats] Release 7.17.3 updating components versions (#24224) ([a7beda8](https://github.com/bitnami/charts/commit/a7beda8ff081293fa2f9069bf697f89c5db6c3e6)), closes [#24224](https://github.com/bitnami/charts/issues/24224)
 
 ## <small>7.17.2 (2024-02-28)</small>
 
-* [bitnami/nats] Release 7.17.2 updating components versions (#23810) ([7886f31](https://github.com/bitnami/charts/commit/7886f31)), closes [#23810](https://github.com/bitnami/charts/issues/23810)
+* [bitnami/nats] Release 7.17.2 updating components versions (#23810) ([7886f31](https://github.com/bitnami/charts/commit/7886f314ed248b2be68a1a4ef8ad9fe0e6049a2a)), closes [#23810](https://github.com/bitnami/charts/issues/23810)
 
 ## <small>7.17.1 (2024-02-21)</small>
 
-* [bitnami/nats] Release 7.17.1 updating components versions (#23671) ([889bdd0](https://github.com/bitnami/charts/commit/889bdd0)), closes [#23671](https://github.com/bitnami/charts/issues/23671)
+* [bitnami/nats] Release 7.17.1 updating components versions (#23671) ([889bdd0](https://github.com/bitnami/charts/commit/889bdd023efb9cf63e2083889d784a2ed0ea55fe)), closes [#23671](https://github.com/bitnami/charts/issues/23671)
 
 ## 7.17.0 (2024-02-20)
 
-* [bitnami/nats] chore: :recycle: Move all emptydirs to one ([8e186b6](https://github.com/bitnami/charts/commit/8e186b6))
+* [bitnami/nats] chore: :recycle: Move all emptydirs to one ([8e186b6](https://github.com/bitnami/charts/commit/8e186b6d76538b361342c1ea00f25274d63c97e2))
 
 ## 7.16.0 (2024-02-20)
 
-* [bitnami/nats] feat: :sparkles: :lock: Add readOnlyRootFilesystem support (#23613) ([0bbd7a8](https://github.com/bitnami/charts/commit/0bbd7a8)), closes [#23613](https://github.com/bitnami/charts/issues/23613)
+* [bitnami/nats] feat: :sparkles: :lock: Add readOnlyRootFilesystem support (#23613) ([0bbd7a8](https://github.com/bitnami/charts/commit/0bbd7a8ff6ef39d94c0c97e09eb0fba499958310)), closes [#23613](https://github.com/bitnami/charts/issues/23613)
 
 ## 7.15.0 (2024-02-20)
 
-* [bitnami/*] Bump all versions (#23602) ([b70ee2a](https://github.com/bitnami/charts/commit/b70ee2a)), closes [#23602](https://github.com/bitnami/charts/issues/23602)
+* [bitnami/*] Bump all versions (#23602) ([b70ee2a](https://github.com/bitnami/charts/commit/b70ee2a30e4dc256bf0ac52928fb2fa7a70f049b)), closes [#23602](https://github.com/bitnami/charts/issues/23602)
 
 ## 7.14.0 (2024-02-20)
 
-* [bitnami/nats] feat: :sparkles: :lock: Add resource preset support (#23496) ([945f059](https://github.com/bitnami/charts/commit/945f059)), closes [#23496](https://github.com/bitnami/charts/issues/23496)
+* [bitnami/nats] feat: :sparkles: :lock: Add resource preset support (#23496) ([945f059](https://github.com/bitnami/charts/commit/945f059ec6455be07bf131eea36ed744ac3a9ac8)), closes [#23496](https://github.com/bitnami/charts/issues/23496)
 
 ## 7.13.0 (2024-02-14)
 
-* [bitnami/nats] feat: :lock: Enable networkPolicy (#23018) ([a2030c9](https://github.com/bitnami/charts/commit/a2030c9)), closes [#23018](https://github.com/bitnami/charts/issues/23018)
+* [bitnami/nats] feat: :lock: Enable networkPolicy (#23018) ([a2030c9](https://github.com/bitnami/charts/commit/a2030c91524666997c987127e9ff601ddab80b8b)), closes [#23018](https://github.com/bitnami/charts/issues/23018)
 
 ## <small>7.12.5 (2024-02-08)</small>
 
-* [bitnami/nats] Release 7.12.5 updating components versions (#23316) ([6bdfcc2](https://github.com/bitnami/charts/commit/6bdfcc2)), closes [#23316](https://github.com/bitnami/charts/issues/23316)
+* [bitnami/nats] Release 7.12.5 updating components versions (#23316) ([6bdfcc2](https://github.com/bitnami/charts/commit/6bdfcc2517fd4981657f74057ea70fb7ba9ee46f)), closes [#23316](https://github.com/bitnami/charts/issues/23316)
 
 ## <small>7.12.4 (2024-02-07)</small>
 
-* [bitnami/nats] Release 7.12.4 updating components versions (#23244) ([4c4d5e8](https://github.com/bitnami/charts/commit/4c4d5e8)), closes [#23244](https://github.com/bitnami/charts/issues/23244)
+* [bitnami/nats] Release 7.12.4 updating components versions (#23244) ([4c4d5e8](https://github.com/bitnami/charts/commit/4c4d5e8fa56cc70e600e1f587b2c5f00647f2b7d)), closes [#23244](https://github.com/bitnami/charts/issues/23244)
 
 ## <small>7.12.3 (2024-02-03)</small>
 
-* [bitnami/nats] Release 7.12.3 updating components versions (#23167) ([56bc229](https://github.com/bitnami/charts/commit/56bc229)), closes [#23167](https://github.com/bitnami/charts/issues/23167)
+* [bitnami/nats] Release 7.12.3 updating components versions (#23167) ([56bc229](https://github.com/bitnami/charts/commit/56bc22995604e7e1156d2ddc4f58d842059fb1dc)), closes [#23167](https://github.com/bitnami/charts/issues/23167)
 
 ## <small>7.12.2 (2024-01-31)</small>
 
-* [bitnami/nats] Release 7.12.2 updating components versions (#22947) ([9d23953](https://github.com/bitnami/charts/commit/9d23953)), closes [#22947](https://github.com/bitnami/charts/issues/22947)
+* [bitnami/nats] Release 7.12.2 updating components versions (#22947) ([9d23953](https://github.com/bitnami/charts/commit/9d239539c7e8d664830d88f95d3f53b41560cb72)), closes [#22947](https://github.com/bitnami/charts/issues/22947)
 
 ## <small>7.12.1 (2024-01-26)</small>
 
-* [bitnami/*] Move documentation sections from docs.bitnami.com back to the README (#22203) ([7564f36](https://github.com/bitnami/charts/commit/7564f36)), closes [#22203](https://github.com/bitnami/charts/issues/22203)
-* [bitnami/nats] fix: :bug: Set seLinuxOptions to null for Openshift compatibility (#22633) ([b3f6141](https://github.com/bitnami/charts/commit/b3f6141)), closes [#22633](https://github.com/bitnami/charts/issues/22633)
+* [bitnami/*] Move documentation sections from docs.bitnami.com back to the README (#22203) ([7564f36](https://github.com/bitnami/charts/commit/7564f36ca1e95ff30ee686652b7ab8690561a707)), closes [#22203](https://github.com/bitnami/charts/issues/22203)
+* [bitnami/nats] fix: :bug: Set seLinuxOptions to null for Openshift compatibility (#22633) ([b3f6141](https://github.com/bitnami/charts/commit/b3f6141b410a07ce05cb886fcfbf426227992657)), closes [#22633](https://github.com/bitnami/charts/issues/22633)
 
 ## 7.12.0 (2024-01-22)
 
-* [bitnami/nats] fix: :lock: Move service-account token auto-mount to pod declaration (#22494) ([371834d](https://github.com/bitnami/charts/commit/371834d)), closes [#22494](https://github.com/bitnami/charts/issues/22494)
+* [bitnami/nats] fix: :lock: Move service-account token auto-mount to pod declaration (#22494) ([371834d](https://github.com/bitnami/charts/commit/371834d23f96141a051fc2ecf8ba96cf7db582b6)), closes [#22494](https://github.com/bitnami/charts/issues/22494)
 
 ## <small>7.11.1 (2024-01-18)</small>
 
-* [bitnami/nats] Release 7.11.1 updating components versions (#22352) ([e03cabc](https://github.com/bitnami/charts/commit/e03cabc)), closes [#22352](https://github.com/bitnami/charts/issues/22352)
+* [bitnami/nats] Release 7.11.1 updating components versions (#22352) ([e03cabc](https://github.com/bitnami/charts/commit/e03cabc722fc70e434270428c8acde585108203c)), closes [#22352](https://github.com/bitnami/charts/issues/22352)
 
 ## 7.11.0 (2024-01-16)
 
-* [bitnami/*] Fix ref links (in comments) (#21822) ([e4fa296](https://github.com/bitnami/charts/commit/e4fa296)), closes [#21822](https://github.com/bitnami/charts/issues/21822)
-* [bitnami/nats] fix: :lock: Improve podSecurityContext and containerSecurityContext with essential se ([271268d](https://github.com/bitnami/charts/commit/271268d)), closes [#22164](https://github.com/bitnami/charts/issues/22164)
+* [bitnami/*] Fix ref links (in comments) (#21822) ([e4fa296](https://github.com/bitnami/charts/commit/e4fa296106b225cf8c82445727c675c7c725e380)), closes [#21822](https://github.com/bitnami/charts/issues/21822)
+* [bitnami/nats] fix: :lock: Improve podSecurityContext and containerSecurityContext with essential se ([271268d](https://github.com/bitnami/charts/commit/271268d7c8fcdd2c730d768138cebd46c15e4e62)), closes [#22164](https://github.com/bitnami/charts/issues/22164)
 
 ## <small>7.10.10 (2024-01-11)</small>
 
-* [bitnami/nats] Release 7.10.10 updating components versions (#21983) ([3706792](https://github.com/bitnami/charts/commit/3706792)), closes [#21983](https://github.com/bitnami/charts/issues/21983)
+* [bitnami/nats] Release 7.10.10 updating components versions (#21983) ([3706792](https://github.com/bitnami/charts/commit/370679248fe63dd08aafbd89472bb5f723fb497d)), closes [#21983](https://github.com/bitnami/charts/issues/21983)
 
 ## <small>7.10.9 (2024-01-11)</small>
 
-* [bitnami/nats] Release 7.10.9 updating components versions (#21980) ([1d8f349](https://github.com/bitnami/charts/commit/1d8f349)), closes [#21980](https://github.com/bitnami/charts/issues/21980)
+* [bitnami/nats] Release 7.10.9 updating components versions (#21980) ([1d8f349](https://github.com/bitnami/charts/commit/1d8f349a7531c448bbe7abb18d5d9267065174b1)), closes [#21980](https://github.com/bitnami/charts/issues/21980)
 
 ## <small>7.10.8 (2024-01-10)</small>
 
-* [bitnami/*] Fix docs.bitnami.com broken links (#21901) ([f35506d](https://github.com/bitnami/charts/commit/f35506d)), closes [#21901](https://github.com/bitnami/charts/issues/21901)
-* [bitnami/*] Update copyright: Year and company (#21815) ([6c4bf75](https://github.com/bitnami/charts/commit/6c4bf75)), closes [#21815](https://github.com/bitnami/charts/issues/21815)
-* [bitnami/nats] Release 7.10.8 updating components versions (#21964) ([cc11eac](https://github.com/bitnami/charts/commit/cc11eac)), closes [#21964](https://github.com/bitnami/charts/issues/21964)
+* [bitnami/*] Fix docs.bitnami.com broken links (#21901) ([f35506d](https://github.com/bitnami/charts/commit/f35506d2dadee4f097986e7792df1f53ab215b5d)), closes [#21901](https://github.com/bitnami/charts/issues/21901)
+* [bitnami/*] Update copyright: Year and company (#21815) ([6c4bf75](https://github.com/bitnami/charts/commit/6c4bf75dec58fc7c9aee9f089777b1a858c17d5b)), closes [#21815](https://github.com/bitnami/charts/issues/21815)
+* [bitnami/nats] Release 7.10.8 updating components versions (#21964) ([cc11eac](https://github.com/bitnami/charts/commit/cc11eac3a69b4b484e39d1d40c78e71b732a377f)), closes [#21964](https://github.com/bitnami/charts/issues/21964)
 
 ## <small>7.10.7 (2023-12-07)</small>
 
-* [bitnami/nats] Release 7.10.7 updating components versions (#21454) ([db3f0c6](https://github.com/bitnami/charts/commit/db3f0c6)), closes [#21454](https://github.com/bitnami/charts/issues/21454)
+* [bitnami/nats] Release 7.10.7 updating components versions (#21454) ([db3f0c6](https://github.com/bitnami/charts/commit/db3f0c6add5d1c18945545deb43a21ba8d8d8e46)), closes [#21454](https://github.com/bitnami/charts/issues/21454)
 
 ## <small>7.10.6 (2023-12-07)</small>
 
-* [bitnami/nats] Release 7.10.6 updating components versions (#21442) ([686922d](https://github.com/bitnami/charts/commit/686922d)), closes [#21442](https://github.com/bitnami/charts/issues/21442)
+* [bitnami/nats] Release 7.10.6 updating components versions (#21442) ([686922d](https://github.com/bitnami/charts/commit/686922d2818a6e6b6c5eff89a9afb8c0c48aa766)), closes [#21442](https://github.com/bitnami/charts/issues/21442)
 
 ## <small>7.10.5 (2023-12-04)</small>
 
-* [bitnami/nats] Release 7.10.5 updating components versions (#21398) ([10ad731](https://github.com/bitnami/charts/commit/10ad731)), closes [#21398](https://github.com/bitnami/charts/issues/21398)
+* [bitnami/nats] Release 7.10.5 updating components versions (#21398) ([10ad731](https://github.com/bitnami/charts/commit/10ad7318fa52658923c638a204f0deb8a48a007b)), closes [#21398](https://github.com/bitnami/charts/issues/21398)
 
 ## <small>7.10.4 (2023-11-21)</small>
 
-* [bitnami/*] Remove relative links to non-README sections, add verification for that and update TL;DR ([1103633](https://github.com/bitnami/charts/commit/1103633)), closes [#20967](https://github.com/bitnami/charts/issues/20967)
-* [bitnami/*] Rename solutions to "Bitnami package for ..." (#21038) ([b82f979](https://github.com/bitnami/charts/commit/b82f979)), closes [#21038](https://github.com/bitnami/charts/issues/21038)
-* [bitnami/nats] Release 7.10.4 updating components versions (#21144) ([819909d](https://github.com/bitnami/charts/commit/819909d)), closes [#21144](https://github.com/bitnami/charts/issues/21144)
+* [bitnami/*] Remove relative links to non-README sections, add verification for that and update TL;DR ([1103633](https://github.com/bitnami/charts/commit/11036334d82df0490aa4abdb591543cab6cf7d7f)), closes [#20967](https://github.com/bitnami/charts/issues/20967)
+* [bitnami/*] Rename solutions to "Bitnami package for ..." (#21038) ([b82f979](https://github.com/bitnami/charts/commit/b82f979e4fb63423fe6e2192c946d09d79c944fc)), closes [#21038](https://github.com/bitnami/charts/issues/21038)
+* [bitnami/nats] Release 7.10.4 updating components versions (#21144) ([819909d](https://github.com/bitnami/charts/commit/819909dc50c30c52bcfcd44d0e33f906c3387f99)), closes [#21144](https://github.com/bitnami/charts/issues/21144)
 
 ## <small>7.10.3 (2023-11-10)</small>
 
-* [bitnami/nats] Release 7.10.3 updating components versions (#20878) ([c710309](https://github.com/bitnami/charts/commit/c710309)), closes [#20878](https://github.com/bitnami/charts/issues/20878)
+* [bitnami/nats] Release 7.10.3 updating components versions (#20878) ([c710309](https://github.com/bitnami/charts/commit/c710309886811723bb0df3d62ffb4b1e644ecd17)), closes [#20878](https://github.com/bitnami/charts/issues/20878)
 
 ## <small>7.10.2 (2023-11-09)</small>
 
-* [bitnami/nats] Release 7.10.2 updating components versions (#20823) ([e4d81b2](https://github.com/bitnami/charts/commit/e4d81b2)), closes [#20823](https://github.com/bitnami/charts/issues/20823)
+* [bitnami/nats] Release 7.10.2 updating components versions (#20823) ([e4d81b2](https://github.com/bitnami/charts/commit/e4d81b28bb445e28650c16222081d84dc572bda3)), closes [#20823](https://github.com/bitnami/charts/issues/20823)
 
 ## <small>7.10.1 (2023-11-08)</small>
 
-* [bitnami/nats] Release 7.10.1 updating components versions (#20762) ([3bab671](https://github.com/bitnami/charts/commit/3bab671)), closes [#20762](https://github.com/bitnami/charts/issues/20762)
+* [bitnami/nats] Release 7.10.1 updating components versions (#20762) ([3bab671](https://github.com/bitnami/charts/commit/3bab67187e38596497e9f8efee6a5e849c5ff304)), closes [#20762](https://github.com/bitnami/charts/issues/20762)
 
 ## 7.10.0 (2023-11-06)
 
-* [bitnami/nats] feat: :sparkles: Add support for PSA restricted policy (#20513) ([3387862](https://github.com/bitnami/charts/commit/3387862)), closes [#20513](https://github.com/bitnami/charts/issues/20513)
+* [bitnami/nats] feat: :sparkles: Add support for PSA restricted policy (#20513) ([3387862](https://github.com/bitnami/charts/commit/3387862c5b2eef51f721d6e2b518e9d53cb9a4cc)), closes [#20513](https://github.com/bitnami/charts/issues/20513)
 
 ## <small>7.9.10 (2023-10-27)</small>
 
-* [bitnami/*] Rename VMware Application Catalog (#20361) ([3acc734](https://github.com/bitnami/charts/commit/3acc734)), closes [#20361](https://github.com/bitnami/charts/issues/20361)
-* [bitnami/*] Skip image's tag in the README files of the Bitnami Charts (#19841) ([bb9a01b](https://github.com/bitnami/charts/commit/bb9a01b)), closes [#19841](https://github.com/bitnami/charts/issues/19841)
-* [bitnami/*] Standardize documentation (#19835) ([af5f753](https://github.com/bitnami/charts/commit/af5f753)), closes [#19835](https://github.com/bitnami/charts/issues/19835)
-* [bitnami/nats] Release 7.9.10 updating components versions (#20490) ([84c4250](https://github.com/bitnami/charts/commit/84c4250)), closes [#20490](https://github.com/bitnami/charts/issues/20490)
+* [bitnami/*] Rename VMware Application Catalog (#20361) ([3acc734](https://github.com/bitnami/charts/commit/3acc73472beb6fb56c4d99f929061001205bc57e)), closes [#20361](https://github.com/bitnami/charts/issues/20361)
+* [bitnami/*] Skip image's tag in the README files of the Bitnami Charts (#19841) ([bb9a01b](https://github.com/bitnami/charts/commit/bb9a01b65911c87e48318db922cc05eb42785e42)), closes [#19841](https://github.com/bitnami/charts/issues/19841)
+* [bitnami/*] Standardize documentation (#19835) ([af5f753](https://github.com/bitnami/charts/commit/af5f7530c1bc8c5ded53a6c4f7b8f384ac1804f2)), closes [#19835](https://github.com/bitnami/charts/issues/19835)
+* [bitnami/nats] Release 7.9.10 updating components versions (#20490) ([84c4250](https://github.com/bitnami/charts/commit/84c4250d22dc424a6356ab93c2caea300f11f399)), closes [#20490](https://github.com/bitnami/charts/issues/20490)
 
 ## <small>7.9.9 (2023-10-16)</small>
 
-* [bitnami/nats] test: :white_check_mark: Add ginkgo persistence tests (#20253) ([109e6e6](https://github.com/bitnami/charts/commit/109e6e6)), closes [#20253](https://github.com/bitnami/charts/issues/20253)
+* [bitnami/nats] test: :white_check_mark: Add ginkgo persistence tests (#20253) ([109e6e6](https://github.com/bitnami/charts/commit/109e6e6ebbbee0191dd522a82e2031f244eca82a)), closes [#20253](https://github.com/bitnami/charts/issues/20253)
 
 ## <small>7.9.8 (2023-10-13)</small>
 
-* [bitnami/nats] Release 7.9.8 (#20213) ([5c1eba2](https://github.com/bitnami/charts/commit/5c1eba2)), closes [#20213](https://github.com/bitnami/charts/issues/20213)
+* [bitnami/nats] Release 7.9.8 (#20213) ([5c1eba2](https://github.com/bitnami/charts/commit/5c1eba2292e516cb1a7aa31100f4139357809fb4)), closes [#20213](https://github.com/bitnami/charts/issues/20213)
 
 ## <small>7.9.7 (2023-10-11)</small>
 
-* [bitnami/nats] Release 7.9.7 (#20058) ([1a91e0a](https://github.com/bitnami/charts/commit/1a91e0a)), closes [#20058](https://github.com/bitnami/charts/issues/20058)
+* [bitnami/nats] Release 7.9.7 (#20058) ([1a91e0a](https://github.com/bitnami/charts/commit/1a91e0a69bc6b60ddda13f9e8b0ab6593fff35ae)), closes [#20058](https://github.com/bitnami/charts/issues/20058)
 
 ## <small>7.9.6 (2023-10-09)</small>
 
-* [bitnami/*] Update Helm charts prerequisites (#19745) ([eb755dd](https://github.com/bitnami/charts/commit/eb755dd)), closes [#19745](https://github.com/bitnami/charts/issues/19745)
-* [bitnami/nats] Release 7.9.6 (#19876) ([5ede572](https://github.com/bitnami/charts/commit/5ede572)), closes [#19876](https://github.com/bitnami/charts/issues/19876)
+* [bitnami/*] Update Helm charts prerequisites (#19745) ([eb755dd](https://github.com/bitnami/charts/commit/eb755dd36a4dd3cf6635be8e0598f9a7f4c4a554)), closes [#19745](https://github.com/bitnami/charts/issues/19745)
+* [bitnami/nats] Release 7.9.6 (#19876) ([5ede572](https://github.com/bitnami/charts/commit/5ede5726f21ff502d84a1db0ca74bd0b3b0be50e)), closes [#19876](https://github.com/bitnami/charts/issues/19876)
 
 ## <small>7.9.5 (2023-10-04)</small>
 
-* [bitnami/nats] Release 7.9.5 (#19728) ([ba3f800](https://github.com/bitnami/charts/commit/ba3f800)), closes [#19728](https://github.com/bitnami/charts/issues/19728)
+* [bitnami/nats] Release 7.9.5 (#19728) ([ba3f800](https://github.com/bitnami/charts/commit/ba3f8002abd659ba760b8995fd169b898e5b8316)), closes [#19728](https://github.com/bitnami/charts/issues/19728)
 
 ## <small>7.9.4 (2023-09-20)</small>
 
-* [bitnami/nats] Release 7.9.4 (#19442) ([1a4c704](https://github.com/bitnami/charts/commit/1a4c704)), closes [#19442](https://github.com/bitnami/charts/issues/19442)
+* [bitnami/nats] Release 7.9.4 (#19442) ([1a4c704](https://github.com/bitnami/charts/commit/1a4c7040c56ab0171549877477d64f9a5d329314)), closes [#19442](https://github.com/bitnami/charts/issues/19442)
 
 ## <small>7.9.3 (2023-09-20)</small>
 
-* [bitnami/nats] Release 7.9.3 (#19411) ([e4b3631](https://github.com/bitnami/charts/commit/e4b3631)), closes [#19411](https://github.com/bitnami/charts/issues/19411)
-* Autogenerate schema files (#19194) ([a2c2090](https://github.com/bitnami/charts/commit/a2c2090)), closes [#19194](https://github.com/bitnami/charts/issues/19194)
-* Revert "Autogenerate schema files (#19194)" (#19335) ([73d80be](https://github.com/bitnami/charts/commit/73d80be)), closes [#19194](https://github.com/bitnami/charts/issues/19194) [#19335](https://github.com/bitnami/charts/issues/19335)
+* [bitnami/nats] Release 7.9.3 (#19411) ([e4b3631](https://github.com/bitnami/charts/commit/e4b3631dde88ea2fed8030a05a8bafcf526ef4d3)), closes [#19411](https://github.com/bitnami/charts/issues/19411)
+* Autogenerate schema files (#19194) ([a2c2090](https://github.com/bitnami/charts/commit/a2c2090b5ac97f47b745c8028c6452bf99739772)), closes [#19194](https://github.com/bitnami/charts/issues/19194)
+* Revert "Autogenerate schema files (#19194)" (#19335) ([73d80be](https://github.com/bitnami/charts/commit/73d80be525c88fb4b8a54451a55acd506e337062)), closes [#19194](https://github.com/bitnami/charts/issues/19194) [#19335](https://github.com/bitnami/charts/issues/19335)
 
 ## <small>7.9.2 (2023-09-07)</small>
 
-* [bitnami/nats] Release 7.9.2 (#19152) ([5f11bee](https://github.com/bitnami/charts/commit/5f11bee)), closes [#19152](https://github.com/bitnami/charts/issues/19152)
+* [bitnami/nats] Release 7.9.2 (#19152) ([5f11bee](https://github.com/bitnami/charts/commit/5f11bee0e6350e8c32820fed6707573604fbe525)), closes [#19152](https://github.com/bitnami/charts/issues/19152)
 
 ## <small>7.9.1 (2023-09-06)</small>
 
-* [bitnami/nats: Use merge helper]: (#19079) ([c9d7e48](https://github.com/bitnami/charts/commit/c9d7e48)), closes [#19079](https://github.com/bitnami/charts/issues/19079)
+* [bitnami/nats: Use merge helper]: (#19079) ([c9d7e48](https://github.com/bitnami/charts/commit/c9d7e4886debcf6c0cd2487662b678eb265e7f1e)), closes [#19079](https://github.com/bitnami/charts/issues/19079)
 
 ## 7.9.0 (2023-08-22)
 
-* [bitnami/nats] Support for customizing standard labels (#18357) ([4bfe638](https://github.com/bitnami/charts/commit/4bfe638)), closes [#18357](https://github.com/bitnami/charts/issues/18357)
+* [bitnami/nats] Support for customizing standard labels (#18357) ([4bfe638](https://github.com/bitnami/charts/commit/4bfe63814a3b50ba5ad58178c2231212a69c7876)), closes [#18357](https://github.com/bitnami/charts/issues/18357)
 
 ## <small>7.8.10 (2023-08-20)</small>
 
-* [bitnami/nats] Release 7.8.10 (#18693) ([7d1e606](https://github.com/bitnami/charts/commit/7d1e606)), closes [#18693](https://github.com/bitnami/charts/issues/18693)
+* [bitnami/nats] Release 7.8.10 (#18693) ([7d1e606](https://github.com/bitnami/charts/commit/7d1e606e8f32b4f44d4e10c74b38be1385359981)), closes [#18693](https://github.com/bitnami/charts/issues/18693)
 
 ## <small>7.8.9 (2023-08-17)</small>
 
-* [bitnami/nats] Release 7.8.9 (#18561) ([65ba279](https://github.com/bitnami/charts/commit/65ba279)), closes [#18561](https://github.com/bitnami/charts/issues/18561)
+* [bitnami/nats] Release 7.8.9 (#18561) ([65ba279](https://github.com/bitnami/charts/commit/65ba27939286e0c910e6c51cb3e077559b35e1fd)), closes [#18561](https://github.com/bitnami/charts/issues/18561)
 
 ## <small>7.8.8 (2023-08-04)</small>
 
-* [bitnami/nats] Release 7.8.8 (#18218) ([5bf9130](https://github.com/bitnami/charts/commit/5bf9130)), closes [#18218](https://github.com/bitnami/charts/issues/18218)
+* [bitnami/nats] Release 7.8.8 (#18218) ([5bf9130](https://github.com/bitnami/charts/commit/5bf9130051fce7c9664ac202fd9fa6760d508e3d)), closes [#18218](https://github.com/bitnami/charts/issues/18218)
 
 ## <small>7.8.7 (2023-07-26)</small>
 
-* [bitnami/nats] Release 7.8.7 (#17921) ([857a7da](https://github.com/bitnami/charts/commit/857a7da)), closes [#17921](https://github.com/bitnami/charts/issues/17921)
+* [bitnami/nats] Release 7.8.7 (#17921) ([857a7da](https://github.com/bitnami/charts/commit/857a7da44700392743861413e1ac80cbfc23393f)), closes [#17921](https://github.com/bitnami/charts/issues/17921)
 
 ## <small>7.8.6 (2023-07-15)</small>
 
-* [bitnami/nats] Release 7.8.6 (#17699) ([5a8030f](https://github.com/bitnami/charts/commit/5a8030f)), closes [#17699](https://github.com/bitnami/charts/issues/17699)
-* Add copyright header (#17300) ([da68be8](https://github.com/bitnami/charts/commit/da68be8)), closes [#17300](https://github.com/bitnami/charts/issues/17300)
-* Update charts readme (#17217) ([31b3c0a](https://github.com/bitnami/charts/commit/31b3c0a)), closes [#17217](https://github.com/bitnami/charts/issues/17217)
+* [bitnami/nats] Release 7.8.6 (#17699) ([5a8030f](https://github.com/bitnami/charts/commit/5a8030f89b6e755a8f730f092f472cabbbccf7e8)), closes [#17699](https://github.com/bitnami/charts/issues/17699)
+* Add copyright header (#17300) ([da68be8](https://github.com/bitnami/charts/commit/da68be8e951225133c7dfb572d5101ca3d61c5ae)), closes [#17300](https://github.com/bitnami/charts/issues/17300)
+* Update charts readme (#17217) ([31b3c0a](https://github.com/bitnami/charts/commit/31b3c0afd968ff4429107e34101f7509e6a0e913)), closes [#17217](https://github.com/bitnami/charts/issues/17217)
 
 ## <small>7.8.5 (2023-06-20)</small>
 
-* [bitnami/nats] Release 7.8.5 (#17243) ([387882a](https://github.com/bitnami/charts/commit/387882a)), closes [#17243](https://github.com/bitnami/charts/issues/17243)
+* [bitnami/nats] Release 7.8.5 (#17243) ([387882a](https://github.com/bitnami/charts/commit/387882a1e0bc18399d0852d7f75d8e17bc1153c2)), closes [#17243](https://github.com/bitnami/charts/issues/17243)
 
 ## <small>7.8.4 (2023-06-13)</small>
 
-* [bitnami/*] Change copyright section in READMEs (#17006) ([ef986a1](https://github.com/bitnami/charts/commit/ef986a1)), closes [#17006](https://github.com/bitnami/charts/issues/17006)
-* [bitnami/nats] Release 7.8.4 (#17113) ([bed6ebf](https://github.com/bitnami/charts/commit/bed6ebf)), closes [#17113](https://github.com/bitnami/charts/issues/17113)
-* [bitnami/several] Change copyright section in READMEs (#16989) ([5b6a5cf](https://github.com/bitnami/charts/commit/5b6a5cf)), closes [#16989](https://github.com/bitnami/charts/issues/16989)
+* [bitnami/*] Change copyright section in READMEs (#17006) ([ef986a1](https://github.com/bitnami/charts/commit/ef986a1605241102b3dcafe9fd8089e6fc1201ad)), closes [#17006](https://github.com/bitnami/charts/issues/17006)
+* [bitnami/nats] Release 7.8.4 (#17113) ([bed6ebf](https://github.com/bitnami/charts/commit/bed6ebf2533fb4dad3f79d63389f7035c8328549)), closes [#17113](https://github.com/bitnami/charts/issues/17113)
+* [bitnami/several] Change copyright section in READMEs (#16989) ([5b6a5cf](https://github.com/bitnami/charts/commit/5b6a5cfb7625a751848a2e5cd796bd7278f406ca)), closes [#16989](https://github.com/bitnami/charts/issues/16989)
 
 ## <small>7.8.3 (2023-05-21)</small>
 
-* [bitnami/nats] Release 7.8.3 (#16827) ([a86b8b0](https://github.com/bitnami/charts/commit/a86b8b0)), closes [#16827](https://github.com/bitnami/charts/issues/16827)
+* [bitnami/nats] Release 7.8.3 (#16827) ([a86b8b0](https://github.com/bitnami/charts/commit/a86b8b0934d9da73a02a5c3a96616c99a3dcfabd)), closes [#16827](https://github.com/bitnami/charts/issues/16827)
 
 ## <small>7.8.2 (2023-05-18)</small>
 
-* [bitnami/nats] Release 7.8.2 (#16741) ([058fd19](https://github.com/bitnami/charts/commit/058fd19)), closes [#16741](https://github.com/bitnami/charts/issues/16741)
+* [bitnami/nats] Release 7.8.2 (#16741) ([058fd19](https://github.com/bitnami/charts/commit/058fd191cab693881cc0c1a183266f1b0f8c8773)), closes [#16741](https://github.com/bitnami/charts/issues/16741)
 
 ## <small>7.8.1 (2023-05-11)</small>
 
-* add metrics port to network policy (#16438) ([116b029](https://github.com/bitnami/charts/commit/116b029)), closes [#16438](https://github.com/bitnami/charts/issues/16438)
-* Add wording for enterprise page (#16560) ([8f22774](https://github.com/bitnami/charts/commit/8f22774)), closes [#16560](https://github.com/bitnami/charts/issues/16560)
+* add metrics port to network policy (#16438) ([116b029](https://github.com/bitnami/charts/commit/116b029b535c8e11864878eb17c59f90749401f9)), closes [#16438](https://github.com/bitnami/charts/issues/16438)
+* Add wording for enterprise page (#16560) ([8f22774](https://github.com/bitnami/charts/commit/8f2277440b976d52785ba9149762ad8620a73d1f)), closes [#16560](https://github.com/bitnami/charts/issues/16560)
 
 ## 7.8.0 (2023-05-09)
 
-* [bitnami/several] Adapt Chart.yaml to set desired OCI annotations (#16546) ([fc9b18f](https://github.com/bitnami/charts/commit/fc9b18f)), closes [#16546](https://github.com/bitnami/charts/issues/16546)
+* [bitnami/several] Adapt Chart.yaml to set desired OCI annotations (#16546) ([fc9b18f](https://github.com/bitnami/charts/commit/fc9b18f2e98805d4df629acbcde696f44f973344)), closes [#16546](https://github.com/bitnami/charts/issues/16546)
 
 ## <small>7.7.1 (2023-05-09)</small>
 
-* [bitnami/nats] Release 7.7.1 (#16481) ([6d3f79d](https://github.com/bitnami/charts/commit/6d3f79d)), closes [#16481](https://github.com/bitnami/charts/issues/16481)
+* [bitnami/nats] Release 7.7.1 (#16481) ([6d3f79d](https://github.com/bitnami/charts/commit/6d3f79d2aa3ad02731d93d77e8f14a8ca93753da)), closes [#16481](https://github.com/bitnami/charts/issues/16481)
 
 ## 7.7.0 (2023-04-20)
 
-* [bitnami/*] Make Helm charts 100% OCI (#15998) ([8841510](https://github.com/bitnami/charts/commit/8841510)), closes [#15998](https://github.com/bitnami/charts/issues/15998)
+* [bitnami/*] Make Helm charts 100% OCI (#15998) ([8841510](https://github.com/bitnami/charts/commit/884151035efcbf2e1b3206e7def85511073fb57d)), closes [#15998](https://github.com/bitnami/charts/issues/15998)
 
 ## <small>7.6.2 (2023-04-17)</small>
 
-* [bitnami/nats] Release 7.6.2 (#16097) ([82daefb](https://github.com/bitnami/charts/commit/82daefb)), closes [#16097](https://github.com/bitnami/charts/issues/16097)
+* [bitnami/nats] Release 7.6.2 (#16097) ([82daefb](https://github.com/bitnami/charts/commit/82daefb6152224c70890874da0cc5bdcbaebde59)), closes [#16097](https://github.com/bitnami/charts/issues/16097)
 
 ## <small>7.6.1 (2023-04-01)</small>
 
-* [bitnami/nats] Release 7.6.1 (#15872) ([ad744ab](https://github.com/bitnami/charts/commit/ad744ab)), closes [#15872](https://github.com/bitnami/charts/issues/15872)
+* [bitnami/nats] Release 7.6.1 (#15872) ([ad744ab](https://github.com/bitnami/charts/commit/ad744abd9d2644f03dfbf21ed88254ae7dc89031)), closes [#15872](https://github.com/bitnami/charts/issues/15872)
 
 ## 7.6.0 (2023-03-21)
 
-* [bitnami/nats] Add support for service.headless.annotations (#15437) ([5937c6d](https://github.com/bitnami/charts/commit/5937c6d)), closes [#15437](https://github.com/bitnami/charts/issues/15437)
+* [bitnami/nats] Add support for service.headless.annotations (#15437) ([5937c6d](https://github.com/bitnami/charts/commit/5937c6d5cf65451e5bf6713312d6efcb8819ac8f)), closes [#15437](https://github.com/bitnami/charts/issues/15437)
 
 ## <small>7.5.13 (2023-03-18)</small>
 
-* [bitnami/charts] Apply linter to README files (#15357) ([0e29e60](https://github.com/bitnami/charts/commit/0e29e60)), closes [#15357](https://github.com/bitnami/charts/issues/15357)
-* [bitnami/nats] Release 7.5.13 (#15581) ([93a0362](https://github.com/bitnami/charts/commit/93a0362)), closes [#15581](https://github.com/bitnami/charts/issues/15581)
+* [bitnami/charts] Apply linter to README files (#15357) ([0e29e60](https://github.com/bitnami/charts/commit/0e29e600d3adc8b1b46e506eccb3decfab3b4e63)), closes [#15357](https://github.com/bitnami/charts/issues/15357)
+* [bitnami/nats] Release 7.5.13 (#15581) ([93a0362](https://github.com/bitnami/charts/commit/93a0362a16360270fd066e881d669a95b9bdca7c)), closes [#15581](https://github.com/bitnami/charts/issues/15581)
 
 ## <small>7.5.12 (2023-03-02)</small>
 
-* [bitnami/nats] Release 7.5.12 (#15303) ([a38e124](https://github.com/bitnami/charts/commit/a38e124)), closes [#15303](https://github.com/bitnami/charts/issues/15303)
+* [bitnami/nats] Release 7.5.12 (#15303) ([a38e124](https://github.com/bitnami/charts/commit/a38e1242821eccc15e3b0c2b45f0a22598d49437)), closes [#15303](https://github.com/bitnami/charts/issues/15303)
 
 ## <small>7.5.11 (2023-03-01)</small>
 
-* [bitnami/nats] Release 7.5.11 (#15243) ([ee89748](https://github.com/bitnami/charts/commit/ee89748)), closes [#15243](https://github.com/bitnami/charts/issues/15243)
+* [bitnami/nats] Release 7.5.11 (#15243) ([ee89748](https://github.com/bitnami/charts/commit/ee8974880a05f448441657dbc111cc488a43d289)), closes [#15243](https://github.com/bitnami/charts/issues/15243)
 
 ## <small>7.5.10 (2023-02-17)</small>
 
-* [bitnami/*] Fix markdown linter issues (#14874) ([a51e0e8](https://github.com/bitnami/charts/commit/a51e0e8)), closes [#14874](https://github.com/bitnami/charts/issues/14874)
-* [bitnami/*] Fix markdown linter issues 2 (#14890) ([aa96572](https://github.com/bitnami/charts/commit/aa96572)), closes [#14890](https://github.com/bitnami/charts/issues/14890)
-* [bitnami/*] Remove unexpected extra spaces (#14873) ([c97c714](https://github.com/bitnami/charts/commit/c97c714)), closes [#14873](https://github.com/bitnami/charts/issues/14873)
-* [bitnami/nats] Release 7.5.10 (#14998) ([fb6c4b4](https://github.com/bitnami/charts/commit/fb6c4b4)), closes [#14998](https://github.com/bitnami/charts/issues/14998)
+* [bitnami/*] Fix markdown linter issues (#14874) ([a51e0e8](https://github.com/bitnami/charts/commit/a51e0e8d35495b907f3e70dd2f8e7c3bcbf4166a)), closes [#14874](https://github.com/bitnami/charts/issues/14874)
+* [bitnami/*] Fix markdown linter issues 2 (#14890) ([aa96572](https://github.com/bitnami/charts/commit/aa9657237ee8df4a46db0d7fdf8a23230dd6902a)), closes [#14890](https://github.com/bitnami/charts/issues/14890)
+* [bitnami/*] Remove unexpected extra spaces (#14873) ([c97c714](https://github.com/bitnami/charts/commit/c97c714887380d47eae7bfeff316bf01595ecd1d)), closes [#14873](https://github.com/bitnami/charts/issues/14873)
+* [bitnami/nats] Release 7.5.10 (#14998) ([fb6c4b4](https://github.com/bitnami/charts/commit/fb6c4b48217273757110fa44a99995b5f332e97b)), closes [#14998](https://github.com/bitnami/charts/issues/14998)
 
 ## <small>7.5.9 (2023-02-07)</small>
 
-* [bitnami/nats] Release 7.5.9 (#14770) ([a16cb91](https://github.com/bitnami/charts/commit/a16cb91)), closes [#14770](https://github.com/bitnami/charts/issues/14770)
+* [bitnami/nats] Release 7.5.9 (#14770) ([a16cb91](https://github.com/bitnami/charts/commit/a16cb91e7e7544d73218918ff3657e92214103cc)), closes [#14770](https://github.com/bitnami/charts/issues/14770)
 
 ## <small>7.5.8 (2023-02-02)</small>
 
-* [bitnami/*] Change copyright date (#14682) ([add4ec7](https://github.com/bitnami/charts/commit/add4ec7)), closes [#14682](https://github.com/bitnami/charts/issues/14682)
-* [bitnami/nats] Release 7.5.8 (#14734) ([8ec55d4](https://github.com/bitnami/charts/commit/8ec55d4)), closes [#14734](https://github.com/bitnami/charts/issues/14734)
+* [bitnami/*] Change copyright date (#14682) ([add4ec7](https://github.com/bitnami/charts/commit/add4ec701108ac36ed4de2dffbdf407a0d091067)), closes [#14682](https://github.com/bitnami/charts/issues/14682)
+* [bitnami/nats] Release 7.5.8 (#14734) ([8ec55d4](https://github.com/bitnami/charts/commit/8ec55d42f9b6e1bfa9c5d5c2e8e42e23d394da1a)), closes [#14734](https://github.com/bitnami/charts/issues/14734)
 
 ## <small>7.5.7 (2023-01-31)</small>
 
-* [bitnami/*] Add license annotation and remove obsolete engine parameter (#14293) ([da2a794](https://github.com/bitnami/charts/commit/da2a794)), closes [#14293](https://github.com/bitnami/charts/issues/14293)
-* [bitnami/*] Change licenses annotation format (#14377) ([0ab7608](https://github.com/bitnami/charts/commit/0ab7608)), closes [#14377](https://github.com/bitnami/charts/issues/14377)
-* [bitnami/*] Unify READMEs (#14472) ([2064fb8](https://github.com/bitnami/charts/commit/2064fb8)), closes [#14472](https://github.com/bitnami/charts/issues/14472)
-* [bitnami/nats] Don't regenerate self-signed certs on upgrade (#14643) ([8929b3f](https://github.com/bitnami/charts/commit/8929b3f)), closes [#14643](https://github.com/bitnami/charts/issues/14643)
+* [bitnami/*] Add license annotation and remove obsolete engine parameter (#14293) ([da2a794](https://github.com/bitnami/charts/commit/da2a7943bae95b6e9b5b4ed972c15e990b69fdb0)), closes [#14293](https://github.com/bitnami/charts/issues/14293)
+* [bitnami/*] Change licenses annotation format (#14377) ([0ab7608](https://github.com/bitnami/charts/commit/0ab760862c660fcc78cffadf8e1d8cdd70881473)), closes [#14377](https://github.com/bitnami/charts/issues/14377)
+* [bitnami/*] Unify READMEs (#14472) ([2064fb8](https://github.com/bitnami/charts/commit/2064fb8dcc78a845cdede8211af8c3cc52551161)), closes [#14472](https://github.com/bitnami/charts/issues/14472)
+* [bitnami/nats] Don't regenerate self-signed certs on upgrade (#14643) ([8929b3f](https://github.com/bitnami/charts/commit/8929b3f7de6470e610fc2826adc4e6ec32764246)), closes [#14643](https://github.com/bitnami/charts/issues/14643)
 
 ## <small>7.5.6 (2023-01-06)</small>
 
-* [bitnami/nats] Release 7.5.6 (#14214) ([eb8e2ed](https://github.com/bitnami/charts/commit/eb8e2ed)), closes [#14214](https://github.com/bitnami/charts/issues/14214)
+* [bitnami/nats] Release 7.5.6 (#14214) ([eb8e2ed](https://github.com/bitnami/charts/commit/eb8e2ed1939b9af98ab87895ebdd6d19274377b2)), closes [#14214](https://github.com/bitnami/charts/issues/14214)
 
 ## <small>7.5.5 (2022-12-20)</small>
 
-* [bitnami/nats] Release 7.5.5 (#14052) ([669a7a4](https://github.com/bitnami/charts/commit/669a7a4)), closes [#14052](https://github.com/bitnami/charts/issues/14052)
+* [bitnami/nats] Release 7.5.5 (#14052) ([669a7a4](https://github.com/bitnami/charts/commit/669a7a44b26e3cc3b874a57c86d822ce154da451)), closes [#14052](https://github.com/bitnami/charts/issues/14052)
 
 ## <small>7.5.4 (2022-12-10)</small>
 
-* [bitnami/nats] Release 7.5.4 (#13901) ([2be1a07](https://github.com/bitnami/charts/commit/2be1a07)), closes [#13901](https://github.com/bitnami/charts/issues/13901)
+* [bitnami/nats] Release 7.5.4 (#13901) ([2be1a07](https://github.com/bitnami/charts/commit/2be1a07303bb36f56b0f99fd1e52dc8b17c6fefe)), closes [#13901](https://github.com/bitnami/charts/issues/13901)
 
 ## <small>7.5.3 (2022-11-23)</small>
 
-* [bitnami/nats] Release 7.5.3 (#13649) ([15b2642](https://github.com/bitnami/charts/commit/15b2642)), closes [#13649](https://github.com/bitnami/charts/issues/13649)
+* [bitnami/nats] Release 7.5.3 (#13649) ([15b2642](https://github.com/bitnami/charts/commit/15b2642b55120e08393a6fda488320afdf309658)), closes [#13649](https://github.com/bitnami/charts/issues/13649)
 
 ## <small>7.5.2 (2022-11-18)</small>
 
-* [bitnami/nats] fix apiversion hardcode for statefulset (#13565) ([a6db70a](https://github.com/bitnami/charts/commit/a6db70a)), closes [#13565](https://github.com/bitnami/charts/issues/13565)
+* [bitnami/nats] fix apiversion hardcode for statefulset (#13565) ([a6db70a](https://github.com/bitnami/charts/commit/a6db70ae67d0bf26a896a73eee2a10ff8b622034)), closes [#13565](https://github.com/bitnami/charts/issues/13565)
 
 ## <small>7.5.1 (2022-11-17)</small>
 
-* [bitnami/nats] Release 7.5.1 (#13573) ([e381d4b](https://github.com/bitnami/charts/commit/e381d4b)), closes [#13573](https://github.com/bitnami/charts/issues/13573)
+* [bitnami/nats] Release 7.5.1 (#13573) ([e381d4b](https://github.com/bitnami/charts/commit/e381d4b4ec846778711ebd305735165e5680ab4d)), closes [#13573](https://github.com/bitnami/charts/issues/13573)
 
 ## 7.5.0 (2022-11-15)
 
-* [bitnami/nats] Add support for JetStream (#13512) ([742c890](https://github.com/bitnami/charts/commit/742c890)), closes [#13512](https://github.com/bitnami/charts/issues/13512)
+* [bitnami/nats] Add support for JetStream (#13512) ([742c890](https://github.com/bitnami/charts/commit/742c890a237d86c72104ebd1bad3436d134e8e2b)), closes [#13512](https://github.com/bitnami/charts/issues/13512)
 
 ## <small>7.4.12 (2022-11-07)</small>
 
-* [bitnami/nats] Release 7.4.12 (#13363) ([cfe56c4](https://github.com/bitnami/charts/commit/cfe56c4)), closes [#13363](https://github.com/bitnami/charts/issues/13363)
+* [bitnami/nats] Release 7.4.12 (#13363) ([cfe56c4](https://github.com/bitnami/charts/commit/cfe56c435349a5727c9f0fb29c5e34b6ed440853)), closes [#13363](https://github.com/bitnami/charts/issues/13363)
 
 ## <small>7.4.11 (2022-11-02)</small>
 
-* [bitnami/nats] Release 7.4.11 (#13302) ([9a58261](https://github.com/bitnami/charts/commit/9a58261)), closes [#13302](https://github.com/bitnami/charts/issues/13302)
+* [bitnami/nats] Release 7.4.11 (#13302) ([9a58261](https://github.com/bitnami/charts/commit/9a5826133eb1b6b186a16f4f6af57b265fff9a43)), closes [#13302](https://github.com/bitnami/charts/issues/13302)
 
 ## <small>7.4.10 (2022-10-28)</small>
 
-* [bitnami/*] Use new default branch name in links (#12943) ([a529e02](https://github.com/bitnami/charts/commit/a529e02)), closes [#12943](https://github.com/bitnami/charts/issues/12943)
-* [bitnami/nats] Release 7.4.10 (#13208) ([25af3e1](https://github.com/bitnami/charts/commit/25af3e1)), closes [#13208](https://github.com/bitnami/charts/issues/13208)
+* [bitnami/*] Use new default branch name in links (#12943) ([a529e02](https://github.com/bitnami/charts/commit/a529e02597d49d944eba1eb0f190713293247176)), closes [#12943](https://github.com/bitnami/charts/issues/12943)
+* [bitnami/nats] Release 7.4.10 (#13208) ([25af3e1](https://github.com/bitnami/charts/commit/25af3e1a207065c6ddf92875f41ee2c1ae9ae0e0)), closes [#13208](https://github.com/bitnami/charts/issues/13208)
 
 ## <small>7.4.9 (2022-10-11)</small>
 
-* [bitnami/nats] Release 7.4.9 (#12893) ([58ebfe9](https://github.com/bitnami/charts/commit/58ebfe9)), closes [#12893](https://github.com/bitnami/charts/issues/12893)
-* Generic README instructions related to the repo (#12792) ([3cf6b10](https://github.com/bitnami/charts/commit/3cf6b10)), closes [#12792](https://github.com/bitnami/charts/issues/12792)
+* [bitnami/nats] Release 7.4.9 (#12893) ([58ebfe9](https://github.com/bitnami/charts/commit/58ebfe9d9a2f95f5a2f1235bf863a4916450c5f6)), closes [#12893](https://github.com/bitnami/charts/issues/12893)
+* Generic README instructions related to the repo (#12792) ([3cf6b10](https://github.com/bitnami/charts/commit/3cf6b10e10e60df4b3e191d6b99aa99a9f597755)), closes [#12792](https://github.com/bitnami/charts/issues/12792)
 
 ## <small>7.4.8 (2022-09-30)</small>
 
-* [bitnami/nats] Release 7.4.8 (#12760) ([85da8c0](https://github.com/bitnami/charts/commit/85da8c0)), closes [#12760](https://github.com/bitnami/charts/issues/12760)
+* [bitnami/nats] Release 7.4.8 (#12760) ([85da8c0](https://github.com/bitnami/charts/commit/85da8c0c6dd6aabc1f1ff25d487a8c602b54b504)), closes [#12760](https://github.com/bitnami/charts/issues/12760)
 
 ## <small>7.4.7 (2022-09-30)</small>
 
-* [bitnami/nats] Release 7.4.7 (#12743) ([30859b0](https://github.com/bitnami/charts/commit/30859b0)), closes [#12743](https://github.com/bitnami/charts/issues/12743)
+* [bitnami/nats] Release 7.4.7 (#12743) ([30859b0](https://github.com/bitnami/charts/commit/30859b01553ddf69b9e7b6374f60640d45cbe477)), closes [#12743](https://github.com/bitnami/charts/issues/12743)
 
 ## <small>7.4.6 (2022-09-23)</small>
 
-* [bitnami/nats] Release 7.4.6 (#12646) ([32ac716](https://github.com/bitnami/charts/commit/32ac716)), closes [#12646](https://github.com/bitnami/charts/issues/12646)
+* [bitnami/nats] Release 7.4.6 (#12646) ([32ac716](https://github.com/bitnami/charts/commit/32ac7169794652ef525e71fa2b22f0e91b1bd656)), closes [#12646](https://github.com/bitnami/charts/issues/12646)
 
 ## <small>7.4.5 (2022-09-20)</small>
 
-* [bitnami/nats] Use custom probes if given (#12533) ([9e4498c](https://github.com/bitnami/charts/commit/9e4498c)), closes [#12533](https://github.com/bitnami/charts/issues/12533) [#12354](https://github.com/bitnami/charts/issues/12354)
+* [bitnami/nats] Use custom probes if given (#12533) ([9e4498c](https://github.com/bitnami/charts/commit/9e4498ccf1a1813bcf9e4f5363c45971844f995e)), closes [#12533](https://github.com/bitnami/charts/issues/12533) [#12354](https://github.com/bitnami/charts/issues/12354)
 
 ## <small>7.4.4 (2022-09-12)</small>
 
-* [bitnami/nats] Release 7.4.4 (#12375) ([7b02b60](https://github.com/bitnami/charts/commit/7b02b60)), closes [#12375](https://github.com/bitnami/charts/issues/12375)
+* [bitnami/nats] Release 7.4.4 (#12375) ([7b02b60](https://github.com/bitnami/charts/commit/7b02b60b7bc507965495c75ad915df7abdae63e5)), closes [#12375](https://github.com/bitnami/charts/issues/12375)
 
 ## <small>7.4.3 (2022-09-11)</small>
 
-* [bitnami/nats] Release 7.4.3 (#12356) ([0fb4b06](https://github.com/bitnami/charts/commit/0fb4b06)), closes [#12356](https://github.com/bitnami/charts/issues/12356)
+* [bitnami/nats] Release 7.4.3 (#12356) ([0fb4b06](https://github.com/bitnami/charts/commit/0fb4b06dac86a92e773ba80349c41d3320eea899)), closes [#12356](https://github.com/bitnami/charts/issues/12356)
 
 ## <small>7.4.2 (2022-09-03)</small>
 
-* [bitnami/nats] Release 7.4.2 (#12271) ([0ef95ab](https://github.com/bitnami/charts/commit/0ef95ab)), closes [#12271](https://github.com/bitnami/charts/issues/12271)
+* [bitnami/nats] Release 7.4.2 (#12271) ([0ef95ab](https://github.com/bitnami/charts/commit/0ef95ab5077158aadf7052d54337eac886bac177)), closes [#12271](https://github.com/bitnami/charts/issues/12271)
 
 ## <small>7.4.1 (2022-08-23)</small>
 
-* [bitnami/nats] Update Chart.lock (#12080) ([d5da7b6](https://github.com/bitnami/charts/commit/d5da7b6)), closes [#12080](https://github.com/bitnami/charts/issues/12080)
+* [bitnami/nats] Update Chart.lock (#12080) ([d5da7b6](https://github.com/bitnami/charts/commit/d5da7b694bc11777f0db3e98cf8d9f0bafcb79b1)), closes [#12080](https://github.com/bitnami/charts/issues/12080)
 
 ## 7.4.0 (2022-08-22)
 
-* [bitnami/nats] Add support for image digest apart from tag (#11934) ([6f0e63b](https://github.com/bitnami/charts/commit/6f0e63b)), closes [#11934](https://github.com/bitnami/charts/issues/11934)
+* [bitnami/nats] Add support for image digest apart from tag (#11934) ([6f0e63b](https://github.com/bitnami/charts/commit/6f0e63b2673bba1fc7e14590e5acf70b91e3c205)), closes [#11934](https://github.com/bitnami/charts/issues/11934)
 
 ## <small>7.3.12 (2022-08-19)</small>
 
-* [bitnami/nats] fix cluster port in nats networkpolicy resource (#11845) ([7defa86](https://github.com/bitnami/charts/commit/7defa86)), closes [#11845](https://github.com/bitnami/charts/issues/11845)
+* [bitnami/nats] fix cluster port in nats networkpolicy resource (#11845) ([7defa86](https://github.com/bitnami/charts/commit/7defa8656c561ac787c6cf45f6192f7a891a46bd)), closes [#11845](https://github.com/bitnami/charts/issues/11845)
 
 ## <small>7.3.11 (2022-08-18)</small>
 
-* [bitnami/nats] Adjust the naming style for resources (#11819) ([75336a7](https://github.com/bitnami/charts/commit/75336a7)), closes [#11819](https://github.com/bitnami/charts/issues/11819)
+* [bitnami/nats] Adjust the naming style for resources (#11819) ([75336a7](https://github.com/bitnami/charts/commit/75336a70b8efb5581c012b9bf9fa7b4d5535badf)), closes [#11819](https://github.com/bitnami/charts/issues/11819)
 
 ## <small>7.3.10 (2022-08-04)</small>
 
-* [bitnami/nats] Release 7.3.10 updating components versions ([fa2ee47](https://github.com/bitnami/charts/commit/fa2ee47))
+* [bitnami/nats] Release 7.3.10 updating components versions ([fa2ee47](https://github.com/bitnami/charts/commit/fa2ee47a95f5ee8df6e81d49a87c40f84f2cbd9e))
 
 ## <small>7.3.9 (2022-08-04)</small>
 
-* [bitnami/nats] Release 7.3.9 updating components versions ([371dbfe](https://github.com/bitnami/charts/commit/371dbfe))
+* [bitnami/nats] Release 7.3.9 updating components versions ([371dbfe](https://github.com/bitnami/charts/commit/371dbfe21bfee81276967ef0b2b33ada6c0667d0))
 
 ## <small>7.3.8 (2022-08-02)</small>
 
-* [bitnami/*] Update URLs to point to the new bitnami/containers monorepo (#11352) ([d665af0](https://github.com/bitnami/charts/commit/d665af0)), closes [#11352](https://github.com/bitnami/charts/issues/11352)
-* [bitnami/nats] Release 7.3.8 updating components versions ([8596617](https://github.com/bitnami/charts/commit/8596617))
+* [bitnami/*] Update URLs to point to the new bitnami/containers monorepo (#11352) ([d665af0](https://github.com/bitnami/charts/commit/d665af0c708846192d8d5fb2f5f9ea65dd464ab0)), closes [#11352](https://github.com/bitnami/charts/issues/11352)
+* [bitnami/nats] Release 7.3.8 updating components versions ([8596617](https://github.com/bitnami/charts/commit/859661799ac7fa70f9bece615274f2a98a13aeb7))
 
 ## <small>7.3.7 (2022-07-04)</small>
 
-* [bitnami/nats] Release 7.3.7 updating components versions ([7738db9](https://github.com/bitnami/charts/commit/7738db9))
+* [bitnami/nats] Release 7.3.7 updating components versions ([7738db9](https://github.com/bitnami/charts/commit/7738db991b49dc05e19e4b618c17abce84051c24))
 
 ## <small>7.3.6 (2022-06-30)</small>
 
-* [bitnami/nats] Release 7.3.6 updating components versions ([386ff80](https://github.com/bitnami/charts/commit/386ff80))
+* [bitnami/nats] Release 7.3.6 updating components versions ([386ff80](https://github.com/bitnami/charts/commit/386ff8014bbc12d66646d234761a7e8e97556a96))
 
 ## <small>7.3.5 (2022-06-10)</small>
 
-* [bitnami/*] Replace Kubeapps URL in READMEs (and kubeapps Chart.yaml) and remove BKPR references (#1 ([c6a7914](https://github.com/bitnami/charts/commit/c6a7914)), closes [#10600](https://github.com/bitnami/charts/issues/10600)
-* [bitnami/nats] Release 7.3.5 updating components versions ([008a1d2](https://github.com/bitnami/charts/commit/008a1d2))
+* [bitnami/*] Replace Kubeapps URL in READMEs (and kubeapps Chart.yaml) and remove BKPR references (#1 ([c6a7914](https://github.com/bitnami/charts/commit/c6a7914361e5aea6016fb45bf4d621edfd111d32)), closes [#10600](https://github.com/bitnami/charts/issues/10600)
+* [bitnami/nats] Release 7.3.5 updating components versions ([008a1d2](https://github.com/bitnami/charts/commit/008a1d2b97bc8f13ab61edac44015494cfeb75e0))
 
 ## <small>7.3.4 (2022-06-06)</small>
 
-* [bitnami/nats] Release 7.3.4 updating components versions ([5b5ad88](https://github.com/bitnami/charts/commit/5b5ad88))
+* [bitnami/nats] Release 7.3.4 updating components versions ([5b5ad88](https://github.com/bitnami/charts/commit/5b5ad88166922711b61c9c91f4f5aa96d7556ad6))
 
 ## <small>7.3.3 (2022-06-01)</small>
 
-* [bitnami/several] Replace maintainers email by url (#10523) ([ff3cf61](https://github.com/bitnami/charts/commit/ff3cf61)), closes [#10523](https://github.com/bitnami/charts/issues/10523)
+* [bitnami/several] Replace maintainers email by url (#10523) ([ff3cf61](https://github.com/bitnami/charts/commit/ff3cf617a1680509b0f3855d17c4ccff7b29a0ff)), closes [#10523](https://github.com/bitnami/charts/issues/10523)
 
 ## <small>7.3.2 (2022-05-30)</small>
 
-* [bitnami/several] Replace base64 --decode with base64 -d (#10495) ([099286a](https://github.com/bitnami/charts/commit/099286a)), closes [#10495](https://github.com/bitnami/charts/issues/10495)
+* [bitnami/several] Replace base64 --decode with base64 -d (#10495) ([099286a](https://github.com/bitnami/charts/commit/099286ae7a87784cf809df0b64ab24f7ff0144c8)), closes [#10495](https://github.com/bitnami/charts/issues/10495)
 
 ## <small>7.3.1 (2022-05-27)</small>
 
-* [bitnami/nats] Release 7.3.1 updating components versions ([13e431d](https://github.com/bitnami/charts/commit/13e431d))
+* [bitnami/nats] Release 7.3.1 updating components versions ([13e431d](https://github.com/bitnami/charts/commit/13e431d161c8de692d741aeb7c70fc54cc0c365b))
 
 ## 7.3.0 (2022-05-26)
 
-* [bitnami/nats] Add missing service parameter (#10423) ([0e0f9a1](https://github.com/bitnami/charts/commit/0e0f9a1)), closes [#10423](https://github.com/bitnami/charts/issues/10423)
+* [bitnami/nats] Add missing service parameter (#10423) ([0e0f9a1](https://github.com/bitnami/charts/commit/0e0f9a1b8c1eb0f332ef051fd70bc2d58a3c2539)), closes [#10423](https://github.com/bitnami/charts/issues/10423)
 
 ## <small>7.2.5 (2022-05-24)</small>
 
-* [bitnami/nats] Release 7.2.5 updating components versions ([9f9e0a8](https://github.com/bitnami/charts/commit/9f9e0a8))
+* [bitnami/nats] Release 7.2.5 updating components versions ([9f9e0a8](https://github.com/bitnami/charts/commit/9f9e0a899a06ae70f164138ccc2ba1e0886c6dec))
 
 ## <small>7.2.4 (2022-05-21)</small>
 
-* [bitnami/nats] Release 7.2.4 updating components versions ([9cea7cc](https://github.com/bitnami/charts/commit/9cea7cc))
+* [bitnami/nats] Release 7.2.4 updating components versions ([9cea7cc](https://github.com/bitnami/charts/commit/9cea7cc10621e7a58f20ccedf27d34e3e828cbeb))
 
 ## <small>7.2.3 (2022-05-20)</small>
 
-* [bitnami/nats] Release 7.2.3 updating components versions ([4275097](https://github.com/bitnami/charts/commit/4275097))
+* [bitnami/nats] Release 7.2.3 updating components versions ([4275097](https://github.com/bitnami/charts/commit/427509793e36038ecbf6d714df82ce5cd36c8a9b))
 
 ## <small>7.2.2 (2022-05-19)</small>
 
-* [bitnami/nats] Release 7.2.2 updating components versions ([de70acb](https://github.com/bitnami/charts/commit/de70acb))
+* [bitnami/nats] Release 7.2.2 updating components versions ([de70acb](https://github.com/bitnami/charts/commit/de70acbe8911e5f1f749f5c51ecb1904210dda87))
 
 ## <small>7.2.1 (2022-05-18)</small>
 
-* [bitnami/nats] Release 7.2.1 updating components versions ([8b921f6](https://github.com/bitnami/charts/commit/8b921f6))
+* [bitnami/nats] Release 7.2.1 updating components versions ([8b921f6](https://github.com/bitnami/charts/commit/8b921f611002c50dbe111d714a1d7fac743b0673))
 
 ## 7.2.0 (2022-05-16)
 
-* [bitnami/*] add ingress extraRules feature (#10253) ([0f6cbb9](https://github.com/bitnami/charts/commit/0f6cbb9)), closes [#10253](https://github.com/bitnami/charts/issues/10253)
-* [bitnami/*] Remove old 'ci' files (#10171) ([5df30c4](https://github.com/bitnami/charts/commit/5df30c4)), closes [#10171](https://github.com/bitnami/charts/issues/10171)
-* [bitnami/nats] Add missing namespace metadata (#10144) ([1bb28ab](https://github.com/bitnami/charts/commit/1bb28ab)), closes [#10144](https://github.com/bitnami/charts/issues/10144)
+* [bitnami/*] add ingress extraRules feature (#10253) ([0f6cbb9](https://github.com/bitnami/charts/commit/0f6cbb9099b0e56685cc1d36ba50340f3d7278a1)), closes [#10253](https://github.com/bitnami/charts/issues/10253)
+* [bitnami/*] Remove old 'ci' files (#10171) ([5df30c4](https://github.com/bitnami/charts/commit/5df30c44dbd1812da8786579ce4a94917d46a6ad)), closes [#10171](https://github.com/bitnami/charts/issues/10171)
+* [bitnami/nats] Add missing namespace metadata (#10144) ([1bb28ab](https://github.com/bitnami/charts/commit/1bb28ab6f4c9eab348eb55c73bb59a30005bd70c)), closes [#10144](https://github.com/bitnami/charts/issues/10144)
 
 ## <small>7.1.20 (2022-05-11)</small>
 
-* [bitnami/*] Fix typo in comments (relay -> rely) (#10151) ([9cfe4a4](https://github.com/bitnami/charts/commit/9cfe4a4)), closes [#10151](https://github.com/bitnami/charts/issues/10151)
+* [bitnami/*] Fix typo in comments (relay -> rely) (#10151) ([9cfe4a4](https://github.com/bitnami/charts/commit/9cfe4a48cc35851faea6be7ffb2a978d223befa0)), closes [#10151](https://github.com/bitnami/charts/issues/10151)
 
 ## <small>7.1.19 (2022-05-05)</small>
 
-* [bitnami/nats] Release 7.1.19 updating components versions ([5519520](https://github.com/bitnami/charts/commit/5519520))
+* [bitnami/nats] Release 7.1.19 updating components versions ([5519520](https://github.com/bitnami/charts/commit/5519520c06a89d18880f45197017e34835a896c3))
 
 ## <small>7.1.18 (2022-04-22)</small>
 
-* [bitnami/nats] Release 7.1.18 updating components versions ([fd10679](https://github.com/bitnami/charts/commit/fd10679))
+* [bitnami/nats] Release 7.1.18 updating components versions ([fd10679](https://github.com/bitnami/charts/commit/fd1067904babe14a35bdc6d605fc0726f34c6bd0))
 
 ## <small>7.1.17 (2022-04-20)</small>
 
-* [bitnami/nats] Release 7.1.17 updating components versions ([0eb7a39](https://github.com/bitnami/charts/commit/0eb7a39))
+* [bitnami/nats] Release 7.1.17 updating components versions ([0eb7a39](https://github.com/bitnami/charts/commit/0eb7a395960f29bbfe4aeec4fef416ce8f90d4d9))
 
 ## <small>7.1.16 (2022-04-19)</small>
 
-* [bitnami/nats] Release 7.1.16 updating components versions ([131f55e](https://github.com/bitnami/charts/commit/131f55e))
+* [bitnami/nats] Release 7.1.16 updating components versions ([131f55e](https://github.com/bitnami/charts/commit/131f55eb40544ad7c85332ec822f03c5f432ab46))
 
 ## <small>7.1.15 (2022-04-03)</small>
 
-* [bitnami/nats] Release 7.1.15 updating components versions ([fd15bda](https://github.com/bitnami/charts/commit/fd15bda))
+* [bitnami/nats] Release 7.1.15 updating components versions ([fd15bda](https://github.com/bitnami/charts/commit/fd15bda703bd72796ce6da3be6f4c39b1d7d15cd))
 
 ## <small>7.1.14 (2022-04-02)</small>
 
-* [bitnami/nats] Release 7.1.14 updating components versions ([1323ecc](https://github.com/bitnami/charts/commit/1323ecc))
+* [bitnami/nats] Release 7.1.14 updating components versions ([1323ecc](https://github.com/bitnami/charts/commit/1323ecc5d0bcd15ffafc6d55091bdcb315565a44))
 
 ## <small>7.1.13 (2022-03-28)</small>
 
-* [bitnami/nats] Release 7.1.13 updating components versions ([36ae776](https://github.com/bitnami/charts/commit/36ae776))
+* [bitnami/nats] Release 7.1.13 updating components versions ([36ae776](https://github.com/bitnami/charts/commit/36ae7767973c7c036e4285a718c166ee083324a0))
 
 ## <small>7.1.12 (2022-03-27)</small>
 
-* [bitnami/nats] Release 7.1.12 updating components versions ([98afb18](https://github.com/bitnami/charts/commit/98afb18))
+* [bitnami/nats] Release 7.1.12 updating components versions ([98afb18](https://github.com/bitnami/charts/commit/98afb182d05960c82dd70eb45025cacaa9b7af42))
 
 ## <small>7.1.11 (2022-03-21)</small>
 
-* [bitnami/nats] Fix context for include inside range extraHosts (#9437) ([7bfde8e](https://github.com/bitnami/charts/commit/7bfde8e)), closes [#9437](https://github.com/bitnami/charts/issues/9437)
+* [bitnami/nats] Fix context for include inside range extraHosts (#9437) ([7bfde8e](https://github.com/bitnami/charts/commit/7bfde8e2568658a35cd569a8eee8f76e7bf4e33b)), closes [#9437](https://github.com/bitnami/charts/issues/9437)
 
 ## <small>7.1.10 (2022-03-16)</small>
 
-* [bitnami/nats] Release 7.1.10 updating components versions ([4d61730](https://github.com/bitnami/charts/commit/4d61730))
+* [bitnami/nats] Release 7.1.10 updating components versions ([4d61730](https://github.com/bitnami/charts/commit/4d61730f72b6968d0d0e30bf24b77c59befd78ff))
 
 ## <small>7.1.9 (2022-03-10)</small>
 
-* [bitnami/nats] Release 7.1.9 updating components versions ([3ba1284](https://github.com/bitnami/charts/commit/3ba1284))
+* [bitnami/nats] Release 7.1.9 updating components versions ([3ba1284](https://github.com/bitnami/charts/commit/3ba12843a905efc70cf1ff7e97df2b09f94fa671))
 
 ## <small>7.1.8 (2022-02-27)</small>
 
-* [bitnami/nats] Release 7.1.8 updating components versions ([5148922](https://github.com/bitnami/charts/commit/5148922))
+* [bitnami/nats] Release 7.1.8 updating components versions ([5148922](https://github.com/bitnami/charts/commit/5148922d33ea9b284600e353dc67ab87e2c7986e))
 
 ## <small>7.1.7 (2022-02-25)</small>
 
-* [bitnami/nats] Release 7.1.7 updating components versions ([c519eef](https://github.com/bitnami/charts/commit/c519eef))
+* [bitnami/nats] Release 7.1.7 updating components versions ([c519eef](https://github.com/bitnami/charts/commit/c519eef14ae01b025368e5a6c91407a54b1933cf))
 
 ## <small>7.1.6 (2022-02-21)</small>
 
-* [bitnami/nats] Do not hardcode PDB apiVersion (#9107) ([c73b3cd](https://github.com/bitnami/charts/commit/c73b3cd)), closes [#9107](https://github.com/bitnami/charts/issues/9107)
-* Non utf8 chars (#8923) ([6ffd18f](https://github.com/bitnami/charts/commit/6ffd18f)), closes [#8923](https://github.com/bitnami/charts/issues/8923)
+* [bitnami/nats] Do not hardcode PDB apiVersion (#9107) ([c73b3cd](https://github.com/bitnami/charts/commit/c73b3cd333bb0255e9c815c8e6a3b703da7fb529)), closes [#9107](https://github.com/bitnami/charts/issues/9107)
+* Non utf8 chars (#8923) ([6ffd18f](https://github.com/bitnami/charts/commit/6ffd18fbbdf10e94ea1a90cf5b84ef610ac2a72d)), closes [#8923](https://github.com/bitnami/charts/issues/8923)
 
 ## <small>7.1.5 (2022-02-05)</small>
 
-* [bitnami/nats] Release 7.1.5 updating components versions ([fb3496c](https://github.com/bitnami/charts/commit/fb3496c))
+* [bitnami/nats] Release 7.1.5 updating components versions ([fb3496c](https://github.com/bitnami/charts/commit/fb3496cb6c35f5a449c7f0fd16d5516c16978118))
 
 ## <small>7.1.4 (2022-02-02)</small>
 
-* [bitnami/*] Make use of new "common.ingress.certManagerRequest" helper (#8862) ([12e4c37](https://github.com/bitnami/charts/commit/12e4c37)), closes [#8862](https://github.com/bitnami/charts/issues/8862)
+* [bitnami/*] Make use of new "common.ingress.certManagerRequest" helper (#8862) ([12e4c37](https://github.com/bitnami/charts/commit/12e4c3733eaeaa9a5579fdf917fa098a0f2aae23)), closes [#8862](https://github.com/bitnami/charts/issues/8862)
 
 ## <small>7.1.3 (2022-01-20)</small>
 
-* [bitnami/*] Readme automation (#8579) ([78d1938](https://github.com/bitnami/charts/commit/78d1938)), closes [#8579](https://github.com/bitnami/charts/issues/8579)
-* [bitnami/*] Update READMEs (#8716) ([b9a9533](https://github.com/bitnami/charts/commit/b9a9533)), closes [#8716](https://github.com/bitnami/charts/issues/8716)
-* [bitnami/several] Change prerequisites (#8725) ([8d740c5](https://github.com/bitnami/charts/commit/8d740c5)), closes [#8725](https://github.com/bitnami/charts/issues/8725)
+* [bitnami/*] Readme automation (#8579) ([78d1938](https://github.com/bitnami/charts/commit/78d193831c900d178198491ffd08fa2217a64ecd)), closes [#8579](https://github.com/bitnami/charts/issues/8579)
+* [bitnami/*] Update READMEs (#8716) ([b9a9533](https://github.com/bitnami/charts/commit/b9a953337590eb2979453385874a267bacf50936)), closes [#8716](https://github.com/bitnami/charts/issues/8716)
+* [bitnami/several] Change prerequisites (#8725) ([8d740c5](https://github.com/bitnami/charts/commit/8d740c566cfdb7e2d933c40128b4e919fce953a5)), closes [#8725](https://github.com/bitnami/charts/issues/8725)
 
 ## <small>7.1.2 (2022-01-14)</small>
 
-* [bitnami/nats] Release 7.1.2 updating components versions ([c02e168](https://github.com/bitnami/charts/commit/c02e168))
+* [bitnami/nats] Release 7.1.2 updating components versions ([c02e168](https://github.com/bitnami/charts/commit/c02e168368cda702e73c2dca995ec9bab0a08d26))
 
 ## <small>7.1.1 (2022-01-11)</small>
 
-* [bitnami/nats] Release 7.1.1 updating components versions ([1e5f022](https://github.com/bitnami/charts/commit/1e5f022))
+* [bitnami/nats] Release 7.1.1 updating components versions ([1e5f022](https://github.com/bitnami/charts/commit/1e5f02225baa936b72d1cfdc372fd0acd7b72b5f))
 
 ## 7.1.0 (2022-01-05)
 
-* [bitnami/several] Adapt templating format (#8562) ([8cad18a](https://github.com/bitnami/charts/commit/8cad18a)), closes [#8562](https://github.com/bitnami/charts/issues/8562)
-* [bitnami/several] Add license to the README ([05f7633](https://github.com/bitnami/charts/commit/05f7633))
-* [bitnami/several] Add license to the README ([32fb238](https://github.com/bitnami/charts/commit/32fb238))
-* [bitnami/several] Add license to the README ([b87c2f7](https://github.com/bitnami/charts/commit/b87c2f7))
+* [bitnami/several] Adapt templating format (#8562) ([8cad18a](https://github.com/bitnami/charts/commit/8cad18aed9966a6f0208e5ad6cee46cb217f47ab)), closes [#8562](https://github.com/bitnami/charts/issues/8562)
+* [bitnami/several] Add license to the README ([05f7633](https://github.com/bitnami/charts/commit/05f763372501d596e57db713dd53ff4ff3027cc4))
+* [bitnami/several] Add license to the README ([32fb238](https://github.com/bitnami/charts/commit/32fb238e60a0affc6debd3142eaa3c3d9089ec2a))
+* [bitnami/several] Add license to the README ([b87c2f7](https://github.com/bitnami/charts/commit/b87c2f7899d48a8b02c506765e6ae82937e9ba3f))
 
 ## <small>7.0.4 (2022-01-01)</small>
 
-* [bitnami/nats] Release 7.0.4 updating components versions ([cdfea9f](https://github.com/bitnami/charts/commit/cdfea9f))
+* [bitnami/nats] Release 7.0.4 updating components versions ([cdfea9f](https://github.com/bitnami/charts/commit/cdfea9fa1788838a91a16eeacacd66132459913f))
 
 ## <small>7.0.3 (2021-12-02)</small>
 
-* [bitnami/nats] Release 7.0.3 updating components versions ([4ea9b87](https://github.com/bitnami/charts/commit/4ea9b87))
+* [bitnami/nats] Release 7.0.3 updating components versions ([4ea9b87](https://github.com/bitnami/charts/commit/4ea9b8743494b460bb344c463358a75caa4bfb68))
 
 ## <small>7.0.2 (2021-11-29)</small>
 
-* [bitnami/several] Regenerate README tables ([e8e4e6a](https://github.com/bitnami/charts/commit/e8e4e6a))
-* [bitnami/several] Replace HTTP by HTTPS when possible (#8259) ([eafb5bd](https://github.com/bitnami/charts/commit/eafb5bd)), closes [#8259](https://github.com/bitnami/charts/issues/8259)
+* [bitnami/several] Regenerate README tables ([e8e4e6a](https://github.com/bitnami/charts/commit/e8e4e6a9f7c924bcdab52f269cb60dbfeef840a9))
+* [bitnami/several] Replace HTTP by HTTPS when possible (#8259) ([eafb5bd](https://github.com/bitnami/charts/commit/eafb5bd5a2cc3aaf04fc1e8ebedd73f420d76864)), closes [#8259](https://github.com/bitnami/charts/issues/8259)
 
 ## <small>7.0.1 (2021-11-22)</small>
 
-* [bitnami/nats] Release 7.0.1 updating components versions ([fad97a9](https://github.com/bitnami/charts/commit/fad97a9))
-* [bitnami/several] Regenerate README tables ([7b091c0](https://github.com/bitnami/charts/commit/7b091c0))
+* [bitnami/nats] Release 7.0.1 updating components versions ([fad97a9](https://github.com/bitnami/charts/commit/fad97a95b1c5c40329e528e44d1f6334f5bf9aad))
+* [bitnami/several] Regenerate README tables ([7b091c0](https://github.com/bitnami/charts/commit/7b091c0808ef00425c404cb97fe73c0578ccf1a3))
 
 ## 7.0.0 (2021-11-18)
 
-* [bitnami/nats] New major version (#8150) ([74e1356](https://github.com/bitnami/charts/commit/74e1356)), closes [#8150](https://github.com/bitnami/charts/issues/8150)
-* [bitnami/several] Regenerate README tables ([ef52074](https://github.com/bitnami/charts/commit/ef52074))
+* [bitnami/nats] New major version (#8150) ([74e1356](https://github.com/bitnami/charts/commit/74e13562542d9eb2ca1f7ee23bfc9195c7fb5d82)), closes [#8150](https://github.com/bitnami/charts/issues/8150)
+* [bitnami/several] Regenerate README tables ([ef52074](https://github.com/bitnami/charts/commit/ef52074d5f3dd00218322cd201f83ee55f9dd1e6))
 
 ## <small>6.6.1 (2021-11-05)</small>
 
-* [bitnami/nats] Release 6.6.1 updating components versions ([f51bbf1](https://github.com/bitnami/charts/commit/f51bbf1))
+* [bitnami/nats] Release 6.6.1 updating components versions ([f51bbf1](https://github.com/bitnami/charts/commit/f51bbf1e83748f3c18ab7e1bcf4226f2c2414b61))
 
 ## 6.6.0 (2021-11-03)
 
-* [bitnami/nats] Rename configuration node for authentication user map (#8009) ([34dc184](https://github.com/bitnami/charts/commit/34dc184)), closes [#8009](https://github.com/bitnami/charts/issues/8009) [#7791](https://github.com/bitnami/charts/issues/7791)
-* [bitnami/several] Regenerate README tables ([3cefed3](https://github.com/bitnami/charts/commit/3cefed3))
+* [bitnami/nats] Rename configuration node for authentication user map (#8009) ([34dc184](https://github.com/bitnami/charts/commit/34dc1844210967d9627731d0c41175243477503f)), closes [#8009](https://github.com/bitnami/charts/issues/8009) [#7791](https://github.com/bitnami/charts/issues/7791)
+* [bitnami/several] Regenerate README tables ([3cefed3](https://github.com/bitnami/charts/commit/3cefed3ef961fbd7596242b1165bcfa229a9cadb))
 
 ## <small>6.5.3 (2021-10-29)</small>
 
-* [bitnami/nats] Release 6.5.3 updating components versions ([9e6216b](https://github.com/bitnami/charts/commit/9e6216b))
-* [bitnami/several] Regenerate README tables ([412cf6a](https://github.com/bitnami/charts/commit/412cf6a))
+* [bitnami/nats] Release 6.5.3 updating components versions ([9e6216b](https://github.com/bitnami/charts/commit/9e6216b6563afe6b857b6104027c8b8afa52ea45))
+* [bitnami/several] Regenerate README tables ([412cf6a](https://github.com/bitnami/charts/commit/412cf6a513cb0c03444a6e7811c6f27193239a10))
 
 ## <small>6.5.2 (2021-10-26)</small>
 
-* [bitnami/nats] Release 6.5.2 updating components versions ([b3e7e05](https://github.com/bitnami/charts/commit/b3e7e05))
+* [bitnami/nats] Release 6.5.2 updating components versions ([b3e7e05](https://github.com/bitnami/charts/commit/b3e7e05872a5bf02d5dacc554c2095e3b052da5b))
 
 ## <small>6.5.1 (2021-10-22)</small>
 
-* [bitnami/several] Add chart info to NOTES.txt (#7889) ([a6751cd](https://github.com/bitnami/charts/commit/a6751cd)), closes [#7889](https://github.com/bitnami/charts/issues/7889)
-* [bitnami/several] Regenerate README tables ([d8e471f](https://github.com/bitnami/charts/commit/d8e471f))
+* [bitnami/several] Add chart info to NOTES.txt (#7889) ([a6751cd](https://github.com/bitnami/charts/commit/a6751cdd33c461fabbc459fbea6f219ec64ab6b2)), closes [#7889](https://github.com/bitnami/charts/issues/7889)
+* [bitnami/several] Regenerate README tables ([d8e471f](https://github.com/bitnami/charts/commit/d8e471fea607ff755d06b8c7dffb98008ea34a53))
 
 ## 6.5.0 (2021-10-14)
 
-* [bitnami/*] Generate READMEs (#7790) ([0833a8c](https://github.com/bitnami/charts/commit/0833a8c)), closes [#7790](https://github.com/bitnami/charts/issues/7790)
-* [bitnami/nats] Allow configuring client authentication user map (#7791) ([be89a00](https://github.com/bitnami/charts/commit/be89a00)), closes [#7791](https://github.com/bitnami/charts/issues/7791)
+* [bitnami/*] Generate READMEs (#7790) ([0833a8c](https://github.com/bitnami/charts/commit/0833a8c16300d68abf6030639c3479d8fb031e25)), closes [#7790](https://github.com/bitnami/charts/issues/7790)
+* [bitnami/nats] Allow configuring client authentication user map (#7791) ([be89a00](https://github.com/bitnami/charts/commit/be89a00ab62e16a163c53cacc76e718b332f9a50)), closes [#7791](https://github.com/bitnami/charts/issues/7791)
 
 ## <small>6.4.11 (2021-10-13)</small>
 
-* [bitnami/nats] Release 6.4.11 updating components versions ([4008b7a](https://github.com/bitnami/charts/commit/4008b7a))
+* [bitnami/nats] Release 6.4.11 updating components versions ([4008b7a](https://github.com/bitnami/charts/commit/4008b7ad0d7edfd52f34c7789d3200b7527fc945))
 
 ## <small>6.4.10 (2021-10-07)</small>
 
-* [bitnami/*] Fix service monitors selectors (#7720) ([1279593](https://github.com/bitnami/charts/commit/1279593)), closes [#7720](https://github.com/bitnami/charts/issues/7720)
+* [bitnami/*] Fix service monitors selectors (#7720) ([1279593](https://github.com/bitnami/charts/commit/1279593765044df99902bfee8dcfaeb60e95f125)), closes [#7720](https://github.com/bitnami/charts/issues/7720)
 
 ## <small>6.4.9 (2021-10-01)</small>
 
-* [bitnami/*] Drop support for deprecated cert-manager annotation (#7646) ([4297b79](https://github.com/bitnami/charts/commit/4297b79)), closes [#7646](https://github.com/bitnami/charts/issues/7646)
-* [bitnami/*] Generate READMEs with new generator version (#7614) ([e5ab2e6](https://github.com/bitnami/charts/commit/e5ab2e6)), closes [#7614](https://github.com/bitnami/charts/issues/7614)
-* [bitnami/several] Regenerate README tables ([a8d100a](https://github.com/bitnami/charts/commit/a8d100a))
+* [bitnami/*] Drop support for deprecated cert-manager annotation (#7646) ([4297b79](https://github.com/bitnami/charts/commit/4297b792e48fba9c7c3b8fed447a856632c61201)), closes [#7646](https://github.com/bitnami/charts/issues/7646)
+* [bitnami/*] Generate READMEs with new generator version (#7614) ([e5ab2e6](https://github.com/bitnami/charts/commit/e5ab2e6ecdd6bce800863f154cda524ff9f6c117)), closes [#7614](https://github.com/bitnami/charts/issues/7614)
+* [bitnami/several] Regenerate README tables ([a8d100a](https://github.com/bitnami/charts/commit/a8d100a745750c3bfc01c68be65905822d620898))
 
 ## <small>6.4.8 (2021-09-24)</small>
 
-* [bitnami/nats] Release 6.4.8 updating components versions ([468a3df](https://github.com/bitnami/charts/commit/468a3df))
-* [bitnami/several] Regenerate README tables ([79eac44](https://github.com/bitnami/charts/commit/79eac44))
+* [bitnami/nats] Release 6.4.8 updating components versions ([468a3df](https://github.com/bitnami/charts/commit/468a3df90020d9e5f10b9b66392bcf2b805cfe02))
+* [bitnami/several] Regenerate README tables ([79eac44](https://github.com/bitnami/charts/commit/79eac4490bf5d0abe582920d9662a892c9666870))
 
 ## <small>6.4.7 (2021-09-22)</small>
 
-* [bitnami/nats] Release 6.4.7 updating components versions ([1c00c36](https://github.com/bitnami/charts/commit/1c00c36))
-* [bitnami/several] Regenerate README tables ([8e0a1b3](https://github.com/bitnami/charts/commit/8e0a1b3))
+* [bitnami/nats] Release 6.4.7 updating components versions ([1c00c36](https://github.com/bitnami/charts/commit/1c00c3628575666a60256d6922a7d77e9cf8c484))
+* [bitnami/several] Regenerate README tables ([8e0a1b3](https://github.com/bitnami/charts/commit/8e0a1b3fb53e174a999f4372ac8d3620e73cf10e))
 
 ## <small>6.4.6 (2021-09-10)</small>
 
-* [bitnami/nats] Release 6.4.6 updating components versions ([d90c724](https://github.com/bitnami/charts/commit/d90c724))
-* [bitnami/several] Regenerate README tables ([64d5d74](https://github.com/bitnami/charts/commit/64d5d74))
+* [bitnami/nats] Release 6.4.6 updating components versions ([d90c724](https://github.com/bitnami/charts/commit/d90c7245496c059ec0390b294945404492eae625))
+* [bitnami/several] Regenerate README tables ([64d5d74](https://github.com/bitnami/charts/commit/64d5d747b84299ca9f63ea8a586b13870abe31a6))
 
 ## <small>6.4.5 (2021-08-27)</small>
 
-* [bitnami/nats] Release 6.4.5 updating components versions ([4f5a084](https://github.com/bitnami/charts/commit/4f5a084))
-* [bitnami/several] Regenerate README tables ([da2513b](https://github.com/bitnami/charts/commit/da2513b))
+* [bitnami/nats] Release 6.4.5 updating components versions ([4f5a084](https://github.com/bitnami/charts/commit/4f5a08443cb07487f1f8f5344120b251afe1505a))
+* [bitnami/several] Regenerate README tables ([da2513b](https://github.com/bitnami/charts/commit/da2513bf0a33819f3b1151d387c631a9ffdb03e2))
 
 ## <small>6.4.4 (2021-08-26)</small>
 
-* [bitnami/nats] Release 6.4.4 updating components versions ([390f004](https://github.com/bitnami/charts/commit/390f004))
+* [bitnami/nats] Release 6.4.4 updating components versions ([390f004](https://github.com/bitnami/charts/commit/390f00496e976d14ead47595f85cf8004be306da))
 
 ## <small>6.4.3 (2021-08-25)</small>
 
-* [bitnami/nats] Release 6.4.3 updating components versions ([012d4b0](https://github.com/bitnami/charts/commit/012d4b0))
-* [bitnami/nats] Updated README (#7146) ([0b2e915](https://github.com/bitnami/charts/commit/0b2e915)), closes [#7146](https://github.com/bitnami/charts/issues/7146)
-* [bitnami/several] Regenerate README tables ([6c107e8](https://github.com/bitnami/charts/commit/6c107e8))
+* [bitnami/nats] Release 6.4.3 updating components versions ([012d4b0](https://github.com/bitnami/charts/commit/012d4b05b10657338ae3d4585edcaaed02ae1536))
+* [bitnami/nats] Updated README (#7146) ([0b2e915](https://github.com/bitnami/charts/commit/0b2e915d4278b2cc13ef23efce08bbe68f833551)), closes [#7146](https://github.com/bitnami/charts/issues/7146)
+* [bitnami/several] Regenerate README tables ([6c107e8](https://github.com/bitnami/charts/commit/6c107e835d6caf8db2e8b17dcd48c5971637e013))
 
 ## <small>6.4.2 (2021-08-05)</small>
 
-* [bitnami/nats] Release 6.4.2 updating components versions ([e538b91](https://github.com/bitnami/charts/commit/e538b91))
+* [bitnami/nats] Release 6.4.2 updating components versions ([e538b91](https://github.com/bitnami/charts/commit/e538b91a0f0228c83f001b3a656e040a63abbb47))
 
 ## <small>6.4.1 (2021-08-02)</small>
 
-* [bitnami/nats] Release 6.4.1 updating components versions ([1f14490](https://github.com/bitnami/charts/commit/1f14490))
+* [bitnami/nats] Release 6.4.1 updating components versions ([1f14490](https://github.com/bitnami/charts/commit/1f1449012b968475294abee50de1e7b4d28b6872))
 
 ## 6.4.0 (2021-07-27)
 
-* [bitnami/several] Add diagnostic mode (#7012) ([f1344b0](https://github.com/bitnami/charts/commit/f1344b0)), closes [#7012](https://github.com/bitnami/charts/issues/7012)
+* [bitnami/several] Add diagnostic mode (#7012) ([f1344b0](https://github.com/bitnami/charts/commit/f1344b0361c5a93bf971d08f0fc64d3c8588cbf9)), closes [#7012](https://github.com/bitnami/charts/issues/7012)
 
 ## <small>6.3.13 (2021-07-20)</small>
 
-* [bitnami/several] Fix default values and regenerate README (I) (#6991) ([d4fd5eb](https://github.com/bitnami/charts/commit/d4fd5eb)), closes [#6991](https://github.com/bitnami/charts/issues/6991)
+* [bitnami/several] Fix default values and regenerate README (I) (#6991) ([d4fd5eb](https://github.com/bitnami/charts/commit/d4fd5eb610c16816f9f94d73ca9c71ac63ff0549)), closes [#6991](https://github.com/bitnami/charts/issues/6991)
 
 ## <small>6.3.12 (2021-07-15)</small>
 
-* [bitnami/*] Adapt values.yaml of MySQL, NATS and  NGINX charts (#6910) ([97543ce](https://github.com/bitnami/charts/commit/97543ce)), closes [#6910](https://github.com/bitnami/charts/issues/6910)
+* [bitnami/*] Adapt values.yaml of MySQL, NATS and  NGINX charts (#6910) ([97543ce](https://github.com/bitnami/charts/commit/97543ce59612ccd6da1f68bee37693e32d9f47d6)), closes [#6910](https://github.com/bitnami/charts/issues/6910)
 
 ## <small>6.3.11 (2021-07-07)</small>
 
-* [bitnami/nats] Release 6.3.11 updating components versions ([501aaa5](https://github.com/bitnami/charts/commit/501aaa5))
+* [bitnami/nats] Release 6.3.11 updating components versions ([501aaa5](https://github.com/bitnami/charts/commit/501aaa5c112f2637395900cfe8e2b9eb5dcd62aa))
 
 ## <small>6.3.10 (2021-06-30)</small>
 
-* [bitnami/nats] Release 6.3.10 updating components versions ([77df34c](https://github.com/bitnami/charts/commit/77df34c))
+* [bitnami/nats] Release 6.3.10 updating components versions ([77df34c](https://github.com/bitnami/charts/commit/77df34ca6871e06c7bcaa51291b90afe964ec323))
 
 ## <small>6.3.9 (2021-06-25)</small>
 
-* [bitnami/nats] Release 6.3.9 updating components versions ([c3b7851](https://github.com/bitnami/charts/commit/c3b7851))
-* [bitnami/nats] Update NATS client instructions in NOTES.txt (#6712) ([61bdf19](https://github.com/bitnami/charts/commit/61bdf19)), closes [#6712](https://github.com/bitnami/charts/issues/6712)
+* [bitnami/nats] Release 6.3.9 updating components versions ([c3b7851](https://github.com/bitnami/charts/commit/c3b78512076a1c2a0f1994ac34eba39ab789b1bd))
+* [bitnami/nats] Update NATS client instructions in NOTES.txt (#6712) ([61bdf19](https://github.com/bitnami/charts/commit/61bdf19734c48f077528890fc283441165e993c2)), closes [#6712](https://github.com/bitnami/charts/issues/6712)
 
 ## <small>6.3.8 (2021-06-21)</small>
 
-* [bitnami/nats] Release 6.3.8 updating components versions ([9a45625](https://github.com/bitnami/charts/commit/9a45625))
+* [bitnami/nats] Release 6.3.8 updating components versions ([9a45625](https://github.com/bitnami/charts/commit/9a45625406de6cbb306c4d957b4609e78fc114f5))
 
 ## <small>6.3.7 (2021-06-18)</small>
 
-* [bitnami/nats] Release 6.3.7 updating components versions ([06ec33b](https://github.com/bitnami/charts/commit/06ec33b))
+* [bitnami/nats] Release 6.3.7 updating components versions ([06ec33b](https://github.com/bitnami/charts/commit/06ec33b6a7e84ea14d6cddd334d0da4d87593968))
 
 ## <small>6.3.6 (2021-05-25)</small>
 
-* [bitnami/nats] Release 6.3.6 updating components versions ([599a6ab](https://github.com/bitnami/charts/commit/599a6ab))
+* [bitnami/nats] Release 6.3.6 updating components versions ([599a6ab](https://github.com/bitnami/charts/commit/599a6ab0eaa18649c89e85a040c675c19cafa22f))
 
 ## <small>6.3.5 (2021-05-23)</small>
 
-* [bitnami/nats] Release 6.3.5 updating components versions ([758bb4c](https://github.com/bitnami/charts/commit/758bb4c))
+* [bitnami/nats] Release 6.3.5 updating components versions ([758bb4c](https://github.com/bitnami/charts/commit/758bb4cf309c47082250dd50ba07fb3d3d8830c5))
 
 ## <small>6.3.4 (2021-05-21)</small>
 
-* [bitnami/nats] Release 6.3.4 updating components versions ([af0953e](https://github.com/bitnami/charts/commit/af0953e))
+* [bitnami/nats] Release 6.3.4 updating components versions ([af0953e](https://github.com/bitnami/charts/commit/af0953eb7cd4fd9e664f179b1d191f948fd72944))
 
 ## <small>6.3.3 (2021-05-13)</small>
 
-* [bitnami/nats] Release 6.3.3 updating components versions ([1a78603](https://github.com/bitnami/charts/commit/1a78603))
+* [bitnami/nats] Release 6.3.3 updating components versions ([1a78603](https://github.com/bitnami/charts/commit/1a78603409e2606a6ae276bd84e33508a21daecf))
 
 ## <small>6.3.2 (2021-05-08)</small>
 
-* [bitnami/nats] Release 6.3.2 updating components versions ([f599e61](https://github.com/bitnami/charts/commit/f599e61))
+* [bitnami/nats] Release 6.3.2 updating components versions ([f599e61](https://github.com/bitnami/charts/commit/f599e61cd377c6ac3e8fa4bce5b9224008a2d259))
 
 ## <small>6.3.1 (2021-04-30)</small>
 
-* [bitnami/nats] Release 6.3.1 updating components versions ([8abe128](https://github.com/bitnami/charts/commit/8abe128))
+* [bitnami/nats] Release 6.3.1 updating components versions ([8abe128](https://github.com/bitnami/charts/commit/8abe1281259ef50298068022f77a322776720a20))
 
 ## 6.3.0 (2021-04-23)
 
-* [bitnami/nats] Adds auth.timeout value to manage client authentication timeout setting (#6177) ([4fcbbd4](https://github.com/bitnami/charts/commit/4fcbbd4)), closes [#6177](https://github.com/bitnami/charts/issues/6177)
+* [bitnami/nats] Adds auth.timeout value to manage client authentication timeout setting (#6177) ([4fcbbd4](https://github.com/bitnami/charts/commit/4fcbbd43cc815c1d9eb8d1a6f91625d4910d1537)), closes [#6177](https://github.com/bitnami/charts/issues/6177)
 
 ## <small>6.2.6 (2021-04-21)</small>
 
-* [bitnami/nats] Fix monitoring ingress endpoint (#6167) ([52b5afd](https://github.com/bitnami/charts/commit/52b5afd)), closes [#6167](https://github.com/bitnami/charts/issues/6167)
+* [bitnami/nats] Fix monitoring ingress endpoint (#6167) ([52b5afd](https://github.com/bitnami/charts/commit/52b5afd9582ff29e6789dca54ef94c0b0769677f)), closes [#6167](https://github.com/bitnami/charts/issues/6167)
 
 ## <small>6.2.5 (2021-04-06)</small>
 
-* [bitnami/nats] Add tcp- to the beginning of each services port name to make them compatible with Ist ([77a6efb](https://github.com/bitnami/charts/commit/77a6efb)), closes [#6015](https://github.com/bitnami/charts/issues/6015)
+* [bitnami/nats] Add tcp- to the beginning of each services port name to make them compatible with Ist ([77a6efb](https://github.com/bitnami/charts/commit/77a6efbcc8675935a5ae4ef0954de27215b3992e)), closes [#6015](https://github.com/bitnami/charts/issues/6015)
 
 ## <small>6.2.4 (2021-04-03)</small>
 
-* [bitnami/nats] Release 6.2.4 updating components versions ([a51c01c](https://github.com/bitnami/charts/commit/a51c01c))
+* [bitnami/nats] Release 6.2.4 updating components versions ([a51c01c](https://github.com/bitnami/charts/commit/a51c01cc367dd8a3806319958d6330c3beb712b5))
 
 ## <small>6.2.3 (2021-03-19)</small>
 
-* [bitnami/nats] fix: Quote string values in config file (#5802) ([b9c7003](https://github.com/bitnami/charts/commit/b9c7003)), closes [#5802](https://github.com/bitnami/charts/issues/5802)
+* [bitnami/nats] fix: Quote string values in config file (#5802) ([b9c7003](https://github.com/bitnami/charts/commit/b9c70039a697837098f195d1e2bcd8bf7c28b66c)), closes [#5802](https://github.com/bitnami/charts/issues/5802)
 
 ## <small>6.2.2 (2021-03-11)</small>
 
-* [bitnami/*] Add notice regarding parameters immutability after chart installation (#4853) ([5f09573](https://github.com/bitnami/charts/commit/5f09573)), closes [#4853](https://github.com/bitnami/charts/issues/4853)
-* [bitnami/nats] Release 6.2.2 updating components versions ([b0a0756](https://github.com/bitnami/charts/commit/b0a0756))
+* [bitnami/*] Add notice regarding parameters immutability after chart installation (#4853) ([5f09573](https://github.com/bitnami/charts/commit/5f095734f92555dec7cd0e3ee961f315eac170ff)), closes [#4853](https://github.com/bitnami/charts/issues/4853)
+* [bitnami/nats] Release 6.2.2 updating components versions ([b0a0756](https://github.com/bitnami/charts/commit/b0a0756b61fe50434c65686dfa26bc28caaf6e25))
 
 ## <small>6.2.1 (2021-02-09)</small>
 
-* [bitnami/nats] Release 6.2.1 updating components versions ([afedf5d](https://github.com/bitnami/charts/commit/afedf5d))
+* [bitnami/nats] Release 6.2.1 updating components versions ([afedf5d](https://github.com/bitnami/charts/commit/afedf5d1186c5049d136bb83910e3d526c301184))
 
 ## 6.2.0 (2021-01-28)
 
-* [bitnami/nats] Add hostAlias (#5276) ([44ed815](https://github.com/bitnami/charts/commit/44ed815)), closes [#5276](https://github.com/bitnami/charts/issues/5276)
+* [bitnami/nats] Add hostAlias (#5276) ([44ed815](https://github.com/bitnami/charts/commit/44ed815852c111490d0d805934a2863d54565054)), closes [#5276](https://github.com/bitnami/charts/issues/5276)
 
 ## <small>6.1.2 (2021-01-25)</small>
 
-* [bitnami/*] Unify icons in Chart.yaml and add missing fields (#5206) ([0462921](https://github.com/bitnami/charts/commit/0462921)), closes [#5206](https://github.com/bitnami/charts/issues/5206)
+* [bitnami/*] Unify icons in Chart.yaml and add missing fields (#5206) ([0462921](https://github.com/bitnami/charts/commit/0462921418ca8d54308b7466197a6d53ffae4628)), closes [#5206](https://github.com/bitnami/charts/issues/5206)
 
 ## <small>6.1.1 (2021-01-19)</small>
 
-* [bitnami/*] Change helm version in the prerequisites (#5090) ([c5e67a3](https://github.com/bitnami/charts/commit/c5e67a3)), closes [#5090](https://github.com/bitnami/charts/issues/5090)
-* [bitnami/nats] Drop values-production.yaml support (#5123) ([0e69340](https://github.com/bitnami/charts/commit/0e69340)), closes [#5123](https://github.com/bitnami/charts/issues/5123)
+* [bitnami/*] Change helm version in the prerequisites (#5090) ([c5e67a3](https://github.com/bitnami/charts/commit/c5e67a388743cbee28439d2cabca27884b9daf97)), closes [#5090](https://github.com/bitnami/charts/issues/5090)
+* [bitnami/nats] Drop values-production.yaml support (#5123) ([0e69340](https://github.com/bitnami/charts/commit/0e69340bb52ffe84a8e271fc8a29a73ee641c30c)), closes [#5123](https://github.com/bitnami/charts/issues/5123)
 
 ## 6.1.0 (2021-01-14)
 
-* [bitnami/nats] Adapt ingress rules to k8s 1.20 (#4995) ([c403a80](https://github.com/bitnami/charts/commit/c403a80)), closes [#4995](https://github.com/bitnami/charts/issues/4995)
+* [bitnami/nats] Adapt ingress rules to k8s 1.20 (#4995) ([c403a80](https://github.com/bitnami/charts/commit/c403a806c0374754e932d02d13059c62959144de)), closes [#4995](https://github.com/bitnami/charts/issues/4995)
 
 ## <small>6.0.5 (2021-01-09)</small>
 
-* [bitnami/nats] Release 6.0.5 updating components versions ([c7e06de](https://github.com/bitnami/charts/commit/c7e06de))
+* [bitnami/nats] Release 6.0.5 updating components versions ([c7e06de](https://github.com/bitnami/charts/commit/c7e06de83dad40a35235d67a512640dc075d6814))
 
 ## <small>6.0.4 (2021-01-08)</small>
 
-* [bitnami/*] Fix typo in README (leaviness > liveness) (#4917) ([80ca826](https://github.com/bitnami/charts/commit/80ca826)), closes [#4917](https://github.com/bitnami/charts/issues/4917)
+* [bitnami/*] Fix typo in README (leaviness > liveness) (#4917) ([80ca826](https://github.com/bitnami/charts/commit/80ca8265b58602ded240c97025017607da6e1fd2)), closes [#4917](https://github.com/bitnami/charts/issues/4917)
 
 ## <small>6.0.3 (2020-12-14)</small>
 
-* [bitnami/*] fix typos (#4699) ([49adc63](https://github.com/bitnami/charts/commit/49adc63)), closes [#4699](https://github.com/bitnami/charts/issues/4699)
-* Fix extraFlags (#4719) ([1299fb0](https://github.com/bitnami/charts/commit/1299fb0)), closes [#4719](https://github.com/bitnami/charts/issues/4719)
+* [bitnami/*] fix typos (#4699) ([49adc63](https://github.com/bitnami/charts/commit/49adc63b672da976c55af2e077aa5648a357b77f)), closes [#4699](https://github.com/bitnami/charts/issues/4699)
+* Fix extraFlags (#4719) ([1299fb0](https://github.com/bitnami/charts/commit/1299fb0c724907581fe79a5470453061c9ba68dd)), closes [#4719](https://github.com/bitnami/charts/issues/4719)
 
 ## <small>6.0.2 (2020-12-11)</small>
 
-* [bitnami/*] Update dependencies (#4694) ([2826c12](https://github.com/bitnami/charts/commit/2826c12)), closes [#4694](https://github.com/bitnami/charts/issues/4694)
+* [bitnami/*] Update dependencies (#4694) ([2826c12](https://github.com/bitnami/charts/commit/2826c125b42505f28431301e3c1bbe5366e47a01)), closes [#4694](https://github.com/bitnami/charts/issues/4694)
 
 ## <small>6.0.1 (2020-12-10)</small>
 
-* [bitnami/nats] Release 6.0.1 updating components versions ([3503019](https://github.com/bitnami/charts/commit/3503019))
+* [bitnami/nats] Release 6.0.1 updating components versions ([3503019](https://github.com/bitnami/charts/commit/3503019810bdd257d7c7af260fbfcb2d023ef5a8))
 
 ## 6.0.0 (2020-11-30)
 
-* [bitnami/nats] New major version (#4515) ([ab944a9](https://github.com/bitnami/charts/commit/ab944a9)), closes [#4515](https://github.com/bitnami/charts/issues/4515)
+* [bitnami/nats] New major version (#4515) ([ab944a9](https://github.com/bitnami/charts/commit/ab944a997bb8a951bb9782e07942b790989b9cca)), closes [#4515](https://github.com/bitnami/charts/issues/4515)
 
 ## 5.0.0 (2020-11-10)
 
-* [bitnami/nats] Major version. Adapt Chart to apiVersion: v2 (#4265) ([c8b6335](https://github.com/bitnami/charts/commit/c8b6335)), closes [#4265](https://github.com/bitnami/charts/issues/4265)
+* [bitnami/nats] Major version. Adapt Chart to apiVersion: v2 (#4265) ([c8b6335](https://github.com/bitnami/charts/commit/c8b6335ec8945b2ec0523d7709b04d80cf7ffb22)), closes [#4265](https://github.com/bitnami/charts/issues/4265)
 
 ## <small>4.5.8 (2020-11-03)</small>
 
-* [bitnami/*] Include link to Troubleshootin guide on README.md (#4136) ([c08a20e](https://github.com/bitnami/charts/commit/c08a20e)), closes [#4136](https://github.com/bitnami/charts/issues/4136)
-* [bitnami/nats] Release 4.5.8 updating components versions ([7816d76](https://github.com/bitnami/charts/commit/7816d76))
+* [bitnami/*] Include link to Troubleshootin guide on README.md (#4136) ([c08a20e](https://github.com/bitnami/charts/commit/c08a20e3db004215383004ff023a73fcc2522e72)), closes [#4136](https://github.com/bitnami/charts/issues/4136)
+* [bitnami/nats] Release 4.5.8 updating components versions ([7816d76](https://github.com/bitnami/charts/commit/7816d7638ae47ab0355f4f023ed399fb059d1ee7))
 
 ## <small>4.5.7 (2020-10-21)</small>
 
-* [bitnami/nats] Release 4.5.7 updating components versions ([1c78f7f](https://github.com/bitnami/charts/commit/1c78f7f))
+* [bitnami/nats] Release 4.5.7 updating components versions ([1c78f7f](https://github.com/bitnami/charts/commit/1c78f7f268069d992de3b428d9fa84ae472c23f1))
 
 ## <small>4.5.6 (2020-10-06)</small>
 
-* [bitnami/nats] Check if it's available ingress api 'networking.k8s.io/v1beta1' (#3890) ([94a7a68](https://github.com/bitnami/charts/commit/94a7a68)), closes [#3890](https://github.com/bitnami/charts/issues/3890)
+* [bitnami/nats] Check if it's available ingress api 'networking.k8s.io/v1beta1' (#3890) ([94a7a68](https://github.com/bitnami/charts/commit/94a7a686844668e143a7c9c1f8f4519f78776e97)), closes [#3890](https://github.com/bitnami/charts/issues/3890)
 
 ## <small>4.5.5 (2020-09-21)</small>
 
-* [bitnami/nats] Release 4.5.5 updating components versions ([4f72776](https://github.com/bitnami/charts/commit/4f72776))
+* [bitnami/nats] Release 4.5.5 updating components versions ([4f72776](https://github.com/bitnami/charts/commit/4f727761e2918ebbad0f6aa5a43a6a3e734c7668))
 
 ## <small>4.5.4 (2020-09-04)</small>
 
-* [bitnami/metrics-server] Add source repo (#3577) ([1ed12f9](https://github.com/bitnami/charts/commit/1ed12f9)), closes [#3577](https://github.com/bitnami/charts/issues/3577)
-* [bitnami/nats] Release 4.5.4 updating components versions ([234772f](https://github.com/bitnami/charts/commit/234772f))
+* [bitnami/metrics-server] Add source repo (#3577) ([1ed12f9](https://github.com/bitnami/charts/commit/1ed12f96af75322b46afdb2b3d9907c11b13f765)), closes [#3577](https://github.com/bitnami/charts/issues/3577)
+* [bitnami/nats] Release 4.5.4 updating components versions ([234772f](https://github.com/bitnami/charts/commit/234772f1e637944cad01f149189d26d9e80c217b))
 
 ## <small>4.5.3 (2020-09-01)</small>
 
-* [bitnami/nats] Release 4.5.3 updating components versions ([9746505](https://github.com/bitnami/charts/commit/9746505))
+* [bitnami/nats] Release 4.5.3 updating components versions ([9746505](https://github.com/bitnami/charts/commit/974650557d6dcbcff7d5524e40c52f7db7857e77))
 
 ## <small>4.5.2 (2020-08-02)</small>
 
-* [bitnami/*] Fix TL;DR typo in READMEs (#3280) ([3d7ab40](https://github.com/bitnami/charts/commit/3d7ab40)), closes [#3280](https://github.com/bitnami/charts/issues/3280)
-* [bitnami/all] Add categories (#3075) ([63bde06](https://github.com/bitnami/charts/commit/63bde06)), closes [#3075](https://github.com/bitnami/charts/issues/3075)
-* [bitnami/nats] Release 4.5.2 updating components versions ([487bb9c](https://github.com/bitnami/charts/commit/487bb9c))
+* [bitnami/*] Fix TL;DR typo in READMEs (#3280) ([3d7ab40](https://github.com/bitnami/charts/commit/3d7ab406fecd64f1af25f53e7d27f03ec95b29a4)), closes [#3280](https://github.com/bitnami/charts/issues/3280)
+* [bitnami/all] Add categories (#3075) ([63bde06](https://github.com/bitnami/charts/commit/63bde066b87a140fab52264d0522401ab3d63509)), closes [#3075](https://github.com/bitnami/charts/issues/3075)
+* [bitnami/nats] Release 4.5.2 updating components versions ([487bb9c](https://github.com/bitnami/charts/commit/487bb9c69b0204a6e0db8ebffb03ccc5314abc72))
 
 ## <small>4.5.1 (2020-07-07)</small>
 
-* [bitnami/nats] Release 4.5.1 updating components versions ([83bb4e1](https://github.com/bitnami/charts/commit/83bb4e1))
+* [bitnami/nats] Release 4.5.1 updating components versions ([83bb4e1](https://github.com/bitnami/charts/commit/83bb4e17ea2eca1669183a5808d46504dc3a2377))
 
 ## 4.5.0 (2020-07-07)
 
-* [bitnami/nats] adding pod disruption budget support (#3005) ([d23e6e2](https://github.com/bitnami/charts/commit/d23e6e2)), closes [#3005](https://github.com/bitnami/charts/issues/3005)
+* [bitnami/nats] adding pod disruption budget support (#3005) ([d23e6e2](https://github.com/bitnami/charts/commit/d23e6e23850ddf5da54eb9203f2cd63a088e05a5)), closes [#3005](https://github.com/bitnami/charts/issues/3005)
 
 ## <small>4.4.1 (2020-06-24)</small>
 
-* [bitnami/nats] Release 4.4.1 updating components versions ([f65fcac](https://github.com/bitnami/charts/commit/f65fcac))
+* [bitnami/nats] Release 4.4.1 updating components versions ([f65fcac](https://github.com/bitnami/charts/commit/f65fcacefe4935adcdb0e1071f50df074eb0b4a7))
 
 ## 4.4.0 (2020-06-01)
 
-* [bitnami/nats] Service Monitor (#2691) ([c904766](https://github.com/bitnami/charts/commit/c904766)), closes [#2691](https://github.com/bitnami/charts/issues/2691)
-* update bitnami/common to be compatible with helm v2.12+ (#2615) ([c7751eb](https://github.com/bitnami/charts/commit/c7751eb)), closes [#2615](https://github.com/bitnami/charts/issues/2615)
+* [bitnami/nats] Service Monitor (#2691) ([c904766](https://github.com/bitnami/charts/commit/c904766323b18c78fe73e16a10bdf6b31c71f003)), closes [#2691](https://github.com/bitnami/charts/issues/2691)
+* update bitnami/common to be compatible with helm v2.12+ (#2615) ([c7751eb](https://github.com/bitnami/charts/commit/c7751eb5764e468e1854b58a1b8491d2b13e0a4a)), closes [#2615](https://github.com/bitnami/charts/issues/2615)
 
 ## <small>4.3.13 (2020-05-14)</small>
 
-* [bitnami/nats] Release 4.3.13 updating components versions ([ef7bc48](https://github.com/bitnami/charts/commit/ef7bc48))
+* [bitnami/nats] Release 4.3.13 updating components versions ([ef7bc48](https://github.com/bitnami/charts/commit/ef7bc4822e6f0ac4ece54dd258670418e4cd7c62))
 
 ## <small>4.3.12 (2020-04-22)</small>
 
-* [bitnami/nats] Release 4.3.12 updating components versions ([7c03575](https://github.com/bitnami/charts/commit/7c03575))
+* [bitnami/nats] Release 4.3.12 updating components versions ([7c03575](https://github.com/bitnami/charts/commit/7c035759a59b969f6600221387df8962bad76b1a))
 
 ## <small>4.3.11 (2020-04-16)</small>
 
-* [bitnami/nats] Release 4.3.11 updating components versions ([d34d447](https://github.com/bitnami/charts/commit/d34d447))
+* [bitnami/nats] Release 4.3.11 updating components versions ([d34d447](https://github.com/bitnami/charts/commit/d34d4475e1214b2846796dce7fa130c5873f7fff))
 
 ## <small>4.3.10 (2020-04-01)</small>
 
-* [bitnami/nats] Release 4.3.10 updating components versions ([c35eb16](https://github.com/bitnami/charts/commit/c35eb16))
+* [bitnami/nats] Release 4.3.10 updating components versions ([c35eb16](https://github.com/bitnami/charts/commit/c35eb162ac8d6e0a5a7d54e1073b560c07997085))
 
 ## <small>4.3.9 (2020-03-26)</small>
 
-* [bitnami/nats] Release 4.3.9 updating components versions ([684af43](https://github.com/bitnami/charts/commit/684af43))
+* [bitnami/nats] Release 4.3.9 updating components versions ([684af43](https://github.com/bitnami/charts/commit/684af436b5a65f245168b112ac4d9c938f10b4b6))
 
 ## <small>4.3.8 (2020-03-20)</small>
 
-* [bitnami/nats] Release 4.3.8 updating components versions ([4ff4b62](https://github.com/bitnami/charts/commit/4ff4b62))
+* [bitnami/nats] Release 4.3.8 updating components versions ([4ff4b62](https://github.com/bitnami/charts/commit/4ff4b6266a175340ef4b48a0a8944b484f2522ee))
 
 ## <small>4.3.7 (2020-03-11)</small>
 
-* [bitnami/nats] Release 4.3.7 updating components versions ([618b1ee](https://github.com/bitnami/charts/commit/618b1ee))
+* [bitnami/nats] Release 4.3.7 updating components versions ([618b1ee](https://github.com/bitnami/charts/commit/618b1ee6c7d22ef66521dd01b1196fd28c96891e))
 
 ## <small>4.3.6 (2020-03-11)</small>
 
-* Move charts from upstreamed folder to bitnami (#2032) ([a0e44f7](https://github.com/bitnami/charts/commit/a0e44f7)), closes [#2032](https://github.com/bitnami/charts/issues/2032)
+* Move charts from upstreamed folder to bitnami (#2032) ([a0e44f7](https://github.com/bitnami/charts/commit/a0e44f7d6a10b8b5643186130ea420887cb72c7c)), closes [#2032](https://github.com/bitnami/charts/issues/2032)

--- a/bitnami/nats/Chart.yaml
+++ b/bitnami/nats/Chart.yaml
@@ -31,4 +31,4 @@ maintainers:
 name: nats
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/nats
-version: 8.2.1
+version: 8.2.2

--- a/bitnami/nats/templates/statefulset.yaml
+++ b/bitnami/nats/templates/statefulset.yaml
@@ -121,7 +121,7 @@ spec:
           {{- else if .Values.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.livenessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
-              path: /
+              path: /healthz
               port: monitoring
           {{- end }}
           {{- if .Values.customReadinessProbe }}


### PR DESCRIPTION
### Description of the change
This PR aims to use different liveness/readiness probes to improve overall security and avoid unnecessary container restarts. [More info](https://github.com/zegl/kube-score/blob/master/README_PROBES.md).

### Benefits

Increase availability and resilience.

### Possible drawbacks

N/A

### Applicable issues

- fixes #

### Additional information

- Related to #23537

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- ~[X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)~
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
