### PR TITLE
[bitnami/appsmith] Use different liveness/readiness probes

### DIFF
--- a/bitnami/appsmith/CHANGELOG.md
+++ b/bitnami/appsmith/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 3.2.1 (2024-05-22)
+## 3.2.2 (2024-05-23)
 
-* [bitnami/appsmith] Release 3.2.1 ([#26335](https://github.com/bitnami/charts/pull/26335))
+* [bitnami/appsmith] Use different liveness/readiness probes ([#26332](https://github.com/bitnami/charts/pull/26332))
+
+## <small>3.2.1 (2024-05-22)</small>
+
+* [bitnami/appsmith] Release 3.2.1 (#26335) ([091403e](https://github.com/bitnami/charts/commit/091403e4e8ee633aedc047c9fe713c7215152e71)), closes [#26335](https://github.com/bitnami/charts/issues/26335)
 
 ## 3.2.0 (2024-05-21)
 

--- a/bitnami/appsmith/Chart.lock
+++ b/bitnami/appsmith/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: redis
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 19.4.0
+  version: 19.5.0
 - name: mongodb
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 15.5.1
+  version: 15.5.2
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 2.19.3
-digest: sha256:ca11d14a9b288a39f6e78da9f528ae7ff17ed76dfdcc30a7b8d032ca100e969b
-generated: "2024-05-22T13:33:45.402484875Z"
+digest: sha256:f918e85ea46e0e3aaf864c2a6d9e0a3bdb85aa41f89fb23004bbbc0c19edbf36
+generated: "2024-05-23T16:38:10.276516+02:00"

--- a/bitnami/appsmith/Chart.yaml
+++ b/bitnami/appsmith/Chart.yaml
@@ -39,4 +39,4 @@ maintainers:
 name: appsmith
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/appsmith
-version: 3.2.1
+version: 3.2.2

--- a/bitnami/appsmith/templates/backend/deployment.yaml
+++ b/bitnami/appsmith/templates/backend/deployment.yaml
@@ -223,7 +223,7 @@ spec:
           {{- else if .Values.backend.readinessProbe.enabled }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.backend.readinessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
-              path: /api/v1/users/me
+              path: /api/v1/health
               port: http
           {{- end }}
           {{- if .Values.backend.customStartupProbe }}
@@ -231,7 +231,7 @@ spec:
           {{- else if .Values.backend.startupProbe.enabled }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.backend.startupProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
-              path: /api/v1/users/me
+              path: /api/v1/health
               port: http
           {{- end }}
           {{- end }}

--- a/bitnami/appsmith/templates/backend/deployment.yaml
+++ b/bitnami/appsmith/templates/backend/deployment.yaml
@@ -215,8 +215,7 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.backend.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.backend.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.backend.livenessProbe "enabled") "context" $) | nindent 12 }}
-            httpGet:
-              path: /api/v1/users/me
+            tcpSocket:
               port: http
           {{- end }}
           {{- if .Values.backend.customReadinessProbe }}

--- a/bitnami/appsmith/templates/client/deployment.yaml
+++ b/bitnami/appsmith/templates/client/deployment.yaml
@@ -163,8 +163,7 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.client.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.client.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.client.livenessProbe "enabled") "context" $) | nindent 12 }}
-            httpGet:
-              path: /
+            tcpSocket:
               port: http
           {{- end }}
           {{- if .Values.client.customReadinessProbe }}

--- a/bitnami/appsmith/templates/rts/deployment.yaml
+++ b/bitnami/appsmith/templates/rts/deployment.yaml
@@ -139,8 +139,7 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.rts.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.rts.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.rts.livenessProbe "enabled") "context" $) | nindent 12 }}
-            httpGet:
-              path: /rts-api/v1/health-check
+            tcpSocket:
               port: http
           {{- end }}
           {{- if .Values.rts.customReadinessProbe }}


### PR DESCRIPTION
### Description of the change
This PR aims to use different liveness/readiness probes to improve overall security and avoid unnecessary container restarts. [More info](https://github.com/zegl/kube-score/blob/master/README_PROBES.md).

### Benefits

Increase availability and resilience.

### Possible drawbacks

N/A

### Applicable issues

- fixes #

### Additional information

- Related to #23537

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- ~[X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)~
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
