### PR TITLE
[bitnami/contour] Use different liveness/readiness probes

### DIFF
--- a/bitnami/contour/CHANGELOG.md
+++ b/bitnami/contour/CHANGELOG.md
@@ -1,1098 +1,1103 @@
 # Changelog
 
+## 18.1.1 (2024-05-22)
+
+* [bitnami/contour] Use different liveness/readiness probes ([#26339](https://github.com/bitnami/charts/pull/26339))
+
 ## 18.1.0 (2024-05-21)
 
-* [bitnami/contour] feat: :sparkles: :lock: Add warning when original images are replaced ([#26191](https://github.com/bitnami/charts/pulls/26191))
+* [bitnami/*] ci: :construction_worker: Add tag and changelog support (#25359) ([91c707c](https://github.com/bitnami/charts/commit/91c707c9e4e574725a09505d2d313fb93f1b4c0a)), closes [#25359](https://github.com/bitnami/charts/issues/25359)
+* [bitnami/contour] feat: :sparkles: :lock: Add warning when original images are replaced (#26191) ([d08dbe7](https://github.com/bitnami/charts/commit/d08dbe7f8eaac2d6c0df86841427db7a71a24289)), closes [#26191](https://github.com/bitnami/charts/issues/26191)
 
 ## <small>18.0.1 (2024-05-18)</small>
 
-* [bitnami/contour] Release 18.0.1 updating components versions (#26005) ([5319ab5](https://github.com/bitnami/charts/commit/5319ab5)), closes [#26005](https://github.com/bitnami/charts/issues/26005)
+* [bitnami/contour] Release 18.0.1 updating components versions (#26005) ([5319ab5](https://github.com/bitnami/charts/commit/5319ab5c0b0aa4f51a4f6b5096274a3dabab262b)), closes [#26005](https://github.com/bitnami/charts/issues/26005)
 
 ## 18.0.0 (2024-05-16)
 
-* [bitnami/contour] Release 18.0.0 (#25957) ([0230017](https://github.com/bitnami/charts/commit/0230017)), closes [#25957](https://github.com/bitnami/charts/issues/25957)
+* [bitnami/contour] Release 18.0.0 (#25957) ([0230017](https://github.com/bitnami/charts/commit/0230017f75827a5443bd5d40de27ba081b4fa987)), closes [#25957](https://github.com/bitnami/charts/issues/25957)
 
 ## <small>17.1.1 (2024-05-16)</small>
 
-* [bitnami/contour] Release 17.1.1 updating components versions (#25949) ([8798df6](https://github.com/bitnami/charts/commit/8798df6)), closes [#25949](https://github.com/bitnami/charts/issues/25949)
+* [bitnami/contour] Release 17.1.1 updating components versions (#25949) ([8798df6](https://github.com/bitnami/charts/commit/8798df6137b3806d5bbfa2ea022ce84efe91d6e6)), closes [#25949](https://github.com/bitnami/charts/issues/25949)
 
 ## 17.1.0 (2024-05-15)
 
-* [bitnami/contour] PDB review (#25881) ([9d8ab33](https://github.com/bitnami/charts/commit/9d8ab33)), closes [#25881](https://github.com/bitnami/charts/issues/25881)
+* [bitnami/contour] PDB review (#25881) ([9d8ab33](https://github.com/bitnami/charts/commit/9d8ab338b6fa8881f0258ebacb64da36065c3a47)), closes [#25881](https://github.com/bitnami/charts/issues/25881)
 
 ## <small>17.0.14 (2024-05-13)</small>
 
-* [bitnami/contour] Release 17.0.14 updating components versions (#25764) ([08b3287](https://github.com/bitnami/charts/commit/08b3287)), closes [#25764](https://github.com/bitnami/charts/issues/25764)
+* [bitnami/contour] Release 17.0.14 updating components versions (#25764) ([08b3287](https://github.com/bitnami/charts/commit/08b3287f9c9808de783f69417d55fd9ac4588f97)), closes [#25764](https://github.com/bitnami/charts/issues/25764)
 
 ## <small>17.0.13 (2024-05-13)</small>
 
-* [bitnami/*] Change non-root and rolling-tags doc URLs (#25628) ([b067c94](https://github.com/bitnami/charts/commit/b067c94)), closes [#25628](https://github.com/bitnami/charts/issues/25628)
-* [bitnami/contour] Release 17.0.13 updating components versions (#25716) ([55248fa](https://github.com/bitnami/charts/commit/55248fa)), closes [#25716](https://github.com/bitnami/charts/issues/25716)
+* [bitnami/*] Change non-root and rolling-tags doc URLs (#25628) ([b067c94](https://github.com/bitnami/charts/commit/b067c94f6bcde427863c197fd355f0b5ba12ff5b)), closes [#25628](https://github.com/bitnami/charts/issues/25628)
+* [bitnami/contour] Release 17.0.13 updating components versions (#25716) ([55248fa](https://github.com/bitnami/charts/commit/55248fa730a80b4ae4ad2e62ebb8b87ff2ba735e)), closes [#25716](https://github.com/bitnami/charts/issues/25716)
 
 ## <small>17.0.12 (2024-05-08)</small>
 
-* [bitnami/contour] Release 17.0.12 (#25601) ([a80e33e](https://github.com/bitnami/charts/commit/a80e33e)), closes [#25601](https://github.com/bitnami/charts/issues/25601)
+* [bitnami/contour] Release 17.0.12 (#25601) ([a80e33e](https://github.com/bitnami/charts/commit/a80e33e40a8c6c95a5ef857374db02eb2243e3c9)), closes [#25601](https://github.com/bitnami/charts/issues/25601)
 
 ## <small>17.0.11 (2024-05-07)</small>
 
-* [bitnami/contour] Release 17.0.11 updating components versions (#25586) ([7be7258](https://github.com/bitnami/charts/commit/7be7258)), closes [#25586](https://github.com/bitnami/charts/issues/25586)
+* [bitnami/contour] Release 17.0.11 updating components versions (#25586) ([7be7258](https://github.com/bitnami/charts/commit/7be7258e8ed030d264f600039dadc36fe24bf0ec)), closes [#25586](https://github.com/bitnami/charts/issues/25586)
 
 ## <small>17.0.10 (2024-05-06)</small>
 
-* [bitnami/*] Set new header/owner (#25558) ([8d1dc11](https://github.com/bitnami/charts/commit/8d1dc11)), closes [#25558](https://github.com/bitnami/charts/issues/25558)
-* [bitnami/contour] Adding missing named port for shutdown-manager container (#25524) ([37917b8](https://github.com/bitnami/charts/commit/37917b8)), closes [#25524](https://github.com/bitnami/charts/issues/25524)
+* [bitnami/*] Set new header/owner (#25558) ([8d1dc11](https://github.com/bitnami/charts/commit/8d1dc11f5fb30db6fba50c43d7af59d2f79deed3)), closes [#25558](https://github.com/bitnami/charts/issues/25558)
+* [bitnami/contour] Adding missing named port for shutdown-manager container (#25524) ([37917b8](https://github.com/bitnami/charts/commit/37917b81d37998b282445012abccecc47aca2af3)), closes [#25524](https://github.com/bitnami/charts/issues/25524)
 
 ## <small>17.0.9 (2024-05-02)</small>
 
-* [bitnami/contour] Release 17.0.9 updating components versions (#25497) ([fee17a7](https://github.com/bitnami/charts/commit/fee17a7)), closes [#25497](https://github.com/bitnami/charts/issues/25497)
+* [bitnami/contour] Release 17.0.9 updating components versions (#25497) ([fee17a7](https://github.com/bitnami/charts/commit/fee17a7e57795753bea5c9753e35e42a19b1629c)), closes [#25497](https://github.com/bitnami/charts/issues/25497)
 
 ## <small>17.0.8 (2024-05-02)</small>
 
-* [bitnami/contour] Release 17.0.8 updating components versions (#25494) ([642e52c](https://github.com/bitnami/charts/commit/642e52c)), closes [#25494](https://github.com/bitnami/charts/issues/25494)
-* [bitnami/multiple charts] Fix typo: "NetworkPolice" vs "NetworkPolicy" (#25348) ([6970c1b](https://github.com/bitnami/charts/commit/6970c1b)), closes [#25348](https://github.com/bitnami/charts/issues/25348)
-* Replace VMware by Broadcom copyright text (#25306) ([a5e4bd0](https://github.com/bitnami/charts/commit/a5e4bd0)), closes [#25306](https://github.com/bitnami/charts/issues/25306)
+* [bitnami/contour] Release 17.0.8 updating components versions (#25494) ([642e52c](https://github.com/bitnami/charts/commit/642e52c33471593102c28f596ea2ea973a3aac59)), closes [#25494](https://github.com/bitnami/charts/issues/25494)
+* [bitnami/multiple charts] Fix typo: "NetworkPolice" vs "NetworkPolicy" (#25348) ([6970c1b](https://github.com/bitnami/charts/commit/6970c1ba245873506e73d459c6eac1e4919b778f)), closes [#25348](https://github.com/bitnami/charts/issues/25348)
+* Replace VMware by Broadcom copyright text (#25306) ([a5e4bd0](https://github.com/bitnami/charts/commit/a5e4bd0e35e419203793976a78d9d0a13de92c76)), closes [#25306](https://github.com/bitnami/charts/issues/25306)
 
 ## <small>17.0.7 (2024-04-22)</small>
 
-* [bitnami/contour] Fix list configmaps forbidden when contour's version is above 1.28 (#25177) ([a8cdb55](https://github.com/bitnami/charts/commit/a8cdb55)), closes [#25177](https://github.com/bitnami/charts/issues/25177)
+* [bitnami/contour] Fix list configmaps forbidden when contour's version is above 1.28 (#25177) ([a8cdb55](https://github.com/bitnami/charts/commit/a8cdb55c8620c3abdf1badb9343b957ea92102b5)), closes [#25177](https://github.com/bitnami/charts/issues/25177)
 
 ## <small>17.0.6 (2024-04-19)</small>
 
-* [bitnami/contour] fix: :bug: :lock: Expose missing ports in deployment spec (#25069) ([63375e7](https://github.com/bitnami/charts/commit/63375e7)), closes [#25069](https://github.com/bitnami/charts/issues/25069)
+* [bitnami/contour] fix: :bug: :lock: Expose missing ports in deployment spec (#25069) ([63375e7](https://github.com/bitnami/charts/commit/63375e7e253557f306da8ecac9d547be5d7d7212)), closes [#25069](https://github.com/bitnami/charts/issues/25069)
 
 ## <small>17.0.5 (2024-04-10)</small>
 
-* [bitnami/contour] Release 17.0.5 (#25117) ([3e6a241](https://github.com/bitnami/charts/commit/3e6a241)), closes [#25117](https://github.com/bitnami/charts/issues/25117)
+* [bitnami/contour] Release 17.0.5 (#25117) ([3e6a241](https://github.com/bitnami/charts/commit/3e6a2418f71343139cbaa82c331f8c0ccdd20aed)), closes [#25117](https://github.com/bitnami/charts/issues/25117)
 
 ## <small>17.0.4 (2024-04-10)</small>
 
-* [bitnami/contour] Move envoy customReadinessProbe template to envoy container (#24860) ([1ba2751](https://github.com/bitnami/charts/commit/1ba2751)), closes [#24860](https://github.com/bitnami/charts/issues/24860)
+* [bitnami/contour] Move envoy customReadinessProbe template to envoy container (#24860) ([1ba2751](https://github.com/bitnami/charts/commit/1ba2751bd312e3d610183c8e30b1e578abcb0153)), closes [#24860](https://github.com/bitnami/charts/issues/24860)
 
 ## <small>17.0.3 (2024-04-05)</small>
 
-* [bitnami/contour] Release 17.0.3 updating components versions (#25003) ([ae5aed0](https://github.com/bitnami/charts/commit/ae5aed0)), closes [#25003](https://github.com/bitnami/charts/issues/25003)
+* [bitnami/contour] Release 17.0.3 updating components versions (#25003) ([ae5aed0](https://github.com/bitnami/charts/commit/ae5aed0313e94a25388cf3ef18d07bcb0201a748)), closes [#25003](https://github.com/bitnami/charts/issues/25003)
 
 ## <small>17.0.2 (2024-04-04)</small>
 
-* [bitnami/contour] Release 17.0.2 (#24877) ([1cc7bba](https://github.com/bitnami/charts/commit/1cc7bba)), closes [#24877](https://github.com/bitnami/charts/issues/24877)
-* Update resourcesPreset comments (#24467) ([92e3e8a](https://github.com/bitnami/charts/commit/92e3e8a)), closes [#24467](https://github.com/bitnami/charts/issues/24467)
+* [bitnami/contour] Release 17.0.2 (#24877) ([1cc7bba](https://github.com/bitnami/charts/commit/1cc7bbaefc64397ec5acd9a16a9afa94461ebbdf)), closes [#24877](https://github.com/bitnami/charts/issues/24877)
+* Update resourcesPreset comments (#24467) ([92e3e8a](https://github.com/bitnami/charts/commit/92e3e8a507326d2a20a8f10ab3e7746a2ec5c554)), closes [#24467](https://github.com/bitnami/charts/issues/24467)
 
 ## <small>17.0.1 (2024-03-19)</small>
 
-* [bitnami/*] Reorder Chart sections (#24455) ([0cf4048](https://github.com/bitnami/charts/commit/0cf4048)), closes [#24455](https://github.com/bitnami/charts/issues/24455)
-* [bitnami/contour] Release 17.0.1 (#24556) ([3955916](https://github.com/bitnami/charts/commit/3955916)), closes [#24556](https://github.com/bitnami/charts/issues/24556)
+* [bitnami/*] Reorder Chart sections (#24455) ([0cf4048](https://github.com/bitnami/charts/commit/0cf4048e8743f70a9753d460655bd030cbff6824)), closes [#24455](https://github.com/bitnami/charts/issues/24455)
+* [bitnami/contour] Release 17.0.1 (#24556) ([3955916](https://github.com/bitnami/charts/commit/39559160e307220f5176e197f0d046918d92161b)), closes [#24556](https://github.com/bitnami/charts/issues/24556)
 
 ## 17.0.0 (2024-03-15)
 
-* [bitnami/contour] feat!: :lock: :boom: Improve security defaults (#24285) ([2020212](https://github.com/bitnami/charts/commit/2020212)), closes [#24285](https://github.com/bitnami/charts/issues/24285)
+* [bitnami/contour] feat!: :lock: :boom: Improve security defaults (#24285) ([2020212](https://github.com/bitnami/charts/commit/202021260033f90da167a53dd02d64dd7f236d82)), closes [#24285](https://github.com/bitnami/charts/issues/24285)
 
 ## <small>16.0.2 (2024-03-08)</small>
 
-* [bitnami/contour] Release 16.0.2 updating components versions (#24308) ([365e8c6](https://github.com/bitnami/charts/commit/365e8c6)), closes [#24308](https://github.com/bitnami/charts/issues/24308)
+* [bitnami/contour] Release 16.0.2 updating components versions (#24308) ([365e8c6](https://github.com/bitnami/charts/commit/365e8c6f44b1446b0a2ea5e83887db1c74057188)), closes [#24308](https://github.com/bitnami/charts/issues/24308)
 
 ## <small>16.0.1 (2024-03-08)</small>
 
-* [bitnami/contour] Release 16.0.1 updating components versions (#24304) ([324db73](https://github.com/bitnami/charts/commit/324db73)), closes [#24304](https://github.com/bitnami/charts/issues/24304)
+* [bitnami/contour] Release 16.0.1 updating components versions (#24304) ([324db73](https://github.com/bitnami/charts/commit/324db7375504459659b8cec5844e525b9324d6df)), closes [#24304](https://github.com/bitnami/charts/issues/24304)
 
 ## 16.0.0 (2024-03-06)
 
-* [bitnami/contour] feat: :sparkles: :lock: Add automatic adaptation for Openshift restricted-v2 SCC ( ([7dd2fd2](https://github.com/bitnami/charts/commit/7dd2fd2)), closes [#24072](https://github.com/bitnami/charts/issues/24072)
-* [bitnami/contour] Release 16.0.0 (#24219) ([e5d608b](https://github.com/bitnami/charts/commit/e5d608b)), closes [#24219](https://github.com/bitnami/charts/issues/24219)
+* [bitnami/contour] feat: :sparkles: :lock: Add automatic adaptation for Openshift restricted-v2 SCC ( ([7dd2fd2](https://github.com/bitnami/charts/commit/7dd2fd2f89bb0cff354fd4b5314e97104455f4e0)), closes [#24072](https://github.com/bitnami/charts/issues/24072)
+* [bitnami/contour] Release 16.0.0 (#24219) ([e5d608b](https://github.com/bitnami/charts/commit/e5d608bff142fa6ae92ef0fa62822d4f1d066a17)), closes [#24219](https://github.com/bitnami/charts/issues/24219)
 
 ## 15.6.0 (2024-03-05)
 
-* [bitnami/contour] feat: :sparkles: :lock: Add runAsGroup (#23882) ([4c1fde4](https://github.com/bitnami/charts/commit/4c1fde4)), closes [#23882](https://github.com/bitnami/charts/issues/23882)
+* [bitnami/contour] feat: :sparkles: :lock: Add runAsGroup (#23882) ([4c1fde4](https://github.com/bitnami/charts/commit/4c1fde4f742d96ed749cf110d26ff8c3338b18c8)), closes [#23882](https://github.com/bitnami/charts/issues/23882)
 
 ## <small>15.5.3 (2024-03-05)</small>
 
-* [bitnami/contour] fix: :bug: Add missing if/end statement to resources section (#24056) ([5f93147](https://github.com/bitnami/charts/commit/5f93147)), closes [#24056](https://github.com/bitnami/charts/issues/24056)
+* [bitnami/contour] fix: :bug: Add missing if/end statement to resources section (#24056) ([5f93147](https://github.com/bitnami/charts/commit/5f9314746d16da23191bccf27b363a9f4d9a36cf)), closes [#24056](https://github.com/bitnami/charts/issues/24056)
 
 ## <small>15.5.2 (2024-02-21)</small>
 
-* [bitnami/contour] Release 15.5.2 updating components versions (#23739) ([20ae965](https://github.com/bitnami/charts/commit/20ae965)), closes [#23739](https://github.com/bitnami/charts/issues/23739)
+* [bitnami/contour] Release 15.5.2 updating components versions (#23739) ([20ae965](https://github.com/bitnami/charts/commit/20ae965367da3598d4e5dff5e19ef5140a791c52)), closes [#23739](https://github.com/bitnami/charts/issues/23739)
 
 ## <small>15.5.1 (2024-02-21)</small>
 
-* [bitnami/contour] feat: :sparkles: :lock: Add resource preset support (#23439) ([47c0da6](https://github.com/bitnami/charts/commit/47c0da6)), closes [#23439](https://github.com/bitnami/charts/issues/23439)
-* [bitnami/contour] Release 15.5.1 (#23639) ([093408f](https://github.com/bitnami/charts/commit/093408f)), closes [#23639](https://github.com/bitnami/charts/issues/23639)
+* [bitnami/contour] feat: :sparkles: :lock: Add resource preset support (#23439) ([47c0da6](https://github.com/bitnami/charts/commit/47c0da6cbb306e92b8a926ff781f5b78c8ee18e2)), closes [#23439](https://github.com/bitnami/charts/issues/23439)
+* [bitnami/contour] Release 15.5.1 (#23639) ([093408f](https://github.com/bitnami/charts/commit/093408f263e7763bf0ced11a6f3bc93e68fa5ab9)), closes [#23639](https://github.com/bitnami/charts/issues/23639)
 
 ## 15.5.0 (2024-02-20)
 
-* [bitnami/*] Bump all versions (#23602) ([b70ee2a](https://github.com/bitnami/charts/commit/b70ee2a)), closes [#23602](https://github.com/bitnami/charts/issues/23602)
+* [bitnami/*] Bump all versions (#23602) ([b70ee2a](https://github.com/bitnami/charts/commit/b70ee2a30e4dc256bf0ac52928fb2fa7a70f049b)), closes [#23602](https://github.com/bitnami/charts/issues/23602)
 
 ## 15.4.0 (2024-02-08)
 
-* [bitnami/contour] feat: :lock: Enable networkPolicy (#23329) ([534b481](https://github.com/bitnami/charts/commit/534b481)), closes [#23329](https://github.com/bitnami/charts/issues/23329)
+* [bitnami/contour] feat: :lock: Enable networkPolicy (#23329) ([534b481](https://github.com/bitnami/charts/commit/534b481fd37c8aa52d9caec651f5e37c4b479d47)), closes [#23329](https://github.com/bitnami/charts/issues/23329)
 
 ## <small>15.3.7 (2024-02-07)</small>
 
-* [bitnami/contour] Release 15.3.7 updating components versions (#23267) ([e902196](https://github.com/bitnami/charts/commit/e902196)), closes [#23267](https://github.com/bitnami/charts/issues/23267)
+* [bitnami/contour] Release 15.3.7 updating components versions (#23267) ([e902196](https://github.com/bitnami/charts/commit/e902196dfdc7efb3a72577cafc66c53a8315bf35)), closes [#23267](https://github.com/bitnami/charts/issues/23267)
 
 ## <small>15.3.6 (2024-02-07)</small>
 
-* [bitnami/contour] Release 15.3.6 updating components versions (#23222) ([591e4e2](https://github.com/bitnami/charts/commit/591e4e2)), closes [#23222](https://github.com/bitnami/charts/issues/23222)
+* [bitnami/contour] Release 15.3.6 updating components versions (#23222) ([591e4e2](https://github.com/bitnami/charts/commit/591e4e25af8a62a4bbfd90fa85956f5cbbd720de)), closes [#23222](https://github.com/bitnami/charts/issues/23222)
 
 ## <small>15.3.5 (2024-02-02)</small>
 
-* [bitnami/contour] Release 15.3.5 updating components versions (#23065) ([ced5968](https://github.com/bitnami/charts/commit/ced5968)), closes [#23065](https://github.com/bitnami/charts/issues/23065)
+* [bitnami/contour] Release 15.3.5 updating components versions (#23065) ([ced5968](https://github.com/bitnami/charts/commit/ced596820ac50e8db0cd0f741a5f96a97283c908)), closes [#23065](https://github.com/bitnami/charts/issues/23065)
 
 ## <small>15.3.4 (2024-01-31)</small>
 
-* [bitnami/contour] Update CRDs and add headers for automatic update (#22885) ([71b4a1a](https://github.com/bitnami/charts/commit/71b4a1a)), closes [#22885](https://github.com/bitnami/charts/issues/22885)
+* [bitnami/contour] Update CRDs and add headers for automatic update (#22885) ([71b4a1a](https://github.com/bitnami/charts/commit/71b4a1abc4fb2c1c3ab2a60640a0c26dc1af4916)), closes [#22885](https://github.com/bitnami/charts/issues/22885)
 
 ## <small>15.3.3 (2024-01-30)</small>
 
-* [bitnami/contour] Release 15.3.3 updating components versions (#22851) ([ef7d158](https://github.com/bitnami/charts/commit/ef7d158)), closes [#22851](https://github.com/bitnami/charts/issues/22851)
+* [bitnami/contour] Release 15.3.3 updating components versions (#22851) ([ef7d158](https://github.com/bitnami/charts/commit/ef7d158c2907ba7b56bc5ae6a2cf7c6b7ebcc551)), closes [#22851](https://github.com/bitnami/charts/issues/22851)
 
 ## <small>15.3.2 (2024-01-26)</small>
 
-* [bitnami/contour] Release 15.3.2 updating components versions (#22770) ([4b40fca](https://github.com/bitnami/charts/commit/4b40fca)), closes [#22770](https://github.com/bitnami/charts/issues/22770)
+* [bitnami/contour] Release 15.3.2 updating components versions (#22770) ([4b40fca](https://github.com/bitnami/charts/commit/4b40fcafd741555c425d0e0a441eab38efa8ab32)), closes [#22770](https://github.com/bitnami/charts/issues/22770)
 
 ## <small>15.3.1 (2024-01-26)</small>
 
-* [bitnami/contour] Release 15.1.1 updating components versions (#22265) ([79df86d](https://github.com/bitnami/charts/commit/79df86d)), closes [#22265](https://github.com/bitnami/charts/issues/22265)
+* [bitnami/contour] Release 15.1.1 updating components versions (#22265) ([79df86d](https://github.com/bitnami/charts/commit/79df86db7b3e7dcebeaa282fcd98418a39461d23)), closes [#22265](https://github.com/bitnami/charts/issues/22265)
 
 ## 15.3.0 (2024-01-26)
 
-* [bitnami/*] Move documentation sections from docs.bitnami.com back to the README (#22203) ([7564f36](https://github.com/bitnami/charts/commit/7564f36)), closes [#22203](https://github.com/bitnami/charts/issues/22203)
-* [bitnami/contour] Add contour multi az service (#21994) ([867cf51](https://github.com/bitnami/charts/commit/867cf51)), closes [#21994](https://github.com/bitnami/charts/issues/21994) [#20563](https://github.com/bitnami/charts/issues/20563)
+* [bitnami/*] Move documentation sections from docs.bitnami.com back to the README (#22203) ([7564f36](https://github.com/bitnami/charts/commit/7564f36ca1e95ff30ee686652b7ab8690561a707)), closes [#22203](https://github.com/bitnami/charts/issues/22203)
+* [bitnami/contour] Add contour multi az service (#21994) ([867cf51](https://github.com/bitnami/charts/commit/867cf51c57c717639dacc6a47d6b0d24cdf11947)), closes [#21994](https://github.com/bitnami/charts/issues/21994) [#20563](https://github.com/bitnami/charts/issues/20563)
 
 ## <small>15.2.1 (2024-01-24)</small>
 
-* [bitnami/contour] fix: :bug: Set seLinuxOptions to null for Openshift compatibility (#22577) ([9b002ef](https://github.com/bitnami/charts/commit/9b002ef)), closes [#22577](https://github.com/bitnami/charts/issues/22577)
+* [bitnami/contour] fix: :bug: Set seLinuxOptions to null for Openshift compatibility (#22577) ([9b002ef](https://github.com/bitnami/charts/commit/9b002efd97783264633b68105690caf28c1398bb)), closes [#22577](https://github.com/bitnami/charts/issues/22577)
 
 ## 15.2.0 (2024-01-22)
 
-* [bitnami/contour] fix: :lock: Move service-account token auto-mount to pod declaration (#22392) ([cfbc329](https://github.com/bitnami/charts/commit/cfbc329)), closes [#22392](https://github.com/bitnami/charts/issues/22392)
+* [bitnami/contour] fix: :lock: Move service-account token auto-mount to pod declaration (#22392) ([cfbc329](https://github.com/bitnami/charts/commit/cfbc3293727f6f8340c7b224fc837dcabf43c90d)), closes [#22392](https://github.com/bitnami/charts/issues/22392)
 
 ## <small>15.1.1 (2024-01-18)</small>
 
-* [bitnami/contour] Update CRDs and add source header (#22370) ([1389de6](https://github.com/bitnami/charts/commit/1389de6)), closes [#22370](https://github.com/bitnami/charts/issues/22370)
+* [bitnami/contour] Update CRDs and add source header (#22370) ([1389de6](https://github.com/bitnami/charts/commit/1389de6e35c004f6abcc1ff62e160eed31a7aa91)), closes [#22370](https://github.com/bitnami/charts/issues/22370)
 
 ## 15.1.0 (2024-01-17)
 
-* [bitnami/*] Fix ref links (in comments) (#21822) ([e4fa296](https://github.com/bitnami/charts/commit/e4fa296)), closes [#21822](https://github.com/bitnami/charts/issues/21822)
-* [bitnami/contour] fix: :lock: Improve podSecurityContext and containerSecurityContext with essential ([834ea25](https://github.com/bitnami/charts/commit/834ea25)), closes [#22108](https://github.com/bitnami/charts/issues/22108)
+* [bitnami/*] Fix ref links (in comments) (#21822) ([e4fa296](https://github.com/bitnami/charts/commit/e4fa296106b225cf8c82445727c675c7c725e380)), closes [#21822](https://github.com/bitnami/charts/issues/21822)
+* [bitnami/contour] fix: :lock: Improve podSecurityContext and containerSecurityContext with essential ([834ea25](https://github.com/bitnami/charts/commit/834ea25375c90c196069609c1f32f533e508c45e)), closes [#22108](https://github.com/bitnami/charts/issues/22108)
 
 ## <small>15.0.2 (2024-01-10)</small>
 
-* [bitnami/*] Fix docs.bitnami.com broken links (#21901) ([f35506d](https://github.com/bitnami/charts/commit/f35506d)), closes [#21901](https://github.com/bitnami/charts/issues/21901)
-* [bitnami/*] Update copyright: Year and company (#21815) ([6c4bf75](https://github.com/bitnami/charts/commit/6c4bf75)), closes [#21815](https://github.com/bitnami/charts/issues/21815)
-* [bitnami/contour] Release 15.0.2 updating components versions (#21933) ([5684474](https://github.com/bitnami/charts/commit/5684474)), closes [#21933](https://github.com/bitnami/charts/issues/21933)
+* [bitnami/*] Fix docs.bitnami.com broken links (#21901) ([f35506d](https://github.com/bitnami/charts/commit/f35506d2dadee4f097986e7792df1f53ab215b5d)), closes [#21901](https://github.com/bitnami/charts/issues/21901)
+* [bitnami/*] Update copyright: Year and company (#21815) ([6c4bf75](https://github.com/bitnami/charts/commit/6c4bf75dec58fc7c9aee9f089777b1a858c17d5b)), closes [#21815](https://github.com/bitnami/charts/issues/21815)
+* [bitnami/contour] Release 15.0.2 updating components versions (#21933) ([5684474](https://github.com/bitnami/charts/commit/5684474c0a82c9ac069bc0630c17214bb12fb414)), closes [#21933](https://github.com/bitnami/charts/issues/21933)
 
 ## <small>15.0.1 (2023-12-07)</small>
 
-* [bitnami/contour] Release 15.0.1 updating components versions (#21420) ([4ae6174](https://github.com/bitnami/charts/commit/4ae6174)), closes [#21420](https://github.com/bitnami/charts/issues/21420)
+* [bitnami/contour] Release 15.0.1 updating components versions (#21420) ([4ae6174](https://github.com/bitnami/charts/commit/4ae6174b533547923b5c1f8d529e2d648f1de48d)), closes [#21420](https://github.com/bitnami/charts/issues/21420)
 
 ## 15.0.0 (2023-11-22)
 
-* [bitnami/contour] Release 15.0.0 updating components versions (#21203) ([c7ebe3f](https://github.com/bitnami/charts/commit/c7ebe3f)), closes [#21203](https://github.com/bitnami/charts/issues/21203)
+* [bitnami/contour] Release 15.0.0 updating components versions (#21203) ([c7ebe3f](https://github.com/bitnami/charts/commit/c7ebe3fe6dc01f4aaa0b0f2c9bd387a0cbbddfae)), closes [#21203](https://github.com/bitnami/charts/issues/21203)
 
 ## <small>14.2.4 (2023-11-21)</small>
 
-* [bitnami/*] Rename solutions to "Bitnami package for ..." (#21038) ([b82f979](https://github.com/bitnami/charts/commit/b82f979)), closes [#21038](https://github.com/bitnami/charts/issues/21038)
-* [bitnami/contour] Release 14.2.4 updating components versions (#21103) ([90733ac](https://github.com/bitnami/charts/commit/90733ac)), closes [#21103](https://github.com/bitnami/charts/issues/21103)
+* [bitnami/*] Rename solutions to "Bitnami package for ..." (#21038) ([b82f979](https://github.com/bitnami/charts/commit/b82f979e4fb63423fe6e2192c946d09d79c944fc)), closes [#21038](https://github.com/bitnami/charts/issues/21038)
+* [bitnami/contour] Release 14.2.4 updating components versions (#21103) ([90733ac](https://github.com/bitnami/charts/commit/90733ac5e7f0caa95f56edf59aa5133ab4680fdd)), closes [#21103](https://github.com/bitnami/charts/issues/21103)
 
 ## <small>14.2.3 (2023-11-17)</small>
 
-* [bitnami/contour] Fix useHostPort backwards compatibility (#21033) ([ea196bd](https://github.com/bitnami/charts/commit/ea196bd)), closes [#21033](https://github.com/bitnami/charts/issues/21033)
+* [bitnami/contour] Fix useHostPort backwards compatibility (#21033) ([ea196bd](https://github.com/bitnami/charts/commit/ea196bd5962febf6fd34ab8c44d9c3eb5755b327)), closes [#21033](https://github.com/bitnami/charts/issues/21033)
 
 ## <small>14.2.2 (2023-11-16)</small>
 
-* [bitnami/contour] Release 14.2.2 updating components versions (#21019) ([f38697e](https://github.com/bitnami/charts/commit/f38697e)), closes [#21019](https://github.com/bitnami/charts/issues/21019)
+* [bitnami/contour] Release 14.2.2 updating components versions (#21019) ([f38697e](https://github.com/bitnami/charts/commit/f38697e7a5c80c69c1c4362220fd94db49256d35)), closes [#21019](https://github.com/bitnami/charts/issues/21019)
 
 ## <small>14.2.1 (2023-11-16)</small>
 
-* [bitnami/*] Remove relative links to non-README sections, add verification for that and update TL;DR ([1103633](https://github.com/bitnami/charts/commit/1103633)), closes [#20967](https://github.com/bitnami/charts/issues/20967)
-* [bitnami/contour] Release 14.2.1 updating components versions (#21018) ([fb0551c](https://github.com/bitnami/charts/commit/fb0551c)), closes [#21018](https://github.com/bitnami/charts/issues/21018)
+* [bitnami/*] Remove relative links to non-README sections, add verification for that and update TL;DR ([1103633](https://github.com/bitnami/charts/commit/11036334d82df0490aa4abdb591543cab6cf7d7f)), closes [#20967](https://github.com/bitnami/charts/issues/20967)
+* [bitnami/contour] Release 14.2.1 updating components versions (#21018) ([fb0551c](https://github.com/bitnami/charts/commit/fb0551ca51722850f0dd6e75d389b68282c1fe1b)), closes [#21018](https://github.com/bitnami/charts/issues/21018)
 
 ## 14.2.0 (2023-11-14)
 
-* [bitnami/contour] feat: allow custom metrics port for service monitor and allow enabling/disabling h ([11f5d58](https://github.com/bitnami/charts/commit/11f5d58)), closes [#20492](https://github.com/bitnami/charts/issues/20492)
+* [bitnami/contour] feat: allow custom metrics port for service monitor and allow enabling/disabling h ([11f5d58](https://github.com/bitnami/charts/commit/11f5d5839fcc40983d533b6dc3e7318377fe69aa)), closes [#20492](https://github.com/bitnami/charts/issues/20492)
 
 ## 14.1.0 (2023-11-09)
 
-* update contour crds (#20562) ([b7af8f2](https://github.com/bitnami/charts/commit/b7af8f2)), closes [#20562](https://github.com/bitnami/charts/issues/20562)
+* update contour crds (#20562) ([b7af8f2](https://github.com/bitnami/charts/commit/b7af8f2c8892a3c53ab78231b749bb0da29a47c3)), closes [#20562](https://github.com/bitnami/charts/issues/20562)
 
 ## <small>14.0.2 (2023-11-08)</small>
 
-* [bitnami/contour] Release 14.0.2 updating components versions (#20801) ([41a0cd5](https://github.com/bitnami/charts/commit/41a0cd5)), closes [#20801](https://github.com/bitnami/charts/issues/20801)
+* [bitnami/contour] Release 14.0.2 updating components versions (#20801) ([41a0cd5](https://github.com/bitnami/charts/commit/41a0cd508efce197f688f870497310627a6efe71)), closes [#20801](https://github.com/bitnami/charts/issues/20801)
 
 ## <small>14.0.1 (2023-11-08)</small>
 
-* [bitnami/contour] Release 14.0.1 updating components versions (#20724) ([d39b54d](https://github.com/bitnami/charts/commit/d39b54d)), closes [#20724](https://github.com/bitnami/charts/issues/20724)
+* [bitnami/contour] Release 14.0.1 updating components versions (#20724) ([d39b54d](https://github.com/bitnami/charts/commit/d39b54db2ad832974c29c29dae0ee6cf630de39d)), closes [#20724](https://github.com/bitnami/charts/issues/20724)
 
 ## 14.0.0 (2023-11-07)
 
-* [bitnami/contour] feat!: :sparkles: :boom: Add support for PSA restricted policy (#20417) ([5127ee9](https://github.com/bitnami/charts/commit/5127ee9)), closes [#20417](https://github.com/bitnami/charts/issues/20417)
+* [bitnami/contour] feat!: :sparkles: :boom: Add support for PSA restricted policy (#20417) ([5127ee9](https://github.com/bitnami/charts/commit/5127ee9be226e2065dc43bdaeb059e8f8e546279)), closes [#20417](https://github.com/bitnami/charts/issues/20417)
 
 ## 13.2.0 (2023-10-30)
 
-* [bitnami/*] Rename VMware Application Catalog (#20361) ([3acc734](https://github.com/bitnami/charts/commit/3acc734)), closes [#20361](https://github.com/bitnami/charts/issues/20361)
-* [bitnami/*] Skip image's tag in the README files of the Bitnami Charts (#19841) ([bb9a01b](https://github.com/bitnami/charts/commit/bb9a01b)), closes [#19841](https://github.com/bitnami/charts/issues/19841)
-* [bitnami/*] Standardize documentation (#19835) ([af5f753](https://github.com/bitnami/charts/commit/af5f753)), closes [#19835](https://github.com/bitnami/charts/issues/19835)
-* Update httpproxies CRD (#20499) ([e5a2327](https://github.com/bitnami/charts/commit/e5a2327)), closes [#20499](https://github.com/bitnami/charts/issues/20499)
+* [bitnami/*] Rename VMware Application Catalog (#20361) ([3acc734](https://github.com/bitnami/charts/commit/3acc73472beb6fb56c4d99f929061001205bc57e)), closes [#20361](https://github.com/bitnami/charts/issues/20361)
+* [bitnami/*] Skip image's tag in the README files of the Bitnami Charts (#19841) ([bb9a01b](https://github.com/bitnami/charts/commit/bb9a01b65911c87e48318db922cc05eb42785e42)), closes [#19841](https://github.com/bitnami/charts/issues/19841)
+* [bitnami/*] Standardize documentation (#19835) ([af5f753](https://github.com/bitnami/charts/commit/af5f7530c1bc8c5ded53a6c4f7b8f384ac1804f2)), closes [#19835](https://github.com/bitnami/charts/issues/19835)
+* Update httpproxies CRD (#20499) ([e5a2327](https://github.com/bitnami/charts/commit/e5a2327b2cb707cd95c2f7abbeccf9b2b4ebb72a)), closes [#20499](https://github.com/bitnami/charts/issues/20499)
 
 ## <small>13.1.5 (2023-10-17)</small>
 
-* [bitnami/contour] Release 13.1.5 (#20291) ([6d0a719](https://github.com/bitnami/charts/commit/6d0a719)), closes [#20291](https://github.com/bitnami/charts/issues/20291)
+* [bitnami/contour] Release 13.1.5 (#20291) ([6d0a719](https://github.com/bitnami/charts/commit/6d0a719b29439180cffb31333af7ae3c7050f9c1)), closes [#20291](https://github.com/bitnami/charts/issues/20291)
 
 ## <small>13.1.4 (2023-10-12)</small>
 
-* [bitnami/contour] Release 13.1.4 (#20177) ([eb7c267](https://github.com/bitnami/charts/commit/eb7c267)), closes [#20177](https://github.com/bitnami/charts/issues/20177)
+* [bitnami/contour] Release 13.1.4 (#20177) ([eb7c267](https://github.com/bitnami/charts/commit/eb7c2677664f1ab2fa8df9fb3a06a15939c6ce74)), closes [#20177](https://github.com/bitnami/charts/issues/20177)
 
 ## <small>13.1.3 (2023-10-09)</small>
 
-* [bitnami/contour] Release 13.1.2 (#19820) ([b6190fb](https://github.com/bitnami/charts/commit/b6190fb)), closes [#19820](https://github.com/bitnami/charts/issues/19820)
+* [bitnami/contour] Release 13.1.2 (#19820) ([b6190fb](https://github.com/bitnami/charts/commit/b6190fbb09c51a49c98faa61db9e69ffa1f02cc6)), closes [#19820](https://github.com/bitnami/charts/issues/19820)
 
 ## <small>13.1.2 (2023-10-09)</small>
 
-* [bitnami/*] Update Helm charts prerequisites (#19745) ([eb755dd](https://github.com/bitnami/charts/commit/eb755dd)), closes [#19745](https://github.com/bitnami/charts/issues/19745)
-* [bitnami/contour] bump bitnami/common (#19782) ([1dbd7dd](https://github.com/bitnami/charts/commit/1dbd7dd)), closes [#19782](https://github.com/bitnami/charts/issues/19782)
+* [bitnami/*] Update Helm charts prerequisites (#19745) ([eb755dd](https://github.com/bitnami/charts/commit/eb755dd36a4dd3cf6635be8e0598f9a7f4c4a554)), closes [#19745](https://github.com/bitnami/charts/issues/19745)
+* [bitnami/contour] bump bitnami/common (#19782) ([1dbd7dd](https://github.com/bitnami/charts/commit/1dbd7dd9ce2f2a4cdd3e9ac83fbf518d59708e19)), closes [#19782](https://github.com/bitnami/charts/issues/19782)
 
 ## <small>13.1.1 (2023-10-03)</small>
 
-* [bitnami/contour] Release 13.1.1 (#19700) ([c0a6abc](https://github.com/bitnami/charts/commit/c0a6abc)), closes [#19700](https://github.com/bitnami/charts/issues/19700)
+* [bitnami/contour] Release 13.1.1 (#19700) ([c0a6abc](https://github.com/bitnami/charts/commit/c0a6abc558edcc017ae77bf7a80fb39fbfaaa369)), closes [#19700](https://github.com/bitnami/charts/issues/19700)
 
 ## 13.1.0 (2023-09-25)
 
-* [bitnami/contour]Feat/using contourconfiguration crd for contour (#17452) ([9979e38](https://github.com/bitnami/charts/commit/9979e38)), closes [#17452](https://github.com/bitnami/charts/issues/17452)
+* [bitnami/contour]Feat/using contourconfiguration crd for contour (#17452) ([9979e38](https://github.com/bitnami/charts/commit/9979e38ff62dc7c1d856bcc0a5e3caf8a2b2d0dd)), closes [#17452](https://github.com/bitnami/charts/issues/17452)
 
 ## 13.0.0 (2023-09-18)
 
-* [bitnami/contour] Release 13.0.0 (#19365) ([e8aea9c](https://github.com/bitnami/charts/commit/e8aea9c)), closes [#19365](https://github.com/bitnami/charts/issues/19365)
+* [bitnami/contour] Release 13.0.0 (#19365) ([e8aea9c](https://github.com/bitnami/charts/commit/e8aea9cb6d636337b2f4af43cc6be3c1c34b091d)), closes [#19365](https://github.com/bitnami/charts/issues/19365)
 
 ## <small>12.6.4 (2023-09-18)</small>
 
-* [bitnami/contour] Use different app.kubernetes.io/version label on subcomponents (#19329) ([2966ebf](https://github.com/bitnami/charts/commit/2966ebf)), closes [#19329](https://github.com/bitnami/charts/issues/19329)
-* Revert "Autogenerate schema files (#19194)" (#19335) ([73d80be](https://github.com/bitnami/charts/commit/73d80be)), closes [#19194](https://github.com/bitnami/charts/issues/19194) [#19335](https://github.com/bitnami/charts/issues/19335)
+* [bitnami/contour] Use different app.kubernetes.io/version label on subcomponents (#19329) ([2966ebf](https://github.com/bitnami/charts/commit/2966ebf33aca52a9ed59d82790929ee5a9c57929)), closes [#19329](https://github.com/bitnami/charts/issues/19329)
+* Revert "Autogenerate schema files (#19194)" (#19335) ([73d80be](https://github.com/bitnami/charts/commit/73d80be525c88fb4b8a54451a55acd506e337062)), closes [#19194](https://github.com/bitnami/charts/issues/19194) [#19335](https://github.com/bitnami/charts/issues/19335)
 
 ## <small>12.6.3 (2023-09-12)</small>
 
-* [bitnami/contour] Release 12.6.3 (#19237) ([67de3c6](https://github.com/bitnami/charts/commit/67de3c6)), closes [#19237](https://github.com/bitnami/charts/issues/19237)
+* [bitnami/contour] Release 12.6.3 (#19237) ([67de3c6](https://github.com/bitnami/charts/commit/67de3c6ed681ffa237aabc22c5a6a058aa03c7dd)), closes [#19237](https://github.com/bitnami/charts/issues/19237)
 
 ## <small>12.6.2 (2023-09-11)</small>
 
-* [bitnami/contour] Release 12.6.2 (#19232) ([56045b9](https://github.com/bitnami/charts/commit/56045b9)), closes [#19232](https://github.com/bitnami/charts/issues/19232)
-* Autogenerate schema files (#19194) ([a2c2090](https://github.com/bitnami/charts/commit/a2c2090)), closes [#19194](https://github.com/bitnami/charts/issues/19194)
+* [bitnami/contour] Release 12.6.2 (#19232) ([56045b9](https://github.com/bitnami/charts/commit/56045b95a6ca6d091a50177e83e5f7cba5abd306)), closes [#19232](https://github.com/bitnami/charts/issues/19232)
+* Autogenerate schema files (#19194) ([a2c2090](https://github.com/bitnami/charts/commit/a2c2090b5ac97f47b745c8028c6452bf99739772)), closes [#19194](https://github.com/bitnami/charts/issues/19194)
 
 ## <small>12.6.1 (2023-09-06)</small>
 
-* [bitnami/contour]: Use merge helper (#19029) ([4dd4494](https://github.com/bitnami/charts/commit/4dd4494)), closes [#19029](https://github.com/bitnami/charts/issues/19029)
+* [bitnami/contour]: Use merge helper (#19029) ([4dd4494](https://github.com/bitnami/charts/commit/4dd4494a2c885b34b2c670ac34d8edca173e0fa3)), closes [#19029](https://github.com/bitnami/charts/issues/19029)
 
 ## 12.6.0 (2023-08-29)
 
-* [bitnami/contour] Rename envoy.containerSecurityContextEnvoyInit as envoy.initConfig.containerSecuri ([ede23fe](https://github.com/bitnami/charts/commit/ede23fe)), closes [#18923](https://github.com/bitnami/charts/issues/18923)
+* [bitnami/contour] Rename envoy.containerSecurityContextEnvoyInit as envoy.initConfig.containerSecuri ([ede23fe](https://github.com/bitnami/charts/commit/ede23fe2f71373bc0dcfc56d3fc393d75adc2b15)), closes [#18923](https://github.com/bitnami/charts/issues/18923)
 
 ## 12.5.0 (2023-08-25)
 
-* [bitnami/contour] Add envoy prometheus rules template (#17795) ([92bdf99](https://github.com/bitnami/charts/commit/92bdf99)), closes [#17795](https://github.com/bitnami/charts/issues/17795)
+* [bitnami/contour] Add envoy prometheus rules template (#17795) ([92bdf99](https://github.com/bitnami/charts/commit/92bdf994628a698afbeb0705eadb0d3cd151bba9)), closes [#17795](https://github.com/bitnami/charts/issues/17795)
 
 ## 12.4.0 (2023-08-22)
 
-* [bitnami/contour] Support for customizing standard labels (#18296) ([408dd47](https://github.com/bitnami/charts/commit/408dd47)), closes [#18296](https://github.com/bitnami/charts/issues/18296)
+* [bitnami/contour] Support for customizing standard labels (#18296) ([408dd47](https://github.com/bitnami/charts/commit/408dd47fd43a18e9742ecc5ea586b38a1ae3de01)), closes [#18296](https://github.com/bitnami/charts/issues/18296)
 
 ## <small>12.3.2 (2023-08-19)</small>
 
-* [bitnami/contour] Release 12.3.2 (#18652) ([edd606f](https://github.com/bitnami/charts/commit/edd606f)), closes [#18652](https://github.com/bitnami/charts/issues/18652)
+* [bitnami/contour] Release 12.3.2 (#18652) ([edd606f](https://github.com/bitnami/charts/commit/edd606fa59189a4a80b8a8003fa0511653dd7c6c)), closes [#18652](https://github.com/bitnami/charts/issues/18652)
 
 ## <small>12.3.1 (2023-08-17)</small>
 
-* [bitnami/contour] Release 12.3.1 (#18507) ([cd0b4ff](https://github.com/bitnami/charts/commit/cd0b4ff)), closes [#18507](https://github.com/bitnami/charts/issues/18507)
+* [bitnami/contour] Release 12.3.1 (#18507) ([cd0b4ff](https://github.com/bitnami/charts/commit/cd0b4ff04b57b0db5f493bc91e97d9a8ac63b2a6)), closes [#18507](https://github.com/bitnami/charts/issues/18507)
 
 ## 12.3.0 (2023-08-17)
 
-* [bitnami/contour] Added suport for behavior on Envoy HPA (#18471) ([f9f72a2](https://github.com/bitnami/charts/commit/f9f72a2)), closes [#18471](https://github.com/bitnami/charts/issues/18471)
+* [bitnami/contour] Added suport for behavior on Envoy HPA (#18471) ([f9f72a2](https://github.com/bitnami/charts/commit/f9f72a2c453a8ad2a10c0bec45f05af08e273ad7)), closes [#18471](https://github.com/bitnami/charts/issues/18471)
 
 ## <small>12.2.8 (2023-08-14)</small>
 
-* [bitnami/contour] Use envoy resources for envoy daemonset and deployment initContainers (#18366) ([b914bb5](https://github.com/bitnami/charts/commit/b914bb5)), closes [#18366](https://github.com/bitnami/charts/issues/18366)
+* [bitnami/contour] Use envoy resources for envoy daemonset and deployment initContainers (#18366) ([b914bb5](https://github.com/bitnami/charts/commit/b914bb51489c679596f07200924c27bc1dc61a92)), closes [#18366](https://github.com/bitnami/charts/issues/18366)
 
 ## <small>12.2.7 (2023-08-09)</small>
 
-* [bitnami/contour] Release 12.2.7 (#18310) ([7b4d074](https://github.com/bitnami/charts/commit/7b4d074)), closes [#18310](https://github.com/bitnami/charts/issues/18310)
+* [bitnami/contour] Release 12.2.7 (#18310) ([7b4d074](https://github.com/bitnami/charts/commit/7b4d0746a7c57d402a8df67b265ef67dc76f406b)), closes [#18310](https://github.com/bitnami/charts/issues/18310)
 
 ## <small>12.2.6 (2023-08-08)</small>
 
-* [bitnami/contour] chore: :page_facing_up: Remove license in CRDs (#18277) ([dade8ac](https://github.com/bitnami/charts/commit/dade8ac)), closes [#18277](https://github.com/bitnami/charts/issues/18277)
-* [bitnami/contour] chore: :truck: Move resources to templates/crds folder (#18252) ([752cc5a](https://github.com/bitnami/charts/commit/752cc5a)), closes [#18252](https://github.com/bitnami/charts/issues/18252)
+* [bitnami/contour] chore: :page_facing_up: Remove license in CRDs (#18277) ([dade8ac](https://github.com/bitnami/charts/commit/dade8ac13acd8973fa4c61c7e874a48491bef941)), closes [#18277](https://github.com/bitnami/charts/issues/18277)
+* [bitnami/contour] chore: :truck: Move resources to templates/crds folder (#18252) ([752cc5a](https://github.com/bitnami/charts/commit/752cc5a761905140e753c7987a21ae114d9b43b0)), closes [#18252](https://github.com/bitnami/charts/issues/18252)
 
 ## <small>12.2.5 (2023-08-08)</small>
 
-* [bitnami/contour] add ipFamilies to contour envoy service.yaml (#18096) ([5a68df7](https://github.com/bitnami/charts/commit/5a68df7)), closes [#18096](https://github.com/bitnami/charts/issues/18096)
+* [bitnami/contour] add ipFamilies to contour envoy service.yaml (#18096) ([5a68df7](https://github.com/bitnami/charts/commit/5a68df7c95d65274b3e357dbfbc2e35f6397ff10)), closes [#18096](https://github.com/bitnami/charts/issues/18096)
 
 ## <small>12.2.4 (2023-07-27)</small>
 
-* [bitnami/contour] Release 12.2.4 (#17995) ([59f5386](https://github.com/bitnami/charts/commit/59f5386)), closes [#17995](https://github.com/bitnami/charts/issues/17995)
+* [bitnami/contour] Release 12.2.4 (#17995) ([59f5386](https://github.com/bitnami/charts/commit/59f5386477b85f9447ddc3f60ce04bc23085154b)), closes [#17995](https://github.com/bitnami/charts/issues/17995)
 
 ## <small>12.2.3 (2023-07-26)</small>
 
-* [bitnami/contour] Release 12.2.3 (#17980) ([69ab8f8](https://github.com/bitnami/charts/commit/69ab8f8)), closes [#17980](https://github.com/bitnami/charts/issues/17980)
+* [bitnami/contour] Release 12.2.3 (#17980) ([69ab8f8](https://github.com/bitnami/charts/commit/69ab8f8ac1d6dd518c3b3d033d941b355d056c98)), closes [#17980](https://github.com/bitnami/charts/issues/17980)
 
 ## <small>12.2.2 (2023-07-25)</small>
 
-* [bitnami/contour] Release 12.2.2 (#17872) ([83258cb](https://github.com/bitnami/charts/commit/83258cb)), closes [#17872](https://github.com/bitnami/charts/issues/17872)
+* [bitnami/contour] Release 12.2.2 (#17872) ([83258cb](https://github.com/bitnami/charts/commit/83258cb17c815543c4eed053f6ce7aff0901077f)), closes [#17872](https://github.com/bitnami/charts/issues/17872)
 
 ## <small>12.2.1 (2023-07-24)</small>
 
-* [bitnami/contour] Add namespace field for envoy metrics service (#17790) ([3729506](https://github.com/bitnami/charts/commit/3729506)), closes [#17790](https://github.com/bitnami/charts/issues/17790)
+* [bitnami/contour] Add namespace field for envoy metrics service (#17790) ([3729506](https://github.com/bitnami/charts/commit/3729506bcfa8ab587697778f72713fd905fee4d3)), closes [#17790](https://github.com/bitnami/charts/issues/17790)
 
 ## 12.2.0 (2023-07-19)
 
-* [bitnami/contour] allow to manipulate container securityContext fields for each container (#17456) ([235c3c9](https://github.com/bitnami/charts/commit/235c3c9)), closes [#17456](https://github.com/bitnami/charts/issues/17456)
+* [bitnami/contour] allow to manipulate container securityContext fields for each container (#17456) ([235c3c9](https://github.com/bitnami/charts/commit/235c3c9e8d0452542798753b2834c71aa5ca74f6)), closes [#17456](https://github.com/bitnami/charts/issues/17456)
 
 ## <small>12.1.2 (2023-07-13)</small>
 
-* [bitnami/contour] Release 12.1.2 (#17637) ([844e23c](https://github.com/bitnami/charts/commit/844e23c)), closes [#17637](https://github.com/bitnami/charts/issues/17637)
-* Add copyright header (#17300) ([da68be8](https://github.com/bitnami/charts/commit/da68be8)), closes [#17300](https://github.com/bitnami/charts/issues/17300)
-* Update charts readme (#17217) ([31b3c0a](https://github.com/bitnami/charts/commit/31b3c0a)), closes [#17217](https://github.com/bitnami/charts/issues/17217)
+* [bitnami/contour] Release 12.1.2 (#17637) ([844e23c](https://github.com/bitnami/charts/commit/844e23c306df89fc626822752a94181b994c2e9c)), closes [#17637](https://github.com/bitnami/charts/issues/17637)
+* Add copyright header (#17300) ([da68be8](https://github.com/bitnami/charts/commit/da68be8e951225133c7dfb572d5101ca3d61c5ae)), closes [#17300](https://github.com/bitnami/charts/issues/17300)
+* Update charts readme (#17217) ([31b3c0a](https://github.com/bitnami/charts/commit/31b3c0afd968ff4429107e34101f7509e6a0e913)), closes [#17217](https://github.com/bitnami/charts/issues/17217)
 
 ## <small>12.1.1 (2023-06-20)</small>
 
-* [bitnami/*] Change copyright section in READMEs (#17006) ([ef986a1](https://github.com/bitnami/charts/commit/ef986a1)), closes [#17006](https://github.com/bitnami/charts/issues/17006)
-* [bitnami/contour] Release 12.1.1 (#17202) ([450a2c3](https://github.com/bitnami/charts/commit/450a2c3)), closes [#17202](https://github.com/bitnami/charts/issues/17202)
-* [bitnami/several] Change copyright section in READMEs (#16989) ([5b6a5cf](https://github.com/bitnami/charts/commit/5b6a5cf)), closes [#16989](https://github.com/bitnami/charts/issues/16989)
+* [bitnami/*] Change copyright section in READMEs (#17006) ([ef986a1](https://github.com/bitnami/charts/commit/ef986a1605241102b3dcafe9fd8089e6fc1201ad)), closes [#17006](https://github.com/bitnami/charts/issues/17006)
+* [bitnami/contour] Release 12.1.1 (#17202) ([450a2c3](https://github.com/bitnami/charts/commit/450a2c305cc7a90ee7955b8d55f99719f2b44961)), closes [#17202](https://github.com/bitnami/charts/issues/17202)
+* [bitnami/several] Change copyright section in READMEs (#16989) ([5b6a5cf](https://github.com/bitnami/charts/commit/5b6a5cfb7625a751848a2e5cd796bd7278f406ca)), closes [#16989](https://github.com/bitnami/charts/issues/16989)
 
 ## 12.1.0 (2023-05-25)
 
-* [bitnami/contour] Add prometheusRule to contour (#16562) ([507ba74](https://github.com/bitnami/charts/commit/507ba74)), closes [#16562](https://github.com/bitnami/charts/issues/16562)
+* [bitnami/contour] Add prometheusRule to contour (#16562) ([507ba74](https://github.com/bitnami/charts/commit/507ba74574fa643bc6672536d277652df5bfa7f7)), closes [#16562](https://github.com/bitnami/charts/issues/16562)
 
 ## <small>12.0.4 (2023-05-25)</small>
 
-* [bitnami/contour] add grpcroutes to RBAC (#16889) ([2410fc6](https://github.com/bitnami/charts/commit/2410fc6)), closes [#16889](https://github.com/bitnami/charts/issues/16889)
+* [bitnami/contour] add grpcroutes to RBAC (#16889) ([2410fc6](https://github.com/bitnami/charts/commit/2410fc63836575453a197a1246a7ef843e60e168)), closes [#16889](https://github.com/bitnami/charts/issues/16889)
 
 ## <small>12.0.3 (2023-05-23)</small>
 
-* [bitnami/contour] Sync CRDs with upstream (#16651) ([c396e7c](https://github.com/bitnami/charts/commit/c396e7c)), closes [#16651](https://github.com/bitnami/charts/issues/16651)
+* [bitnami/contour] Sync CRDs with upstream (#16651) ([c396e7c](https://github.com/bitnami/charts/commit/c396e7c6487e821944a26a1fa4aaeeb5c3d0b0d5)), closes [#16651](https://github.com/bitnami/charts/issues/16651)
 
 ## <small>12.0.2 (2023-05-21)</small>
 
-* [bitnami/contour] Release 12.0.2 (#16758) ([cbe1942](https://github.com/bitnami/charts/commit/cbe1942)), closes [#16758](https://github.com/bitnami/charts/issues/16758)
+* [bitnami/contour] Release 12.0.2 (#16758) ([cbe1942](https://github.com/bitnami/charts/commit/cbe194286c425ca04eaa44f1924388315f5914d0)), closes [#16758](https://github.com/bitnami/charts/issues/16758)
 
 ## <small>12.0.1 (2023-05-18)</small>
 
-* [bitnami/contour] add feature to deploy multi envoy by proxy chart (#16718) ([264d3e2](https://github.com/bitnami/charts/commit/264d3e2)), closes [#16718](https://github.com/bitnami/charts/issues/16718)
+* [bitnami/contour] add feature to deploy multi envoy by proxy chart (#16718) ([264d3e2](https://github.com/bitnami/charts/commit/264d3e22ee75c4dd259710b5ced16ec5f078f93f)), closes [#16718](https://github.com/bitnami/charts/issues/16718)
 
 ## 12.0.0 (2023-05-12)
 
-* [bitnami/contour] Release 12.0.0 (#16627) ([fe34be6](https://github.com/bitnami/charts/commit/fe34be6)), closes [#16627](https://github.com/bitnami/charts/issues/16627)
-* Add wording for enterprise page (#16560) ([8f22774](https://github.com/bitnami/charts/commit/8f22774)), closes [#16560](https://github.com/bitnami/charts/issues/16560)
+* [bitnami/contour] Release 12.0.0 (#16627) ([fe34be6](https://github.com/bitnami/charts/commit/fe34be6110607bffe6c481aea02905c995a624b7)), closes [#16627](https://github.com/bitnami/charts/issues/16627)
+* Add wording for enterprise page (#16560) ([8f22774](https://github.com/bitnami/charts/commit/8f2277440b976d52785ba9149762ad8620a73d1f)), closes [#16560](https://github.com/bitnami/charts/issues/16560)
 
 ## 11.4.0 (2023-05-09)
 
-* [bitnami/several] Adapt Chart.yaml to set desired OCI annotations (#16546) ([fc9b18f](https://github.com/bitnami/charts/commit/fc9b18f)), closes [#16546](https://github.com/bitnami/charts/issues/16546)
+* [bitnami/several] Adapt Chart.yaml to set desired OCI annotations (#16546) ([fc9b18f](https://github.com/bitnami/charts/commit/fc9b18f2e98805d4df629acbcde696f44f973344)), closes [#16546](https://github.com/bitnami/charts/issues/16546)
 
 ## <small>11.3.2 (2023-05-09)</small>
 
-* [bitnami/contour] Release 11.3.2 (#16509) ([283a33a](https://github.com/bitnami/charts/commit/283a33a)), closes [#16509](https://github.com/bitnami/charts/issues/16509)
+* [bitnami/contour] Release 11.3.2 (#16509) ([283a33a](https://github.com/bitnami/charts/commit/283a33ac37b79402f7d5e346705c58da0ad02488)), closes [#16509](https://github.com/bitnami/charts/issues/16509)
 
 ## <small>11.3.1 (2023-04-29)</small>
 
-* [bitnami/contour] Release 11.3.1 (#16280) ([69d8c1d](https://github.com/bitnami/charts/commit/69d8c1d)), closes [#16280](https://github.com/bitnami/charts/issues/16280)
+* [bitnami/contour] Release 11.3.1 (#16280) ([69d8c1d](https://github.com/bitnami/charts/commit/69d8c1d2e90bb9e6a86e5e18868177cb66132efd)), closes [#16280](https://github.com/bitnami/charts/issues/16280)
 
 ## 11.3.0 (2023-04-24)
 
-* [bitnami/contour] Added option to set leader-election-resource-name. (#16152) ([483dde1](https://github.com/bitnami/charts/commit/483dde1)), closes [#16152](https://github.com/bitnami/charts/issues/16152)
+* [bitnami/contour] Added option to set leader-election-resource-name. (#16152) ([483dde1](https://github.com/bitnami/charts/commit/483dde1bdcb874f01535bb9f00652468ceedf2fe)), closes [#16152](https://github.com/bitnami/charts/issues/16152)
 
 ## 11.2.0 (2023-04-20)
 
-* [bitnami/*] Make Helm charts 100% OCI (#15998) ([8841510](https://github.com/bitnami/charts/commit/8841510)), closes [#15998](https://github.com/bitnami/charts/issues/15998)
+* [bitnami/*] Make Helm charts 100% OCI (#15998) ([8841510](https://github.com/bitnami/charts/commit/884151035efcbf2e1b3206e7def85511073fb57d)), closes [#15998](https://github.com/bitnami/charts/issues/15998)
 
 ## <small>11.1.3 (2023-04-05)</small>
 
-* [bitnami/contour] Release 11.1.3 (#15973) ([a669ad2](https://github.com/bitnami/charts/commit/a669ad2)), closes [#15973](https://github.com/bitnami/charts/issues/15973)
+* [bitnami/contour] Release 11.1.3 (#15973) ([a669ad2](https://github.com/bitnami/charts/commit/a669ad22f6aba4883f2eeca5f60c8c2d218c0b2f)), closes [#15973](https://github.com/bitnami/charts/issues/15973)
 
 ## <small>11.1.2 (2023-04-01)</small>
 
-* [bitnami/contour] Release 11.1.2 (#15844) ([1354e3f](https://github.com/bitnami/charts/commit/1354e3f)), closes [#15844](https://github.com/bitnami/charts/issues/15844)
+* [bitnami/contour] Release 11.1.2 (#15844) ([1354e3f](https://github.com/bitnami/charts/commit/1354e3f851caa85420a8f87ec111d28611ca9c82)), closes [#15844](https://github.com/bitnami/charts/issues/15844)
 
 ## <small>11.1.1 (2023-03-18)</small>
 
-* [bitnami/contour] Release 11.1.1 (#15560) ([62b4458](https://github.com/bitnami/charts/commit/62b4458)), closes [#15560](https://github.com/bitnami/charts/issues/15560)
+* [bitnami/contour] Release 11.1.1 (#15560) ([62b4458](https://github.com/bitnami/charts/commit/62b445856a834aa9895a6f5a32d7a72ff5beecad)), closes [#15560](https://github.com/bitnami/charts/issues/15560)
 
 ## 11.1.0 (2023-03-17)
 
-* [bitnami/contour] Adds support for Overload Manager (#15513) (#15523) ([86a6f38](https://github.com/bitnami/charts/commit/86a6f38)), closes [#15513](https://github.com/bitnami/charts/issues/15513) [#15523](https://github.com/bitnami/charts/issues/15523) [#15513](https://github.com/bitnami/charts/issues/15513) [#15513](https://github.com/bitnami/charts/issues/15513)
+* [bitnami/contour] Adds support for Overload Manager (#15513) (#15523) ([86a6f38](https://github.com/bitnami/charts/commit/86a6f383a275916c2936dc7fefd0c4e62db56085)), closes [#15513](https://github.com/bitnami/charts/issues/15513) [#15523](https://github.com/bitnami/charts/issues/15523) [#15513](https://github.com/bitnami/charts/issues/15513) [#15513](https://github.com/bitnami/charts/issues/15513)
 
 ## <small>11.0.4 (2023-03-14)</small>
 
-* [bitnami/contour] Release 11.0.4 (#15504) ([194cf3b](https://github.com/bitnami/charts/commit/194cf3b)), closes [#15504](https://github.com/bitnami/charts/issues/15504)
+* [bitnami/contour] Release 11.0.4 (#15504) ([194cf3b](https://github.com/bitnami/charts/commit/194cf3b42bf489554b1c698102243baee2d74401)), closes [#15504](https://github.com/bitnami/charts/issues/15504)
 
 ## <small>11.0.3 (2023-03-10)</small>
 
-* [bitnami/contour] Support all securitycontext fields (#15392) (#15448) ([b5e5443](https://github.com/bitnami/charts/commit/b5e5443)), closes [#15392](https://github.com/bitnami/charts/issues/15392) [#15448](https://github.com/bitnami/charts/issues/15448)
+* [bitnami/contour] Support all securitycontext fields (#15392) (#15448) ([b5e5443](https://github.com/bitnami/charts/commit/b5e5443b8ff8e7da45bafdd7a3cbbc2fb8ab6279)), closes [#15392](https://github.com/bitnami/charts/issues/15392) [#15448](https://github.com/bitnami/charts/issues/15448)
 
 ## <small>11.0.2 (2023-03-09)</small>
 
-* [bitnami/charts] Apply linter to README files (#15357) ([0e29e60](https://github.com/bitnami/charts/commit/0e29e60)), closes [#15357](https://github.com/bitnami/charts/issues/15357)
-* [bitnami/contour] add contour.logFormat configuration (#14968) ([e485da6](https://github.com/bitnami/charts/commit/e485da6)), closes [#14968](https://github.com/bitnami/charts/issues/14968)
-* [bitnami/contour] Sync upstream CRD and templates (#15371) ([34db3ae](https://github.com/bitnami/charts/commit/34db3ae)), closes [#15371](https://github.com/bitnami/charts/issues/15371) [#15354](https://github.com/bitnami/charts/issues/15354)
+* [bitnami/charts] Apply linter to README files (#15357) ([0e29e60](https://github.com/bitnami/charts/commit/0e29e600d3adc8b1b46e506eccb3decfab3b4e63)), closes [#15357](https://github.com/bitnami/charts/issues/15357)
+* [bitnami/contour] add contour.logFormat configuration (#14968) ([e485da6](https://github.com/bitnami/charts/commit/e485da6a5b4755313348c1521b4b9458b0558364)), closes [#14968](https://github.com/bitnami/charts/issues/14968)
+* [bitnami/contour] Sync upstream CRD and templates (#15371) ([34db3ae](https://github.com/bitnami/charts/commit/34db3aee0e471574efd715a38f36b1adc62cec02)), closes [#15371](https://github.com/bitnami/charts/issues/15371) [#15354](https://github.com/bitnami/charts/issues/15354)
 
 ## <small>11.0.1 (2023-03-01)</small>
 
-* [bitnami/contour] Release 11.0.1 (#15198) ([afc0e5d](https://github.com/bitnami/charts/commit/afc0e5d)), closes [#15198](https://github.com/bitnami/charts/issues/15198)
+* [bitnami/contour] Release 11.0.1 (#15198) ([afc0e5d](https://github.com/bitnami/charts/commit/afc0e5d9071c32a613e022ef02b6a33bdf25f7fa)), closes [#15198](https://github.com/bitnami/charts/issues/15198)
 
 ## 11.0.0 (2023-02-17)
 
-* [bitnami/*] Fix markdown linter issues (#14874) ([a51e0e8](https://github.com/bitnami/charts/commit/a51e0e8)), closes [#14874](https://github.com/bitnami/charts/issues/14874)
-* [bitnami/*] Fix markdown linter issues 2 (#14890) ([aa96572](https://github.com/bitnami/charts/commit/aa96572)), closes [#14890](https://github.com/bitnami/charts/issues/14890)
-* [bitnami/*] Remove unexpected extra spaces (#14873) ([c97c714](https://github.com/bitnami/charts/commit/c97c714)), closes [#14873](https://github.com/bitnami/charts/issues/14873)
-* [bitnami/contour] Release 11.0.0 (#14933) ([70b9a82](https://github.com/bitnami/charts/commit/70b9a82)), closes [#14933](https://github.com/bitnami/charts/issues/14933)
+* [bitnami/*] Fix markdown linter issues (#14874) ([a51e0e8](https://github.com/bitnami/charts/commit/a51e0e8d35495b907f3e70dd2f8e7c3bcbf4166a)), closes [#14874](https://github.com/bitnami/charts/issues/14874)
+* [bitnami/*] Fix markdown linter issues 2 (#14890) ([aa96572](https://github.com/bitnami/charts/commit/aa9657237ee8df4a46db0d7fdf8a23230dd6902a)), closes [#14890](https://github.com/bitnami/charts/issues/14890)
+* [bitnami/*] Remove unexpected extra spaces (#14873) ([c97c714](https://github.com/bitnami/charts/commit/c97c714887380d47eae7bfeff316bf01595ecd1d)), closes [#14873](https://github.com/bitnami/charts/issues/14873)
+* [bitnami/contour] Release 11.0.0 (#14933) ([70b9a82](https://github.com/bitnami/charts/commit/70b9a82a8645e23432fb3d631de5b9a570045853)), closes [#14933](https://github.com/bitnami/charts/issues/14933)
 
 ## <small>10.2.2 (2023-02-08)</small>
 
-* [bitnami/*] Change copyright date (#14682) ([add4ec7](https://github.com/bitnami/charts/commit/add4ec7)), closes [#14682](https://github.com/bitnami/charts/issues/14682)
-* [bitnami/contour] Release 10.2.2 (#14798) ([fdb01b7](https://github.com/bitnami/charts/commit/fdb01b7)), closes [#14798](https://github.com/bitnami/charts/issues/14798)
+* [bitnami/*] Change copyright date (#14682) ([add4ec7](https://github.com/bitnami/charts/commit/add4ec701108ac36ed4de2dffbdf407a0d091067)), closes [#14682](https://github.com/bitnami/charts/issues/14682)
+* [bitnami/contour] Release 10.2.2 (#14798) ([fdb01b7](https://github.com/bitnami/charts/commit/fdb01b7138f1bd4c1324bc5b44fa6554d4e85e6c)), closes [#14798](https://github.com/bitnami/charts/issues/14798)
 
 ## <small>10.2.1 (2023-01-31)</small>
 
-* [bitnami/contour] Don't regenerate self-signed certs on upgrade (#14615) ([f184741](https://github.com/bitnami/charts/commit/f184741)), closes [#14615](https://github.com/bitnami/charts/issues/14615)
+* [bitnami/contour] Don't regenerate self-signed certs on upgrade (#14615) ([f184741](https://github.com/bitnami/charts/commit/f1847418b41f46a9a0aa78dc622a822d6366a9e4)), closes [#14615](https://github.com/bitnami/charts/issues/14615)
 
 ## 10.2.0 (2023-01-26)
 
-* [bitnami/contour] Added option to set ingress-status-address. (#14543) ([b7153dd](https://github.com/bitnami/charts/commit/b7153dd)), closes [#14543](https://github.com/bitnami/charts/issues/14543)
+* [bitnami/contour] Added option to set ingress-status-address. (#14543) ([b7153dd](https://github.com/bitnami/charts/commit/b7153ddea0b0ad22a6d947260c9df77ed428de31)), closes [#14543](https://github.com/bitnami/charts/issues/14543)
 
 ## <small>10.1.5 (2023-01-25)</small>
 
-* [bitnami/*] Change licenses annotation format (#14377) ([0ab7608](https://github.com/bitnami/charts/commit/0ab7608)), closes [#14377](https://github.com/bitnami/charts/issues/14377)
-* [bitnami/*] Unify READMEs (#14472) ([2064fb8](https://github.com/bitnami/charts/commit/2064fb8)), closes [#14472](https://github.com/bitnami/charts/issues/14472)
-* [bitnami/contour] Added option to override envoy service name (#14513) ([9762524](https://github.com/bitnami/charts/commit/9762524)), closes [#14513](https://github.com/bitnami/charts/issues/14513)
+* [bitnami/*] Change licenses annotation format (#14377) ([0ab7608](https://github.com/bitnami/charts/commit/0ab760862c660fcc78cffadf8e1d8cdd70881473)), closes [#14377](https://github.com/bitnami/charts/issues/14377)
+* [bitnami/*] Unify READMEs (#14472) ([2064fb8](https://github.com/bitnami/charts/commit/2064fb8dcc78a845cdede8211af8c3cc52551161)), closes [#14472](https://github.com/bitnami/charts/issues/14472)
+* [bitnami/contour] Added option to override envoy service name (#14513) ([9762524](https://github.com/bitnami/charts/commit/9762524419e7ab2f49599d03c353aa43a51ddb0f)), closes [#14513](https://github.com/bitnami/charts/issues/14513)
 
 ## <small>10.1.4 (2023-01-12)</small>
 
-* [bitnami/*] Add license annotation and remove obsolete engine parameter (#14293) ([da2a794](https://github.com/bitnami/charts/commit/da2a794)), closes [#14293](https://github.com/bitnami/charts/issues/14293)
-* [bitnami/contour] Release 10.1.4 (#14301) ([9a42e57](https://github.com/bitnami/charts/commit/9a42e57)), closes [#14301](https://github.com/bitnami/charts/issues/14301)
+* [bitnami/*] Add license annotation and remove obsolete engine parameter (#14293) ([da2a794](https://github.com/bitnami/charts/commit/da2a7943bae95b6e9b5b4ed972c15e990b69fdb0)), closes [#14293](https://github.com/bitnami/charts/issues/14293)
+* [bitnami/contour] Release 10.1.4 (#14301) ([9a42e57](https://github.com/bitnami/charts/commit/9a42e574b777e41e743db532ec9829c008b26fc0)), closes [#14301](https://github.com/bitnami/charts/issues/14301)
 
 ## <small>10.1.3 (2022-12-13)</small>
 
-* [bitnami/contour] Release 10.1.3 (#13937) ([fbd383c](https://github.com/bitnami/charts/commit/fbd383c)), closes [#13937](https://github.com/bitnami/charts/issues/13937)
+* [bitnami/contour] Release 10.1.3 (#13937) ([fbd383c](https://github.com/bitnami/charts/commit/fbd383cf37cb0afe48de3ae0a51d453c4d075d09)), closes [#13937](https://github.com/bitnami/charts/issues/13937)
 
 ## <small>10.1.2 (2022-12-07)</small>
 
-* [bitnami/contour] Release 10.1.2 (#13854) ([1e66c7f](https://github.com/bitnami/charts/commit/1e66c7f)), closes [#13854](https://github.com/bitnami/charts/issues/13854)
+* [bitnami/contour] Release 10.1.2 (#13854) ([1e66c7f](https://github.com/bitnami/charts/commit/1e66c7f5265b148a772b96c2a2e688ebedb561f6)), closes [#13854](https://github.com/bitnami/charts/issues/13854)
 
 ## <small>10.1.1 (2022-12-04)</small>
 
-* [bitnami/contour] Release 10.1.1 (#13827) ([2d092a0](https://github.com/bitnami/charts/commit/2d092a0)), closes [#13827](https://github.com/bitnami/charts/issues/13827)
+* [bitnami/contour] Release 10.1.1 (#13827) ([2d092a0](https://github.com/bitnami/charts/commit/2d092a02cbd6c1cd0fb6697967001db7dff455f4)), closes [#13827](https://github.com/bitnami/charts/issues/13827)
 
 ## 10.1.0 (2022-12-01)
 
-* [bitnami/contour] Adding CRDs for Contour 1.23 (#13404) ([1d70327](https://github.com/bitnami/charts/commit/1d70327)), closes [#13404](https://github.com/bitnami/charts/issues/13404) [#22](https://github.com/bitnami/charts/issues/22)
+* [bitnami/contour] Adding CRDs for Contour 1.23 (#13404) ([1d70327](https://github.com/bitnami/charts/commit/1d7032746053d5cabce07519d93f491bd256c725)), closes [#13404](https://github.com/bitnami/charts/issues/13404) [#22](https://github.com/bitnami/charts/issues/22)
 
 ## <small>10.0.1 (2022-11-30)</small>
 
-* [bitnami/contour] adds missing RBAC to watch Gateway API ReferenceGrants (#13637) ([947e13a](https://github.com/bitnami/charts/commit/947e13a)), closes [#13637](https://github.com/bitnami/charts/issues/13637)
+* [bitnami/contour] adds missing RBAC to watch Gateway API ReferenceGrants (#13637) ([947e13a](https://github.com/bitnami/charts/commit/947e13a1a607e9b15daaca9af21b8b9ffdf986c1)), closes [#13637](https://github.com/bitnami/charts/issues/13637)
 
 ## 10.0.0 (2022-11-07)
 
-* [bitnami/contour] Release 10.0.0 (#13355) ([5e56ca8](https://github.com/bitnami/charts/commit/5e56ca8)), closes [#13355](https://github.com/bitnami/charts/issues/13355)
+* [bitnami/contour] Release 10.0.0 (#13355) ([5e56ca8](https://github.com/bitnami/charts/commit/5e56ca86f96d6a29a5c495d93f389f10aedbe3bc)), closes [#13355](https://github.com/bitnami/charts/issues/13355)
 
 ## 9.2.0 (2022-11-03)
 
-* [bitnami/contour] Add loadBalancerClass options (#13311) ([ec3cc99](https://github.com/bitnami/charts/commit/ec3cc99)), closes [#13311](https://github.com/bitnami/charts/issues/13311)
+* [bitnami/contour] Add loadBalancerClass options (#13311) ([ec3cc99](https://github.com/bitnami/charts/commit/ec3cc99cab7760786020415c0a4ed0d9dd9087f4)), closes [#13311](https://github.com/bitnami/charts/issues/13311)
 
 ## <small>9.1.7 (2022-10-31)</small>
 
-* [bitnami/*] Use new default branch name in links (#12943) ([a529e02](https://github.com/bitnami/charts/commit/a529e02)), closes [#12943](https://github.com/bitnami/charts/issues/12943)
-* change apiversion hardcode for deployment (#13247) ([d31a9dc](https://github.com/bitnami/charts/commit/d31a9dc)), closes [#13247](https://github.com/bitnami/charts/issues/13247)
+* [bitnami/*] Use new default branch name in links (#12943) ([a529e02](https://github.com/bitnami/charts/commit/a529e02597d49d944eba1eb0f190713293247176)), closes [#12943](https://github.com/bitnami/charts/issues/12943)
+* change apiversion hardcode for deployment (#13247) ([d31a9dc](https://github.com/bitnami/charts/commit/d31a9dcbe8f7afc99bdd913ba2ef17fa075adbd9)), closes [#13247](https://github.com/bitnami/charts/issues/13247)
 
 ## <small>9.1.6 (2022-10-08)</small>
 
-* [bitnami/contour] Release 9.1.6 updating components versions ([bef931c](https://github.com/bitnami/charts/commit/bef931c))
+* [bitnami/contour] Release 9.1.6 updating components versions ([bef931c](https://github.com/bitnami/charts/commit/bef931c534d566277a165044eeda03bd6f31c209))
 
 ## <small>9.1.5 (2022-10-05)</small>
 
-* [bitnami/contour] Update maintainers (#12817) ([7619fb0](https://github.com/bitnami/charts/commit/7619fb0)), closes [#12817](https://github.com/bitnami/charts/issues/12817)
-* Generic README instructions related to the repo (#12792) ([3cf6b10](https://github.com/bitnami/charts/commit/3cf6b10)), closes [#12792](https://github.com/bitnami/charts/issues/12792)
+* [bitnami/contour] Update maintainers (#12817) ([7619fb0](https://github.com/bitnami/charts/commit/7619fb0a56382cfcf4d54e0a77d5b3452975083d)), closes [#12817](https://github.com/bitnami/charts/issues/12817)
+* Generic README instructions related to the repo (#12792) ([3cf6b10](https://github.com/bitnami/charts/commit/3cf6b10e10e60df4b3e191d6b99aa99a9f597755)), closes [#12792](https://github.com/bitnami/charts/issues/12792)
 
 ## <small>9.1.4 (2022-09-29)</small>
 
-* [bitnami/contour] Include labels in envoy servicemonitor (#12689) ([4eb3ec9](https://github.com/bitnami/charts/commit/4eb3ec9)), closes [#12689](https://github.com/bitnami/charts/issues/12689)
+* [bitnami/contour] Include labels in envoy servicemonitor (#12689) ([4eb3ec9](https://github.com/bitnami/charts/commit/4eb3ec99eed8b32f18cdbc94ab510f45f1bd3924)), closes [#12689](https://github.com/bitnami/charts/issues/12689)
 
 ## <small>9.1.3 (2022-09-21)</small>
 
-* [bitnami/contour] Updates Contour CRDs to release 1.22 (https://github.com/projectcontour/contour/bl ([e3f86e3](https://github.com/bitnami/charts/commit/e3f86e3)), closes [#11756](https://github.com/bitnami/charts/issues/11756) [#12308](https://github.com/bitnami/charts/issues/12308)
-* [bitnami/contour] Use custom probes if given (#12487) ([81507fe](https://github.com/bitnami/charts/commit/81507fe)), closes [#12487](https://github.com/bitnami/charts/issues/12487) [#12354](https://github.com/bitnami/charts/issues/12354)
+* [bitnami/contour] Updates Contour CRDs to release 1.22 (https://github.com/projectcontour/contour/bl ([e3f86e3](https://github.com/bitnami/charts/commit/e3f86e3c1945a67191825dd060313d5fcd851189)), closes [#11756](https://github.com/bitnami/charts/issues/11756) [#12308](https://github.com/bitnami/charts/issues/12308)
+* [bitnami/contour] Use custom probes if given (#12487) ([81507fe](https://github.com/bitnami/charts/commit/81507fe7f3eae202ec7f98f0f269bd5289d7ce2a)), closes [#12487](https://github.com/bitnami/charts/issues/12487) [#12354](https://github.com/bitnami/charts/issues/12354)
 
 ## <small>9.1.2 (2022-09-08)</small>
 
-* [bitnami/contour] Release 9.1.2 updating components versions ([c75e3d5](https://github.com/bitnami/charts/commit/c75e3d5))
+* [bitnami/contour] Release 9.1.2 updating components versions ([c75e3d5](https://github.com/bitnami/charts/commit/c75e3d579bf60c50efeedad42e1e6a94837f3f59))
 
 ## <small>9.1.1 (2022-08-23)</small>
 
-* [bitnami/contour] Update Chart.lock (#12034) ([7ad618d](https://github.com/bitnami/charts/commit/7ad618d)), closes [#12034](https://github.com/bitnami/charts/issues/12034)
+* [bitnami/contour] Update Chart.lock (#12034) ([7ad618d](https://github.com/bitnami/charts/commit/7ad618d12a1ee0c37516d9c56901ceb9ed3001d9)), closes [#12034](https://github.com/bitnami/charts/issues/12034)
 
 ## 9.1.0 (2022-08-22)
 
-* [bitnami/contour] Add support for image digest apart from tag (#11871) ([8001af4](https://github.com/bitnami/charts/commit/8001af4)), closes [#11871](https://github.com/bitnami/charts/issues/11871)
-* [bitnami/contour] Sync release 9.0.3 values to README (#11675) ([aa8d300](https://github.com/bitnami/charts/commit/aa8d300)), closes [#11675](https://github.com/bitnami/charts/issues/11675)
+* [bitnami/contour] Add support for image digest apart from tag (#11871) ([8001af4](https://github.com/bitnami/charts/commit/8001af4a05639c6178e94cb25787b9739482acfb)), closes [#11871](https://github.com/bitnami/charts/issues/11871)
+* [bitnami/contour] Sync release 9.0.3 values to README (#11675) ([aa8d300](https://github.com/bitnami/charts/commit/aa8d300a22a12dab8560c660369ca63424564c2c)), closes [#11675](https://github.com/bitnami/charts/issues/11675)
 
 ## <small>9.0.3 (2022-08-09)</small>
 
-* [bitnami/contour] Release 9.0.3 updating components versions ([6c919c9](https://github.com/bitnami/charts/commit/6c919c9))
-* [bitnami/contour] Sync 9.0.2 Values to README (#11656) ([974f899](https://github.com/bitnami/charts/commit/974f899)), closes [#11656](https://github.com/bitnami/charts/issues/11656)
+* [bitnami/contour] Release 9.0.3 updating components versions ([6c919c9](https://github.com/bitnami/charts/commit/6c919c9de37bcfdf5195170daea8ed0d29b453db))
+* [bitnami/contour] Sync 9.0.2 Values to README (#11656) ([974f899](https://github.com/bitnami/charts/commit/974f8991e20d70b17074a1f1df124fc3c849bddb)), closes [#11656](https://github.com/bitnami/charts/issues/11656)
 
 ## <small>9.0.2 (2022-08-04)</small>
 
-* [bitnami/contour] Release 9.0.2 updating components versions ([5669b49](https://github.com/bitnami/charts/commit/5669b49))
+* [bitnami/contour] Release 9.0.2 updating components versions ([5669b49](https://github.com/bitnami/charts/commit/5669b496c7794d217191da2936abe8f40ddc8890))
 
 ## <small>9.0.1 (2022-08-04)</small>
 
-* [bitnami/contour] Release 9.0.1 updating components versions ([c80fc01](https://github.com/bitnami/charts/commit/c80fc01))
+* [bitnami/contour] Release 9.0.1 updating components versions ([c80fc01](https://github.com/bitnami/charts/commit/c80fc01f19970fb7a027acf2116d6cea87289723))
 
 ## 9.0.0 (2022-08-02)
 
-* [bitnami/contour] Release 9.0.0 updating components versions ([6ea7b13](https://github.com/bitnami/charts/commit/6ea7b13))
+* [bitnami/contour] Release 9.0.0 updating components versions ([6ea7b13](https://github.com/bitnami/charts/commit/6ea7b13ca8ef2e188f54e32ae76ce2b8f3be4bc3))
 
 ## <small>8.0.7 (2022-08-02)</small>
 
-* [bitnami/contour] Release 8.0.7 updating components versions ([e33a874](https://github.com/bitnami/charts/commit/e33a874))
+* [bitnami/contour] Release 8.0.7 updating components versions ([e33a874](https://github.com/bitnami/charts/commit/e33a874ee4f9f2a1d84d5198d564a6ff6df58b12))
 
 ## <small>8.0.6 (2022-07-27)</small>
 
-* [bitnami/*] Update URLs to point to the new bitnami/containers monorepo (#11352) ([d665af0](https://github.com/bitnami/charts/commit/d665af0)), closes [#11352](https://github.com/bitnami/charts/issues/11352)
-* [bitnami/contour] Release 8.0.6 updating components versions ([c458bb7](https://github.com/bitnami/charts/commit/c458bb7))
+* [bitnami/*] Update URLs to point to the new bitnami/containers monorepo (#11352) ([d665af0](https://github.com/bitnami/charts/commit/d665af0c708846192d8d5fb2f5f9ea65dd464ab0)), closes [#11352](https://github.com/bitnami/charts/issues/11352)
+* [bitnami/contour] Release 8.0.6 updating components versions ([c458bb7](https://github.com/bitnami/charts/commit/c458bb74cf9941e523eb0cb75a9eacc2afa819cd))
 
 ## <small>8.0.5 (2022-07-18)</small>
 
-* [bitnami/contour] Adjust the naming style for resource (#11182) ([98a7f7e](https://github.com/bitnami/charts/commit/98a7f7e)), closes [#11182](https://github.com/bitnami/charts/issues/11182)
+* [bitnami/contour] Adjust the naming style for resource (#11182) ([98a7f7e](https://github.com/bitnami/charts/commit/98a7f7ed4d900069ad5b896770e08065a6e39dac)), closes [#11182](https://github.com/bitnami/charts/issues/11182)
 
 ## <small>8.0.4 (2022-06-30)</small>
 
-* [bitnami/contour] Release 8.0.4 updating components versions ([cff330e](https://github.com/bitnami/charts/commit/cff330e))
+* [bitnami/contour] Release 8.0.4 updating components versions ([cff330e](https://github.com/bitnami/charts/commit/cff330ea86a1ddc1b6f5ca7563bb1767de078edd))
 
 ## <small>8.0.3 (2022-06-23)</small>
 
-*  [bitnami/contour] fix render bug for type: Recreate (#10815) ([2d93628](https://github.com/bitnami/charts/commit/2d93628)), closes [#10815](https://github.com/bitnami/charts/issues/10815)
+*  [bitnami/contour] fix render bug for type: Recreate (#10815) ([2d93628](https://github.com/bitnami/charts/commit/2d93628a4364bcf8b28bd7e47f8281e228249e65)), closes [#10815](https://github.com/bitnami/charts/issues/10815)
 
 ## <small>8.0.2 (2022-06-20)</small>
 
-* [bitnami/contour] fix the mismatch between README.md and values.yaml (#10779) ([ecdec9d](https://github.com/bitnami/charts/commit/ecdec9d)), closes [#10779](https://github.com/bitnami/charts/issues/10779)
+* [bitnami/contour] fix the mismatch between README.md and values.yaml (#10779) ([ecdec9d](https://github.com/bitnami/charts/commit/ecdec9d9653fc8037762d2edcb777d885c2d8372)), closes [#10779](https://github.com/bitnami/charts/issues/10779)
 
 ## <small>8.0.1 (2022-06-14)</small>
 
-* [bitnami/contour] Release 8.0.1 updating components versions ([a72fcb2](https://github.com/bitnami/charts/commit/a72fcb2))
+* [bitnami/contour] Release 8.0.1 updating components versions ([a72fcb2](https://github.com/bitnami/charts/commit/a72fcb26f54d7a9765c18ce41a7813173d1e0753))
 
 ## 8.0.0 (2022-06-10)
 
-* [bitnami/*] Replace Kubeapps URL in READMEs (and kubeapps Chart.yaml) and remove BKPR references (#1 ([c6a7914](https://github.com/bitnami/charts/commit/c6a7914)), closes [#10600](https://github.com/bitnami/charts/issues/10600)
-* [bitnami/contour] feat!: :arrow_up: Bump contour to branch 1.21 (#10712) ([8ee3e22](https://github.com/bitnami/charts/commit/8ee3e22)), closes [#10712](https://github.com/bitnami/charts/issues/10712)
+* [bitnami/*] Replace Kubeapps URL in READMEs (and kubeapps Chart.yaml) and remove BKPR references (#1 ([c6a7914](https://github.com/bitnami/charts/commit/c6a7914361e5aea6016fb45bf4d621edfd111d32)), closes [#10600](https://github.com/bitnami/charts/issues/10600)
+* [bitnami/contour] feat!: :arrow_up: Bump contour to branch 1.21 (#10712) ([8ee3e22](https://github.com/bitnami/charts/commit/8ee3e22d41d6a5f3993d25a30edfcbdc279df313)), closes [#10712](https://github.com/bitnami/charts/issues/10712)
 
 ## <small>7.10.2 (2022-06-06)</small>
 
-* [bitnami/contour] Release 7.10.2 updating components versions ([0c32e83](https://github.com/bitnami/charts/commit/0c32e83))
+* [bitnami/contour] Release 7.10.2 updating components versions ([0c32e83](https://github.com/bitnami/charts/commit/0c32e83bd5ac05cd9f2f17e60b0e3f3aaa6d0c8f))
 
 ## <small>7.10.1 (2022-06-01)</small>
 
-* [bitnami/several] Replace maintainers email by url (#10523) ([ff3cf61](https://github.com/bitnami/charts/commit/ff3cf61)), closes [#10523](https://github.com/bitnami/charts/issues/10523)
+* [bitnami/several] Replace maintainers email by url (#10523) ([ff3cf61](https://github.com/bitnami/charts/commit/ff3cf617a1680509b0f3855d17c4ccff7b29a0ff)), closes [#10523](https://github.com/bitnami/charts/issues/10523)
 
 ## 7.10.0 (2022-05-26)
 
-* [bitnami/contour] Chart standardised (#10280) ([2c82b2d](https://github.com/bitnami/charts/commit/2c82b2d)), closes [#10280](https://github.com/bitnami/charts/issues/10280)
+* [bitnami/contour] Chart standardised (#10280) ([2c82b2d](https://github.com/bitnami/charts/commit/2c82b2df5403310b96a320ad8a20225e5ba0a5c5)), closes [#10280](https://github.com/bitnami/charts/issues/10280)
 
 ## <small>7.9.2 (2022-05-20)</small>
 
-* [bitnami/*] Fix HPA API version template usage (#10332) ([85ce7af](https://github.com/bitnami/charts/commit/85ce7af)), closes [#10332](https://github.com/bitnami/charts/issues/10332)
+* [bitnami/*] Fix HPA API version template usage (#10332) ([85ce7af](https://github.com/bitnami/charts/commit/85ce7af79a6a44d8b90e4907064ca77efe7c8288)), closes [#10332](https://github.com/bitnami/charts/issues/10332)
 
 ## <small>7.9.1 (2022-05-18)</small>
 
-* Fix securityContext in default-backend deployment (#10265) ([45c8e49](https://github.com/bitnami/charts/commit/45c8e49)), closes [#10265](https://github.com/bitnami/charts/issues/10265)
+* Fix securityContext in default-backend deployment (#10265) ([45c8e49](https://github.com/bitnami/charts/commit/45c8e49ddcc14f0a86a28201e9cad51b3b048a29)), closes [#10265](https://github.com/bitnami/charts/issues/10265)
 
 ## 7.9.0 (2022-05-16)
 
-* [bitnami/*] add ingress extraRules feature (#10253) ([0f6cbb9](https://github.com/bitnami/charts/commit/0f6cbb9)), closes [#10253](https://github.com/bitnami/charts/issues/10253)
+* [bitnami/*] add ingress extraRules feature (#10253) ([0f6cbb9](https://github.com/bitnami/charts/commit/0f6cbb9099b0e56685cc1d36ba50340f3d7278a1)), closes [#10253](https://github.com/bitnami/charts/issues/10253)
 
 ## <small>7.8.2 (2022-05-13)</small>
 
-* [bitnami/contour] Use the new helper for HPA API version (#10196) ([452e491](https://github.com/bitnami/charts/commit/452e491)), closes [#10196](https://github.com/bitnami/charts/issues/10196)
+* [bitnami/contour] Use the new helper for HPA API version (#10196) ([452e491](https://github.com/bitnami/charts/commit/452e491735b22bb72d8b0132ab72dafe7d886f0f)), closes [#10196](https://github.com/bitnami/charts/issues/10196)
 
 ## <small>7.8.1 (2022-05-13)</small>
 
-* [bitnami/*] Remove old 'ci' files (#10171) ([5df30c4](https://github.com/bitnami/charts/commit/5df30c4)), closes [#10171](https://github.com/bitnami/charts/issues/10171)
-* [bitnami/*] Unify k8s directives separators (#10185) ([2650214](https://github.com/bitnami/charts/commit/2650214)), closes [#10185](https://github.com/bitnami/charts/issues/10185)
+* [bitnami/*] Remove old 'ci' files (#10171) ([5df30c4](https://github.com/bitnami/charts/commit/5df30c44dbd1812da8786579ce4a94917d46a6ad)), closes [#10171](https://github.com/bitnami/charts/issues/10171)
+* [bitnami/*] Unify k8s directives separators (#10185) ([2650214](https://github.com/bitnami/charts/commit/26502141d146ca3bdfb3bf744fcdec8ca5cece44)), closes [#10185](https://github.com/bitnami/charts/issues/10185)
 
 ## 7.8.0 (2022-04-25)
 
-* [bitnami/contour] Add contour root-namespaces option (#9895) ([f0d3028](https://github.com/bitnami/charts/commit/f0d3028)), closes [#9895](https://github.com/bitnami/charts/issues/9895)
+* [bitnami/contour] Add contour root-namespaces option (#9895) ([f0d3028](https://github.com/bitnami/charts/commit/f0d3028ce32ef2c8d9f286dc9d17447c1ea0c415)), closes [#9895](https://github.com/bitnami/charts/issues/9895)
 
 ## <small>7.7.2 (2022-04-20)</small>
 
-* [bitnami/contour] Release 7.7.2 updating components versions ([15f2c61](https://github.com/bitnami/charts/commit/15f2c61))
+* [bitnami/contour] Release 7.7.2 updating components versions ([15f2c61](https://github.com/bitnami/charts/commit/15f2c61bf41124804d2bba8f69f7897f34f54da2))
 
 ## <small>7.7.1 (2022-04-19)</small>
 
-* [bitnami/contour] Release 7.7.1 updating components versions ([57d2784](https://github.com/bitnami/charts/commit/57d2784))
+* [bitnami/contour] Release 7.7.1 updating components versions ([57d2784](https://github.com/bitnami/charts/commit/57d2784927b2e2e498e459a6eca85ed1ddbeb360))
 
 ## 7.7.0 (2022-04-11)
 
-* [bitnami/contour]: Add contour debug level option. (#9749) ([4a94de4](https://github.com/bitnami/charts/commit/4a94de4)), closes [#9749](https://github.com/bitnami/charts/issues/9749)
+* [bitnami/contour]: Add contour debug level option. (#9749) ([4a94de4](https://github.com/bitnami/charts/commit/4a94de4eafacc50019cc702ccf1c0bb688ec0937)), closes [#9749](https://github.com/bitnami/charts/issues/9749)
 
 ## 7.6.0 (2022-04-06)
 
-* [bitnami/contour] Allow disable envoy shutdown manager (#9678) ([65c5f5b](https://github.com/bitnami/charts/commit/65c5f5b)), closes [#9678](https://github.com/bitnami/charts/issues/9678)
+* [bitnami/contour] Allow disable envoy shutdown manager (#9678) ([65c5f5b](https://github.com/bitnami/charts/commit/65c5f5b865df03a39eb8400301c56c06a0adc01e)), closes [#9678](https://github.com/bitnami/charts/issues/9678)
 
 ## 7.5.0 (2022-04-06)
 
-* [bitnami/contour] Add behindSslProxy flag (#9584) ([127299e](https://github.com/bitnami/charts/commit/127299e)), closes [#9584](https://github.com/bitnami/charts/issues/9584)
+* [bitnami/contour] Add behindSslProxy flag (#9584) ([127299e](https://github.com/bitnami/charts/commit/127299e6f01df33d7034c26f5279c074686343fc)), closes [#9584](https://github.com/bitnami/charts/issues/9584)
 
 ## <small>7.4.8 (2022-04-03)</small>
 
-* [bitnami/contour] Release 7.4.8 updating components versions ([8571dfd](https://github.com/bitnami/charts/commit/8571dfd))
+* [bitnami/contour] Release 7.4.8 updating components versions ([8571dfd](https://github.com/bitnami/charts/commit/8571dfd1d69655e5621ef48f2eb5e07dd1b351d6))
 
 ## <small>7.4.7 (2022-04-02)</small>
 
-* [bitnami/contour] Release 7.4.7 updating components versions ([e20bbe0](https://github.com/bitnami/charts/commit/e20bbe0))
+* [bitnami/contour] Release 7.4.7 updating components versions ([e20bbe0](https://github.com/bitnami/charts/commit/e20bbe0813fcc5d9de654a61528073cb9ab302c9))
 
 ## <small>7.4.6 (2022-03-28)</small>
 
-* [bitnami/contour] Release 7.4.6 updating components versions ([6b5e51b](https://github.com/bitnami/charts/commit/6b5e51b))
+* [bitnami/contour] Release 7.4.6 updating components versions ([6b5e51b](https://github.com/bitnami/charts/commit/6b5e51b141c86df3c155a2e7ce366bacec0313b2))
 
 ## <small>7.4.5 (2022-03-27)</small>
 
-* [bitnami/contour] Release 7.4.5 updating components versions ([ce340de](https://github.com/bitnami/charts/commit/ce340de))
+* [bitnami/contour] Release 7.4.5 updating components versions ([ce340de](https://github.com/bitnami/charts/commit/ce340de9a2b462c0f956bcfdf4b6dd501403d2f3))
 
 ## <small>7.4.4 (2022-03-17)</small>
 
-* [bitnami/contour] Release 7.4.4 updating components versions ([18e4191](https://github.com/bitnami/charts/commit/18e4191))
+* [bitnami/contour] Release 7.4.4 updating components versions ([18e4191](https://github.com/bitnami/charts/commit/18e4191b7da3d1c1b22294f25da028b5bcba5635))
 
 ## <small>7.4.3 (2022-03-16)</small>
 
-* [bitnami/contour] Release 7.4.3 updating components versions ([31b830d](https://github.com/bitnami/charts/commit/31b830d))
+* [bitnami/contour] Release 7.4.3 updating components versions ([31b830d](https://github.com/bitnami/charts/commit/31b830d20d0232cc1b1c4d877aeb28c550644dde))
 
 ## <small>7.4.2 (2022-03-09)</small>
 
-* [bitnami/contour] Sync CRDs with contour release 1.20.1 (#9309) ([9c07034](https://github.com/bitnami/charts/commit/9c07034)), closes [#9309](https://github.com/bitnami/charts/issues/9309)
+* [bitnami/contour] Sync CRDs with contour release 1.20.1 (#9309) ([9c07034](https://github.com/bitnami/charts/commit/9c070343eecb574204a39c31498ad758ca379ab8)), closes [#9309](https://github.com/bitnami/charts/issues/9309)
 
 ## <small>7.4.1 (2022-03-04)</small>
 
-* Support dual stack of contour ingress (#9290) ([253f5d8](https://github.com/bitnami/charts/commit/253f5d8)), closes [#9290](https://github.com/bitnami/charts/issues/9290)
+* Support dual stack of contour ingress (#9290) ([253f5d8](https://github.com/bitnami/charts/commit/253f5d8f4adab944e9330128338c912a0b96e143)), closes [#9290](https://github.com/bitnami/charts/issues/9290)
 
 ## 7.4.0 (2022-03-03)
 
-* [bitnami/contour] Add support for changing lifetime for tls certificate generated by contour certgen ([6c25394](https://github.com/bitnami/charts/commit/6c25394)), closes [#9273](https://github.com/bitnami/charts/issues/9273)
+* [bitnami/contour] Add support for changing lifetime for tls certificate generated by contour certgen ([6c25394](https://github.com/bitnami/charts/commit/6c25394b403c1c81a207557cff730f462f13a2f5)), closes [#9273](https://github.com/bitnami/charts/issues/9273)
 
 ## <small>7.3.11 (2022-02-27)</small>
 
-* [bitnami/contour] Release 7.3.11 updating components versions ([02fbff7](https://github.com/bitnami/charts/commit/02fbff7))
+* [bitnami/contour] Release 7.3.11 updating components versions ([02fbff7](https://github.com/bitnami/charts/commit/02fbff7f420d9a197ed619a40770beab9f9cc350))
 
 ## <small>7.3.10 (2022-02-25)</small>
 
-* [bitnami/contour] Allow for xds-port configurability (#9200) ([2d7c856](https://github.com/bitnami/charts/commit/2d7c856)), closes [#9200](https://github.com/bitnami/charts/issues/9200)
-* [bitnami/contour] Release 7.3.10 updating components versions ([2505542](https://github.com/bitnami/charts/commit/2505542))
+* [bitnami/contour] Allow for xds-port configurability (#9200) ([2d7c856](https://github.com/bitnami/charts/commit/2d7c856b703667d5040ad8935d1508ef0dc88720)), closes [#9200](https://github.com/bitnami/charts/issues/9200)
+* [bitnami/contour] Release 7.3.10 updating components versions ([2505542](https://github.com/bitnami/charts/commit/2505542afb1d7d8880c84f60fb356e1341174ffe))
 
 ## <small>7.3.9 (2022-02-25)</small>
 
-* [bitnami/contour] Release 7.3.9 updating components versions ([a3708a3](https://github.com/bitnami/charts/commit/a3708a3))
+* [bitnami/contour] Release 7.3.9 updating components versions ([a3708a3](https://github.com/bitnami/charts/commit/a3708a31a1b54391e1b175183d9eeafe7eff6400))
 
 ## <small>7.3.8 (2022-02-21)</small>
 
-* [bitnami/contour] Do not hardcode PDB apiVersion (#9093) ([866a973](https://github.com/bitnami/charts/commit/866a973)), closes [#9093](https://github.com/bitnami/charts/issues/9093)
+* [bitnami/contour] Do not hardcode PDB apiVersion (#9093) ([866a973](https://github.com/bitnami/charts/commit/866a97378fed21afef1268001a2b57c4d41a762d)), closes [#9093](https://github.com/bitnami/charts/issues/9093)
 
 ## <small>7.3.7 (2022-02-21)</small>
 
-* [bitnami/contour] Support namespace-scoped leader election (#9030) ([d3b94ee](https://github.com/bitnami/charts/commit/d3b94ee)), closes [#9030](https://github.com/bitnami/charts/issues/9030)
+* [bitnami/contour] Support namespace-scoped leader election (#9030) ([d3b94ee](https://github.com/bitnami/charts/commit/d3b94ee1ec46aaf86f997ab2d6735a0f49bbc2e9)), closes [#9030](https://github.com/bitnami/charts/issues/9030)
 
 ## <small>7.3.6 (2022-02-16)</small>
 
-* [bitnami/contour] Support Gateway API v1alpha2 resources and API groups (#9029) ([2f9e53a](https://github.com/bitnami/charts/commit/2f9e53a)), closes [#9029](https://github.com/bitnami/charts/issues/9029)
+* [bitnami/contour] Support Gateway API v1alpha2 resources and API groups (#9029) ([2f9e53a](https://github.com/bitnami/charts/commit/2f9e53a97e440e9dc85fe00b307ebe45e87203cc)), closes [#9029](https://github.com/bitnami/charts/issues/9029)
 
 ## <small>7.3.5 (2022-02-15)</small>
 
-* [bitnami/contour] Release 7.3.5 updating components versions ([0901394](https://github.com/bitnami/charts/commit/0901394))
+* [bitnami/contour] Release 7.3.5 updating components versions ([0901394](https://github.com/bitnami/charts/commit/09013945ecc643fbff35e4a4c6f4e99d19514228))
 
 ## <small>7.3.4 (2022-02-14)</small>
 
-* [bitnami/contour] Release 7.3.4 updating components versions ([f81b5e4](https://github.com/bitnami/charts/commit/f81b5e4))
-* Non utf8 chars (#8923) ([6ffd18f](https://github.com/bitnami/charts/commit/6ffd18f)), closes [#8923](https://github.com/bitnami/charts/issues/8923)
+* [bitnami/contour] Release 7.3.4 updating components versions ([f81b5e4](https://github.com/bitnami/charts/commit/f81b5e4e3f83f6eb3ec7ac4681a83cc7ad0cefb1))
+* Non utf8 chars (#8923) ([6ffd18f](https://github.com/bitnami/charts/commit/6ffd18fbbdf10e94ea1a90cf5b84ef610ac2a72d)), closes [#8923](https://github.com/bitnami/charts/issues/8923)
 
 ## <small>7.3.3 (2022-01-20)</small>
 
-* [bitnami/*] Readme automation (#8579) ([78d1938](https://github.com/bitnami/charts/commit/78d1938)), closes [#8579](https://github.com/bitnami/charts/issues/8579)
-* [bitnami/*] Update READMEs (#8716) ([b9a9533](https://github.com/bitnami/charts/commit/b9a9533)), closes [#8716](https://github.com/bitnami/charts/issues/8716)
-* [bitnami/several] Change prerequisites (#8725) ([8d740c5](https://github.com/bitnami/charts/commit/8d740c5)), closes [#8725](https://github.com/bitnami/charts/issues/8725)
+* [bitnami/*] Readme automation (#8579) ([78d1938](https://github.com/bitnami/charts/commit/78d193831c900d178198491ffd08fa2217a64ecd)), closes [#8579](https://github.com/bitnami/charts/issues/8579)
+* [bitnami/*] Update READMEs (#8716) ([b9a9533](https://github.com/bitnami/charts/commit/b9a953337590eb2979453385874a267bacf50936)), closes [#8716](https://github.com/bitnami/charts/issues/8716)
+* [bitnami/several] Change prerequisites (#8725) ([8d740c5](https://github.com/bitnami/charts/commit/8d740c566cfdb7e2d933c40128b4e919fce953a5)), closes [#8725](https://github.com/bitnami/charts/issues/8725)
 
 ## <small>7.3.2 (2022-01-15)</small>
 
-* [bitnami/contour] Release 7.3.2 updating components versions ([30f8658](https://github.com/bitnami/charts/commit/30f8658))
+* [bitnami/contour] Release 7.3.2 updating components versions ([30f8658](https://github.com/bitnami/charts/commit/30f8658b60e1388766dd98fd1baa3425c837da3e))
 
 ## <small>7.3.1 (2022-01-11)</small>
 
-* [bitnami/contour]: fix typos (#8626) ([c145746](https://github.com/bitnami/charts/commit/c145746)), closes [#8626](https://github.com/bitnami/charts/issues/8626)
+* [bitnami/contour]: fix typos (#8626) ([c145746](https://github.com/bitnami/charts/commit/c145746c8d17432ebf6ab43cd544f4ad0a616c19)), closes [#8626](https://github.com/bitnami/charts/issues/8626)
 
 ## 7.3.0 (2022-01-11)
 
-* [bitnami/contour] Added ability to use sidecars in Envoy pods also in daemonset mode (#8612) ([8e68608](https://github.com/bitnami/charts/commit/8e68608)), closes [#8612](https://github.com/bitnami/charts/issues/8612)
+* [bitnami/contour] Added ability to use sidecars in Envoy pods also in daemonset mode (#8612) ([8e68608](https://github.com/bitnami/charts/commit/8e68608c5ce4fc600db268d39b51076164a85223)), closes [#8612](https://github.com/bitnami/charts/issues/8612)
 
 ## 7.2.0 (2022-01-05)
 
-* [bitnami/several] Adapt templating format (#8562) ([8cad18a](https://github.com/bitnami/charts/commit/8cad18a)), closes [#8562](https://github.com/bitnami/charts/issues/8562)
-* [bitnami/several] Add license to the README ([05f7633](https://github.com/bitnami/charts/commit/05f7633))
-* [bitnami/several] Add license to the README ([32fb238](https://github.com/bitnami/charts/commit/32fb238))
-* [bitnami/several] Add license to the README ([b87c2f7](https://github.com/bitnami/charts/commit/b87c2f7))
+* [bitnami/several] Adapt templating format (#8562) ([8cad18a](https://github.com/bitnami/charts/commit/8cad18aed9966a6f0208e5ad6cee46cb217f47ab)), closes [#8562](https://github.com/bitnami/charts/issues/8562)
+* [bitnami/several] Add license to the README ([05f7633](https://github.com/bitnami/charts/commit/05f763372501d596e57db713dd53ff4ff3027cc4))
+* [bitnami/several] Add license to the README ([32fb238](https://github.com/bitnami/charts/commit/32fb238e60a0affc6debd3142eaa3c3d9089ec2a))
+* [bitnami/several] Add license to the README ([b87c2f7](https://github.com/bitnami/charts/commit/b87c2f7899d48a8b02c506765e6ae82937e9ba3f))
 
 ## 7.1.0 (2021-12-29)
 
-* [bitnami/contour] Added ability to use sidecars in Envoy pods (#8512) ([0961801](https://github.com/bitnami/charts/commit/0961801)), closes [#8512](https://github.com/bitnami/charts/issues/8512)
+* [bitnami/contour] Added ability to use sidecars in Envoy pods (#8512) ([0961801](https://github.com/bitnami/charts/commit/0961801c2588342afee9b5027fc4626d714b015f)), closes [#8512](https://github.com/bitnami/charts/issues/8512)
 
 ## <small>7.0.8 (2021-12-23)</small>
 
-* [bitnami/contour] Fix applying default ingress label even if not default #8450 (#8478) ([ed7e1c0](https://github.com/bitnami/charts/commit/ed7e1c0)), closes [#8450](https://github.com/bitnami/charts/issues/8450) [#8478](https://github.com/bitnami/charts/issues/8478) [#8450](https://github.com/bitnami/charts/issues/8450) [#8450](https://github.com/bitnami/charts/issues/8450)
+* [bitnami/contour] Fix applying default ingress label even if not default #8450 (#8478) ([ed7e1c0](https://github.com/bitnami/charts/commit/ed7e1c0bcdfa5adc278cc7a8b7fc7847580ec865)), closes [#8450](https://github.com/bitnami/charts/issues/8450) [#8478](https://github.com/bitnami/charts/issues/8478) [#8450](https://github.com/bitnami/charts/issues/8450) [#8450](https://github.com/bitnami/charts/issues/8450)
 
 ## <small>7.0.7 (2021-12-16)</small>
 
-* [bitnami/contour] Release 7.0.7 updating components versions ([0585102](https://github.com/bitnami/charts/commit/0585102))
+* [bitnami/contour] Release 7.0.7 updating components versions ([0585102](https://github.com/bitnami/charts/commit/05851020ceb74bff1d8a1664d1ebaac5e780b76e))
 
 ## <small>7.0.6 (2021-12-09)</small>
 
-* [bitnami/contour] Release 7.0.6 updating components versions ([b62b4b5](https://github.com/bitnami/charts/commit/b62b4b5))
+* [bitnami/contour] Release 7.0.6 updating components versions ([b62b4b5](https://github.com/bitnami/charts/commit/b62b4b51b195701c80c037eb7a21d315dbe53e3c))
 
 ## <small>7.0.5 (2021-11-30)</small>
 
-* [bitnami/contour] Remove ttlSecondsAfterFinished from Job (#8270) ([6e0499c](https://github.com/bitnami/charts/commit/6e0499c)), closes [#8270](https://github.com/bitnami/charts/issues/8270)
+* [bitnami/contour] Remove ttlSecondsAfterFinished from Job (#8270) ([6e0499c](https://github.com/bitnami/charts/commit/6e0499cce3e0c59eaad8c70a8fb669800a3ff232)), closes [#8270](https://github.com/bitnami/charts/issues/8270)
 
 ## <small>7.0.4 (2021-11-29)</small>
 
-* [bitnami/several] Fix deadlinks in README.md (#8215) ([99e90d2](https://github.com/bitnami/charts/commit/99e90d2)), closes [#8215](https://github.com/bitnami/charts/issues/8215)
-* [bitnami/several] Replace HTTP by HTTPS when possible (#8259) ([eafb5bd](https://github.com/bitnami/charts/commit/eafb5bd)), closes [#8259](https://github.com/bitnami/charts/issues/8259)
+* [bitnami/several] Fix deadlinks in README.md (#8215) ([99e90d2](https://github.com/bitnami/charts/commit/99e90d244b3244e059a42f72dcbecd3cda2b66bb)), closes [#8215](https://github.com/bitnami/charts/issues/8215)
+* [bitnami/several] Replace HTTP by HTTPS when possible (#8259) ([eafb5bd](https://github.com/bitnami/charts/commit/eafb5bd5a2cc3aaf04fc1e8ebedd73f420d76864)), closes [#8259](https://github.com/bitnami/charts/issues/8259)
 
 ## <small>7.0.3 (2021-11-19)</small>
 
-* [bitnami/contour]: fix for #8174 (#8175) ([9347af1](https://github.com/bitnami/charts/commit/9347af1)), closes [#8174](https://github.com/bitnami/charts/issues/8174) [#8175](https://github.com/bitnami/charts/issues/8175)
+* [bitnami/contour]: fix for #8174 (#8175) ([9347af1](https://github.com/bitnami/charts/commit/9347af1ee1dbf42b79ce9245118536dbf138849d)), closes [#8174](https://github.com/bitnami/charts/issues/8174) [#8175](https://github.com/bitnami/charts/issues/8175)
 
 ## <small>7.0.2 (2021-11-17)</small>
 
-* [bitnami/contour]fix:Changing envoy containerPorts for http & https to > 1024 range (#8166) ([d2b3108](https://github.com/bitnami/charts/commit/d2b3108)), closes [#8166](https://github.com/bitnami/charts/issues/8166) [#8162](https://github.com/bitnami/charts/issues/8162)
+* [bitnami/contour]fix:Changing envoy containerPorts for http & https to > 1024 range (#8166) ([d2b3108](https://github.com/bitnami/charts/commit/d2b31088671519ee44f71ac6bebe83f7e1d07d52)), closes [#8166](https://github.com/bitnami/charts/issues/8166) [#8162](https://github.com/bitnami/charts/issues/8162)
 
 ## <small>7.0.1 (2021-11-11)</small>
 
-* [bitnami/contour] Set default value for ingressClass.default (#8069) ([cd04949](https://github.com/bitnami/charts/commit/cd04949)), closes [#8069](https://github.com/bitnami/charts/issues/8069)
-* [bitnami/several] Regenerate README tables ([14b89ea](https://github.com/bitnami/charts/commit/14b89ea))
+* [bitnami/contour] Set default value for ingressClass.default (#8069) ([cd04949](https://github.com/bitnami/charts/commit/cd04949eda7606cb365b23b1747130af559ff10d)), closes [#8069](https://github.com/bitnami/charts/issues/8069)
+* [bitnami/several] Regenerate README tables ([14b89ea](https://github.com/bitnami/charts/commit/14b89eadad5eaf515b99c0392eb9461fff50f4a1))
 
 ## 7.0.0 (2021-11-09)
 
-* [bitnami/contour,aspnet-core] Apply standardizations (#7543) ([1f2fc92](https://github.com/bitnami/charts/commit/1f2fc92)), closes [#7543](https://github.com/bitnami/charts/issues/7543) [#8065](https://github.com/bitnami/charts/issues/8065)
+* [bitnami/contour,aspnet-core] Apply standardizations (#7543) ([1f2fc92](https://github.com/bitnami/charts/commit/1f2fc92870504496396165b80b1f6500aed2feb5)), closes [#7543](https://github.com/bitnami/charts/issues/7543) [#8065](https://github.com/bitnami/charts/issues/8065)
 
 ## <small>6.0.2 (2021-11-09)</small>
 
-* [bitnami/contour] Allow deploying without explicit IngressClass (#8046) ([5d03d2a](https://github.com/bitnami/charts/commit/5d03d2a)), closes [#8046](https://github.com/bitnami/charts/issues/8046) [#8041](https://github.com/bitnami/charts/issues/8041) [#8041](https://github.com/bitnami/charts/issues/8041) [#7668](https://github.com/bitnami/charts/issues/7668) [/github.com/bitnami/charts/pull/8046#discussion_r744552904](https://github.com//github.com/bitnami/charts/pull/8046/issues/discussion_r744552904)
+* [bitnami/contour] Allow deploying without explicit IngressClass (#8046) ([5d03d2a](https://github.com/bitnami/charts/commit/5d03d2a9a916ac45dd4bbe06c06f274feed20421)), closes [#8046](https://github.com/bitnami/charts/issues/8046) [#8041](https://github.com/bitnami/charts/issues/8041) [#8041](https://github.com/bitnami/charts/issues/8041) [#7668](https://github.com/bitnami/charts/issues/7668) [/github.com/bitnami/charts/pull/8046#discussion_r744552904](https://github.com//github.com/bitnami/charts/pull/8046/issues/discussion_r744552904)
 
 ## <small>6.0.1 (2021-10-22)</small>
 
-* [bitnami/several] Add chart info to NOTES.txt (#7889) ([a6751cd](https://github.com/bitnami/charts/commit/a6751cd)), closes [#7889](https://github.com/bitnami/charts/issues/7889)
-* [bitnami/several] Regenerate README tables ([fbb0358](https://github.com/bitnami/charts/commit/fbb0358))
+* [bitnami/several] Add chart info to NOTES.txt (#7889) ([a6751cd](https://github.com/bitnami/charts/commit/a6751cdd33c461fabbc459fbea6f219ec64ab6b2)), closes [#7889](https://github.com/bitnami/charts/issues/7889)
+* [bitnami/several] Regenerate README tables ([fbb0358](https://github.com/bitnami/charts/commit/fbb0358f0d99d2ea30fa27cd14af89ca1217dc4b))
 
 ## 6.0.0 (2021-10-21)
 
-* [bitnami/contour] - MAJOR Upgrade Contour to 1.19 & CRD (#7887) ([2669fab](https://github.com/bitnami/charts/commit/2669fab)), closes [#7887](https://github.com/bitnami/charts/issues/7887)
-* [bitnami/several] Regenerate README tables ([cdcf8c1](https://github.com/bitnami/charts/commit/cdcf8c1))
+* [bitnami/contour] - MAJOR Upgrade Contour to 1.19 & CRD (#7887) ([2669fab](https://github.com/bitnami/charts/commit/2669fab866ac1d5b0e63fd1f1156773be4a35105)), closes [#7887](https://github.com/bitnami/charts/issues/7887)
+* [bitnami/several] Regenerate README tables ([cdcf8c1](https://github.com/bitnami/charts/commit/cdcf8c1407a9a23b93fadf513be21ca1f9c7c056))
 
 ## 5.7.0 (2021-10-06)
 
-* [bitnami/contour] Add IngressClass resource creation support (#7668) ([176f189](https://github.com/bitnami/charts/commit/176f189)), closes [#7668](https://github.com/bitnami/charts/issues/7668)
+* [bitnami/contour] Add IngressClass resource creation support (#7668) ([176f189](https://github.com/bitnami/charts/commit/176f1891ca4a78b2d1ba8bf146c4a4f67ef59221)), closes [#7668](https://github.com/bitnami/charts/issues/7668)
 
 ## <small>5.6.1 (2021-10-05)</small>
 
-* [bitnami/contour] Release 5.6.1 updating components versions ([18fcde3](https://github.com/bitnami/charts/commit/18fcde3))
+* [bitnami/contour] Release 5.6.1 updating components versions ([18fcde3](https://github.com/bitnami/charts/commit/18fcde3fcf96e633f30b39ccaf8a39cd69b0d4ce))
 
 ## 5.6.0 (2021-10-01)
 
-* [bitnami/contour] Make envoy minReadySeconds configurable (#7644) ([2385aa2](https://github.com/bitnami/charts/commit/2385aa2)), closes [#7644](https://github.com/bitnami/charts/issues/7644) [/github.com/bitnami/charts/pull/7644#discussion_r718239245](https://github.com//github.com/bitnami/charts/pull/7644/issues/discussion_r718239245)
-* [bitnami/contour]: Updating Contour configuration link because it was moved (#7561) ([23696cb](https://github.com/bitnami/charts/commit/23696cb)), closes [#7561](https://github.com/bitnami/charts/issues/7561)
+* [bitnami/contour] Make envoy minReadySeconds configurable (#7644) ([2385aa2](https://github.com/bitnami/charts/commit/2385aa21e21f5aed2e21bab46806fb5b2a166cde)), closes [#7644](https://github.com/bitnami/charts/issues/7644) [/github.com/bitnami/charts/pull/7644#discussion_r718239245](https://github.com//github.com/bitnami/charts/pull/7644/issues/discussion_r718239245)
+* [bitnami/contour]: Updating Contour configuration link because it was moved (#7561) ([23696cb](https://github.com/bitnami/charts/commit/23696cb4b185f2f2cc4141a3a9cf0efbd9efe566)), closes [#7561](https://github.com/bitnami/charts/issues/7561)
 
 ## <small>5.5.3 (2021-09-23)</small>
 
-* [bitnami/contour] - 7571 Add targetPort as values to aws nlb ssl termination (#7571) ([a218757](https://github.com/bitnami/charts/commit/a218757)), closes [#7571](https://github.com/bitnami/charts/issues/7571)
-* [bitnami/several] Regenerate README tables ([fa939b3](https://github.com/bitnami/charts/commit/fa939b3))
+* [bitnami/contour] - 7571 Add targetPort as values to aws nlb ssl termination (#7571) ([a218757](https://github.com/bitnami/charts/commit/a218757c58878cdc04f97234198e040295df1170)), closes [#7571](https://github.com/bitnami/charts/issues/7571)
+* [bitnami/several] Regenerate README tables ([fa939b3](https://github.com/bitnami/charts/commit/fa939b373a54c01c20aa28cdd4e7cfb2953ce2a4))
 
 ## <small>5.5.2 (2021-09-20)</small>
 
-* [bitnami/contour] Release 5.5.2 updating components versions ([0801385](https://github.com/bitnami/charts/commit/0801385))
+* [bitnami/contour] Release 5.5.2 updating components versions ([0801385](https://github.com/bitnami/charts/commit/0801385004a731c702e07eb0a587325c1bb70c53))
 
 ## <small>5.5.1 (2021-09-02)</small>
 
-* [bitnami/contour] Fix ingressClass (#7381) ([2950cdb](https://github.com/bitnami/charts/commit/2950cdb)), closes [#7381](https://github.com/bitnami/charts/issues/7381)
-* [bitnami/several] Regenerate README tables ([64d5d74](https://github.com/bitnami/charts/commit/64d5d74))
+* [bitnami/contour] Fix ingressClass (#7381) ([2950cdb](https://github.com/bitnami/charts/commit/2950cdb9860444340ecc68b2d2a7a66924ed8b8f)), closes [#7381](https://github.com/bitnami/charts/issues/7381)
+* [bitnami/several] Regenerate README tables ([64d5d74](https://github.com/bitnami/charts/commit/64d5d747b84299ca9f63ea8a586b13870abe31a6))
 
 ## 5.5.0 (2021-08-31)
 
-* [bitnami/contour] Add additional volume for admin sock (#7353) ([6d13120](https://github.com/bitnami/charts/commit/6d13120)), closes [#7353](https://github.com/bitnami/charts/issues/7353)
+* [bitnami/contour] Add additional volume for admin sock (#7353) ([6d13120](https://github.com/bitnami/charts/commit/6d13120a0b2e96c48d312722dbffbd8fc1c23978)), closes [#7353](https://github.com/bitnami/charts/issues/7353)
 
 ## 5.4.0 (2021-08-27)
 
-* [bitnami/contour] envoy/shutdown-manager allow set resources to fix HPA (#7313) ([68af3f3](https://github.com/bitnami/charts/commit/68af3f3)), closes [#7313](https://github.com/bitnami/charts/issues/7313)
-* [bitnami/several] Regenerate README tables ([da2513b](https://github.com/bitnami/charts/commit/da2513b))
+* [bitnami/contour] envoy/shutdown-manager allow set resources to fix HPA (#7313) ([68af3f3](https://github.com/bitnami/charts/commit/68af3f30b751ebf84bb08c0dfa65f5cde2a09564)), closes [#7313](https://github.com/bitnami/charts/issues/7313)
+* [bitnami/several] Regenerate README tables ([da2513b](https://github.com/bitnami/charts/commit/da2513bf0a33819f3b1151d387c631a9ffdb03e2))
 
 ## <small>5.3.1 (2021-08-26)</small>
 
-* [bitnami/contour] Release 5.3.1 updating components versions ([d53e7b4](https://github.com/bitnami/charts/commit/d53e7b4))
+* [bitnami/contour] Release 5.3.1 updating components versions ([d53e7b4](https://github.com/bitnami/charts/commit/d53e7b45db8e248e524e0180fb06d1900131f869))
 
 ## 5.3.0 (2021-08-25)
 
-* [bitnami/contour] Envoy: add support for kind Deployment (#7293) ([a561f35](https://github.com/bitnami/charts/commit/a561f35)), closes [#7293](https://github.com/bitnami/charts/issues/7293)
-* [bitnami/several] Regenerate README tables ([04e7724](https://github.com/bitnami/charts/commit/04e7724))
+* [bitnami/contour] Envoy: add support for kind Deployment (#7293) ([a561f35](https://github.com/bitnami/charts/commit/a561f35d44e28cdde51b715ec02a939776dc07dd)), closes [#7293](https://github.com/bitnami/charts/issues/7293)
+* [bitnami/several] Regenerate README tables ([04e7724](https://github.com/bitnami/charts/commit/04e77240da01c2daa3d9d8aca0cf94ddc3aaa6f0))
 
 ## 5.2.0 (2021-08-24)
 
-* [bitnami/contour] Bump envoy version bundled in contour Helm Chart (#7301) ([05f83e5](https://github.com/bitnami/charts/commit/05f83e5)), closes [#7301](https://github.com/bitnami/charts/issues/7301)
-* [bitnami/several] Regenerate README tables ([6c107e8](https://github.com/bitnami/charts/commit/6c107e8))
+* [bitnami/contour] Bump envoy version bundled in contour Helm Chart (#7301) ([05f83e5](https://github.com/bitnami/charts/commit/05f83e513bfb79c0efdc69b8403d4643cf792e58)), closes [#7301](https://github.com/bitnami/charts/issues/7301)
+* [bitnami/several] Regenerate README tables ([6c107e8](https://github.com/bitnami/charts/commit/6c107e835d6caf8db2e8b17dcd48c5971637e013))
 
 ## 5.1.0 (2021-08-03)
 
-* [bitnami/contour] Aidan/sidecar rbac options (#7119) ([e034c05](https://github.com/bitnami/charts/commit/e034c05)), closes [#7119](https://github.com/bitnami/charts/issues/7119)
+* [bitnami/contour] Aidan/sidecar rbac options (#7119) ([e034c05](https://github.com/bitnami/charts/commit/e034c053103ee81396df4ef11a22e716d92e116b)), closes [#7119](https://github.com/bitnami/charts/issues/7119)
 
 ## <small>5.0.4 (2021-08-02)</small>
 
-* [bitnami/contour] Sync CRDs with contour release 1.18 (#7099) ([bfb6543](https://github.com/bitnami/charts/commit/bfb6543)), closes [#7099](https://github.com/bitnami/charts/issues/7099)
-* [bitnami/several] Update READMEs (#7108) ([44961d9](https://github.com/bitnami/charts/commit/44961d9)), closes [#7108](https://github.com/bitnami/charts/issues/7108)
+* [bitnami/contour] Sync CRDs with contour release 1.18 (#7099) ([bfb6543](https://github.com/bitnami/charts/commit/bfb65431805d22c6a758f3dda928bd244468f103)), closes [#7099](https://github.com/bitnami/charts/issues/7099)
+* [bitnami/several] Update READMEs (#7108) ([44961d9](https://github.com/bitnami/charts/commit/44961d9cdfae1b0d06808124c4b47e8adc3de146)), closes [#7108](https://github.com/bitnami/charts/issues/7108)
 
 ## <small>5.0.3 (2021-07-28)</small>
 
-* [bitnami/contour] Release 5.0.3 updating components versions ([b506bb4](https://github.com/bitnami/charts/commit/b506bb4))
-* [bitnami/several] Upadte READMEs ([eb3c291](https://github.com/bitnami/charts/commit/eb3c291))
+* [bitnami/contour] Release 5.0.3 updating components versions ([b506bb4](https://github.com/bitnami/charts/commit/b506bb4f6b421d29964abcd68edbd21954d5416c))
+* [bitnami/several] Upadte READMEs ([eb3c291](https://github.com/bitnami/charts/commit/eb3c2916be233280f2226d9cdceb57b08ab4a23b))
 
 ## <small>5.0.2 (2021-07-23)</small>
 
-* [bitnami/contour] Release 5.0.2 updating components versions ([c3d7b6b](https://github.com/bitnami/charts/commit/c3d7b6b))
+* [bitnami/contour] Release 5.0.2 updating components versions ([c3d7b6b](https://github.com/bitnami/charts/commit/c3d7b6beae4559c5f048b4b234a26b28ddc9897e))
 
 ## <small>5.0.1 (2021-07-22)</small>
 
-* [bitnami/several] Fix default values and regenerate README (#7023) ([c443ded](https://github.com/bitnami/charts/commit/c443ded)), closes [#7023](https://github.com/bitnami/charts/issues/7023)
+* [bitnami/several] Fix default values and regenerate README (#7023) ([c443ded](https://github.com/bitnami/charts/commit/c443ded691a1184a72af7b812759fad54b240ae9)), closes [#7023](https://github.com/bitnami/charts/issues/7023)
 
 ## 5.0.0 (2021-07-22)
 
-* [bitnami/contour] Synchronized all CRD with official yaml render v0.2.9 > v0.5.0 (#6907) ([e6ae400](https://github.com/bitnami/charts/commit/e6ae400)), closes [#6907](https://github.com/bitnami/charts/issues/6907)
+* [bitnami/contour] Synchronized all CRD with official yaml render v0.2.9 > v0.5.0 (#6907) ([e6ae400](https://github.com/bitnami/charts/commit/e6ae400f247cad7cbd8d311bf3b0fc59976347de)), closes [#6907](https://github.com/bitnami/charts/issues/6907)
 
 ## <small>4.3.11 (2021-07-19)</small>
 
-* [bitnami/*] Adapt values.yaml of Cert Manager, Consul and Contour to readme-generator (#6761) ([98d775d](https://github.com/bitnami/charts/commit/98d775d)), closes [#6761](https://github.com/bitnami/charts/issues/6761)
+* [bitnami/*] Adapt values.yaml of Cert Manager, Consul and Contour to readme-generator (#6761) ([98d775d](https://github.com/bitnami/charts/commit/98d775dbe19c10a2f31a0b4fcdc69820c05ac3a2)), closes [#6761](https://github.com/bitnami/charts/issues/6761)
 
 ## <small>4.3.10 (2021-07-07)</small>
 
-* [bitnami/contour] Release 4.3.10 updating components versions ([f3329c0](https://github.com/bitnami/charts/commit/f3329c0))
+* [bitnami/contour] Release 4.3.10 updating components versions ([f3329c0](https://github.com/bitnami/charts/commit/f3329c07a6736ec0b6013f51b4d8c8bfad38024c))
 
 ## <small>4.3.9 (2021-06-21)</small>
 
-* [bitnami/contour] Release 4.3.9 updating components versions ([2cb6af5](https://github.com/bitnami/charts/commit/2cb6af5))
+* [bitnami/contour] Release 4.3.9 updating components versions ([2cb6af5](https://github.com/bitnami/charts/commit/2cb6af5539a2cb1fd18dfa64bf71af57f77e821b))
 
 ## <small>4.3.8 (2021-06-19)</small>
 
-* [bitnami/contour] Release 4.3.8 updating components versions ([3079997](https://github.com/bitnami/charts/commit/3079997))
+* [bitnami/contour] Release 4.3.8 updating components versions ([3079997](https://github.com/bitnami/charts/commit/307999771a798ffce60b79d9c7cc9e279cd97f98))
 
 ## <small>4.3.7 (2021-06-18)</small>
 
-* [bitnami/contour] Release 4.3.7 updating components versions ([e759a86](https://github.com/bitnami/charts/commit/e759a86))
+* [bitnami/contour] Release 4.3.7 updating components versions ([e759a86](https://github.com/bitnami/charts/commit/e759a86628dadce897750efe57c6d8fdd30af5d2))
 
 ## <small>4.3.6 (2021-05-27)</small>
 
-* [bitnami/contour] Release 4.3.6 updating components versions ([69faffb](https://github.com/bitnami/charts/commit/69faffb))
+* [bitnami/contour] Release 4.3.6 updating components versions ([69faffb](https://github.com/bitnami/charts/commit/69faffb49775755c3ca82559127537507eedc323))
 
 ## <small>4.3.5 (2021-05-26)</small>
 
-* [bitnami/contour] Parametrize envoy.serviceAccount.automountServiceAccountToken value (#6463) ([b7ef490](https://github.com/bitnami/charts/commit/b7ef490)), closes [#6463](https://github.com/bitnami/charts/issues/6463)
+* [bitnami/contour] Parametrize envoy.serviceAccount.automountServiceAccountToken value (#6463) ([b7ef490](https://github.com/bitnami/charts/commit/b7ef490a5b29f729cab5ff19b9ceb66979556792)), closes [#6463](https://github.com/bitnami/charts/issues/6463)
 
 ## <small>4.3.4 (2021-05-23)</small>
 
-* [bitnami/contour] Release 4.3.4 updating components versions ([a0ef400](https://github.com/bitnami/charts/commit/a0ef400))
+* [bitnami/contour] Release 4.3.4 updating components versions ([a0ef400](https://github.com/bitnami/charts/commit/a0ef400a7adfcf3cd95ae70d47c102ed3ea6e4e1))
 
 ## <small>4.3.3 (2021-05-13)</small>
 
-* [bitnami/contour] Release 4.3.3 updating components versions ([7ce50d3](https://github.com/bitnami/charts/commit/7ce50d3))
+* [bitnami/contour] Release 4.3.3 updating components versions ([7ce50d3](https://github.com/bitnami/charts/commit/7ce50d3c2a035a0825705401a66688ff546dbc15))
 
 ## <small>4.3.2 (2021-04-30)</small>
 
-* [bitnami/contour] Release 4.3.2 updating components versions ([703bb1c](https://github.com/bitnami/charts/commit/703bb1c))
+* [bitnami/contour] Release 4.3.2 updating components versions ([703bb1c](https://github.com/bitnami/charts/commit/703bb1c5794b054b7e4cfc821ce842d5f723c8b8))
 
 ## <small>4.3.1 (2021-04-16)</small>
 
-* [bitnami/contour] Release 4.3.1 updating components versions ([08e4472](https://github.com/bitnami/charts/commit/08e4472))
+* [bitnami/contour] Release 4.3.1 updating components versions ([08e4472](https://github.com/bitnami/charts/commit/08e447271e7f4a171bcb67415176ab06f7f29f22))
 
 ## 4.3.0 (2021-04-12)
 
-* [bitnami/contour] Add the possibility to set HostIP (#6000) ([b3749e6](https://github.com/bitnami/charts/commit/b3749e6)), closes [#6000](https://github.com/bitnami/charts/issues/6000)
+* [bitnami/contour] Add the possibility to set HostIP (#6000) ([b3749e6](https://github.com/bitnami/charts/commit/b3749e6b10ec62ce437fefa02111b8b05bc5b999)), closes [#6000](https://github.com/bitnami/charts/issues/6000)
 
 ## <small>4.2.2 (2021-04-01)</small>
 
-* [bitnami/contour] Release 4.2.2 updating components versions ([f81c5fd](https://github.com/bitnami/charts/commit/f81c5fd))
+* [bitnami/contour] Release 4.2.2 updating components versions ([f81c5fd](https://github.com/bitnami/charts/commit/f81c5fd7892e614d6c2bf7d23528225c14424b50))
 
 ## <small>4.2.1 (2021-03-19)</small>
 
-* [bitnami/contour] Add ingressclasses to RBAC (#5836) ([d8e16ad](https://github.com/bitnami/charts/commit/d8e16ad)), closes [#5836](https://github.com/bitnami/charts/issues/5836)
+* [bitnami/contour] Add ingressclasses to RBAC (#5836) ([d8e16ad](https://github.com/bitnami/charts/commit/d8e16ad8b8b00286f6d13b091d300443511aea14)), closes [#5836](https://github.com/bitnami/charts/issues/5836)
 
 ## 4.2.0 (2021-03-18)
 
-* [bitnami/contour] Envoy extraArgs (#5823) ([36a2d1f](https://github.com/bitnami/charts/commit/36a2d1f)), closes [#5823](https://github.com/bitnami/charts/issues/5823)
+* [bitnami/contour] Envoy extraArgs (#5823) ([36a2d1f](https://github.com/bitnami/charts/commit/36a2d1f3113a93a1c4415e4b1674446fc755963f)), closes [#5823](https://github.com/bitnami/charts/issues/5823)
 
 ## <small>4.1.4 (2021-03-05)</small>
 
-* [bitnami/contour] Release 4.1.4 updating components versions ([af6f4b1](https://github.com/bitnami/charts/commit/af6f4b1))
+* [bitnami/contour] Release 4.1.4 updating components versions ([af6f4b1](https://github.com/bitnami/charts/commit/af6f4b1a95934e5e6bc7be185c898f65897ef822))
 
 ## <small>4.1.3 (2021-02-22)</small>
 
-* [bitnami/*] Use common macro to define RBAC apiVersion (#5585) ([71fb99f](https://github.com/bitnami/charts/commit/71fb99f)), closes [#5585](https://github.com/bitnami/charts/issues/5585)
+* [bitnami/*] Use common macro to define RBAC apiVersion (#5585) ([71fb99f](https://github.com/bitnami/charts/commit/71fb99f541e971b1daafaa20ffb7d18b153b8d60)), closes [#5585](https://github.com/bitnami/charts/issues/5585)
 
 ## <small>4.1.2 (2021-02-09)</small>
 
-* [bitnami/contour] Release 4.1.2 updating components versions ([a4cf3e9](https://github.com/bitnami/charts/commit/a4cf3e9))
+* [bitnami/contour] Release 4.1.2 updating components versions ([a4cf3e9](https://github.com/bitnami/charts/commit/a4cf3e9e7b4a8707d8797f93f5df318e83902216))
 
 ## <small>4.1.1 (2021-02-02)</small>
 
-* [bitnami/contour] Fix contour defaultBackend with k8s >= 1.19 (#5350) ([f33d481](https://github.com/bitnami/charts/commit/f33d481)), closes [#5350](https://github.com/bitnami/charts/issues/5350)
+* [bitnami/contour] Fix contour defaultBackend with k8s >= 1.19 (#5350) ([f33d481](https://github.com/bitnami/charts/commit/f33d4811e8de121cd11434986bc5ea81c37e178c)), closes [#5350](https://github.com/bitnami/charts/issues/5350)
 
 ## 4.1.0 (2021-01-28)
 
-* [bitnami/contour] Add hostAliases (#5219) ([0083eed](https://github.com/bitnami/charts/commit/0083eed)), closes [#5219](https://github.com/bitnami/charts/issues/5219)
+* [bitnami/contour] Add hostAliases (#5219) ([0083eed](https://github.com/bitnami/charts/commit/0083eed546c879e4fe126d04434b4da6400d755d)), closes [#5219](https://github.com/bitnami/charts/issues/5219)
 
 ## <small>4.0.2 (2021-01-27)</small>
 
-* [bitnami/contour] Release 4.0.2 updating components versions ([5f0217c](https://github.com/bitnami/charts/commit/5f0217c))
+* [bitnami/contour] Release 4.0.2 updating components versions ([5f0217c](https://github.com/bitnami/charts/commit/5f0217c73f34cf29126caf71022c7adcaa4770d9))
 
 ## <small>4.0.1 (2021-01-27)</small>
 
-* [bitnami/contour] Release 4.0.1 updating components versions ([8c4cfd8](https://github.com/bitnami/charts/commit/8c4cfd8))
+* [bitnami/contour] Release 4.0.1 updating components versions ([8c4cfd8](https://github.com/bitnami/charts/commit/8c4cfd87ce6e65ba5ad30e9f75e38c4ea754eb04))
 
 ## 4.0.0 (2021-01-26)
 
-* [bitnami/contour] Change CRDs approach to handle CRD upgrades (#3665) ([25e31a0](https://github.com/bitnami/charts/commit/25e31a0)), closes [#3665](https://github.com/bitnami/charts/issues/3665) [/github.com/projectcontour/contour/issues/2050#issuecomment-673722738](https://github.com//github.com/projectcontour/contour/issues/2050/issues/issuecomment-673722738)
+* [bitnami/contour] Change CRDs approach to handle CRD upgrades (#3665) ([25e31a0](https://github.com/bitnami/charts/commit/25e31a06445d10d93bb9f07516353b9821b0b9f8)), closes [#3665](https://github.com/bitnami/charts/issues/3665) [/github.com/projectcontour/contour/issues/2050#issuecomment-673722738](https://github.com//github.com/projectcontour/contour/issues/2050/issues/issuecomment-673722738)
 
 ## <small>3.3.4 (2021-01-25)</small>
 
-* [bitnami/*] Unify icons in Chart.yaml and add missing fields (#5206) ([0462921](https://github.com/bitnami/charts/commit/0462921)), closes [#5206](https://github.com/bitnami/charts/issues/5206)
+* [bitnami/*] Unify icons in Chart.yaml and add missing fields (#5206) ([0462921](https://github.com/bitnami/charts/commit/0462921418ca8d54308b7466197a6d53ffae4628)), closes [#5206](https://github.com/bitnami/charts/issues/5206)
 
 ## <small>3.3.3 (2021-01-21)</small>
 
-* [bitnami/*] Change helm version in the prerequisites (#5090) ([c5e67a3](https://github.com/bitnami/charts/commit/c5e67a3)), closes [#5090](https://github.com/bitnami/charts/issues/5090)
-* [bitnami/contour] Release 3.3.3 updating components versions ([fa9eaaf](https://github.com/bitnami/charts/commit/fa9eaaf))
+* [bitnami/*] Change helm version in the prerequisites (#5090) ([c5e67a3](https://github.com/bitnami/charts/commit/c5e67a388743cbee28439d2cabca27884b9daf97)), closes [#5090](https://github.com/bitnami/charts/issues/5090)
+* [bitnami/contour] Release 3.3.3 updating components versions ([fa9eaaf](https://github.com/bitnami/charts/commit/fa9eaaf43e6af71770f0ae95800005972ae1d626))
 
 ## <small>3.3.2 (2021-01-17)</small>
 
-* [bitnami/contour] Release 3.3.2 updating components versions ([f0e9680](https://github.com/bitnami/charts/commit/f0e9680))
+* [bitnami/contour] Release 3.3.2 updating components versions ([f0e9680](https://github.com/bitnami/charts/commit/f0e9680c1a1c7ed0128a5e8f40e32f61b01376b2))
 
 ## <small>3.3.1 (2021-01-08)</small>
 
-* [bitnami/*] Fix typo in README (leaviness > liveness) (#4917) ([80ca826](https://github.com/bitnami/charts/commit/80ca826)), closes [#4917](https://github.com/bitnami/charts/issues/4917)
+* [bitnami/*] Fix typo in README (leaviness > liveness) (#4917) ([80ca826](https://github.com/bitnami/charts/commit/80ca8265b58602ded240c97025017607da6e1fd2)), closes [#4917](https://github.com/bitnami/charts/issues/4917)
 
 ## 3.3.0 (2021-01-07)
 
-* [bitnami/contour] Implement a default backend for convenience (#4881) ([02b55a0](https://github.com/bitnami/charts/commit/02b55a0)), closes [#4881](https://github.com/bitnami/charts/issues/4881) [/github.com/bitnami/charts/pull/3788#pullrequestreview-516865711](https://github.com//github.com/bitnami/charts/pull/3788/issues/pullrequestreview-516865711)
+* [bitnami/contour] Implement a default backend for convenience (#4881) ([02b55a0](https://github.com/bitnami/charts/commit/02b55a0d33c34878d2030a26843c1f7088939bd2)), closes [#4881](https://github.com/bitnami/charts/issues/4881) [/github.com/bitnami/charts/pull/3788#pullrequestreview-516865711](https://github.com//github.com/bitnami/charts/pull/3788/issues/pullrequestreview-516865711)
 
 ## 3.2.0 (2020-12-22)
 
-* [bitnami/contour] Allow extra arguments to be specified, and passed to Contour container (#4790) ([fa692bf](https://github.com/bitnami/charts/commit/fa692bf)), closes [#4790](https://github.com/bitnami/charts/issues/4790)
+* [bitnami/contour] Allow extra arguments to be specified, and passed to Contour container (#4790) ([fa692bf](https://github.com/bitnami/charts/commit/fa692bfbc4bf0f5e1f4e17fdddea8821dc570e45)), closes [#4790](https://github.com/bitnami/charts/issues/4790)
 
 ## 3.1.0 (2020-12-21)
 
-* [bitnami/contour] Explicit namespaces (#4786) ([5654349](https://github.com/bitnami/charts/commit/5654349)), closes [#4786](https://github.com/bitnami/charts/issues/4786)
+* [bitnami/contour] Explicit namespaces (#4786) ([5654349](https://github.com/bitnami/charts/commit/5654349bdf6c77453999bab9f5485489abbca1ef)), closes [#4786](https://github.com/bitnami/charts/issues/4786)
 
 ## <small>3.0.3 (2020-12-18)</small>
 
-* [bitnami/*] fix typos (#4699) ([49adc63](https://github.com/bitnami/charts/commit/49adc63)), closes [#4699](https://github.com/bitnami/charts/issues/4699)
-* [bitnami/contour] Release 3.0.3 updating components versions ([a781cfe](https://github.com/bitnami/charts/commit/a781cfe))
+* [bitnami/*] fix typos (#4699) ([49adc63](https://github.com/bitnami/charts/commit/49adc63b672da976c55af2e077aa5648a357b77f)), closes [#4699](https://github.com/bitnami/charts/issues/4699)
+* [bitnami/contour] Release 3.0.3 updating components versions ([a781cfe](https://github.com/bitnami/charts/commit/a781cfe4495efb5f27f0eccb0e5228de5520596a))
 
 ## <small>3.0.2 (2020-12-11)</small>
 
-* [bitnami/*] Update dependencies (#4694) ([2826c12](https://github.com/bitnami/charts/commit/2826c12)), closes [#4694](https://github.com/bitnami/charts/issues/4694)
+* [bitnami/*] Update dependencies (#4694) ([2826c12](https://github.com/bitnami/charts/commit/2826c125b42505f28431301e3c1bbe5366e47a01)), closes [#4694](https://github.com/bitnami/charts/issues/4694)
 
 ## <small>3.0.1 (2020-12-11)</small>
 
-* [bitnami/contour] Release 3.0.1 updating components versions ([0e04d39](https://github.com/bitnami/charts/commit/0e04d39))
+* [bitnami/contour] Release 3.0.1 updating components versions ([0e04d39](https://github.com/bitnami/charts/commit/0e04d3979474028e17aa8dafcacf821ca07fca3b))
 
 ## 3.0.0 (2020-11-11)
 
-* [bitnami/contour] Major version. Adapt Chart to apiVersion: v2 (#4299) ([4c79dec](https://github.com/bitnami/charts/commit/4c79dec)), closes [#4299](https://github.com/bitnami/charts/issues/4299)
+* [bitnami/contour] Major version. Adapt Chart to apiVersion: v2 (#4299) ([4c79dec](https://github.com/bitnami/charts/commit/4c79dec4c738a1754481d9732b924a1cb338f323)), closes [#4299](https://github.com/bitnami/charts/issues/4299)
 
 ## <small>2.3.5 (2020-11-07)</small>
 
-* [bitnami/*] Include link to Troubleshootin guide on README.md (#4136) ([c08a20e](https://github.com/bitnami/charts/commit/c08a20e)), closes [#4136](https://github.com/bitnami/charts/issues/4136)
-* [bitnami/contour] Release 2.3.5 updating components versions ([2008b7e](https://github.com/bitnami/charts/commit/2008b7e))
+* [bitnami/*] Include link to Troubleshootin guide on README.md (#4136) ([c08a20e](https://github.com/bitnami/charts/commit/c08a20e3db004215383004ff023a73fcc2522e72)), closes [#4136](https://github.com/bitnami/charts/issues/4136)
+* [bitnami/contour] Release 2.3.5 updating components versions ([2008b7e](https://github.com/bitnami/charts/commit/2008b7e78f097eefe4b981776d63197cce6eeafb))
 
 ## <small>2.3.4 (2020-10-19)</small>
 
-* [bitnami/contour] fix: automatic update of ingress.status by contour (#4042) ([f059891](https://github.com/bitnami/charts/commit/f059891)), closes [#4042](https://github.com/bitnami/charts/issues/4042)
+* [bitnami/contour] fix: automatic update of ingress.status by contour (#4042) ([f059891](https://github.com/bitnami/charts/commit/f059891cdb8e6f98f69da3c47e7ef8643ae77c7d)), closes [#4042](https://github.com/bitnami/charts/issues/4042)
 
 ## <small>2.3.3 (2020-10-19)</small>
 
-* [bitnami/contour] Contour v1.9 (#4023) ([bc6113f](https://github.com/bitnami/charts/commit/bc6113f)), closes [#4023](https://github.com/bitnami/charts/issues/4023)
+* [bitnami/contour] Contour v1.9 (#4023) ([bc6113f](https://github.com/bitnami/charts/commit/bc6113f6cdbcaa1faae272d3c6f5c3beee017c86)), closes [#4023](https://github.com/bitnami/charts/issues/4023)
 
 ## <small>2.3.2 (2020-09-30)</small>
 
-* [bitnami/contour] Release 2.3.2 updating components versions ([6a8f329](https://github.com/bitnami/charts/commit/6a8f329))
+* [bitnami/contour] Release 2.3.2 updating components versions ([6a8f329](https://github.com/bitnami/charts/commit/6a8f329969e5db9f289057af776032ef006adcc9))
 
 ## <small>2.3.1 (2020-09-30)</small>
 
-* [bitnami/contour] add podAnnotations to templates (#3811) ([9217b41](https://github.com/bitnami/charts/commit/9217b41)), closes [#3811](https://github.com/bitnami/charts/issues/3811)
+* [bitnami/contour] add podAnnotations to templates (#3811) ([9217b41](https://github.com/bitnami/charts/commit/9217b41d9704876a2131fa91d5034a3e5f5ba5ad)), closes [#3811](https://github.com/bitnami/charts/issues/3811)
 
 ## 2.3.0 (2020-09-28)
 
-* [bitnami/contour] feat: support existing secret for tls (#3777) ([abd8de3](https://github.com/bitnami/charts/commit/abd8de3)), closes [#3777](https://github.com/bitnami/charts/issues/3777)
+* [bitnami/contour] feat: support existing secret for tls (#3777) ([abd8de3](https://github.com/bitnami/charts/commit/abd8de35e4856f165de064b5ccc318d56c96ea99)), closes [#3777](https://github.com/bitnami/charts/issues/3777)
 
 ## 2.2.0 (2020-09-24)
 
-* [bitnami/*] Affinity based on common presets (#3746) ([01884c7](https://github.com/bitnami/charts/commit/01884c7)), closes [#3746](https://github.com/bitnami/charts/issues/3746)
+* [bitnami/*] Affinity based on common presets (#3746) ([01884c7](https://github.com/bitnami/charts/commit/01884c767c48c38e6fa4c2984bd1acd5d6d81f9e)), closes [#3746](https://github.com/bitnami/charts/issues/3746)
 
 ## <small>2.1.1 (2020-09-18)</small>
 
-* [bitnami/contour]: Fix installation notes to display correct kubectl commands (#3706) ([8bfacfa](https://github.com/bitnami/charts/commit/8bfacfa)), closes [#3706](https://github.com/bitnami/charts/issues/3706)
+* [bitnami/contour]: Fix installation notes to display correct kubectl commands (#3706) ([8bfacfa](https://github.com/bitnami/charts/commit/8bfacfaa23af65ed2cbcfeba870c9b15f70aeb4e)), closes [#3706](https://github.com/bitnami/charts/issues/3706)
 
 ## 2.1.0 (2020-09-16)
 
-* [bitnami/contour] Configurable envoy ports (#3674) ([dc0d079](https://github.com/bitnami/charts/commit/dc0d079)), closes [#3674](https://github.com/bitnami/charts/issues/3674)
+* [bitnami/contour] Configurable envoy ports (#3674) ([dc0d079](https://github.com/bitnami/charts/commit/dc0d0793e303de2220214f1a3528bcf3c4da7697)), closes [#3674](https://github.com/bitnami/charts/issues/3674)
 
 ## 2.0.0 (2020-09-09)
 
-* [bitnami/contour] Sync upstream changes and chart standardization (#3381) ([91fa2c0](https://github.com/bitnami/charts/commit/91fa2c0)), closes [#3381](https://github.com/bitnami/charts/issues/3381) [#2721](https://github.com/bitnami/charts/issues/2721) [projectcontour/contour#2050](https://github.com/projectcontour/contour/issues/2050) [#3566](https://github.com/bitnami/charts/issues/3566) [#2](https://github.com/bitnami/charts/issues/2) [#2961](https://github.com/bitnami/charts/issues/2961)
-* [bitnami/metrics-server] Add source repo (#3577) ([1ed12f9](https://github.com/bitnami/charts/commit/1ed12f9)), closes [#3577](https://github.com/bitnami/charts/issues/3577)
+* [bitnami/contour] Sync upstream changes and chart standardization (#3381) ([91fa2c0](https://github.com/bitnami/charts/commit/91fa2c00546400263b5396a3424e94815627a266)), closes [#3381](https://github.com/bitnami/charts/issues/3381) [#2721](https://github.com/bitnami/charts/issues/2721) [projectcontour/contour#2050](https://github.com/projectcontour/contour/issues/2050) [#3566](https://github.com/bitnami/charts/issues/3566) [#2](https://github.com/bitnami/charts/issues/2) [#2961](https://github.com/bitnami/charts/issues/2961)
+* [bitnami/metrics-server] Add source repo (#3577) ([1ed12f9](https://github.com/bitnami/charts/commit/1ed12f96af75322b46afdb2b3d9907c11b13f765)), closes [#3577](https://github.com/bitnami/charts/issues/3577)
 
 ## <small>1.2.2 (2020-09-03)</small>
 
-* [bitnami/contour] Release 1.2.2 updating components versions ([e78cf86](https://github.com/bitnami/charts/commit/e78cf86))
+* [bitnami/contour] Release 1.2.2 updating components versions ([e78cf86](https://github.com/bitnami/charts/commit/e78cf865c94cdd3217c3f5e714bba0e57d9dc1d9))
 
 ## <small>1.2.1 (2020-08-28)</small>
 
-* [bitnami/contour] Release 1.2.1 updating components versions ([96dfc13](https://github.com/bitnami/charts/commit/96dfc13))
+* [bitnami/contour] Release 1.2.1 updating components versions ([96dfc13](https://github.com/bitnami/charts/commit/96dfc13354b1bef7abd66354d511962e59c940bf))
 
 ## 1.2.0 (2020-08-10)
 
-* [bitnami/contour] Add ability to specify ingressClass and restart pods on config change (#3367) ([5f45523](https://github.com/bitnami/charts/commit/5f45523)), closes [#3367](https://github.com/bitnami/charts/issues/3367)
+* [bitnami/contour] Add ability to specify ingressClass and restart pods on config change (#3367) ([5f45523](https://github.com/bitnami/charts/commit/5f4552393784db0359a7d6e2a3186fb8cb26aa02)), closes [#3367](https://github.com/bitnami/charts/issues/3367)
 
 ## <small>1.1.3 (2020-08-04)</small>
 
-* [bitnami/contour] Release 1.1.3 updating components versions ([0473298](https://github.com/bitnami/charts/commit/0473298))
+* [bitnami/contour] Release 1.1.3 updating components versions ([0473298](https://github.com/bitnami/charts/commit/04732989c72fb1a03aaed8798d0ae24345190475))
 
 ## <small>1.1.2 (2020-07-31)</small>
 
-* [bitnami/*] Fix TL;DR typo in READMEs (#3280) ([3d7ab40](https://github.com/bitnami/charts/commit/3d7ab40)), closes [#3280](https://github.com/bitnami/charts/issues/3280)
-* [bitnami/contour] Release 1.1.2 updating components versions ([bb61d33](https://github.com/bitnami/charts/commit/bb61d33))
+* [bitnami/*] Fix TL;DR typo in READMEs (#3280) ([3d7ab40](https://github.com/bitnami/charts/commit/3d7ab406fecd64f1af25f53e7d27f03ec95b29a4)), closes [#3280](https://github.com/bitnami/charts/issues/3280)
+* [bitnami/contour] Release 1.1.2 updating components versions ([bb61d33](https://github.com/bitnami/charts/commit/bb61d33b122e7ad50525342839cd591ba04121b6))
 
 ## <small>1.1.1 (2020-07-14)</small>
 
-* [bitnami/contour] Release 1.1.1 updating components versions ([615e694](https://github.com/bitnami/charts/commit/615e694))
+* [bitnami/contour] Release 1.1.1 updating components versions ([615e694](https://github.com/bitnami/charts/commit/615e6940cecfd0b19bcdc70dcbcbc1900374cc12))
 
 ## 1.1.0 (2020-07-14)
 
-* [bitnami/all] Add categories (#3075) ([63bde06](https://github.com/bitnami/charts/commit/63bde06)), closes [#3075](https://github.com/bitnami/charts/issues/3075)
-* [bitnami/chart] Add NLB load balancer support, run envoy container as root (#2961) ([074f69f](https://github.com/bitnami/charts/commit/074f69f)), closes [#2961](https://github.com/bitnami/charts/issues/2961)
+* [bitnami/all] Add categories (#3075) ([63bde06](https://github.com/bitnami/charts/commit/63bde066b87a140fab52264d0522401ab3d63509)), closes [#3075](https://github.com/bitnami/charts/issues/3075)
+* [bitnami/chart] Add NLB load balancer support, run envoy container as root (#2961) ([074f69f](https://github.com/bitnami/charts/commit/074f69f45be0bc32620eef91a7a9112b53836098)), closes [#2961](https://github.com/bitnami/charts/issues/2961)
 
 ## <small>1.0.4 (2020-07-07)</small>
 
-* [bitnami/contour] Release 1.0.4 updating components versions ([62eaa78](https://github.com/bitnami/charts/commit/62eaa78))
+* [bitnami/contour] Release 1.0.4 updating components versions ([62eaa78](https://github.com/bitnami/charts/commit/62eaa7850fac6b5600495e8d1ed8a78517764dfa))
 
 ## <small>1.0.3 (2020-07-07)</small>
 
-* [bitnami/contour, metallb] Fix incorrect icons (#3034) ([fc8c3a7](https://github.com/bitnami/charts/commit/fc8c3a7)), closes [#3034](https://github.com/bitnami/charts/issues/3034)
-* [bitnami/metallb][bitnami/contour] Revert appVersion change (#3046) ([726ad74](https://github.com/bitnami/charts/commit/726ad74)), closes [#3046](https://github.com/bitnami/charts/issues/3046)
+* [bitnami/contour, metallb] Fix incorrect icons (#3034) ([fc8c3a7](https://github.com/bitnami/charts/commit/fc8c3a72013787466877579754b0e5d46a2b8274)), closes [#3034](https://github.com/bitnami/charts/issues/3034)
+* [bitnami/metallb][bitnami/contour] Revert appVersion change (#3046) ([726ad74](https://github.com/bitnami/charts/commit/726ad748f927dd21704eaef50fbeb2ea35752d81)), closes [#3046](https://github.com/bitnami/charts/issues/3046)
 
 ## <small>1.0.2 (2020-07-03)</small>
 
-* [bitnami/contour] Release 1.0.2 updating components versions ([fb6879b](https://github.com/bitnami/charts/commit/fb6879b))
+* [bitnami/contour] Release 1.0.2 updating components versions ([fb6879b](https://github.com/bitnami/charts/commit/fb6879b118f820b9e49517970edd7318e17789ba))
 
 ## <small>1.0.1 (2020-06-26)</small>
 
-* [bitnami/contour] Release 1.0.1 updating components versions ([419917f](https://github.com/bitnami/charts/commit/419917f))
+* [bitnami/contour] Release 1.0.1 updating components versions ([419917f](https://github.com/bitnami/charts/commit/419917fc11883f81c92bca652f43a9e78107fd80))
 
 ## 1.0.0 (2020-06-24)
 
-* [bitnami/contour] Release 1.0.0 updating components versions ([bc5b010](https://github.com/bitnami/charts/commit/bc5b010))
+* [bitnami/contour] Release 1.0.0 updating components versions ([bc5b010](https://github.com/bitnami/charts/commit/bc5b0101dc4da84a5198d2f6768b1ba347a39331))
 
 ## 0.3.0 (2020-06-19)
 
-* [bitnami/contour] Adding the Contour Helm Chart. (#2069) ([15c13ec](https://github.com/bitnami/charts/commit/15c13ec)), closes [#2069](https://github.com/bitnami/charts/issues/2069)
+* [bitnami/contour] Adding the Contour Helm Chart. (#2069) ([15c13ec](https://github.com/bitnami/charts/commit/15c13ec45a64f95eb624c3b542655c5985a8a5d9)), closes [#2069](https://github.com/bitnami/charts/issues/2069)

--- a/bitnami/contour/Chart.yaml
+++ b/bitnami/contour/Chart.yaml
@@ -32,4 +32,4 @@ maintainers:
 name: contour
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/contour
-version: 18.1.0
+version: 18.1.1

--- a/bitnami/contour/templates/contour/deployment.yaml
+++ b/bitnami/contour/templates/contour/deployment.yaml
@@ -146,8 +146,7 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.contour.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.contour.livenessProbe.enabled }}
           livenessProbe:
-            httpGet:
-              path: /healthz
+            tcpSocket:
               port: {{ .Values.contour.containerPorts.metrics }}
             initialDelaySeconds: {{ .Values.contour.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.contour.livenessProbe.periodSeconds }}

--- a/bitnami/contour/templates/default-backend/deployment.yaml
+++ b/bitnami/contour/templates/default-backend/deployment.yaml
@@ -115,10 +115,8 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.defaultBackend.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.defaultBackend.livenessProbe.enabled }}
           livenessProbe:
-            httpGet:
-              path: /
+            tcpSocket:
               port: http
-              scheme: HTTP
             initialDelaySeconds: {{ .Values.defaultBackend.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.defaultBackend.livenessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.defaultBackend.livenessProbe.timeoutSeconds }}

--- a/bitnami/contour/templates/envoy/daemonset.yaml
+++ b/bitnami/contour/templates/envoy/daemonset.yaml
@@ -252,8 +252,7 @@ spec:
           {{- end }}
           {{- if .Values.envoy.livenessProbe.enabled }}
           livenessProbe:
-            httpGet:
-              path: /ready
+            tcpSocket:
               port: {{ .Values.envoy.containerPorts.metrics }}
             initialDelaySeconds: {{ .Values.envoy.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.envoy.livenessProbe.periodSeconds }}

--- a/bitnami/contour/templates/envoy/deployment.yaml
+++ b/bitnami/contour/templates/envoy/deployment.yaml
@@ -265,8 +265,7 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.envoy.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.envoy.livenessProbe.enabled }}
           livenessProbe:
-            httpGet:
-              path: /ready
+            tcpsocket:
               port: {{ .Values.envoy.containerPorts.metrics }}
             initialDelaySeconds: {{ .Values.envoy.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.envoy.livenessProbe.periodSeconds }}


### PR DESCRIPTION
### Description of the change
This PR aims to use different liveness/readiness probes to improve overall security and avoid unnecessary container restarts. [More info](https://github.com/zegl/kube-score/blob/master/README_PROBES.md).

### Benefits

Increase availability and resilience.

### Possible drawbacks

N/A

### Applicable issues

- fixes #

### Additional information

- Related to #23537

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- ~[X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)~
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
