### PR TITLE
[bitnami/milvus] Use different liveness/readiness probes

### DIFF
--- a/bitnami/milvus/Chart.lock
+++ b/bitnami/milvus/Chart.lock
@@ -1,15 +1,15 @@
 dependencies:
 - name: etcd
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 10.0.11
+  version: 10.1.0
 - name: kafka
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 28.2.6
+  version: 28.3.0
 - name: minio
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 14.5.0
+  version: 14.6.0
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 2.19.3
-digest: sha256:448dc3f00f8e79a56c21b227728698a5aae292a854b141391ea776a742d3cc60
-generated: "2024-05-21T14:13:10.126618783+02:00"
+digest: sha256:ef9986f0a85b0d88cb95c1b595a463a5e8a12c5bd77cbf7303b5497a7a1be809
+generated: "2024-05-22T12:47:47.016193+02:00"

--- a/bitnami/milvus/Chart.yaml
+++ b/bitnami/milvus/Chart.yaml
@@ -48,4 +48,4 @@ maintainers:
 name: milvus
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/milvus
-version: 7.1.0
+version: 7.1.1

--- a/bitnami/milvus/templates/attu/deployment.yaml
+++ b/bitnami/milvus/templates/attu/deployment.yaml
@@ -128,8 +128,7 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.attu.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.attu.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.attu.livenessProbe "enabled") "context" $) | nindent 12 }}
-            httpGet:
-              path: /
+            tcpSocket:
               port: http
           {{- end }}
           {{- if .Values.attu.customReadinessProbe }}

--- a/bitnami/milvus/templates/data-coordinator/deployment.yaml
+++ b/bitnami/milvus/templates/data-coordinator/deployment.yaml
@@ -139,8 +139,7 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.dataCoord.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.dataCoord.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.dataCoord.livenessProbe "enabled") "context" $) | nindent 12 }}
-            httpGet:
-              path: /healthz
+            tcpSocket:
               port: http-metrics
           {{- end }}
           {{- if .Values.dataCoord.customReadinessProbe }}

--- a/bitnami/milvus/templates/data-node/deployment.yaml
+++ b/bitnami/milvus/templates/data-node/deployment.yaml
@@ -139,8 +139,7 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.dataNode.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.dataNode.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.dataNode.livenessProbe "enabled") "context" $) | nindent 12 }}
-            httpGet:
-              path: /healthz
+            tcpSocket:
               port: http-metrics
           {{- end }}
           {{- if .Values.dataNode.customReadinessProbe }}

--- a/bitnami/milvus/templates/index-coordinator/deployment.yaml
+++ b/bitnami/milvus/templates/index-coordinator/deployment.yaml
@@ -139,8 +139,7 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.indexCoord.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.indexCoord.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.indexCoord.livenessProbe "enabled") "context" $) | nindent 12 }}
-            httpGet:
-              path: /healthz
+            tcpSocket:
               port: http-metrics
           {{- end }}
           {{- if .Values.indexCoord.customReadinessProbe }}

--- a/bitnami/milvus/templates/index-node/deployment.yaml
+++ b/bitnami/milvus/templates/index-node/deployment.yaml
@@ -139,8 +139,7 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.indexNode.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.indexNode.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.indexNode.livenessProbe "enabled") "context" $) | nindent 12 }}
-            httpGet:
-              path: /healthz
+            tcpSocket:
               port: http-metrics
           {{- end }}
           {{- if .Values.indexNode.customReadinessProbe }}

--- a/bitnami/milvus/templates/proxy/deployment.yaml
+++ b/bitnami/milvus/templates/proxy/deployment.yaml
@@ -141,8 +141,7 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.proxy.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.proxy.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.proxy.livenessProbe "enabled") "context" $) | nindent 12 }}
-            httpGet:
-              path: /healthz
+            tcpSocket:
               port: http-metrics
           {{- end }}
           {{- if .Values.proxy.customReadinessProbe }}

--- a/bitnami/milvus/templates/query-coordinator/deployment.yaml
+++ b/bitnami/milvus/templates/query-coordinator/deployment.yaml
@@ -139,8 +139,7 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.queryCoord.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.queryCoord.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.queryCoord.livenessProbe "enabled") "context" $) | nindent 12 }}
-            httpGet:
-              path: /healthz
+            tcpSocket:
               port: http-metrics
           {{- end }}
           {{- if .Values.queryCoord.customReadinessProbe }}

--- a/bitnami/milvus/templates/query-node/deployment.yaml
+++ b/bitnami/milvus/templates/query-node/deployment.yaml
@@ -139,8 +139,7 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.queryNode.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.queryNode.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.queryNode.livenessProbe "enabled") "context" $) | nindent 12 }}
-            httpGet:
-              path: /healthz
+            tcpSocket:
               port: http-metrics
           {{- end }}
           {{- if .Values.queryNode.customReadinessProbe }}

--- a/bitnami/milvus/templates/root-coordinator/deployment.yaml
+++ b/bitnami/milvus/templates/root-coordinator/deployment.yaml
@@ -139,8 +139,7 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.rootCoord.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.rootCoord.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.rootCoord.livenessProbe "enabled") "context" $) | nindent 12 }}
-            httpGet:
-              path: /healthz
+            tcpSocket:
               port: http-metrics
           {{- end }}
           {{- if .Values.rootCoord.customReadinessProbe }}


### PR DESCRIPTION
### Description of the change
This PR aims to use different liveness/readiness probes to improve overall security and avoid unnecessary container restarts. [More info](https://github.com/zegl/kube-score/blob/master/README_PROBES.md).

### Benefits

Increase availability and resilience.

### Possible drawbacks

N/A

### Applicable issues

- fixes #

### Additional information

- Related to #23537

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- ~[X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)~
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
