### PR TITLE
[bitnami/harbor] Use different liveness/readiness probes

### DIFF
--- a/bitnami/harbor/CHANGELOG.md
+++ b/bitnami/harbor/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
+## 21.2.1 (2024-05-22)
+
+* [bitnami/harbor] Use different liveness/readiness probes ([#26327](https://github.com/bitnami/charts/pulls/26327))
+
 ## 21.2.0 (2024-05-21)
 
-* [bitnami/harbor] feat: :sparkles: :lock: Add warning when original images are replaced ([#26216](https://github.com/bitnami/charts/pulls/26216))
+* [bitnami/*] ci: :construction_worker: Add tag and changelog support (#25359) ([91c707c](https://github.com/bitnami/charts/commit/91c707c)), closes [#25359](https://github.com/bitnami/charts/issues/25359)
+* [bitnami/harbor] feat: :sparkles: :lock: Add warning when original images are replaced (#26216) ([611ada1](https://github.com/bitnami/charts/commit/611ada1)), closes [#26216](https://github.com/bitnami/charts/issues/26216)
 
 ## <small>21.1.6 (2024-05-18)</small>
 

--- a/bitnami/harbor/Chart.lock
+++ b/bitnami/harbor/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: redis
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 19.3.4
+  version: 19.4.0
 - name: postgresql
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 15.3.5
+  version: 15.4.0
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 2.19.3
-digest: sha256:633b7efcc7d7cfc2a74f8072a0857b604a8acd3a65837e8ac1d791ac8e2b68b4
-generated: "2024-05-21T13:49:08.502472994+02:00"
+digest: sha256:6d6332281f46e2b579d3054fd4976fdec6e6669c42352a8ca4d2c5e6fc4a34be
+generated: "2024-05-22T13:20:31.750276+02:00"

--- a/bitnami/harbor/Chart.yaml
+++ b/bitnami/harbor/Chart.yaml
@@ -55,4 +55,4 @@ maintainers:
 name: harbor
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/harbor
-version: 21.2.0
+version: 21.2.1

--- a/bitnami/harbor/templates/core/core-dpl.yaml
+++ b/bitnami/harbor/templates/core/core-dpl.yaml
@@ -178,9 +178,7 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.core.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.core.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.core.livenessProbe "enabled") "context" $) | nindent 12 }}
-            httpGet:
-              path: /api/v2.0/ping
-              scheme: {{ ternary "https" "http" .Values.internalTLS.enabled | upper }}
+            tcpSocket:
               port: {{ ternary "https" "http" .Values.internalTLS.enabled }}
           {{- end }}
           {{- if .Values.core.customReadinessProbe }}

--- a/bitnami/harbor/templates/exporter/exporter-dpl.yaml
+++ b/bitnami/harbor/templates/exporter/exporter-dpl.yaml
@@ -144,10 +144,8 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.exporter.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.exporter.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.exporter.livenessProbe "enabled") "context" $) | nindent 12 }}
-            httpGet:
-              path: {{ .Values.metrics.path | quote }}
+            tcpSocket:
               port: metrics
-              scheme: HTTP
           {{- end }}
           {{- if .Values.exporter.customReadinessProbe }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.exporter.customReadinessProbe "context" $) | nindent 12 }}

--- a/bitnami/harbor/templates/jobservice/jobservice-dpl.yaml
+++ b/bitnami/harbor/templates/jobservice/jobservice-dpl.yaml
@@ -194,10 +194,8 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.jobservice.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.jobservice.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.jobservice.livenessProbe "enabled") "context" $) | nindent 12 }}
-            httpGet:
-              path: /api/v1/stats
+            tcpSocket:
               port: {{ ternary "https" "http" .Values.internalTLS.enabled }}
-              scheme: {{ ternary "https" "http" .Values.internalTLS.enabled | upper }}
           {{- end }}
           {{- if .Values.jobservice.customReadinessProbe }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.jobservice.customReadinessProbe "context" $) | nindent 12 }}

--- a/bitnami/harbor/templates/nginx/deployment.yaml
+++ b/bitnami/harbor/templates/nginx/deployment.yaml
@@ -157,10 +157,8 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.nginx.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.nginx.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.nginx.livenessProbe "enabled") "context" $) | nindent 12 }}
-            httpGet:
-              path: /
+            tcpSocket:
               port: {{ ternary "https" "http" .Values.nginx.tls.enabled }}
-              scheme: {{ ternary "https" "http" .Values.nginx.tls.enabled  | upper }}
           {{- end }}
           {{- if .Values.nginx.customReadinessProbe }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.nginx.customReadinessProbe "context" $) | nindent 12 }}

--- a/bitnami/harbor/templates/portal/portal-dpl.yaml
+++ b/bitnami/harbor/templates/portal/portal-dpl.yaml
@@ -120,10 +120,8 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.portal.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.portal.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.portal.livenessProbe "enabled") "context" $) | nindent 12 }}
-            httpGet:
-              path: /
+            tcpSocket:
               port: {{ ternary "https" "http" .Values.internalTLS.enabled }}
-              scheme: {{ ternary "https" "http" .Values.internalTLS.enabled | upper }}
           {{- end }}
           {{- if .Values.portal.customReadinessProbe }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.portal.customReadinessProbe "context" $) | nindent 12 }}

--- a/bitnami/harbor/templates/registry/registry-dpl.yaml
+++ b/bitnami/harbor/templates/registry/registry-dpl.yaml
@@ -174,9 +174,7 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.registry.server.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.registry.server.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.registry.server.livenessProbe "enabled") "context" $) | nindent 12 }}
-            httpGet:
-              path: /
-              scheme: {{ ternary "https" "http" .Values.internalTLS.enabled | upper }}
+            tcpSocket:
               port: registry
           {{- end }}
           {{- if .Values.registry.server.customReadinessProbe }}
@@ -330,9 +328,7 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.registry.controller.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.registry.controller.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.registry.controller.livenessProbe "enabled") "context" $) | nindent 12 }}
-            httpGet:
-              path: /api/health
-              scheme: {{ ternary "https" "http" .Values.internalTLS.enabled | upper }}
+            tcpSocket:
               port: registryctl
           {{- end }}
           {{- if .Values.registry.controller.customReadinessProbe }}


### PR DESCRIPTION
### Description of the change
This PR aims to use different liveness/readiness probes to improve overall security and avoid unnecessary container restarts. [More info](https://github.com/zegl/kube-score/blob/master/README_PROBES.md).

### Benefits

Increase availability and resilience.

### Possible drawbacks

N/A

### Applicable issues

- fixes #

### Additional information

- Related to #23537

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- ~[X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)~
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
