### PR TITLE
[bitnami/pinniped] Use different liveness/readiness probes

### DIFF
--- a/bitnami/pinniped/CHANGELOG.md
+++ b/bitnami/pinniped/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
+## 2.1.1 (2024-05-22)
+
+* [bitnami/pinniped] Use different liveness/readiness probes ([#26321](https://github.com/bitnami/charts/pulls/26321))
+
 ## 2.1.0 (2024-05-21)
 
-* [bitnami/pinniped] feat: :sparkles: :lock: Add warning when original images are replaced ([#26263](https://github.com/bitnami/charts/pulls/26263))
+* [bitnami/*] ci: :construction_worker: Add tag and changelog support (#25359) ([91c707c](https://github.com/bitnami/charts/commit/91c707c)), closes [#25359](https://github.com/bitnami/charts/issues/25359)
+* [bitnami/pinniped] feat: :sparkles: :lock: Add warning when original images are replaced (#26263) ([c061c62](https://github.com/bitnami/charts/commit/c061c62)), closes [#26263](https://github.com/bitnami/charts/issues/26263)
 
 ## <small>2.0.8 (2024-05-18)</small>
 

--- a/bitnami/pinniped/Chart.yaml
+++ b/bitnami/pinniped/Chart.yaml
@@ -27,4 +27,4 @@ maintainers:
 name: pinniped
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/pinniped
-version: 2.1.0
+version: 2.1.1

--- a/bitnami/pinniped/templates/concierge/deployment.yaml
+++ b/bitnami/pinniped/templates/concierge/deployment.yaml
@@ -127,10 +127,8 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.concierge.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.concierge.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.concierge.livenessProbe "enabled") "context" $) | nindent 12 }}
-            httpGet:
-              path: /healthz
+            tcpSocket:
               port: https-api
-              scheme: HTTPS
           {{- end }}
           {{- if .Values.concierge.customReadinessProbe }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.concierge.customReadinessProbe "context" $) | nindent 12 }}

--- a/bitnami/pinniped/templates/supervisor/deployment.yaml
+++ b/bitnami/pinniped/templates/supervisor/deployment.yaml
@@ -120,10 +120,8 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.supervisor.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.supervisor.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.supervisor.livenessProbe "enabled") "context" $) | nindent 12 }}
-            httpGet:
-              path: /healthz
+            tcpSocket:
               port: https
-              scheme: HTTPS
           {{- end }}
           {{- if .Values.supervisor.customReadinessProbe }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.supervisor.customReadinessProbe "context" $) | nindent 12 }}


### PR DESCRIPTION
### Description of the change
This PR aims to use different liveness/readiness probes to improve overall security and avoid unnecessary container restarts. [More info](https://github.com/zegl/kube-score/blob/master/README_PROBES.md).

### Benefits

Increase availability and resilience.

### Possible drawbacks

N/A

### Applicable issues

- fixes #

### Additional information

- Related to #23537

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- ~[X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)~
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
