### PR TITLE
[bitnami/concourse] Use different liveness/readiness probes

### DIFF
--- a/bitnami/concourse/CHANGELOG.md
+++ b/bitnami/concourse/CHANGELOG.md
@@ -1,662 +1,667 @@
 # Changelog
 
+## 4.2.1 (2024-05-22)
+
+* [bitnami/concourse] Use different liveness/readiness probes ([#26340](https://github.com/bitnami/charts/pull/26340))
+
 ## 4.2.0 (2024-05-21)
 
-* [bitnami/concourse] feat: :sparkles: :lock: Add warning when original images are replaced ([#26189](https://github.com/bitnami/charts/pulls/26189))
+* [bitnami/*] ci: :construction_worker: Add tag and changelog support (#25359) ([91c707c](https://github.com/bitnami/charts/commit/91c707c9e4e574725a09505d2d313fb93f1b4c0a)), closes [#25359](https://github.com/bitnami/charts/issues/25359)
+* [bitnami/concourse] feat: :sparkles: :lock: Add warning when original images are replaced (#26189) ([2c3742a](https://github.com/bitnami/charts/commit/2c3742ac0105f0ec3955b8443d8b07dbe109fd05)), closes [#26189](https://github.com/bitnami/charts/issues/26189)
 
 ## 4.1.0 (2024-05-20)
 
-* [bitnami/concourse] PDB review (#25869) ([d8a78da](https://github.com/bitnami/charts/commit/d8a78da)), closes [#25869](https://github.com/bitnami/charts/issues/25869)
+* [bitnami/concourse] PDB review (#25869) ([d8a78da](https://github.com/bitnami/charts/commit/d8a78daca1557e14278d8aebe109d58692b710f2)), closes [#25869](https://github.com/bitnami/charts/issues/25869)
 
 ## <small>4.0.2 (2024-05-18)</small>
 
-* [bitnami/*] Change non-root and rolling-tags doc URLs (#25628) ([b067c94](https://github.com/bitnami/charts/commit/b067c94)), closes [#25628](https://github.com/bitnami/charts/issues/25628)
-* [bitnami/*] Set new header/owner (#25558) ([8d1dc11](https://github.com/bitnami/charts/commit/8d1dc11)), closes [#25558](https://github.com/bitnami/charts/issues/25558)
-* [bitnami/concourse] Release 4.0.2 updating components versions (#26091) ([61ac7dd](https://github.com/bitnami/charts/commit/61ac7dd)), closes [#26091](https://github.com/bitnami/charts/issues/26091)
-* [bitnami/multiple charts] Fix typo: "NetworkPolice" vs "NetworkPolicy" (#25348) ([6970c1b](https://github.com/bitnami/charts/commit/6970c1b)), closes [#25348](https://github.com/bitnami/charts/issues/25348)
-* Replace VMware by Broadcom copyright text (#25306) ([a5e4bd0](https://github.com/bitnami/charts/commit/a5e4bd0)), closes [#25306](https://github.com/bitnami/charts/issues/25306)
+* [bitnami/*] Change non-root and rolling-tags doc URLs (#25628) ([b067c94](https://github.com/bitnami/charts/commit/b067c94f6bcde427863c197fd355f0b5ba12ff5b)), closes [#25628](https://github.com/bitnami/charts/issues/25628)
+* [bitnami/*] Set new header/owner (#25558) ([8d1dc11](https://github.com/bitnami/charts/commit/8d1dc11f5fb30db6fba50c43d7af59d2f79deed3)), closes [#25558](https://github.com/bitnami/charts/issues/25558)
+* [bitnami/concourse] Release 4.0.2 updating components versions (#26091) ([61ac7dd](https://github.com/bitnami/charts/commit/61ac7dd0375e0f6525feeab317e1b65aa9e0f41f)), closes [#26091](https://github.com/bitnami/charts/issues/26091)
+* [bitnami/multiple charts] Fix typo: "NetworkPolice" vs "NetworkPolicy" (#25348) ([6970c1b](https://github.com/bitnami/charts/commit/6970c1ba245873506e73d459c6eac1e4919b778f)), closes [#25348](https://github.com/bitnami/charts/issues/25348)
+* Replace VMware by Broadcom copyright text (#25306) ([a5e4bd0](https://github.com/bitnami/charts/commit/a5e4bd0e35e419203793976a78d9d0a13de92c76)), closes [#25306](https://github.com/bitnami/charts/issues/25306)
 
 ## <small>4.0.1 (2024-04-21)</small>
 
-* [bitnami/concourse] Release 4.0.1 (#25293) ([0ce4fbb](https://github.com/bitnami/charts/commit/0ce4fbb)), closes [#25293](https://github.com/bitnami/charts/issues/25293)
-* Update resourcesPreset comments (#24467) ([92e3e8a](https://github.com/bitnami/charts/commit/92e3e8a)), closes [#24467](https://github.com/bitnami/charts/issues/24467)
+* [bitnami/concourse] Release 4.0.1 (#25293) ([0ce4fbb](https://github.com/bitnami/charts/commit/0ce4fbbc4a185226929c796039d50201c2741637)), closes [#25293](https://github.com/bitnami/charts/issues/25293)
+* Update resourcesPreset comments (#24467) ([92e3e8a](https://github.com/bitnami/charts/commit/92e3e8a507326d2a20a8f10ab3e7746a2ec5c554)), closes [#24467](https://github.com/bitnami/charts/issues/24467)
 
 ## 4.0.0 (2024-04-01)
 
-* [bitnami/*] Reorder Chart sections (#24455) ([0cf4048](https://github.com/bitnami/charts/commit/0cf4048)), closes [#24455](https://github.com/bitnami/charts/issues/24455)
-* [bitnami/concourse] feat!: :lock: :boom: Improve security defaults (#24541) ([00e0013](https://github.com/bitnami/charts/commit/00e0013)), closes [#24541](https://github.com/bitnami/charts/issues/24541)
+* [bitnami/*] Reorder Chart sections (#24455) ([0cf4048](https://github.com/bitnami/charts/commit/0cf4048e8743f70a9753d460655bd030cbff6824)), closes [#24455](https://github.com/bitnami/charts/issues/24455)
+* [bitnami/concourse] feat!: :lock: :boom: Improve security defaults (#24541) ([00e0013](https://github.com/bitnami/charts/commit/00e0013229a6bcba7a9571c163c62b3272d5f2a4)), closes [#24541](https://github.com/bitnami/charts/issues/24541)
 
 ## <small>3.7.3 (2024-03-12)</small>
 
-* [bitnami/concourse] Release 3.7.3 updating components versions (#24366) ([2b79469](https://github.com/bitnami/charts/commit/2b79469)), closes [#24366](https://github.com/bitnami/charts/issues/24366)
+* [bitnami/concourse] Release 3.7.3 updating components versions (#24366) ([2b79469](https://github.com/bitnami/charts/commit/2b7946956919ab70f77914d4295263c5f12815ed)), closes [#24366](https://github.com/bitnami/charts/issues/24366)
 
 ## <small>3.7.2 (2024-03-11)</small>
 
-* [bitnami/concourse] Release 3.7.2 updating components versions (#24356) ([3dff7b1](https://github.com/bitnami/charts/commit/3dff7b1)), closes [#24356](https://github.com/bitnami/charts/issues/24356)
+* [bitnami/concourse] Release 3.7.2 updating components versions (#24356) ([3dff7b1](https://github.com/bitnami/charts/commit/3dff7b14bce7eb08adb0f69c99f04b88d84ab728)), closes [#24356](https://github.com/bitnami/charts/issues/24356)
 
 ## <small>3.7.1 (2024-03-06)</small>
 
-* [bitnami/concourse] Release 3.7.1 updating components versions (#24189) ([5bab2ae](https://github.com/bitnami/charts/commit/5bab2ae)), closes [#24189](https://github.com/bitnami/charts/issues/24189)
+* [bitnami/concourse] Release 3.7.1 updating components versions (#24189) ([5bab2ae](https://github.com/bitnami/charts/commit/5bab2ae0db06f82fa447e9a70cc08012b3691228)), closes [#24189](https://github.com/bitnami/charts/issues/24189)
 
 ## 3.7.0 (2024-03-06)
 
-* [bitnami/concourse] feat: :sparkles: :lock: Add automatic adaptation for Openshift restricted-v2 SCC ([57f00a7](https://github.com/bitnami/charts/commit/57f00a7)), closes [#24070](https://github.com/bitnami/charts/issues/24070)
+* [bitnami/concourse] feat: :sparkles: :lock: Add automatic adaptation for Openshift restricted-v2 SCC ([57f00a7](https://github.com/bitnami/charts/commit/57f00a74c8ef438a9db4bc36430906bdaac89722)), closes [#24070](https://github.com/bitnami/charts/issues/24070)
 
 ## 3.6.0 (2024-02-27)
 
-* [bitnami/concourse] feat: :sparkles: :lock: Add readOnlyRootFilesystem support (#23878) ([e2a4425](https://github.com/bitnami/charts/commit/e2a4425)), closes [#23878](https://github.com/bitnami/charts/issues/23878)
+* [bitnami/concourse] feat: :sparkles: :lock: Add readOnlyRootFilesystem support (#23878) ([e2a4425](https://github.com/bitnami/charts/commit/e2a4425b31cd799879b2f87c0259696a9327918c)), closes [#23878](https://github.com/bitnami/charts/issues/23878)
 
 ## <small>3.5.3 (2024-02-27)</small>
 
-* [bitnami/concourse] Release 3.5.3 updating components versions (#23934) ([e71e2a9](https://github.com/bitnami/charts/commit/e71e2a9)), closes [#23934](https://github.com/bitnami/charts/issues/23934)
+* [bitnami/concourse] Release 3.5.3 updating components versions (#23934) ([e71e2a9](https://github.com/bitnami/charts/commit/e71e2a9218b51b765c558082a2b4ff0bc9427db6)), closes [#23934](https://github.com/bitnami/charts/issues/23934)
 
 ## <small>3.5.2 (2024-02-21)</small>
 
-* [bitnami/concourse] Release 3.5.2 updating components versions (#23741) ([ec0ec17](https://github.com/bitnami/charts/commit/ec0ec17)), closes [#23741](https://github.com/bitnami/charts/issues/23741)
+* [bitnami/concourse] Release 3.5.2 updating components versions (#23741) ([ec0ec17](https://github.com/bitnami/charts/commit/ec0ec17b1c5ce6df0d02a68005afe2814061cdbb)), closes [#23741](https://github.com/bitnami/charts/issues/23741)
 
 ## <small>3.5.1 (2024-02-21)</small>
 
-* [bitnami/concourse] feat: :sparkles: :lock: Add resource preset support (#23437) ([0829956](https://github.com/bitnami/charts/commit/0829956)), closes [#23437](https://github.com/bitnami/charts/issues/23437)
-* [bitnami/concourse] Release 3.5.1 updating components versions (#23638) ([23a6493](https://github.com/bitnami/charts/commit/23a6493)), closes [#23638](https://github.com/bitnami/charts/issues/23638)
+* [bitnami/concourse] feat: :sparkles: :lock: Add resource preset support (#23437) ([0829956](https://github.com/bitnami/charts/commit/08299565064ded952d543c5abda9a0359cdf7d39)), closes [#23437](https://github.com/bitnami/charts/issues/23437)
+* [bitnami/concourse] Release 3.5.1 updating components versions (#23638) ([23a6493](https://github.com/bitnami/charts/commit/23a649387194cbc681602d5538f3d26961f8e163)), closes [#23638](https://github.com/bitnami/charts/issues/23638)
 
 ## 3.5.0 (2024-02-20)
 
-* [bitnami/*] Bump all versions (#23602) ([b70ee2a](https://github.com/bitnami/charts/commit/b70ee2a)), closes [#23602](https://github.com/bitnami/charts/issues/23602)
+* [bitnami/*] Bump all versions (#23602) ([b70ee2a](https://github.com/bitnami/charts/commit/b70ee2a30e4dc256bf0ac52928fb2fa7a70f049b)), closes [#23602](https://github.com/bitnami/charts/issues/23602)
 
 ## 3.4.0 (2024-02-08)
 
-* [bitnami/concourse] feat: :lock: Enable networkPolicy (#23334) ([0e35bb2](https://github.com/bitnami/charts/commit/0e35bb2)), closes [#23334](https://github.com/bitnami/charts/issues/23334)
+* [bitnami/concourse] feat: :lock: Enable networkPolicy (#23334) ([0e35bb2](https://github.com/bitnami/charts/commit/0e35bb2fcf820012b5f9a4d2cc8773da00de881b)), closes [#23334](https://github.com/bitnami/charts/issues/23334)
 
 ## <small>3.3.9 (2024-02-08)</small>
 
-* [bitnami/concourse] Release 3.3.9 updating components versions (#23326) ([e5a1f5f](https://github.com/bitnami/charts/commit/e5a1f5f)), closes [#23326](https://github.com/bitnami/charts/issues/23326)
+* [bitnami/concourse] Release 3.3.9 updating components versions (#23326) ([e5a1f5f](https://github.com/bitnami/charts/commit/e5a1f5f706a957a4a990ca68ee0a25d261aafcb3)), closes [#23326](https://github.com/bitnami/charts/issues/23326)
 
 ## <small>3.3.8 (2024-02-07)</small>
 
-* [bitnami/concourse] Release 3.3.8 updating components versions (#23268) ([4d04bac](https://github.com/bitnami/charts/commit/4d04bac)), closes [#23268](https://github.com/bitnami/charts/issues/23268)
+* [bitnami/concourse] Release 3.3.8 updating components versions (#23268) ([4d04bac](https://github.com/bitnami/charts/commit/4d04bac229d35de8f69619868ec24978a940e3ce)), closes [#23268](https://github.com/bitnami/charts/issues/23268)
 
 ## <small>3.3.7 (2024-02-07)</small>
 
-* [bitnami/concourse] Release 3.3.7 updating components versions (#23223) ([9d747fc](https://github.com/bitnami/charts/commit/9d747fc)), closes [#23223](https://github.com/bitnami/charts/issues/23223)
+* [bitnami/concourse] Release 3.3.7 updating components versions (#23223) ([9d747fc](https://github.com/bitnami/charts/commit/9d747fc4035ab571af09d2ed57a1c43e46212625)), closes [#23223](https://github.com/bitnami/charts/issues/23223)
 
 ## <small>3.3.6 (2024-02-03)</small>
 
-* [bitnami/concourse] Release 3.3.6 updating components versions (#23091) ([984c80b](https://github.com/bitnami/charts/commit/984c80b)), closes [#23091](https://github.com/bitnami/charts/issues/23091)
+* [bitnami/concourse] Release 3.3.6 updating components versions (#23091) ([984c80b](https://github.com/bitnami/charts/commit/984c80b7d78b2eaca3d63e5c90e4d25bb5d6833e)), closes [#23091](https://github.com/bitnami/charts/issues/23091)
 
 ## <small>3.3.5 (2024-02-02)</small>
 
-* [bitnami/concourse] Release 3.3.5 updating components versions (#23039) ([b8b6d2e](https://github.com/bitnami/charts/commit/b8b6d2e)), closes [#23039](https://github.com/bitnami/charts/issues/23039)
+* [bitnami/concourse] Release 3.3.5 updating components versions (#23039) ([b8b6d2e](https://github.com/bitnami/charts/commit/b8b6d2e378225243f6ded5565ee04aae77074f74)), closes [#23039](https://github.com/bitnami/charts/issues/23039)
 
 ## <small>3.3.4 (2024-01-30)</small>
 
-* [bitnami/concourse] Release 3.3.4 updating components versions (#22865) ([bd6978e](https://github.com/bitnami/charts/commit/bd6978e)), closes [#22865](https://github.com/bitnami/charts/issues/22865)
+* [bitnami/concourse] Release 3.3.4 updating components versions (#22865) ([bd6978e](https://github.com/bitnami/charts/commit/bd6978e52e364b492560ddc0e739e0d0c270574d)), closes [#22865](https://github.com/bitnami/charts/issues/22865)
 
 ## <small>3.3.3 (2024-01-27)</small>
 
-* [bitnami/concourse] Release 3.3.3 updating components versions (#22791) ([2909547](https://github.com/bitnami/charts/commit/2909547)), closes [#22791](https://github.com/bitnami/charts/issues/22791)
+* [bitnami/concourse] Release 3.3.3 updating components versions (#22791) ([2909547](https://github.com/bitnami/charts/commit/2909547bdea42846f2d0104f023ff39c121d6409)), closes [#22791](https://github.com/bitnami/charts/issues/22791)
 
 ## <small>3.3.2 (2024-01-26)</small>
 
-* [bitnami/concourse] Release 3.3.2 updating components versions (#22768) ([fc36e80](https://github.com/bitnami/charts/commit/fc36e80)), closes [#22768](https://github.com/bitnami/charts/issues/22768)
+* [bitnami/concourse] Release 3.3.2 updating components versions (#22768) ([fc36e80](https://github.com/bitnami/charts/commit/fc36e80c9ae42fd6a423a567c7fa1f6dab44ffd3)), closes [#22768](https://github.com/bitnami/charts/issues/22768)
 
 ## <small>3.3.1 (2024-01-24)</small>
 
-* [bitnami/*] Move documentation sections from docs.bitnami.com back to the README (#22203) ([7564f36](https://github.com/bitnami/charts/commit/7564f36)), closes [#22203](https://github.com/bitnami/charts/issues/22203)
-* [bitnami/concourse] fix: :bug: Set seLinuxOptions to null for Openshift compatibility (#22575) ([c4c2353](https://github.com/bitnami/charts/commit/c4c2353)), closes [#22575](https://github.com/bitnami/charts/issues/22575)
+* [bitnami/*] Move documentation sections from docs.bitnami.com back to the README (#22203) ([7564f36](https://github.com/bitnami/charts/commit/7564f36ca1e95ff30ee686652b7ab8690561a707)), closes [#22203](https://github.com/bitnami/charts/issues/22203)
+* [bitnami/concourse] fix: :bug: Set seLinuxOptions to null for Openshift compatibility (#22575) ([c4c2353](https://github.com/bitnami/charts/commit/c4c2353878f11422976954890bb36035532cd024)), closes [#22575](https://github.com/bitnami/charts/issues/22575)
 
 ## 3.3.0 (2024-01-22)
 
-* [bitnami/concourse] fix: :lock: Move service-account token auto-mount to pod declaration (#22391) ([1f86167](https://github.com/bitnami/charts/commit/1f86167)), closes [#22391](https://github.com/bitnami/charts/issues/22391)
+* [bitnami/concourse] fix: :lock: Move service-account token auto-mount to pod declaration (#22391) ([1f86167](https://github.com/bitnami/charts/commit/1f86167ee10a3abdac0357232ec2f99ec3c526d7)), closes [#22391](https://github.com/bitnami/charts/issues/22391)
 
 ## <small>3.2.1 (2024-01-18)</small>
 
-* [bitnami/concourse] Release 3.2.1 updating components versions (#22262) ([be1a7ca](https://github.com/bitnami/charts/commit/be1a7ca)), closes [#22262](https://github.com/bitnami/charts/issues/22262)
+* [bitnami/concourse] Release 3.2.1 updating components versions (#22262) ([be1a7ca](https://github.com/bitnami/charts/commit/be1a7ca8c4397ebcefc86210426e7ddd6bb703ee)), closes [#22262](https://github.com/bitnami/charts/issues/22262)
 
 ## 3.2.0 (2024-01-16)
 
-* [bitnami/concourse] fix: :lock: Improve podSecurityContext and containerSecurityContext with essenti ([d27cd90](https://github.com/bitnami/charts/commit/d27cd90)), closes [#22106](https://github.com/bitnami/charts/issues/22106)
+* [bitnami/concourse] fix: :lock: Improve podSecurityContext and containerSecurityContext with essenti ([d27cd90](https://github.com/bitnami/charts/commit/d27cd906f8a8a16c8e5d1706be79b12e183a7b61)), closes [#22106](https://github.com/bitnami/charts/issues/22106)
 
 ## <small>3.1.1 (2024-01-13)</small>
 
-* [bitnami/*] Fix ref links (in comments) (#21822) ([e4fa296](https://github.com/bitnami/charts/commit/e4fa296)), closes [#21822](https://github.com/bitnami/charts/issues/21822)
-* [bitnami/concourse] Release 3.1.1 updating components versions (#22077) ([352eace](https://github.com/bitnami/charts/commit/352eace)), closes [#22077](https://github.com/bitnami/charts/issues/22077)
+* [bitnami/*] Fix ref links (in comments) (#21822) ([e4fa296](https://github.com/bitnami/charts/commit/e4fa296106b225cf8c82445727c675c7c725e380)), closes [#21822](https://github.com/bitnami/charts/issues/21822)
+* [bitnami/concourse] Release 3.1.1 updating components versions (#22077) ([352eace](https://github.com/bitnami/charts/commit/352eace3adb7c2c3d3056ef22593a16c94a1ab90)), closes [#22077](https://github.com/bitnami/charts/issues/22077)
 
 ## 3.1.0 (2024-01-10)
 
-* [bitnami/concourse] feat: :sparkles: Add seccompProfile to containerSecurityContext (#21907) ([a505657](https://github.com/bitnami/charts/commit/a505657)), closes [#21907](https://github.com/bitnami/charts/issues/21907)
+* [bitnami/concourse] feat: :sparkles: Add seccompProfile to containerSecurityContext (#21907) ([a505657](https://github.com/bitnami/charts/commit/a50565719ec0d2ed87e2bab6c99585bd579e4549)), closes [#21907](https://github.com/bitnami/charts/issues/21907)
 
 ## <small>3.0.16 (2024-01-10)</small>
 
-* [bitnami/*] Fix docs.bitnami.com broken links (#21901) ([f35506d](https://github.com/bitnami/charts/commit/f35506d)), closes [#21901](https://github.com/bitnami/charts/issues/21901)
-* [bitnami/*] Update copyright: Year and company (#21815) ([6c4bf75](https://github.com/bitnami/charts/commit/6c4bf75)), closes [#21815](https://github.com/bitnami/charts/issues/21815)
-* [bitnami/concourse] Release 3.0.16 updating components versions (#21930) ([f9d922d](https://github.com/bitnami/charts/commit/f9d922d)), closes [#21930](https://github.com/bitnami/charts/issues/21930)
+* [bitnami/*] Fix docs.bitnami.com broken links (#21901) ([f35506d](https://github.com/bitnami/charts/commit/f35506d2dadee4f097986e7792df1f53ab215b5d)), closes [#21901](https://github.com/bitnami/charts/issues/21901)
+* [bitnami/*] Update copyright: Year and company (#21815) ([6c4bf75](https://github.com/bitnami/charts/commit/6c4bf75dec58fc7c9aee9f089777b1a858c17d5b)), closes [#21815](https://github.com/bitnami/charts/issues/21815)
+* [bitnami/concourse] Release 3.0.16 updating components versions (#21930) ([f9d922d](https://github.com/bitnami/charts/commit/f9d922deb7471fe96fcf59d0d64e932a419db4d2)), closes [#21930](https://github.com/bitnami/charts/issues/21930)
 
 ## <small>3.0.15 (2024-01-02)</small>
 
-* [bitnami/concourse] Release 3.0.15 updating components versions (#21811) ([2c1085b](https://github.com/bitnami/charts/commit/2c1085b)), closes [#21811](https://github.com/bitnami/charts/issues/21811)
+* [bitnami/concourse] Release 3.0.15 updating components versions (#21811) ([2c1085b](https://github.com/bitnami/charts/commit/2c1085b278bdd648d011ad88a2483c2f26af41ee)), closes [#21811](https://github.com/bitnami/charts/issues/21811)
 
 ## <small>3.0.14 (2023-12-15)</small>
 
-* [bitnami/concourse] Release 3.0.14 updating components versions (#21599) ([96f74ea](https://github.com/bitnami/charts/commit/96f74ea)), closes [#21599](https://github.com/bitnami/charts/issues/21599)
+* [bitnami/concourse] Release 3.0.14 updating components versions (#21599) ([96f74ea](https://github.com/bitnami/charts/commit/96f74ea81c10e83e6856199dbcafcb244c280dc4)), closes [#21599](https://github.com/bitnami/charts/issues/21599)
 
 ## <small>3.0.13 (2023-12-12)</small>
 
-* [bitnami/concourse] Release 3.0.13 updating components versions (#21535) ([4184a64](https://github.com/bitnami/charts/commit/4184a64)), closes [#21535](https://github.com/bitnami/charts/issues/21535)
+* [bitnami/concourse] Release 3.0.13 updating components versions (#21535) ([4184a64](https://github.com/bitnami/charts/commit/4184a643d0f39a63f892e84c5328870a5d1d91f0)), closes [#21535](https://github.com/bitnami/charts/issues/21535)
 
 ## <small>3.0.12 (2023-11-30)</small>
 
-* [bitnami/concourse] Release 3.0.12 updating components versions (#21317) ([b708df9](https://github.com/bitnami/charts/commit/b708df9)), closes [#21317](https://github.com/bitnami/charts/issues/21317)
+* [bitnami/concourse] Release 3.0.12 updating components versions (#21317) ([b708df9](https://github.com/bitnami/charts/commit/b708df9c4c048c66f23eb0b3535119ebef1e7afc)), closes [#21317](https://github.com/bitnami/charts/issues/21317)
 
 ## <small>3.0.11 (2023-11-27)</small>
 
-* [bitnami/concourse] Release 3.0.11 updating components versions (#21277) ([3a73978](https://github.com/bitnami/charts/commit/3a73978)), closes [#21277](https://github.com/bitnami/charts/issues/21277)
+* [bitnami/concourse] Release 3.0.11 updating components versions (#21277) ([3a73978](https://github.com/bitnami/charts/commit/3a739784bb0eaa63715ff6a275154ecd4a0f672e)), closes [#21277](https://github.com/bitnami/charts/issues/21277)
 
 ## <small>3.0.10 (2023-11-21)</small>
 
-* [bitnami/*] Rename solutions to "Bitnami package for ..." (#21038) ([b82f979](https://github.com/bitnami/charts/commit/b82f979)), closes [#21038](https://github.com/bitnami/charts/issues/21038)
-* [bitnami/concourse] Release 3.0.10 updating components versions (#21104) ([9fb0a4f](https://github.com/bitnami/charts/commit/9fb0a4f)), closes [#21104](https://github.com/bitnami/charts/issues/21104)
-* Update readme-generator links (#21043) ([1581eba](https://github.com/bitnami/charts/commit/1581eba)), closes [#21043](https://github.com/bitnami/charts/issues/21043)
+* [bitnami/*] Rename solutions to "Bitnami package for ..." (#21038) ([b82f979](https://github.com/bitnami/charts/commit/b82f979e4fb63423fe6e2192c946d09d79c944fc)), closes [#21038](https://github.com/bitnami/charts/issues/21038)
+* [bitnami/concourse] Release 3.0.10 updating components versions (#21104) ([9fb0a4f](https://github.com/bitnami/charts/commit/9fb0a4fd4ae6c7328000cdee882052ffa239fc79)), closes [#21104](https://github.com/bitnami/charts/issues/21104)
+* Update readme-generator links (#21043) ([1581eba](https://github.com/bitnami/charts/commit/1581eba8044d730a763c266f279ac2ac782f764d)), closes [#21043](https://github.com/bitnami/charts/issues/21043)
 
 ## <small>3.0.9 (2023-11-16)</small>
 
-* [bitnami/*] Remove relative links to non-README sections, add verification for that and update TL;DR ([1103633](https://github.com/bitnami/charts/commit/1103633)), closes [#20967](https://github.com/bitnami/charts/issues/20967)
-* [bitnami/concourse] Release 3.0.9 updating components versions (#21008) ([032ef80](https://github.com/bitnami/charts/commit/032ef80)), closes [#21008](https://github.com/bitnami/charts/issues/21008)
+* [bitnami/*] Remove relative links to non-README sections, add verification for that and update TL;DR ([1103633](https://github.com/bitnami/charts/commit/11036334d82df0490aa4abdb591543cab6cf7d7f)), closes [#20967](https://github.com/bitnami/charts/issues/20967)
+* [bitnami/concourse] Release 3.0.9 updating components versions (#21008) ([032ef80](https://github.com/bitnami/charts/commit/032ef80f750dda1208e11f5d10ec7ab19813438b)), closes [#21008](https://github.com/bitnami/charts/issues/21008)
 
 ## <small>3.0.8 (2023-11-09)</small>
 
-* [bitnami/concourse] Release 3.0.8 updating components versions (#20839) ([64b33ef](https://github.com/bitnami/charts/commit/64b33ef)), closes [#20839](https://github.com/bitnami/charts/issues/20839)
+* [bitnami/concourse] Release 3.0.8 updating components versions (#20839) ([64b33ef](https://github.com/bitnami/charts/commit/64b33efd67aac08de04b6c2ba9d6b8ed5ba64439)), closes [#20839](https://github.com/bitnami/charts/issues/20839)
 
 ## <small>3.0.7 (2023-11-09)</small>
 
-* [bitnami/*] Rename VMware Application Catalog (#20361) ([3acc734](https://github.com/bitnami/charts/commit/3acc734)), closes [#20361](https://github.com/bitnami/charts/issues/20361)
-* [bitnami/*] Skip image's tag in the README files of the Bitnami Charts (#19841) ([bb9a01b](https://github.com/bitnami/charts/commit/bb9a01b)), closes [#19841](https://github.com/bitnami/charts/issues/19841)
-* [bitnami/*] Standardize documentation (#19835) ([af5f753](https://github.com/bitnami/charts/commit/af5f753)), closes [#19835](https://github.com/bitnami/charts/issues/19835)
-* [bitnami/concourse] Release 3.0.7 updating components versions (#20726) ([96d291a](https://github.com/bitnami/charts/commit/96d291a)), closes [#20726](https://github.com/bitnami/charts/issues/20726)
+* [bitnami/*] Rename VMware Application Catalog (#20361) ([3acc734](https://github.com/bitnami/charts/commit/3acc73472beb6fb56c4d99f929061001205bc57e)), closes [#20361](https://github.com/bitnami/charts/issues/20361)
+* [bitnami/*] Skip image's tag in the README files of the Bitnami Charts (#19841) ([bb9a01b](https://github.com/bitnami/charts/commit/bb9a01b65911c87e48318db922cc05eb42785e42)), closes [#19841](https://github.com/bitnami/charts/issues/19841)
+* [bitnami/*] Standardize documentation (#19835) ([af5f753](https://github.com/bitnami/charts/commit/af5f7530c1bc8c5ded53a6c4f7b8f384ac1804f2)), closes [#19835](https://github.com/bitnami/charts/issues/19835)
+* [bitnami/concourse] Release 3.0.7 updating components versions (#20726) ([96d291a](https://github.com/bitnami/charts/commit/96d291aecc0faab94b193692b29a9a71150e1fba)), closes [#20726](https://github.com/bitnami/charts/issues/20726)
 
 ## <small>3.0.6 (2023-10-15)</small>
 
-* [bitnami/concourse] Release 3.0.6 updating components versions (#20176) ([6d86049](https://github.com/bitnami/charts/commit/6d86049)), closes [#20176](https://github.com/bitnami/charts/issues/20176)
+* [bitnami/concourse] Release 3.0.6 updating components versions (#20176) ([6d86049](https://github.com/bitnami/charts/commit/6d86049d61a324510c7ca67ebf423a473ef818eb)), closes [#20176](https://github.com/bitnami/charts/issues/20176)
 
 ## <small>3.0.5 (2023-10-09)</small>
 
-* [bitnami/concourse] Release 3.0.5 (#19896) ([b471d92](https://github.com/bitnami/charts/commit/b471d92)), closes [#19896](https://github.com/bitnami/charts/issues/19896)
+* [bitnami/concourse] Release 3.0.5 (#19896) ([b471d92](https://github.com/bitnami/charts/commit/b471d92d15335f2b00de288c776a63b7562f0184)), closes [#19896](https://github.com/bitnami/charts/issues/19896)
 
 ## <small>3.0.4 (2023-10-09)</small>
 
-* [bitnami/*] Update Helm charts prerequisites (#19745) ([eb755dd](https://github.com/bitnami/charts/commit/eb755dd)), closes [#19745](https://github.com/bitnami/charts/issues/19745)
-* [bitnami/concourse] Release 3.0.4 (#19816) ([170087f](https://github.com/bitnami/charts/commit/170087f)), closes [#19816](https://github.com/bitnami/charts/issues/19816)
+* [bitnami/*] Update Helm charts prerequisites (#19745) ([eb755dd](https://github.com/bitnami/charts/commit/eb755dd36a4dd3cf6635be8e0598f9a7f4c4a554)), closes [#19745](https://github.com/bitnami/charts/issues/19745)
+* [bitnami/concourse] Release 3.0.4 (#19816) ([170087f](https://github.com/bitnami/charts/commit/170087ff29c3140391265def0b5a0f47dce7f1a5)), closes [#19816](https://github.com/bitnami/charts/issues/19816)
 
 ## <small>3.0.3 (2023-10-03)</small>
 
-* [bitnami/concourse] Release 3.0.3 (#19698) ([23451fa](https://github.com/bitnami/charts/commit/23451fa)), closes [#19698](https://github.com/bitnami/charts/issues/19698)
+* [bitnami/concourse] Release 3.0.3 (#19698) ([23451fa](https://github.com/bitnami/charts/commit/23451fa9a8c2ba3bbb1797a684fb3aae626d7499)), closes [#19698](https://github.com/bitnami/charts/issues/19698)
 
 ## <small>3.0.2 (2023-10-03)</small>
 
-* [bitnami/concourse] Use common capabilities for PSP (#19625) ([0a714c2](https://github.com/bitnami/charts/commit/0a714c2)), closes [#19625](https://github.com/bitnami/charts/issues/19625)
+* [bitnami/concourse] Use common capabilities for PSP (#19625) ([0a714c2](https://github.com/bitnami/charts/commit/0a714c2fe347e0adadb930db161d7cec07420ee0)), closes [#19625](https://github.com/bitnami/charts/issues/19625)
 
 ## <small>3.0.1 (2023-09-29)</small>
 
-* [bitnami/concourse] Release 3.0.1 (#19651) ([09de562](https://github.com/bitnami/charts/commit/09de562)), closes [#19651](https://github.com/bitnami/charts/issues/19651)
+* [bitnami/concourse] Release 3.0.1 (#19651) ([09de562](https://github.com/bitnami/charts/commit/09de562f520717519b71ba9de729e366f7937d95)), closes [#19651](https://github.com/bitnami/charts/issues/19651)
 
 ## 3.0.0 (2023-09-29)
 
-* [bitnami/concourse] Update dependencies (#19611) ([a82dcb8](https://github.com/bitnami/charts/commit/a82dcb8)), closes [#19611](https://github.com/bitnami/charts/issues/19611)
+* [bitnami/concourse] Update dependencies (#19611) ([a82dcb8](https://github.com/bitnami/charts/commit/a82dcb880823733880fddb3de0d3ca92d5254deb)), closes [#19611](https://github.com/bitnami/charts/issues/19611)
 
 ## <small>2.3.8 (2023-09-26)</small>
 
-* [bitnami/concourse] Release 2.3.8 (#19539) ([7186a8c](https://github.com/bitnami/charts/commit/7186a8c)), closes [#19539](https://github.com/bitnami/charts/issues/19539)
+* [bitnami/concourse] Release 2.3.8 (#19539) ([7186a8c](https://github.com/bitnami/charts/commit/7186a8c26eac2caa38e6dd0f2cd5f32f54db064a)), closes [#19539](https://github.com/bitnami/charts/issues/19539)
 
 ## <small>2.3.7 (2023-09-19)</small>
 
-* [bitnami/*] Update readme files (#19277) ([e56aeb2](https://github.com/bitnami/charts/commit/e56aeb2)), closes [#19277](https://github.com/bitnami/charts/issues/19277)
-* [bitnami/concourse] Release 2.3.7 (#19383) ([ba38d75](https://github.com/bitnami/charts/commit/ba38d75)), closes [#19383](https://github.com/bitnami/charts/issues/19383)
-* Revert "Autogenerate schema files (#19194)" (#19335) ([73d80be](https://github.com/bitnami/charts/commit/73d80be)), closes [#19194](https://github.com/bitnami/charts/issues/19194) [#19335](https://github.com/bitnami/charts/issues/19335)
+* [bitnami/*] Update readme files (#19277) ([e56aeb2](https://github.com/bitnami/charts/commit/e56aeb2fbfbf5b6e42375db48cc7ae1ef1c3a823)), closes [#19277](https://github.com/bitnami/charts/issues/19277)
+* [bitnami/concourse] Release 2.3.7 (#19383) ([ba38d75](https://github.com/bitnami/charts/commit/ba38d75ce1c1cb43cc929c0e1436c36d374b0552)), closes [#19383](https://github.com/bitnami/charts/issues/19383)
+* Revert "Autogenerate schema files (#19194)" (#19335) ([73d80be](https://github.com/bitnami/charts/commit/73d80be525c88fb4b8a54451a55acd506e337062)), closes [#19194](https://github.com/bitnami/charts/issues/19194) [#19335](https://github.com/bitnami/charts/issues/19335)
 
 ## <small>2.3.6 (2023-09-17)</small>
 
-* [bitnami/concourse] Release 2.3.6 (#19315) ([fd6cbb1](https://github.com/bitnami/charts/commit/fd6cbb1)), closes [#19315](https://github.com/bitnami/charts/issues/19315)
-* Autogenerate schema files (#19194) ([a2c2090](https://github.com/bitnami/charts/commit/a2c2090)), closes [#19194](https://github.com/bitnami/charts/issues/19194)
+* [bitnami/concourse] Release 2.3.6 (#19315) ([fd6cbb1](https://github.com/bitnami/charts/commit/fd6cbb19f8321fe38c6578b332cb4facd1db958a)), closes [#19315](https://github.com/bitnami/charts/issues/19315)
+* Autogenerate schema files (#19194) ([a2c2090](https://github.com/bitnami/charts/commit/a2c2090b5ac97f47b745c8028c6452bf99739772)), closes [#19194](https://github.com/bitnami/charts/issues/19194)
 
 ## <small>2.3.5 (2023-09-08)</small>
 
-* [bitnami/concourse] Release 2.3.5 (#19201) ([a743866](https://github.com/bitnami/charts/commit/a743866)), closes [#19201](https://github.com/bitnami/charts/issues/19201)
+* [bitnami/concourse] Release 2.3.5 (#19201) ([a743866](https://github.com/bitnami/charts/commit/a7438662366466c17e61c9ff9c57823bdc2e0226)), closes [#19201](https://github.com/bitnami/charts/issues/19201)
 
 ## <small>2.3.4 (2023-09-06)</small>
 
-* [bitnami/concourse: Use merge helper]: (#19027) ([a6a132a](https://github.com/bitnami/charts/commit/a6a132a)), closes [#19027](https://github.com/bitnami/charts/issues/19027)
+* [bitnami/concourse: Use merge helper]: (#19027) ([a6a132a](https://github.com/bitnami/charts/commit/a6a132a00bd959ad2860e29599303ed4ec74ad94)), closes [#19027](https://github.com/bitnami/charts/issues/19027)
 
 ## <small>2.3.3 (2023-08-28)</small>
 
-* [bitnami/concourse] Release 2.3.3 (#18920) ([66a27da](https://github.com/bitnami/charts/commit/66a27da)), closes [#18920](https://github.com/bitnami/charts/issues/18920)
+* [bitnami/concourse] Release 2.3.3 (#18920) ([66a27da](https://github.com/bitnami/charts/commit/66a27daa728f1fd9347ffcfa8426baf6077e9d51)), closes [#18920](https://github.com/bitnami/charts/issues/18920)
 
 ## <small>2.3.2 (2023-08-26)</small>
 
-* [bitnami/concourse] Release 2.3.2 (#18877) ([8409921](https://github.com/bitnami/charts/commit/8409921)), closes [#18877](https://github.com/bitnami/charts/issues/18877)
+* [bitnami/concourse] Release 2.3.2 (#18877) ([8409921](https://github.com/bitnami/charts/commit/8409921923a933e7283a068518f068858b6b451f)), closes [#18877](https://github.com/bitnami/charts/issues/18877)
 
 ## <small>2.3.1 (2023-08-24)</small>
 
-* [bitnami/concourse] Release 2.3.1 (#18844) ([51bfc5c](https://github.com/bitnami/charts/commit/51bfc5c)), closes [#18844](https://github.com/bitnami/charts/issues/18844)
+* [bitnami/concourse] Release 2.3.1 (#18844) ([51bfc5c](https://github.com/bitnami/charts/commit/51bfc5c1785ec0045e70cd1111fbf0b2ee31d19d)), closes [#18844](https://github.com/bitnami/charts/issues/18844)
 
 ## 2.3.0 (2023-08-23)
 
-* [bitnami/concourse] Support for customizing standard labels (#18460) ([7434f7e](https://github.com/bitnami/charts/commit/7434f7e)), closes [#18460](https://github.com/bitnami/charts/issues/18460)
+* [bitnami/concourse] Support for customizing standard labels (#18460) ([7434f7e](https://github.com/bitnami/charts/commit/7434f7e31ee64a16787e0a81d18d413de1384cd4)), closes [#18460](https://github.com/bitnami/charts/issues/18460)
 
 ## <small>2.2.12 (2023-08-19)</small>
 
-* [bitnami/concourse] Release 2.2.12 (#18650) ([5837141](https://github.com/bitnami/charts/commit/5837141)), closes [#18650](https://github.com/bitnami/charts/issues/18650)
+* [bitnami/concourse] Release 2.2.12 (#18650) ([5837141](https://github.com/bitnami/charts/commit/583714197d91bec9956fb4a6576362f096f7f315)), closes [#18650](https://github.com/bitnami/charts/issues/18650)
 
 ## <small>2.2.11 (2023-08-17)</small>
 
-* [bitnami/concourse] Release 2.2.11 (#18505) ([02354ab](https://github.com/bitnami/charts/commit/02354ab)), closes [#18505](https://github.com/bitnami/charts/issues/18505)
+* [bitnami/concourse] Release 2.2.11 (#18505) ([02354ab](https://github.com/bitnami/charts/commit/02354ab3504bed91d0c703107dd182e9361314ba)), closes [#18505](https://github.com/bitnami/charts/issues/18505)
 
 ## <small>2.2.10 (2023-08-11)</small>
 
-* [bitnami/concourse] Release 2.2.10 (#18370) ([d4eff8d](https://github.com/bitnami/charts/commit/d4eff8d)), closes [#18370](https://github.com/bitnami/charts/issues/18370)
+* [bitnami/concourse] Release 2.2.10 (#18370) ([d4eff8d](https://github.com/bitnami/charts/commit/d4eff8d78be50bac3b9d21921d1606266fc8e60e)), closes [#18370](https://github.com/bitnami/charts/issues/18370)
 
 ## <small>2.2.9 (2023-08-11)</small>
 
-* [bitnami/concourse] Release 2.2.9 (#18368) ([be9445f](https://github.com/bitnami/charts/commit/be9445f)), closes [#18368](https://github.com/bitnami/charts/issues/18368)
+* [bitnami/concourse] Release 2.2.9 (#18368) ([be9445f](https://github.com/bitnami/charts/commit/be9445f6fdc50787cf3a248ea749defca22d9ca2)), closes [#18368](https://github.com/bitnami/charts/issues/18368)
 
 ## <small>2.2.8 (2023-08-10)</small>
 
-* [bitnami/concourse] Release 2.2.8 (#18342) ([7322516](https://github.com/bitnami/charts/commit/7322516)), closes [#18342](https://github.com/bitnami/charts/issues/18342)
+* [bitnami/concourse] Release 2.2.8 (#18342) ([7322516](https://github.com/bitnami/charts/commit/73225165582bb1869d4aff05e4fc273d8948f1cc)), closes [#18342](https://github.com/bitnami/charts/issues/18342)
 
 ## <small>2.2.7 (2023-07-28)</small>
 
-* [bitnami/concourse] Release 2.2.7 (#18006) ([ae07e78](https://github.com/bitnami/charts/commit/ae07e78)), closes [#18006](https://github.com/bitnami/charts/issues/18006)
+* [bitnami/concourse] Release 2.2.7 (#18006) ([ae07e78](https://github.com/bitnami/charts/commit/ae07e78ea802d085aba5ebe46bb6673733d102f7)), closes [#18006](https://github.com/bitnami/charts/issues/18006)
 
 ## <small>2.2.6 (2023-07-26)</small>
 
-* [bitnami/concourse] Release 2.2.6 (#17967) ([1d363b4](https://github.com/bitnami/charts/commit/1d363b4)), closes [#17967](https://github.com/bitnami/charts/issues/17967)
+* [bitnami/concourse] Release 2.2.6 (#17967) ([1d363b4](https://github.com/bitnami/charts/commit/1d363b44acf0f0d74065065ab83d66354a9a7aba)), closes [#17967](https://github.com/bitnami/charts/issues/17967)
 
 ## <small>2.2.5 (2023-07-26)</small>
 
-* [bitnami/concourse] Release 2.2.5 (#17815) ([d53dd8a](https://github.com/bitnami/charts/commit/d53dd8a)), closes [#17815](https://github.com/bitnami/charts/issues/17815)
+* [bitnami/concourse] Release 2.2.5 (#17815) ([d53dd8a](https://github.com/bitnami/charts/commit/d53dd8a551423d764689c95bbfb6cdb78ec14172)), closes [#17815](https://github.com/bitnami/charts/issues/17815)
 
 ## <small>2.2.4 (2023-07-15)</small>
 
-* [bitnami/concourse] Release 2.2.4 (#17633) ([9f4d1af](https://github.com/bitnami/charts/commit/9f4d1af)), closes [#17633](https://github.com/bitnami/charts/issues/17633)
-* Use os-shell in tempate and Jaeger runtime params (#17557) ([91a49eb](https://github.com/bitnami/charts/commit/91a49eb)), closes [#17557](https://github.com/bitnami/charts/issues/17557)
+* [bitnami/concourse] Release 2.2.4 (#17633) ([9f4d1af](https://github.com/bitnami/charts/commit/9f4d1afc546df7b2ed34856ef4417d38c81d0794)), closes [#17633](https://github.com/bitnami/charts/issues/17633)
+* Use os-shell in tempate and Jaeger runtime params (#17557) ([91a49eb](https://github.com/bitnami/charts/commit/91a49eb1e3c81c7b7c6c28d1bc5d6d6ae698c1e2)), closes [#17557](https://github.com/bitnami/charts/issues/17557)
 
 ## <small>2.2.3 (2023-07-06)</small>
 
-* [bitnami/concourse] Release 2.2.3 (#17500) ([6e275fa](https://github.com/bitnami/charts/commit/6e275fa)), closes [#17500](https://github.com/bitnami/charts/issues/17500)
-* Add copyright header (#17300) ([da68be8](https://github.com/bitnami/charts/commit/da68be8)), closes [#17300](https://github.com/bitnami/charts/issues/17300)
-* Update charts readme (#17217) ([31b3c0a](https://github.com/bitnami/charts/commit/31b3c0a)), closes [#17217](https://github.com/bitnami/charts/issues/17217)
+* [bitnami/concourse] Release 2.2.3 (#17500) ([6e275fa](https://github.com/bitnami/charts/commit/6e275fa3aca2e0df33ffc00514c5f5e89c26a36e)), closes [#17500](https://github.com/bitnami/charts/issues/17500)
+* Add copyright header (#17300) ([da68be8](https://github.com/bitnami/charts/commit/da68be8e951225133c7dfb572d5101ca3d61c5ae)), closes [#17300](https://github.com/bitnami/charts/issues/17300)
+* Update charts readme (#17217) ([31b3c0a](https://github.com/bitnami/charts/commit/31b3c0afd968ff4429107e34101f7509e6a0e913)), closes [#17217](https://github.com/bitnami/charts/issues/17217)
 
 ## <small>2.2.2 (2023-06-21)</small>
 
-* [bitnami/*] Change copyright section in READMEs (#17006) ([ef986a1](https://github.com/bitnami/charts/commit/ef986a1)), closes [#17006](https://github.com/bitnami/charts/issues/17006)
-* [bitnami/concourse] Remove namespace field for cluster wide resources #17256 ([009e8ec](https://github.com/bitnami/charts/commit/009e8ec)), closes [#17256](https://github.com/bitnami/charts/issues/17256)
-* [bitnami/several] Change copyright section in READMEs (#16989) ([5b6a5cf](https://github.com/bitnami/charts/commit/5b6a5cf)), closes [#16989](https://github.com/bitnami/charts/issues/16989)
+* [bitnami/*] Change copyright section in READMEs (#17006) ([ef986a1](https://github.com/bitnami/charts/commit/ef986a1605241102b3dcafe9fd8089e6fc1201ad)), closes [#17006](https://github.com/bitnami/charts/issues/17006)
+* [bitnami/concourse] Remove namespace field for cluster wide resources #17256 ([009e8ec](https://github.com/bitnami/charts/commit/009e8eccc8ef5d6c53d2a9c28f71080959a24bd7)), closes [#17256](https://github.com/bitnami/charts/issues/17256)
+* [bitnami/several] Change copyright section in READMEs (#16989) ([5b6a5cf](https://github.com/bitnami/charts/commit/5b6a5cfb7625a751848a2e5cd796bd7278f406ca)), closes [#16989](https://github.com/bitnami/charts/issues/16989)
 
 ## <small>2.2.1 (2023-05-21)</small>
 
-* [bitnami/concourse] Release 2.2.1 (#16846) ([9fc58ce](https://github.com/bitnami/charts/commit/9fc58ce)), closes [#16846](https://github.com/bitnami/charts/issues/16846)
-* Add wording for enterprise page (#16560) ([8f22774](https://github.com/bitnami/charts/commit/8f22774)), closes [#16560](https://github.com/bitnami/charts/issues/16560)
+* [bitnami/concourse] Release 2.2.1 (#16846) ([9fc58ce](https://github.com/bitnami/charts/commit/9fc58ceb5659234afb2daec48bdbd84526144c6f)), closes [#16846](https://github.com/bitnami/charts/issues/16846)
+* Add wording for enterprise page (#16560) ([8f22774](https://github.com/bitnami/charts/commit/8f2277440b976d52785ba9149762ad8620a73d1f)), closes [#16560](https://github.com/bitnami/charts/issues/16560)
 
 ## 2.2.0 (2023-05-09)
 
-* [bitnami/several] Adapt Chart.yaml to set desired OCI annotations (#16546) ([fc9b18f](https://github.com/bitnami/charts/commit/fc9b18f)), closes [#16546](https://github.com/bitnami/charts/issues/16546)
+* [bitnami/several] Adapt Chart.yaml to set desired OCI annotations (#16546) ([fc9b18f](https://github.com/bitnami/charts/commit/fc9b18f2e98805d4df629acbcde696f44f973344)), closes [#16546](https://github.com/bitnami/charts/issues/16546)
 
 ## <small>2.1.2 (2023-05-09)</small>
 
-* [bitnami/concourse] Release 2.1.2 (#16448) ([0bad76f](https://github.com/bitnami/charts/commit/0bad76f)), closes [#16448](https://github.com/bitnami/charts/issues/16448)
+* [bitnami/concourse] Release 2.1.2 (#16448) ([0bad76f](https://github.com/bitnami/charts/commit/0bad76feb0c3d79b0da5c9045043c433a061ac1c)), closes [#16448](https://github.com/bitnami/charts/issues/16448)
 
 ## <small>2.1.1 (2023-04-29)</small>
 
-* [bitnami/concourse] Release 2.1.1 (#16278) ([46e045f](https://github.com/bitnami/charts/commit/46e045f)), closes [#16278](https://github.com/bitnami/charts/issues/16278)
+* [bitnami/concourse] Release 2.1.1 (#16278) ([46e045f](https://github.com/bitnami/charts/commit/46e045fd1ab612d354f90383f66706ee57730562)), closes [#16278](https://github.com/bitnami/charts/issues/16278)
 
 ## 2.1.0 (2023-04-20)
 
-* [bitnami/*] Make Helm charts 100% OCI (#15998) ([8841510](https://github.com/bitnami/charts/commit/8841510)), closes [#15998](https://github.com/bitnami/charts/issues/15998)
+* [bitnami/*] Make Helm charts 100% OCI (#15998) ([8841510](https://github.com/bitnami/charts/commit/884151035efcbf2e1b3206e7def85511073fb57d)), closes [#15998](https://github.com/bitnami/charts/issues/15998)
 
 ## <small>2.0.7 (2023-04-01)</small>
 
-* [bitnami/concourse] Release 2.0.7 (#15851) ([7b79f04](https://github.com/bitnami/charts/commit/7b79f04)), closes [#15851](https://github.com/bitnami/charts/issues/15851)
+* [bitnami/concourse] Release 2.0.7 (#15851) ([7b79f04](https://github.com/bitnami/charts/commit/7b79f042a9ef59a6d592f0242f1c88b86628bdd8)), closes [#15851](https://github.com/bitnami/charts/issues/15851)
 
 ## <small>2.0.6 (2023-03-18)</small>
 
-* [bitnami/charts] Apply linter to README files (#15357) ([0e29e60](https://github.com/bitnami/charts/commit/0e29e60)), closes [#15357](https://github.com/bitnami/charts/issues/15357)
-* [bitnami/concourse] Release 2.0.6 (#15574) ([78a8777](https://github.com/bitnami/charts/commit/78a8777)), closes [#15574](https://github.com/bitnami/charts/issues/15574)
+* [bitnami/charts] Apply linter to README files (#15357) ([0e29e60](https://github.com/bitnami/charts/commit/0e29e600d3adc8b1b46e506eccb3decfab3b4e63)), closes [#15357](https://github.com/bitnami/charts/issues/15357)
+* [bitnami/concourse] Release 2.0.6 (#15574) ([78a8777](https://github.com/bitnami/charts/commit/78a8777807a05ed1ca2fb2b07a9ebbc046667f05)), closes [#15574](https://github.com/bitnami/charts/issues/15574)
 
 ## <small>2.0.5 (2023-03-01)</small>
 
-* [bitnami/concourse] Release 2.0.5 (#15197) ([442a900](https://github.com/bitnami/charts/commit/442a900)), closes [#15197](https://github.com/bitnami/charts/issues/15197)
-* Fixes dead links (#15065) ([9e99fd9](https://github.com/bitnami/charts/commit/9e99fd9)), closes [#15065](https://github.com/bitnami/charts/issues/15065)
+* [bitnami/concourse] Release 2.0.5 (#15197) ([442a900](https://github.com/bitnami/charts/commit/442a900b5b9cad76aa038206e9d41bb122154253)), closes [#15197](https://github.com/bitnami/charts/issues/15197)
+* Fixes dead links (#15065) ([9e99fd9](https://github.com/bitnami/charts/commit/9e99fd94d89605c2aa47417ae80eecb86719d904)), closes [#15065](https://github.com/bitnami/charts/issues/15065)
 
 ## <small>2.0.4 (2023-02-18)</small>
 
-* [bitnami/*] Fix markdown linter issues (#14874) ([a51e0e8](https://github.com/bitnami/charts/commit/a51e0e8)), closes [#14874](https://github.com/bitnami/charts/issues/14874)
-* [bitnami/*] Fix markdown linter issues 2 (#14890) ([aa96572](https://github.com/bitnami/charts/commit/aa96572)), closes [#14890](https://github.com/bitnami/charts/issues/14890)
-* [bitnami/*] Remove unexpected extra spaces (#14873) ([c97c714](https://github.com/bitnami/charts/commit/c97c714)), closes [#14873](https://github.com/bitnami/charts/issues/14873)
-* [bitnami/concourse] Release 2.0.4 (#15054) ([08e0f42](https://github.com/bitnami/charts/commit/08e0f42)), closes [#15054](https://github.com/bitnami/charts/issues/15054)
+* [bitnami/*] Fix markdown linter issues (#14874) ([a51e0e8](https://github.com/bitnami/charts/commit/a51e0e8d35495b907f3e70dd2f8e7c3bcbf4166a)), closes [#14874](https://github.com/bitnami/charts/issues/14874)
+* [bitnami/*] Fix markdown linter issues 2 (#14890) ([aa96572](https://github.com/bitnami/charts/commit/aa9657237ee8df4a46db0d7fdf8a23230dd6902a)), closes [#14890](https://github.com/bitnami/charts/issues/14890)
+* [bitnami/*] Remove unexpected extra spaces (#14873) ([c97c714](https://github.com/bitnami/charts/commit/c97c714887380d47eae7bfeff316bf01595ecd1d)), closes [#14873](https://github.com/bitnami/charts/issues/14873)
+* [bitnami/concourse] Release 2.0.4 (#15054) ([08e0f42](https://github.com/bitnami/charts/commit/08e0f4207adbe191e16e26a7cb43cfb609443e54)), closes [#15054](https://github.com/bitnami/charts/issues/15054)
 
 ## <small>2.0.3 (2023-02-09)</small>
 
-* [bitnami/concourse] Release 2.0.3 (#14699) ([ec066e6](https://github.com/bitnami/charts/commit/ec066e6)), closes [#14699](https://github.com/bitnami/charts/issues/14699)
+* [bitnami/concourse] Release 2.0.3 (#14699) ([ec066e6](https://github.com/bitnami/charts/commit/ec066e6d03f355667671b0000177d2b8090d28d8)), closes [#14699](https://github.com/bitnami/charts/issues/14699)
 
 ## <small>2.0.2 (2023-01-31)</small>
 
-* [bitnami/*] Add license annotation and remove obsolete engine parameter (#14293) ([da2a794](https://github.com/bitnami/charts/commit/da2a794)), closes [#14293](https://github.com/bitnami/charts/issues/14293)
-* [bitnami/*] Change copyright date (#14682) ([add4ec7](https://github.com/bitnami/charts/commit/add4ec7)), closes [#14682](https://github.com/bitnami/charts/issues/14682)
-* [bitnami/*] Change licenses annotation format (#14377) ([0ab7608](https://github.com/bitnami/charts/commit/0ab7608)), closes [#14377](https://github.com/bitnami/charts/issues/14377)
-* [bitnami/*] Unify READMEs (#14472) ([2064fb8](https://github.com/bitnami/charts/commit/2064fb8)), closes [#14472](https://github.com/bitnami/charts/issues/14472)
-* [bitnami/concourse] Don't regenerate self-signed certs on upgrade (#14613) ([32cac87](https://github.com/bitnami/charts/commit/32cac87)), closes [#14613](https://github.com/bitnami/charts/issues/14613)
+* [bitnami/*] Add license annotation and remove obsolete engine parameter (#14293) ([da2a794](https://github.com/bitnami/charts/commit/da2a7943bae95b6e9b5b4ed972c15e990b69fdb0)), closes [#14293](https://github.com/bitnami/charts/issues/14293)
+* [bitnami/*] Change copyright date (#14682) ([add4ec7](https://github.com/bitnami/charts/commit/add4ec701108ac36ed4de2dffbdf407a0d091067)), closes [#14682](https://github.com/bitnami/charts/issues/14682)
+* [bitnami/*] Change licenses annotation format (#14377) ([0ab7608](https://github.com/bitnami/charts/commit/0ab760862c660fcc78cffadf8e1d8cdd70881473)), closes [#14377](https://github.com/bitnami/charts/issues/14377)
+* [bitnami/*] Unify READMEs (#14472) ([2064fb8](https://github.com/bitnami/charts/commit/2064fb8dcc78a845cdede8211af8c3cc52551161)), closes [#14472](https://github.com/bitnami/charts/issues/14472)
+* [bitnami/concourse] Don't regenerate self-signed certs on upgrade (#14613) ([32cac87](https://github.com/bitnami/charts/commit/32cac8713b75c8a93b8008d6fb334e36632e4b51)), closes [#14613](https://github.com/bitnami/charts/issues/14613)
 
 ## <small>2.0.1 (2022-11-12)</small>
 
-* [bitnami/concourse] Release 2.0.1 (#13491) ([53f274f](https://github.com/bitnami/charts/commit/53f274f)), closes [#13491](https://github.com/bitnami/charts/issues/13491)
+* [bitnami/concourse] Release 2.0.1 (#13491) ([53f274f](https://github.com/bitnami/charts/commit/53f274ff5b060a0e782232ca1681fa0c62ba7d9e)), closes [#13491](https://github.com/bitnami/charts/issues/13491)
 
 ## 2.0.0 (2022-10-28)
 
-* [bitnami/*] Use new default branch name in links (#12943) ([a529e02](https://github.com/bitnami/charts/commit/a529e02)), closes [#12943](https://github.com/bitnami/charts/issues/12943)
-* [bitnami/concourse] Update dependencies (#13213) ([6922a1b](https://github.com/bitnami/charts/commit/6922a1b)), closes [#13213](https://github.com/bitnami/charts/issues/13213)
+* [bitnami/*] Use new default branch name in links (#12943) ([a529e02](https://github.com/bitnami/charts/commit/a529e02597d49d944eba1eb0f190713293247176)), closes [#12943](https://github.com/bitnami/charts/issues/12943)
+* [bitnami/concourse] Update dependencies (#13213) ([6922a1b](https://github.com/bitnami/charts/commit/6922a1b797c9f03ba67592e91584cfabd3f25b67)), closes [#13213](https://github.com/bitnami/charts/issues/13213)
 
 ## <small>1.5.3 (2022-10-13)</small>
 
-* [bitnami/concourse] Release 1.5.3 (#12939) ([1f3b8e2](https://github.com/bitnami/charts/commit/1f3b8e2)), closes [#12939](https://github.com/bitnami/charts/issues/12939)
-* Generic README instructions related to the repo (#12792) ([3cf6b10](https://github.com/bitnami/charts/commit/3cf6b10)), closes [#12792](https://github.com/bitnami/charts/issues/12792)
+* [bitnami/concourse] Release 1.5.3 (#12939) ([1f3b8e2](https://github.com/bitnami/charts/commit/1f3b8e251f2269f2a6fb87a6370597b177be7b82)), closes [#12939](https://github.com/bitnami/charts/issues/12939)
+* Generic README instructions related to the repo (#12792) ([3cf6b10](https://github.com/bitnami/charts/commit/3cf6b10e10e60df4b3e191d6b99aa99a9f597755)), closes [#12792](https://github.com/bitnami/charts/issues/12792)
 
 ## <small>1.5.2 (2022-09-30)</small>
 
-* [bitnami/concourse] Force new version publishing (#12758) ([2d125bc](https://github.com/bitnami/charts/commit/2d125bc)), closes [#12758](https://github.com/bitnami/charts/issues/12758)
+* [bitnami/concourse] Force new version publishing (#12758) ([2d125bc](https://github.com/bitnami/charts/commit/2d125bca771aa5db59e2bd557beac8e81f5fac9e)), closes [#12758](https://github.com/bitnami/charts/issues/12758)
 
 ## <small>1.5.1 (2022-09-29)</small>
 
-* [bitnami/concourse] Release 1.5.1 (#12723) ([8768541](https://github.com/bitnami/charts/commit/8768541)), closes [#12723](https://github.com/bitnami/charts/issues/12723)
+* [bitnami/concourse] Release 1.5.1 (#12723) ([8768541](https://github.com/bitnami/charts/commit/876854198ad92bcb60b4524c2660e4ba803a2733)), closes [#12723](https://github.com/bitnami/charts/issues/12723)
 
 ## 1.5.0 (2022-09-23)
 
-* [bitnami/concourse] Add tests and publishing using VIB (#12578) ([05e85dc](https://github.com/bitnami/charts/commit/05e85dc)), closes [#12578](https://github.com/bitnami/charts/issues/12578)
+* [bitnami/concourse] Add tests and publishing using VIB (#12578) ([05e85dc](https://github.com/bitnami/charts/commit/05e85dcad0456a49744d41b42f4b004769160b75)), closes [#12578](https://github.com/bitnami/charts/issues/12578)
 
 ## <small>1.4.3 (2022-09-21)</small>
 
-* [bitnami/concourse] Use custom probes if given (#12485) ([6fa3731](https://github.com/bitnami/charts/commit/6fa3731)), closes [#12485](https://github.com/bitnami/charts/issues/12485) [#12354](https://github.com/bitnami/charts/issues/12354)
+* [bitnami/concourse] Use custom probes if given (#12485) ([6fa3731](https://github.com/bitnami/charts/commit/6fa3731cbcf21eb1714246906c579c6d816d3292)), closes [#12485](https://github.com/bitnami/charts/issues/12485) [#12354](https://github.com/bitnami/charts/issues/12354)
 
 ## <small>1.4.2 (2022-08-30)</small>
 
-* [bitnami/concourse] Release 1.4.2 updating components versions ([50fe9cc](https://github.com/bitnami/charts/commit/50fe9cc))
+* [bitnami/concourse] Release 1.4.2 updating components versions ([50fe9cc](https://github.com/bitnami/charts/commit/50fe9cc0caeea5bbdecb538a73b98520fdc46258))
 
 ## <small>1.4.1 (2022-08-23)</small>
 
-* [bitnami/concourse] Update Chart.lock (#12102) ([c8baa56](https://github.com/bitnami/charts/commit/c8baa56)), closes [#12102](https://github.com/bitnami/charts/issues/12102)
+* [bitnami/concourse] Update Chart.lock (#12102) ([c8baa56](https://github.com/bitnami/charts/commit/c8baa561098654ff2aa1348cbf44241213f387ca)), closes [#12102](https://github.com/bitnami/charts/issues/12102)
 
 ## 1.4.0 (2022-08-22)
 
-* [bitnami/concourse] Add support for image digest apart from tag (#11870) ([e678e9b](https://github.com/bitnami/charts/commit/e678e9b)), closes [#11870](https://github.com/bitnami/charts/issues/11870)
+* [bitnami/concourse] Add support for image digest apart from tag (#11870) ([e678e9b](https://github.com/bitnami/charts/commit/e678e9b39c896fbdd5ea5bc5bc4966d7a647f18f)), closes [#11870](https://github.com/bitnami/charts/issues/11870)
 
 ## <small>1.3.12 (2022-08-08)</small>
 
-* [bitnami/concourse] Release 1.3.12 updating components versions ([789e1b0](https://github.com/bitnami/charts/commit/789e1b0))
+* [bitnami/concourse] Release 1.3.12 updating components versions ([789e1b0](https://github.com/bitnami/charts/commit/789e1b096ee116e8d96bcaa900529031063caed3))
 
 ## <small>1.3.11 (2022-08-04)</small>
 
-* [bitnami/concourse] Release 1.3.11 updating components versions ([9da7d2f](https://github.com/bitnami/charts/commit/9da7d2f))
+* [bitnami/concourse] Release 1.3.11 updating components versions ([9da7d2f](https://github.com/bitnami/charts/commit/9da7d2ffe23bdb9760e70487e3ce6c4b07520d27))
 
 ## <small>1.3.10 (2022-08-04)</small>
 
-* [bitnami/concourse] Release 1.3.10 updating components versions ([755e0e2](https://github.com/bitnami/charts/commit/755e0e2))
+* [bitnami/concourse] Release 1.3.10 updating components versions ([755e0e2](https://github.com/bitnami/charts/commit/755e0e21b1aebd0cca670996f47b64fb382e20ae))
 
 ## <small>1.3.9 (2022-08-02)</small>
 
-* [bitnami/*] Update URLs to point to the new bitnami/containers monorepo (#11352) ([d665af0](https://github.com/bitnami/charts/commit/d665af0)), closes [#11352](https://github.com/bitnami/charts/issues/11352)
-* [bitnami/concourse] Release 1.3.9 updating components versions ([824d752](https://github.com/bitnami/charts/commit/824d752))
+* [bitnami/*] Update URLs to point to the new bitnami/containers monorepo (#11352) ([d665af0](https://github.com/bitnami/charts/commit/d665af0c708846192d8d5fb2f5f9ea65dd464ab0)), closes [#11352](https://github.com/bitnami/charts/issues/11352)
+* [bitnami/concourse] Release 1.3.9 updating components versions ([824d752](https://github.com/bitnami/charts/commit/824d75274927f7c4893792c80580ac95e1fcafde))
 
 ## <small>1.3.8 (2022-07-16)</small>
 
-* [bitnami/concourse] Release 1.3.8 updating components versions ([fbdbc9f](https://github.com/bitnami/charts/commit/fbdbc9f))
+* [bitnami/concourse] Release 1.3.8 updating components versions ([fbdbc9f](https://github.com/bitnami/charts/commit/fbdbc9f12e48f9ed16f5947b9dddd32379797e92))
 
 ## <small>1.3.7 (2022-06-30)</small>
 
-* [bitnami/concourse] Release 1.3.7 updating components versions ([ac41a26](https://github.com/bitnami/charts/commit/ac41a26))
+* [bitnami/concourse] Release 1.3.7 updating components versions ([ac41a26](https://github.com/bitnami/charts/commit/ac41a26b4fbfbbac3323e297a166c0393a773b52))
 
 ## <small>1.3.6 (2022-06-14)</small>
 
-* [bitnami/concourse] Release 1.3.6 updating components versions ([859be7a](https://github.com/bitnami/charts/commit/859be7a))
+* [bitnami/concourse] Release 1.3.6 updating components versions ([859be7a](https://github.com/bitnami/charts/commit/859be7a85181badcd9fc47b0294a601e70619c80))
 
 ## <small>1.3.5 (2022-06-10)</small>
 
-* [bitnami/concourse] Release 1.3.5 updating components versions ([cb8ce35](https://github.com/bitnami/charts/commit/cb8ce35))
+* [bitnami/concourse] Release 1.3.5 updating components versions ([cb8ce35](https://github.com/bitnami/charts/commit/cb8ce35b5a78b582834050e5fefff0b9a74b574d))
 
 ## <small>1.3.4 (2022-06-07)</small>
 
-* [bitnami/*] Replace Kubeapps URL in READMEs (and kubeapps Chart.yaml) and remove BKPR references (#1 ([c6a7914](https://github.com/bitnami/charts/commit/c6a7914)), closes [#10600](https://github.com/bitnami/charts/issues/10600)
-* Fix tolerations and topologySpreadConstraints default values (#10623) ([5b22c66](https://github.com/bitnami/charts/commit/5b22c66)), closes [#10623](https://github.com/bitnami/charts/issues/10623)
+* [bitnami/*] Replace Kubeapps URL in READMEs (and kubeapps Chart.yaml) and remove BKPR references (#1 ([c6a7914](https://github.com/bitnami/charts/commit/c6a7914361e5aea6016fb45bf4d621edfd111d32)), closes [#10600](https://github.com/bitnami/charts/issues/10600)
+* Fix tolerations and topologySpreadConstraints default values (#10623) ([5b22c66](https://github.com/bitnami/charts/commit/5b22c6677afa2e3c60eeb4150ff04440dfd1c292)), closes [#10623](https://github.com/bitnami/charts/issues/10623)
 
 ## <small>1.3.3 (2022-06-07)</small>
 
-* [bitnami/concourse] Release 1.3.3 updating components versions ([4e7e25d](https://github.com/bitnami/charts/commit/4e7e25d))
+* [bitnami/concourse] Release 1.3.3 updating components versions ([4e7e25d](https://github.com/bitnami/charts/commit/4e7e25d018ea7a3dc93b82d1f431c8b495aa3c78))
 
 ## <small>1.3.2 (2022-06-01)</small>
 
-* [bitnami/several] Replace maintainers email by url (#10523) ([ff3cf61](https://github.com/bitnami/charts/commit/ff3cf61)), closes [#10523](https://github.com/bitnami/charts/issues/10523)
+* [bitnami/several] Replace maintainers email by url (#10523) ([ff3cf61](https://github.com/bitnami/charts/commit/ff3cf617a1680509b0f3855d17c4ccff7b29a0ff)), closes [#10523](https://github.com/bitnami/charts/issues/10523)
 
 ## <small>1.3.1 (2022-05-30)</small>
 
-* [bitnami/several] Replace base64 --decode with base64 -d (#10495) ([099286a](https://github.com/bitnami/charts/commit/099286a)), closes [#10495](https://github.com/bitnami/charts/issues/10495)
+* [bitnami/several] Replace base64 --decode with base64 -d (#10495) ([099286a](https://github.com/bitnami/charts/commit/099286ae7a87784cf809df0b64ab24f7ff0144c8)), closes [#10495](https://github.com/bitnami/charts/issues/10495)
 
 ## 1.3.0 (2022-05-26)
 
-* [bitnami/concourse] Add missing service parameter (#10404) ([a02c257](https://github.com/bitnami/charts/commit/a02c257)), closes [#10404](https://github.com/bitnami/charts/issues/10404)
+* [bitnami/concourse] Add missing service parameter (#10404) ([a02c257](https://github.com/bitnami/charts/commit/a02c25739b2f28fa36bdc477df96ee74195eee78)), closes [#10404](https://github.com/bitnami/charts/issues/10404)
 
 ## <small>1.2.6 (2022-05-25)</small>
 
-* [bitnami/concourse] Release 1.2.6 updating components versions ([813a1bc](https://github.com/bitnami/charts/commit/813a1bc))
+* [bitnami/concourse] Release 1.2.6 updating components versions ([813a1bc](https://github.com/bitnami/charts/commit/813a1bc9dc1cf4de0bbd9469f91fc5c6aeb0f912))
 
 ## <small>1.2.5 (2022-05-24)</small>
 
-* [bitnami/concourse] Use the new helper for HPA API version (#10195) ([3933bdf](https://github.com/bitnami/charts/commit/3933bdf)), closes [#10195](https://github.com/bitnami/charts/issues/10195)
+* [bitnami/concourse] Use the new helper for HPA API version (#10195) ([3933bdf](https://github.com/bitnami/charts/commit/3933bdf52912697278af153e42f6acdc72da0977)), closes [#10195](https://github.com/bitnami/charts/issues/10195)
 
 ## <small>1.2.4 (2022-05-21)</small>
 
-* [bitnami/concourse] Release 1.2.4 updating components versions ([39243af](https://github.com/bitnami/charts/commit/39243af))
+* [bitnami/concourse] Release 1.2.4 updating components versions ([39243af](https://github.com/bitnami/charts/commit/39243af460f5fd84b129dc6d62ea902f09daec76))
 
 ## <small>1.2.3 (2022-05-20)</small>
 
-* [bitnami/concourse] Release 1.2.3 updating components versions ([0f3ec87](https://github.com/bitnami/charts/commit/0f3ec87))
+* [bitnami/concourse] Release 1.2.3 updating components versions ([0f3ec87](https://github.com/bitnami/charts/commit/0f3ec8799e351ca6762ef8cb186cc1d41eb370e0))
 
 ## <small>1.2.2 (2022-05-19)</small>
 
-* [bitnami/concourse] Release 1.2.2 updating components versions ([320481c](https://github.com/bitnami/charts/commit/320481c))
+* [bitnami/concourse] Release 1.2.2 updating components versions ([320481c](https://github.com/bitnami/charts/commit/320481c1e6d4afa3e6d2affafcd109848eaff35b))
 
 ## <small>1.2.1 (2022-05-18)</small>
 
-* [bitnami/concourse] Release 1.2.1 updating components versions ([91f4cdf](https://github.com/bitnami/charts/commit/91f4cdf))
+* [bitnami/concourse] Release 1.2.1 updating components versions ([91f4cdf](https://github.com/bitnami/charts/commit/91f4cdf057a6a347a8cf82520d8a963776c06fd7))
 
 ## 1.2.0 (2022-05-16)
 
-* [bitnami/*] add ingress extraRules feature (#10253) ([0f6cbb9](https://github.com/bitnami/charts/commit/0f6cbb9)), closes [#10253](https://github.com/bitnami/charts/issues/10253)
+* [bitnami/*] add ingress extraRules feature (#10253) ([0f6cbb9](https://github.com/bitnami/charts/commit/0f6cbb9099b0e56685cc1d36ba50340f3d7278a1)), closes [#10253](https://github.com/bitnami/charts/issues/10253)
 
 ## 1.1.0 (2022-05-13)
 
-* [bitnami/concourse] Add conjur integration to concourse (#10167) ([d21d31d](https://github.com/bitnami/charts/commit/d21d31d)), closes [#10167](https://github.com/bitnami/charts/issues/10167)
+* [bitnami/concourse] Add conjur integration to concourse (#10167) ([d21d31d](https://github.com/bitnami/charts/commit/d21d31deba6f5310b9e6e9b08e868b694a065a2f)), closes [#10167](https://github.com/bitnami/charts/issues/10167)
 
 ## <small>1.0.20 (2022-05-13)</small>
 
-* [bitnami/*] Fix typo in comments (relay -> rely) (#10151) ([9cfe4a4](https://github.com/bitnami/charts/commit/9cfe4a4)), closes [#10151](https://github.com/bitnami/charts/issues/10151)
-* [bitnami/*] Remove old 'ci' files (#10171) ([5df30c4](https://github.com/bitnami/charts/commit/5df30c4)), closes [#10171](https://github.com/bitnami/charts/issues/10171)
-* [bitnami/*] Unify k8s directives separators (#10185) ([2650214](https://github.com/bitnami/charts/commit/2650214)), closes [#10185](https://github.com/bitnami/charts/issues/10185)
+* [bitnami/*] Fix typo in comments (relay -> rely) (#10151) ([9cfe4a4](https://github.com/bitnami/charts/commit/9cfe4a48cc35851faea6be7ffb2a978d223befa0)), closes [#10151](https://github.com/bitnami/charts/issues/10151)
+* [bitnami/*] Remove old 'ci' files (#10171) ([5df30c4](https://github.com/bitnami/charts/commit/5df30c44dbd1812da8786579ce4a94917d46a6ad)), closes [#10171](https://github.com/bitnami/charts/issues/10171)
+* [bitnami/*] Unify k8s directives separators (#10185) ([2650214](https://github.com/bitnami/charts/commit/26502141d146ca3bdfb3bf744fcdec8ca5cece44)), closes [#10185](https://github.com/bitnami/charts/issues/10185)
 
 ## <small>1.0.19 (2022-05-11)</small>
 
-* [bitnami/concourse] Add missing namespace metadata (#10111) ([17337c6](https://github.com/bitnami/charts/commit/17337c6)), closes [#10111](https://github.com/bitnami/charts/issues/10111)
+* [bitnami/concourse] Add missing namespace metadata (#10111) ([17337c6](https://github.com/bitnami/charts/commit/17337c6ad796d2dc5a8b18aa8eae9f703b787d7a)), closes [#10111](https://github.com/bitnami/charts/issues/10111)
 
 ## <small>1.0.18 (2022-04-21)</small>
 
-* [bitnami/concourse] Release 1.0.18 updating components versions ([328b360](https://github.com/bitnami/charts/commit/328b360))
+* [bitnami/concourse] Release 1.0.18 updating components versions ([328b360](https://github.com/bitnami/charts/commit/328b360683aa6719940d22aba3607bb419410f76))
 
 ## <small>1.0.17 (2022-04-20)</small>
 
-* [bitnami/concourse] Release 1.0.17 updating components versions ([294b4fc](https://github.com/bitnami/charts/commit/294b4fc))
+* [bitnami/concourse] Release 1.0.17 updating components versions ([294b4fc](https://github.com/bitnami/charts/commit/294b4fc55ff244251bad1a5646888a92ce866470))
 
 ## <small>1.0.16 (2022-04-19)</small>
 
-* [bitnami/concourse] Release 1.0.16 updating components versions ([36dff4c](https://github.com/bitnami/charts/commit/36dff4c))
+* [bitnami/concourse] Release 1.0.16 updating components versions ([36dff4c](https://github.com/bitnami/charts/commit/36dff4caad7da62c2cd30ddbfb9ec277773e64b6))
 
 ## <small>1.0.15 (2022-04-06)</small>
 
-* [bitnami/concourse] Release 1.0.15 updating components versions ([a996fb1](https://github.com/bitnami/charts/commit/a996fb1))
+* [bitnami/concourse] Release 1.0.15 updating components versions ([a996fb1](https://github.com/bitnami/charts/commit/a996fb1490523d77936cc71c98c57068fc267217))
 
 ## <small>1.0.14 (2022-04-02)</small>
 
-* [bitnami/concourse] Release 1.0.14 updating components versions ([337e995](https://github.com/bitnami/charts/commit/337e995))
+* [bitnami/concourse] Release 1.0.14 updating components versions ([337e995](https://github.com/bitnami/charts/commit/337e9958f7499b6055d4744ced27325e2696ef84))
 
 ## <small>1.0.13 (2022-03-29)</small>
 
-* [bitnami/concourse] Release 1.0.13 updating components versions ([765898c](https://github.com/bitnami/charts/commit/765898c))
+* [bitnami/concourse] Release 1.0.13 updating components versions ([765898c](https://github.com/bitnami/charts/commit/765898cdd1a3f468dde75d6d3e97d20ec5c5222a))
 
 ## <small>1.0.12 (2022-03-28)</small>
 
-* [bitnami/concourse] Release 1.0.12 updating components versions ([d758134](https://github.com/bitnami/charts/commit/d758134))
+* [bitnami/concourse] Release 1.0.12 updating components versions ([d758134](https://github.com/bitnami/charts/commit/d758134008477156c12194fc6d2b7864fc250704))
 
 ## <small>1.0.11 (2022-03-28)</small>
 
-* [bitnami/concourse] Release 1.0.11 updating components versions ([eda9df5](https://github.com/bitnami/charts/commit/eda9df5))
+* [bitnami/concourse] Release 1.0.11 updating components versions ([eda9df5](https://github.com/bitnami/charts/commit/eda9df509e60e8d78f4164c02c2153dd6f9f8b4b))
 
 ## <small>1.0.10 (2022-03-27)</small>
 
-* [bitnami/concourse] Release 1.0.10 updating components versions ([00cffac](https://github.com/bitnami/charts/commit/00cffac))
+* [bitnami/concourse] Release 1.0.10 updating components versions ([00cffac](https://github.com/bitnami/charts/commit/00cffac2f2b51443144da9571274ea73fe89bf8c))
 
 ## <small>1.0.9 (2022-03-18)</small>
 
-* [bitnami/concourse] Release 1.0.9 updating components versions ([5145c34](https://github.com/bitnami/charts/commit/5145c34))
+* [bitnami/concourse] Release 1.0.9 updating components versions ([5145c34](https://github.com/bitnami/charts/commit/5145c3498926062f8fd0639184e373c4ba155f98))
 
 ## <small>1.0.8 (2022-03-18)</small>
 
-* [bitnami/concourse] Release 1.0.8 updating components versions ([451f852](https://github.com/bitnami/charts/commit/451f852))
+* [bitnami/concourse] Release 1.0.8 updating components versions ([451f852](https://github.com/bitnami/charts/commit/451f85217e78d76ebf9389fbd683b7821cdd56f4))
 
 ## <small>1.0.7 (2022-03-16)</small>
 
-* [bitnami/concourse] Release 1.0.7 updating components versions ([8a8093d](https://github.com/bitnami/charts/commit/8a8093d))
+* [bitnami/concourse] Release 1.0.7 updating components versions ([8a8093d](https://github.com/bitnami/charts/commit/8a8093d3796bd6c33dcb7c1b35f1e71efec8776c))
 
 ## <small>1.0.6 (2022-03-10)</small>
 
-* [bitnami/concourse] Release 1.0.6 updating components versions ([fcf61bf](https://github.com/bitnami/charts/commit/fcf61bf))
+* [bitnami/concourse] Release 1.0.6 updating components versions ([fcf61bf](https://github.com/bitnami/charts/commit/fcf61bfda4107e33b4a3d6081f9cec07c1a32daa))
 
 ## <small>1.0.5 (2022-03-01)</small>
 
-* [bitnami/concourse] Release 1.0.5 updating components versions ([e9126fb](https://github.com/bitnami/charts/commit/e9126fb))
+* [bitnami/concourse] Release 1.0.5 updating components versions ([e9126fb](https://github.com/bitnami/charts/commit/e9126fbaa8d5c5f8d3fa75fdecc478af9ab7c338))
 
 ## <small>1.0.4 (2022-02-28)</small>
 
-* [bitnami/concourse] Release 1.0.4 updating components versions ([19f7c8e](https://github.com/bitnami/charts/commit/19f7c8e))
+* [bitnami/concourse] Release 1.0.4 updating components versions ([19f7c8e](https://github.com/bitnami/charts/commit/19f7c8eb8b8ed87efcda32c5761d8f6c86b99180))
 
 ## <small>1.0.3 (2022-02-21)</small>
 
-* [bitnami/concourse] Add flag '-r' to xargs in volumePermissions init-container (#9129) ([265d124](https://github.com/bitnami/charts/commit/265d124)), closes [#9129](https://github.com/bitnami/charts/issues/9129)
+* [bitnami/concourse] Add flag '-r' to xargs in volumePermissions init-container (#9129) ([265d124](https://github.com/bitnami/charts/commit/265d124a785eb233a808730b6e190df321f9fe69)), closes [#9129](https://github.com/bitnami/charts/issues/9129)
 
 ## <small>1.0.2 (2022-02-15)</small>
 
-* [bitnami/concourse] Release 1.0.2 updating components versions ([41abb9a](https://github.com/bitnami/charts/commit/41abb9a))
+* [bitnami/concourse] Release 1.0.2 updating components versions ([41abb9a](https://github.com/bitnami/charts/commit/41abb9a7e89bc3db0df7064348fda7eff0c408a4))
 
 ## <small>1.0.1 (2022-02-11)</small>
 
-* [bitnami/concourse] Add support to PostgreSQL globals (#8988) ([39e7c8c](https://github.com/bitnami/charts/commit/39e7c8c)), closes [#8988](https://github.com/bitnami/charts/issues/8988)
+* [bitnami/concourse] Add support to PostgreSQL globals (#8988) ([39e7c8c](https://github.com/bitnami/charts/commit/39e7c8c4752cc06862ae30ad714d499149e8a1b9)), closes [#8988](https://github.com/bitnami/charts/issues/8988)
 
 ## 1.0.0 (2022-02-09)
 
-* [bitnami/concourse] Chart standardization (#8926) ([4539cb3](https://github.com/bitnami/charts/commit/4539cb3)), closes [#8926](https://github.com/bitnami/charts/issues/8926)
+* [bitnami/concourse] Chart standardization (#8926) ([4539cb3](https://github.com/bitnami/charts/commit/4539cb3ac0395cad93cd3f523cc798c47e9b3c4b)), closes [#8926](https://github.com/bitnami/charts/issues/8926)
 
 ## <small>0.2.2 (2022-01-20)</small>
 
-* [bitnami/*] Readme automation (#8579) ([78d1938](https://github.com/bitnami/charts/commit/78d1938)), closes [#8579](https://github.com/bitnami/charts/issues/8579)
-* [bitnami/*] Update READMEs (#8716) ([b9a9533](https://github.com/bitnami/charts/commit/b9a9533)), closes [#8716](https://github.com/bitnami/charts/issues/8716)
-* [bitnami/several] Change prerequisites (#8725) ([8d740c5](https://github.com/bitnami/charts/commit/8d740c5)), closes [#8725](https://github.com/bitnami/charts/issues/8725)
+* [bitnami/*] Readme automation (#8579) ([78d1938](https://github.com/bitnami/charts/commit/78d193831c900d178198491ffd08fa2217a64ecd)), closes [#8579](https://github.com/bitnami/charts/issues/8579)
+* [bitnami/*] Update READMEs (#8716) ([b9a9533](https://github.com/bitnami/charts/commit/b9a953337590eb2979453385874a267bacf50936)), closes [#8716](https://github.com/bitnami/charts/issues/8716)
+* [bitnami/several] Change prerequisites (#8725) ([8d740c5](https://github.com/bitnami/charts/commit/8d740c566cfdb7e2d933c40128b4e919fce953a5)), closes [#8725](https://github.com/bitnami/charts/issues/8725)
 
 ## <small>0.2.1 (2022-01-11)</small>
 
-* [bitnami/concourse] Release 0.2.1 updating components versions ([0659238](https://github.com/bitnami/charts/commit/0659238))
+* [bitnami/concourse] Release 0.2.1 updating components versions ([0659238](https://github.com/bitnami/charts/commit/065923842f8653ff981d6ac4892bceb6575bd3d8))
 
 ## 0.2.0 (2022-01-05)
 
-* [bitnami/several] Adapt templating format (#8562) ([8cad18a](https://github.com/bitnami/charts/commit/8cad18a)), closes [#8562](https://github.com/bitnami/charts/issues/8562)
+* [bitnami/several] Adapt templating format (#8562) ([8cad18a](https://github.com/bitnami/charts/commit/8cad18aed9966a6f0208e5ad6cee46cb217f47ab)), closes [#8562](https://github.com/bitnami/charts/issues/8562)
 
 ## <small>0.1.18 (2022-01-04)</small>
 
-* [bitnami/several] Add license to the README ([05f7633](https://github.com/bitnami/charts/commit/05f7633))
-* [bitnami/several] Add license to the README ([32fb238](https://github.com/bitnami/charts/commit/32fb238))
-* [bitnami/several] Add license to the README ([b87c2f7](https://github.com/bitnami/charts/commit/b87c2f7))
-* [bitnami/several] Fix issue with quote when followed by }} (#8561) ([58077af](https://github.com/bitnami/charts/commit/58077af)), closes [#8561](https://github.com/bitnami/charts/issues/8561)
+* [bitnami/several] Add license to the README ([05f7633](https://github.com/bitnami/charts/commit/05f763372501d596e57db713dd53ff4ff3027cc4))
+* [bitnami/several] Add license to the README ([32fb238](https://github.com/bitnami/charts/commit/32fb238e60a0affc6debd3142eaa3c3d9089ec2a))
+* [bitnami/several] Add license to the README ([b87c2f7](https://github.com/bitnami/charts/commit/b87c2f7899d48a8b02c506765e6ae82937e9ba3f))
+* [bitnami/several] Fix issue with quote when followed by }} (#8561) ([58077af](https://github.com/bitnami/charts/commit/58077af58f40e74e7af41485bcca493e38523537)), closes [#8561](https://github.com/bitnami/charts/issues/8561)
 
 ## <small>0.1.17 (2021-12-17)</small>
 
-* [bitnami/concourse] Release 0.1.17 updating components versions ([e2bfe5a](https://github.com/bitnami/charts/commit/e2bfe5a))
+* [bitnami/concourse] Release 0.1.17 updating components versions ([e2bfe5a](https://github.com/bitnami/charts/commit/e2bfe5a78299862c73a503b46831acdb80ce1d06))
 
 ## <small>0.1.16 (2021-12-16)</small>
 
-* [bitnami/concourse] Release 0.1.16 updating components versions ([96ad836](https://github.com/bitnami/charts/commit/96ad836))
-* [bitnami/several] Regenerate README tables ([8150149](https://github.com/bitnami/charts/commit/8150149))
+* [bitnami/concourse] Release 0.1.16 updating components versions ([96ad836](https://github.com/bitnami/charts/commit/96ad836e1e37fad8f73936a9fd25431d26c5a20c))
+* [bitnami/several] Regenerate README tables ([8150149](https://github.com/bitnami/charts/commit/8150149f0bb746e86ff0029fc375d43775bdf15a))
 
 ## <small>0.1.15 (2021-11-29)</small>
 
-* [bitnami/several] Replace HTTP by HTTPS when possible (#8259) ([eafb5bd](https://github.com/bitnami/charts/commit/eafb5bd)), closes [#8259](https://github.com/bitnami/charts/issues/8259)
+* [bitnami/several] Replace HTTP by HTTPS when possible (#8259) ([eafb5bd](https://github.com/bitnami/charts/commit/eafb5bd5a2cc3aaf04fc1e8ebedd73f420d76864)), closes [#8259](https://github.com/bitnami/charts/issues/8259)
 
 ## <small>0.1.14 (2021-11-28)</small>
 
-* [bitnami/concourse] Release 0.1.14 updating components versions ([f5dd520](https://github.com/bitnami/charts/commit/f5dd520))
-* [bitnami/concourse] Updated README (#7964) ([ffaaa3c](https://github.com/bitnami/charts/commit/ffaaa3c)), closes [#7964](https://github.com/bitnami/charts/issues/7964)
-* [bitnami/several] Regenerate README tables ([3cefed3](https://github.com/bitnami/charts/commit/3cefed3))
+* [bitnami/concourse] Release 0.1.14 updating components versions ([f5dd520](https://github.com/bitnami/charts/commit/f5dd520d105be51bc5f10d006520df6ce3fcdd42))
+* [bitnami/concourse] Updated README (#7964) ([ffaaa3c](https://github.com/bitnami/charts/commit/ffaaa3c4514420e9a007d0652e7f82b3ab57bda1)), closes [#7964](https://github.com/bitnami/charts/issues/7964)
+* [bitnami/several] Regenerate README tables ([3cefed3](https://github.com/bitnami/charts/commit/3cefed3ef961fbd7596242b1165bcfa229a9cadb))
 
 ## <small>0.1.13 (2021-10-29)</small>
 
-* [bitnami/concourse] Release 0.1.13 updating components versions ([f12eae9](https://github.com/bitnami/charts/commit/f12eae9))
+* [bitnami/concourse] Release 0.1.13 updating components versions ([f12eae9](https://github.com/bitnami/charts/commit/f12eae99be6c0bc0716ae88d8a562a3c0d040ed6))
 
 ## <small>0.1.12 (2021-10-27)</small>
 
-* [bitnami/*] Mark PodSecurityPolicy resources as deprecated (#7948) ([5cac753](https://github.com/bitnami/charts/commit/5cac753)), closes [#7948](https://github.com/bitnami/charts/issues/7948)
-* [bitnami/several] Regenerate README tables ([412cf6a](https://github.com/bitnami/charts/commit/412cf6a))
+* [bitnami/*] Mark PodSecurityPolicy resources as deprecated (#7948) ([5cac753](https://github.com/bitnami/charts/commit/5cac7539dcb6c3baef06ed6676bfa99c16fdb5fe)), closes [#7948](https://github.com/bitnami/charts/issues/7948)
+* [bitnami/several] Regenerate README tables ([412cf6a](https://github.com/bitnami/charts/commit/412cf6a513cb0c03444a6e7811c6f27193239a10))
 
 ## <small>0.1.11 (2021-10-26)</small>
 
-* [bitnami/concourse] Release 0.1.11 updating components versions ([c94bbbb](https://github.com/bitnami/charts/commit/c94bbbb))
+* [bitnami/concourse] Release 0.1.11 updating components versions ([c94bbbb](https://github.com/bitnami/charts/commit/c94bbbb6c46582a48d2e72c5ce40b91256a9c16e))
 
 ## <small>0.1.10 (2021-10-22)</small>
 
-* [bitnami/several] Add chart info to NOTES.txt (#7889) ([a6751cd](https://github.com/bitnami/charts/commit/a6751cd)), closes [#7889](https://github.com/bitnami/charts/issues/7889)
+* [bitnami/several] Add chart info to NOTES.txt (#7889) ([a6751cd](https://github.com/bitnami/charts/commit/a6751cdd33c461fabbc459fbea6f219ec64ab6b2)), closes [#7889](https://github.com/bitnami/charts/issues/7889)
 
 ## <small>0.1.9 (2021-10-19)</small>
 
-* [bitnami/several] Change pullPolicy for bitnami-shell image (#7852) ([9711a33](https://github.com/bitnami/charts/commit/9711a33)), closes [#7852](https://github.com/bitnami/charts/issues/7852)
-* [bitnami/several] Regenerate README tables ([0a26eaa](https://github.com/bitnami/charts/commit/0a26eaa))
+* [bitnami/several] Change pullPolicy for bitnami-shell image (#7852) ([9711a33](https://github.com/bitnami/charts/commit/9711a33c6eec72ea79143c4b7574dbe6a148d6b2)), closes [#7852](https://github.com/bitnami/charts/issues/7852)
+* [bitnami/several] Regenerate README tables ([0a26eaa](https://github.com/bitnami/charts/commit/0a26eaafd6ad234046aa91c79a44a1d45f55724e))
 
 ## <small>0.1.8 (2021-10-17)</small>
 
-* [bitnami/concourse] Release 0.1.8 updating components versions ([e2f9916](https://github.com/bitnami/charts/commit/e2f9916))
+* [bitnami/concourse] Release 0.1.8 updating components versions ([e2f9916](https://github.com/bitnami/charts/commit/e2f99160ddaacb74c3ec6baa889832d71e13bc6f))
 
 ## <small>0.1.7 (2021-10-01)</small>
 
-* [bitnami/*] Drop support for deprecated cert-manager annotation (#7582) ([a081792](https://github.com/bitnami/charts/commit/a081792)), closes [#7582](https://github.com/bitnami/charts/issues/7582)
-* [bitnami/several] Regenerate README tables ([003a0fb](https://github.com/bitnami/charts/commit/003a0fb))
+* [bitnami/*] Drop support for deprecated cert-manager annotation (#7582) ([a081792](https://github.com/bitnami/charts/commit/a08179293543f063e5de966a9976ca967161de7b)), closes [#7582](https://github.com/bitnami/charts/issues/7582)
+* [bitnami/several] Regenerate README tables ([003a0fb](https://github.com/bitnami/charts/commit/003a0fbaedeb775c546b8d8452b7a5ab0a63af52))
 
 ## <small>0.1.6 (2021-09-17)</small>
 
-* [bitnami/concourse] Release 0.1.6 updating components versions ([d09ed9f](https://github.com/bitnami/charts/commit/d09ed9f))
-* [bitnami/several] Regenerate README tables ([a94b593](https://github.com/bitnami/charts/commit/a94b593))
+* [bitnami/concourse] Release 0.1.6 updating components versions ([d09ed9f](https://github.com/bitnami/charts/commit/d09ed9fa48550343ccfb146ac3cc9878e3b8e1c0))
+* [bitnami/several] Regenerate README tables ([a94b593](https://github.com/bitnami/charts/commit/a94b5937a8665743457afc158202ebc33405c8e1))
 
 ## <small>0.1.5 (2021-09-10)</small>
 
-* [bitnami/concourse] Release 0.1.5 updating components versions ([b4c77d4](https://github.com/bitnami/charts/commit/b4c77d4))
-* [bitnami/several] Regenerate README tables ([da2513b](https://github.com/bitnami/charts/commit/da2513b))
+* [bitnami/concourse] Release 0.1.5 updating components versions ([b4c77d4](https://github.com/bitnami/charts/commit/b4c77d48967ae423d2ddca002078e840f341bb19))
+* [bitnami/several] Regenerate README tables ([da2513b](https://github.com/bitnami/charts/commit/da2513bf0a33819f3b1151d387c631a9ffdb03e2))
 
 ## <small>0.1.4 (2021-08-25)</small>
 
-* [bitnami/concourse] Release 0.1.4 updating components versions ([a5602a0](https://github.com/bitnami/charts/commit/a5602a0))
-* [bitnami/several] Fix default values when using `foo: |` (#7092) ([fe91297](https://github.com/bitnami/charts/commit/fe91297)), closes [#7092](https://github.com/bitnami/charts/issues/7092)
-* [bitnami/several] Update READMEs (#7108) ([44961d9](https://github.com/bitnami/charts/commit/44961d9)), closes [#7108](https://github.com/bitnami/charts/issues/7108)
+* [bitnami/concourse] Release 0.1.4 updating components versions ([a5602a0](https://github.com/bitnami/charts/commit/a5602a0ca3c9f6d6088553e6c456d4701d21f1b4))
+* [bitnami/several] Fix default values when using `foo: |` (#7092) ([fe91297](https://github.com/bitnami/charts/commit/fe91297fdf3f6c74aee31c423912e4ac19b55c94)), closes [#7092](https://github.com/bitnami/charts/issues/7092)
+* [bitnami/several] Update READMEs (#7108) ([44961d9](https://github.com/bitnami/charts/commit/44961d9cdfae1b0d06808124c4b47e8adc3de146)), closes [#7108](https://github.com/bitnami/charts/issues/7108)
 
 ## <small>0.1.3 (2021-07-29)</small>
 
-* [bitnami/concourse] Release 0.1.3 updating components versions ([47b60e2](https://github.com/bitnami/charts/commit/47b60e2))
+* [bitnami/concourse] Release 0.1.3 updating components versions ([47b60e2](https://github.com/bitnami/charts/commit/47b60e228bf43dc107a0f689ab3d543eabff86a6))
 
 ## <small>0.1.2 (2021-07-29)</small>
 
-* [bitnami/concourse] Fix nil value (#7093) ([f394e1a](https://github.com/bitnami/charts/commit/f394e1a)), closes [#7093](https://github.com/bitnami/charts/issues/7093)
+* [bitnami/concourse] Fix nil value (#7093) ([f394e1a](https://github.com/bitnami/charts/commit/f394e1a5e24e720505141fcc47d9e9ccf5c38319)), closes [#7093](https://github.com/bitnami/charts/issues/7093)
 
 ## <small>0.1.1 (2021-07-22)</small>
 
-* [bitnami/several] Fix default values and regenerate README (#7023) ([c443ded](https://github.com/bitnami/charts/commit/c443ded)), closes [#7023](https://github.com/bitnami/charts/issues/7023)
+* [bitnami/several] Fix default values and regenerate README (#7023) ([c443ded](https://github.com/bitnami/charts/commit/c443ded691a1184a72af7b812759fad54b240ae9)), closes [#7023](https://github.com/bitnami/charts/issues/7023)
 
 ## 0.1.0 (2021-07-17)
 
-* [bitnami/concourse] Add new Concourse Helm chart (#6799) ([4a31699](https://github.com/bitnami/charts/commit/4a31699)), closes [#6799](https://github.com/bitnami/charts/issues/6799)
+* [bitnami/concourse] Add new Concourse Helm chart (#6799) ([4a31699](https://github.com/bitnami/charts/commit/4a31699234add1268ed2438966a5dc87e1def739)), closes [#6799](https://github.com/bitnami/charts/issues/6799)

--- a/bitnami/concourse/Chart.lock
+++ b/bitnami/concourse/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: postgresql
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 15.3.5
+  version: 15.4.0
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 2.19.3
-digest: sha256:2edee02d333f1aea930b77f47e152371e2ef8ab6ce931baf1acc46a25b94182e
-generated: "2024-05-21T13:31:03.576573303+02:00"
+digest: sha256:929be65a3e8735983a5dbe2c9177e3b2cc66003f2076173eb6a6cc9da7e316d6
+generated: "2024-05-22T16:14:53.251288+02:00"

--- a/bitnami/concourse/Chart.yaml
+++ b/bitnami/concourse/Chart.yaml
@@ -37,4 +37,4 @@ maintainers:
 name: concourse
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/concourse
-version: 4.2.0
+version: 4.2.1

--- a/bitnami/concourse/templates/web/deployment.yaml
+++ b/bitnami/concourse/templates/web/deployment.yaml
@@ -372,8 +372,7 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.web.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.web.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.web.livenessProbe "enabled") "context" $) | nindent 12 }}
-            httpGet:
-              path: {{ .Values.web.baseUrl | trimSuffix "/" }}/api/v1/info
+            tcpSocket:
               port: http
           {{- end }}
           {{- if .Values.web.customReadinessProbe }}

--- a/bitnami/concourse/templates/worker/deployment.yaml
+++ b/bitnami/concourse/templates/worker/deployment.yaml
@@ -200,8 +200,7 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.worker.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.worker.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.worker.livenessProbe "enabled") "context" $) | nindent 12 }}
-            httpGet:
-              path: /
+            tcpSocket:
               port: healthz
           {{- end }}
           {{- if .Values.worker.customReadinessProbe }}

--- a/bitnami/concourse/templates/worker/statefulset.yaml
+++ b/bitnami/concourse/templates/worker/statefulset.yaml
@@ -226,8 +226,7 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.worker.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.worker.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.worker.livenessProbe "enabled") "context" $) | nindent 12 }}
-            httpGet:
-              path: /
+            tcpSocket:
               port: healthz
           {{- end }}
           {{- if .Values.worker.customReadinessProbe }}


### PR DESCRIPTION
### Description of the change
This PR aims to use different liveness/readiness probes to improve overall security and avoid unnecessary container restarts. [More info](https://github.com/zegl/kube-score/blob/master/README_PROBES.md).

### Benefits

Increase availability and resilience.

### Possible drawbacks

N/A

### Applicable issues

- fixes #

### Additional information

- Related to #23537

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- ~[X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)~
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
