### PR TITLE
[bitnami/grafana-operator] Use different liveness/readiness probes

### DIFF
--- a/bitnami/grafana-operator/CHANGELOG.md
+++ b/bitnami/grafana-operator/CHANGELOG.md
@@ -1,923 +1,928 @@
 # Changelog
 
+## 4.3.1 (2024-05-22)
+
+* [bitnami/grafana-operator] Use different liveness/readiness probes ([#26330](https://github.com/bitnami/charts/pulls/26330))
+
 ## 4.3.0 (2024-05-21)
 
-* [bitnami/grafana-operator] feat: :sparkles: :lock: Add warning when original images are replaced ([#26212](https://github.com/bitnami/charts/pulls/26212))
+* [bitnami/*] ci: :construction_worker: Add tag and changelog support (#25359) ([91c707c](https://github.com/bitnami/charts/commit/91c707c9e4e574725a09505d2d313fb93f1b4c0a)), closes [#25359](https://github.com/bitnami/charts/issues/25359)
+* [bitnami/grafana-operator] feat: :sparkles: :lock: Add warning when original images are replaced (#2 ([20d7406](https://github.com/bitnami/charts/commit/20d7406aefe28928205604bb1cbea70ea676e6e9)), closes [#26212](https://github.com/bitnami/charts/issues/26212)
 
 ## <small>4.2.5 (2024-05-20)</small>
 
-* [bitnami/grafana-operator] Release 4.2.5 updating components versions (#26139) ([7203b23](https://github.com/bitnami/charts/commit/7203b23)), closes [#26139](https://github.com/bitnami/charts/issues/26139)
+* [bitnami/grafana-operator] Release 4.2.5 updating components versions (#26139) ([7203b23](https://github.com/bitnami/charts/commit/7203b234f23df7dfeb90d504f75ab6b3b426a913)), closes [#26139](https://github.com/bitnami/charts/issues/26139)
 
 ## <small>4.2.4 (2024-05-18)</small>
 
-* [bitnami/grafana-operator] Release 4.2.4 updating components versions (#26020) ([abe62e6](https://github.com/bitnami/charts/commit/abe62e6)), closes [#26020](https://github.com/bitnami/charts/issues/26020)
+* [bitnami/grafana-operator] Release 4.2.4 updating components versions (#26020) ([abe62e6](https://github.com/bitnami/charts/commit/abe62e613ee009959132fad6a5b1494457e94dbc)), closes [#26020](https://github.com/bitnami/charts/issues/26020)
 
 ## <small>4.2.3 (2024-05-14)</small>
 
-* [bitnami/grafana-operator] Release 4.2.3 updating components versions (#25761) ([1bfe905](https://github.com/bitnami/charts/commit/1bfe905)), closes [#25761](https://github.com/bitnami/charts/issues/25761)
+* [bitnami/grafana-operator] Release 4.2.3 updating components versions (#25761) ([1bfe905](https://github.com/bitnami/charts/commit/1bfe905a907c5d0406bce914bc6c8fdeedd52023)), closes [#25761](https://github.com/bitnami/charts/issues/25761)
 
 ## <small>4.2.2 (2024-05-13)</small>
 
-* [bitnami/*] Change non-root and rolling-tags doc URLs (#25628) ([b067c94](https://github.com/bitnami/charts/commit/b067c94)), closes [#25628](https://github.com/bitnami/charts/issues/25628)
-* [bitnami/grafana-operator] Fixes the indentation for the auth subsections within config section. (#2 ([9acd313](https://github.com/bitnami/charts/commit/9acd313)), closes [#25467](https://github.com/bitnami/charts/issues/25467)
+* [bitnami/*] Change non-root and rolling-tags doc URLs (#25628) ([b067c94](https://github.com/bitnami/charts/commit/b067c94f6bcde427863c197fd355f0b5ba12ff5b)), closes [#25628](https://github.com/bitnami/charts/issues/25628)
+* [bitnami/grafana-operator] Fixes the indentation for the auth subsections within config section. (#2 ([9acd313](https://github.com/bitnami/charts/commit/9acd313bffb76611d3364b94ed0a7d7e611990d9)), closes [#25467](https://github.com/bitnami/charts/issues/25467)
 
 ## <small>4.2.1 (2024-05-07)</small>
 
-* [bitnami/grafana-operator] Add missing CRD: GrafanaContactPoints (#25517) ([eee0623](https://github.com/bitnami/charts/commit/eee0623)), closes [#25517](https://github.com/bitnami/charts/issues/25517)
-* [bitnami/grafana-operator] Release 4.2.1 updating components versions (#25595) ([fcf633d](https://github.com/bitnami/charts/commit/fcf633d)), closes [#25595](https://github.com/bitnami/charts/issues/25595)
+* [bitnami/grafana-operator] Add missing CRD: GrafanaContactPoints (#25517) ([eee0623](https://github.com/bitnami/charts/commit/eee0623670658089c3ae56d1150c39488a1f15d9)), closes [#25517](https://github.com/bitnami/charts/issues/25517)
+* [bitnami/grafana-operator] Release 4.2.1 updating components versions (#25595) ([fcf633d](https://github.com/bitnami/charts/commit/fcf633d7050a5ccc9bfada09216271b2e83e7ab3)), closes [#25595](https://github.com/bitnami/charts/issues/25595)
 
 ## 4.2.0 (2024-05-06)
 
-* [bitnami/*] Set new header/owner (#25558) ([8d1dc11](https://github.com/bitnami/charts/commit/8d1dc11)), closes [#25558](https://github.com/bitnami/charts/issues/25558)
-* [bitnami/grafana-operator] Add additional labels to pods in the grafana deployment (#25330) ([0079a25](https://github.com/bitnami/charts/commit/0079a25)), closes [#25330](https://github.com/bitnami/charts/issues/25330)
+* [bitnami/*] Set new header/owner (#25558) ([8d1dc11](https://github.com/bitnami/charts/commit/8d1dc11f5fb30db6fba50c43d7af59d2f79deed3)), closes [#25558](https://github.com/bitnami/charts/issues/25558)
+* [bitnami/grafana-operator] Add additional labels to pods in the grafana deployment (#25330) ([0079a25](https://github.com/bitnami/charts/commit/0079a25a7b83a8b3708294e54e301228ca6540da)), closes [#25330](https://github.com/bitnami/charts/issues/25330)
 
 ## <small>4.1.1 (2024-05-01)</small>
 
-* [bitnami/grafana-operator] Release 4.1.1 (#25483) ([4a083ef](https://github.com/bitnami/charts/commit/4a083ef)), closes [#25483](https://github.com/bitnami/charts/issues/25483)
-* [bitnami/multiple charts] Fix typo: "NetworkPolice" vs "NetworkPolicy" (#25348) ([6970c1b](https://github.com/bitnami/charts/commit/6970c1b)), closes [#25348](https://github.com/bitnami/charts/issues/25348)
-* Replace VMware by Broadcom copyright text (#25306) ([a5e4bd0](https://github.com/bitnami/charts/commit/a5e4bd0)), closes [#25306](https://github.com/bitnami/charts/issues/25306)
+* [bitnami/grafana-operator] Release 4.1.1 (#25483) ([4a083ef](https://github.com/bitnami/charts/commit/4a083ef4cc8b6a8c9a9ce8552b1305dc4fdf895a)), closes [#25483](https://github.com/bitnami/charts/issues/25483)
+* [bitnami/multiple charts] Fix typo: "NetworkPolice" vs "NetworkPolicy" (#25348) ([6970c1b](https://github.com/bitnami/charts/commit/6970c1ba245873506e73d459c6eac1e4919b778f)), closes [#25348](https://github.com/bitnami/charts/issues/25348)
+* Replace VMware by Broadcom copyright text (#25306) ([a5e4bd0](https://github.com/bitnami/charts/commit/a5e4bd0e35e419203793976a78d9d0a13de92c76)), closes [#25306](https://github.com/bitnami/charts/issues/25306)
 
 ## 4.1.0 (2024-04-18)
 
-* [bitnami/grafana-operator] fix: :bug: :lock: Expose missing ports in deployment spec (#25078) ([556d484](https://github.com/bitnami/charts/commit/556d484)), closes [#25078](https://github.com/bitnami/charts/issues/25078)
+* [bitnami/grafana-operator] fix: :bug: :lock: Expose missing ports in deployment spec (#25078) ([556d484](https://github.com/bitnami/charts/commit/556d484ae9a21657b01cdcadbd0c5ff0892a4c19)), closes [#25078](https://github.com/bitnami/charts/issues/25078)
 
 ## <small>4.0.4 (2024-04-15)</small>
 
-* [bitnami/grafana-operator] fix: :bug: Honor allowExternalEgress in networkPolicy (#25152) ([b7c0bba](https://github.com/bitnami/charts/commit/b7c0bba)), closes [#25152](https://github.com/bitnami/charts/issues/25152)
+* [bitnami/grafana-operator] fix: :bug: Honor allowExternalEgress in networkPolicy (#25152) ([b7c0bba](https://github.com/bitnami/charts/commit/b7c0bba2d5d09af1cd02eaf1c728c12c5987f743)), closes [#25152](https://github.com/bitnami/charts/issues/25152)
 
 ## <small>4.0.3 (2024-04-05)</small>
 
-* [bitnami/grafana-operator] Release 4.0.3 updating components versions (#24948) ([413ee88](https://github.com/bitnami/charts/commit/413ee88)), closes [#24948](https://github.com/bitnami/charts/issues/24948)
+* [bitnami/grafana-operator] Release 4.0.3 updating components versions (#24948) ([413ee88](https://github.com/bitnami/charts/commit/413ee887de6776e3652e59fe6dcfad638e469f2e)), closes [#24948](https://github.com/bitnami/charts/issues/24948)
 
 ## <small>4.0.2 (2024-04-05)</small>
 
-* [bitnami/grafana-operator] Release 4.0.2 (#24936) ([03775b3](https://github.com/bitnami/charts/commit/03775b3)), closes [#24936](https://github.com/bitnami/charts/issues/24936)
+* [bitnami/grafana-operator] Release 4.0.2 (#24936) ([03775b3](https://github.com/bitnami/charts/commit/03775b373c191cb45594d1dbb1d66595894dade8)), closes [#24936](https://github.com/bitnami/charts/issues/24936)
 
 ## <small>4.0.1 (2024-04-04)</small>
 
-* [bitnami/grafana-operator] Release 4.0.1 (#24883) ([35d41df](https://github.com/bitnami/charts/commit/35d41df)), closes [#24883](https://github.com/bitnami/charts/issues/24883)
-* Update resourcesPreset comments (#24467) ([92e3e8a](https://github.com/bitnami/charts/commit/92e3e8a)), closes [#24467](https://github.com/bitnami/charts/issues/24467)
+* [bitnami/grafana-operator] Release 4.0.1 (#24883) ([35d41df](https://github.com/bitnami/charts/commit/35d41df94673f41e6e4879b802aa991f703dc9a5)), closes [#24883](https://github.com/bitnami/charts/issues/24883)
+* Update resourcesPreset comments (#24467) ([92e3e8a](https://github.com/bitnami/charts/commit/92e3e8a507326d2a20a8f10ab3e7746a2ec5c554)), closes [#24467](https://github.com/bitnami/charts/issues/24467)
 
 ## 4.0.0 (2024-04-01)
 
-* [bitnami/grafana-operator] feat!: :lock: :boom: Improve security defaults (#24647) ([2e4b5de](https://github.com/bitnami/charts/commit/2e4b5de)), closes [#24647](https://github.com/bitnami/charts/issues/24647)
+* [bitnami/grafana-operator] feat!: :lock: :boom: Improve security defaults (#24647) ([2e4b5de](https://github.com/bitnami/charts/commit/2e4b5defda0e50792bc129db7b021a15a552ac0e)), closes [#24647](https://github.com/bitnami/charts/issues/24647)
 
 ## <small>3.12.3 (2024-03-19)</small>
 
-* [bitnami/*] Reorder Chart sections (#24455) ([0cf4048](https://github.com/bitnami/charts/commit/0cf4048)), closes [#24455](https://github.com/bitnami/charts/issues/24455)
-* [bitnami/grafana-operator] Release 3.12.3 (#24552) ([6689fe8](https://github.com/bitnami/charts/commit/6689fe8)), closes [#24552](https://github.com/bitnami/charts/issues/24552)
+* [bitnami/*] Reorder Chart sections (#24455) ([0cf4048](https://github.com/bitnami/charts/commit/0cf4048e8743f70a9753d460655bd030cbff6824)), closes [#24455](https://github.com/bitnami/charts/issues/24455)
+* [bitnami/grafana-operator] Release 3.12.3 (#24552) ([6689fe8](https://github.com/bitnami/charts/commit/6689fe8863d7a1aa7ff5c9b0e40c7e6263d38353)), closes [#24552](https://github.com/bitnami/charts/issues/24552)
 
 ## <small>3.12.2 (2024-03-15)</small>
 
-* [bitnami/grafana-operator] Add new AlertRuleGroupo CRD and update netpol (#24400) ([86ba921](https://github.com/bitnami/charts/commit/86ba921)), closes [#24400](https://github.com/bitnami/charts/issues/24400)
+* [bitnami/grafana-operator] Add new AlertRuleGroupo CRD and update netpol (#24400) ([86ba921](https://github.com/bitnami/charts/commit/86ba9214f09113b0e58026426fc555be2d41d364)), closes [#24400](https://github.com/bitnami/charts/issues/24400)
 
 ## <small>3.12.1 (2024-03-13)</small>
 
-* [bitnami/grafana-operator] Release 3.12.1 (#24402) ([b466ccc](https://github.com/bitnami/charts/commit/b466ccc)), closes [#24402](https://github.com/bitnami/charts/issues/24402)
+* [bitnami/grafana-operator] Release 3.12.1 (#24402) ([b466ccc](https://github.com/bitnami/charts/commit/b466cccab4c3b8f8bb47b3dc31baa559b8ac0cf2)), closes [#24402](https://github.com/bitnami/charts/issues/24402)
 
 ## 3.12.0 (2024-03-11)
 
-* [bitnami/grafana-operator] feat: :sparkles: :lock: Add support for readOnlyRootFilesystem (#24340) ([12db6b1](https://github.com/bitnami/charts/commit/12db6b1)), closes [#24340](https://github.com/bitnami/charts/issues/24340)
+* [bitnami/grafana-operator] feat: :sparkles: :lock: Add support for readOnlyRootFilesystem (#24340) ([12db6b1](https://github.com/bitnami/charts/commit/12db6b1568557dfdf7060b16a58b07c97f25a199)), closes [#24340](https://github.com/bitnami/charts/issues/24340)
 
 ## <small>3.11.1 (2024-03-06)</small>
 
-* [bitnami/grafana-operator] Release 3.11.1 updating components versions (#24202) ([9007624](https://github.com/bitnami/charts/commit/9007624)), closes [#24202](https://github.com/bitnami/charts/issues/24202)
+* [bitnami/grafana-operator] Release 3.11.1 updating components versions (#24202) ([9007624](https://github.com/bitnami/charts/commit/900762414ba73c7daf7cc5180382f63f39b0bab9)), closes [#24202](https://github.com/bitnami/charts/issues/24202)
 
 ## 3.11.0 (2024-03-06)
 
-* [bitnami/grafana-operator] feat: :sparkles: :lock: Add automatic adaptation for Openshift restricted ([89a1ac4](https://github.com/bitnami/charts/commit/89a1ac4)), closes [#24090](https://github.com/bitnami/charts/issues/24090)
+* [bitnami/grafana-operator] feat: :sparkles: :lock: Add automatic adaptation for Openshift restricted ([89a1ac4](https://github.com/bitnami/charts/commit/89a1ac413d19b035bf6beea68b492807df61399b)), closes [#24090](https://github.com/bitnami/charts/issues/24090)
 
 ## <small>3.10.2 (2024-02-21)</small>
 
-* [bitnami/grafana-operator] Release 3.10.2 updating components versions (#23759) ([17bcd6b](https://github.com/bitnami/charts/commit/17bcd6b)), closes [#23759](https://github.com/bitnami/charts/issues/23759)
+* [bitnami/grafana-operator] Release 3.10.2 updating components versions (#23759) ([17bcd6b](https://github.com/bitnami/charts/commit/17bcd6ba4be67240b991ede3f9cc371fcef9e433)), closes [#23759](https://github.com/bitnami/charts/issues/23759)
 
 ## <small>3.10.1 (2024-02-21)</small>
 
-* [bitnami/grafana-operator] Release 3.10.1 updating components versions (#23653) ([1dbb318](https://github.com/bitnami/charts/commit/1dbb318)), closes [#23653](https://github.com/bitnami/charts/issues/23653)
+* [bitnami/grafana-operator] Release 3.10.1 updating components versions (#23653) ([1dbb318](https://github.com/bitnami/charts/commit/1dbb31811a89b258eca6ac0f7f62284fcb272981)), closes [#23653](https://github.com/bitnami/charts/issues/23653)
 
 ## 3.10.0 (2024-02-20)
 
-* [bitnami/*] Bump all versions (#23602) ([b70ee2a](https://github.com/bitnami/charts/commit/b70ee2a)), closes [#23602](https://github.com/bitnami/charts/issues/23602)
+* [bitnami/*] Bump all versions (#23602) ([b70ee2a](https://github.com/bitnami/charts/commit/b70ee2a30e4dc256bf0ac52928fb2fa7a70f049b)), closes [#23602](https://github.com/bitnami/charts/issues/23602)
 
 ## 3.9.0 (2024-02-16)
 
-* [bitnami/grafana-operator] feat: :sparkles: :lock: Add resource preset support (#23457) ([fdbf651](https://github.com/bitnami/charts/commit/fdbf651)), closes [#23457](https://github.com/bitnami/charts/issues/23457)
+* [bitnami/grafana-operator] feat: :sparkles: :lock: Add resource preset support (#23457) ([fdbf651](https://github.com/bitnami/charts/commit/fdbf651d30881a17ae31f762288ac6979d2e4355)), closes [#23457](https://github.com/bitnami/charts/issues/23457)
 
 ## <small>3.8.4 (2024-02-11)</small>
 
-* [bitnami/grafana-operator] Release 3.8.4 (#23391) ([b556c09](https://github.com/bitnami/charts/commit/b556c09)), closes [#23391](https://github.com/bitnami/charts/issues/23391)
+* [bitnami/grafana-operator] Release 3.8.4 (#23391) ([b556c09](https://github.com/bitnami/charts/commit/b556c0984387bd1ce0c296acbc16e7cf82ea82ad)), closes [#23391](https://github.com/bitnami/charts/issues/23391)
 
 ## <small>3.8.3 (2024-02-09)</small>
 
-* [bitnami/grafana-operator] Release 3.8.3 updating components versions (#23372) ([ae5d98b](https://github.com/bitnami/charts/commit/ae5d98b)), closes [#23372](https://github.com/bitnami/charts/issues/23372)
+* [bitnami/grafana-operator] Release 3.8.3 updating components versions (#23372) ([ae5d98b](https://github.com/bitnami/charts/commit/ae5d98bc741d71c464cae0469a0f86c166db8b6e)), closes [#23372](https://github.com/bitnami/charts/issues/23372)
 
 ## <small>3.8.2 (2024-02-08)</small>
 
-* [bitnami/grafana-operator] Release 3.8.2 (#23321) ([8556eb8](https://github.com/bitnami/charts/commit/8556eb8)), closes [#23321](https://github.com/bitnami/charts/issues/23321)
+* [bitnami/grafana-operator] Release 3.8.2 (#23321) ([8556eb8](https://github.com/bitnami/charts/commit/8556eb81a6257f191af7619f02004022173fc6e0)), closes [#23321](https://github.com/bitnami/charts/issues/23321)
 
 ## <small>3.8.1 (2024-02-07)</small>
 
-* [bitnami/grafana-operator] Release 3.8.1 updating components versions (#23292) ([adb12dd](https://github.com/bitnami/charts/commit/adb12dd)), closes [#23292](https://github.com/bitnami/charts/issues/23292)
+* [bitnami/grafana-operator] Release 3.8.1 updating components versions (#23292) ([adb12dd](https://github.com/bitnami/charts/commit/adb12ddc88bb3c0159e9ba46fc1426eb979775aa)), closes [#23292](https://github.com/bitnami/charts/issues/23292)
 
 ## 3.8.0 (2024-02-07)
 
-* [bitnami/grafana-operator] feat: :lock: Enable networkPolicy (#23209) ([c569b75](https://github.com/bitnami/charts/commit/c569b75)), closes [#23209](https://github.com/bitnami/charts/issues/23209)
+* [bitnami/grafana-operator] feat: :lock: Enable networkPolicy (#23209) ([c569b75](https://github.com/bitnami/charts/commit/c569b757d3e10fe0a52e55bd2d3bf632287edc0d)), closes [#23209](https://github.com/bitnami/charts/issues/23209)
 
 ## <small>3.7.4 (2024-02-07)</small>
 
-* [bitnami/grafana-operator] Release 3.7.4 updating components versions (#23227) ([2d1dab8](https://github.com/bitnami/charts/commit/2d1dab8)), closes [#23227](https://github.com/bitnami/charts/issues/23227)
+* [bitnami/grafana-operator] Release 3.7.4 updating components versions (#23227) ([2d1dab8](https://github.com/bitnami/charts/commit/2d1dab82fc1db30fc91215f05017c1978b76e787)), closes [#23227](https://github.com/bitnami/charts/issues/23227)
 
 ## <small>3.7.3 (2024-02-02)</small>
 
-* [bitnami/grafana-operator] Release 3.7.3 updating components versions (#23073) ([a705e2d](https://github.com/bitnami/charts/commit/a705e2d)), closes [#23073](https://github.com/bitnami/charts/issues/23073)
+* [bitnami/grafana-operator] Release 3.7.3 updating components versions (#23073) ([a705e2d](https://github.com/bitnami/charts/commit/a705e2dd015364fda5f78d2e340835cfce874478)), closes [#23073](https://github.com/bitnami/charts/issues/23073)
 
 ## <small>3.7.2 (2024-02-01)</small>
 
-* [bitnami/grafana-operator] fix: :bug: Set seLinuxOptions to null for Openshift compatibility (#22595 ([38ada76](https://github.com/bitnami/charts/commit/38ada76)), closes [#22595](https://github.com/bitnami/charts/issues/22595)
-* [bitnami/grafana-operator] Release 3.7.2 updating components versions (#23000) ([ae5666a](https://github.com/bitnami/charts/commit/ae5666a)), closes [#23000](https://github.com/bitnami/charts/issues/23000)
+* [bitnami/grafana-operator] fix: :bug: Set seLinuxOptions to null for Openshift compatibility (#22595 ([38ada76](https://github.com/bitnami/charts/commit/38ada76f3ef6e46865f6217ae10e30a8d44caabf)), closes [#22595](https://github.com/bitnami/charts/issues/22595)
+* [bitnami/grafana-operator] Release 3.7.2 updating components versions (#23000) ([ae5666a](https://github.com/bitnami/charts/commit/ae5666a7d1f8b49fb431c85f0e8c166a36e7a14f)), closes [#23000](https://github.com/bitnami/charts/issues/23000)
 
 ## <small>3.7.1 (2024-01-24)</small>
 
-* [bitnami/*] Move documentation sections from docs.bitnami.com back to the README (#22203) ([7564f36](https://github.com/bitnami/charts/commit/7564f36)), closes [#22203](https://github.com/bitnami/charts/issues/22203)
-* [bitnami/grafana-operator] Release 3.7.1 (#22707) ([9fa223d](https://github.com/bitnami/charts/commit/9fa223d)), closes [#22707](https://github.com/bitnami/charts/issues/22707)
+* [bitnami/*] Move documentation sections from docs.bitnami.com back to the README (#22203) ([7564f36](https://github.com/bitnami/charts/commit/7564f36ca1e95ff30ee686652b7ab8690561a707)), closes [#22203](https://github.com/bitnami/charts/issues/22203)
+* [bitnami/grafana-operator] Release 3.7.1 (#22707) ([9fa223d](https://github.com/bitnami/charts/commit/9fa223d1de62bd86b1e0bc89c2a63e533bd42240)), closes [#22707](https://github.com/bitnami/charts/issues/22707)
 
 ## 3.7.0 (2024-01-22)
 
-* [bitnami/grafana-operator] fix: :lock: Move service-account token auto-mount to pod declaration (#22 ([9a8c3e6](https://github.com/bitnami/charts/commit/9a8c3e6)), closes [#22408](https://github.com/bitnami/charts/issues/22408)
-* [bitnami/grafana-operator] Update CRDs and add source header (#22373) ([d6948f3](https://github.com/bitnami/charts/commit/d6948f3)), closes [#22373](https://github.com/bitnami/charts/issues/22373)
+* [bitnami/grafana-operator] fix: :lock: Move service-account token auto-mount to pod declaration (#22 ([9a8c3e6](https://github.com/bitnami/charts/commit/9a8c3e66b5d63e237f64bee4406499d76cb8a3de)), closes [#22408](https://github.com/bitnami/charts/issues/22408)
+* [bitnami/grafana-operator] Update CRDs and add source header (#22373) ([d6948f3](https://github.com/bitnami/charts/commit/d6948f3dd63ee33cac803599f28cfe739b4bd382)), closes [#22373](https://github.com/bitnami/charts/issues/22373)
 
 ## <small>3.6.1 (2024-01-18)</small>
 
-* [bitnami/grafana-operator] Release 3.6.1 updating components versions (#22278) ([5a5c58d](https://github.com/bitnami/charts/commit/5a5c58d)), closes [#22278](https://github.com/bitnami/charts/issues/22278)
+* [bitnami/grafana-operator] Release 3.6.1 updating components versions (#22278) ([5a5c58d](https://github.com/bitnami/charts/commit/5a5c58d5444cf268d032a032be9e138c3c3f8b66)), closes [#22278](https://github.com/bitnami/charts/issues/22278)
 
 ## 3.6.0 (2024-01-16)
 
-* [bitnami/*] Fix ref links (in comments) (#21822) ([e4fa296](https://github.com/bitnami/charts/commit/e4fa296)), closes [#21822](https://github.com/bitnami/charts/issues/21822)
-* [bitnami/grafana-operator] fix: :lock: Improve podSecurityContext and containerSecurityContext with  ([dc9b31d](https://github.com/bitnami/charts/commit/dc9b31d)), closes [#22126](https://github.com/bitnami/charts/issues/22126)
+* [bitnami/*] Fix ref links (in comments) (#21822) ([e4fa296](https://github.com/bitnami/charts/commit/e4fa296106b225cf8c82445727c675c7c725e380)), closes [#21822](https://github.com/bitnami/charts/issues/21822)
+* [bitnami/grafana-operator] fix: :lock: Improve podSecurityContext and containerSecurityContext with  ([dc9b31d](https://github.com/bitnami/charts/commit/dc9b31df2e5558acacd25083ab4cac9621644d9d)), closes [#22126](https://github.com/bitnami/charts/issues/22126)
 
 ## <small>3.5.14 (2024-01-10)</small>
 
-* [bitnami/grafana-operator] Release 3.5.14 (#21943) ([3a9bb81](https://github.com/bitnami/charts/commit/3a9bb81)), closes [#21943](https://github.com/bitnami/charts/issues/21943)
+* [bitnami/grafana-operator] Release 3.5.14 (#21943) ([3a9bb81](https://github.com/bitnami/charts/commit/3a9bb81b7a49951e43b2fe5030bf4f7328d3165c)), closes [#21943](https://github.com/bitnami/charts/issues/21943)
 
 ## <small>3.5.13 (2024-01-09)</small>
 
-* [bitnami/*] Fix docs.bitnami.com broken links (#21901) ([f35506d](https://github.com/bitnami/charts/commit/f35506d)), closes [#21901](https://github.com/bitnami/charts/issues/21901)
-* [bitnami/grafana-operator] Release 3.5.13 updating components versions (#21924) ([c5644f4](https://github.com/bitnami/charts/commit/c5644f4)), closes [#21924](https://github.com/bitnami/charts/issues/21924)
-* [bitnami/grafana-operator] Watch only the current namespace if using `namespaceScope=true` (#21404) ([5f709e7](https://github.com/bitnami/charts/commit/5f709e7)), closes [#21404](https://github.com/bitnami/charts/issues/21404) [#21288](https://github.com/bitnami/charts/issues/21288)
-* Fix grafana labels on deployment and service (#21778) ([802558a](https://github.com/bitnami/charts/commit/802558a)), closes [#21778](https://github.com/bitnami/charts/issues/21778)
+* [bitnami/*] Fix docs.bitnami.com broken links (#21901) ([f35506d](https://github.com/bitnami/charts/commit/f35506d2dadee4f097986e7792df1f53ab215b5d)), closes [#21901](https://github.com/bitnami/charts/issues/21901)
+* [bitnami/grafana-operator] Release 3.5.13 updating components versions (#21924) ([c5644f4](https://github.com/bitnami/charts/commit/c5644f47876211394acd62a5d32665485c1f80ad)), closes [#21924](https://github.com/bitnami/charts/issues/21924)
+* [bitnami/grafana-operator] Watch only the current namespace if using `namespaceScope=true` (#21404) ([5f709e7](https://github.com/bitnami/charts/commit/5f709e7815776940b600d87a506681e58202b73a)), closes [#21404](https://github.com/bitnami/charts/issues/21404) [#21288](https://github.com/bitnami/charts/issues/21288)
+* Fix grafana labels on deployment and service (#21778) ([802558a](https://github.com/bitnami/charts/commit/802558a3ea91295488b1af9f48977bdd41f5130f)), closes [#21778](https://github.com/bitnami/charts/issues/21778)
 
 ## <small>3.5.12 (2024-01-03)</small>
 
-* [bitnami/*] Update copyright: Year and company (#21815) ([6c4bf75](https://github.com/bitnami/charts/commit/6c4bf75)), closes [#21815](https://github.com/bitnami/charts/issues/21815)
-* [bitnami/grafana-operator] Release 3.5.12 updating components versions (#21825) ([b389109](https://github.com/bitnami/charts/commit/b389109)), closes [#21825](https://github.com/bitnami/charts/issues/21825)
+* [bitnami/*] Update copyright: Year and company (#21815) ([6c4bf75](https://github.com/bitnami/charts/commit/6c4bf75dec58fc7c9aee9f089777b1a858c17d5b)), closes [#21815](https://github.com/bitnami/charts/issues/21815)
+* [bitnami/grafana-operator] Release 3.5.12 updating components versions (#21825) ([b389109](https://github.com/bitnami/charts/commit/b3891096d36a82f3746dd86d9ca509b156bdfbba)), closes [#21825](https://github.com/bitnami/charts/issues/21825)
 
 ## <small>3.5.11 (2023-12-11)</small>
 
-* [bitnami/grafana-operator] Release 3.5.11 updating components versions (#21507) ([c623cbb](https://github.com/bitnami/charts/commit/c623cbb)), closes [#21507](https://github.com/bitnami/charts/issues/21507)
+* [bitnami/grafana-operator] Release 3.5.11 updating components versions (#21507) ([c623cbb](https://github.com/bitnami/charts/commit/c623cbbaa3c6aeb540de720a5bce88f56be1d5eb)), closes [#21507](https://github.com/bitnami/charts/issues/21507)
 
 ## <small>3.5.10 (2023-12-06)</small>
 
-* [bitnami/grafana-operator] Release 3.5.10 updating components versions (#21423) ([895f12d](https://github.com/bitnami/charts/commit/895f12d)), closes [#21423](https://github.com/bitnami/charts/issues/21423)
+* [bitnami/grafana-operator] Release 3.5.10 updating components versions (#21423) ([895f12d](https://github.com/bitnami/charts/commit/895f12d78d2b33c1a4e4eccfe78bc53f937f9e9a)), closes [#21423](https://github.com/bitnami/charts/issues/21423)
 
 ## <small>3.5.9 (2023-11-28)</small>
 
-* [bitnami/grafana-operator] Release 3.5.9 updating components versions (#21289) ([e3a53ca](https://github.com/bitnami/charts/commit/e3a53ca)), closes [#21289](https://github.com/bitnami/charts/issues/21289)
+* [bitnami/grafana-operator] Release 3.5.9 updating components versions (#21289) ([e3a53ca](https://github.com/bitnami/charts/commit/e3a53caee362cda38f9720500584e034d2783307)), closes [#21289](https://github.com/bitnami/charts/issues/21289)
 
 ## <small>3.5.8 (2023-11-23)</small>
 
-* [bitnami/grafana-operator] Release 3.5.8 updating components versions (#21226) ([327c20c](https://github.com/bitnami/charts/commit/327c20c)), closes [#21226](https://github.com/bitnami/charts/issues/21226)
+* [bitnami/grafana-operator] Release 3.5.8 updating components versions (#21226) ([327c20c](https://github.com/bitnami/charts/commit/327c20cccc0a191ba558fbbc29eafb3189e60cd8)), closes [#21226](https://github.com/bitnami/charts/issues/21226)
 
 ## <small>3.5.7 (2023-11-22)</small>
 
-* [bitnami/*] Rename solutions to "Bitnami package for ..." (#21038) ([b82f979](https://github.com/bitnami/charts/commit/b82f979)), closes [#21038](https://github.com/bitnami/charts/issues/21038)
-* [bitnami/grafana-operator] Release 3.5.7 updating components versions (#21189) ([1279bfd](https://github.com/bitnami/charts/commit/1279bfd)), closes [#21189](https://github.com/bitnami/charts/issues/21189)
+* [bitnami/*] Rename solutions to "Bitnami package for ..." (#21038) ([b82f979](https://github.com/bitnami/charts/commit/b82f979e4fb63423fe6e2192c946d09d79c944fc)), closes [#21038](https://github.com/bitnami/charts/issues/21038)
+* [bitnami/grafana-operator] Release 3.5.7 updating components versions (#21189) ([1279bfd](https://github.com/bitnami/charts/commit/1279bfdd1678f1a2687ab706023c5d5b8dc3e0aa)), closes [#21189](https://github.com/bitnami/charts/issues/21189)
 
 ## <small>3.5.6 (2023-11-17)</small>
 
-* [bitnami/*] Remove relative links to non-README sections, add verification for that and update TL;DR ([1103633](https://github.com/bitnami/charts/commit/1103633)), closes [#20967](https://github.com/bitnami/charts/issues/20967)
-* [bitnami/grafana-operator] Fix namespace restriction bug (#20960) (#20962) ([e8ac63a](https://github.com/bitnami/charts/commit/e8ac63a)), closes [#20960](https://github.com/bitnami/charts/issues/20960) [#20962](https://github.com/bitnami/charts/issues/20962)
+* [bitnami/*] Remove relative links to non-README sections, add verification for that and update TL;DR ([1103633](https://github.com/bitnami/charts/commit/11036334d82df0490aa4abdb591543cab6cf7d7f)), closes [#20967](https://github.com/bitnami/charts/issues/20967)
+* [bitnami/grafana-operator] Fix namespace restriction bug (#20960) (#20962) ([e8ac63a](https://github.com/bitnami/charts/commit/e8ac63a5a89a2ea01ce50fe1dc35cf25e44fcad8)), closes [#20960](https://github.com/bitnami/charts/issues/20960) [#20962](https://github.com/bitnami/charts/issues/20962)
 
 ## <small>3.5.5 (2023-11-14)</small>
 
-* [bitnami/grafana-operator]  Fix namespace reference (#20884) ([556d4cf](https://github.com/bitnami/charts/commit/556d4cf)), closes [#20884](https://github.com/bitnami/charts/issues/20884)
+* [bitnami/grafana-operator]  Fix namespace reference (#20884) ([556d4cf](https://github.com/bitnami/charts/commit/556d4cf24a014bff5af44e347ec32daec457efc0)), closes [#20884](https://github.com/bitnami/charts/issues/20884)
 
 ## <small>3.5.4 (2023-11-09)</small>
 
-* [bitnami/grafana-operator] Release 3.5.4 updating components versions (#20852) ([d00c995](https://github.com/bitnami/charts/commit/d00c995)), closes [#20852](https://github.com/bitnami/charts/issues/20852)
+* [bitnami/grafana-operator] Release 3.5.4 updating components versions (#20852) ([d00c995](https://github.com/bitnami/charts/commit/d00c9955b8cdb3ba1df667f603517acd24402ab7)), closes [#20852](https://github.com/bitnami/charts/issues/20852)
 
 ## <small>3.5.3 (2023-11-09)</small>
 
-* [bitnami/grafana-operator] Release 3.5.3 updating components versions (#20812) ([7e83bcf](https://github.com/bitnami/charts/commit/7e83bcf)), closes [#20812](https://github.com/bitnami/charts/issues/20812)
+* [bitnami/grafana-operator] Release 3.5.3 updating components versions (#20812) ([7e83bcf](https://github.com/bitnami/charts/commit/7e83bcf2d638df9e53fa73d66058ca6857bd8a5e)), closes [#20812](https://github.com/bitnami/charts/issues/20812)
 
 ## <small>3.5.2 (2023-11-08)</small>
 
-* [bitnami/grafana-operator] Release 3.5.2 updating components versions (#20733) ([df51ed0](https://github.com/bitnami/charts/commit/df51ed0)), closes [#20733](https://github.com/bitnami/charts/issues/20733)
+* [bitnami/grafana-operator] Release 3.5.2 updating components versions (#20733) ([df51ed0](https://github.com/bitnami/charts/commit/df51ed01b6c9f5ac7edb90f3515c6e08b671d6fa)), closes [#20733](https://github.com/bitnami/charts/issues/20733)
 
 ## <small>3.5.1 (2023-11-06)</small>
 
-* [bitnami/grafana-operator] Release 3.5.1 (#20596) ([7def7db](https://github.com/bitnami/charts/commit/7def7db)), closes [#20596](https://github.com/bitnami/charts/issues/20596)
+* [bitnami/grafana-operator] Release 3.5.1 (#20596) ([7def7db](https://github.com/bitnami/charts/commit/7def7db2e0281cee0650458fccb5f3f76037d4b4)), closes [#20596](https://github.com/bitnami/charts/issues/20596)
 
 ## 3.5.0 (2023-10-31)
 
-* [bitnami/grafana-operator] feat: :sparkles: Add support for PSA restricted policy (#20446) ([d3f177a](https://github.com/bitnami/charts/commit/d3f177a)), closes [#20446](https://github.com/bitnami/charts/issues/20446)
+* [bitnami/grafana-operator] feat: :sparkles: Add support for PSA restricted policy (#20446) ([d3f177a](https://github.com/bitnami/charts/commit/d3f177a6ce5a7cfa17d2fcb3c47a0fca209f6443)), closes [#20446](https://github.com/bitnami/charts/issues/20446)
 
 ## <small>3.4.11 (2023-10-25)</small>
 
-* [bitnami/*] Rename VMware Application Catalog (#20361) ([3acc734](https://github.com/bitnami/charts/commit/3acc734)), closes [#20361](https://github.com/bitnami/charts/issues/20361)
-* [bitnami/*] Skip image's tag in the README files of the Bitnami Charts (#19841) ([bb9a01b](https://github.com/bitnami/charts/commit/bb9a01b)), closes [#19841](https://github.com/bitnami/charts/issues/19841)
-* [bitnami/*] Standardize documentation (#19835) ([af5f753](https://github.com/bitnami/charts/commit/af5f753)), closes [#19835](https://github.com/bitnami/charts/issues/19835)
-* [bitnami/grafana-operator]: fix grafana.serviceAccount (#20363) ([c7d5f7c](https://github.com/bitnami/charts/commit/c7d5f7c)), closes [#20363](https://github.com/bitnami/charts/issues/20363)
+* [bitnami/*] Rename VMware Application Catalog (#20361) ([3acc734](https://github.com/bitnami/charts/commit/3acc73472beb6fb56c4d99f929061001205bc57e)), closes [#20361](https://github.com/bitnami/charts/issues/20361)
+* [bitnami/*] Skip image's tag in the README files of the Bitnami Charts (#19841) ([bb9a01b](https://github.com/bitnami/charts/commit/bb9a01b65911c87e48318db922cc05eb42785e42)), closes [#19841](https://github.com/bitnami/charts/issues/19841)
+* [bitnami/*] Standardize documentation (#19835) ([af5f753](https://github.com/bitnami/charts/commit/af5f7530c1bc8c5ded53a6c4f7b8f384ac1804f2)), closes [#19835](https://github.com/bitnami/charts/issues/19835)
+* [bitnami/grafana-operator]: fix grafana.serviceAccount (#20363) ([c7d5f7c](https://github.com/bitnami/charts/commit/c7d5f7c02e7e70c3699e10573a2e894257433f44)), closes [#20363](https://github.com/bitnami/charts/issues/20363)
 
 ## <small>3.4.10 (2023-10-12)</small>
 
-* [bitnami/grafana-operator] Release 3.4.10 (#20139) ([c7ad1eb](https://github.com/bitnami/charts/commit/c7ad1eb)), closes [#20139](https://github.com/bitnami/charts/issues/20139)
+* [bitnami/grafana-operator] Release 3.4.10 (#20139) ([c7ad1eb](https://github.com/bitnami/charts/commit/c7ad1eb30dbcc00b3b0d1dab0be441ada28779bf)), closes [#20139](https://github.com/bitnami/charts/issues/20139)
 
 ## <small>3.4.9 (2023-10-11)</small>
 
-* [bitnami/grafana-operator] Release 3.4.9 (#20041) ([8680ffd](https://github.com/bitnami/charts/commit/8680ffd)), closes [#20041](https://github.com/bitnami/charts/issues/20041)
+* [bitnami/grafana-operator] Release 3.4.9 (#20041) ([8680ffd](https://github.com/bitnami/charts/commit/8680ffd09c876e83782a549a8c902eb1a2be8b25)), closes [#20041](https://github.com/bitnami/charts/issues/20041)
 
 ## <small>3.4.8 (2023-10-09)</small>
 
-* [bitnami/*] Update Helm charts prerequisites (#19745) ([eb755dd](https://github.com/bitnami/charts/commit/eb755dd)), closes [#19745](https://github.com/bitnami/charts/issues/19745)
-* [bitnami/grafana-operator] Release 3.4.8 (#19824) ([58365e4](https://github.com/bitnami/charts/commit/58365e4)), closes [#19824](https://github.com/bitnami/charts/issues/19824)
+* [bitnami/*] Update Helm charts prerequisites (#19745) ([eb755dd](https://github.com/bitnami/charts/commit/eb755dd36a4dd3cf6635be8e0598f9a7f4c4a554)), closes [#19745](https://github.com/bitnami/charts/issues/19745)
+* [bitnami/grafana-operator] Release 3.4.8 (#19824) ([58365e4](https://github.com/bitnami/charts/commit/58365e459b6422134b76b75a03e3153a8c8a2598)), closes [#19824](https://github.com/bitnami/charts/issues/19824)
 
 ## <small>3.4.7 (2023-10-03)</small>
 
-* [bitnami/grafana-operator] Release 3.4.7 (#19712) ([57bcdce](https://github.com/bitnami/charts/commit/57bcdce)), closes [#19712](https://github.com/bitnami/charts/issues/19712)
+* [bitnami/grafana-operator] Release 3.4.7 (#19712) ([57bcdce](https://github.com/bitnami/charts/commit/57bcdce5147080630cf7fe8f8181edfad9c027b1)), closes [#19712](https://github.com/bitnami/charts/issues/19712)
 
 ## <small>3.4.6 (2023-09-20)</small>
 
-* [bitnami/grafana-operator] Update rbac-clustescope.yaml (#19264) ([58001ca](https://github.com/bitnami/charts/commit/58001ca)), closes [#19264](https://github.com/bitnami/charts/issues/19264)
-* Revert "Autogenerate schema files (#19194)" (#19335) ([73d80be](https://github.com/bitnami/charts/commit/73d80be)), closes [#19194](https://github.com/bitnami/charts/issues/19194) [#19335](https://github.com/bitnami/charts/issues/19335)
+* [bitnami/grafana-operator] Update rbac-clustescope.yaml (#19264) ([58001ca](https://github.com/bitnami/charts/commit/58001ca49fcac715b4f57e4bc1823949fc9c2fcb)), closes [#19264](https://github.com/bitnami/charts/issues/19264)
+* Revert "Autogenerate schema files (#19194)" (#19335) ([73d80be](https://github.com/bitnami/charts/commit/73d80be525c88fb4b8a54451a55acd506e337062)), closes [#19194](https://github.com/bitnami/charts/issues/19194) [#19335](https://github.com/bitnami/charts/issues/19335)
 
 ## <small>3.4.5 (2023-09-12)</small>
 
-* [bitnami/grafana-operator] Release 3.4.5 (#19245) ([cef61ee](https://github.com/bitnami/charts/commit/cef61ee)), closes [#19245](https://github.com/bitnami/charts/issues/19245)
-* Autogenerate schema files (#19194) ([a2c2090](https://github.com/bitnami/charts/commit/a2c2090)), closes [#19194](https://github.com/bitnami/charts/issues/19194)
+* [bitnami/grafana-operator] Release 3.4.5 (#19245) ([cef61ee](https://github.com/bitnami/charts/commit/cef61eedb6893deadf42eb900092e3e77ca5258a)), closes [#19245](https://github.com/bitnami/charts/issues/19245)
+* Autogenerate schema files (#19194) ([a2c2090](https://github.com/bitnami/charts/commit/a2c2090b5ac97f47b745c8028c6452bf99739772)), closes [#19194](https://github.com/bitnami/charts/issues/19194)
 
 ## <small>3.4.4 (2023-09-08)</small>
 
-* [bitnami/grafana-operator]: Use merge helper (#19046) ([36b6169](https://github.com/bitnami/charts/commit/36b6169)), closes [#19046](https://github.com/bitnami/charts/issues/19046)
+* [bitnami/grafana-operator]: Use merge helper (#19046) ([36b6169](https://github.com/bitnami/charts/commit/36b616986bdb3b62aba434f63f99c4fd70b060b7)), closes [#19046](https://github.com/bitnami/charts/issues/19046)
 
 ## <small>3.4.3 (2023-09-07)</small>
 
-* [grafana-operator]: Fix persistence (#19010) ([27fea24](https://github.com/bitnami/charts/commit/27fea24)), closes [#19010](https://github.com/bitnami/charts/issues/19010)
+* [grafana-operator]: Fix persistence (#19010) ([27fea24](https://github.com/bitnami/charts/commit/27fea24667a0251b0592f18d051c29fa8c47b742)), closes [#19010](https://github.com/bitnami/charts/issues/19010)
 
 ## <small>3.4.2 (2023-09-05)</small>
 
-* [bitnami/grafana-operator] Release 3.4.2 (#19123) ([4b7be44](https://github.com/bitnami/charts/commit/4b7be44)), closes [#19123](https://github.com/bitnami/charts/issues/19123)
+* [bitnami/grafana-operator] Release 3.4.2 (#19123) ([4b7be44](https://github.com/bitnami/charts/commit/4b7be44aae0a7057bc2f87b252614aceb70c3f1d)), closes [#19123](https://github.com/bitnami/charts/issues/19123)
 
 ## <small>3.4.1 (2023-09-01)</small>
 
-* [bitnami/grafana-operator]: fix ingress annotations (#18973) ([4d6e483](https://github.com/bitnami/charts/commit/4d6e483)), closes [#18973](https://github.com/bitnami/charts/issues/18973)
+* [bitnami/grafana-operator]: fix ingress annotations (#18973) ([4d6e483](https://github.com/bitnami/charts/commit/4d6e48384b41327563861845449d9e4cfdf8c2db)), closes [#18973](https://github.com/bitnami/charts/issues/18973)
 
 ## 3.4.0 (2023-08-25)
 
-* [Grafana Operator]: Bump minor version (#18849) ([fc73576](https://github.com/bitnami/charts/commit/fc73576)), closes [#18849](https://github.com/bitnami/charts/issues/18849)
+* [Grafana Operator]: Bump minor version (#18849) ([fc73576](https://github.com/bitnami/charts/commit/fc73576ce5b49724f69c7104f84447181b877c86)), closes [#18849](https://github.com/bitnami/charts/issues/18849)
 
 ## 3.3.0 (2023-08-22)
 
-* [bitnami/grafana-operator] Support for customizing standard labels (#18305) ([ec057c1](https://github.com/bitnami/charts/commit/ec057c1)), closes [#18305](https://github.com/bitnami/charts/issues/18305)
+* [bitnami/grafana-operator] Support for customizing standard labels (#18305) ([ec057c1](https://github.com/bitnami/charts/commit/ec057c1cb98158b2b8fd36a316e9d7deb633d1cb)), closes [#18305](https://github.com/bitnami/charts/issues/18305)
 
 ## <small>3.3.2 (2023-08-21)</small>
 
-* [bitnami/grafana-operator] Release 3.3.2 (#18665) ([f09f1d3](https://github.com/bitnami/charts/commit/f09f1d3)), closes [#18665](https://github.com/bitnami/charts/issues/18665)
+* [bitnami/grafana-operator] Release 3.3.2 (#18665) ([f09f1d3](https://github.com/bitnami/charts/commit/f09f1d3e1a75bc8a85763199e38ae2cc535f7b1f)), closes [#18665](https://github.com/bitnami/charts/issues/18665)
 
 ## <small>3.3.1 (2023-08-17)</small>
 
-* [bitnami/grafana-operator] Fix: volumes and secret mounts for grafana-operator (#18233) ([02de09a](https://github.com/bitnami/charts/commit/02de09a)), closes [#18233](https://github.com/bitnami/charts/issues/18233)
-* [bitnami/grafana-operator] Release 3.3.1 (#18523) ([81e73db](https://github.com/bitnami/charts/commit/81e73db)), closes [#18523](https://github.com/bitnami/charts/issues/18523)
+* [bitnami/grafana-operator] Fix: volumes and secret mounts for grafana-operator (#18233) ([02de09a](https://github.com/bitnami/charts/commit/02de09acdcbbed17cb2440325cdb4614f420ebb1)), closes [#18233](https://github.com/bitnami/charts/issues/18233)
+* [bitnami/grafana-operator] Release 3.3.1 (#18523) ([81e73db](https://github.com/bitnami/charts/commit/81e73db6aa859ce66c89798134797f8971a6c437)), closes [#18523](https://github.com/bitnami/charts/issues/18523)
 
 ## <small>3.2.2 (2023-08-08)</small>
 
-* [bitnami/grafana-operator] chore: :page_facing_up: Remove license in CRDs (#18262) ([111672b](https://github.com/bitnami/charts/commit/111672b)), closes [#18262](https://github.com/bitnami/charts/issues/18262)
+* [bitnami/grafana-operator] chore: :page_facing_up: Remove license in CRDs (#18262) ([111672b](https://github.com/bitnami/charts/commit/111672b207f8909d8c0247f70f17dafd206a8925)), closes [#18262](https://github.com/bitnami/charts/issues/18262)
 
 ## <small>3.2.1 (2023-08-04)</small>
 
-* [grafana-operator] fix: move sidecar definition to deployment section (#18122) ([a4c19b2](https://github.com/bitnami/charts/commit/a4c19b2)), closes [#18122](https://github.com/bitnami/charts/issues/18122)
+* [grafana-operator] fix: move sidecar definition to deployment section (#18122) ([a4c19b2](https://github.com/bitnami/charts/commit/a4c19b25c93ac5cefcbba63ed1cc0ac467abee9e)), closes [#18122](https://github.com/bitnami/charts/issues/18122)
 
 ## 3.2.0 (2023-08-03)
 
-* [bitnami/grafana-operator]: Grafana object to follow new CRD (#18038) ([87da4b9](https://github.com/bitnami/charts/commit/87da4b9)), closes [#18038](https://github.com/bitnami/charts/issues/18038)
+* [bitnami/grafana-operator]: Grafana object to follow new CRD (#18038) ([87da4b9](https://github.com/bitnami/charts/commit/87da4b985cd6fcd76e30d14571ccd5cb316534a0)), closes [#18038](https://github.com/bitnami/charts/issues/18038)
 
 ## <small>3.1.4 (2023-08-02)</small>
 
-* Update CRDs to match grafana operator 5.3.0 release (#18124) ([a243d14](https://github.com/bitnami/charts/commit/a243d14)), closes [#18124](https://github.com/bitnami/charts/issues/18124)
+* Update CRDs to match grafana operator 5.3.0 release (#18124) ([a243d14](https://github.com/bitnami/charts/commit/a243d14a941269403dbf8585fb45065db7985a14)), closes [#18124](https://github.com/bitnami/charts/issues/18124)
 
 ## <small>3.1.3 (2023-07-26)</small>
 
-* [bitnami/grafana-operator] Add missing image pull secrets for Grafana deployment (#17876) ([5019f0a](https://github.com/bitnami/charts/commit/5019f0a)), closes [#17876](https://github.com/bitnami/charts/issues/17876)
-* [bitnami/grafana-operator] Release 3.1.3 updating components versions (#17942) ([23c20db](https://github.com/bitnami/charts/commit/23c20db)), closes [#17942](https://github.com/bitnami/charts/issues/17942)
+* [bitnami/grafana-operator] Add missing image pull secrets for Grafana deployment (#17876) ([5019f0a](https://github.com/bitnami/charts/commit/5019f0a6052514dbae0a56e3fa5829138a9043a2)), closes [#17876](https://github.com/bitnami/charts/issues/17876)
+* [bitnami/grafana-operator] Release 3.1.3 updating components versions (#17942) ([23c20db](https://github.com/bitnami/charts/commit/23c20db78eca21d335ca360dd048c10fe8d9c1af)), closes [#17942](https://github.com/bitnami/charts/issues/17942)
 
 ## <small>3.1.2 (2023-07-25)</small>
 
-* [bitnami/grafana-operator] Release 3.1.2 (#17878) ([6eddbb4](https://github.com/bitnami/charts/commit/6eddbb4)), closes [#17878](https://github.com/bitnami/charts/issues/17878)
+* [bitnami/grafana-operator] Release 3.1.2 (#17878) ([6eddbb4](https://github.com/bitnami/charts/commit/6eddbb482212e89618764a7fc8d45bd205cd2841)), closes [#17878](https://github.com/bitnami/charts/issues/17878)
 
 ## <small>3.1.1 (2023-07-24)</small>
 
-* [bitnami/grafana-operator] Release 3.1.1 (#17848) ([9d3896b](https://github.com/bitnami/charts/commit/9d3896b)), closes [#17848](https://github.com/bitnami/charts/issues/17848)
+* [bitnami/grafana-operator] Release 3.1.1 (#17848) ([9d3896b](https://github.com/bitnami/charts/commit/9d3896bf7b26ed73b87448e997859095de63b95c)), closes [#17848](https://github.com/bitnami/charts/issues/17848)
 
 ## 3.1.0 (2023-07-24)
 
-* [bitnami/grafana-operator]: Use Bitnami Grafana image by default (#17845) ([acbf9bf](https://github.com/bitnami/charts/commit/acbf9bf)), closes [#17845](https://github.com/bitnami/charts/issues/17845)
+* [bitnami/grafana-operator]: Use Bitnami Grafana image by default (#17845) ([acbf9bf](https://github.com/bitnami/charts/commit/acbf9bf351002d664520c8df55526d0b7d8c5ac0)), closes [#17845](https://github.com/bitnami/charts/issues/17845)
 
 ## <small>3.0.4 (2023-07-21)</small>
 
-* [bitnami/grafana-operator] fix host for ingress.rules if ingress is enabled (#17793) ([9afcb64](https://github.com/bitnami/charts/commit/9afcb64)), closes [#17793](https://github.com/bitnami/charts/issues/17793)
+* [bitnami/grafana-operator] fix host for ingress.rules if ingress is enabled (#17793) ([9afcb64](https://github.com/bitnami/charts/commit/9afcb64295dba45cfb46f025d884dddf0d0e135d)), closes [#17793](https://github.com/bitnami/charts/issues/17793)
 
 ## <small>3.0.3 (2023-07-15)</small>
 
-* [bitnami/grafana-operator] Release 3 (#17603) ([11ecc0b](https://github.com/bitnami/charts/commit/11ecc0b)), closes [#17603](https://github.com/bitnami/charts/issues/17603)
+* [bitnami/grafana-operator] Release 3 (#17603) ([11ecc0b](https://github.com/bitnami/charts/commit/11ecc0bf3b38285d5fd7e41477e187813b422acb)), closes [#17603](https://github.com/bitnami/charts/issues/17603)
 
 ## <small>3.0.2 (2023-07-11)</small>
 
-* [bitnami/grafana-operator] Release 3.0.2 (#17547) ([42fd3d4](https://github.com/bitnami/charts/commit/42fd3d4)), closes [#17547](https://github.com/bitnami/charts/issues/17547)
+* [bitnami/grafana-operator] Release 3.0.2 (#17547) ([42fd3d4](https://github.com/bitnami/charts/commit/42fd3d4321cdf4528a1483d2359b59ba3fe434b5)), closes [#17547](https://github.com/bitnami/charts/issues/17547)
 
 ## <small>3.0.1 (2023-07-10)</small>
 
-* [bitnami/grafana-operator] Release 3.0.1 (#17541) ([31c2e36](https://github.com/bitnami/charts/commit/31c2e36)), closes [#17541](https://github.com/bitnami/charts/issues/17541)
+* [bitnami/grafana-operator] Release 3.0.1 (#17541) ([31c2e36](https://github.com/bitnami/charts/commit/31c2e363f521bfb864fcea318d9042e87175da46)), closes [#17541](https://github.com/bitnami/charts/issues/17541)
 
 ## 3.0.0 (2023-07-07)
 
-* [bitnami/*] Change copyright section in READMEs (#17006) ([ef986a1](https://github.com/bitnami/charts/commit/ef986a1)), closes [#17006](https://github.com/bitnami/charts/issues/17006)
-* [bitnami/grafana-operator] Release 3.0.0 (#17152) ([1711ba8](https://github.com/bitnami/charts/commit/1711ba8)), closes [#17152](https://github.com/bitnami/charts/issues/17152)
-* [bitnami/several] Change copyright section in READMEs (#16989) ([5b6a5cf](https://github.com/bitnami/charts/commit/5b6a5cf)), closes [#16989](https://github.com/bitnami/charts/issues/16989)
-* Add copyright header (#17300) ([da68be8](https://github.com/bitnami/charts/commit/da68be8)), closes [#17300](https://github.com/bitnami/charts/issues/17300)
-* Update charts readme (#17217) ([31b3c0a](https://github.com/bitnami/charts/commit/31b3c0a)), closes [#17217](https://github.com/bitnami/charts/issues/17217)
+* [bitnami/*] Change copyright section in READMEs (#17006) ([ef986a1](https://github.com/bitnami/charts/commit/ef986a1605241102b3dcafe9fd8089e6fc1201ad)), closes [#17006](https://github.com/bitnami/charts/issues/17006)
+* [bitnami/grafana-operator] Release 3.0.0 (#17152) ([1711ba8](https://github.com/bitnami/charts/commit/1711ba88107d9b7d540f570c5c5e6d2316e9b4e2)), closes [#17152](https://github.com/bitnami/charts/issues/17152)
+* [bitnami/several] Change copyright section in READMEs (#16989) ([5b6a5cf](https://github.com/bitnami/charts/commit/5b6a5cfb7625a751848a2e5cd796bd7278f406ca)), closes [#16989](https://github.com/bitnami/charts/issues/16989)
+* Add copyright header (#17300) ([da68be8](https://github.com/bitnami/charts/commit/da68be8e951225133c7dfb572d5101ca3d61c5ae)), closes [#17300](https://github.com/bitnami/charts/issues/17300)
+* Update charts readme (#17217) ([31b3c0a](https://github.com/bitnami/charts/commit/31b3c0afd968ff4429107e34101f7509e6a0e913)), closes [#17217](https://github.com/bitnami/charts/issues/17217)
 
 ## <small>2.9.3 (2023-05-30)</small>
 
-* [bitnami/grafana-operator] Release 2.9.3 (#16959) ([c9eef04](https://github.com/bitnami/charts/commit/c9eef04)), closes [#16959](https://github.com/bitnami/charts/issues/16959)
+* [bitnami/grafana-operator] Release 2.9.3 (#16959) ([c9eef04](https://github.com/bitnami/charts/commit/c9eef04fbed175328fd2be893e9c2021a8e0ae3e)), closes [#16959](https://github.com/bitnami/charts/issues/16959)
 
 ## <small>2.9.2 (2023-05-21)</small>
 
-* [bitnami/grafana-operator] Release 2.9.2 (#16767) ([e7ebc2b](https://github.com/bitnami/charts/commit/e7ebc2b)), closes [#16767](https://github.com/bitnami/charts/issues/16767)
+* [bitnami/grafana-operator] Release 2.9.2 (#16767) ([e7ebc2b](https://github.com/bitnami/charts/commit/e7ebc2bc7ef031e72d58d4066f1e47bace215e54)), closes [#16767](https://github.com/bitnami/charts/issues/16767)
 
 ## <small>2.9.1 (2023-05-11)</small>
 
-* [bitnami/grafana-operator]  List and watch verbs for namespaces (#16360) ([bda54d0](https://github.com/bitnami/charts/commit/bda54d0)), closes [#16360](https://github.com/bitnami/charts/issues/16360)
-* Add wording for enterprise page (#16560) ([8f22774](https://github.com/bitnami/charts/commit/8f22774)), closes [#16560](https://github.com/bitnami/charts/issues/16560)
+* [bitnami/grafana-operator]  List and watch verbs for namespaces (#16360) ([bda54d0](https://github.com/bitnami/charts/commit/bda54d04a38469073201705eb93a36d34f75d01d)), closes [#16360](https://github.com/bitnami/charts/issues/16360)
+* Add wording for enterprise page (#16560) ([8f22774](https://github.com/bitnami/charts/commit/8f2277440b976d52785ba9149762ad8620a73d1f)), closes [#16560](https://github.com/bitnami/charts/issues/16560)
 
 ## 2.9.0 (2023-05-09)
 
-* [bitnami/several] Adapt Chart.yaml to set desired OCI annotations (#16546) ([fc9b18f](https://github.com/bitnami/charts/commit/fc9b18f)), closes [#16546](https://github.com/bitnami/charts/issues/16546)
+* [bitnami/several] Adapt Chart.yaml to set desired OCI annotations (#16546) ([fc9b18f](https://github.com/bitnami/charts/commit/fc9b18f2e98805d4df629acbcde696f44f973344)), closes [#16546](https://github.com/bitnami/charts/issues/16546)
 
 ## <small>2.8.2 (2023-05-09)</small>
 
-* [bitnami/grafana-operator] Release 2.8.2 (#16511) ([7cc6220](https://github.com/bitnami/charts/commit/7cc6220)), closes [#16511](https://github.com/bitnami/charts/issues/16511)
+* [bitnami/grafana-operator] Release 2.8.2 (#16511) ([7cc6220](https://github.com/bitnami/charts/commit/7cc622055f7fbdb55bef333be400ee9beffe4aa8)), closes [#16511](https://github.com/bitnami/charts/issues/16511)
 
 ## <small>2.8.1 (2023-05-01)</small>
 
-* [bitnami/grafana-operator] Release 2.8.1 (#16299) ([0aff878](https://github.com/bitnami/charts/commit/0aff878)), closes [#16299](https://github.com/bitnami/charts/issues/16299)
+* [bitnami/grafana-operator] Release 2.8.1 (#16299) ([0aff878](https://github.com/bitnami/charts/commit/0aff878cdc35109c7035dd8b731d7e818bb37866)), closes [#16299](https://github.com/bitnami/charts/issues/16299)
 
 ## 2.8.0 (2023-04-20)
 
-* [bitnami/*] Make Helm charts 100% OCI (#15998) ([8841510](https://github.com/bitnami/charts/commit/8841510)), closes [#15998](https://github.com/bitnami/charts/issues/15998)
+* [bitnami/*] Make Helm charts 100% OCI (#15998) ([8841510](https://github.com/bitnami/charts/commit/884151035efcbf2e1b3206e7def85511073fb57d)), closes [#15998](https://github.com/bitnami/charts/issues/15998)
 
 ## <small>2.7.25 (2023-04-01)</small>
 
-* [bitnami/grafana-operator] Release 2.7.25 (#15869) ([0f20551](https://github.com/bitnami/charts/commit/0f20551)), closes [#15869](https://github.com/bitnami/charts/issues/15869)
+* [bitnami/grafana-operator] Release 2.7.25 (#15869) ([0f20551](https://github.com/bitnami/charts/commit/0f205513ac5854c66a358efafae1f02fd7ced362)), closes [#15869](https://github.com/bitnami/charts/issues/15869)
 
 ## <small>2.7.24 (2023-03-18)</small>
 
-* [bitnami/grafana-operator] Release 2.7.24 (#15566) ([54bfc3c](https://github.com/bitnami/charts/commit/54bfc3c)), closes [#15566](https://github.com/bitnami/charts/issues/15566)
+* [bitnami/grafana-operator] Release 2.7.24 (#15566) ([54bfc3c](https://github.com/bitnami/charts/commit/54bfc3ce0eb8e6bbdd1f118574780e351b07f5bd)), closes [#15566](https://github.com/bitnami/charts/issues/15566)
 
 ## <small>2.7.23 (2023-03-14)</small>
 
-* [bitnami/charts] Apply linter to README files (#15357) ([0e29e60](https://github.com/bitnami/charts/commit/0e29e60)), closes [#15357](https://github.com/bitnami/charts/issues/15357)
-* [bitnami/grafana-operator] Release 2.7.23 (#15492) ([23cf886](https://github.com/bitnami/charts/commit/23cf886)), closes [#15492](https://github.com/bitnami/charts/issues/15492)
+* [bitnami/charts] Apply linter to README files (#15357) ([0e29e60](https://github.com/bitnami/charts/commit/0e29e600d3adc8b1b46e506eccb3decfab3b4e63)), closes [#15357](https://github.com/bitnami/charts/issues/15357)
+* [bitnami/grafana-operator] Release 2.7.23 (#15492) ([23cf886](https://github.com/bitnami/charts/commit/23cf8860bdb7519b625c4235f7d6f73ec8cb9161)), closes [#15492](https://github.com/bitnami/charts/issues/15492)
 
 ## <small>2.7.22 (2023-03-01)</small>
 
-* [bitnami/grafana-operator] Release 2.7.22 (#15207) ([b3395f0](https://github.com/bitnami/charts/commit/b3395f0)), closes [#15207](https://github.com/bitnami/charts/issues/15207)
+* [bitnami/grafana-operator] Release 2.7.22 (#15207) ([b3395f0](https://github.com/bitnami/charts/commit/b3395f0b93fcdb09010da79a71de581ef4e99695)), closes [#15207](https://github.com/bitnami/charts/issues/15207)
 
 ## <small>2.7.21 (2023-03-01)</small>
 
-* [bitnami/grafana-operator] - Adding support for existing volume provisioned outside the chart (#1517 ([047dabf](https://github.com/bitnami/charts/commit/047dabf)), closes [#15176](https://github.com/bitnami/charts/issues/15176)
+* [bitnami/grafana-operator] - Adding support for existing volume provisioned outside the chart (#1517 ([047dabf](https://github.com/bitnami/charts/commit/047dabfce9217be18f4528c841f1694da9c4335c)), closes [#15176](https://github.com/bitnami/charts/issues/15176)
 
 ## <small>2.7.20 (2023-02-17)</small>
 
-* [bitnami/*] Fix markdown linter issues (#14874) ([a51e0e8](https://github.com/bitnami/charts/commit/a51e0e8)), closes [#14874](https://github.com/bitnami/charts/issues/14874)
-* [bitnami/*] Fix markdown linter issues 2 (#14890) ([aa96572](https://github.com/bitnami/charts/commit/aa96572)), closes [#14890](https://github.com/bitnami/charts/issues/14890)
-* [bitnami/*] Remove unexpected extra spaces (#14873) ([c97c714](https://github.com/bitnami/charts/commit/c97c714)), closes [#14873](https://github.com/bitnami/charts/issues/14873)
-* [bitnami/grafana-operator] Release 2.7.20 (#14966) ([3ad5223](https://github.com/bitnami/charts/commit/3ad5223)), closes [#14966](https://github.com/bitnami/charts/issues/14966)
+* [bitnami/*] Fix markdown linter issues (#14874) ([a51e0e8](https://github.com/bitnami/charts/commit/a51e0e8d35495b907f3e70dd2f8e7c3bcbf4166a)), closes [#14874](https://github.com/bitnami/charts/issues/14874)
+* [bitnami/*] Fix markdown linter issues 2 (#14890) ([aa96572](https://github.com/bitnami/charts/commit/aa9657237ee8df4a46db0d7fdf8a23230dd6902a)), closes [#14890](https://github.com/bitnami/charts/issues/14890)
+* [bitnami/*] Remove unexpected extra spaces (#14873) ([c97c714](https://github.com/bitnami/charts/commit/c97c714887380d47eae7bfeff316bf01595ecd1d)), closes [#14873](https://github.com/bitnami/charts/issues/14873)
+* [bitnami/grafana-operator] Release 2.7.20 (#14966) ([3ad5223](https://github.com/bitnami/charts/commit/3ad52232fa3d3cc028ffacf66516681920cb110a)), closes [#14966](https://github.com/bitnami/charts/issues/14966)
 
 ## <small>2.7.19 (2023-02-14)</small>
 
-* updates grafana-operator crds to 4.9.0 (#14854) ([8c1fe86](https://github.com/bitnami/charts/commit/8c1fe86)), closes [#14854](https://github.com/bitnami/charts/issues/14854)
+* updates grafana-operator crds to 4.9.0 (#14854) ([8c1fe86](https://github.com/bitnami/charts/commit/8c1fe86142ade8b92e01f2fe1e8f38451abbb804)), closes [#14854](https://github.com/bitnami/charts/issues/14854)
 
 ## <small>2.7.18 (2023-02-10)</small>
 
-* [bitnami/grafana-operator] Release 2.7.18 (#14833) ([f8b3f1d](https://github.com/bitnami/charts/commit/f8b3f1d)), closes [#14833](https://github.com/bitnami/charts/issues/14833)
+* [bitnami/grafana-operator] Release 2.7.18 (#14833) ([f8b3f1d](https://github.com/bitnami/charts/commit/f8b3f1d44bd9132d815c4764e28f8fc0281d6e74)), closes [#14833](https://github.com/bitnami/charts/issues/14833)
 
 ## <small>2.7.17 (2023-02-01)</small>
 
-* [bitnami/grafana-operator] Release 2.7.17 (#14700) ([277cb6f](https://github.com/bitnami/charts/commit/277cb6f)), closes [#14700](https://github.com/bitnami/charts/issues/14700)
+* [bitnami/grafana-operator] Release 2.7.17 (#14700) ([277cb6f](https://github.com/bitnami/charts/commit/277cb6f031512780246679f74ffde02e9e89b2bc)), closes [#14700](https://github.com/bitnami/charts/issues/14700)
 
 ## <small>2.7.16 (2023-01-31)</small>
 
-* [bitnami/*] Change copyright date (#14682) ([add4ec7](https://github.com/bitnami/charts/commit/add4ec7)), closes [#14682](https://github.com/bitnami/charts/issues/14682)
-* [bitnami/*] Change licenses annotation format (#14377) ([0ab7608](https://github.com/bitnami/charts/commit/0ab7608)), closes [#14377](https://github.com/bitnami/charts/issues/14377)
-* [bitnami/*] Unify READMEs (#14472) ([2064fb8](https://github.com/bitnami/charts/commit/2064fb8)), closes [#14472](https://github.com/bitnami/charts/issues/14472)
-* [bitnami/grafana-operator] Release 2.7.16 (#14570) ([6a9e507](https://github.com/bitnami/charts/commit/6a9e507)), closes [#14570](https://github.com/bitnami/charts/issues/14570)
+* [bitnami/*] Change copyright date (#14682) ([add4ec7](https://github.com/bitnami/charts/commit/add4ec701108ac36ed4de2dffbdf407a0d091067)), closes [#14682](https://github.com/bitnami/charts/issues/14682)
+* [bitnami/*] Change licenses annotation format (#14377) ([0ab7608](https://github.com/bitnami/charts/commit/0ab760862c660fcc78cffadf8e1d8cdd70881473)), closes [#14377](https://github.com/bitnami/charts/issues/14377)
+* [bitnami/*] Unify READMEs (#14472) ([2064fb8](https://github.com/bitnami/charts/commit/2064fb8dcc78a845cdede8211af8c3cc52551161)), closes [#14472](https://github.com/bitnami/charts/issues/14472)
+* [bitnami/grafana-operator] Release 2.7.16 (#14570) ([6a9e507](https://github.com/bitnami/charts/commit/6a9e507e6c1ae73ea9eaa3227ae0abe37960626d)), closes [#14570](https://github.com/bitnami/charts/issues/14570)
 
 ## <small>2.7.15 (2023-01-12)</small>
 
-* [bitnami/*] Add license annotation and remove obsolete engine parameter (#14293) ([da2a794](https://github.com/bitnami/charts/commit/da2a794)), closes [#14293](https://github.com/bitnami/charts/issues/14293)
-* [bitnami/grafana-operator] Revert #14181 and #14103 (#14309) ([1225395](https://github.com/bitnami/charts/commit/1225395)), closes [#14181](https://github.com/bitnami/charts/issues/14181) [#14103](https://github.com/bitnami/charts/issues/14103) [#14309](https://github.com/bitnami/charts/issues/14309) [#14181](https://github.com/bitnami/charts/issues/14181) [#14103](https://github.com/bitnami/charts/issues/14103)
+* [bitnami/*] Add license annotation and remove obsolete engine parameter (#14293) ([da2a794](https://github.com/bitnami/charts/commit/da2a7943bae95b6e9b5b4ed972c15e990b69fdb0)), closes [#14293](https://github.com/bitnami/charts/issues/14293)
+* [bitnami/grafana-operator] Revert #14181 and #14103 (#14309) ([1225395](https://github.com/bitnami/charts/commit/12253957032992b6f2f6ecc7b9b74cc22b0ef340)), closes [#14181](https://github.com/bitnami/charts/issues/14181) [#14103](https://github.com/bitnami/charts/issues/14103) [#14309](https://github.com/bitnami/charts/issues/14309) [#14181](https://github.com/bitnami/charts/issues/14181) [#14103](https://github.com/bitnami/charts/issues/14103)
 
 ## <small>2.7.14 (2023-01-09)</small>
 
-* [bitnami/grafana.operator] Added initContainers to Grafana pods spec. (#14181) ([c5e50ac](https://github.com/bitnami/charts/commit/c5e50ac)), closes [#14181](https://github.com/bitnami/charts/issues/14181)
+* [bitnami/grafana.operator] Added initContainers to Grafana pods spec. (#14181) ([c5e50ac](https://github.com/bitnami/charts/commit/c5e50aca1bf890d02ec1c355e142aa44c314f116)), closes [#14181](https://github.com/bitnami/charts/issues/14181)
 
 ## <small>2.7.13 (2023-01-04)</small>
 
-* [bitnami/grafana-operator] Added initContainers definition to Grafana pods into Grafana Operator. (# ([ba23085](https://github.com/bitnami/charts/commit/ba23085)), closes [#14103](https://github.com/bitnami/charts/issues/14103)
+* [bitnami/grafana-operator] Added initContainers definition to Grafana pods into Grafana Operator. (# ([ba23085](https://github.com/bitnami/charts/commit/ba23085c1b9eb595fdf338ad8b0e4af68e0e829b)), closes [#14103](https://github.com/bitnami/charts/issues/14103)
 
 ## <small>2.7.12 (2022-12-31)</small>
 
-* [bitnami/grafana-operator] Release 2.7.12 (#14145) ([46f287c](https://github.com/bitnami/charts/commit/46f287c)), closes [#14145](https://github.com/bitnami/charts/issues/14145)
+* [bitnami/grafana-operator] Release 2.7.12 (#14145) ([46f287c](https://github.com/bitnami/charts/commit/46f287c11aee97d109ddeec84355e0ef772f3b2c)), closes [#14145](https://github.com/bitnami/charts/issues/14145)
 
 ## <small>2.7.11 (2022-12-13)</small>
 
-* [bitnami/grafana-operator] Release 2.7.11 (#13787) ([b37fc18](https://github.com/bitnami/charts/commit/b37fc18)), closes [#13787](https://github.com/bitnami/charts/issues/13787)
+* [bitnami/grafana-operator] Release 2.7.11 (#13787) ([b37fc18](https://github.com/bitnami/charts/commit/b37fc18c9d48a7a1cef58dd03754b5a030941349)), closes [#13787](https://github.com/bitnami/charts/issues/13787)
 
 ## <small>2.7.10 (2022-11-18)</small>
 
-* [bitnami/grafana-operator] Release 2.7.10 (#13586) ([2e78f7b](https://github.com/bitnami/charts/commit/2e78f7b)), closes [#13586](https://github.com/bitnami/charts/issues/13586)
-* adjust the naming style for resources to make them not pass the length limit (#13345) ([0ff5afe](https://github.com/bitnami/charts/commit/0ff5afe)), closes [#13345](https://github.com/bitnami/charts/issues/13345)
+* [bitnami/grafana-operator] Release 2.7.10 (#13586) ([2e78f7b](https://github.com/bitnami/charts/commit/2e78f7bcc6a19f751ea4a27c638a996b826a0627)), closes [#13586](https://github.com/bitnami/charts/issues/13586)
+* adjust the naming style for resources to make them not pass the length limit (#13345) ([0ff5afe](https://github.com/bitnami/charts/commit/0ff5afe3d62671894a68407cbdb0da31f10ee5f3)), closes [#13345](https://github.com/bitnami/charts/issues/13345)
 
 ## <small>2.7.9 (2022-11-08)</small>
 
-* [bitnami/grafana-operator] Fix wrong argument name for parameter `zapLevel` (#13372) ([4bbbd0f](https://github.com/bitnami/charts/commit/4bbbd0f)), closes [#13372](https://github.com/bitnami/charts/issues/13372) [1#L87](https://github.com/1/issues/L87)
+* [bitnami/grafana-operator] Fix wrong argument name for parameter `zapLevel` (#13372) ([4bbbd0f](https://github.com/bitnami/charts/commit/4bbbd0f25ff19f20e92a38c761147b94f3f45b00)), closes [#13372](https://github.com/bitnami/charts/issues/13372) [1#L87](https://github.com/1/issues/L87)
 
 ## <small>2.7.8 (2022-10-19)</small>
 
-* [bitnami/*] Use new default branch name in links (#12943) ([a529e02](https://github.com/bitnami/charts/commit/a529e02)), closes [#12943](https://github.com/bitnami/charts/issues/12943)
-* [bitnami/grafana-operator] Release 2.7.8 (#13029) ([e5b437f](https://github.com/bitnami/charts/commit/e5b437f)), closes [#13029](https://github.com/bitnami/charts/issues/13029)
+* [bitnami/*] Use new default branch name in links (#12943) ([a529e02](https://github.com/bitnami/charts/commit/a529e02597d49d944eba1eb0f190713293247176)), closes [#12943](https://github.com/bitnami/charts/issues/12943)
+* [bitnami/grafana-operator] Release 2.7.8 (#13029) ([e5b437f](https://github.com/bitnami/charts/commit/e5b437f46e69eeea13fe9a0a5dfa1d6d142f504a)), closes [#13029](https://github.com/bitnami/charts/issues/13029)
 
 ## <small>2.7.7 (2022-10-10)</small>
 
-* Fix 12875/update grafana crds (#12876) ([5765742](https://github.com/bitnami/charts/commit/5765742)), closes [#12876](https://github.com/bitnami/charts/issues/12876)
+* Fix 12875/update grafana crds (#12876) ([5765742](https://github.com/bitnami/charts/commit/57657423aa3c3ccb08847e9ad3d3bde805c32d44)), closes [#12876](https://github.com/bitnami/charts/issues/12876)
 
 ## <small>2.7.6 (2022-10-07)</small>
 
-* [bitnami/grafana-operator] Update maintainers (#12852) ([5a0c42e](https://github.com/bitnami/charts/commit/5a0c42e)), closes [#12852](https://github.com/bitnami/charts/issues/12852)
+* [bitnami/grafana-operator] Update maintainers (#12852) ([5a0c42e](https://github.com/bitnami/charts/commit/5a0c42e18a9effc2c0481da15d21f93d5331d028)), closes [#12852](https://github.com/bitnami/charts/issues/12852)
 
 ## <small>2.7.5 (2022-10-06)</small>
 
-* [bitnami/grafana-operator] Release 2.7.5 (#12835) ([4c9f3fd](https://github.com/bitnami/charts/commit/4c9f3fd)), closes [#12835](https://github.com/bitnami/charts/issues/12835)
-* Generic README instructions related to the repo (#12792) ([3cf6b10](https://github.com/bitnami/charts/commit/3cf6b10)), closes [#12792](https://github.com/bitnami/charts/issues/12792)
+* [bitnami/grafana-operator] Release 2.7.5 (#12835) ([4c9f3fd](https://github.com/bitnami/charts/commit/4c9f3fdaff1ff088519d53cadce38f082c042bcf)), closes [#12835](https://github.com/bitnami/charts/issues/12835)
+* Generic README instructions related to the repo (#12792) ([3cf6b10](https://github.com/bitnami/charts/commit/3cf6b10e10e60df4b3e191d6b99aa99a9f597755)), closes [#12792](https://github.com/bitnami/charts/issues/12792)
 
 ## <small>2.7.4 (2022-09-22)</small>
 
-* [bitnami/grafana-operator] Use custom probes if given (#12501) ([fb2eee4](https://github.com/bitnami/charts/commit/fb2eee4)), closes [#12501](https://github.com/bitnami/charts/issues/12501) [#12354](https://github.com/bitnami/charts/issues/12354)
+* [bitnami/grafana-operator] Use custom probes if given (#12501) ([fb2eee4](https://github.com/bitnami/charts/commit/fb2eee42e2a2a4c0d28322c865fd772c9c40eeb1)), closes [#12501](https://github.com/bitnami/charts/issues/12501) [#12354](https://github.com/bitnami/charts/issues/12354)
 
 ## <small>2.7.3 (2022-09-18)</small>
 
-* [bitnami/grafana-operator] Release 2.7.3 updating components versions ([51e5781](https://github.com/bitnami/charts/commit/51e5781))
+* [bitnami/grafana-operator] Release 2.7.3 updating components versions ([51e5781](https://github.com/bitnami/charts/commit/51e5781c7d1e9837e6cd229a6d33cb1a701b2b15))
 
 ## <small>2.7.2 (2022-09-07)</small>
 
-* [bitnami/grafana-operator] update crds to 4.6.0 (#12285) ([1e69de9](https://github.com/bitnami/charts/commit/1e69de9)), closes [#12285](https://github.com/bitnami/charts/issues/12285)
+* [bitnami/grafana-operator] update crds to 4.6.0 (#12285) ([1e69de9](https://github.com/bitnami/charts/commit/1e69de9dac85a98f4bbca65d40c945a04d17e82d)), closes [#12285](https://github.com/bitnami/charts/issues/12285)
 
 ## <small>2.7.1 (2022-08-23)</small>
 
-* [bitnami/grafana-operator] Update Chart.lock (#12060) ([1d08d35](https://github.com/bitnami/charts/commit/1d08d35)), closes [#12060](https://github.com/bitnami/charts/issues/12060)
+* [bitnami/grafana-operator] Update Chart.lock (#12060) ([1d08d35](https://github.com/bitnami/charts/commit/1d08d35b1cb10b7886a53909c5f82404f3913038)), closes [#12060](https://github.com/bitnami/charts/issues/12060)
 
 ## 2.7.0 (2022-08-22)
 
-* [bitnami/grafana-operator] Add support for image digest apart from tag (#11896) ([357781a](https://github.com/bitnami/charts/commit/357781a)), closes [#11896](https://github.com/bitnami/charts/issues/11896)
+* [bitnami/grafana-operator] Add support for image digest apart from tag (#11896) ([357781a](https://github.com/bitnami/charts/commit/357781af4d16781071a956ae1b1414d3a5b76bcb)), closes [#11896](https://github.com/bitnami/charts/issues/11896)
 
 ## <small>2.6.12 (2022-08-19)</small>
 
-* [bitnami/grafana-operator] Release 2.6.12 updating components versions ([775c615](https://github.com/bitnami/charts/commit/775c615))
+* [bitnami/grafana-operator] Release 2.6.12 updating components versions ([775c615](https://github.com/bitnami/charts/commit/775c615373aa16739dee51b1be246c4d8af7ca6c))
 
 ## <small>2.6.11 (2022-08-09)</small>
 
-* [bitnami/grafana-operator] Release 2.6.11 updating components versions ([a27af0a](https://github.com/bitnami/charts/commit/a27af0a))
+* [bitnami/grafana-operator] Release 2.6.11 updating components versions ([a27af0a](https://github.com/bitnami/charts/commit/a27af0aa953db72a409b5d679057b831c2a1d779))
 
 ## <small>2.6.10 (2022-08-04)</small>
 
-* [bitnami/grafana-operator] Release 2.6.10 updating components versions ([078f304](https://github.com/bitnami/charts/commit/078f304))
+* [bitnami/grafana-operator] Release 2.6.10 updating components versions ([078f304](https://github.com/bitnami/charts/commit/078f3049c7332aee6a74354d115677bd2f6c578b))
 
 ## <small>2.6.9 (2022-08-03)</small>
 
-* [bitnami/grafana-operator] Release 2.6.9 updating components versions ([19e52ef](https://github.com/bitnami/charts/commit/19e52ef))
+* [bitnami/grafana-operator] Release 2.6.9 updating components versions ([19e52ef](https://github.com/bitnami/charts/commit/19e52efca8ac60a55729161e4bb0063438eb38a5))
 
 ## <small>2.6.8 (2022-08-02)</small>
 
-* [bitnami/*] Update URLs to point to the new bitnami/containers monorepo (#11352) ([d665af0](https://github.com/bitnami/charts/commit/d665af0)), closes [#11352](https://github.com/bitnami/charts/issues/11352)
-* [bitnami/grafana-operator] Release 2.6.8 updating components versions ([03c611f](https://github.com/bitnami/charts/commit/03c611f))
+* [bitnami/*] Update URLs to point to the new bitnami/containers monorepo (#11352) ([d665af0](https://github.com/bitnami/charts/commit/d665af0c708846192d8d5fb2f5f9ea65dd464ab0)), closes [#11352](https://github.com/bitnami/charts/issues/11352)
+* [bitnami/grafana-operator] Release 2.6.8 updating components versions ([03c611f](https://github.com/bitnami/charts/commit/03c611f099127a5014aa41c0f78eb82c3d3460e8))
 
 ## <small>2.6.7 (2022-07-25)</small>
 
-* [bitnami/grafana-operator] Release 2.6.7 updating components versions ([d728ecb](https://github.com/bitnami/charts/commit/d728ecb))
+* [bitnami/grafana-operator] Release 2.6.7 updating components versions ([d728ecb](https://github.com/bitnami/charts/commit/d728ecbd072de6a5af9996152f1f5c1aaa7fddd5))
 
 ## <small>2.6.6 (2022-07-12)</small>
 
-* [bitnami/grafana-operator] Release 2.6.6 updating components versions ([d2ba23c](https://github.com/bitnami/charts/commit/d2ba23c))
+* [bitnami/grafana-operator] Release 2.6.6 updating components versions ([d2ba23c](https://github.com/bitnami/charts/commit/d2ba23c7ba289bbc2e783de6e6b3f810fd325d9f))
 
 ## <small>2.6.5 (2022-07-10)</small>
 
-* [bitnami/grafana-operator] Release 2.6.5 updating components versions ([dafe574](https://github.com/bitnami/charts/commit/dafe574))
+* [bitnami/grafana-operator] Release 2.6.5 updating components versions ([dafe574](https://github.com/bitnami/charts/commit/dafe574a1427cb09c91352fb581c3bb54eb5ef81))
 
 ## <small>2.6.4 (2022-06-30)</small>
 
-* [bitnami/grafana-operator] Release 2.6.4 updating components versions ([f50cc3e](https://github.com/bitnami/charts/commit/f50cc3e))
+* [bitnami/grafana-operator] Release 2.6.4 updating components versions ([f50cc3e](https://github.com/bitnami/charts/commit/f50cc3edbc9db47ac3d17154e29d402f46668283))
 
 ## <small>2.6.3 (2022-06-10)</small>
 
-* [bitnami/*] Replace Kubeapps URL in READMEs (and kubeapps Chart.yaml) and remove BKPR references (#1 ([c6a7914](https://github.com/bitnami/charts/commit/c6a7914)), closes [#10600](https://github.com/bitnami/charts/issues/10600)
-* [bitnami/grafana-operator] Release 2.6.3 updating components versions ([5232d01](https://github.com/bitnami/charts/commit/5232d01))
+* [bitnami/*] Replace Kubeapps URL in READMEs (and kubeapps Chart.yaml) and remove BKPR references (#1 ([c6a7914](https://github.com/bitnami/charts/commit/c6a7914361e5aea6016fb45bf4d621edfd111d32)), closes [#10600](https://github.com/bitnami/charts/issues/10600)
+* [bitnami/grafana-operator] Release 2.6.3 updating components versions ([5232d01](https://github.com/bitnami/charts/commit/5232d013752db49ca1c52551a752ef31b166cffc))
 
 ## <small>2.6.2 (2022-06-06)</small>
 
-* [bitnami/grafana-operator] Release 2.6.2 updating components versions ([ea47b13](https://github.com/bitnami/charts/commit/ea47b13))
+* [bitnami/grafana-operator] Release 2.6.2 updating components versions ([ea47b13](https://github.com/bitnami/charts/commit/ea47b138516a6cb21324e621a58a35d400a25776))
 
 ## <small>2.6.1 (2022-06-01)</small>
 
-* [bitnami/several] Replace maintainers email by url (#10523) ([ff3cf61](https://github.com/bitnami/charts/commit/ff3cf61)), closes [#10523](https://github.com/bitnami/charts/issues/10523)
+* [bitnami/several] Replace maintainers email by url (#10523) ([ff3cf61](https://github.com/bitnami/charts/commit/ff3cf617a1680509b0f3855d17c4ccff7b29a0ff)), closes [#10523](https://github.com/bitnami/charts/issues/10523)
 
 ## 2.6.0 (2022-05-26)
 
-* [bitnami/grafana-operator] Chart standardised (#10277) ([fc99498](https://github.com/bitnami/charts/commit/fc99498)), closes [#10277](https://github.com/bitnami/charts/issues/10277)
+* [bitnami/grafana-operator] Chart standardised (#10277) ([fc99498](https://github.com/bitnami/charts/commit/fc994985711e6fa0a01e3388cd794d20a86030aa)), closes [#10277](https://github.com/bitnami/charts/issues/10277)
 
 ## <small>2.5.8 (2022-05-21)</small>
 
-* [bitnami/grafana-operator] Release 2.5.8 updating components versions ([e6f253c](https://github.com/bitnami/charts/commit/e6f253c))
+* [bitnami/grafana-operator] Release 2.5.8 updating components versions ([e6f253c](https://github.com/bitnami/charts/commit/e6f253c7b059635e820f18a7dc000b34472a6e75))
 
 ## <small>2.5.7 (2022-05-20)</small>
 
-* [bitnami/grafana-operator] Release 2.5.7 updating components versions ([a51d91a](https://github.com/bitnami/charts/commit/a51d91a))
+* [bitnami/grafana-operator] Release 2.5.7 updating components versions ([a51d91a](https://github.com/bitnami/charts/commit/a51d91a7c202d8a1745e3410e53c63a0621f5768))
 
 ## <small>2.5.6 (2022-05-19)</small>
 
-* [bitnami/grafana-operator] Release 2.5.6 updating components versions ([3eb3a46](https://github.com/bitnami/charts/commit/3eb3a46))
+* [bitnami/grafana-operator] Release 2.5.6 updating components versions ([3eb3a46](https://github.com/bitnami/charts/commit/3eb3a4660d7d96799169d84448acf19dc8e5a3ee))
 
 ## <small>2.5.5 (2022-05-18)</small>
 
-* [bitnami/grafana-operator] Release 2.5.5 updating components versions ([555e3db](https://github.com/bitnami/charts/commit/555e3db))
+* [bitnami/grafana-operator] Release 2.5.5 updating components versions ([555e3db](https://github.com/bitnami/charts/commit/555e3dbed9082aeaee52108b3b1c8e060812c628))
 
 ## <small>2.5.4 (2022-05-13)</small>
 
-* [bitnami/*] Unify k8s directives separators (#10185) ([2650214](https://github.com/bitnami/charts/commit/2650214)), closes [#10185](https://github.com/bitnami/charts/issues/10185)
+* [bitnami/*] Unify k8s directives separators (#10185) ([2650214](https://github.com/bitnami/charts/commit/26502141d146ca3bdfb3bf744fcdec8ca5cece44)), closes [#10185](https://github.com/bitnami/charts/issues/10185)
 
 ## <small>2.5.3 (2022-05-12)</small>
 
-* [bitnami/{grafana-operator|kube-prometheus}] CRDs should not include unnecessary dashes (#10169) ([0b123f4](https://github.com/bitnami/charts/commit/0b123f4)), closes [#10169](https://github.com/bitnami/charts/issues/10169)
+* [bitnami/{grafana-operator|kube-prometheus}] CRDs should not include unnecessary dashes (#10169) ([0b123f4](https://github.com/bitnami/charts/commit/0b123f47ebc3215a7f3acddc9a752b1ed5552f83)), closes [#10169](https://github.com/bitnami/charts/issues/10169)
 
 ## <small>2.5.2 (2022-05-09)</small>
 
-* [bitnami/grafana-operator] Release 2.5.2 updating components versions ([59d5091](https://github.com/bitnami/charts/commit/59d5091))
+* [bitnami/grafana-operator] Release 2.5.2 updating components versions ([59d5091](https://github.com/bitnami/charts/commit/59d5091a5ff2dfa74aa30fe21445f6dbafa538c4))
 
 ## <small>2.5.1 (2022-05-06)</small>
 
-* [bitnami/grafana-operator] Release 2.5.1 updating components versions ([2b1e3e2](https://github.com/bitnami/charts/commit/2b1e3e2))
+* [bitnami/grafana-operator] Release 2.5.1 updating components versions ([2b1e3e2](https://github.com/bitnami/charts/commit/2b1e3e2ba02264e10d58439ac51b2a92b4128a26))
 
 ## 2.5.0 (2022-04-28)
 
-* [bitnami/grafana-operator] Add parameters to configure plugins init image (#9909) ([44e5ada](https://github.com/bitnami/charts/commit/44e5ada)), closes [#9909](https://github.com/bitnami/charts/issues/9909)
+* [bitnami/grafana-operator] Add parameters to configure plugins init image (#9909) ([44e5ada](https://github.com/bitnami/charts/commit/44e5ada71a2a2e04117c19380b8e5c6e1a7226dc)), closes [#9909](https://github.com/bitnami/charts/issues/9909)
 
 ## <small>2.4.1 (2022-04-27)</small>
 
-* [bitnami/grafana-operator] Release 2.4.1 updating components versions ([3cb640e](https://github.com/bitnami/charts/commit/3cb640e))
+* [bitnami/grafana-operator] Release 2.4.1 updating components versions ([3cb640e](https://github.com/bitnami/charts/commit/3cb640e6e8b203a7a2516229e3c02c311978e4f8))
 
 ## 2.4.0 (2022-04-26)
 
-* [bitnami/grafana-operator] Make ingress host optional (#9922) ([a123207](https://github.com/bitnami/charts/commit/a123207)), closes [#9922](https://github.com/bitnami/charts/issues/9922)
+* [bitnami/grafana-operator] Make ingress host optional (#9922) ([a123207](https://github.com/bitnami/charts/commit/a123207427afdd688dab2bab1f13ede20973fb59)), closes [#9922](https://github.com/bitnami/charts/issues/9922)
 
 ## <small>2.3.7 (2022-04-19)</small>
 
-* [bitnami/grafana-operator] Release 2.3.7 updating components versions ([cb1be1b](https://github.com/bitnami/charts/commit/cb1be1b))
+* [bitnami/grafana-operator] Release 2.3.7 updating components versions ([cb1be1b](https://github.com/bitnami/charts/commit/cb1be1b0d93372a10bae2307264fcc62ed2cdc9a))
 
 ## <small>2.3.6 (2022-04-11)</small>
 
-* Add missing RBAC resource for OpenShift routes (#9733) ([2c3bbe4](https://github.com/bitnami/charts/commit/2c3bbe4)), closes [#9733](https://github.com/bitnami/charts/issues/9733)
+* Add missing RBAC resource for OpenShift routes (#9733) ([2c3bbe4](https://github.com/bitnami/charts/commit/2c3bbe490e410abb6bba777b08d5d6a754ea0b10)), closes [#9733](https://github.com/bitnami/charts/issues/9733)
 
 ## <small>2.3.5 (2022-04-05)</small>
 
-* [bitnami/grafana-operator] Include namespace on every manifest (#9673) ([6b3555e](https://github.com/bitnami/charts/commit/6b3555e)), closes [#9673](https://github.com/bitnami/charts/issues/9673)
+* [bitnami/grafana-operator] Include namespace on every manifest (#9673) ([6b3555e](https://github.com/bitnami/charts/commit/6b3555e186c435d431e10882a8210368cd6bae06)), closes [#9673](https://github.com/bitnami/charts/issues/9673)
 
 ## <small>2.3.4 (2022-04-03)</small>
 
-* [bitnami/grafana-operator] Release 2.3.4 updating components versions ([2ed95c1](https://github.com/bitnami/charts/commit/2ed95c1))
+* [bitnami/grafana-operator] Release 2.3.4 updating components versions ([2ed95c1](https://github.com/bitnami/charts/commit/2ed95c1d79ee6a814579cb6c30e7d538cb422f87))
 
 ## <small>2.3.3 (2022-04-02)</small>
 
-* [bitnami/grafana-operator] Release 2.3.3 updating components versions ([79119a5](https://github.com/bitnami/charts/commit/79119a5))
+* [bitnami/grafana-operator] Release 2.3.3 updating components versions ([79119a5](https://github.com/bitnami/charts/commit/79119a5c13d4eb2551d702e702138a806431a049))
 
 ## <small>2.3.2 (2022-03-28)</small>
 
-* [bitnami/grafana-operator] Release 2.3.2 updating components versions ([f7b54d5](https://github.com/bitnami/charts/commit/f7b54d5))
+* [bitnami/grafana-operator] Release 2.3.2 updating components versions ([f7b54d5](https://github.com/bitnami/charts/commit/f7b54d5b9eedf21ce69ae539ef9aeb8ccc0c8cdf))
 
 ## <small>2.3.1 (2022-03-27)</small>
 
-* [bitnami/grafana-operator] Release 2.3.1 updating components versions ([2b6ee11](https://github.com/bitnami/charts/commit/2b6ee11))
+* [bitnami/grafana-operator] Release 2.3.1 updating components versions ([2b6ee11](https://github.com/bitnami/charts/commit/2b6ee113fbea3e93c0d38e81fb0e0573fc6fb67d))
 
 ## 2.3.0 (2022-03-22)
 
-* [bitnami/grafana-operator] Allow configuring service (#9509) ([5b159a7](https://github.com/bitnami/charts/commit/5b159a7)), closes [#9509](https://github.com/bitnami/charts/issues/9509)
+* [bitnami/grafana-operator] Allow configuring service (#9509) ([5b159a7](https://github.com/bitnami/charts/commit/5b159a70ec71d4a59280be1cdb8091660502e51e)), closes [#9509](https://github.com/bitnami/charts/issues/9509)
 
 ## <small>2.2.12 (2022-03-22)</small>
 
-* [bitnami/grafana-operator] Correct dashboardNamespaceSelector expected type. Fixes #9456. (#9500) ([8521b88](https://github.com/bitnami/charts/commit/8521b88)), closes [#9456](https://github.com/bitnami/charts/issues/9456) [#9500](https://github.com/bitnami/charts/issues/9500) [#9456](https://github.com/bitnami/charts/issues/9456)
+* [bitnami/grafana-operator] Correct dashboardNamespaceSelector expected type. Fixes #9456. (#9500) ([8521b88](https://github.com/bitnami/charts/commit/8521b88cc3103f2be95d0ab72494a1b50e186d3d)), closes [#9456](https://github.com/bitnami/charts/issues/9456) [#9500](https://github.com/bitnami/charts/issues/9500) [#9456](https://github.com/bitnami/charts/issues/9456)
 
 ## <small>2.2.11 (2022-03-17)</small>
 
-* [bitnami/grafana-operator] Release 2.2.11 updating components versions ([ca2bb49](https://github.com/bitnami/charts/commit/ca2bb49))
+* [bitnami/grafana-operator] Release 2.2.11 updating components versions ([ca2bb49](https://github.com/bitnami/charts/commit/ca2bb49fac86be47058aca66e622ac7524cbc8f2))
 
 ## <small>2.2.10 (2022-03-16)</small>
 
-* [bitnami/grafana-operator] Release 2.2.10 updating components versions ([ee39db7](https://github.com/bitnami/charts/commit/ee39db7))
+* [bitnami/grafana-operator] Release 2.2.10 updating components versions ([ee39db7](https://github.com/bitnami/charts/commit/ee39db7019b9c733f79f06079ad8af9fdeeea2a9))
 
 ## <small>2.2.9 (2022-02-27)</small>
 
-* [bitnami/grafana-operator] Release 2.2.9 updating components versions ([daed52a](https://github.com/bitnami/charts/commit/daed52a))
+* [bitnami/grafana-operator] Release 2.2.9 updating components versions ([daed52a](https://github.com/bitnami/charts/commit/daed52a397ad5411e52d84adc04c19f49236e5ae))
 
 ## <small>2.2.8 (2022-02-24)</small>
 
-* [bitnami/grafana-operator] Release 2.2.8 updating components versions ([4daf41b](https://github.com/bitnami/charts/commit/4daf41b))
+* [bitnami/grafana-operator] Release 2.2.8 updating components versions ([4daf41b](https://github.com/bitnami/charts/commit/4daf41b77cdd85bb39cdefbd14055395c9a07bda))
 
 ## <small>2.2.7 (2022-02-23)</small>
 
-* [bitnami/grafana-operator] Release 2.2.7 updating components versions ([370da67](https://github.com/bitnami/charts/commit/370da67))
+* [bitnami/grafana-operator] Release 2.2.7 updating components versions ([370da67](https://github.com/bitnami/charts/commit/370da676155507df54fe4b010c87ddd085c2cd53))
 
 ## <small>2.2.6 (2022-02-23)</small>
 
-* [bitnami/grafana-operator] Release 2.2.6 updating components versions ([4f6f9df](https://github.com/bitnami/charts/commit/4f6f9df))
+* [bitnami/grafana-operator] Release 2.2.6 updating components versions ([4f6f9df](https://github.com/bitnami/charts/commit/4f6f9df5a6667afe0aa487d4c239bac722dd1ace))
 
 ## <small>2.2.5 (2022-02-20)</small>
 
-* [bitnami/grafana-operator] Release 2.2.5 updating components versions ([5488177](https://github.com/bitnami/charts/commit/5488177))
+* [bitnami/grafana-operator] Release 2.2.5 updating components versions ([5488177](https://github.com/bitnami/charts/commit/54881778361509e5ab4f8211c7664dec9f648fd8))
 
 ## <small>2.2.4 (2022-02-15)</small>
 
-* [bitnami/grafana-operator] Include nodeSelector parameter (#9002) ([fd9d3ad](https://github.com/bitnami/charts/commit/fd9d3ad)), closes [#9002](https://github.com/bitnami/charts/issues/9002)
+* [bitnami/grafana-operator] Include nodeSelector parameter (#9002) ([fd9d3ad](https://github.com/bitnami/charts/commit/fd9d3ad400a11f48d748deb52c7acf139bf738e7)), closes [#9002](https://github.com/bitnami/charts/issues/9002)
 
 ## <small>2.2.3 (2022-02-13)</small>
 
-* [bitnami/grafana-operator] Release 2.2.3 updating components versions ([fe4fb36](https://github.com/bitnami/charts/commit/fe4fb36))
-* Non utf8 chars (#8923) ([6ffd18f](https://github.com/bitnami/charts/commit/6ffd18f)), closes [#8923](https://github.com/bitnami/charts/issues/8923)
+* [bitnami/grafana-operator] Release 2.2.3 updating components versions ([fe4fb36](https://github.com/bitnami/charts/commit/fe4fb36836a2a00b2ddb5d048b4d0a2b47b39d1c))
+* Non utf8 chars (#8923) ([6ffd18f](https://github.com/bitnami/charts/commit/6ffd18fbbdf10e94ea1a90cf5b84ef610ac2a72d)), closes [#8923](https://github.com/bitnami/charts/issues/8923)
 
 ## <small>2.2.2 (2022-01-20)</small>
 
-* [bitnami/*] Update READMEs (#8716) ([b9a9533](https://github.com/bitnami/charts/commit/b9a9533)), closes [#8716](https://github.com/bitnami/charts/issues/8716)
-* [bitnami/several] Change prerequisites (#8725) ([8d740c5](https://github.com/bitnami/charts/commit/8d740c5)), closes [#8725](https://github.com/bitnami/charts/issues/8725)
+* [bitnami/*] Update READMEs (#8716) ([b9a9533](https://github.com/bitnami/charts/commit/b9a953337590eb2979453385874a267bacf50936)), closes [#8716](https://github.com/bitnami/charts/issues/8716)
+* [bitnami/several] Change prerequisites (#8725) ([8d740c5](https://github.com/bitnami/charts/commit/8d740c566cfdb7e2d933c40128b4e919fce953a5)), closes [#8725](https://github.com/bitnami/charts/issues/8725)
 
 ## <small>2.2.1 (2022-01-18)</small>
 
-* [bitnami/*] Readme automation (#8579) ([78d1938](https://github.com/bitnami/charts/commit/78d1938)), closes [#8579](https://github.com/bitnami/charts/issues/8579)
-* [bitnami/grafana-operator] Add `patch events` permissions to grafana-operator ClusterRole (#8698) ([f4f352f](https://github.com/bitnami/charts/commit/f4f352f)), closes [#8698](https://github.com/bitnami/charts/issues/8698)
+* [bitnami/*] Readme automation (#8579) ([78d1938](https://github.com/bitnami/charts/commit/78d193831c900d178198491ffd08fa2217a64ecd)), closes [#8579](https://github.com/bitnami/charts/issues/8579)
+* [bitnami/grafana-operator] Add `patch events` permissions to grafana-operator ClusterRole (#8698) ([f4f352f](https://github.com/bitnami/charts/commit/f4f352fe9f6d4cc5e3459515399bba03bb936105)), closes [#8698](https://github.com/bitnami/charts/issues/8698)
 
 ## 2.2.0 (2022-01-17)
 
-* [bitnami/grafana-operator] Add deployment.skipCreateAdminAccount to grafana.yaml (#8676) ([df5384c](https://github.com/bitnami/charts/commit/df5384c)), closes [#8676](https://github.com/bitnami/charts/issues/8676) [#8629](https://github.com/bitnami/charts/issues/8629) [#8661](https://github.com/bitnami/charts/issues/8661)
+* [bitnami/grafana-operator] Add deployment.skipCreateAdminAccount to grafana.yaml (#8676) ([df5384c](https://github.com/bitnami/charts/commit/df5384c0aac5b4e815d16bfeca66b501bb4d04a8)), closes [#8676](https://github.com/bitnami/charts/issues/8676) [#8629](https://github.com/bitnami/charts/issues/8629) [#8661](https://github.com/bitnami/charts/issues/8661)
 
 ## <small>2.1.1 (2022-01-05)</small>
 
-* [bitnami/grafana-operator] Release 2.1.1 updating components versions (#8575) ([018c4b3](https://github.com/bitnami/charts/commit/018c4b3)), closes [#8575](https://github.com/bitnami/charts/issues/8575)
+* [bitnami/grafana-operator] Release 2.1.1 updating components versions (#8575) ([018c4b3](https://github.com/bitnami/charts/commit/018c4b30fba3c309420e213266b0526df1450be1)), closes [#8575](https://github.com/bitnami/charts/issues/8575)
 
 ## 2.1.0 (2022-01-04)
 
-* [bitnami/several] Add license to the README ([05f7633](https://github.com/bitnami/charts/commit/05f7633))
-* [bitnami/several] Add license to the README ([32fb238](https://github.com/bitnami/charts/commit/32fb238))
-* [bitnami/several] Add license to the README ([b87c2f7](https://github.com/bitnami/charts/commit/b87c2f7))
-* bitnami/grafana-operator fix default value for accessModes (#8554) ([fde88c7](https://github.com/bitnami/charts/commit/fde88c7)), closes [#8554](https://github.com/bitnami/charts/issues/8554)
+* [bitnami/several] Add license to the README ([05f7633](https://github.com/bitnami/charts/commit/05f763372501d596e57db713dd53ff4ff3027cc4))
+* [bitnami/several] Add license to the README ([32fb238](https://github.com/bitnami/charts/commit/32fb238e60a0affc6debd3142eaa3c3d9089ec2a))
+* [bitnami/several] Add license to the README ([b87c2f7](https://github.com/bitnami/charts/commit/b87c2f7899d48a8b02c506765e6ae82937e9ba3f))
+* bitnami/grafana-operator fix default value for accessModes (#8554) ([fde88c7](https://github.com/bitnami/charts/commit/fde88c7e9cf8315d40cb0e87b1b9aa868c2b1566)), closes [#8554](https://github.com/bitnami/charts/issues/8554)
 
 ## <small>2.0.4 (2021-12-31)</small>
 
-* [bitnami/grafana-operator] add `grafana.ingress.pathType` (#8541) ([2b85adc](https://github.com/bitnami/charts/commit/2b85adc)), closes [#8541](https://github.com/bitnami/charts/issues/8541) [#8540](https://github.com/bitnami/charts/issues/8540)
+* [bitnami/grafana-operator] add `grafana.ingress.pathType` (#8541) ([2b85adc](https://github.com/bitnami/charts/commit/2b85adc44e8c6db03cedc4f1ab982bd757fbcd6e)), closes [#8541](https://github.com/bitnami/charts/issues/8541) [#8540](https://github.com/bitnami/charts/issues/8540)
 
 ## <small>2.0.3 (2021-12-29)</small>
 
-* [bitnami/grafana-operator] Release 2.0.3 updating components versions ([b7897b7](https://github.com/bitnami/charts/commit/b7897b7))
+* [bitnami/grafana-operator] Release 2.0.3 updating components versions ([b7897b7](https://github.com/bitnami/charts/commit/b7897b762c4f3b10a7781aaf37c3abae29f80495))
 
 ## <small>2.0.2 (2021-12-29)</small>
 
-* [bitnami/grafana-operator] Release 2.0.2 updating components versions ([eb05735](https://github.com/bitnami/charts/commit/eb05735))
+* [bitnami/grafana-operator] Release 2.0.2 updating components versions ([eb05735](https://github.com/bitnami/charts/commit/eb057354edf84313cd6264a617a202d3e58efe7c))
 
 ## <small>2.0.1 (2021-12-29)</small>
 
-* [bitnami/grafana-operator] fix: :ambulance: Force bump to force a new release ([0ba75dc](https://github.com/bitnami/charts/commit/0ba75dc))
+* [bitnami/grafana-operator] fix: :ambulance: Force bump to force a new release ([0ba75dc](https://github.com/bitnami/charts/commit/0ba75dcf99bdebcb6b746f42fb11f8a993c7f6ac))
 
 ## 2.0.0 (2021-12-29)
 
-* [bitnami/grafana-operator] Update the grafana-operator chart to version 4.x release. (#8059) ([d87dec2](https://github.com/bitnami/charts/commit/d87dec2)), closes [#8059](https://github.com/bitnami/charts/issues/8059) [#8177](https://github.com/bitnami/charts/issues/8177)
+* [bitnami/grafana-operator] Update the grafana-operator chart to version 4.x release. (#8059) ([d87dec2](https://github.com/bitnami/charts/commit/d87dec202858e218f08470a8a28d5397426b6a6c)), closes [#8059](https://github.com/bitnami/charts/issues/8059) [#8177](https://github.com/bitnami/charts/issues/8177)
 
 ## <small>1.5.5 (2021-12-21)</small>
 
-* [bitnami/grafana-operator] Release 1.5.5 updating components versions ([34a36db](https://github.com/bitnami/charts/commit/34a36db))
+* [bitnami/grafana-operator] Release 1.5.5 updating components versions ([34a36db](https://github.com/bitnami/charts/commit/34a36db80d73fd56ec3c2759be7465828e9fefe7))
 
 ## <small>1.5.4 (2021-12-16)</small>
 
-* [bitnami/grafana-operator] Release 1.5.4 updating components versions ([978a738](https://github.com/bitnami/charts/commit/978a738))
+* [bitnami/grafana-operator] Release 1.5.4 updating components versions ([978a738](https://github.com/bitnami/charts/commit/978a73843d26a72c0dc025b812ef57da3a41d5a8))
 
 ## <small>1.5.3 (2021-12-08)</small>
 
-* [bitnami/grafana-operator] Release 1.5.3 updating components versions ([a54f967](https://github.com/bitnami/charts/commit/a54f967))
+* [bitnami/grafana-operator] Release 1.5.3 updating components versions ([a54f967](https://github.com/bitnami/charts/commit/a54f967241d87e47c8236e5c24caea08a2f0d908))
 
 ## <small>1.5.2 (2021-11-29)</small>
 
-* [bitnami/several] Regenerate README tables ([ac75243](https://github.com/bitnami/charts/commit/ac75243))
-* [bitnami/several] Replace HTTP by HTTPS when possible (#8259) ([eafb5bd](https://github.com/bitnami/charts/commit/eafb5bd)), closes [#8259](https://github.com/bitnami/charts/issues/8259)
+* [bitnami/several] Regenerate README tables ([ac75243](https://github.com/bitnami/charts/commit/ac752431b90e935d0a4dbfef70dc44f24f3d3dd2))
+* [bitnami/several] Replace HTTP by HTTPS when possible (#8259) ([eafb5bd](https://github.com/bitnami/charts/commit/eafb5bd5a2cc3aaf04fc1e8ebedd73f420d76864)), closes [#8259](https://github.com/bitnami/charts/issues/8259)
 
 ## <small>1.5.1 (2021-11-26)</small>
 
-* [bitnami/grafana-operator] Release 1.5.1 updating components versions ([a45a393](https://github.com/bitnami/charts/commit/a45a393))
-* [bitnami/several] Regenerate README tables ([e8e4e6a](https://github.com/bitnami/charts/commit/e8e4e6a))
+* [bitnami/grafana-operator] Release 1.5.1 updating components versions ([a45a393](https://github.com/bitnami/charts/commit/a45a39379f66b7d205cb247aab6c1455ce03d025))
+* [bitnami/several] Regenerate README tables ([e8e4e6a](https://github.com/bitnami/charts/commit/e8e4e6a9f7c924bcdab52f269cb60dbfeef840a9))
 
 ## 1.5.0 (2021-11-22)
 
-* bitnami/grafana-operator add opt-in dashboardNamespaceSelector (#8204) ([e24d53e](https://github.com/bitnami/charts/commit/e24d53e)), closes [#8204](https://github.com/bitnami/charts/issues/8204)
+* bitnami/grafana-operator add opt-in dashboardNamespaceSelector (#8204) ([e24d53e](https://github.com/bitnami/charts/commit/e24d53ec260755e5e94ecc8d193f10685edc7e7c)), closes [#8204](https://github.com/bitnami/charts/issues/8204)
 
 ## 1.4.0 (2021-11-18)
 
-* [bitnami/grafana-operator] Add missing zap args and extraArgs feature (#8177) ([c9aa602](https://github.com/bitnami/charts/commit/c9aa602)), closes [#8177](https://github.com/bitnami/charts/issues/8177)
+* [bitnami/grafana-operator] Add missing zap args and extraArgs feature (#8177) ([c9aa602](https://github.com/bitnami/charts/commit/c9aa602ec329e3d110d807b551cde6848323a0ec)), closes [#8177](https://github.com/bitnami/charts/issues/8177)
 
 ## <small>1.3.6 (2021-10-28)</small>
 
-* [bitnami/grafana-operator] Adds networking.k8s.io to Role binding (#7958) ([5f9a80a](https://github.com/bitnami/charts/commit/5f9a80a)), closes [#7958](https://github.com/bitnami/charts/issues/7958)
-* [bitnami/several] Regenerate README tables ([412cf6a](https://github.com/bitnami/charts/commit/412cf6a))
+* [bitnami/grafana-operator] Adds networking.k8s.io to Role binding (#7958) ([5f9a80a](https://github.com/bitnami/charts/commit/5f9a80a1f11ab0c82ed43586a49d0bf4b5829d87)), closes [#7958](https://github.com/bitnami/charts/issues/7958)
+* [bitnami/several] Regenerate README tables ([412cf6a](https://github.com/bitnami/charts/commit/412cf6a513cb0c03444a6e7811c6f27193239a10))
 
 ## <small>1.3.5 (2021-10-27)</small>
 
-* [bitnami/grafana-operator] Release 1.3.5 updating components versions ([55d04bb](https://github.com/bitnami/charts/commit/55d04bb))
+* [bitnami/grafana-operator] Release 1.3.5 updating components versions ([55d04bb](https://github.com/bitnami/charts/commit/55d04bb029a08fff4067a48f072f825826901509))
 
 ## <small>1.3.4 (2021-10-26)</small>
 
-* [bitnami/grafana-operator] Adding correct API group for ingresses resource (#7915) ([22e8551](https://github.com/bitnami/charts/commit/22e8551)), closes [#7915](https://github.com/bitnami/charts/issues/7915) [#7913](https://github.com/bitnami/charts/issues/7913)
+* [bitnami/grafana-operator] Adding correct API group for ingresses resource (#7915) ([22e8551](https://github.com/bitnami/charts/commit/22e85513e5290cf1171693ac841b769a53a21ff9)), closes [#7915](https://github.com/bitnami/charts/issues/7915) [#7913](https://github.com/bitnami/charts/issues/7913)
 
 ## <small>1.3.3 (2021-10-25)</small>
 
-* [bitnami/grafana-operator] Change of grafana operator GitHub URL (#7912) ([d5c1633](https://github.com/bitnami/charts/commit/d5c1633)), closes [#7912](https://github.com/bitnami/charts/issues/7912)
-* [bitnami/several] Regenerate README tables ([c82619f](https://github.com/bitnami/charts/commit/c82619f))
+* [bitnami/grafana-operator] Change of grafana operator GitHub URL (#7912) ([d5c1633](https://github.com/bitnami/charts/commit/d5c1633116f60618ae01c147966d6bc380a013f9)), closes [#7912](https://github.com/bitnami/charts/issues/7912)
+* [bitnami/several] Regenerate README tables ([c82619f](https://github.com/bitnami/charts/commit/c82619f4141cd18e1b6079fdd84eb5b7bb47d819))
 
 ## <small>1.3.2 (2021-10-24)</small>
 
-* [bitnami/grafana-operator] Release 1.3.2 updating components versions ([6e07b3b](https://github.com/bitnami/charts/commit/6e07b3b))
+* [bitnami/grafana-operator] Release 1.3.2 updating components versions ([6e07b3b](https://github.com/bitnami/charts/commit/6e07b3b9061d0377fbf29e42dd47a281ff3ce9bc))
 
 ## <small>1.3.1 (2021-10-22)</small>
 
-* [bitnami/several] Add chart info to NOTES.txt (#7889) ([a6751cd](https://github.com/bitnami/charts/commit/a6751cd)), closes [#7889](https://github.com/bitnami/charts/issues/7889)
+* [bitnami/several] Add chart info to NOTES.txt (#7889) ([a6751cd](https://github.com/bitnami/charts/commit/a6751cdd33c461fabbc459fbea6f219ec64ab6b2)), closes [#7889](https://github.com/bitnami/charts/issues/7889)
 
 ## 1.3.0 (2021-10-19)
 
-* [bitnami/grafana-operator] Adding support for IngressClassName (#7851) ([2137ea6](https://github.com/bitnami/charts/commit/2137ea6)), closes [#7851](https://github.com/bitnami/charts/issues/7851)
+* [bitnami/grafana-operator] Adding support for IngressClassName (#7851) ([2137ea6](https://github.com/bitnami/charts/commit/2137ea64ea202a257a294eadfe1c3888e7c786dc)), closes [#7851](https://github.com/bitnami/charts/issues/7851)
 
 ## 1.2.0 (2021-10-13)
 
-* [bitnami/grafana-operator] Add labels to the Grafana deployment (deployment, service and ingress res ([abb98e4](https://github.com/bitnami/charts/commit/abb98e4)), closes [#7780](https://github.com/bitnami/charts/issues/7780)
-* [bitnami/several] Regenerate README tables ([ff170d1](https://github.com/bitnami/charts/commit/ff170d1))
+* [bitnami/grafana-operator] Add labels to the Grafana deployment (deployment, service and ingress res ([abb98e4](https://github.com/bitnami/charts/commit/abb98e440152e42204317a060e09ee666c6ba174)), closes [#7780](https://github.com/bitnami/charts/issues/7780)
+* [bitnami/several] Regenerate README tables ([ff170d1](https://github.com/bitnami/charts/commit/ff170d10f8aa6dae0f1e5c3f7d1c69fcec96b731))
 
 ## <small>1.1.4 (2021-09-24)</small>
 
-* [bitnami/grafana-operator] Release 1.1.4 updating components versions ([595b439](https://github.com/bitnami/charts/commit/595b439))
-* [bitnami/grafana-operator] Update README.md ([cea2c75](https://github.com/bitnami/charts/commit/cea2c75))
-* [bitnami/grafana-operator] Updated README (#7389) ([99c010f](https://github.com/bitnami/charts/commit/99c010f)), closes [#7389](https://github.com/bitnami/charts/issues/7389)
+* [bitnami/grafana-operator] Release 1.1.4 updating components versions ([595b439](https://github.com/bitnami/charts/commit/595b439ca61529eca4f1aab8ccbb7594147cac12))
+* [bitnami/grafana-operator] Update README.md ([cea2c75](https://github.com/bitnami/charts/commit/cea2c75702be5e80ded0c45d09d6e6908e0587a0))
+* [bitnami/grafana-operator] Updated README (#7389) ([99c010f](https://github.com/bitnami/charts/commit/99c010f87b7abad7d44a327a183d3046b7d7fe1c)), closes [#7389](https://github.com/bitnami/charts/issues/7389)
 
 ## <small>1.1.3 (2021-09-09)</small>
 
-* [bitnami/several] Regenerate README tables ([da2513b](https://github.com/bitnami/charts/commit/da2513b))
-* Update CRD grafanas.integreatly.org (#7441) ([8757a51](https://github.com/bitnami/charts/commit/8757a51)), closes [#7441](https://github.com/bitnami/charts/issues/7441)
+* [bitnami/several] Regenerate README tables ([da2513b](https://github.com/bitnami/charts/commit/da2513bf0a33819f3b1151d387c631a9ffdb03e2))
+* Update CRD grafanas.integreatly.org (#7441) ([8757a51](https://github.com/bitnami/charts/commit/8757a51c3348c0e4d01041304e4490aef2656579)), closes [#7441](https://github.com/bitnami/charts/issues/7441)
 
 ## <small>1.1.2 (2021-08-25)</small>
 
-* [bitnami/grafana-operator] Release 1.1.2 updating components versions ([79f9100](https://github.com/bitnami/charts/commit/79f9100))
-* [bitnami/several] Regenerate README tables ([6c9124f](https://github.com/bitnami/charts/commit/6c9124f))
+* [bitnami/grafana-operator] Release 1.1.2 updating components versions ([79f9100](https://github.com/bitnami/charts/commit/79f91000b7a504d0024043000f4620c2e6649f18))
+* [bitnami/several] Regenerate README tables ([6c9124f](https://github.com/bitnami/charts/commit/6c9124f79491aa65f53a87c1ed598b47ffa8b411))
 
 ## <small>1.1.1 (2021-08-20)</small>
 
-* [bitnami/grafana-operator] Fix missing RBAC rules in case of cluster wide installation (#7253) ([2b357e9](https://github.com/bitnami/charts/commit/2b357e9)), closes [#7253](https://github.com/bitnami/charts/issues/7253)
+* [bitnami/grafana-operator] Fix missing RBAC rules in case of cluster wide installation (#7253) ([2b357e9](https://github.com/bitnami/charts/commit/2b357e9aaec516e044bdf8be52e3fabe8af4d1ec)), closes [#7253](https://github.com/bitnami/charts/issues/7253)
 
 ## 1.1.0 (2021-08-19)
 
-* [bitnami/grafana-operator] Custom update strategy for Grafana deployment (#6868) ([31fc706](https://github.com/bitnami/charts/commit/31fc706)), closes [#6868](https://github.com/bitnami/charts/issues/6868)
-* [bitnami/several] Regenerate README tables ([6c107e8](https://github.com/bitnami/charts/commit/6c107e8))
+* [bitnami/grafana-operator] Custom update strategy for Grafana deployment (#6868) ([31fc706](https://github.com/bitnami/charts/commit/31fc70640b76f5658fb89db395d7fc0acae1ea8e)), closes [#6868](https://github.com/bitnami/charts/issues/6868)
+* [bitnami/several] Regenerate README tables ([6c107e8](https://github.com/bitnami/charts/commit/6c107e835d6caf8db2e8b17dcd48c5971637e013))
 
 ## <small>1.0.1 (2021-08-02)</small>
 
-* [bitnami/grafana-operator] Release 1.0.1 updating components versions ([83af97d](https://github.com/bitnami/charts/commit/83af97d))
+* [bitnami/grafana-operator] Release 1.0.1 updating components versions ([83af97d](https://github.com/bitnami/charts/commit/83af97d1600cbf3329ea9b70d66f107a22677b17))
 
 ## 1.0.0 (2021-08-02)
 
-* [bitnami/several] Simplify image definition logic removing duplications (#7114) ([43e4eee](https://github.com/bitnami/charts/commit/43e4eee)), closes [#7114](https://github.com/bitnami/charts/issues/7114)
+* [bitnami/several] Simplify image definition logic removing duplications (#7114) ([43e4eee](https://github.com/bitnami/charts/commit/43e4eee921209ca662c7902668b09b3b1a1d28a9)), closes [#7114](https://github.com/bitnami/charts/issues/7114)
 
 ## <small>0.8.2 (2021-07-28)</small>
 
-*  [bitnami/grafana-operator] grafana.serviceAccount config (#7070) ([6b887ca](https://github.com/bitnami/charts/commit/6b887ca)), closes [#7070](https://github.com/bitnami/charts/issues/7070)
-* [bitnami/several] Upadte READMEs ([eb3c291](https://github.com/bitnami/charts/commit/eb3c291))
+*  [bitnami/grafana-operator] grafana.serviceAccount config (#7070) ([6b887ca](https://github.com/bitnami/charts/commit/6b887caa68a0be8fa49073f615b49a42df689a2d)), closes [#7070](https://github.com/bitnami/charts/issues/7070)
+* [bitnami/several] Upadte READMEs ([eb3c291](https://github.com/bitnami/charts/commit/eb3c2916be233280f2226d9cdceb57b08ab4a23b))
 
 ## <small>0.8.1 (2021-07-27)</small>
 
-* [bitnami/several] Fix default values and regenerate README (#7024) ([4c86733](https://github.com/bitnami/charts/commit/4c86733)), closes [#7024](https://github.com/bitnami/charts/issues/7024)
+* [bitnami/several] Fix default values and regenerate README (#7024) ([4c86733](https://github.com/bitnami/charts/commit/4c867335c5c9c5aba041868df16ebb8f64ac68bd)), closes [#7024](https://github.com/bitnami/charts/issues/7024)
 
 ## 0.8.0 (2021-07-26)
 
-* [bitnami/grafana-operator] extraVolumes, extraVolumeMounts, sidecars (#7034) ([aab51cd](https://github.com/bitnami/charts/commit/aab51cd)), closes [#7034](https://github.com/bitnami/charts/issues/7034)
+* [bitnami/grafana-operator] extraVolumes, extraVolumeMounts, sidecars (#7034) ([aab51cd](https://github.com/bitnami/charts/commit/aab51cd17357bf8f4e90803af5d190b4a6c72a4c)), closes [#7034](https://github.com/bitnami/charts/issues/7034)
 
 ## <small>0.7.7 (2021-07-26)</small>
 
-* [bitnami/grafana-operator] Release 0.7.7 updating components versions ([22eb490](https://github.com/bitnami/charts/commit/22eb490))
+* [bitnami/grafana-operator] Release 0.7.7 updating components versions ([22eb490](https://github.com/bitnami/charts/commit/22eb490a0c9b961027ac3ff3e88d5201be3aac58))
 
 ## <small>0.7.6 (2021-07-05)</small>
 
-* [bitnami/*] Adapt values.yaml of fluentd, grafana and grafana-operator charts (#6827) ([2fc70b5](https://github.com/bitnami/charts/commit/2fc70b5)), closes [#6827](https://github.com/bitnami/charts/issues/6827)
+* [bitnami/*] Adapt values.yaml of fluentd, grafana and grafana-operator charts (#6827) ([2fc70b5](https://github.com/bitnami/charts/commit/2fc70b5319014a8e12c4cbb91e933c3b44e0dab3)), closes [#6827](https://github.com/bitnami/charts/issues/6827)
 
 ## <small>0.7.5 (2021-06-26)</small>
 
-* [bitnami/grafana-operator] Release 0.7.5 updating components versions ([c5fbd4e](https://github.com/bitnami/charts/commit/c5fbd4e))
+* [bitnami/grafana-operator] Release 0.7.5 updating components versions ([c5fbd4e](https://github.com/bitnami/charts/commit/c5fbd4e801eee2a62e7ed5f14e2df47350cf415b))
 
 ## <small>0.7.4 (2021-06-13)</small>
 
-* [bitnami/grafana-operator] Release 0.7.4 updating components versions ([4fa3bdd](https://github.com/bitnami/charts/commit/4fa3bdd))
+* [bitnami/grafana-operator] Release 0.7.4 updating components versions ([4fa3bdd](https://github.com/bitnami/charts/commit/4fa3bddc46ee479aad4fa53aa2c42c478f1aaa5a))
 
 ## <small>0.7.3 (2021-06-09)</small>
 
-* [bitnami/grafana operator] Make the securityContexts more customizable. (#6594) ([75208c2](https://github.com/bitnami/charts/commit/75208c2)), closes [#6594](https://github.com/bitnami/charts/issues/6594)
+* [bitnami/grafana operator] Make the securityContexts more customizable. (#6594) ([75208c2](https://github.com/bitnami/charts/commit/75208c2f73dcd4162d0305ba38d8442e3b2d4c8e)), closes [#6594](https://github.com/bitnami/charts/issues/6594)
 
 ## <small>0.7.2 (2021-05-14)</small>
 
-* [bitnami/grafana-operator] Release 0.7.2 updating components versions ([2dd32b4](https://github.com/bitnami/charts/commit/2dd32b4))
+* [bitnami/grafana-operator] Release 0.7.2 updating components versions ([2dd32b4](https://github.com/bitnami/charts/commit/2dd32b4c6be4e41ce9794bd6e234b9c788cd1c39))
 
 ## <small>0.7.1 (2021-05-13)</small>
 
-* [bitnami/grafana-operator] Fix security context changed at #6309 (#6355) ([5284619](https://github.com/bitnami/charts/commit/5284619)), closes [#6309](https://github.com/bitnami/charts/issues/6309) [#6355](https://github.com/bitnami/charts/issues/6355)
+* [bitnami/grafana-operator] Fix security context changed at #6309 (#6355) ([5284619](https://github.com/bitnami/charts/commit/52846194e62179bf6729981de70900de060ab360)), closes [#6309](https://github.com/bitnami/charts/issues/6309) [#6355](https://github.com/bitnami/charts/issues/6355)
 
 ## 0.7.0 (2021-05-07)
 
-*  [bitnami/grafana-operator] Updated and Corrected RBAC and added containerSecurityContext. (#6309) ([14f5d19](https://github.com/bitnami/charts/commit/14f5d19)), closes [#6309](https://github.com/bitnami/charts/issues/6309)
+*  [bitnami/grafana-operator] Updated and Corrected RBAC and added containerSecurityContext. (#6309) ([14f5d19](https://github.com/bitnami/charts/commit/14f5d1988fc8394e2fb1aa1e20159dd5655fa003)), closes [#6309](https://github.com/bitnami/charts/issues/6309)
 
 ## <small>0.6.5 (2021-04-20)</small>
 
-* [bitnami/grafana-operator] Release 0.6.5 updating components versions ([481f733](https://github.com/bitnami/charts/commit/481f733))
+* [bitnami/grafana-operator] Release 0.6.5 updating components versions ([481f733](https://github.com/bitnami/charts/commit/481f733a903df5e7394f383ee9b02bb2920860b5))
 
 ## <small>0.6.4 (2021-03-29)</small>
 
-* [bitnami/grafana-operator] Added support for configmaps in global rbac role. (#5926) ([499d16c](https://github.com/bitnami/charts/commit/499d16c)), closes [#5926](https://github.com/bitnami/charts/issues/5926)
+* [bitnami/grafana-operator] Added support for configmaps in global rbac role. (#5926) ([499d16c](https://github.com/bitnami/charts/commit/499d16cc2fc7fa5f67e73fc6f1c58858418d52be)), closes [#5926](https://github.com/bitnami/charts/issues/5926)
 
 ## <small>0.6.3 (2021-03-24)</small>
 
-* [bitnami/grafana-operator] Fix issue when serviceAccount field is empty (#5896) ([9f9e271](https://github.com/bitnami/charts/commit/9f9e271)), closes [#5896](https://github.com/bitnami/charts/issues/5896)
+* [bitnami/grafana-operator] Fix issue when serviceAccount field is empty (#5896) ([9f9e271](https://github.com/bitnami/charts/commit/9f9e27176b023fc0b5c9413bf118a5d754aec2da)), closes [#5896](https://github.com/bitnami/charts/issues/5896)
 
 ## <small>0.6.2 (2021-03-23)</small>
 
-* [bitnami/grafana-operator] Add image pull secrets to grafana template (#5869) ([dea0b4a](https://github.com/bitnami/charts/commit/dea0b4a)), closes [#5869](https://github.com/bitnami/charts/issues/5869)
+* [bitnami/grafana-operator] Add image pull secrets to grafana template (#5869) ([dea0b4a](https://github.com/bitnami/charts/commit/dea0b4a0b38eb547ab47698b2228d8548ee024cb)), closes [#5869](https://github.com/bitnami/charts/issues/5869)
 
 ## <small>0.6.1 (2021-03-14)</small>
 
-* [bitnami/grafana-operator] Release 0.6.1 updating components versions ([0b48c98](https://github.com/bitnami/charts/commit/0b48c98))
+* [bitnami/grafana-operator] Release 0.6.1 updating components versions ([0b48c98](https://github.com/bitnami/charts/commit/0b48c9808a3caefebd8bb8c3f45086c1d6ecf757))
 
 ## 0.6.0 (2021-03-04)
 
-* [bitnami/grafana-operator] Replace adminUser and adminPassword with config.security.admin_* (#5661) ([7d677b7](https://github.com/bitnami/charts/commit/7d677b7)), closes [#5661](https://github.com/bitnami/charts/issues/5661)
+* [bitnami/grafana-operator] Replace adminUser and adminPassword with config.security.admin_* (#5661) ([7d677b7](https://github.com/bitnami/charts/commit/7d677b72d691b6feb1ba5a21db41375ab7f6633d)), closes [#5661](https://github.com/bitnami/charts/issues/5661)
 
 ## 0.5.0 (2021-03-02)
 
-* [bitnami/grafana-operator] Add support for mounting extra files into the Grafana Pod (#5623) ([5bc1a67](https://github.com/bitnami/charts/commit/5bc1a67)), closes [#5623](https://github.com/bitnami/charts/issues/5623)
+* [bitnami/grafana-operator] Add support for mounting extra files into the Grafana Pod (#5623) ([5bc1a67](https://github.com/bitnami/charts/commit/5bc1a670cb64792e713b053e87e5d9a69666b612)), closes [#5623](https://github.com/bitnami/charts/issues/5623)
 
 ## 0.4.0 (2021-02-26)
 
-* [bitnami/grafana-operator] Provide mechanism to define extra objects (#5614) ([eae34fd](https://github.com/bitnami/charts/commit/eae34fd)), closes [#5614](https://github.com/bitnami/charts/issues/5614)
+* [bitnami/grafana-operator] Provide mechanism to define extra objects (#5614) ([eae34fd](https://github.com/bitnami/charts/commit/eae34fdbf16e2cb6a6f809d72cd22f98f6bceccc)), closes [#5614](https://github.com/bitnami/charts/issues/5614)
 
 ## <small>0.3.2 (2021-02-22)</small>
 
-* [bitnami/*] Use common macro to define RBAC apiVersion (#5585) ([71fb99f](https://github.com/bitnami/charts/commit/71fb99f)), closes [#5585](https://github.com/bitnami/charts/issues/5585)
+* [bitnami/*] Use common macro to define RBAC apiVersion (#5585) ([71fb99f](https://github.com/bitnami/charts/commit/71fb99f541e971b1daafaa20ffb7d18b153b8d60)), closes [#5585](https://github.com/bitnami/charts/issues/5585)
 
 ## <small>0.3.1 (2021-02-12)</small>
 
-* [bitnami/grafana-operator] Release 0.3.1 updating components versions ([17333db](https://github.com/bitnami/charts/commit/17333db))
+* [bitnami/grafana-operator] Release 0.3.1 updating components versions ([17333db](https://github.com/bitnami/charts/commit/17333db774e484dac500d91779ef26e073e9c6cf))
 
 ## 0.3.0 (2021-02-09)
 
-* [bitnami/grafana-operator] Add credentials support (#5429) ([e7b37db](https://github.com/bitnami/charts/commit/e7b37db)), closes [#5429](https://github.com/bitnami/charts/issues/5429)
-* [bitnami/grafana, grafana-operator] Add documentation explaining differences between operator and ch ([fca980f](https://github.com/bitnami/charts/commit/fca980f)), closes [#5362](https://github.com/bitnami/charts/issues/5362)
+* [bitnami/grafana-operator] Add credentials support (#5429) ([e7b37db](https://github.com/bitnami/charts/commit/e7b37db6cebeb5c65d0fda97e66be9a7c0220607)), closes [#5429](https://github.com/bitnami/charts/issues/5429)
+* [bitnami/grafana, grafana-operator] Add documentation explaining differences between operator and ch ([fca980f](https://github.com/bitnami/charts/commit/fca980fc40e8d7a60480e525dd936ac5cba61b0d)), closes [#5362](https://github.com/bitnami/charts/issues/5362)
 
 ## 0.2.0 (2021-01-28)
 
-* [bitnami/grafana-operator] Add hostAliases (#5243) ([9568bdf](https://github.com/bitnami/charts/commit/9568bdf)), closes [#5243](https://github.com/bitnami/charts/issues/5243)
+* [bitnami/grafana-operator] Add hostAliases (#5243) ([9568bdf](https://github.com/bitnami/charts/commit/9568bdf7d791802effe6df1efb5bce5f7b18c3e3)), closes [#5243](https://github.com/bitnami/charts/issues/5243)
 
 ## <small>0.1.5 (2021-01-25)</small>
 
-* [bitnami/*] Unify icons in Chart.yaml and add missing fields (#5206) ([0462921](https://github.com/bitnami/charts/commit/0462921)), closes [#5206](https://github.com/bitnami/charts/issues/5206)
+* [bitnami/*] Unify icons in Chart.yaml and add missing fields (#5206) ([0462921](https://github.com/bitnami/charts/commit/0462921418ca8d54308b7466197a6d53ffae4628)), closes [#5206](https://github.com/bitnami/charts/issues/5206)
 
 ## <small>0.1.4 (2021-01-21)</small>
 
-* [bitnami/*] Change helm version in the prerequisites (#5090) ([c5e67a3](https://github.com/bitnami/charts/commit/c5e67a3)), closes [#5090](https://github.com/bitnami/charts/issues/5090)
-* [bitnami/grafana-operator] Release 0.1.4 updating components versions ([60c6ebf](https://github.com/bitnami/charts/commit/60c6ebf))
+* [bitnami/*] Change helm version in the prerequisites (#5090) ([c5e67a3](https://github.com/bitnami/charts/commit/c5e67a388743cbee28439d2cabca27884b9daf97)), closes [#5090](https://github.com/bitnami/charts/issues/5090)
+* [bitnami/grafana-operator] Release 0.1.4 updating components versions ([60c6ebf](https://github.com/bitnami/charts/commit/60c6ebffe5b272845a4924dbe39eb89f91da93d9))
 
 ## <small>0.1.3 (2021-01-19)</small>
 
-* [bitnami/grafana-operator] Release 0.1.3 updating components versions ([7fc4bb1](https://github.com/bitnami/charts/commit/7fc4bb1))
+* [bitnami/grafana-operator] Release 0.1.3 updating components versions ([7fc4bb1](https://github.com/bitnami/charts/commit/7fc4bb1861524294a96172c52a538f1fa18d8449))
 
 ## <small>0.1.2 (2021-01-15)</small>
 
-* [bitnami/grafana-operator] Update documentation for Plugin Init Container. (#5046) ([fe3bffb](https://github.com/bitnami/charts/commit/fe3bffb)), closes [#5046](https://github.com/bitnami/charts/issues/5046)
+* [bitnami/grafana-operator] Update documentation for Plugin Init Container. (#5046) ([fe3bffb](https://github.com/bitnami/charts/commit/fe3bffb5e190a4102a4a1a25f95c2bbca55223ce)), closes [#5046](https://github.com/bitnami/charts/issues/5046)
 
 ## <small>0.1.1 (2021-01-09)</small>
 
-* [bitnami/grafana-operator] Release 0.1.1 updating components versions ([de0435f](https://github.com/bitnami/charts/commit/de0435f))
+* [bitnami/grafana-operator] Release 0.1.1 updating components versions ([de0435f](https://github.com/bitnami/charts/commit/de0435fea791158be5add37f13fea66593f81566))
 
 ## 0.1.0 (2021-01-08)
 
-* [bitnami/grafana-operator] Added grafana-operator Chart (#3287) ([e630c6e](https://github.com/bitnami/charts/commit/e630c6e)), closes [#3287](https://github.com/bitnami/charts/issues/3287)
+* [bitnami/grafana-operator] Added grafana-operator Chart (#3287) ([e630c6e](https://github.com/bitnami/charts/commit/e630c6ececd540c2429de644b3db429cf26a035e)), closes [#3287](https://github.com/bitnami/charts/issues/3287)

--- a/bitnami/grafana-operator/Chart.yaml
+++ b/bitnami/grafana-operator/Chart.yaml
@@ -30,4 +30,4 @@ maintainers:
 name: grafana-operator
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/grafana-operator
-version: 4.3.0
+version: 4.3.1

--- a/bitnami/grafana-operator/templates/grafana.yaml
+++ b/bitnami/grafana-operator/templates/grafana.yaml
@@ -147,10 +147,8 @@ spec:
                 timeoutSeconds: {{ .Values.grafana.livenessProbe.timeoutSeconds }}
                 successThreshold: {{ .Values.grafana.livenessProbe.successThreshold }}
                 failureThreshold: {{ .Values.grafana.livenessProbe.failureThreshold }}
-                httpGet:
-                  path: /api/health
+                tcpSocket:
                   port: 3000
-                  scheme: HTTP
               {{- end }}
               {{- if .Values.grafana.readinessProbe.enabled }}
               readinessProbe:


### PR DESCRIPTION
### Description of the change
This PR aims to use different liveness/readiness probes to improve overall security and avoid unnecessary container restarts. [More info](https://github.com/zegl/kube-score/blob/master/README_PROBES.md).

### Benefits

Increase availability and resilience.

### Possible drawbacks

N/A

### Applicable issues

- fixes #

### Additional information

- Related to #23537

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- ~[X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)~
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
