### PR TITLE
[bitnami/apisix] Use different liveness/readiness probes

### DIFF
--- a/bitnami/apisix/CHANGELOG.md
+++ b/bitnami/apisix/CHANGELOG.md
@@ -1,261 +1,266 @@
 # Changelog
 
+## 3.1.1 (2024-05-22)
+
+* [bitnami/apisix] Use different liveness/readiness probes ([#26337](https://github.com/bitnami/charts/pull/26337))
+
 ## 3.1.0 (2024-05-21)
 
-* [bitnami/apisix] feat: :sparkles: :lock: Add warning when original images are replaced ([#26180](https://github.com/bitnami/charts/pulls/26180))
+* [bitnami/*] ci: :construction_worker: Add tag and changelog support (#25359) ([91c707c](https://github.com/bitnami/charts/commit/91c707c9e4e574725a09505d2d313fb93f1b4c0a)), closes [#25359](https://github.com/bitnami/charts/issues/25359)
+* [bitnami/apisix] feat: :sparkles: :lock: Add warning when original images are replaced (#26180) ([ff34236](https://github.com/bitnami/charts/commit/ff34236e01aca549eeba0a9e67544d5d562a6da8)), closes [#26180](https://github.com/bitnami/charts/issues/26180)
 
 ## <small>3.0.6 (2024-05-17)</small>
 
-* [bitnami/apisix] Release 3.0.6 updating components versions (#25998) ([8277ffb](https://github.com/bitnami/charts/commit/8277ffb)), closes [#25998](https://github.com/bitnami/charts/issues/25998)
+* [bitnami/apisix] Release 3.0.6 updating components versions (#25998) ([8277ffb](https://github.com/bitnami/charts/commit/8277ffb22a4acb228f4970ff491e34a6db5a7195)), closes [#25998](https://github.com/bitnami/charts/issues/25998)
 
 ## <small>3.0.5 (2024-05-13)</small>
 
-* [bitnami/apisix] Release 3.0.5 updating components versions (#25738) ([cbe8f03](https://github.com/bitnami/charts/commit/cbe8f03)), closes [#25738](https://github.com/bitnami/charts/issues/25738)
+* [bitnami/apisix] Release 3.0.5 updating components versions (#25738) ([cbe8f03](https://github.com/bitnami/charts/commit/cbe8f03d95152df967b4c46b37c2312d84db0107)), closes [#25738](https://github.com/bitnami/charts/issues/25738)
 
 ## <small>3.0.4 (2024-05-13)</small>
 
-* [bitnami/*] Change non-root and rolling-tags doc URLs (#25628) ([b067c94](https://github.com/bitnami/charts/commit/b067c94)), closes [#25628](https://github.com/bitnami/charts/issues/25628)
-* [bitnami/*] Set new header/owner (#25558) ([8d1dc11](https://github.com/bitnami/charts/commit/8d1dc11)), closes [#25558](https://github.com/bitnami/charts/issues/25558)
-* [bitnami/apisix] Release 3.0.4 (#25695) ([7ee0ee7](https://github.com/bitnami/charts/commit/7ee0ee7)), closes [#25695](https://github.com/bitnami/charts/issues/25695)
-* [bitnami/multiple charts] Fix typo: "NetworkPolice" vs "NetworkPolicy" (#25348) ([6970c1b](https://github.com/bitnami/charts/commit/6970c1b)), closes [#25348](https://github.com/bitnami/charts/issues/25348)
-* Replace VMware by Broadcom copyright text (#25306) ([a5e4bd0](https://github.com/bitnami/charts/commit/a5e4bd0)), closes [#25306](https://github.com/bitnami/charts/issues/25306)
+* [bitnami/*] Change non-root and rolling-tags doc URLs (#25628) ([b067c94](https://github.com/bitnami/charts/commit/b067c94f6bcde427863c197fd355f0b5ba12ff5b)), closes [#25628](https://github.com/bitnami/charts/issues/25628)
+* [bitnami/*] Set new header/owner (#25558) ([8d1dc11](https://github.com/bitnami/charts/commit/8d1dc11f5fb30db6fba50c43d7af59d2f79deed3)), closes [#25558](https://github.com/bitnami/charts/issues/25558)
+* [bitnami/apisix] Release 3.0.4 (#25695) ([7ee0ee7](https://github.com/bitnami/charts/commit/7ee0ee7d2de6235716d1f6c1eeceb1cfc697bc1c)), closes [#25695](https://github.com/bitnami/charts/issues/25695)
+* [bitnami/multiple charts] Fix typo: "NetworkPolice" vs "NetworkPolicy" (#25348) ([6970c1b](https://github.com/bitnami/charts/commit/6970c1ba245873506e73d459c6eac1e4919b778f)), closes [#25348](https://github.com/bitnami/charts/issues/25348)
+* Replace VMware by Broadcom copyright text (#25306) ([a5e4bd0](https://github.com/bitnami/charts/commit/a5e4bd0e35e419203793976a78d9d0a13de92c76)), closes [#25306](https://github.com/bitnami/charts/issues/25306)
 
 ## <small>3.0.3 (2024-04-24)</small>
 
-* [bitnami/apisix] Release 3.0.3 (#25355) ([933cba1](https://github.com/bitnami/charts/commit/933cba1)), closes [#25355](https://github.com/bitnami/charts/issues/25355)
+* [bitnami/apisix] Release 3.0.3 (#25355) ([933cba1](https://github.com/bitnami/charts/commit/933cba1d35db8b5c1c4146f0c7207dc30b170f1c)), closes [#25355](https://github.com/bitnami/charts/issues/25355)
 
 ## <small>3.0.2 (2024-04-09)</small>
 
-* [bitnami/apisix] fix: :bug: :lock: Do not expose http-metrics unless metrics.enabled=true (#25041) ([e35f1d6](https://github.com/bitnami/charts/commit/e35f1d6)), closes [#25041](https://github.com/bitnami/charts/issues/25041)
-* Update resourcesPreset comments (#24467) ([92e3e8a](https://github.com/bitnami/charts/commit/92e3e8a)), closes [#24467](https://github.com/bitnami/charts/issues/24467)
+* [bitnami/apisix] fix: :bug: :lock: Do not expose http-metrics unless metrics.enabled=true (#25041) ([e35f1d6](https://github.com/bitnami/charts/commit/e35f1d65e23e5a282f5e832cb279f3ba9eef3f8f)), closes [#25041](https://github.com/bitnami/charts/issues/25041)
+* Update resourcesPreset comments (#24467) ([92e3e8a](https://github.com/bitnami/charts/commit/92e3e8a507326d2a20a8f10ab3e7746a2ec5c554)), closes [#24467](https://github.com/bitnami/charts/issues/24467)
 
 ## <small>3.0.1 (2024-03-22)</small>
 
-* [bitnami/apisix] Fix disable tls on controlPlane and dataPlane (#24600) ([0a85409](https://github.com/bitnami/charts/commit/0a85409)), closes [#24600](https://github.com/bitnami/charts/issues/24600)
+* [bitnami/apisix] Fix disable tls on controlPlane and dataPlane (#24600) ([0a85409](https://github.com/bitnami/charts/commit/0a85409d3a32eb43ff3862b95a3a6d7d9c9450c5)), closes [#24600](https://github.com/bitnami/charts/issues/24600)
 
 ## 3.0.0 (2024-03-19)
 
-* [bitnami/*] Reorder Chart sections (#24455) ([0cf4048](https://github.com/bitnami/charts/commit/0cf4048)), closes [#24455](https://github.com/bitnami/charts/issues/24455)
-* [bitnami/apisix] feat!: :lock: :boom: Improve security defaults (#24509) ([25ba86e](https://github.com/bitnami/charts/commit/25ba86e)), closes [#24509](https://github.com/bitnami/charts/issues/24509)
+* [bitnami/*] Reorder Chart sections (#24455) ([0cf4048](https://github.com/bitnami/charts/commit/0cf4048e8743f70a9753d460655bd030cbff6824)), closes [#24455](https://github.com/bitnami/charts/issues/24455)
+* [bitnami/apisix] feat!: :lock: :boom: Improve security defaults (#24509) ([25ba86e](https://github.com/bitnami/charts/commit/25ba86e67492acd60ab463d9ebd9a52ee72fe354)), closes [#24509](https://github.com/bitnami/charts/issues/24509)
 
 ## 2.10.0 (2024-03-06)
 
-* [bitnami/apisix] feat: :sparkles: :lock: Add automatic adaptation for Openshift restricted-v2 SCC (# ([6e5bd3e](https://github.com/bitnami/charts/commit/6e5bd3e)), closes [#24061](https://github.com/bitnami/charts/issues/24061)
+* [bitnami/apisix] feat: :sparkles: :lock: Add automatic adaptation for Openshift restricted-v2 SCC (# ([6e5bd3e](https://github.com/bitnami/charts/commit/6e5bd3ef90e457d6ee0f3b7984707b92fd014e03)), closes [#24061](https://github.com/bitnami/charts/issues/24061)
 
 ## 2.9.0 (2024-02-27)
 
-* [bitnami/apisix] feat: :sparkles: :lock: Add runAsGroup (#23874) ([166932f](https://github.com/bitnami/charts/commit/166932f)), closes [#23874](https://github.com/bitnami/charts/issues/23874)
+* [bitnami/apisix] feat: :sparkles: :lock: Add runAsGroup (#23874) ([166932f](https://github.com/bitnami/charts/commit/166932f59c7625187cab5a04453582f5b169e1c0)), closes [#23874](https://github.com/bitnami/charts/issues/23874)
 
 ## <small>2.8.2 (2024-02-21)</small>
 
-* [bitnami/apisix] Release 2.8.2 updating components versions (#23733) ([7946235](https://github.com/bitnami/charts/commit/7946235)), closes [#23733](https://github.com/bitnami/charts/issues/23733)
+* [bitnami/apisix] Release 2.8.2 updating components versions (#23733) ([7946235](https://github.com/bitnami/charts/commit/7946235da8cf482a26ba7c4cbd3977d96056bc4d)), closes [#23733](https://github.com/bitnami/charts/issues/23733)
 
 ## <small>2.8.1 (2024-02-21)</small>
 
-* [bitnami/apisix] Release 2.8.1 updating components versions (#23628) ([a5a7f2f](https://github.com/bitnami/charts/commit/a5a7f2f)), closes [#23628](https://github.com/bitnami/charts/issues/23628)
+* [bitnami/apisix] Release 2.8.1 updating components versions (#23628) ([a5a7f2f](https://github.com/bitnami/charts/commit/a5a7f2f3f0c7621f1d443661896b8e1f8980b02b)), closes [#23628](https://github.com/bitnami/charts/issues/23628)
 
 ## 2.8.0 (2024-02-20)
 
-* [bitnami/*] Bump all versions (#23602) ([b70ee2a](https://github.com/bitnami/charts/commit/b70ee2a)), closes [#23602](https://github.com/bitnami/charts/issues/23602)
+* [bitnami/*] Bump all versions (#23602) ([b70ee2a](https://github.com/bitnami/charts/commit/b70ee2a30e4dc256bf0ac52928fb2fa7a70f049b)), closes [#23602](https://github.com/bitnami/charts/issues/23602)
 
 ## 2.7.0 (2024-02-16)
 
-* [bitnami/apisix] feat: :sparkles: :lock: Add resource preset support (#23429) ([98bc8f0](https://github.com/bitnami/charts/commit/98bc8f0)), closes [#23429](https://github.com/bitnami/charts/issues/23429)
+* [bitnami/apisix] feat: :sparkles: :lock: Add resource preset support (#23429) ([98bc8f0](https://github.com/bitnami/charts/commit/98bc8f0994b87bff7382d52268eaa1cdfb9b7730)), closes [#23429](https://github.com/bitnami/charts/issues/23429)
 
 ## <small>2.6.1 (2024-02-14)</small>
 
-* fix: allow disabling tls for dashboard and ingressController properly (#23389) ([633d712](https://github.com/bitnami/charts/commit/633d712)), closes [#23389](https://github.com/bitnami/charts/issues/23389)
+* fix: allow disabling tls for dashboard and ingressController properly (#23389) ([633d712](https://github.com/bitnami/charts/commit/633d7125d19e7c6cd672658fed4a7bf23f12f1b9)), closes [#23389](https://github.com/bitnami/charts/issues/23389)
 
 ## 2.6.0 (2024-02-13)
 
-* [bitnami/apisix] feat: :lock: Enable networkPolicy (#23365) ([98d94a8](https://github.com/bitnami/charts/commit/98d94a8)), closes [#23365](https://github.com/bitnami/charts/issues/23365)
+* [bitnami/apisix] feat: :lock: Enable networkPolicy (#23365) ([98d94a8](https://github.com/bitnami/charts/commit/98d94a899968ea8369c385e965f73623bea28bf6)), closes [#23365](https://github.com/bitnami/charts/issues/23365)
 
 ## <small>2.5.8 (2024-02-09)</small>
 
-* [bitnami/apisix] Release 2.5.8 updating components versions (#23367) ([0ab18bd](https://github.com/bitnami/charts/commit/0ab18bd)), closes [#23367](https://github.com/bitnami/charts/issues/23367)
+* [bitnami/apisix] Release 2.5.8 updating components versions (#23367) ([0ab18bd](https://github.com/bitnami/charts/commit/0ab18bd9efb01fb2b1c0310148970593b0259cee)), closes [#23367](https://github.com/bitnami/charts/issues/23367)
 
 ## <small>2.5.7 (2024-02-09)</small>
 
-* [bitnami/apisix] Release 2.5.7 updating components versions (#23366) ([20003a3](https://github.com/bitnami/charts/commit/20003a3)), closes [#23366](https://github.com/bitnami/charts/issues/23366)
+* [bitnami/apisix] Release 2.5.7 updating components versions (#23366) ([20003a3](https://github.com/bitnami/charts/commit/20003a38cfd0ee96121f2c99ddfef1dc60dec9e6)), closes [#23366](https://github.com/bitnami/charts/issues/23366)
 
 ## <small>2.5.6 (2024-02-05)</small>
 
-* [bitnami/apisix] Release 2.5.6 updating components versions (#23154) ([9b5de30](https://github.com/bitnami/charts/commit/9b5de30)), closes [#23154](https://github.com/bitnami/charts/issues/23154)
+* [bitnami/apisix] Release 2.5.6 updating components versions (#23154) ([9b5de30](https://github.com/bitnami/charts/commit/9b5de30e9a21520dab21ae5bd3d3c022cda5b7c8)), closes [#23154](https://github.com/bitnami/charts/issues/23154)
 
 ## <small>2.5.5 (2024-02-01)</small>
 
-* [bitnami/apisix] Release 2.5.5 updating components versions (#23011) ([a3944a2](https://github.com/bitnami/charts/commit/a3944a2)), closes [#23011](https://github.com/bitnami/charts/issues/23011)
+* [bitnami/apisix] Release 2.5.5 updating components versions (#23011) ([a3944a2](https://github.com/bitnami/charts/commit/a3944a21a4a8cc75879255dc9464381ed5e0e90d)), closes [#23011](https://github.com/bitnami/charts/issues/23011)
 
 ## <small>2.5.4 (2024-01-31)</small>
 
-* [bitnami/apisix] Update CRDs and add headers for automatic update (#22883) ([f827a92](https://github.com/bitnami/charts/commit/f827a92)), closes [#22883](https://github.com/bitnami/charts/issues/22883)
+* [bitnami/apisix] Update CRDs and add headers for automatic update (#22883) ([f827a92](https://github.com/bitnami/charts/commit/f827a927d9013930d94e60a7fd82c0edfe078faf)), closes [#22883](https://github.com/bitnami/charts/issues/22883)
 
 ## <small>2.5.3 (2024-01-30)</small>
 
-* [bitnami/apisix] Release 2.5.3 updating components versions (#22845) ([f9819d9](https://github.com/bitnami/charts/commit/f9819d9)), closes [#22845](https://github.com/bitnami/charts/issues/22845)
+* [bitnami/apisix] Release 2.5.3 updating components versions (#22845) ([f9819d9](https://github.com/bitnami/charts/commit/f9819d96fe31818230285670de2b50996fc09739)), closes [#22845](https://github.com/bitnami/charts/issues/22845)
 
 ## <small>2.5.2 (2024-01-25)</small>
 
-* [bitnami/*] Move documentation sections from docs.bitnami.com back to the README (#22203) ([7564f36](https://github.com/bitnami/charts/commit/7564f36)), closes [#22203](https://github.com/bitnami/charts/issues/22203)
-* [bitnami/apisix] fix: :bug: Set seLinuxOptions to null for Openshift compatibility (#22567) ([6829af8](https://github.com/bitnami/charts/commit/6829af8)), closes [#22567](https://github.com/bitnami/charts/issues/22567)
+* [bitnami/*] Move documentation sections from docs.bitnami.com back to the README (#22203) ([7564f36](https://github.com/bitnami/charts/commit/7564f36ca1e95ff30ee686652b7ab8690561a707)), closes [#22203](https://github.com/bitnami/charts/issues/22203)
+* [bitnami/apisix] fix: :bug: Set seLinuxOptions to null for Openshift compatibility (#22567) ([6829af8](https://github.com/bitnami/charts/commit/6829af8b96ee8ce999da4230103b1c7c4b77622e)), closes [#22567](https://github.com/bitnami/charts/issues/22567)
 
 ## <small>2.5.1 (2024-01-22)</small>
 
-* [bitnami/apisix] fix: :bug: Enable liveness probe (#22520) ([37434b9](https://github.com/bitnami/charts/commit/37434b9)), closes [#22520](https://github.com/bitnami/charts/issues/22520)
+* [bitnami/apisix] fix: :bug: Enable liveness probe (#22520) ([37434b9](https://github.com/bitnami/charts/commit/37434b9b3871354630be44e12f484a630ef97713)), closes [#22520](https://github.com/bitnami/charts/issues/22520)
 
 ## 2.5.0 (2024-01-19)
 
-* [bitnami/apisix] fix: :lock: Move service-account token auto-mount to pod declaration (#22383) ([b0d9555](https://github.com/bitnami/charts/commit/b0d9555)), closes [#22383](https://github.com/bitnami/charts/issues/22383)
+* [bitnami/apisix] fix: :lock: Move service-account token auto-mount to pod declaration (#22383) ([b0d9555](https://github.com/bitnami/charts/commit/b0d955566b932bdd30d1eec409caea91a77c0f07)), closes [#22383](https://github.com/bitnami/charts/issues/22383)
 
 ## <small>2.4.3 (2024-01-18)</small>
 
-* [bitnami/apisix] Release 2.4.3 updating components versions (#22342) ([a86706d](https://github.com/bitnami/charts/commit/a86706d)), closes [#22342](https://github.com/bitnami/charts/issues/22342)
+* [bitnami/apisix] Release 2.4.3 updating components versions (#22342) ([a86706d](https://github.com/bitnami/charts/commit/a86706d2e52ea0ee9e56be4da49eec46a0ba94c6)), closes [#22342](https://github.com/bitnami/charts/issues/22342)
 
 ## <small>2.4.2 (2024-01-17)</small>
 
-* Revert "[bitnami/apisix] feat: :lock: Allow limit access to secrets by namespace (#22224)" ([85fc083](https://github.com/bitnami/charts/commit/85fc083)), closes [#22224](https://github.com/bitnami/charts/issues/22224)
+* Revert "[bitnami/apisix] feat: :lock: Allow limit access to secrets by namespace (#22224)" ([85fc083](https://github.com/bitnami/charts/commit/85fc083c026c8ded296c609be884848770dae769)), closes [#22224](https://github.com/bitnami/charts/issues/22224)
 
 ## <small>2.4.1 (2024-01-17)</small>
 
-* [bitnami/apisix] Fixed the bug of disabling control-plane TLS (#22240) ([8dea304](https://github.com/bitnami/charts/commit/8dea304)), closes [#22240](https://github.com/bitnami/charts/issues/22240)
+* [bitnami/apisix] Fixed the bug of disabling control-plane TLS (#22240) ([8dea304](https://github.com/bitnami/charts/commit/8dea3046ebfc70fd1e758486ad8b31fd13ce7ad8)), closes [#22240](https://github.com/bitnami/charts/issues/22240)
 
 ## 2.4.0 (2024-01-16)
 
-* [bitnami/apisix] feat: :lock: Allow limit access to secrets by namespace (#22224) ([1866370](https://github.com/bitnami/charts/commit/1866370)), closes [#22224](https://github.com/bitnami/charts/issues/22224)
+* [bitnami/apisix] feat: :lock: Allow limit access to secrets by namespace (#22224) ([1866370](https://github.com/bitnami/charts/commit/18663701847c800ae088a774e6dcc959610fcb5f)), closes [#22224](https://github.com/bitnami/charts/issues/22224)
 
 ## 2.3.0 (2024-01-16)
 
-* [bitnami/apisix] fix: :lock: Improve podSecurityContext and containerSecurityContext with essential  ([cb687e3](https://github.com/bitnami/charts/commit/cb687e3)), closes [#22098](https://github.com/bitnami/charts/issues/22098)
+* [bitnami/apisix] fix: :lock: Improve podSecurityContext and containerSecurityContext with essential  ([cb687e3](https://github.com/bitnami/charts/commit/cb687e363fefbe4a64761c7e05861b3aa69bdcf4)), closes [#22098](https://github.com/bitnami/charts/issues/22098)
 
 ## <small>2.2.9 (2024-01-15)</small>
 
-* [bitnami/*] Fix docs.bitnami.com broken links (#21901) ([f35506d](https://github.com/bitnami/charts/commit/f35506d)), closes [#21901](https://github.com/bitnami/charts/issues/21901)
-* [bitnami/*] Fix ref links (in comments) (#21822) ([e4fa296](https://github.com/bitnami/charts/commit/e4fa296)), closes [#21822](https://github.com/bitnami/charts/issues/21822)
-* [bitnami/*] Update copyright: Year and company (#21815) ([6c4bf75](https://github.com/bitnami/charts/commit/6c4bf75)), closes [#21815](https://github.com/bitnami/charts/issues/21815)
-* [bitnami/apisix] fix: :lock: Do not mount service account token unless necessary (#21986) ([c6414aa](https://github.com/bitnami/charts/commit/c6414aa)), closes [#21986](https://github.com/bitnami/charts/issues/21986)
+* [bitnami/*] Fix docs.bitnami.com broken links (#21901) ([f35506d](https://github.com/bitnami/charts/commit/f35506d2dadee4f097986e7792df1f53ab215b5d)), closes [#21901](https://github.com/bitnami/charts/issues/21901)
+* [bitnami/*] Fix ref links (in comments) (#21822) ([e4fa296](https://github.com/bitnami/charts/commit/e4fa296106b225cf8c82445727c675c7c725e380)), closes [#21822](https://github.com/bitnami/charts/issues/21822)
+* [bitnami/*] Update copyright: Year and company (#21815) ([6c4bf75](https://github.com/bitnami/charts/commit/6c4bf75dec58fc7c9aee9f089777b1a858c17d5b)), closes [#21815](https://github.com/bitnami/charts/issues/21815)
+* [bitnami/apisix] fix: :lock: Do not mount service account token unless necessary (#21986) ([c6414aa](https://github.com/bitnami/charts/commit/c6414aa21e14d17cb407677d2cf515d1ecb78371)), closes [#21986](https://github.com/bitnami/charts/issues/21986)
 
 ## <small>2.2.8 (2023-12-31)</small>
 
-* [bitnami/apisix] Release 2.2.8 updating components versions (#21798) ([56a7592](https://github.com/bitnami/charts/commit/56a7592)), closes [#21798](https://github.com/bitnami/charts/issues/21798)
+* [bitnami/apisix] Release 2.2.8 updating components versions (#21798) ([56a7592](https://github.com/bitnami/charts/commit/56a7592a7d26c70a7716f741415cfc0d4f485759)), closes [#21798](https://github.com/bitnami/charts/issues/21798)
 
 ## <small>2.2.7 (2023-11-21)</small>
 
-* [bitnami/*] Rename solutions to "Bitnami package for ..." (#21038) ([b82f979](https://github.com/bitnami/charts/commit/b82f979)), closes [#21038](https://github.com/bitnami/charts/issues/21038)
-* [bitnami/apisix] Release 2.2.7 updating components versions (#21098) ([45ac9e1](https://github.com/bitnami/charts/commit/45ac9e1)), closes [#21098](https://github.com/bitnami/charts/issues/21098)
+* [bitnami/*] Rename solutions to "Bitnami package for ..." (#21038) ([b82f979](https://github.com/bitnami/charts/commit/b82f979e4fb63423fe6e2192c946d09d79c944fc)), closes [#21038](https://github.com/bitnami/charts/issues/21038)
+* [bitnami/apisix] Release 2.2.7 updating components versions (#21098) ([45ac9e1](https://github.com/bitnami/charts/commit/45ac9e142aeb2b56527570496b2ad348930ad269)), closes [#21098](https://github.com/bitnami/charts/issues/21098)
 
 ## <small>2.2.6 (2023-11-21)</small>
 
-* [bitnami/*] Remove relative links to non-README sections, add verification for that and update TL;DR ([1103633](https://github.com/bitnami/charts/commit/1103633)), closes [#20967](https://github.com/bitnami/charts/issues/20967)
-* [bitnami/apisix] Release 2.2.6 updating components versions (#21077) ([99be4bf](https://github.com/bitnami/charts/commit/99be4bf)), closes [#21077](https://github.com/bitnami/charts/issues/21077)
+* [bitnami/*] Remove relative links to non-README sections, add verification for that and update TL;DR ([1103633](https://github.com/bitnami/charts/commit/11036334d82df0490aa4abdb591543cab6cf7d7f)), closes [#20967](https://github.com/bitnami/charts/issues/20967)
+* [bitnami/apisix] Release 2.2.6 updating components versions (#21077) ([99be4bf](https://github.com/bitnami/charts/commit/99be4bf4c1326fcf0592f26b7cd04d06d10d3152)), closes [#21077](https://github.com/bitnami/charts/issues/21077)
 
 ## <small>2.2.5 (2023-11-10)</small>
 
-* [bitnami/apisix] fix: add missing etcd config for data-plane (#20576) ([301d9da](https://github.com/bitnami/charts/commit/301d9da)), closes [#20576](https://github.com/bitnami/charts/issues/20576)
+* [bitnami/apisix] fix: add missing etcd config for data-plane (#20576) ([301d9da](https://github.com/bitnami/charts/commit/301d9daa72b1e6428cbc785e4b52068dfc67a537)), closes [#20576](https://github.com/bitnami/charts/issues/20576)
 
 ## <small>2.2.4 (2023-11-08)</small>
 
-* [bitnami/apisix] Release 2.2.4 updating components versions (#20720) ([fd561e1](https://github.com/bitnami/charts/commit/fd561e1)), closes [#20720](https://github.com/bitnami/charts/issues/20720)
+* [bitnami/apisix] Release 2.2.4 updating components versions (#20720) ([fd561e1](https://github.com/bitnami/charts/commit/fd561e104f40f2cb1ff219b5c0b95bde469d3ee3)), closes [#20720](https://github.com/bitnami/charts/issues/20720)
 
 ## <small>2.2.3 (2023-11-06)</small>
 
-* [bitnami/apisix] Fix ingress template (#18255) ([41bc0e3](https://github.com/bitnami/charts/commit/41bc0e3)), closes [#18255](https://github.com/bitnami/charts/issues/18255)
+* [bitnami/apisix] Fix ingress template (#18255) ([41bc0e3](https://github.com/bitnami/charts/commit/41bc0e3015c7a7ce103261d51d137251aa85dcd3)), closes [#18255](https://github.com/bitnami/charts/issues/18255)
 
 ## <small>2.2.2 (2023-11-04)</small>
 
-* [bitnami/apisix] Release 2.2.2 updating components versions (#20620) ([20f8a17](https://github.com/bitnami/charts/commit/20f8a17)), closes [#20620](https://github.com/bitnami/charts/issues/20620)
+* [bitnami/apisix] Release 2.2.2 updating components versions (#20620) ([20f8a17](https://github.com/bitnami/charts/commit/20f8a17543c4ca6efd9b9859c1a90aaef596f77f)), closes [#20620](https://github.com/bitnami/charts/issues/20620)
 
 ## <small>2.2.1 (2023-11-04)</small>
 
-* [bitnami/apisix] Release 2.2.1 updating components versions (#20619) ([a433454](https://github.com/bitnami/charts/commit/a433454)), closes [#20619](https://github.com/bitnami/charts/issues/20619)
+* [bitnami/apisix] Release 2.2.1 updating components versions (#20619) ([a433454](https://github.com/bitnami/charts/commit/a433454acfc19a579797df861563cb1e45962cc2)), closes [#20619](https://github.com/bitnami/charts/issues/20619)
 
 ## 2.2.0 (2023-10-31)
 
-* [bitnami/*] Rename VMware Application Catalog (#20361) ([3acc734](https://github.com/bitnami/charts/commit/3acc734)), closes [#20361](https://github.com/bitnami/charts/issues/20361)
-* [bitnami/*] Skip image's tag in the README files of the Bitnami Charts (#19841) ([bb9a01b](https://github.com/bitnami/charts/commit/bb9a01b)), closes [#19841](https://github.com/bitnami/charts/issues/19841)
-* [bitnami/*] Standardize documentation (#19835) ([af5f753](https://github.com/bitnami/charts/commit/af5f753)), closes [#19835](https://github.com/bitnami/charts/issues/19835)
-* [bitnami/apisix] feat: :sparkles: Add support for PSA restricted policy (#20419) ([a82dad6](https://github.com/bitnami/charts/commit/a82dad6)), closes [#20419](https://github.com/bitnami/charts/issues/20419)
+* [bitnami/*] Rename VMware Application Catalog (#20361) ([3acc734](https://github.com/bitnami/charts/commit/3acc73472beb6fb56c4d99f929061001205bc57e)), closes [#20361](https://github.com/bitnami/charts/issues/20361)
+* [bitnami/*] Skip image's tag in the README files of the Bitnami Charts (#19841) ([bb9a01b](https://github.com/bitnami/charts/commit/bb9a01b65911c87e48318db922cc05eb42785e42)), closes [#19841](https://github.com/bitnami/charts/issues/19841)
+* [bitnami/*] Standardize documentation (#19835) ([af5f753](https://github.com/bitnami/charts/commit/af5f7530c1bc8c5ded53a6c4f7b8f384ac1804f2)), closes [#19835](https://github.com/bitnami/charts/issues/19835)
+* [bitnami/apisix] feat: :sparkles: Add support for PSA restricted policy (#20419) ([a82dad6](https://github.com/bitnami/charts/commit/a82dad6b879481868097cdc7360225be30b4e36d)), closes [#20419](https://github.com/bitnami/charts/issues/20419)
 
 ## <small>2.1.4 (2023-10-15)</small>
 
-* [bitnami/*] Update Helm charts prerequisites (#19745) ([eb755dd](https://github.com/bitnami/charts/commit/eb755dd)), closes [#19745](https://github.com/bitnami/charts/issues/19745)
-* [bitnami/apisix] Release 2.1.4 (#20178) ([f645841](https://github.com/bitnami/charts/commit/f645841)), closes [#20178](https://github.com/bitnami/charts/issues/20178)
+* [bitnami/*] Update Helm charts prerequisites (#19745) ([eb755dd](https://github.com/bitnami/charts/commit/eb755dd36a4dd3cf6635be8e0598f9a7f4c4a554)), closes [#19745](https://github.com/bitnami/charts/issues/19745)
+* [bitnami/apisix] Release 2.1.4 (#20178) ([f645841](https://github.com/bitnami/charts/commit/f645841ba6245eb47c72c51ed55b82c65a98c748)), closes [#20178](https://github.com/bitnami/charts/issues/20178)
 
 ## <small>2.1.3 (2023-09-19)</small>
 
-* [bitnami/*] Update readme files (#19277) ([e56aeb2](https://github.com/bitnami/charts/commit/e56aeb2)), closes [#19277](https://github.com/bitnami/charts/issues/19277)
-* [bitnami/apisix] Use different app.kubernetes.io/version label on subcomponents (#19325) ([61653c9](https://github.com/bitnami/charts/commit/61653c9)), closes [#19325](https://github.com/bitnami/charts/issues/19325)
-* Autogenerate schema files (#19194) ([a2c2090](https://github.com/bitnami/charts/commit/a2c2090)), closes [#19194](https://github.com/bitnami/charts/issues/19194)
-* Revert "Autogenerate schema files (#19194)" (#19335) ([73d80be](https://github.com/bitnami/charts/commit/73d80be)), closes [#19194](https://github.com/bitnami/charts/issues/19194) [#19335](https://github.com/bitnami/charts/issues/19335)
+* [bitnami/*] Update readme files (#19277) ([e56aeb2](https://github.com/bitnami/charts/commit/e56aeb2fbfbf5b6e42375db48cc7ae1ef1c3a823)), closes [#19277](https://github.com/bitnami/charts/issues/19277)
+* [bitnami/apisix] Use different app.kubernetes.io/version label on subcomponents (#19325) ([61653c9](https://github.com/bitnami/charts/commit/61653c9b9f19ad7d15ace79980e913b7267d7059)), closes [#19325](https://github.com/bitnami/charts/issues/19325)
+* Autogenerate schema files (#19194) ([a2c2090](https://github.com/bitnami/charts/commit/a2c2090b5ac97f47b745c8028c6452bf99739772)), closes [#19194](https://github.com/bitnami/charts/issues/19194)
+* Revert "Autogenerate schema files (#19194)" (#19335) ([73d80be](https://github.com/bitnami/charts/commit/73d80be525c88fb4b8a54451a55acd506e337062)), closes [#19194](https://github.com/bitnami/charts/issues/19194) [#19335](https://github.com/bitnami/charts/issues/19335)
 
 ## <small>2.1.2 (2023-09-08)</small>
 
-* [bitnami/apisix]: Use merge helper (#19020) ([3fa3cb4](https://github.com/bitnami/charts/commit/3fa3cb4)), closes [#19020](https://github.com/bitnami/charts/issues/19020)
+* [bitnami/apisix]: Use merge helper (#19020) ([3fa3cb4](https://github.com/bitnami/charts/commit/3fa3cb4ae9cabe1cc9745f42214475542c889f72)), closes [#19020](https://github.com/bitnami/charts/issues/19020)
 
 ## <small>2.1.1 (2023-09-01)</small>
 
-* [bitnami/apisix] Release 2.1.1 (#18986) ([6d142f7](https://github.com/bitnami/charts/commit/6d142f7)), closes [#18986](https://github.com/bitnami/charts/issues/18986)
+* [bitnami/apisix] Release 2.1.1 (#18986) ([6d142f7](https://github.com/bitnami/charts/commit/6d142f7693b17631b042d8369a431008b4ff130a)), closes [#18986](https://github.com/bitnami/charts/issues/18986)
 
 ## 2.1.0 (2023-08-29)
 
-* [bitnami/apisix] Support for customizing standard labels (#18456) ([8f45915](https://github.com/bitnami/charts/commit/8f45915)), closes [#18456](https://github.com/bitnami/charts/issues/18456)
+* [bitnami/apisix] Support for customizing standard labels (#18456) ([8f45915](https://github.com/bitnami/charts/commit/8f45915be3481a9184a9940530dab1d3e1dcaf0d)), closes [#18456](https://github.com/bitnami/charts/issues/18456)
 
 ## <small>2.0.10 (2023-08-19)</small>
 
-* [bitnami/apisix] Release 2.0.10 (#18644) ([f0494e8](https://github.com/bitnami/charts/commit/f0494e8)), closes [#18644](https://github.com/bitnami/charts/issues/18644)
+* [bitnami/apisix] Release 2.0.10 (#18644) ([f0494e8](https://github.com/bitnami/charts/commit/f0494e86f6f7d4c0b2f839ea6b1639f40a00945c)), closes [#18644](https://github.com/bitnami/charts/issues/18644)
 
 ## <small>2.0.9 (2023-08-17)</small>
 
-* [bitnami/apisix] Release 2.0.9 (#18497) ([ab7de5c](https://github.com/bitnami/charts/commit/ab7de5c)), closes [#18497](https://github.com/bitnami/charts/issues/18497)
+* [bitnami/apisix] Release 2.0.9 (#18497) ([ab7de5c](https://github.com/bitnami/charts/commit/ab7de5c0183582c52b68a11a176ebbc48962316b)), closes [#18497](https://github.com/bitnami/charts/issues/18497)
 
 ## <small>2.0.8 (2023-08-08)</small>
 
-* [bitnami/apisix] chore: :page_facing_up: Remove license in CRDs (#18257) ([ca830ba](https://github.com/bitnami/charts/commit/ca830ba)), closes [#18257](https://github.com/bitnami/charts/issues/18257)
+* [bitnami/apisix] chore: :page_facing_up: Remove license in CRDs (#18257) ([ca830ba](https://github.com/bitnami/charts/commit/ca830ba72226e923335c49928810202a9129d440)), closes [#18257](https://github.com/bitnami/charts/issues/18257)
 
 ## <small>2.0.7 (2023-07-25)</small>
 
-* [bitnami/apisix] Release 2.0.7 (#17856) ([1db0ec6](https://github.com/bitnami/charts/commit/1db0ec6)), closes [#17856](https://github.com/bitnami/charts/issues/17856)
+* [bitnami/apisix] Release 2.0.7 (#17856) ([1db0ec6](https://github.com/bitnami/charts/commit/1db0ec66d32dabe036934c1fafcb43445c30bc18)), closes [#17856](https://github.com/bitnami/charts/issues/17856)
 
 ## <small>2.0.6 (2023-07-20)</small>
 
-* [bitnami/apisix] Release 2.0.6 (#17801) ([9660e28](https://github.com/bitnami/charts/commit/9660e28)), closes [#17801](https://github.com/bitnami/charts/issues/17801)
+* [bitnami/apisix] Release 2.0.6 (#17801) ([9660e28](https://github.com/bitnami/charts/commit/9660e28fcf3add80ca7ef96cd9a84dda62ac82c5)), closes [#17801](https://github.com/bitnami/charts/issues/17801)
 
 ## <small>2.0.5 (2023-07-20)</small>
 
-* [bitnami/apisix] Release 2.0.5 (#17792) ([7ea0ee3](https://github.com/bitnami/charts/commit/7ea0ee3)), closes [#17792](https://github.com/bitnami/charts/issues/17792)
+* [bitnami/apisix] Release 2.0.5 (#17792) ([7ea0ee3](https://github.com/bitnami/charts/commit/7ea0ee395e68db6d41774b10b38b172f6724e5eb)), closes [#17792](https://github.com/bitnami/charts/issues/17792)
 
 ## <small>2.0.4 (2023-07-15)</small>
 
-* [bitnami/apisix] Release 2 (#17599) ([d76f9b7](https://github.com/bitnami/charts/commit/d76f9b7)), closes [#17599](https://github.com/bitnami/charts/issues/17599)
+* [bitnami/apisix] Release 2 (#17599) ([d76f9b7](https://github.com/bitnami/charts/commit/d76f9b7860be1a2ae7ea509f9a1562f48f436766)), closes [#17599](https://github.com/bitnami/charts/issues/17599)
 
 ## <small>2.0.3 (2023-07-12)</small>
 
-* [bitnami/apisix] Reorder chart dependencies (#17583) ([31e5bc6](https://github.com/bitnami/charts/commit/31e5bc6)), closes [#17583](https://github.com/bitnami/charts/issues/17583)
-* Use os-shell in tempate and Jaeger runtime params (#17557) ([91a49eb](https://github.com/bitnami/charts/commit/91a49eb)), closes [#17557](https://github.com/bitnami/charts/issues/17557)
+* [bitnami/apisix] Reorder chart dependencies (#17583) ([31e5bc6](https://github.com/bitnami/charts/commit/31e5bc60ee2422a528f987ec066b453ab847da2a)), closes [#17583](https://github.com/bitnami/charts/issues/17583)
+* Use os-shell in tempate and Jaeger runtime params (#17557) ([91a49eb](https://github.com/bitnami/charts/commit/91a49eb1e3c81c7b7c6c28d1bc5d6d6ae698c1e2)), closes [#17557](https://github.com/bitnami/charts/issues/17557)
 
 ## <small>2.0.2 (2023-06-29)</small>
 
-* [bitnami/apisix] Add the plugins list to the dashboard default config (#17289) ([45a6c7d](https://github.com/bitnami/charts/commit/45a6c7d)), closes [#17289](https://github.com/bitnami/charts/issues/17289)
-* Add copyright header (#17300) ([da68be8](https://github.com/bitnami/charts/commit/da68be8)), closes [#17300](https://github.com/bitnami/charts/issues/17300)
+* [bitnami/apisix] Add the plugins list to the dashboard default config (#17289) ([45a6c7d](https://github.com/bitnami/charts/commit/45a6c7d5a762eae814334c7781a5b6666df5a66b)), closes [#17289](https://github.com/bitnami/charts/issues/17289)
+* Add copyright header (#17300) ([da68be8](https://github.com/bitnami/charts/commit/da68be8e951225133c7dfb572d5101ca3d61c5ae)), closes [#17300](https://github.com/bitnami/charts/issues/17300)
 
 ## <small>2.0.1 (2023-06-22)</small>
 
-* [bitnami/apisix] Release 2.0.1 (#17316) ([eba8256](https://github.com/bitnami/charts/commit/eba8256)), closes [#17316](https://github.com/bitnami/charts/issues/17316)
-* Update charts readme (#17217) ([31b3c0a](https://github.com/bitnami/charts/commit/31b3c0a)), closes [#17217](https://github.com/bitnami/charts/issues/17217)
+* [bitnami/apisix] Release 2.0.1 (#17316) ([eba8256](https://github.com/bitnami/charts/commit/eba825681f1f9fe8f186d041982012335032da08)), closes [#17316](https://github.com/bitnami/charts/issues/17316)
+* Update charts readme (#17217) ([31b3c0a](https://github.com/bitnami/charts/commit/31b3c0afd968ff4429107e34101f7509e6a0e913)), closes [#17217](https://github.com/bitnami/charts/issues/17217)
 
 ## 2.0.0 (2023-06-19)
 
-* [bitnami/*] Change copyright section in READMEs (#17006) ([ef986a1](https://github.com/bitnami/charts/commit/ef986a1)), closes [#17006](https://github.com/bitnami/charts/issues/17006)
-* [bitnami/apisix] Upgrade etcd dependency (#17185) ([d3f1c61](https://github.com/bitnami/charts/commit/d3f1c61)), closes [#17185](https://github.com/bitnami/charts/issues/17185)
-* [bitnami/several] Change copyright section in READMEs (#16989) ([5b6a5cf](https://github.com/bitnami/charts/commit/5b6a5cf)), closes [#16989](https://github.com/bitnami/charts/issues/16989)
+* [bitnami/*] Change copyright section in READMEs (#17006) ([ef986a1](https://github.com/bitnami/charts/commit/ef986a1605241102b3dcafe9fd8089e6fc1201ad)), closes [#17006](https://github.com/bitnami/charts/issues/17006)
+* [bitnami/apisix] Upgrade etcd dependency (#17185) ([d3f1c61](https://github.com/bitnami/charts/commit/d3f1c61666183cd6d35b82b1bafca3b967553747)), closes [#17185](https://github.com/bitnami/charts/issues/17185)
+* [bitnami/several] Change copyright section in READMEs (#16989) ([5b6a5cf](https://github.com/bitnami/charts/commit/5b6a5cfb7625a751848a2e5cd796bd7278f406ca)), closes [#16989](https://github.com/bitnami/charts/issues/16989)
 
 ## <small>1.0.1 (2023-05-23)</small>
 
-* [bitnami/apisix] Release 1.0.1 (#16886) ([2369235](https://github.com/bitnami/charts/commit/2369235)), closes [#16886](https://github.com/bitnami/charts/issues/16886)
+* [bitnami/apisix] Release 1.0.1 (#16886) ([2369235](https://github.com/bitnami/charts/commit/2369235265dec7ce93488dda949a405c57a6e885)), closes [#16886](https://github.com/bitnami/charts/issues/16886)
 
 ## 1.0.0 (2023-05-23)
 
-* [bitnami/apisix] Release 1.0.0 (#16884) ([3e55063](https://github.com/bitnami/charts/commit/3e55063)), closes [#16884](https://github.com/bitnami/charts/issues/16884)
+* [bitnami/apisix] Release 1.0.0 (#16884) ([3e55063](https://github.com/bitnami/charts/commit/3e55063583a6fa68fead339c86f83c51b6b8a6ad)), closes [#16884](https://github.com/bitnami/charts/issues/16884)
 
 ## 0.1.0 (2023-05-23)
 
-* [bitnami/apisix] feat: :tada: Add chart (#16851) ([a289c26](https://github.com/bitnami/charts/commit/a289c26)), closes [#16851](https://github.com/bitnami/charts/issues/16851)
+* [bitnami/apisix] feat: :tada: Add chart (#16851) ([a289c26](https://github.com/bitnami/charts/commit/a289c260d4ff8e9092e4ea000cbc3872e4f9a8de)), closes [#16851](https://github.com/bitnami/charts/issues/16851)

--- a/bitnami/apisix/Chart.lock
+++ b/bitnami/apisix/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: etcd
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 10.0.11
+  version: 10.1.0
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 2.19.3
-digest: sha256:c2b31b3e695a08549b2ea3c0caf353d2dfc55241491497fd1161ae2928aa7f47
-generated: "2024-05-21T13:24:18.473939474+02:00"
+digest: sha256:49e467e0f8013df87e6183f90612ff1322a54918c16f57fa47e04ed8d3fc2930
+generated: "2024-05-22T16:02:07.897582+02:00"

--- a/bitnami/apisix/Chart.yaml
+++ b/bitnami/apisix/Chart.yaml
@@ -45,4 +45,4 @@ sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/apisix
 - https://github.com/bitnami/charts/tree/main/bitnami/apisix-dashboard
 - https://github.com/bitnami/charts/tree/main/bitnami/apisix-ingress-controller
-version: 3.1.0
+version: 3.1.1

--- a/bitnami/apisix/templates/control-plane/dep-ds.yaml
+++ b/bitnami/apisix/templates/control-plane/dep-ds.yaml
@@ -147,8 +147,7 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.controlPlane.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.controlPlane.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.controlPlane.livenessProbe "enabled") "context" $) | nindent 12 }}
-            httpGet:
-              path: /v1/healthcheck
+            tcpSocket:
               port: http-control
           {{- end }}
           {{- if .Values.controlPlane.customReadinessProbe }}

--- a/bitnami/apisix/templates/dashboard/deployment.yaml
+++ b/bitnami/apisix/templates/dashboard/deployment.yaml
@@ -137,8 +137,7 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.dashboard.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.dashboard.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.dashboard.livenessProbe "enabled") "context" $) | nindent 12 }}
-            httpGet:
-              path: /ping
+            tcpSocket:
               port: http
           {{- end }}
           {{- if .Values.dashboard.customReadinessProbe }}

--- a/bitnami/apisix/templates/data-plane/dep-ds.yaml
+++ b/bitnami/apisix/templates/data-plane/dep-ds.yaml
@@ -149,8 +149,7 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.dataPlane.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.dataPlane.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.dataPlane.livenessProbe "enabled") "context" $) | nindent 12 }}
-            httpGet:
-              path: /v1/healthcheck
+            tcpSocket:
               port: http-control
          {{- end }}
           {{- if .Values.dataPlane.customReadinessProbe }}

--- a/bitnami/apisix/templates/ingress-controller/deployment.yaml
+++ b/bitnami/apisix/templates/ingress-controller/deployment.yaml
@@ -138,8 +138,7 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.ingressController.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.ingressController.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.ingressController.livenessProbe "enabled") "context" $) | nindent 12 }}
-            httpGet:
-              path: /healthz
+            tcpSocket:
               port: http
           {{- end }}
           {{- if .Values.ingressController.customReadinessProbe }}


### PR DESCRIPTION
### Description of the change
This PR aims to use different liveness/readiness probes to improve overall security and avoid unnecessary container restarts. [More info](https://github.com/zegl/kube-score/blob/master/README_PROBES.md).

### Benefits

Increase availability and resilience.

### Possible drawbacks

N/A

### Applicable issues

- fixes #

### Additional information

- Related to #23537

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- ~[X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)~
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
