### PR TITLE
[bitnami/airflow] Fix Airflow k8s config generation in the initContainer and filesystem writability

### DIFF
--- a/bitnami/airflow/CHANGELOG.md
+++ b/bitnami/airflow/CHANGELOG.md
@@ -1,1636 +1,1641 @@
 # Changelog
 
+## 18.2.1 (2024-05-22)
+
+* [bitnami/airflow] Fix Airflow k8s config generation in the initContainer and filesystem writability ([#26341](https://github.com/bitnami/charts/pull/26341))
+
 ## 18.2.0 (2024-05-21)
 
-* [bitnami/airflow] feat: :sparkles: :lock: Add warning when original images are replaced ([#26172](https://github.com/bitnami/charts/pulls/26172))
+* [bitnami/*] ci: :construction_worker: Add tag and changelog support (#25359) ([91c707c](https://github.com/bitnami/charts/commit/91c707c9e4e574725a09505d2d313fb93f1b4c0a)), closes [#25359](https://github.com/bitnami/charts/issues/25359)
+* [bitnami/apache] feat: :sparkles: :lock: Add warning when original images are replaced (#26179) ([4e0eeee](https://github.com/bitnami/charts/commit/4e0eeee0c2efaf58de9059102560f255fcbb0f11)), closes [#26179](https://github.com/bitnami/charts/issues/26179)
 
 ## <small>18.1.1 (2024-05-21)</small>
 
-* [bitnami/airflow] Release 18.0.11 updating components versions (#25970) ([79685e6](https://github.com/bitnami/charts/commit/79685e6)), closes [#25970](https://github.com/bitnami/charts/issues/25970)
+* [bitnami/airflow] Release 18.0.11 updating components versions (#25970) ([79685e6](https://github.com/bitnami/charts/commit/79685e6fc39078588e3de2bfbe3da6791aceac8e)), closes [#25970](https://github.com/bitnami/charts/issues/25970)
 
 ## 18.1.0 (2024-05-17)
 
-* [bitnami/airflow] Use different liveness/readiness probes (#25971) ([10b559d](https://github.com/bitnami/charts/commit/10b559d)), closes [#25971](https://github.com/bitnami/charts/issues/25971)
+* [bitnami/airflow] Use different liveness/readiness probes (#25971) ([10b559d](https://github.com/bitnami/charts/commit/10b559db2e30be9e5617aae52fcf470286bc6d2f)), closes [#25971](https://github.com/bitnami/charts/issues/25971)
 
 ## <small>18.0.10 (2024-05-13)</small>
 
-* [bitnami/airflow] Release 18.0.10 updating components versions (#25757) ([e8e580b](https://github.com/bitnami/charts/commit/e8e580b)), closes [#25757](https://github.com/bitnami/charts/issues/25757)
+* [bitnami/airflow] Release 18.0.10 updating components versions (#25757) ([e8e580b](https://github.com/bitnami/charts/commit/e8e580b2b2b95827cc67dcb5a287ba347a3168b9)), closes [#25757](https://github.com/bitnami/charts/issues/25757)
 
 ## <small>18.0.9 (2024-05-13)</small>
 
-* [bitnami/*] Change non-root and rolling-tags doc URLs (#25628) ([b067c94](https://github.com/bitnami/charts/commit/b067c94)), closes [#25628](https://github.com/bitnami/charts/issues/25628)
-* [bitnami/airflow] Release 18.0.9 updating components versions (#25731) ([21d4b21](https://github.com/bitnami/charts/commit/21d4b21)), closes [#25731](https://github.com/bitnami/charts/issues/25731)
+* [bitnami/*] Change non-root and rolling-tags doc URLs (#25628) ([b067c94](https://github.com/bitnami/charts/commit/b067c94f6bcde427863c197fd355f0b5ba12ff5b)), closes [#25628](https://github.com/bitnami/charts/issues/25628)
+* [bitnami/airflow] Release 18.0.9 updating components versions (#25731) ([21d4b21](https://github.com/bitnami/charts/commit/21d4b21c59ca7ae2611f7ab602606cf4393eefe0)), closes [#25731](https://github.com/bitnami/charts/issues/25731)
 
 ## <small>18.0.8 (2024-05-06)</small>
 
-* [bitnami/*] Set new header/owner (#25558) ([8d1dc11](https://github.com/bitnami/charts/commit/8d1dc11)), closes [#25558](https://github.com/bitnami/charts/issues/25558)
-* [bitnami/airflow] Release 18.0.8 updating components versions (#25567) ([24f1ace](https://github.com/bitnami/charts/commit/24f1ace)), closes [#25567](https://github.com/bitnami/charts/issues/25567)
+* [bitnami/*] Set new header/owner (#25558) ([8d1dc11](https://github.com/bitnami/charts/commit/8d1dc11f5fb30db6fba50c43d7af59d2f79deed3)), closes [#25558](https://github.com/bitnami/charts/issues/25558)
+* [bitnami/airflow] Release 18.0.8 updating components versions (#25567) ([24f1ace](https://github.com/bitnami/charts/commit/24f1ace16407969cade216be040ae268472bf372)), closes [#25567](https://github.com/bitnami/charts/issues/25567)
 
 ## <small>18.0.7 (2024-04-26)</small>
 
-* [bitnami/airflow] Release 18.0.7 updating components versions (#25407) ([3fb57af](https://github.com/bitnami/charts/commit/3fb57af)), closes [#25407](https://github.com/bitnami/charts/issues/25407)
-* [bitnami/multiple charts] Fix typo: "NetworkPolice" vs "NetworkPolicy" (#25348) ([6970c1b](https://github.com/bitnami/charts/commit/6970c1b)), closes [#25348](https://github.com/bitnami/charts/issues/25348)
-* Replace VMware by Broadcom copyright text (#25306) ([a5e4bd0](https://github.com/bitnami/charts/commit/a5e4bd0)), closes [#25306](https://github.com/bitnami/charts/issues/25306)
+* [bitnami/airflow] Release 18.0.7 updating components versions (#25407) ([3fb57af](https://github.com/bitnami/charts/commit/3fb57afd05d60af7b377cac6752617d69b10dc6d)), closes [#25407](https://github.com/bitnami/charts/issues/25407)
+* [bitnami/multiple charts] Fix typo: "NetworkPolice" vs "NetworkPolicy" (#25348) ([6970c1b](https://github.com/bitnami/charts/commit/6970c1ba245873506e73d459c6eac1e4919b778f)), closes [#25348](https://github.com/bitnami/charts/issues/25348)
+* Replace VMware by Broadcom copyright text (#25306) ([a5e4bd0](https://github.com/bitnami/charts/commit/a5e4bd0e35e419203793976a78d9d0a13de92c76)), closes [#25306](https://github.com/bitnami/charts/issues/25306)
 
 ## <small>18.0.6 (2024-04-19)</small>
 
-* [bitnami/airflow] Fix clone of initial repositories (#25219) ([7824948](https://github.com/bitnami/charts/commit/7824948)), closes [#25219](https://github.com/bitnami/charts/issues/25219)
+* [bitnami/airflow] Fix clone of initial repositories (#25219) ([7824948](https://github.com/bitnami/charts/commit/78249480860eefd30da45311f0dfcfc341429bfe)), closes [#25219](https://github.com/bitnami/charts/issues/25219)
 
 ## <small>18.0.5 (2024-04-18)</small>
 
-* [bitnami/airflow] Fixing error with default PostgreSQL password (#25138) ([d9df380](https://github.com/bitnami/charts/commit/d9df380)), closes [#25138](https://github.com/bitnami/charts/issues/25138)
-* [bitnami/airflow] Version bump (#25214) ([86c5209](https://github.com/bitnami/charts/commit/86c5209)), closes [#25214](https://github.com/bitnami/charts/issues/25214)
+* [bitnami/airflow] Fixing error with default PostgreSQL password (#25138) ([d9df380](https://github.com/bitnami/charts/commit/d9df38068a96c249cc1a3d8f0d7a8316aeb836bf)), closes [#25138](https://github.com/bitnami/charts/issues/25138)
+* [bitnami/airflow] Version bump (#25214) ([86c5209](https://github.com/bitnami/charts/commit/86c5209f1625d2f775861db13bfb9e07b5cbac19)), closes [#25214](https://github.com/bitnami/charts/issues/25214)
 
 ## <small>18.0.4 (2024-04-12)</small>
 
-* [bitnami/airflow] Fix nil pointer evaluating when using dags.existingConfigmap (#25144) ([f05271d](https://github.com/bitnami/charts/commit/f05271d)), closes [#25144](https://github.com/bitnami/charts/issues/25144)
+* [bitnami/airflow] Fix nil pointer evaluating when using dags.existingConfigmap (#25144) ([f05271d](https://github.com/bitnami/charts/commit/f05271d3b867c8e91395d05aec7f8639d8a9a13b)), closes [#25144](https://github.com/bitnami/charts/issues/25144)
 
 ## <small>18.0.3 (2024-04-09)</small>
 
-* [bitnami/airflow] Release 18.0.3 updating components versions (#25073) ([3d7d7df](https://github.com/bitnami/charts/commit/3d7d7df)), closes [#25073](https://github.com/bitnami/charts/issues/25073)
+* [bitnami/airflow] Release 18.0.3 updating components versions (#25073) ([3d7d7df](https://github.com/bitnami/charts/commit/3d7d7df1e466e07cbb764131606940c406e6544f)), closes [#25073](https://github.com/bitnami/charts/issues/25073)
 
 ## <small>18.0.2 (2024-04-05)</small>
 
-* [bitnami/airflow] Release 18.0.2 (#24988) ([18591a5](https://github.com/bitnami/charts/commit/18591a5)), closes [#24988](https://github.com/bitnami/charts/issues/24988)
+* [bitnami/airflow] Release 18.0.2 (#24988) ([18591a5](https://github.com/bitnami/charts/commit/18591a54bdf5aae863764aacf964634865bdc5b7)), closes [#24988](https://github.com/bitnami/charts/issues/24988)
 
 ## <small>18.0.1 (2024-04-04)</small>
 
-* [bitnami/airflow] Release 18.0.1 updating components versions (#24664) ([e4bbd35](https://github.com/bitnami/charts/commit/e4bbd35)), closes [#24664](https://github.com/bitnami/charts/issues/24664)
-* Update resourcesPreset comments (#24467) ([92e3e8a](https://github.com/bitnami/charts/commit/92e3e8a)), closes [#24467](https://github.com/bitnami/charts/issues/24467)
+* [bitnami/airflow] Release 18.0.1 updating components versions (#24664) ([e4bbd35](https://github.com/bitnami/charts/commit/e4bbd353604142620652af8baf683c3974185d0f)), closes [#24664](https://github.com/bitnami/charts/issues/24664)
+* Update resourcesPreset comments (#24467) ([92e3e8a](https://github.com/bitnami/charts/commit/92e3e8a507326d2a20a8f10ab3e7746a2ec5c554)), closes [#24467](https://github.com/bitnami/charts/issues/24467)
 
 ## 18.0.0 (2024-03-20)
 
-* [bitnami/*] Reorder Chart sections (#24455) ([0cf4048](https://github.com/bitnami/charts/commit/0cf4048)), closes [#24455](https://github.com/bitnami/charts/issues/24455)
-* [bitnami/airflow] feat!: :lock: :boom: Improve security defaults (#24543) ([e54bf09](https://github.com/bitnami/charts/commit/e54bf09)), closes [#24543](https://github.com/bitnami/charts/issues/24543)
+* [bitnami/*] Reorder Chart sections (#24455) ([0cf4048](https://github.com/bitnami/charts/commit/0cf4048e8743f70a9753d460655bd030cbff6824)), closes [#24455](https://github.com/bitnami/charts/issues/24455)
+* [bitnami/airflow] feat!: :lock: :boom: Improve security defaults (#24543) ([e54bf09](https://github.com/bitnami/charts/commit/e54bf09ea259a53292d247fd10fa4d782fd1c421)), closes [#24543](https://github.com/bitnami/charts/issues/24543)
 
 ## <small>17.2.4 (2024-03-13)</small>
 
-* [bitnami/airflow] Release 17.2.4 updating components versions (#24404) ([f7cf935](https://github.com/bitnami/charts/commit/f7cf935)), closes [#24404](https://github.com/bitnami/charts/issues/24404)
+* [bitnami/airflow] Release 17.2.4 updating components versions (#24404) ([f7cf935](https://github.com/bitnami/charts/commit/f7cf9354edf289701f4bec2c61befcacacb06e06)), closes [#24404](https://github.com/bitnami/charts/issues/24404)
 
 ## <small>17.2.3 (2024-03-13)</small>
 
-* [bitnami/airflow] Update chart deps (#24393) ([8699709](https://github.com/bitnami/charts/commit/8699709)), closes [#24393](https://github.com/bitnami/charts/issues/24393)
+* [bitnami/airflow] Update chart deps (#24393) ([8699709](https://github.com/bitnami/charts/commit/8699709e6e8d07f77bd059a45064c3a42bbf942f)), closes [#24393](https://github.com/bitnami/charts/issues/24393)
 
 ## <small>17.2.2 (2024-03-11)</small>
 
-* Fixed issue  [bitnami/airflow] nil pointer evaluating interface {}.gl… (#24318) ([2925b64](https://github.com/bitnami/charts/commit/2925b64)), closes [#24318](https://github.com/bitnami/charts/issues/24318) [#24283](https://github.com/bitnami/charts/issues/24283)
+* Fixed issue  [bitnami/airflow] nil pointer evaluating interface {}.gl… (#24318) ([2925b64](https://github.com/bitnami/charts/commit/2925b64c045b62939937ba9ec690f4818913cc44)), closes [#24318](https://github.com/bitnami/charts/issues/24318) [#24283](https://github.com/bitnami/charts/issues/24283)
 
 ## <small>17.2.1 (2024-03-08)</small>
 
-* [bitnami/airflow] Release 17.2.1 updating components versions (#24297) ([edb7c63](https://github.com/bitnami/charts/commit/edb7c63)), closes [#24297](https://github.com/bitnami/charts/issues/24297)
+* [bitnami/airflow] Release 17.2.1 updating components versions (#24297) ([edb7c63](https://github.com/bitnami/charts/commit/edb7c6326fa46ae8ae52631736b93c2fdba9da49)), closes [#24297](https://github.com/bitnami/charts/issues/24297)
 
 ## 17.2.0 (2024-03-07)
 
-* [bitnami/airflow] feat: :sparkles: :lock: Add support for readOnlyRootFilesystem (#24196) ([b425c53](https://github.com/bitnami/charts/commit/b425c53)), closes [#24196](https://github.com/bitnami/charts/issues/24196)
+* [bitnami/airflow] feat: :sparkles: :lock: Add support for readOnlyRootFilesystem (#24196) ([b425c53](https://github.com/bitnami/charts/commit/b425c53b718ac87b067d81e528ad86c10f0922ff)), closes [#24196](https://github.com/bitnami/charts/issues/24196)
 
 ## 17.1.0 (2024-03-06)
 
-* [bitnami/airflow] feat: :sparkles: :lock: Add automatic adaptation for Openshift restricted-v2 SCC ( ([ce42dc6](https://github.com/bitnami/charts/commit/ce42dc6)), closes [#24060](https://github.com/bitnami/charts/issues/24060)
+* [bitnami/airflow] feat: :sparkles: :lock: Add automatic adaptation for Openshift restricted-v2 SCC ( ([ce42dc6](https://github.com/bitnami/charts/commit/ce42dc65f7ae368b0c8724354bffd8dea455d926)), closes [#24060](https://github.com/bitnami/charts/issues/24060)
 
 ## 17.0.0 (2024-03-04)
 
-* [bitnami/airflow] Update bundled PostgreSQL (#24034) ([c14910d](https://github.com/bitnami/charts/commit/c14910d)), closes [#24034](https://github.com/bitnami/charts/issues/24034)
+* [bitnami/airflow] Update bundled PostgreSQL (#24034) ([c14910d](https://github.com/bitnami/charts/commit/c14910dda4ed9eae61993c37780b66681e237778)), closes [#24034](https://github.com/bitnami/charts/issues/24034)
 
 ## <small>16.8.3 (2024-02-27)</small>
 
-* [bitnami/airflow] Release 16.8.3 updating components versions (#23935) ([2c22209](https://github.com/bitnami/charts/commit/2c22209)), closes [#23935](https://github.com/bitnami/charts/issues/23935)
+* [bitnami/airflow] Release 16.8.3 updating components versions (#23935) ([2c22209](https://github.com/bitnami/charts/commit/2c22209c849d1dddb4b60549c73bfef75f5f7b20)), closes [#23935](https://github.com/bitnami/charts/issues/23935)
 
 ## <small>16.8.2 (2024-02-21)</small>
 
-* [bitnami/airflow] Release 16.8.2 updating components versions (#23735) ([03a44ae](https://github.com/bitnami/charts/commit/03a44ae)), closes [#23735](https://github.com/bitnami/charts/issues/23735)
+* [bitnami/airflow] Release 16.8.2 updating components versions (#23735) ([03a44ae](https://github.com/bitnami/charts/commit/03a44ae68d7aa17f8260926c39842b7c380ec3cc)), closes [#23735](https://github.com/bitnami/charts/issues/23735)
 
 ## <small>16.8.1 (2024-02-21)</small>
 
-* [bitnami/airflow] Release 16.8.1 updating components versions (#23627) ([f2a4fc7](https://github.com/bitnami/charts/commit/f2a4fc7)), closes [#23627](https://github.com/bitnami/charts/issues/23627)
+* [bitnami/airflow] Release 16.8.1 updating components versions (#23627) ([f2a4fc7](https://github.com/bitnami/charts/commit/f2a4fc7c9c3cc88999ea7804e3d0adb9757bc795)), closes [#23627](https://github.com/bitnami/charts/issues/23627)
 
 ## 16.8.0 (2024-02-20)
 
-* [bitnami/*] Bump all versions (#23602) ([b70ee2a](https://github.com/bitnami/charts/commit/b70ee2a)), closes [#23602](https://github.com/bitnami/charts/issues/23602)
+* [bitnami/*] Bump all versions (#23602) ([b70ee2a](https://github.com/bitnami/charts/commit/b70ee2a30e4dc256bf0ac52928fb2fa7a70f049b)), closes [#23602](https://github.com/bitnami/charts/issues/23602)
 
 ## 16.7.0 (2024-02-14)
 
-* [bitnami/airflow] feat: :sparkles: :lock: Add resource preset support (#23413) ([1e2e8e5](https://github.com/bitnami/charts/commit/1e2e8e5)), closes [#23413](https://github.com/bitnami/charts/issues/23413)
+* [bitnami/airflow] feat: :sparkles: :lock: Add resource preset support (#23413) ([1e2e8e5](https://github.com/bitnami/charts/commit/1e2e8e5d12adb912539bc8d3982a03647ad23592)), closes [#23413](https://github.com/bitnami/charts/issues/23413)
 
 ## 16.6.0 (2024-02-14)
 
-* [bitnami/airflow] fix: :bug: Add allowExternalEgress to avoid breaking istio (#23035) ([a5c627e](https://github.com/bitnami/charts/commit/a5c627e)), closes [#23035](https://github.com/bitnami/charts/issues/23035)
+* [bitnami/airflow] fix: :bug: Add allowExternalEgress to avoid breaking istio (#23035) ([a5c627e](https://github.com/bitnami/charts/commit/a5c627e69cc74bdc8706d181b053f9e11072150b)), closes [#23035](https://github.com/bitnami/charts/issues/23035)
 
 ## <small>16.5.5 (2024-02-09)</small>
 
-* [bitnami/airflow] Release 16.5.5 updating components versions (#23361) ([a6933b0](https://github.com/bitnami/charts/commit/a6933b0)), closes [#23361](https://github.com/bitnami/charts/issues/23361)
+* [bitnami/airflow] Release 16.5.5 updating components versions (#23361) ([a6933b0](https://github.com/bitnami/charts/commit/a6933b010bec971a0e88498aa1f25f48d2b503e9)), closes [#23361](https://github.com/bitnami/charts/issues/23361)
 
 ## <small>16.5.4 (2024-02-09)</small>
 
-* [bitnami/airflow] Release 16.5.4 updating components versions (#23358) ([ea39ca7](https://github.com/bitnami/charts/commit/ea39ca7)), closes [#23358](https://github.com/bitnami/charts/issues/23358)
+* [bitnami/airflow] Release 16.5.4 updating components versions (#23358) ([ea39ca7](https://github.com/bitnami/charts/commit/ea39ca7e03fe0de75e58580e9950abf259522ffd)), closes [#23358](https://github.com/bitnami/charts/issues/23358)
 
 ## <small>16.5.3 (2024-02-02)</small>
 
-* [bitnami/airflow] Release 16.5.3 updating components versions (#23062) ([2718627](https://github.com/bitnami/charts/commit/2718627)), closes [#23062](https://github.com/bitnami/charts/issues/23062)
+* [bitnami/airflow] Release 16.5.3 updating components versions (#23062) ([2718627](https://github.com/bitnami/charts/commit/271862787036065ec7837a215dc293c6c1610a0b)), closes [#23062](https://github.com/bitnami/charts/issues/23062)
 
 ## <small>16.5.2 (2024-01-31)</small>
 
-* [bitnami/airflow] Release 16.5.2 updating components versions (#22952) ([36ec702](https://github.com/bitnami/charts/commit/36ec702)), closes [#22952](https://github.com/bitnami/charts/issues/22952)
+* [bitnami/airflow] Release 16.5.2 updating components versions (#22952) ([36ec702](https://github.com/bitnami/charts/commit/36ec7027481cf07eeb813928f9787cdbe5e5ec78)), closes [#22952](https://github.com/bitnami/charts/issues/22952)
 
 ## <small>16.5.1 (2024-01-25)</small>
 
-* [bitnami/airflow] Release 16.5.1 updating components versions (#22732) ([c1191db](https://github.com/bitnami/charts/commit/c1191db)), closes [#22732](https://github.com/bitnami/charts/issues/22732)
+* [bitnami/airflow] Release 16.5.1 updating components versions (#22732) ([c1191db](https://github.com/bitnami/charts/commit/c1191db6eec2754ab838570a93b53a37396b261c)), closes [#22732](https://github.com/bitnami/charts/issues/22732)
 
 ## 16.5.0 (2024-01-25)
 
-* [bitnami/*] Move documentation sections from docs.bitnami.com back to the README (#22203) ([7564f36](https://github.com/bitnami/charts/commit/7564f36)), closes [#22203](https://github.com/bitnami/charts/issues/22203)
-* [bitnami/airflow] feat: 🔒 Enable networkPolicy (#22673) ([37f5c44](https://github.com/bitnami/charts/commit/37f5c44)), closes [#22673](https://github.com/bitnami/charts/issues/22673)
+* [bitnami/*] Move documentation sections from docs.bitnami.com back to the README (#22203) ([7564f36](https://github.com/bitnami/charts/commit/7564f36ca1e95ff30ee686652b7ab8690561a707)), closes [#22203](https://github.com/bitnami/charts/issues/22203)
+* [bitnami/airflow] feat: 🔒 Enable networkPolicy (#22673) ([37f5c44](https://github.com/bitnami/charts/commit/37f5c4407fe36a848cd95b7f45f7037a63d556ca)), closes [#22673](https://github.com/bitnami/charts/issues/22673)
 
 ## <small>16.4.1 (2024-01-24)</small>
 
-* [bitnami/airflow] fix: :bug: Set seLinuxOptions to null for Openshift compatibility (#22565) ([067c1a2](https://github.com/bitnami/charts/commit/067c1a2)), closes [#22565](https://github.com/bitnami/charts/issues/22565)
+* [bitnami/airflow] fix: :bug: Set seLinuxOptions to null for Openshift compatibility (#22565) ([067c1a2](https://github.com/bitnami/charts/commit/067c1a2445b9d1805931a7e19b31ce23e07ea264)), closes [#22565](https://github.com/bitnami/charts/issues/22565)
 
 ## 16.4.0 (2024-01-22)
 
-* [bitnami/airflow] Add probes to scheduler (#22489) ([6bb8ede](https://github.com/bitnami/charts/commit/6bb8ede)), closes [#22489](https://github.com/bitnami/charts/issues/22489)
+* [bitnami/airflow] Add probes to scheduler (#22489) ([6bb8ede](https://github.com/bitnami/charts/commit/6bb8edeccedc5a8dc51263399e0eded57eba3f26)), closes [#22489](https://github.com/bitnami/charts/issues/22489)
 
 ## 16.3.0 (2024-01-19)
 
-* [bitnami/airflow] fix: :lock: Move service-account token auto-mount to pod declaration (#22382) ([4f1eacc](https://github.com/bitnami/charts/commit/4f1eacc)), closes [#22382](https://github.com/bitnami/charts/issues/22382)
+* [bitnami/airflow] fix: :lock: Move service-account token auto-mount to pod declaration (#22382) ([4f1eacc](https://github.com/bitnami/charts/commit/4f1eacc079c0a637e98a99c629784255979ff49e)), closes [#22382](https://github.com/bitnami/charts/issues/22382)
 
 ## <small>16.2.1 (2024-01-18)</small>
 
-* [bitnami/airflow] Release 16.2.1 updating components versions (#22268) ([a4356ba](https://github.com/bitnami/charts/commit/a4356ba)), closes [#22268](https://github.com/bitnami/charts/issues/22268)
+* [bitnami/airflow] Release 16.2.1 updating components versions (#22268) ([a4356ba](https://github.com/bitnami/charts/commit/a4356ba8bf9f8307fc759702a0c6ab293495a736)), closes [#22268](https://github.com/bitnami/charts/issues/22268)
 
 ## 16.2.0 (2024-01-16)
 
-* [bitnami/airflow] fix: :lock: Improve podSecurityContext and containerSecurityContext with essential ([af266ec](https://github.com/bitnami/charts/commit/af266ec)), closes [#22096](https://github.com/bitnami/charts/issues/22096)
+* [bitnami/airflow] fix: :lock: Improve podSecurityContext and containerSecurityContext with essential ([af266ec](https://github.com/bitnami/charts/commit/af266ec4ee9fc1b126db769ca933c56623a97045)), closes [#22096](https://github.com/bitnami/charts/issues/22096)
 
 ## <small>16.1.11 (2024-01-12)</small>
 
-* [bitnami/*] Fix docs.bitnami.com broken links (#21901) ([f35506d](https://github.com/bitnami/charts/commit/f35506d)), closes [#21901](https://github.com/bitnami/charts/issues/21901)
-* [bitnami/*] Fix ref links (in comments) (#21822) ([e4fa296](https://github.com/bitnami/charts/commit/e4fa296)), closes [#21822](https://github.com/bitnami/charts/issues/21822)
-* [bitnami/airflow] fix: :lock: Do not use the default service account (#21988) ([dc576a0](https://github.com/bitnami/charts/commit/dc576a0)), closes [#21988](https://github.com/bitnami/charts/issues/21988)
+* [bitnami/*] Fix docs.bitnami.com broken links (#21901) ([f35506d](https://github.com/bitnami/charts/commit/f35506d2dadee4f097986e7792df1f53ab215b5d)), closes [#21901](https://github.com/bitnami/charts/issues/21901)
+* [bitnami/*] Fix ref links (in comments) (#21822) ([e4fa296](https://github.com/bitnami/charts/commit/e4fa296106b225cf8c82445727c675c7c725e380)), closes [#21822](https://github.com/bitnami/charts/issues/21822)
+* [bitnami/airflow] fix: :lock: Do not use the default service account (#21988) ([dc576a0](https://github.com/bitnami/charts/commit/dc576a0bce88173cb83dbc4bae73c2dd16a8480c)), closes [#21988](https://github.com/bitnami/charts/issues/21988)
 
 ## <small>16.1.10 (2024-01-03)</small>
 
-* [bitnami/airflow] Release 16.1.10 updating components versions (#21843) ([4986592](https://github.com/bitnami/charts/commit/4986592)), closes [#21843](https://github.com/bitnami/charts/issues/21843)
+* [bitnami/airflow] Release 16.1.10 updating components versions (#21843) ([4986592](https://github.com/bitnami/charts/commit/4986592d4fe74f5e3bf0371db750aa57b9469d75)), closes [#21843](https://github.com/bitnami/charts/issues/21843)
 
 ## <small>16.1.9 (2024-01-03)</small>
 
-* [bitnami/*] Update copyright: Year and company (#21815) ([6c4bf75](https://github.com/bitnami/charts/commit/6c4bf75)), closes [#21815](https://github.com/bitnami/charts/issues/21815)
-* [bitnami/airflow] Release 16.1.9 updating components versions (#21837) ([a68d86c](https://github.com/bitnami/charts/commit/a68d86c)), closes [#21837](https://github.com/bitnami/charts/issues/21837)
+* [bitnami/*] Update copyright: Year and company (#21815) ([6c4bf75](https://github.com/bitnami/charts/commit/6c4bf75dec58fc7c9aee9f089777b1a858c17d5b)), closes [#21815](https://github.com/bitnami/charts/issues/21815)
+* [bitnami/airflow] Release 16.1.9 updating components versions (#21837) ([a68d86c](https://github.com/bitnami/charts/commit/a68d86c367925c37f51e3c2b203fd478553eb319)), closes [#21837](https://github.com/bitnami/charts/issues/21837)
 
 ## <small>16.1.8 (2023-12-28)</small>
 
-* [bitnami/airflow] Release 16.1.8 updating components versions (#21777) ([190e449](https://github.com/bitnami/charts/commit/190e449)), closes [#21777](https://github.com/bitnami/charts/issues/21777)
+* [bitnami/airflow] Release 16.1.8 updating components versions (#21777) ([190e449](https://github.com/bitnami/charts/commit/190e4493e8f966c6f83a539e538f351ef5eb1cfa)), closes [#21777](https://github.com/bitnami/charts/issues/21777)
 
 ## <small>16.1.7 (2023-12-14)</small>
 
-* [bitnami/airflow] Release 16.1.7 updating components versions (#21573) ([9164c9f](https://github.com/bitnami/charts/commit/9164c9f)), closes [#21573](https://github.com/bitnami/charts/issues/21573)
+* [bitnami/airflow] Release 16.1.7 updating components versions (#21573) ([9164c9f](https://github.com/bitnami/charts/commit/9164c9f0c58fde1b5b90641ff705ee179f35d46d)), closes [#21573](https://github.com/bitnami/charts/issues/21573)
 
 ## <small>16.1.6 (2023-11-24)</small>
 
-* [bitnami/airflow] Release 16.1.6 updating components versions (#21244) ([47a1dd5](https://github.com/bitnami/charts/commit/47a1dd5)), closes [#21244](https://github.com/bitnami/charts/issues/21244)
+* [bitnami/airflow] Release 16.1.6 updating components versions (#21244) ([47a1dd5](https://github.com/bitnami/charts/commit/47a1dd5a1dfdd2ed0d413d0338713cb3741afc1c)), closes [#21244](https://github.com/bitnami/charts/issues/21244)
 
 ## <small>16.1.5 (2023-11-22)</small>
 
-* [bitnami/airflow] Release 16.1.5 updating components versions (#21187) ([d80c2b5](https://github.com/bitnami/charts/commit/d80c2b5)), closes [#21187](https://github.com/bitnami/charts/issues/21187)
+* [bitnami/airflow] Release 16.1.5 updating components versions (#21187) ([d80c2b5](https://github.com/bitnami/charts/commit/d80c2b51e1c88889dd7d0e0af3f43a0cc3c2ac13)), closes [#21187](https://github.com/bitnami/charts/issues/21187)
 
 ## <small>16.1.4 (2023-11-21)</small>
 
-* [bitnami/*] Rename solutions to "Bitnami package for ..." (#21038) ([b82f979](https://github.com/bitnami/charts/commit/b82f979)), closes [#21038](https://github.com/bitnami/charts/issues/21038)
-* [bitnami/airflow] Release 16.1.4 updating components versions (#21092) ([f640c12](https://github.com/bitnami/charts/commit/f640c12)), closes [#21092](https://github.com/bitnami/charts/issues/21092)
+* [bitnami/*] Rename solutions to "Bitnami package for ..." (#21038) ([b82f979](https://github.com/bitnami/charts/commit/b82f979e4fb63423fe6e2192c946d09d79c944fc)), closes [#21038](https://github.com/bitnami/charts/issues/21038)
+* [bitnami/airflow] Release 16.1.4 updating components versions (#21092) ([f640c12](https://github.com/bitnami/charts/commit/f640c122fe3019b684d8641b300c9e3e9886fdbc)), closes [#21092](https://github.com/bitnami/charts/issues/21092)
 
 ## <small>16.1.3 (2023-11-20)</small>
 
-* [bitnami/*] Remove relative links to non-README sections, add verification for that and update TL;DR ([1103633](https://github.com/bitnami/charts/commit/1103633)), closes [#20967](https://github.com/bitnami/charts/issues/20967)
-* [bitnami/airflow] Improve web.baseUrl helper (#21028) ([6ec633b](https://github.com/bitnami/charts/commit/6ec633b)), closes [#21028](https://github.com/bitnami/charts/issues/21028)
+* [bitnami/*] Remove relative links to non-README sections, add verification for that and update TL;DR ([1103633](https://github.com/bitnami/charts/commit/11036334d82df0490aa4abdb591543cab6cf7d7f)), closes [#20967](https://github.com/bitnami/charts/issues/20967)
+* [bitnami/airflow] Improve web.baseUrl helper (#21028) ([6ec633b](https://github.com/bitnami/charts/commit/6ec633ba194236430b35957024e242b4373c5e58)), closes [#21028](https://github.com/bitnami/charts/issues/21028)
 
 ## <small>16.1.2 (2023-11-08)</small>
 
-* [bitnami/airflow] Release 16.1.2 updating components versions (#20693) ([c71720c](https://github.com/bitnami/charts/commit/c71720c)), closes [#20693](https://github.com/bitnami/charts/issues/20693)
+* [bitnami/airflow] Release 16.1.2 updating components versions (#20693) ([c71720c](https://github.com/bitnami/charts/commit/c71720cdabec7174379c60c757757b5649552e74)), closes [#20693](https://github.com/bitnami/charts/issues/20693)
 
 ## <small>16.1.1 (2023-11-07)</small>
 
-* [bitnami/airflow] Release 16.1.1 updating components versions (#20648) ([832abce](https://github.com/bitnami/charts/commit/832abce)), closes [#20648](https://github.com/bitnami/charts/issues/20648)
+* [bitnami/airflow] Release 16.1.1 updating components versions (#20648) ([832abce](https://github.com/bitnami/charts/commit/832abce41725a62a9ff58f69e64e6b4a8b16ebd8)), closes [#20648](https://github.com/bitnami/charts/issues/20648)
 
 ## 16.1.0 (2023-10-31)
 
-* [bitnami/airflow] feat: :sparkles: Add support for PSA restricted policy (#20378) ([6014674](https://github.com/bitnami/charts/commit/6014674)), closes [#20378](https://github.com/bitnami/charts/issues/20378)
+* [bitnami/airflow] feat: :sparkles: Add support for PSA restricted policy (#20378) ([6014674](https://github.com/bitnami/charts/commit/601467455d1c8543d453685da34672117547d62e)), closes [#20378](https://github.com/bitnami/charts/issues/20378)
 
 ## <small>16.0.7 (2023-10-24)</small>
 
-* [bitnami/*] Rename VMware Application Catalog (#20361) ([3acc734](https://github.com/bitnami/charts/commit/3acc734)), closes [#20361](https://github.com/bitnami/charts/issues/20361)
-* [bitnami/*] Skip image's tag in the README files of the Bitnami Charts (#19841) ([bb9a01b](https://github.com/bitnami/charts/commit/bb9a01b)), closes [#19841](https://github.com/bitnami/charts/issues/19841)
-* [bitnami/*] Standardize documentation (#19835) ([af5f753](https://github.com/bitnami/charts/commit/af5f753)), closes [#19835](https://github.com/bitnami/charts/issues/19835)
-* [bitnami/airflow] Release 16.0.7 updating components versions (#20391) ([18665f3](https://github.com/bitnami/charts/commit/18665f3)), closes [#20391](https://github.com/bitnami/charts/issues/20391)
+* [bitnami/*] Rename VMware Application Catalog (#20361) ([3acc734](https://github.com/bitnami/charts/commit/3acc73472beb6fb56c4d99f929061001205bc57e)), closes [#20361](https://github.com/bitnami/charts/issues/20361)
+* [bitnami/*] Skip image's tag in the README files of the Bitnami Charts (#19841) ([bb9a01b](https://github.com/bitnami/charts/commit/bb9a01b65911c87e48318db922cc05eb42785e42)), closes [#19841](https://github.com/bitnami/charts/issues/19841)
+* [bitnami/*] Standardize documentation (#19835) ([af5f753](https://github.com/bitnami/charts/commit/af5f7530c1bc8c5ded53a6c4f7b8f384ac1804f2)), closes [#19835](https://github.com/bitnami/charts/issues/19835)
+* [bitnami/airflow] Release 16.0.7 updating components versions (#20391) ([18665f3](https://github.com/bitnami/charts/commit/18665f3f62409e7993a57315ee698a80818dc602)), closes [#20391](https://github.com/bitnami/charts/issues/20391)
 
 ## <small>16.0.6 (2023-10-18)</small>
 
-* [bitnami/airflow] Update airflow-worker image including git (#20297) ([6ae316e](https://github.com/bitnami/charts/commit/6ae316e)), closes [#20297](https://github.com/bitnami/charts/issues/20297)
+* [bitnami/airflow] Update airflow-worker image including git (#20297) ([6ae316e](https://github.com/bitnami/charts/commit/6ae316e91c227201298f4a28b3128e9dc418b2c9)), closes [#20297](https://github.com/bitnami/charts/issues/20297)
 
 ## <small>16.0.5 (2023-10-14)</small>
 
-* [bitnami/airflow] Release 16.0.5 (#20238) ([d48a25e](https://github.com/bitnami/charts/commit/d48a25e)), closes [#20238](https://github.com/bitnami/charts/issues/20238)
+* [bitnami/airflow] Release 16.0.5 (#20238) ([d48a25e](https://github.com/bitnami/charts/commit/d48a25ec2d773aa54155659bea799bf3872bccbe)), closes [#20238](https://github.com/bitnami/charts/issues/20238)
 
 ## <small>16.0.4 (2023-10-12)</small>
 
-* [bitnami/airflow] Release 16.0.4 (#20198) ([350f759](https://github.com/bitnami/charts/commit/350f759)), closes [#20198](https://github.com/bitnami/charts/issues/20198)
+* [bitnami/airflow] Release 16.0.4 (#20198) ([350f759](https://github.com/bitnami/charts/commit/350f759392b2cb23805823365a158ba1765fc858)), closes [#20198](https://github.com/bitnami/charts/issues/20198)
 
 ## <small>16.0.3 (2023-10-09)</small>
 
-* [bitnami/*] Update Helm charts prerequisites (#19745) ([eb755dd](https://github.com/bitnami/charts/commit/eb755dd)), closes [#19745](https://github.com/bitnami/charts/issues/19745)
-* [bitnami/airflow] Release 16.0.3 (#19897) ([750120e](https://github.com/bitnami/charts/commit/750120e)), closes [#19897](https://github.com/bitnami/charts/issues/19897)
+* [bitnami/*] Update Helm charts prerequisites (#19745) ([eb755dd](https://github.com/bitnami/charts/commit/eb755dd36a4dd3cf6635be8e0598f9a7f4c4a554)), closes [#19745](https://github.com/bitnami/charts/issues/19745)
+* [bitnami/airflow] Release 16.0.3 (#19897) ([750120e](https://github.com/bitnami/charts/commit/750120eea97df5ab88acff52e0424291661d2699)), closes [#19897](https://github.com/bitnami/charts/issues/19897)
 
 ## <small>16.0.2 (2023-10-06)</small>
 
-* [bitnami/airflow] Release 16.0.2 (#19792) ([62bc084](https://github.com/bitnami/charts/commit/62bc084)), closes [#19792](https://github.com/bitnami/charts/issues/19792)
+* [bitnami/airflow] Release 16.0.2 (#19792) ([62bc084](https://github.com/bitnami/charts/commit/62bc084e683230075f11a9d480c7342cfcdaa416)), closes [#19792](https://github.com/bitnami/charts/issues/19792)
 
 ## <small>16.0.1 (2023-10-06)</small>
 
-* [bitnami/airflow] Release 16.0.1 (#19787) ([7999a79](https://github.com/bitnami/charts/commit/7999a79)), closes [#19787](https://github.com/bitnami/charts/issues/19787)
+* [bitnami/airflow] Release 16.0.1 (#19787) ([7999a79](https://github.com/bitnami/charts/commit/7999a79b9d0b52fb6016fbe20a23c9db2c21d9aa)), closes [#19787](https://github.com/bitnami/charts/issues/19787)
 
 ## 16.0.0 (2023-09-29)
 
-* [bitnami/airflow] Update dependencies(#19609) ([02f1d8e](https://github.com/bitnami/charts/commit/02f1d8e)), closes [#19609](https://github.com/bitnami/charts/issues/19609)
+* [bitnami/airflow] Update dependencies(#19609) ([02f1d8e](https://github.com/bitnami/charts/commit/02f1d8ec59eaccb5364f3a9875eb91480293c2ba)), closes [#19609](https://github.com/bitnami/charts/issues/19609)
 
 ## <small>15.0.7 (2023-09-22)</small>
 
-* [bitnami/airflow] Release 15.0.7 (#19473) ([e56518b](https://github.com/bitnami/charts/commit/e56518b)), closes [#19473](https://github.com/bitnami/charts/issues/19473)
+* [bitnami/airflow] Release 15.0.7 (#19473) ([e56518b](https://github.com/bitnami/charts/commit/e56518bb74a1efbeca9c7a496fcb40d24e94427a)), closes [#19473](https://github.com/bitnami/charts/issues/19473)
 
 ## <small>15.0.6 (2023-09-20)</small>
 
-* [bitnami/airflow] Release 15.0.6 (#19250) ([27b21df](https://github.com/bitnami/charts/commit/27b21df)), closes [#19250](https://github.com/bitnami/charts/issues/19250)
+* [bitnami/airflow] Release 15.0.6 (#19250) ([27b21df](https://github.com/bitnami/charts/commit/27b21df42d37a80a8c1bb47a5e0a44147cf7dd95)), closes [#19250](https://github.com/bitnami/charts/issues/19250)
 
 ## <small>15.0.5 (2023-09-18)</small>
 
-* [bitnami/airflow] Use different app.kubernetes.io/version label on subcomponents (#19324) ([e8970e9](https://github.com/bitnami/charts/commit/e8970e9)), closes [#19324](https://github.com/bitnami/charts/issues/19324)
-* Autogenerate schema files (#19194) ([a2c2090](https://github.com/bitnami/charts/commit/a2c2090)), closes [#19194](https://github.com/bitnami/charts/issues/19194)
-* Revert "Autogenerate schema files (#19194)" (#19335) ([73d80be](https://github.com/bitnami/charts/commit/73d80be)), closes [#19194](https://github.com/bitnami/charts/issues/19194) [#19335](https://github.com/bitnami/charts/issues/19335)
+* [bitnami/airflow] Use different app.kubernetes.io/version label on subcomponents (#19324) ([e8970e9](https://github.com/bitnami/charts/commit/e8970e93c78b0d24113903d5be8a6a8fbe007c4f)), closes [#19324](https://github.com/bitnami/charts/issues/19324)
+* Autogenerate schema files (#19194) ([a2c2090](https://github.com/bitnami/charts/commit/a2c2090b5ac97f47b745c8028c6452bf99739772)), closes [#19194](https://github.com/bitnami/charts/issues/19194)
+* Revert "Autogenerate schema files (#19194)" (#19335) ([73d80be](https://github.com/bitnami/charts/commit/73d80be525c88fb4b8a54451a55acd506e337062)), closes [#19194](https://github.com/bitnami/charts/issues/19194) [#19335](https://github.com/bitnami/charts/issues/19335)
 
 ## <small>15.0.4 (2023-09-07)</small>
 
-* [bitnami/airflow] Release 15.0.4 (#19183) ([2b5ee45](https://github.com/bitnami/charts/commit/2b5ee45)), closes [#19183](https://github.com/bitnami/charts/issues/19183)
+* [bitnami/airflow] Release 15.0.4 (#19183) ([2b5ee45](https://github.com/bitnami/charts/commit/2b5ee4533bef8773e1b62a45d074b0f83ae7f56e)), closes [#19183](https://github.com/bitnami/charts/issues/19183)
 
 ## <small>15.0.3 (2023-09-07)</small>
 
-* [bitnami/airflow: Use merge helper]: (#19018) ([d5cfa86](https://github.com/bitnami/charts/commit/d5cfa86)), closes [#19018](https://github.com/bitnami/charts/issues/19018)
+* [bitnami/airflow: Use merge helper]: (#19018) ([d5cfa86](https://github.com/bitnami/charts/commit/d5cfa860a1c817a75c1bfd5b5d4351bf8f0bffc8)), closes [#19018](https://github.com/bitnami/charts/issues/19018)
 
 ## <small>15.0.2 (2023-08-28)</small>
 
-* [bitnami/airflow] Release 15.0.2 (#18917) ([1e148a6](https://github.com/bitnami/charts/commit/1e148a6)), closes [#18917](https://github.com/bitnami/charts/issues/18917)
+* [bitnami/airflow] Release 15.0.2 (#18917) ([1e148a6](https://github.com/bitnami/charts/commit/1e148a60265741af98c97605964b48f64a246abc)), closes [#18917](https://github.com/bitnami/charts/issues/18917)
 
 ## <small>15.0.1 (2023-08-28)</small>
 
-* [bitnami/airflow] Release 15.0.1 (#18904) ([03335b7](https://github.com/bitnami/charts/commit/03335b7)), closes [#18904](https://github.com/bitnami/charts/issues/18904)
+* [bitnami/airflow] Release 15.0.1 (#18904) ([03335b7](https://github.com/bitnami/charts/commit/03335b7ecb67fe700359545e2aeb4da884e4bef4)), closes [#18904](https://github.com/bitnami/charts/issues/18904)
 
 ## 15.0.0 (2023-08-28)
 
-* [bitnami/airflow] Update Redis' subchart (#18895) ([e8d19bf](https://github.com/bitnami/charts/commit/e8d19bf)), closes [#18895](https://github.com/bitnami/charts/issues/18895)
+* [bitnami/airflow] Update Redis' subchart (#18895) ([e8d19bf](https://github.com/bitnami/charts/commit/e8d19bfdcc9e8c2462542b6c57ca19321fe5132c)), closes [#18895](https://github.com/bitnami/charts/issues/18895)
 
 ## 14.4.0 (2023-08-25)
 
-* [bitnami/airflow] Support for customizing standard labels (#18455) ([441ff99](https://github.com/bitnami/charts/commit/441ff99)), closes [#18455](https://github.com/bitnami/charts/issues/18455)
+* [bitnami/airflow] Support for customizing standard labels (#18455) ([441ff99](https://github.com/bitnami/charts/commit/441ff99f8717a6dfe854c72f8291b6bc0186caa1)), closes [#18455](https://github.com/bitnami/charts/issues/18455)
 
 ## <small>14.3.6 (2023-08-17)</small>
 
-* [bitnami/airflow] Release 14.3.6 (#18495) ([d69d38e](https://github.com/bitnami/charts/commit/d69d38e)), closes [#18495](https://github.com/bitnami/charts/issues/18495)
+* [bitnami/airflow] Release 14.3.6 (#18495) ([d69d38e](https://github.com/bitnami/charts/commit/d69d38e45ef20253913d090970eac4652f7557aa)), closes [#18495](https://github.com/bitnami/charts/issues/18495)
 
 ## <small>14.3.5 (2023-07-25)</small>
 
-* [bitnami/airflow] Release 14.3.5 (#17855) ([683c452](https://github.com/bitnami/charts/commit/683c452)), closes [#17855](https://github.com/bitnami/charts/issues/17855)
+* [bitnami/airflow] Release 14.3.5 (#17855) ([683c452](https://github.com/bitnami/charts/commit/683c45255d099d5a96689a4a8ee0f094bcbf520a)), closes [#17855](https://github.com/bitnami/charts/issues/17855)
 
 ## <small>14.3.4 (2023-07-17)</small>
 
-* [bitnami/airflow] Updates the git container version (#17728) ([85f0b50](https://github.com/bitnami/charts/commit/85f0b50)), closes [#17728](https://github.com/bitnami/charts/issues/17728)
+* [bitnami/airflow] Updates the git container version (#17728) ([85f0b50](https://github.com/bitnami/charts/commit/85f0b50e32d81f4720af678ff096ff3d1907472a)), closes [#17728](https://github.com/bitnami/charts/issues/17728)
 
 ## <small>14.3.3 (2023-07-13)</small>
 
-* [bitnami/airflow] Release 14.3.3 (#17696) ([0224506](https://github.com/bitnami/charts/commit/0224506)), closes [#17696](https://github.com/bitnami/charts/issues/17696)
+* [bitnami/airflow] Release 14.3.3 (#17696) ([0224506](https://github.com/bitnami/charts/commit/02245068138c31d97f4784a79f6b6a83c11bd413)), closes [#17696](https://github.com/bitnami/charts/issues/17696)
 
 ## <small>14.3.2 (2023-07-13)</small>
 
-* [bitnami/airflow] Release 14.3.2 (#17631) ([6830bcd](https://github.com/bitnami/charts/commit/6830bcd)), closes [#17631](https://github.com/bitnami/charts/issues/17631)
-* Use os-shell in tempate and Jaeger runtime params (#17557) ([91a49eb](https://github.com/bitnami/charts/commit/91a49eb)), closes [#17557](https://github.com/bitnami/charts/issues/17557)
+* [bitnami/airflow] Release 14.3.2 (#17631) ([6830bcd](https://github.com/bitnami/charts/commit/6830bcd1f4c7d82c98ccffdaf9db3e72fce4a7b4)), closes [#17631](https://github.com/bitnami/charts/issues/17631)
+* Use os-shell in tempate and Jaeger runtime params (#17557) ([91a49eb](https://github.com/bitnami/charts/commit/91a49eb1e3c81c7b7c6c28d1bc5d6d6ae698c1e2)), closes [#17557](https://github.com/bitnami/charts/issues/17557)
 
 ## <small>14.3.1 (2023-07-11)</small>
 
-* [bitnami/airflow] Release 14.3.1 (#17548) ([66f665f](https://github.com/bitnami/charts/commit/66f665f)), closes [#17548](https://github.com/bitnami/charts/issues/17548)
+* [bitnami/airflow] Release 14.3.1 (#17548) ([66f665f](https://github.com/bitnami/charts/commit/66f665f30051abd5d36b3529b5c36fafe0cc83a6)), closes [#17548](https://github.com/bitnami/charts/issues/17548)
 
 ## 14.3.0 (2023-07-04)
 
-* [bitnami/*] Change copyright section in READMEs (#17006) ([ef986a1](https://github.com/bitnami/charts/commit/ef986a1)), closes [#17006](https://github.com/bitnami/charts/issues/17006)
-* [bitnami/airflow] Release 14.3.0 (#17163) ([f19249b](https://github.com/bitnami/charts/commit/f19249b)), closes [#17163](https://github.com/bitnami/charts/issues/17163)
-* [bitnami/several] Change copyright section in READMEs (#16989) ([5b6a5cf](https://github.com/bitnami/charts/commit/5b6a5cf)), closes [#16989](https://github.com/bitnami/charts/issues/16989)
-* Add copyright header (#17300) ([da68be8](https://github.com/bitnami/charts/commit/da68be8)), closes [#17300](https://github.com/bitnami/charts/issues/17300)
-* Update charts readme (#17217) ([31b3c0a](https://github.com/bitnami/charts/commit/31b3c0a)), closes [#17217](https://github.com/bitnami/charts/issues/17217)
+* [bitnami/*] Change copyright section in READMEs (#17006) ([ef986a1](https://github.com/bitnami/charts/commit/ef986a1605241102b3dcafe9fd8089e6fc1201ad)), closes [#17006](https://github.com/bitnami/charts/issues/17006)
+* [bitnami/airflow] Release 14.3.0 (#17163) ([f19249b](https://github.com/bitnami/charts/commit/f19249b642bf88aac316c7e7f3c372e964158d43)), closes [#17163](https://github.com/bitnami/charts/issues/17163)
+* [bitnami/several] Change copyright section in READMEs (#16989) ([5b6a5cf](https://github.com/bitnami/charts/commit/5b6a5cfb7625a751848a2e5cd796bd7278f406ca)), closes [#16989](https://github.com/bitnami/charts/issues/16989)
+* Add copyright header (#17300) ([da68be8](https://github.com/bitnami/charts/commit/da68be8e951225133c7dfb572d5101ca3d61c5ae)), closes [#17300](https://github.com/bitnami/charts/issues/17300)
+* Update charts readme (#17217) ([31b3c0a](https://github.com/bitnami/charts/commit/31b3c0afd968ff4429107e34101f7509e6a0e913)), closes [#17217](https://github.com/bitnami/charts/issues/17217)
 
 ## <small>14.2.5 (2023-05-31)</small>
 
-* [bitnami/airflow] Release 14.2.5 (#16973) ([0470848](https://github.com/bitnami/charts/commit/0470848)), closes [#16973](https://github.com/bitnami/charts/issues/16973)
+* [bitnami/airflow] Release 14.2.5 (#16973) ([0470848](https://github.com/bitnami/charts/commit/04708485cdc77cf2a44eafe52616d1c4fa5ebb71)), closes [#16973](https://github.com/bitnami/charts/issues/16973)
 
 ## <small>14.2.4 (2023-05-21)</small>
 
-* [bitnami/airflow] Release 14.2.4 (#16825) ([f58db25](https://github.com/bitnami/charts/commit/f58db25)), closes [#16825](https://github.com/bitnami/charts/issues/16825)
+* [bitnami/airflow] Release 14.2.4 (#16825) ([f58db25](https://github.com/bitnami/charts/commit/f58db2591cba761b9b5827c9c530161ff206e724)), closes [#16825](https://github.com/bitnami/charts/issues/16825)
 
 ## <small>14.2.3 (2023-05-18)</small>
 
-* [bitnami/airflow] Release 14.2.3 (#16735) ([b3fcf53](https://github.com/bitnami/charts/commit/b3fcf53)), closes [#16735](https://github.com/bitnami/charts/issues/16735)
+* [bitnami/airflow] Release 14.2.3 (#16735) ([b3fcf53](https://github.com/bitnami/charts/commit/b3fcf5353f575da7c88eca082298dd33521810e2)), closes [#16735](https://github.com/bitnami/charts/issues/16735)
 
 ## <small>14.2.2 (2023-05-16)</small>
 
-* [bitnami/airflow] Release 14.2.2 (#16696) ([17cd804](https://github.com/bitnami/charts/commit/17cd804)), closes [#16696](https://github.com/bitnami/charts/issues/16696)
+* [bitnami/airflow] Release 14.2.2 (#16696) ([17cd804](https://github.com/bitnami/charts/commit/17cd8040fac99e89e05fd71500eae363d773b6ba)), closes [#16696](https://github.com/bitnami/charts/issues/16696)
 
 ## <small>14.2.1 (2023-05-15)</small>
 
-* [bitnami/airflow] Release 14.2.1 (#16657) ([71e547f](https://github.com/bitnami/charts/commit/71e547f)), closes [#16657](https://github.com/bitnami/charts/issues/16657)
-* Add wording for enterprise page (#16560) ([8f22774](https://github.com/bitnami/charts/commit/8f22774)), closes [#16560](https://github.com/bitnami/charts/issues/16560)
+* [bitnami/airflow] Release 14.2.1 (#16657) ([71e547f](https://github.com/bitnami/charts/commit/71e547fb5f5bf0e738b9e71b961bde9b3122e3d6)), closes [#16657](https://github.com/bitnami/charts/issues/16657)
+* Add wording for enterprise page (#16560) ([8f22774](https://github.com/bitnami/charts/commit/8f2277440b976d52785ba9149762ad8620a73d1f)), closes [#16560](https://github.com/bitnami/charts/issues/16560)
 
 ## 14.2.0 (2023-05-09)
 
-* [bitnami/several] Adapt Chart.yaml to set desired OCI annotations (#16546) ([fc9b18f](https://github.com/bitnami/charts/commit/fc9b18f)), closes [#16546](https://github.com/bitnami/charts/issues/16546)
+* [bitnami/several] Adapt Chart.yaml to set desired OCI annotations (#16546) ([fc9b18f](https://github.com/bitnami/charts/commit/fc9b18f2e98805d4df629acbcde696f44f973344)), closes [#16546](https://github.com/bitnami/charts/issues/16546)
 
 ## <small>14.1.3 (2023-05-09)</small>
 
-* [bitnami/airflow] Release 14.1.3 (#16445) ([e6ea76a](https://github.com/bitnami/charts/commit/e6ea76a)), closes [#16445](https://github.com/bitnami/charts/issues/16445)
+* [bitnami/airflow] Release 14.1.3 (#16445) ([e6ea76a](https://github.com/bitnami/charts/commit/e6ea76a15d0cc81339e1abe89c21e12bd4824240)), closes [#16445](https://github.com/bitnami/charts/issues/16445)
 
 ## <small>14.1.2 (2023-05-04)</small>
 
-* [bitnami/airflow] Release 14.1.2 (#16372) ([89ef044](https://github.com/bitnami/charts/commit/89ef044)), closes [#16372](https://github.com/bitnami/charts/issues/16372)
+* [bitnami/airflow] Release 14.1.2 (#16372) ([89ef044](https://github.com/bitnami/charts/commit/89ef0447b436082368e1561e897b980c8ea03abd)), closes [#16372](https://github.com/bitnami/charts/issues/16372)
 
 ## <small>14.1.1 (2023-05-01)</small>
 
-* [bitnami/airflow] Release 14.1.1 (#16312) ([8864174](https://github.com/bitnami/charts/commit/8864174)), closes [#16312](https://github.com/bitnami/charts/issues/16312)
+* [bitnami/airflow] Release 14.1.1 (#16312) ([8864174](https://github.com/bitnami/charts/commit/8864174a691a744a5ff6ddbb93320d36b243d252)), closes [#16312](https://github.com/bitnami/charts/issues/16312)
 
 ## 14.1.0 (2023-04-20)
 
-* [bitnami/*] Make Helm charts 100% OCI (#15998) ([8841510](https://github.com/bitnami/charts/commit/8841510)), closes [#15998](https://github.com/bitnami/charts/issues/15998)
+* [bitnami/*] Make Helm charts 100% OCI (#15998) ([8841510](https://github.com/bitnami/charts/commit/884151035efcbf2e1b3206e7def85511073fb57d)), closes [#15998](https://github.com/bitnami/charts/issues/15998)
 
 ## <small>14.0.17 (2023-04-01)</small>
 
-* [bitnami/airflow] Release 14.0.17 (#15890) ([5397b42](https://github.com/bitnami/charts/commit/5397b42)), closes [#15890](https://github.com/bitnami/charts/issues/15890)
+* [bitnami/airflow] Release 14.0.17 (#15890) ([5397b42](https://github.com/bitnami/charts/commit/5397b4299cc4a4c95cd670ebd4656a4144456bef)), closes [#15890](https://github.com/bitnami/charts/issues/15890)
 
 ## <small>14.0.16 (2023-03-17)</small>
 
-* [bitnami/airflow] Release 14.0.16 (#15546) ([6216c29](https://github.com/bitnami/charts/commit/6216c29)), closes [#15546](https://github.com/bitnami/charts/issues/15546)
+* [bitnami/airflow] Release 14.0.16 (#15546) ([6216c29](https://github.com/bitnami/charts/commit/6216c299412ddf1402aa53d8d79da0c21a67c32d)), closes [#15546](https://github.com/bitnami/charts/issues/15546)
 
 ## <small>14.0.15 (2023-03-16)</small>
 
-* [bitnami/airflow] Release 14.0.15 (#15506) ([23b5136](https://github.com/bitnami/charts/commit/23b5136)), closes [#15506](https://github.com/bitnami/charts/issues/15506)
+* [bitnami/airflow] Release 14.0.15 (#15506) ([23b5136](https://github.com/bitnami/charts/commit/23b51365bff9c9d9301a8d377facb1ff7f282a99)), closes [#15506](https://github.com/bitnami/charts/issues/15506)
 
 ## <small>14.0.14 (2023-03-08)</small>
 
-* [bitnami/airflow] Release 14.0.14 (#15391) ([98c8a6e](https://github.com/bitnami/charts/commit/98c8a6e)), closes [#15391](https://github.com/bitnami/charts/issues/15391)
-* [bitnami/charts] Apply linter to README files (#15357) ([0e29e60](https://github.com/bitnami/charts/commit/0e29e60)), closes [#15357](https://github.com/bitnami/charts/issues/15357)
+* [bitnami/airflow] Release 14.0.14 (#15391) ([98c8a6e](https://github.com/bitnami/charts/commit/98c8a6e93c91216beaaca87269f95bc52eecf87c)), closes [#15391](https://github.com/bitnami/charts/issues/15391)
+* [bitnami/charts] Apply linter to README files (#15357) ([0e29e60](https://github.com/bitnami/charts/commit/0e29e600d3adc8b1b46e506eccb3decfab3b4e63)), closes [#15357](https://github.com/bitnami/charts/issues/15357)
 
 ## <small>14.0.13 (2023-03-01)</small>
 
-* [bitnami/airflow] Release 14.0.13 (#15189) ([47cf7a8](https://github.com/bitnami/charts/commit/47cf7a8)), closes [#15189](https://github.com/bitnami/charts/issues/15189)
+* [bitnami/airflow] Release 14.0.13 (#15189) ([47cf7a8](https://github.com/bitnami/charts/commit/47cf7a8ba6d3dbf65e788f30591000747316f81c)), closes [#15189](https://github.com/bitnami/charts/issues/15189)
 
 ## <small>14.0.12 (2023-02-17)</small>
 
-* [bitnami/*] Fix markdown linter issues (#14874) ([a51e0e8](https://github.com/bitnami/charts/commit/a51e0e8)), closes [#14874](https://github.com/bitnami/charts/issues/14874)
-* [bitnami/*] Fix markdown linter issues 2 (#14890) ([aa96572](https://github.com/bitnami/charts/commit/aa96572)), closes [#14890](https://github.com/bitnami/charts/issues/14890)
-* [bitnami/*] Remove unexpected extra spaces (#14873) ([c97c714](https://github.com/bitnami/charts/commit/c97c714)), closes [#14873](https://github.com/bitnami/charts/issues/14873)
-* [bitnami/airflow] Release 14.0.12 (#14950) ([8aa80ae](https://github.com/bitnami/charts/commit/8aa80ae)), closes [#14950](https://github.com/bitnami/charts/issues/14950)
+* [bitnami/*] Fix markdown linter issues (#14874) ([a51e0e8](https://github.com/bitnami/charts/commit/a51e0e8d35495b907f3e70dd2f8e7c3bcbf4166a)), closes [#14874](https://github.com/bitnami/charts/issues/14874)
+* [bitnami/*] Fix markdown linter issues 2 (#14890) ([aa96572](https://github.com/bitnami/charts/commit/aa9657237ee8df4a46db0d7fdf8a23230dd6902a)), closes [#14890](https://github.com/bitnami/charts/issues/14890)
+* [bitnami/*] Remove unexpected extra spaces (#14873) ([c97c714](https://github.com/bitnami/charts/commit/c97c714887380d47eae7bfeff316bf01595ecd1d)), closes [#14873](https://github.com/bitnami/charts/issues/14873)
+* [bitnami/airflow] Release 14.0.12 (#14950) ([8aa80ae](https://github.com/bitnami/charts/commit/8aa80aeffd2ebef71324aadc5f5c0ae606b2dea8)), closes [#14950](https://github.com/bitnami/charts/issues/14950)
 
 ## <small>14.0.11 (2023-02-02)</small>
 
-* [bitnami/airflow] Release 14.0.11 (#14724) ([3853113](https://github.com/bitnami/charts/commit/3853113)), closes [#14724](https://github.com/bitnami/charts/issues/14724)
+* [bitnami/airflow] Release 14.0.11 (#14724) ([3853113](https://github.com/bitnami/charts/commit/38531131cbe25ee9e3b947171baf6e4887b9d268)), closes [#14724](https://github.com/bitnami/charts/issues/14724)
 
 ## <small>14.0.10 (2023-01-31)</small>
 
-* [bitnami/*] Change copyright date (#14682) ([add4ec7](https://github.com/bitnami/charts/commit/add4ec7)), closes [#14682](https://github.com/bitnami/charts/issues/14682)
-* [bitnami/airflow] Don't regenerate self-signed certs on upgrade (#14605) ([ea61b7f](https://github.com/bitnami/charts/commit/ea61b7f)), closes [#14605](https://github.com/bitnami/charts/issues/14605)
+* [bitnami/*] Change copyright date (#14682) ([add4ec7](https://github.com/bitnami/charts/commit/add4ec701108ac36ed4de2dffbdf407a0d091067)), closes [#14682](https://github.com/bitnami/charts/issues/14682)
+* [bitnami/airflow] Don't regenerate self-signed certs on upgrade (#14605) ([ea61b7f](https://github.com/bitnami/charts/commit/ea61b7f07c1583941cfff0d25a46edc17eadcf9b)), closes [#14605](https://github.com/bitnami/charts/issues/14605)
 
 ## <small>14.0.9 (2023-01-26)</small>
 
-* [bitnami/airflow] Release 14.0.9 (#14551) ([679879c](https://github.com/bitnami/charts/commit/679879c)), closes [#14551](https://github.com/bitnami/charts/issues/14551)
+* [bitnami/airflow] Release 14.0.9 (#14551) ([679879c](https://github.com/bitnami/charts/commit/679879cbdc59fe660569dcb854d631b21ebb9f87)), closes [#14551](https://github.com/bitnami/charts/issues/14551)
 
 ## <small>14.0.8 (2023-01-21)</small>
 
-* [bitnami/*] Add license annotation and remove obsolete engine parameter (#14293) ([da2a794](https://github.com/bitnami/charts/commit/da2a794)), closes [#14293](https://github.com/bitnami/charts/issues/14293)
-* [bitnami/*] Change licenses annotation format (#14377) ([0ab7608](https://github.com/bitnami/charts/commit/0ab7608)), closes [#14377](https://github.com/bitnami/charts/issues/14377)
-* [bitnami/*] Unify READMEs (#14472) ([2064fb8](https://github.com/bitnami/charts/commit/2064fb8)), closes [#14472](https://github.com/bitnami/charts/issues/14472)
-* [bitnami/airflow] Release 14.0.8 (#14484) ([0ddda22](https://github.com/bitnami/charts/commit/0ddda22)), closes [#14484](https://github.com/bitnami/charts/issues/14484)
+* [bitnami/*] Add license annotation and remove obsolete engine parameter (#14293) ([da2a794](https://github.com/bitnami/charts/commit/da2a7943bae95b6e9b5b4ed972c15e990b69fdb0)), closes [#14293](https://github.com/bitnami/charts/issues/14293)
+* [bitnami/*] Change licenses annotation format (#14377) ([0ab7608](https://github.com/bitnami/charts/commit/0ab760862c660fcc78cffadf8e1d8cdd70881473)), closes [#14377](https://github.com/bitnami/charts/issues/14377)
+* [bitnami/*] Unify READMEs (#14472) ([2064fb8](https://github.com/bitnami/charts/commit/2064fb8dcc78a845cdede8211af8c3cc52551161)), closes [#14472](https://github.com/bitnami/charts/issues/14472)
+* [bitnami/airflow] Release 14.0.8 (#14484) ([0ddda22](https://github.com/bitnami/charts/commit/0ddda22efa473b68b7177099f4e4ddf8fde6a7d3)), closes [#14484](https://github.com/bitnami/charts/issues/14484)
 
 ## <small>14.0.7 (2023-01-09)</small>
 
-* [bitnami/airflow] Release 14.0.7 (#14223) ([64eb74e](https://github.com/bitnami/charts/commit/64eb74e)), closes [#14223](https://github.com/bitnami/charts/issues/14223)
+* [bitnami/airflow] Release 14.0.7 (#14223) ([64eb74e](https://github.com/bitnami/charts/commit/64eb74eee33dafb6563d6e7f72c42cee8ecefa99)), closes [#14223](https://github.com/bitnami/charts/issues/14223)
 
 ## <small>14.0.6 (2022-12-10)</small>
 
-* [bitnami/airflow] Release 14.0.6 (#13888) ([49cc63e](https://github.com/bitnami/charts/commit/49cc63e)), closes [#13888](https://github.com/bitnami/charts/issues/13888)
+* [bitnami/airflow] Release 14.0.6 (#13888) ([49cc63e](https://github.com/bitnami/charts/commit/49cc63ea131c11e291b9b8829c4b83f5e3cb117e)), closes [#13888](https://github.com/bitnami/charts/issues/13888)
 
 ## <small>14.0.5 (2022-12-09)</small>
 
-* [bitnami/airflow] Release 14.0.5 (#13879) ([d44979b](https://github.com/bitnami/charts/commit/d44979b)), closes [#13879](https://github.com/bitnami/charts/issues/13879)
+* [bitnami/airflow] Release 14.0.5 (#13879) ([d44979b](https://github.com/bitnami/charts/commit/d44979b86a05b6687271931a28a5154bb47cacc0)), closes [#13879](https://github.com/bitnami/charts/issues/13879)
 
 ## <small>14.0.4 (2022-11-29)</small>
 
-* [bitnami/airflow] Release 14.0.4 (#13748) ([5379598](https://github.com/bitnami/charts/commit/5379598)), closes [#13748](https://github.com/bitnami/charts/issues/13748)
+* [bitnami/airflow] Release 14.0.4 (#13748) ([5379598](https://github.com/bitnami/charts/commit/5379598745bd50d3044a6a664d86dcee418d8d96)), closes [#13748](https://github.com/bitnami/charts/issues/13748)
 
 ## <small>14.0.3 (2022-11-10)</small>
 
-* [bitnami/airflow] Release 14.0.3 (#13440) ([3970c29](https://github.com/bitnami/charts/commit/3970c29)), closes [#13440](https://github.com/bitnami/charts/issues/13440)
+* [bitnami/airflow] Release 14.0.3 (#13440) ([3970c29](https://github.com/bitnami/charts/commit/3970c29f2bdf08fab00bb802519f1b311c46d105)), closes [#13440](https://github.com/bitnami/charts/issues/13440)
 
 ## <small>14.0.2 (2022-11-02)</small>
 
-* [bitnami/airflow] change apiversion hardcode for airflow (#13261) ([47794d1](https://github.com/bitnami/charts/commit/47794d1)), closes [#13261](https://github.com/bitnami/charts/issues/13261)
+* [bitnami/airflow] change apiversion hardcode for airflow (#13261) ([47794d1](https://github.com/bitnami/charts/commit/47794d1ae06e9111bf2586fdeab82565923145b2)), closes [#13261](https://github.com/bitnami/charts/issues/13261)
 
 ## <small>14.0.1 (2022-10-28)</small>
 
-* [bitnami/airflow] Release 13.1.8 (#13194) ([607b8ea](https://github.com/bitnami/charts/commit/607b8ea)), closes [#13194](https://github.com/bitnami/charts/issues/13194)
+* [bitnami/airflow] Release 13.1.8 (#13194) ([607b8ea](https://github.com/bitnami/charts/commit/607b8eabe536086aa5ae778533dc9faf161c17e7)), closes [#13194](https://github.com/bitnami/charts/issues/13194)
 
 ## 14.0.0 (2022-10-28)
 
-* [bitnami/*] Use new default branch name in links (#12943) ([a529e02](https://github.com/bitnami/charts/commit/a529e02)), closes [#12943](https://github.com/bitnami/charts/issues/12943)
-* [bitnami/airflow] Update dependencies (#13217) ([da7739d](https://github.com/bitnami/charts/commit/da7739d)), closes [#13217](https://github.com/bitnami/charts/issues/13217)
+* [bitnami/*] Use new default branch name in links (#12943) ([a529e02](https://github.com/bitnami/charts/commit/a529e02597d49d944eba1eb0f190713293247176)), closes [#12943](https://github.com/bitnami/charts/issues/12943)
+* [bitnami/airflow] Update dependencies (#13217) ([da7739d](https://github.com/bitnami/charts/commit/da7739d9915743b51bdb471f1088fcf3282f5304)), closes [#13217](https://github.com/bitnami/charts/issues/13217)
 
 ## <small>13.1.7 (2022-10-14)</small>
 
-* [bitnami/airflow] Release 13.1.7 (#12956) ([92d8d4e](https://github.com/bitnami/charts/commit/92d8d4e)), closes [#12956](https://github.com/bitnami/charts/issues/12956)
-* Generic README instructions related to the repo (#12792) ([3cf6b10](https://github.com/bitnami/charts/commit/3cf6b10)), closes [#12792](https://github.com/bitnami/charts/issues/12792)
+* [bitnami/airflow] Release 13.1.7 (#12956) ([92d8d4e](https://github.com/bitnami/charts/commit/92d8d4ed8eea8e5fa346321440bce23f0536ec41)), closes [#12956](https://github.com/bitnami/charts/issues/12956)
+* Generic README instructions related to the repo (#12792) ([3cf6b10](https://github.com/bitnami/charts/commit/3cf6b10e10e60df4b3e191d6b99aa99a9f597755)), closes [#12792](https://github.com/bitnami/charts/issues/12792)
 
 ## <small>13.1.6 (2022-09-21)</small>
 
-* [bitnami/airflow] Use custom probes if given (#12437) ([68dd34f](https://github.com/bitnami/charts/commit/68dd34f)), closes [#12437](https://github.com/bitnami/charts/issues/12437) [#12354](https://github.com/bitnami/charts/issues/12354)
+* [bitnami/airflow] Use custom probes if given (#12437) ([68dd34f](https://github.com/bitnami/charts/commit/68dd34f2c187cf9de61b5483f4bdeed1fecd73f8)), closes [#12437](https://github.com/bitnami/charts/issues/12437) [#12354](https://github.com/bitnami/charts/issues/12354)
 
 ## <small>13.1.5 (2022-09-14)</small>
 
-* [bitnami/airflow] Release 13.1.5 (#12425) ([d7696c2](https://github.com/bitnami/charts/commit/d7696c2)), closes [#12425](https://github.com/bitnami/charts/issues/12425)
+* [bitnami/airflow] Release 13.1.5 (#12425) ([d7696c2](https://github.com/bitnami/charts/commit/d7696c240258344e051881f64e58fe60f9f76c71)), closes [#12425](https://github.com/bitnami/charts/issues/12425)
 
 ## <small>13.1.4 (2022-09-07)</small>
 
-* [bitnami/airflow] Release 13.1.4 (#12318) ([7873472](https://github.com/bitnami/charts/commit/7873472)), closes [#12318](https://github.com/bitnami/charts/issues/12318)
+* [bitnami/airflow] Release 13.1.4 (#12318) ([7873472](https://github.com/bitnami/charts/commit/7873472d9165d38046c134759dc507f89253760e)), closes [#12318](https://github.com/bitnami/charts/issues/12318)
 
 ## <small>13.1.3 (2022-08-25)</small>
 
-* [bitnami/airflow] Release 13.1.3 (#12157) ([94fc713](https://github.com/bitnami/charts/commit/94fc713)), closes [#12157](https://github.com/bitnami/charts/issues/12157)
+* [bitnami/airflow] Release 13.1.3 (#12157) ([94fc713](https://github.com/bitnami/charts/commit/94fc713a43f6328c33e1a2fd4fe9b33ac0f41542)), closes [#12157](https://github.com/bitnami/charts/issues/12157)
 
 ## <small>13.1.2 (2022-08-24)</small>
 
-* [bitnami/airflow] Release 13.1.2 (#12131) ([46ec370](https://github.com/bitnami/charts/commit/46ec370)), closes [#12131](https://github.com/bitnami/charts/issues/12131)
+* [bitnami/airflow] Release 13.1.2 (#12131) ([46ec370](https://github.com/bitnami/charts/commit/46ec370fd80bb2a0f95a374172ea93c43a64f9c1)), closes [#12131](https://github.com/bitnami/charts/issues/12131)
 
 ## <small>13.1.1 (2022-08-23)</small>
 
-* [bitnami/airflow] Update Chart.lock (#12105) ([5e5c00a](https://github.com/bitnami/charts/commit/5e5c00a)), closes [#12105](https://github.com/bitnami/charts/issues/12105)
+* [bitnami/airflow] Update Chart.lock (#12105) ([5e5c00a](https://github.com/bitnami/charts/commit/5e5c00a38e4eeb5fa68a0858615d2e22a84f38e1)), closes [#12105](https://github.com/bitnami/charts/issues/12105)
 
 ## 13.1.0 (2022-08-22)
 
-* [bitnami/airflow] Add support for image digest apart from tag (#11865) ([ce75441](https://github.com/bitnami/charts/commit/ce75441)), closes [#11865](https://github.com/bitnami/charts/issues/11865)
+* [bitnami/airflow] Add support for image digest apart from tag (#11865) ([ce75441](https://github.com/bitnami/charts/commit/ce75441d895f2aaa5cd9dfc8f960141f4c4cd03e)), closes [#11865](https://github.com/bitnami/charts/issues/11865)
 
 ## <small>13.0.5 (2022-08-18)</small>
 
-* [bitnami/airflow] Release 13.0.5 (#11820) ([e805bb3](https://github.com/bitnami/charts/commit/e805bb3)), closes [#11820](https://github.com/bitnami/charts/issues/11820)
+* [bitnami/airflow] Release 13.0.5 (#11820) ([e805bb3](https://github.com/bitnami/charts/commit/e805bb3396d4f7e2f9734da67fe9decf09d11e71)), closes [#11820](https://github.com/bitnami/charts/issues/11820)
 
 ## <small>13.0.4 (2022-08-09)</small>
 
-* [bitnami/airflow] Release 13.0.4 (#11649) ([a545d2b](https://github.com/bitnami/charts/commit/a545d2b)), closes [#11649](https://github.com/bitnami/charts/issues/11649)
+* [bitnami/airflow] Release 13.0.4 (#11649) ([a545d2b](https://github.com/bitnami/charts/commit/a545d2bc7573e630ed3fb730f05c648aadd29ddf)), closes [#11649](https://github.com/bitnami/charts/issues/11649)
 
 ## <small>13.0.3 (2022-08-06)</small>
 
-* [bitnami/airflow] Release 13.0.3 (#11622) ([77065ff](https://github.com/bitnami/charts/commit/77065ff)), closes [#11622](https://github.com/bitnami/charts/issues/11622)
+* [bitnami/airflow] Release 13.0.3 (#11622) ([77065ff](https://github.com/bitnami/charts/commit/77065ff3d924dede1b0251e20e236201d86dcdd0)), closes [#11622](https://github.com/bitnami/charts/issues/11622)
 
 ## <small>13.0.2 (2022-08-05)</small>
 
-* [bitnami/airflow] Git permission error in Airflow Helm chart (#11559) ([e0697a7](https://github.com/bitnami/charts/commit/e0697a7)), closes [#11559](https://github.com/bitnami/charts/issues/11559)
+* [bitnami/airflow] Git permission error in Airflow Helm chart (#11559) ([e0697a7](https://github.com/bitnami/charts/commit/e0697a7d31ad87abbfe0ea83f797ce5aef2140a6)), closes [#11559](https://github.com/bitnami/charts/issues/11559)
 
 ## <small>13.0.1 (2022-08-03)</small>
 
-* [bitnami/*] Update URLs to point to the new bitnami/containers monorepo (#11352) ([d665af0](https://github.com/bitnami/charts/commit/d665af0)), closes [#11352](https://github.com/bitnami/charts/issues/11352)
-* [bitnami/airflow] Release 13.0.1 (#11518) ([d6e08a0](https://github.com/bitnami/charts/commit/d6e08a0)), closes [#11518](https://github.com/bitnami/charts/issues/11518)
+* [bitnami/*] Update URLs to point to the new bitnami/containers monorepo (#11352) ([d665af0](https://github.com/bitnami/charts/commit/d665af0c708846192d8d5fb2f5f9ea65dd464ab0)), closes [#11352](https://github.com/bitnami/charts/issues/11352)
+* [bitnami/airflow] Release 13.0.1 (#11518) ([d6e08a0](https://github.com/bitnami/charts/commit/d6e08a061e99731ddde0c574b673846fc578a9d1)), closes [#11518](https://github.com/bitnami/charts/issues/11518)
 
 ## 13.0.0 (2022-07-13)
 
-* [bitnami/airflow] Update Redis subchart (#11173) ([41ca524](https://github.com/bitnami/charts/commit/41ca524)), closes [#11173](https://github.com/bitnami/charts/issues/11173)
+* [bitnami/airflow] Update Redis subchart (#11173) ([41ca524](https://github.com/bitnami/charts/commit/41ca524a84ea11eb101fe22db11d6c8eb8a6d490)), closes [#11173](https://github.com/bitnami/charts/issues/11173)
 
 ## <small>12.5.13 (2022-07-11)</small>
 
-* [bitnami/airflow] Release 12.5.13 (#11106) ([d1c3a7b](https://github.com/bitnami/charts/commit/d1c3a7b)), closes [#11106](https://github.com/bitnami/charts/issues/11106)
+* [bitnami/airflow] Release 12.5.13 (#11106) ([d1c3a7b](https://github.com/bitnami/charts/commit/d1c3a7b7ee4016b440827a86dab1ca5bf44c8fbb)), closes [#11106](https://github.com/bitnami/charts/issues/11106)
 
 ## <small>12.5.12 (2022-07-04)</small>
 
-* [bitnami/airflow] Release 12.5.12 (#11023) ([6362b3e](https://github.com/bitnami/charts/commit/6362b3e)), closes [#11023](https://github.com/bitnami/charts/issues/11023)
-* [bitnami/airflow] update contains args order (#10894) ([a44e476](https://github.com/bitnami/charts/commit/a44e476)), closes [#10894](https://github.com/bitnami/charts/issues/10894)
+* [bitnami/airflow] Release 12.5.12 (#11023) ([6362b3e](https://github.com/bitnami/charts/commit/6362b3eabb692573438d1d352fe3bd8113d9e3c1)), closes [#11023](https://github.com/bitnami/charts/issues/11023)
+* [bitnami/airflow] update contains args order (#10894) ([a44e476](https://github.com/bitnami/charts/commit/a44e476880fcca7c8c11207e6efa48adb7273503)), closes [#10894](https://github.com/bitnami/charts/issues/10894)
 
 ## <small>12.5.11 (2022-06-30)</small>
 
-* [bitnami/airflow] Release 12.5.11 (#10964) ([e545862](https://github.com/bitnami/charts/commit/e545862)), closes [#10964](https://github.com/bitnami/charts/issues/10964)
+* [bitnami/airflow] Release 12.5.11 (#10964) ([e545862](https://github.com/bitnami/charts/commit/e545862d120a4598c97a8fd29049d548683a0922)), closes [#10964](https://github.com/bitnami/charts/issues/10964)
 
 ## <small>12.5.10 (2022-06-25)</small>
 
-* [bitnami/airflow] Allows for LocalKubernetesExecutor to be used, as added in Airflow 2.3 (#10659) (# ([535ab03](https://github.com/bitnami/charts/commit/535ab03)), closes [#10659](https://github.com/bitnami/charts/issues/10659) [#10799](https://github.com/bitnami/charts/issues/10799) [#10659](https://github.com/bitnami/charts/issues/10659)
-* [bitnami/airflow] Release 12.5.10 updating components versions ([b906cb6](https://github.com/bitnami/charts/commit/b906cb6))
+* [bitnami/airflow] Allows for LocalKubernetesExecutor to be used, as added in Airflow 2.3 (#10659) (# ([535ab03](https://github.com/bitnami/charts/commit/535ab03fdd58cfe14e3953b1d8e3e65efbef214b)), closes [#10659](https://github.com/bitnami/charts/issues/10659) [#10799](https://github.com/bitnami/charts/issues/10799) [#10659](https://github.com/bitnami/charts/issues/10659)
+* [bitnami/airflow] Release 12.5.10 updating components versions ([b906cb6](https://github.com/bitnami/charts/commit/b906cb6b01965fe0130572bc63dff6a72bea50f3))
 
 ## <small>12.5.9 (2022-06-20)</small>
 
-* [bitnami/airflow] Release 12.5.9 updating components versions ([5196f8a](https://github.com/bitnami/charts/commit/5196f8a))
+* [bitnami/airflow] Release 12.5.9 updating components versions ([5196f8a](https://github.com/bitnami/charts/commit/5196f8aeda48208c94cab988020e64fa8bc88764))
 
 ## <small>12.5.8 (2022-06-14)</small>
 
-* worker podTemplate's configmap rendered using common.tplvalues.render (#10723) ([0b45ef7](https://github.com/bitnami/charts/commit/0b45ef7)), closes [#10723](https://github.com/bitnami/charts/issues/10723)
+* worker podTemplate's configmap rendered using common.tplvalues.render (#10723) ([0b45ef7](https://github.com/bitnami/charts/commit/0b45ef7ed3971af804471582b4a0fdf38dda554c)), closes [#10723](https://github.com/bitnami/charts/issues/10723)
 
 ## <small>12.5.7 (2022-06-10)</small>
 
-* [bitnami/airflow] Release 12.5.7 updating components versions ([8ec4740](https://github.com/bitnami/charts/commit/8ec4740))
+* [bitnami/airflow] Release 12.5.7 updating components versions ([8ec4740](https://github.com/bitnami/charts/commit/8ec4740905a0dbb6d2e554cc073dfdf0999e7719))
 
 ## <small>12.5.6 (2022-06-08)</small>
 
-* [bitnami/*] Replace Kubeapps URL in READMEs (and kubeapps Chart.yaml) and remove BKPR references (#1 ([c6a7914](https://github.com/bitnami/charts/commit/c6a7914)), closes [#10600](https://github.com/bitnami/charts/issues/10600)
-* [bitnami/airflow] Fix topologySpreadConstraints default values (#10622) ([4cb7f5c](https://github.com/bitnami/charts/commit/4cb7f5c)), closes [#10622](https://github.com/bitnami/charts/issues/10622)
+* [bitnami/*] Replace Kubeapps URL in READMEs (and kubeapps Chart.yaml) and remove BKPR references (#1 ([c6a7914](https://github.com/bitnami/charts/commit/c6a7914361e5aea6016fb45bf4d621edfd111d32)), closes [#10600](https://github.com/bitnami/charts/issues/10600)
+* [bitnami/airflow] Fix topologySpreadConstraints default values (#10622) ([4cb7f5c](https://github.com/bitnami/charts/commit/4cb7f5c05a490ddb945772fc502b6cbe20e7c030)), closes [#10622](https://github.com/bitnami/charts/issues/10622)
 
 ## <small>12.5.5 (2022-06-06)</small>
 
-* [bitnami/airflow] Release 12.5.5 updating components versions ([087b159](https://github.com/bitnami/charts/commit/087b159))
+* [bitnami/airflow] Release 12.5.5 updating components versions ([087b159](https://github.com/bitnami/charts/commit/087b159ffb26000f5dfbf77f632b9c618c584215))
 
 ## <small>12.5.4 (2022-06-04)</small>
 
-* [bitnami/airflow] Release 12.5.4 updating components versions ([7d41614](https://github.com/bitnami/charts/commit/7d41614))
+* [bitnami/airflow] Release 12.5.4 updating components versions ([7d41614](https://github.com/bitnami/charts/commit/7d41614a6e43ff6118a4310a3e72cf230bce94a8))
 
 ## <small>12.5.3 (2022-06-03)</small>
 
-* [bitnami/airflow] Release 12.5.3 updating components versions ([f0e91e0](https://github.com/bitnami/charts/commit/f0e91e0))
+* [bitnami/airflow] Release 12.5.3 updating components versions ([f0e91e0](https://github.com/bitnami/charts/commit/f0e91e0fe359398dabbb548950d0824c217289e8))
 
 ## <small>12.5.2 (2022-06-02)</small>
 
-* Update Redis trademark references ([2cada87](https://github.com/bitnami/charts/commit/2cada87))
+* Update Redis trademark references ([2cada87](https://github.com/bitnami/charts/commit/2cada87ed4967d5cb578b0409a0bb1edee79029a))
 
 ## <small>12.5.1 (2022-06-01)</small>
 
-* [bitnami/several] Replace maintainers email by url (#10523) ([ff3cf61](https://github.com/bitnami/charts/commit/ff3cf61)), closes [#10523](https://github.com/bitnami/charts/issues/10523)
+* [bitnami/several] Replace maintainers email by url (#10523) ([ff3cf61](https://github.com/bitnami/charts/commit/ff3cf617a1680509b0f3855d17c4ccff7b29a0ff)), closes [#10523](https://github.com/bitnami/charts/issues/10523)
 
 ## 12.5.0 (2022-05-30)
 
-* [bitnami/airflow] Standardise ldap options (#10415) ([6d1b305](https://github.com/bitnami/charts/commit/6d1b305)), closes [#10415](https://github.com/bitnami/charts/issues/10415)
+* [bitnami/airflow] Standardise ldap options (#10415) ([6d1b305](https://github.com/bitnami/charts/commit/6d1b305b77a9eeb37973d29ee9fa70681b135681)), closes [#10415](https://github.com/bitnami/charts/issues/10415)
 
 ## 12.4.0 (2022-05-27)
 
-* [bitnami/airflow] Add missing service parameter (#10402) ([793381b](https://github.com/bitnami/charts/commit/793381b)), closes [#10402](https://github.com/bitnami/charts/issues/10402)
+* [bitnami/airflow] Add missing service parameter (#10402) ([793381b](https://github.com/bitnami/charts/commit/793381b431df55a9a02679359624e09c3fc5641e)), closes [#10402](https://github.com/bitnami/charts/issues/10402)
 
 ## <small>12.3.9 (2022-05-27)</small>
 
-* Add missing command and args to chart (#10341) ([503f008](https://github.com/bitnami/charts/commit/503f008)), closes [#10341](https://github.com/bitnami/charts/issues/10341)
+* Add missing command and args to chart (#10341) ([503f008](https://github.com/bitnami/charts/commit/503f008aefef015dac471a5cb1ee3be330601609)), closes [#10341](https://github.com/bitnami/charts/issues/10341)
 
 ## <small>12.3.8 (2022-05-26)</small>
 
-* [bitnami/airflow] Use the new helper for HPA API version (#10191) ([a282df1](https://github.com/bitnami/charts/commit/a282df1)), closes [#10191](https://github.com/bitnami/charts/issues/10191)
+* [bitnami/airflow] Use the new helper for HPA API version (#10191) ([a282df1](https://github.com/bitnami/charts/commit/a282df190b8f41dcf22c349ad01270f156ea6e32)), closes [#10191](https://github.com/bitnami/charts/issues/10191)
 
 ## <small>12.3.7 (2022-05-25)</small>
 
-* [bitnami/airflow] Release 12.3.7 updating components versions ([93e3a9e](https://github.com/bitnami/charts/commit/93e3a9e))
+* [bitnami/airflow] Release 12.3.7 updating components versions ([93e3a9e](https://github.com/bitnami/charts/commit/93e3a9eef29db6076bda1c89b4c1287916c26d9a))
 
 ## <small>12.3.6 (2022-05-22)</small>
 
-* [bitnami/airflow] Release 12.3.6 updating components versions ([1003549](https://github.com/bitnami/charts/commit/1003549))
+* [bitnami/airflow] Release 12.3.6 updating components versions ([1003549](https://github.com/bitnami/charts/commit/1003549688ec58bdc04f607495893696d08666fb))
 
 ## <small>12.3.5 (2022-05-21)</small>
 
-* [bitnami/airflow] Release 12.3.5 updating components versions ([aa1fc09](https://github.com/bitnami/charts/commit/aa1fc09))
+* [bitnami/airflow] Release 12.3.5 updating components versions ([aa1fc09](https://github.com/bitnami/charts/commit/aa1fc09dacb7bc064512f410c29abbf6dd95fcfe))
 
 ## <small>12.3.4 (2022-05-20)</small>
 
-* [bitnami/*] Fix HPA API version template usage (#10332) ([85ce7af](https://github.com/bitnami/charts/commit/85ce7af)), closes [#10332](https://github.com/bitnami/charts/issues/10332)
+* [bitnami/*] Fix HPA API version template usage (#10332) ([85ce7af](https://github.com/bitnami/charts/commit/85ce7af79a6a44d8b90e4907064ca77efe7c8288)), closes [#10332](https://github.com/bitnami/charts/issues/10332)
 
 ## <small>12.3.3 (2022-05-19)</small>
 
-* [bitnami/airflow] Release 12.3.3 updating components versions ([05b1e73](https://github.com/bitnami/charts/commit/05b1e73))
+* [bitnami/airflow] Release 12.3.3 updating components versions ([05b1e73](https://github.com/bitnami/charts/commit/05b1e73601b4e007188929d0efe6456ba2c69c02))
 
 ## <small>12.3.2 (2022-05-19)</small>
 
-* [bitnami/airflow] Release 12.3.2 updating components versions ([52cd618](https://github.com/bitnami/charts/commit/52cd618))
+* [bitnami/airflow] Release 12.3.2 updating components versions ([52cd618](https://github.com/bitnami/charts/commit/52cd61818328cbed0b1534e104596fa853571fb7))
 
 ## <small>12.3.1 (2022-05-18)</small>
 
-* [bitnami/airflow] Release 12.3.1 updating components versions ([715cb29](https://github.com/bitnami/charts/commit/715cb29))
+* [bitnami/airflow] Release 12.3.1 updating components versions ([715cb29](https://github.com/bitnami/charts/commit/715cb2995933eaaf6434c69accf9e1aa43c9d70e))
 
 ## 12.3.0 (2022-05-16)
 
-* [bitnami/*] add ingress extraRules feature (#10253) ([0f6cbb9](https://github.com/bitnami/charts/commit/0f6cbb9)), closes [#10253](https://github.com/bitnami/charts/issues/10253)
+* [bitnami/*] add ingress extraRules feature (#10253) ([0f6cbb9](https://github.com/bitnami/charts/commit/0f6cbb9099b0e56685cc1d36ba50340f3d7278a1)), closes [#10253](https://github.com/bitnami/charts/issues/10253)
 
 ## <small>12.2.4 (2022-05-13)</small>
 
-* [bitnami/*] Remove old 'ci' files (#10171) ([5df30c4](https://github.com/bitnami/charts/commit/5df30c4)), closes [#10171](https://github.com/bitnami/charts/issues/10171)
-* [bitnami/*] Unify k8s directives separators (#10185) ([2650214](https://github.com/bitnami/charts/commit/2650214)), closes [#10185](https://github.com/bitnami/charts/issues/10185)
+* [bitnami/*] Remove old 'ci' files (#10171) ([5df30c4](https://github.com/bitnami/charts/commit/5df30c44dbd1812da8786579ce4a94917d46a6ad)), closes [#10171](https://github.com/bitnami/charts/issues/10171)
+* [bitnami/*] Unify k8s directives separators (#10185) ([2650214](https://github.com/bitnami/charts/commit/26502141d146ca3bdfb3bf744fcdec8ca5cece44)), closes [#10185](https://github.com/bitnami/charts/issues/10185)
 
 ## <small>12.2.3 (2022-05-12)</small>
 
-* [bitnami/*] Fix typo in comments (relay -> rely) (#10151) ([9cfe4a4](https://github.com/bitnami/charts/commit/9cfe4a4)), closes [#10151](https://github.com/bitnami/charts/issues/10151)
-* [bitnami/airflow] Add missing namespace metadata (#10096) ([fd3164c](https://github.com/bitnami/charts/commit/fd3164c)), closes [#10096](https://github.com/bitnami/charts/issues/10096)
+* [bitnami/*] Fix typo in comments (relay -> rely) (#10151) ([9cfe4a4](https://github.com/bitnami/charts/commit/9cfe4a48cc35851faea6be7ffb2a978d223befa0)), closes [#10151](https://github.com/bitnami/charts/issues/10151)
+* [bitnami/airflow] Add missing namespace metadata (#10096) ([fd3164c](https://github.com/bitnami/charts/commit/fd3164c23aab94d3dc0364e30c2fd092e4ab0a1e)), closes [#10096](https://github.com/bitnami/charts/issues/10096)
 
 ## <small>12.2.2 (2022-05-10)</small>
 
-* [bitnami/airflow] fix: Implement intended behavior for terminationGracePeriodSeconds (#10089) ([a919f82](https://github.com/bitnami/charts/commit/a919f82)), closes [#10089](https://github.com/bitnami/charts/issues/10089)
+* [bitnami/airflow] fix: Implement intended behavior for terminationGracePeriodSeconds (#10089) ([a919f82](https://github.com/bitnami/charts/commit/a919f82c4333956f940c84c2bdfb2cf88a8201bb)), closes [#10089](https://github.com/bitnami/charts/issues/10089)
 
 ## <small>12.2.1 (2022-04-21)</small>
 
-* [bitnami/airflow] Release 12.2.1 updating components versions ([60258f0](https://github.com/bitnami/charts/commit/60258f0))
+* [bitnami/airflow] Release 12.2.1 updating components versions ([60258f0](https://github.com/bitnami/charts/commit/60258f077b0dc6c88d53323ef724fcf30d4ec122))
 
 ## 12.2.0 (2022-04-20)
 
-* [bitnami/airflow] feat: Airflow extraEnvVarsSecrets list (#9794) ([eee4360](https://github.com/bitnami/charts/commit/eee4360)), closes [#9794](https://github.com/bitnami/charts/issues/9794)
+* [bitnami/airflow] feat: Airflow extraEnvVarsSecrets list (#9794) ([eee4360](https://github.com/bitnami/charts/commit/eee43602a4521d77dd70de19b7265ed3d559d555)), closes [#9794](https://github.com/bitnami/charts/issues/9794)
 
 ## <small>12.1.10 (2022-04-20)</small>
 
-* [bitnami/airflow] Release 12.1.10 updating components versions ([def65b7](https://github.com/bitnami/charts/commit/def65b7))
+* [bitnami/airflow] Release 12.1.10 updating components versions ([def65b7](https://github.com/bitnami/charts/commit/def65b7a75f4f964e11ec162a6e9450a5b3155f6))
 
 ## <small>12.1.9 (2022-04-19)</small>
 
-* [bitnami/airflow] Release 12.1.9 updating components versions ([2d03447](https://github.com/bitnami/charts/commit/2d03447))
+* [bitnami/airflow] Release 12.1.9 updating components versions ([2d03447](https://github.com/bitnami/charts/commit/2d03447e725558178c59a70551b004a7c0651758))
 
 ## <small>12.1.8 (2022-04-12)</small>
 
-* Add expected .Values.extraEnvVarsSecret behavior to (#9764) ([8ac1f72](https://github.com/bitnami/charts/commit/8ac1f72)), closes [#9764](https://github.com/bitnami/charts/issues/9764)
+* Add expected .Values.extraEnvVarsSecret behavior to (#9764) ([8ac1f72](https://github.com/bitnami/charts/commit/8ac1f72a802f713b4613b57a53137489206a1cf3)), closes [#9764](https://github.com/bitnami/charts/issues/9764)
 
 ## <small>12.1.7 (2022-04-11)</small>
 
-* [bitnami/airflow] condition to accept extraEnvVarsCM added in the chart templates (#9760) ([4909611](https://github.com/bitnami/charts/commit/4909611)), closes [#9760](https://github.com/bitnami/charts/issues/9760)
+* [bitnami/airflow] condition to accept extraEnvVarsCM added in the chart templates (#9760) ([4909611](https://github.com/bitnami/charts/commit/490961133cc7e8609e657be3753f3845a1b0e405)), closes [#9760](https://github.com/bitnami/charts/issues/9760)
 
 ## <small>12.1.6 (2022-04-07)</small>
 
-* [bitnami/airflow] Release 12.1.6 updating components versions ([f9cea2f](https://github.com/bitnami/charts/commit/f9cea2f))
+* [bitnami/airflow] Release 12.1.6 updating components versions ([f9cea2f](https://github.com/bitnami/charts/commit/f9cea2f26f6d8d0f046fdfb69725fff68034bf3f))
 
 ## <small>12.1.5 (2022-04-06)</small>
 
-* [bitnami/airflow] Release 12.1.5 updating components versions ([9b7efc8](https://github.com/bitnami/charts/commit/9b7efc8))
+* [bitnami/airflow] Release 12.1.5 updating components versions ([9b7efc8](https://github.com/bitnami/charts/commit/9b7efc8b7b0164f2753077efe27b5c3d1b02de7a))
 
 ## <small>12.1.4 (2022-04-05)</small>
 
-* [bitnami/airflow] Release 12.1.4 updating components versions ([18b4d52](https://github.com/bitnami/charts/commit/18b4d52))
+* [bitnami/airflow] Release 12.1.4 updating components versions ([18b4d52](https://github.com/bitnami/charts/commit/18b4d525122db533989ca19e28dbd0e61f977c21))
 
 ## <small>12.1.3 (2022-04-03)</small>
 
-* [bitnami/airflow] Release 12.1.3 updating components versions ([bb9807e](https://github.com/bitnami/charts/commit/bb9807e))
+* [bitnami/airflow] Release 12.1.3 updating components versions ([bb9807e](https://github.com/bitnami/charts/commit/bb9807ec594a0e101bb6dc2a13cd82d3802ae4f9))
 
 ## <small>12.1.2 (2022-04-02)</small>
 
-* [bitnami/airflow] Release 12.1.2 updating components versions ([2a03eb3](https://github.com/bitnami/charts/commit/2a03eb3))
+* [bitnami/airflow] Release 12.1.2 updating components versions ([2a03eb3](https://github.com/bitnami/charts/commit/2a03eb3a4512c91b8c69f7087f19c2f9f57d32a0))
 
 ## <small>12.1.1 (2022-03-29)</small>
 
-* [bitnami/airflow] Release 12.1.1 updating components versions ([e068303](https://github.com/bitnami/charts/commit/e068303))
+* [bitnami/airflow] Release 12.1.1 updating components versions ([e068303](https://github.com/bitnami/charts/commit/e0683032ca8a2a935646ce46fa6e68c6f8b71779))
 
 ## 12.1.0 (2022-03-29)
 
-* [bitnami/airflow] Add common values for all pods (#9599) ([e105499](https://github.com/bitnami/charts/commit/e105499)), closes [#9599](https://github.com/bitnami/charts/issues/9599)
+* [bitnami/airflow] Add common values for all pods (#9599) ([e105499](https://github.com/bitnami/charts/commit/e1054996fff2b88857d57cd4beaba64adf150b4f)), closes [#9599](https://github.com/bitnami/charts/issues/9599)
 
 ## <small>12.0.16 (2022-03-28)</small>
 
-* [bitnami/airflow] Release 12.0.16 updating components versions ([1ec7768](https://github.com/bitnami/charts/commit/1ec7768))
+* [bitnami/airflow] Release 12.0.16 updating components versions ([1ec7768](https://github.com/bitnami/charts/commit/1ec77686c34a4458ca5460b1052e144957b81c49))
 
 ## <small>12.0.15 (2022-03-27)</small>
 
-* [bitnami/airflow] Release 12.0.15 updating components versions ([ac86143](https://github.com/bitnami/charts/commit/ac86143))
+* [bitnami/airflow] Release 12.0.15 updating components versions ([ac86143](https://github.com/bitnami/charts/commit/ac861432d59ec4bd36f321830bffb20ec7341951))
 
 ## <small>12.0.14 (2022-03-18)</small>
 
-* [bitnami/airflow] Release 12.0.14 updating components versions ([0dcef68](https://github.com/bitnami/charts/commit/0dcef68))
+* [bitnami/airflow] Release 12.0.14 updating components versions ([0dcef68](https://github.com/bitnami/charts/commit/0dcef68545330156ce714832d18a22bdd6ef1765))
 
 ## <small>12.0.13 (2022-03-17)</small>
 
-* [bitnami/airflow] Release 12.0.13 updating components versions ([c625ade](https://github.com/bitnami/charts/commit/c625ade))
+* [bitnami/airflow] Release 12.0.13 updating components versions ([c625ade](https://github.com/bitnami/charts/commit/c625adec6f9bcf5ef48d0c3f5623ff30e5793c29))
 
 ## <small>12.0.12 (2022-03-16)</small>
 
-* [bitnami/airflow] Release 12.0.12 updating components versions ([d399f87](https://github.com/bitnami/charts/commit/d399f87))
+* [bitnami/airflow] Release 12.0.12 updating components versions ([d399f87](https://github.com/bitnami/charts/commit/d399f876ffe4cc6dc315090e55ef1fc5523cbb8e))
 
 ## <small>12.0.11 (2022-03-15)</small>
 
-* [bitnami/airflow] Fix typo in container port (#9411) ([6998b02](https://github.com/bitnami/charts/commit/6998b02)), closes [#9411](https://github.com/bitnami/charts/issues/9411)
+* [bitnami/airflow] Fix typo in container port (#9411) ([6998b02](https://github.com/bitnami/charts/commit/6998b0212e4f8a6531a8afa696164de6113c44fd)), closes [#9411](https://github.com/bitnami/charts/issues/9411)
 
 ## <small>12.0.10 (2022-03-09)</small>
 
-* [bitnami/airflow] Release 12.0.10 updating components versions ([a07f6a9](https://github.com/bitnami/charts/commit/a07f6a9))
+* [bitnami/airflow] Release 12.0.10 updating components versions ([a07f6a9](https://github.com/bitnami/charts/commit/a07f6a9daa10b6f1779a69fa8dd5cb03256b95bf))
 
 ## <small>12.0.9 (2022-03-07)</small>
 
-* [bitnami/airflow] Fix git containers security context (#9239) ([c353b59](https://github.com/bitnami/charts/commit/c353b59)), closes [#9239](https://github.com/bitnami/charts/issues/9239)
+* [bitnami/airflow] Fix git containers security context (#9239) ([c353b59](https://github.com/bitnami/charts/commit/c353b59c08c1e3026efff64d8d6d8561f0836670)), closes [#9239](https://github.com/bitnami/charts/issues/9239)
 
 ## <small>12.0.8 (2022-03-04)</small>
 
-* [bitnami/several] Reorder subcharts (#9299) ([a041f6b](https://github.com/bitnami/charts/commit/a041f6b)), closes [#9299](https://github.com/bitnami/charts/issues/9299)
+* [bitnami/several] Reorder subcharts (#9299) ([a041f6b](https://github.com/bitnami/charts/commit/a041f6b0ff2dea82b3d030cb99454cede94dbc9a)), closes [#9299](https://github.com/bitnami/charts/issues/9299)
 
 ## <small>12.0.7 (2022-03-01)</small>
 
-* [bitnami/airflow] Release 12.0.7 updating components versions ([9608b76](https://github.com/bitnami/charts/commit/9608b76))
+* [bitnami/airflow] Release 12.0.7 updating components versions ([9608b76](https://github.com/bitnami/charts/commit/9608b76bc9bb3dc7192729c9b6f244737c59a688))
 
 ## <small>12.0.6 (2022-02-27)</small>
 
-* [bitnami/airflow] Release 12.0.6 updating components versions ([385312f](https://github.com/bitnami/charts/commit/385312f))
+* [bitnami/airflow] Release 12.0.6 updating components versions ([385312f](https://github.com/bitnami/charts/commit/385312f5bb1afdd782a2a44c36c5b92db3034907))
 
 ## <small>12.0.5 (2022-02-21)</small>
 
-* [bitnami/airflow] Do not hardcode PDB apiVersion (#9088) ([5d747ef](https://github.com/bitnami/charts/commit/5d747ef)), closes [#9088](https://github.com/bitnami/charts/issues/9088)
+* [bitnami/airflow] Do not hardcode PDB apiVersion (#9088) ([5d747ef](https://github.com/bitnami/charts/commit/5d747efe8ed7669288c2883ebb8b7d36b091e272)), closes [#9088](https://github.com/bitnami/charts/issues/9088)
 
 ## <small>12.0.4 (2022-02-20)</small>
 
-* [bitnami/airflow] Release 12.0.4 updating components versions ([df16451](https://github.com/bitnami/charts/commit/df16451))
+* [bitnami/airflow] Release 12.0.4 updating components versions ([df16451](https://github.com/bitnami/charts/commit/df16451f53b25e6660cc0b631fc6acd82f609dba))
 
 ## <small>12.0.3 (2022-02-19)</small>
 
-* [bitnami/airflow] Release 12.0.3 updating components versions ([d062aaa](https://github.com/bitnami/charts/commit/d062aaa))
+* [bitnami/airflow] Release 12.0.3 updating components versions ([d062aaa](https://github.com/bitnami/charts/commit/d062aaac3f52e568454d72e0b71d9d16bfadaba8))
 
 ## <small>12.0.2 (2022-02-18)</small>
 
-* Fix template errors when enabling dags (#9057) ([d59fa20](https://github.com/bitnami/charts/commit/d59fa20)), closes [#9057](https://github.com/bitnami/charts/issues/9057)
+* Fix template errors when enabling dags (#9057) ([d59fa20](https://github.com/bitnami/charts/commit/d59fa20006f03d7212ac598a463b81909880955b)), closes [#9057](https://github.com/bitnami/charts/issues/9057)
 
 ## <small>12.0.1 (2022-02-10)</small>
 
-* [bitnami/airflow] Fix for custom service port (#8963) ([996d75b](https://github.com/bitnami/charts/commit/996d75b)), closes [#8963](https://github.com/bitnami/charts/issues/8963)
+* [bitnami/airflow] Fix for custom service port (#8963) ([996d75b](https://github.com/bitnami/charts/commit/996d75ba26077d6cf889e8f046f1b7b674d705d0)), closes [#8963](https://github.com/bitnami/charts/issues/8963)
 
 ## 12.0.0 (2022-02-09)
 
-* [bitnami/airflow] Chart standardization (#8909) ([6746686](https://github.com/bitnami/charts/commit/6746686)), closes [#8909](https://github.com/bitnami/charts/issues/8909)
-* Non utf8 chars (#8923) ([6ffd18f](https://github.com/bitnami/charts/commit/6ffd18f)), closes [#8923](https://github.com/bitnami/charts/issues/8923)
+* [bitnami/airflow] Chart standardization (#8909) ([6746686](https://github.com/bitnami/charts/commit/67466863795fb6c50fdce30c9c2d5b7b2f5ea687)), closes [#8909](https://github.com/bitnami/charts/issues/8909)
+* Non utf8 chars (#8923) ([6ffd18f](https://github.com/bitnami/charts/commit/6ffd18fbbdf10e94ea1a90cf5b84ef610ac2a72d)), closes [#8923](https://github.com/bitnami/charts/issues/8923)
 
 ## <small>11.4.2 (2022-02-04)</small>
 
-* [bitnami/airflow] Release 11.4.2 updating components versions ([fd78a9b](https://github.com/bitnami/charts/commit/fd78a9b))
+* [bitnami/airflow] Release 11.4.2 updating components versions ([fd78a9b](https://github.com/bitnami/charts/commit/fd78a9b306a82ef0d30418b5b47db45c254cf07b))
 
 ## <small>11.4.1 (2022-01-25)</small>
 
-* [bitnami/airflow] Add 'patch' verb to pod (#8777) ([17e711f](https://github.com/bitnami/charts/commit/17e711f)), closes [#8777](https://github.com/bitnami/charts/issues/8777)
+* [bitnami/airflow] Add 'patch' verb to pod (#8777) ([17e711f](https://github.com/bitnami/charts/commit/17e711f09a7c1cbd9517a4bb6da94fe5041c75fc)), closes [#8777](https://github.com/bitnami/charts/issues/8777)
 
 ## 11.4.0 (2022-01-21)
 
-* [bitnami/airflow] Add volumeClaimTemplates for Worker StatefulSet (#8711) ([1198cba](https://github.com/bitnami/charts/commit/1198cba)), closes [#8711](https://github.com/bitnami/charts/issues/8711)
+* [bitnami/airflow] Add volumeClaimTemplates for Worker StatefulSet (#8711) ([1198cba](https://github.com/bitnami/charts/commit/1198cbaa0cf68b0b5231dc4f911f9ac3c14f1bb6)), closes [#8711](https://github.com/bitnami/charts/issues/8711)
 
 ## <small>11.3.1 (2022-01-20)</small>
 
-* [bitnami/*] Readme automation (#8579) ([78d1938](https://github.com/bitnami/charts/commit/78d1938)), closes [#8579](https://github.com/bitnami/charts/issues/8579)
-* [bitnami/*] Update READMEs (#8716) ([b9a9533](https://github.com/bitnami/charts/commit/b9a9533)), closes [#8716](https://github.com/bitnami/charts/issues/8716)
-* [bitnami/several] Change prerequisites (#8725) ([8d740c5](https://github.com/bitnami/charts/commit/8d740c5)), closes [#8725](https://github.com/bitnami/charts/issues/8725)
+* [bitnami/*] Readme automation (#8579) ([78d1938](https://github.com/bitnami/charts/commit/78d193831c900d178198491ffd08fa2217a64ecd)), closes [#8579](https://github.com/bitnami/charts/issues/8579)
+* [bitnami/*] Update READMEs (#8716) ([b9a9533](https://github.com/bitnami/charts/commit/b9a953337590eb2979453385874a267bacf50936)), closes [#8716](https://github.com/bitnami/charts/issues/8716)
+* [bitnami/several] Change prerequisites (#8725) ([8d740c5](https://github.com/bitnami/charts/commit/8d740c566cfdb7e2d933c40128b4e919fce953a5)), closes [#8725](https://github.com/bitnami/charts/issues/8725)
 
 ## 11.3.0 (2022-01-12)
 
-* Add ingressClassName parameter (#8627) ([6cc9eb4](https://github.com/bitnami/charts/commit/6cc9eb4)), closes [#8627](https://github.com/bitnami/charts/issues/8627)
+* Add ingressClassName parameter (#8627) ([6cc9eb4](https://github.com/bitnami/charts/commit/6cc9eb4317d624241054cee3b99ff24da37e2057)), closes [#8627](https://github.com/bitnami/charts/issues/8627)
 
 ## 11.2.0 (2022-01-05)
 
-* [bitnami/several] Adapt templating format (#8562) ([8cad18a](https://github.com/bitnami/charts/commit/8cad18a)), closes [#8562](https://github.com/bitnami/charts/issues/8562)
+* [bitnami/several] Adapt templating format (#8562) ([8cad18a](https://github.com/bitnami/charts/commit/8cad18aed9966a6f0208e5ad6cee46cb217f47ab)), closes [#8562](https://github.com/bitnami/charts/issues/8562)
 
 ## <small>11.1.14 (2022-01-05)</small>
 
-* [bitnami/airflow] Release 11.1.14 updating components versions ([b095932](https://github.com/bitnami/charts/commit/b095932))
-* [bitnami/several] Add license to the README ([05f7633](https://github.com/bitnami/charts/commit/05f7633))
-* [bitnami/several] Add license to the README ([32fb238](https://github.com/bitnami/charts/commit/32fb238))
-* [bitnami/several] Add license to the README ([b87c2f7](https://github.com/bitnami/charts/commit/b87c2f7))
+* [bitnami/airflow] Release 11.1.14 updating components versions ([b095932](https://github.com/bitnami/charts/commit/b095932fb1f37ada30949a33715ed511096d2222))
+* [bitnami/several] Add license to the README ([05f7633](https://github.com/bitnami/charts/commit/05f763372501d596e57db713dd53ff4ff3027cc4))
+* [bitnami/several] Add license to the README ([32fb238](https://github.com/bitnami/charts/commit/32fb238e60a0affc6debd3142eaa3c3d9089ec2a))
+* [bitnami/several] Add license to the README ([b87c2f7](https://github.com/bitnami/charts/commit/b87c2f7899d48a8b02c506765e6ae82937e9ba3f))
 
 ## <small>11.1.13 (2021-12-28)</small>
 
-* [bitnami/airflow] Release 11.1.13 updating components versions ([66a6e8d](https://github.com/bitnami/charts/commit/66a6e8d))
+* [bitnami/airflow] Release 11.1.13 updating components versions ([66a6e8d](https://github.com/bitnami/charts/commit/66a6e8dda4ba54005c2031b7a748b1b1ecee20b7))
 
 ## <small>11.1.12 (2021-12-21)</small>
 
-* [bitnami/airflow] Release 11.1.12 updating components versions ([0bf3bbc](https://github.com/bitnami/charts/commit/0bf3bbc))
-* Fixed typo in README.md (#8459) ([d58acfb](https://github.com/bitnami/charts/commit/d58acfb)), closes [#8459](https://github.com/bitnami/charts/issues/8459)
+* [bitnami/airflow] Release 11.1.12 updating components versions ([0bf3bbc](https://github.com/bitnami/charts/commit/0bf3bbc372b630e4c5ac7db55e34a53fe039e205))
+* Fixed typo in README.md (#8459) ([d58acfb](https://github.com/bitnami/charts/commit/d58acfb3804c1768eae9f7991e2ab53d2bff7ed7)), closes [#8459](https://github.com/bitnami/charts/issues/8459)
 
 ## <small>11.1.11 (2021-12-09)</small>
 
-* [bitnami/airflow] Ensure LDAP related env. vars values are quoted (#8357) ([4edc8dd](https://github.com/bitnami/charts/commit/4edc8dd)), closes [#8357](https://github.com/bitnami/charts/issues/8357)
+* [bitnami/airflow] Ensure LDAP related env. vars values are quoted (#8357) ([4edc8dd](https://github.com/bitnami/charts/commit/4edc8dd855d72c807b157eb5258d62ac40404540)), closes [#8357](https://github.com/bitnami/charts/issues/8357)
 
 ## <small>11.1.10 (2021-12-09)</small>
 
-* fix: airflow worker init container (#8342) ([2928175](https://github.com/bitnami/charts/commit/2928175)), closes [#8342](https://github.com/bitnami/charts/issues/8342)
+* fix: airflow worker init container (#8342) ([2928175](https://github.com/bitnami/charts/commit/2928175369de93f0b2e69e91283b621e59a8d856)), closes [#8342](https://github.com/bitnami/charts/issues/8342)
 
 ## <small>11.1.9 (2021-11-29)</small>
 
-* [bitnami/several] Fix deadlinks in README.md (#8215) ([99e90d2](https://github.com/bitnami/charts/commit/99e90d2)), closes [#8215](https://github.com/bitnami/charts/issues/8215)
-* [bitnami/several] Regenerate README tables ([3d7ca74](https://github.com/bitnami/charts/commit/3d7ca74))
-* [bitnami/several] Replace HTTP by HTTPS when possible (#8259) ([eafb5bd](https://github.com/bitnami/charts/commit/eafb5bd)), closes [#8259](https://github.com/bitnami/charts/issues/8259)
+* [bitnami/several] Fix deadlinks in README.md (#8215) ([99e90d2](https://github.com/bitnami/charts/commit/99e90d244b3244e059a42f72dcbecd3cda2b66bb)), closes [#8215](https://github.com/bitnami/charts/issues/8215)
+* [bitnami/several] Regenerate README tables ([3d7ca74](https://github.com/bitnami/charts/commit/3d7ca74b3b732b0620497ae7b399545117510209))
+* [bitnami/several] Replace HTTP by HTTPS when possible (#8259) ([eafb5bd](https://github.com/bitnami/charts/commit/eafb5bd5a2cc3aaf04fc1e8ebedd73f420d76864)), closes [#8259](https://github.com/bitnami/charts/issues/8259)
 
 ## <small>11.1.8 (2021-11-16)</small>
 
-* [bitnami/airflow] Release 11.1.8 updating components versions ([2a7bd3a](https://github.com/bitnami/charts/commit/2a7bd3a))
-* [bitnami/several] Regenerate README tables ([3cefed3](https://github.com/bitnami/charts/commit/3cefed3))
+* [bitnami/airflow] Release 11.1.8 updating components versions ([2a7bd3a](https://github.com/bitnami/charts/commit/2a7bd3aae2096784509b92d1dab48cfb1606c675))
+* [bitnami/several] Regenerate README tables ([3cefed3](https://github.com/bitnami/charts/commit/3cefed3ef961fbd7596242b1165bcfa229a9cadb))
 
 ## <small>11.1.7 (2021-10-30)</small>
 
-* [bitnami/airflow] Release 11.1.7 updating components versions ([e642d87](https://github.com/bitnami/charts/commit/e642d87))
-* [bitnami/several] Regenerate README tables ([412cf6a](https://github.com/bitnami/charts/commit/412cf6a))
+* [bitnami/airflow] Release 11.1.7 updating components versions ([e642d87](https://github.com/bitnami/charts/commit/e642d87d575f9abc1632154af1e29956625ee067))
+* [bitnami/several] Regenerate README tables ([412cf6a](https://github.com/bitnami/charts/commit/412cf6a513cb0c03444a6e7811c6f27193239a10))
 
 ## <small>11.1.6 (2021-10-26)</small>
 
-* [bitnami/airflow] Release 11.1.6 updating components versions ([d43dc37](https://github.com/bitnami/charts/commit/d43dc37))
+* [bitnami/airflow] Release 11.1.6 updating components versions ([d43dc37](https://github.com/bitnami/charts/commit/d43dc379be32c95e0560c61279fb6b9a42f065cc))
 
 ## <small>11.1.5 (2021-10-22)</small>
 
-* [bitnami/several] Add chart info to NOTES.txt (#7889) ([a6751cd](https://github.com/bitnami/charts/commit/a6751cd)), closes [#7889](https://github.com/bitnami/charts/issues/7889)
+* [bitnami/several] Add chart info to NOTES.txt (#7889) ([a6751cd](https://github.com/bitnami/charts/commit/a6751cdd33c461fabbc459fbea6f219ec64ab6b2)), closes [#7889](https://github.com/bitnami/charts/issues/7889)
 
 ## <small>11.1.4 (2021-10-21)</small>
 
-* [bitnami/airflow] add quote to AIRFLOW_LDAP_ALLOW_SELF_SIGNED (#7883) ([03a311d](https://github.com/bitnami/charts/commit/03a311d)), closes [#7883](https://github.com/bitnami/charts/issues/7883)
-* [bitnami/several] Regenerate README tables ([681f9fa](https://github.com/bitnami/charts/commit/681f9fa))
+* [bitnami/airflow] add quote to AIRFLOW_LDAP_ALLOW_SELF_SIGNED (#7883) ([03a311d](https://github.com/bitnami/charts/commit/03a311dbab9360136258601dc5d8dd638d4e36e4)), closes [#7883](https://github.com/bitnami/charts/issues/7883)
+* [bitnami/several] Regenerate README tables ([681f9fa](https://github.com/bitnami/charts/commit/681f9fa6cdbbb742d383db2d9fc6da1251f3d3e5))
 
 ## <small>11.1.3 (2021-10-19)</small>
 
-* [bitnami/airflow] Release 11.1.3 updating components versions ([4743f6c](https://github.com/bitnami/charts/commit/4743f6c))
-* Correct the comment (#7684) ([1da6e0c](https://github.com/bitnami/charts/commit/1da6e0c)), closes [#7684](https://github.com/bitnami/charts/issues/7684)
+* [bitnami/airflow] Release 11.1.3 updating components versions ([4743f6c](https://github.com/bitnami/charts/commit/4743f6c509c7765f5adec6fbc5e27f6d5899cefd))
+* Correct the comment (#7684) ([1da6e0c](https://github.com/bitnami/charts/commit/1da6e0cec601cfa0be94b7319553f16342e4c638)), closes [#7684](https://github.com/bitnami/charts/issues/7684)
 
 ## <small>11.1.2 (2021-10-14)</small>
 
-* [bitnami/several] Regenerate README tables ([194a909](https://github.com/bitnami/charts/commit/194a909))
-* Fixed broken links in Airflow and Thanos READMEs (#7804) ([87ba524](https://github.com/bitnami/charts/commit/87ba524)), closes [#7804](https://github.com/bitnami/charts/issues/7804)
+* [bitnami/several] Regenerate README tables ([194a909](https://github.com/bitnami/charts/commit/194a909268377a6820d91f788c0380f427637ce6))
+* Fixed broken links in Airflow and Thanos READMEs (#7804) ([87ba524](https://github.com/bitnami/charts/commit/87ba524f7b085adc8b31bdf4432ddf3f493bee06)), closes [#7804](https://github.com/bitnami/charts/issues/7804)
 
 ## <small>11.1.1 (2021-10-08)</small>
 
-* [bitnami/airflow] Release 11.1.1 updating components versions ([cd390f2](https://github.com/bitnami/charts/commit/cd390f2))
+* [bitnami/airflow] Release 11.1.1 updating components versions ([cd390f2](https://github.com/bitnami/charts/commit/cd390f22e2c4ac94428ed0e382885bfae7f2d57c))
 
 ## 11.1.0 (2021-10-08)
 
-* [bitnami/airflow] fix dag_id could not be found with dagConfigMap and Kubernetes executor (#7716) ([21d12f9](https://github.com/bitnami/charts/commit/21d12f9)), closes [#7716](https://github.com/bitnami/charts/issues/7716)
+* [bitnami/airflow] fix dag_id could not be found with dagConfigMap and Kubernetes executor (#7716) ([21d12f9](https://github.com/bitnami/charts/commit/21d12f9282ccdd1048fc37ebf0dd278c84a17341)), closes [#7716](https://github.com/bitnami/charts/issues/7716)
 
 ## <small>11.0.8 (2021-10-01)</small>
 
-* [bitnami/*] Drop support for deprecated cert-manager annotation (#7582) ([a081792](https://github.com/bitnami/charts/commit/a081792)), closes [#7582](https://github.com/bitnami/charts/issues/7582)
+* [bitnami/*] Drop support for deprecated cert-manager annotation (#7582) ([a081792](https://github.com/bitnami/charts/commit/a08179293543f063e5de966a9976ca967161de7b)), closes [#7582](https://github.com/bitnami/charts/issues/7582)
 
 ## <small>11.0.7 (2021-09-29)</small>
 
-* [bitnami/*] Fix readme-generator metadata and regenerate READMEs (#7649) ([d58fc96](https://github.com/bitnami/charts/commit/d58fc96)), closes [#7649](https://github.com/bitnami/charts/issues/7649)
+* [bitnami/*] Fix readme-generator metadata and regenerate READMEs (#7649) ([d58fc96](https://github.com/bitnami/charts/commit/d58fc96d78129724a0f72beb297f76926f04ac6e)), closes [#7649](https://github.com/bitnami/charts/issues/7649)
 
 ## <small>11.0.6 (2021-09-29)</small>
 
-* [bitnami/airflow] Release 11.0.6 updating components versions ([e3f095f](https://github.com/bitnami/charts/commit/e3f095f))
+* [bitnami/airflow] Release 11.0.6 updating components versions ([e3f095f](https://github.com/bitnami/charts/commit/e3f095ff34a734655db6624e5ed6f0c5f3fb594c))
 
 ## <small>11.0.5 (2021-09-28)</small>
 
-* Fix/airflow notes (#7642) ([e34ee5c](https://github.com/bitnami/charts/commit/e34ee5c)), closes [#7642](https://github.com/bitnami/charts/issues/7642)
+* Fix/airflow notes (#7642) ([e34ee5c](https://github.com/bitnami/charts/commit/e34ee5c5aeafabe15cbf0d2b0fecb18483bc6415)), closes [#7642](https://github.com/bitnami/charts/issues/7642)
 
 ## <small>11.0.4 (2021-09-23)</small>
 
-* [bitnami/airflow] Fix cannot fetch logs in worker nodes (#7603) ([ca00baa](https://github.com/bitnami/charts/commit/ca00baa)), closes [#7603](https://github.com/bitnami/charts/issues/7603)
+* [bitnami/airflow] Fix cannot fetch logs in worker nodes (#7603) ([ca00baa](https://github.com/bitnami/charts/commit/ca00baab7a0eccf75b8d84ed8b60ab2fd5daac2b)), closes [#7603](https://github.com/bitnami/charts/issues/7603)
 
 ## <small>11.0.3 (2021-09-23)</small>
 
-* [bitnami/several] Regenerate README tables ([89851a4](https://github.com/bitnami/charts/commit/89851a4))
-* [bitnami/wordpress] Use the dependency fullname template (#7472) ([ae7e0dd](https://github.com/bitnami/charts/commit/ae7e0dd)), closes [#7472](https://github.com/bitnami/charts/issues/7472)
+* [bitnami/several] Regenerate README tables ([89851a4](https://github.com/bitnami/charts/commit/89851a4f2013f902876ec046a4ef1748c70eb65c))
+* [bitnami/wordpress] Use the dependency fullname template (#7472) ([ae7e0dd](https://github.com/bitnami/charts/commit/ae7e0dd6a687b283e9d57939143511f938bfe654)), closes [#7472](https://github.com/bitnami/charts/issues/7472)
 
 ## <small>11.0.2 (2021-09-19)</small>
 
-* [bitnami/airflow] Release 11.0.2 updating components versions ([fe4539b](https://github.com/bitnami/charts/commit/fe4539b))
+* [bitnami/airflow] Release 11.0.2 updating components versions ([fe4539b](https://github.com/bitnami/charts/commit/fe4539be0494d8585ddcb5ce2c2db185dab15580))
 
 ## <small>11.0.1 (2021-09-15)</small>
 
-* [bitnami/airflow] fixes the ERR_TOO_MANY_REDIRECTS error that happen when try to login using Airflow ([1fed783](https://github.com/bitnami/charts/commit/1fed783)), closes [#7484](https://github.com/bitnami/charts/issues/7484)
-* [bitnami/several] Regenerate README tables ([5c79422](https://github.com/bitnami/charts/commit/5c79422))
+* [bitnami/airflow] fixes the ERR_TOO_MANY_REDIRECTS error that happen when try to login using Airflow ([1fed783](https://github.com/bitnami/charts/commit/1fed78346cad8f0d64cfea177e648b98cdbfe953)), closes [#7484](https://github.com/bitnami/charts/issues/7484)
+* [bitnami/several] Regenerate README tables ([5c79422](https://github.com/bitnami/charts/commit/5c7942235d3169332e8dadb380cd757416f28946))
 
 ## 11.0.0 (2021-09-14)
 
-* [bitnami/ several charts] Redis dependency upgrade (#7481) ([bbed564](https://github.com/bitnami/charts/commit/bbed564)), closes [#7481](https://github.com/bitnami/charts/issues/7481)
+* [bitnami/ several charts] Redis dependency upgrade (#7481) ([bbed564](https://github.com/bitnami/charts/commit/bbed5645fc1e93bde1341f50ba47c614b53ba42a)), closes [#7481](https://github.com/bitnami/charts/issues/7481)
 
 ## <small>10.3.4 (2021-09-14)</small>
 
-* [bitnami/airflow] Release 10.3.4 updating components versions ([ff8b148](https://github.com/bitnami/charts/commit/ff8b148))
+* [bitnami/airflow] Release 10.3.4 updating components versions ([ff8b148](https://github.com/bitnami/charts/commit/ff8b148a8dc9eb309f802f603b77bbae5b2c4cbf))
 
 ## <small>10.3.3 (2021-09-10)</small>
 
-* [bitnami/airflow] Worker resources to be customizable using 'k8s-executor' (#7452) ([2526e0b](https://github.com/bitnami/charts/commit/2526e0b)), closes [#7452](https://github.com/bitnami/charts/issues/7452)
-* [bitnami/several] Regenerate README tables ([e0a27b4](https://github.com/bitnami/charts/commit/e0a27b4))
+* [bitnami/airflow] Worker resources to be customizable using 'k8s-executor' (#7452) ([2526e0b](https://github.com/bitnami/charts/commit/2526e0b0a34e7b2dc626f1ba06b67b8a4481785a)), closes [#7452](https://github.com/bitnami/charts/issues/7452)
+* [bitnami/several] Regenerate README tables ([e0a27b4](https://github.com/bitnami/charts/commit/e0a27b4c05c509da51859373dad032294438af74))
 
 ## <small>10.3.2 (2021-09-02)</small>
 
-* [bitnami/airflow] Release 10.3.2 updating components versions ([c18930d](https://github.com/bitnami/charts/commit/c18930d))
-* [bitnami/several] Regenerate README tables ([da2513b](https://github.com/bitnami/charts/commit/da2513b))
+* [bitnami/airflow] Release 10.3.2 updating components versions ([c18930d](https://github.com/bitnami/charts/commit/c18930d36727940a7c420f84b5578f347930873c))
+* [bitnami/several] Regenerate README tables ([da2513b](https://github.com/bitnami/charts/commit/da2513bf0a33819f3b1151d387c631a9ffdb03e2))
 
 ## <small>10.3.1 (2021-08-26)</small>
 
-* [bitnami/airflow] Release 10.3.1 updating components versions ([269883d](https://github.com/bitnami/charts/commit/269883d))
-* [bitnami/several] Regenerate README tables ([6c9124f](https://github.com/bitnami/charts/commit/6c9124f))
+* [bitnami/airflow] Release 10.3.1 updating components versions ([269883d](https://github.com/bitnami/charts/commit/269883d7baf2098b227e092032e6ea309efb3494))
+* [bitnami/several] Regenerate README tables ([6c9124f](https://github.com/bitnami/charts/commit/6c9124f79491aa65f53a87c1ed598b47ffa8b411))
 
 ## 10.3.0 (2021-08-20)
 
-* [bitnami/airflow] Add Extra Environment Variables to Metrics Deployment (#7250) ([3a98707](https://github.com/bitnami/charts/commit/3a98707)), closes [#7250](https://github.com/bitnami/charts/issues/7250)
-* [bitnami/several] Regenerate README tables ([6c107e8](https://github.com/bitnami/charts/commit/6c107e8))
+* [bitnami/airflow] Add Extra Environment Variables to Metrics Deployment (#7250) ([3a98707](https://github.com/bitnami/charts/commit/3a98707b5bfcf6504fbe0906f131046067d66b74)), closes [#7250](https://github.com/bitnami/charts/issues/7250)
+* [bitnami/several] Regenerate README tables ([6c107e8](https://github.com/bitnami/charts/commit/6c107e835d6caf8db2e8b17dcd48c5971637e013))
 
 ## <small>10.2.8 (2021-08-04)</small>
 
-* [bitnami/airflow] Release 10.2.8 updating components versions ([e4d8d2d](https://github.com/bitnami/charts/commit/e4d8d2d))
+* [bitnami/airflow] Release 10.2.8 updating components versions ([e4d8d2d](https://github.com/bitnami/charts/commit/e4d8d2d4a39af77492326b42bb720526073270dc))
 
 ## <small>10.2.7 (2021-07-27)</small>
 
-* [bitnami/several] Bump version and update READMEs (#7069) ([6340bff](https://github.com/bitnami/charts/commit/6340bff)), closes [#7069](https://github.com/bitnami/charts/issues/7069)
-* Replace <sup> strings with &trade; in the README files (#7066) ([d298b49](https://github.com/bitnami/charts/commit/d298b49)), closes [#7066](https://github.com/bitnami/charts/issues/7066)
+* [bitnami/several] Bump version and update READMEs (#7069) ([6340bff](https://github.com/bitnami/charts/commit/6340bff66f93c8c797bda3ca0842e4bf770059f1)), closes [#7069](https://github.com/bitnami/charts/issues/7069)
+* Replace <sup> strings with &trade; in the README files (#7066) ([d298b49](https://github.com/bitnami/charts/commit/d298b4996da33c9580c2594e6dc8ad665dd0ebab)), closes [#7066](https://github.com/bitnami/charts/issues/7066)
 
 ## <small>10.2.6 (2021-07-21)</small>
 
-* [bitnami/airflow] Remove nil values (#6966) ([697f25c](https://github.com/bitnami/charts/commit/697f25c)), closes [#6966](https://github.com/bitnami/charts/issues/6966)
+* [bitnami/airflow] Remove nil values (#6966) ([697f25c](https://github.com/bitnami/charts/commit/697f25c7ed4470280158208fdc2c283324fe4c58)), closes [#6966](https://github.com/bitnami/charts/issues/6966)
 
 ## <small>10.2.5 (2021-07-15)</small>
 
-* [bitnami/airflow] Release 10.2.5 updating components versions ([fe8e369](https://github.com/bitnami/charts/commit/fe8e369))
+* [bitnami/airflow] Release 10.2.5 updating components versions ([fe8e369](https://github.com/bitnami/charts/commit/fe8e3696f8f15566dc42440bd52c125514747dcc))
 
 ## <small>10.2.4 (2021-07-09)</small>
 
-* [bitnami/airflow] fix ldap tls value (#6854) ([3628b41](https://github.com/bitnami/charts/commit/3628b41)), closes [#6854](https://github.com/bitnami/charts/issues/6854)
+* [bitnami/airflow] fix ldap tls value (#6854) ([3628b41](https://github.com/bitnami/charts/commit/3628b41e485215dce9aa6e8e553e4b063cb6a316)), closes [#6854](https://github.com/bitnami/charts/issues/6854)
 
 ## <small>10.2.3 (2021-07-05)</small>
 
-* [bitnami/airflow] Release 10.2.3 updating components versions ([136ec0c](https://github.com/bitnami/charts/commit/136ec0c))
+* [bitnami/airflow] Release 10.2.3 updating components versions ([136ec0c](https://github.com/bitnami/charts/commit/136ec0c12a75f8ae11f62b748b61fbc137cd369e))
 
 ## <small>10.2.2 (2021-06-24)</small>
 
-* [bitnami/airflow] Adapt Airflow values.yaml to readme-generator (#6636) ([bfed122](https://github.com/bitnami/charts/commit/bfed122)), closes [#6636](https://github.com/bitnami/charts/issues/6636)
+* [bitnami/airflow] Adapt Airflow values.yaml to readme-generator (#6636) ([bfed122](https://github.com/bitnami/charts/commit/bfed122a747cacb6958fc5d1b460ecb8b48b88cd)), closes [#6636](https://github.com/bitnami/charts/issues/6636)
 
 ## <small>10.2.1 (2021-06-17)</small>
 
-* [bitnami/airflow] Release 10.2.1 updating components versions ([90cdff5](https://github.com/bitnami/charts/commit/90cdff5))
+* [bitnami/airflow] Release 10.2.1 updating components versions ([90cdff5](https://github.com/bitnami/charts/commit/90cdff507ce247e2e96cf72ba45f0fc15601d555))
 
 ## 10.2.0 (2021-06-17)
 
-* [bitnami/airflow]: add servicemonitor for metrics scraping fixes #6552 (#6580) ([0c177b8](https://github.com/bitnami/charts/commit/0c177b8)), closes [#6552](https://github.com/bitnami/charts/issues/6552) [#6580](https://github.com/bitnami/charts/issues/6580)
+* [bitnami/airflow]: add servicemonitor for metrics scraping fixes #6552 (#6580) ([0c177b8](https://github.com/bitnami/charts/commit/0c177b89108102ea09a365ac9a58e33f8b743737)), closes [#6552](https://github.com/bitnami/charts/issues/6552) [#6580](https://github.com/bitnami/charts/issues/6580)
 
 ## <small>10.1.1 (2021-06-15)</small>
 
-* [bitnami/airflow] Fix debug value to true instead of 1 (#6643) ([87908e7](https://github.com/bitnami/charts/commit/87908e7)), closes [#6643](https://github.com/bitnami/charts/issues/6643)
+* [bitnami/airflow] Fix debug value to true instead of 1 (#6643) ([87908e7](https://github.com/bitnami/charts/commit/87908e72c362cd5ac7e59944e09aa4ded35ec07b)), closes [#6643](https://github.com/bitnami/charts/issues/6643)
 
 ## 10.1.0 (2021-06-11)
 
-* [bitnami/airflow] Add support for CeleryKubernetesExecutor (#6096) ([876752e](https://github.com/bitnami/charts/commit/876752e)), closes [#6096](https://github.com/bitnami/charts/issues/6096)
+* [bitnami/airflow] Add support for CeleryKubernetesExecutor (#6096) ([876752e](https://github.com/bitnami/charts/commit/876752e718639d17fe6610214c295a79a0296bda)), closes [#6096](https://github.com/bitnami/charts/issues/6096)
 
 ## <small>10.0.8 (2021-05-24)</small>
 
-* [bitnami/airflow] Release 10.0.8 updating components versions ([b17aeb6](https://github.com/bitnami/charts/commit/b17aeb6))
+* [bitnami/airflow] Release 10.0.8 updating components versions ([b17aeb6](https://github.com/bitnami/charts/commit/b17aeb6db78914f9fc8f62f522b1da0232a3c83f))
 
 ## <small>10.0.7 (2021-05-23)</small>
 
-* [bitnami/airflow] Release 10.0.7 updating components versions ([0802c58](https://github.com/bitnami/charts/commit/0802c58))
+* [bitnami/airflow] Release 10.0.7 updating components versions ([0802c58](https://github.com/bitnami/charts/commit/0802c584c8e337b296833481bb30a8c02d167c2e))
 
 ## <small>10.0.6 (2021-05-20)</small>
 
-* [bitnami/airflow] Fix typo in web deployment when enabling LDAP (#6422) ([8d9e7a5](https://github.com/bitnami/charts/commit/8d9e7a5)), closes [#6422](https://github.com/bitnami/charts/issues/6422)
+* [bitnami/airflow] Fix typo in web deployment when enabling LDAP (#6422) ([8d9e7a5](https://github.com/bitnami/charts/commit/8d9e7a599f225e45c15662be04f1f1c37dacbfc0)), closes [#6422](https://github.com/bitnami/charts/issues/6422)
 
 ## <small>10.0.5 (2021-05-18)</small>
 
-* [bitnami/airflow] fix customReadinessProbe typo ([b21ef5f](https://github.com/bitnami/charts/commit/b21ef5f))
+* [bitnami/airflow] fix customReadinessProbe typo ([b21ef5f](https://github.com/bitnami/charts/commit/b21ef5fb70504887e964076dd8c63d72112eb933))
 
 ## <small>10.0.4 (2021-05-05)</small>
 
-* [bitnami/airflow] Take worker.resources in values.yaml into consideration, when using KubernetesExec ([421fca2](https://github.com/bitnami/charts/commit/421fca2)), closes [#6298](https://github.com/bitnami/charts/issues/6298)
+* [bitnami/airflow] Take worker.resources in values.yaml into consideration, when using KubernetesExec ([421fca2](https://github.com/bitnami/charts/commit/421fca263ffc9103612876a39508bdc804dcc230)), closes [#6298](https://github.com/bitnami/charts/issues/6298)
 
 ## <small>10.0.3 (2021-05-05)</small>
 
-* Update NOTES.txt (#6292) ([ee5597c](https://github.com/bitnami/charts/commit/ee5597c)), closes [#6292](https://github.com/bitnami/charts/issues/6292)
+* Update NOTES.txt (#6292) ([ee5597c](https://github.com/bitnami/charts/commit/ee5597c86b1cd3587fb50feb1dbc7518195c8cab)), closes [#6292](https://github.com/bitnami/charts/issues/6292)
 
 ## <small>10.0.2 (2021-05-04)</small>
 
-* [bitnami/airflow] Fixed Git Sync Plugin Path (#6273) ([98ae292](https://github.com/bitnami/charts/commit/98ae292)), closes [#6273](https://github.com/bitnami/charts/issues/6273)
+* [bitnami/airflow] Fixed Git Sync Plugin Path (#6273) ([98ae292](https://github.com/bitnami/charts/commit/98ae2923eb18fe87f80650968ff7aba0559a81e4)), closes [#6273](https://github.com/bitnami/charts/issues/6273)
 
 ## <small>10.0.1 (2021-04-29)</small>
 
-* [bitnami/airflow] Release 10.0.1 updating components versions ([1890d5b](https://github.com/bitnami/charts/commit/1890d5b))
+* [bitnami/airflow] Release 10.0.1 updating components versions ([1890d5b](https://github.com/bitnami/charts/commit/1890d5bff55ab910a376bba40dae5da99647f641))
 
 ## 10.0.0 (2021-04-28)
 
-* [bitnami/*] Update redis subchart to new major (#6079) ([c7e8ef4](https://github.com/bitnami/charts/commit/c7e8ef4)), closes [#6079](https://github.com/bitnami/charts/issues/6079)
+* [bitnami/*] Update redis subchart to new major (#6079) ([c7e8ef4](https://github.com/bitnami/charts/commit/c7e8ef4d5d09aa638910471c77ef488ebe4b26cd)), closes [#6079](https://github.com/bitnami/charts/issues/6079)
 
 ## <small>9.0.5 (2021-04-19)</small>
 
-* [bitnami/airflow] Fix tolerations for Airflow Exporter (#6100) ([8e8fd41](https://github.com/bitnami/charts/commit/8e8fd41)), closes [#6100](https://github.com/bitnami/charts/issues/6100)
+* [bitnami/airflow] Fix tolerations for Airflow Exporter (#6100) ([8e8fd41](https://github.com/bitnami/charts/commit/8e8fd418d0543350a56dd742d9fe2d6c22e84c6f)), closes [#6100](https://github.com/bitnami/charts/issues/6100)
 
 ## <small>9.0.4 (2021-04-13)</small>
 
-* [bitnami/chart] Avoid crash when clone/sync git repository (#6063) ([65fa0a5](https://github.com/bitnami/charts/commit/65fa0a5)), closes [#6063](https://github.com/bitnami/charts/issues/6063)
+* [bitnami/chart] Avoid crash when clone/sync git repository (#6063) ([65fa0a5](https://github.com/bitnami/charts/commit/65fa0a5fb3283cbd5fd50b1c0e1149c235402a5f)), closes [#6063](https://github.com/bitnami/charts/issues/6063)
 
 ## <small>9.0.3 (2021-04-12)</small>
 
-* [bitnami/airflow] Fix incorrect clone-repositories container generation (#6070) ([e3d3efa](https://github.com/bitnami/charts/commit/e3d3efa)), closes [#6070](https://github.com/bitnami/charts/issues/6070)
+* [bitnami/airflow] Fix incorrect clone-repositories container generation (#6070) ([e3d3efa](https://github.com/bitnami/charts/commit/e3d3efa3b9a9d8ad42fb463acd6c59c91c7efecf)), closes [#6070](https://github.com/bitnami/charts/issues/6070)
 
 ## <small>9.0.2 (2021-04-09)</small>
 
-* [bitnami/airflow] Fix worker (#6060) ([f88bb46](https://github.com/bitnami/charts/commit/f88bb46)), closes [#6060](https://github.com/bitnami/charts/issues/6060)
+* [bitnami/airflow] Fix worker (#6060) ([f88bb46](https://github.com/bitnami/charts/commit/f88bb46978733ffb503e40c6f61eadbdcbebe94c)), closes [#6060](https://github.com/bitnami/charts/issues/6060)
 
 ## <small>9.0.1 (2021-04-09)</small>
 
-* [bitnami/airflow] Fix comment and README to reflect LocalExecutor config: Local Executor -> LocalExe ([5257497](https://github.com/bitnami/charts/commit/5257497)), closes [#6058](https://github.com/bitnami/charts/issues/6058)
+* [bitnami/airflow] Fix comment and README to reflect LocalExecutor config: Local Executor -> LocalExe ([5257497](https://github.com/bitnami/charts/commit/5257497414e6a630bfc9e8cedc8df20e57a9cf22)), closes [#6058](https://github.com/bitnami/charts/issues/6058)
 
 ## 9.0.0 (2021-04-08)
 
-* [bitnami/airflow] Adapt web image to the new major release (#5733) ([1585083](https://github.com/bitnami/charts/commit/1585083)), closes [#5733](https://github.com/bitnami/charts/issues/5733)
+* [bitnami/airflow] Adapt web image to the new major release (#5733) ([1585083](https://github.com/bitnami/charts/commit/158508392bb38d47b8a3d95752cbc9ef55b69018)), closes [#5733](https://github.com/bitnami/charts/issues/5733)
 
 ## <small>8.2.3 (2021-04-05)</small>
 
-* [bitnami/airflow] Avoid cloning dags/plugins repositories on container restarts (#6009) ([0f53335](https://github.com/bitnami/charts/commit/0f53335)), closes [#6009](https://github.com/bitnami/charts/issues/6009)
+* [bitnami/airflow] Avoid cloning dags/plugins repositories on container restarts (#6009) ([0f53335](https://github.com/bitnami/charts/commit/0f533353344384d8729b71001fc230cf8c7865a7)), closes [#6009](https://github.com/bitnami/charts/issues/6009)
 
 ## <small>8.2.2 (2021-04-05)</small>
 
-* [bitnami/airflow] Fix typo inside README.md (#6003) ([868f5f6](https://github.com/bitnami/charts/commit/868f5f6)), closes [#6003](https://github.com/bitnami/charts/issues/6003)
+* [bitnami/airflow] Fix typo inside README.md (#6003) ([868f5f6](https://github.com/bitnami/charts/commit/868f5f673abda88e71d3894d3c7148192873ba63)), closes [#6003](https://github.com/bitnami/charts/issues/6003)
 
 ## <small>8.2.1 (2021-04-01)</small>
 
-* fixed postgressql-pvc labels while exporting env variable:POSTGRESQL_PVC (#5934) ([e8dd450](https://github.com/bitnami/charts/commit/e8dd450)), closes [#5934](https://github.com/bitnami/charts/issues/5934)
+* fixed postgressql-pvc labels while exporting env variable:POSTGRESQL_PVC (#5934) ([e8dd450](https://github.com/bitnami/charts/commit/e8dd4509d03abaf69f4627392bd2ccba845ed9b3)), closes [#5934](https://github.com/bitnami/charts/issues/5934)
 
 ## 8.2.0 (2021-03-31)
 
-* Airflow worker toleration (#5925) ([8bae199](https://github.com/bitnami/charts/commit/8bae199)), closes [#5925](https://github.com/bitnami/charts/issues/5925)
+* Airflow worker toleration (#5925) ([8bae199](https://github.com/bitnami/charts/commit/8bae1992d48b014933a3bd45af850591edadbef0)), closes [#5925](https://github.com/bitnami/charts/issues/5925)
 
 ## <small>8.1.3 (2021-03-24)</small>
 
-* [bitnami/airflow]replace dashes with underscores to allow imports in git-sync (#5898) ([ddffff4](https://github.com/bitnami/charts/commit/ddffff4)), closes [#5898](https://github.com/bitnami/charts/issues/5898)
+* [bitnami/airflow]replace dashes with underscores to allow imports in git-sync (#5898) ([ddffff4](https://github.com/bitnami/charts/commit/ddffff44b14f30cff06090f53c277203f0561e83)), closes [#5898](https://github.com/bitnami/charts/issues/5898)
 
 ## <small>8.1.2 (2021-03-24)</small>
 
-* [bitnami/airflow]replace dashes with underscores to allow imports in git-sync (#5893) ([ae8f508](https://github.com/bitnami/charts/commit/ae8f508)), closes [#5893](https://github.com/bitnami/charts/issues/5893)
+* [bitnami/airflow]replace dashes with underscores to allow imports in git-sync (#5893) ([ae8f508](https://github.com/bitnami/charts/commit/ae8f5080ed0fb91d8a454d11d2f4677b277e102c)), closes [#5893](https://github.com/bitnami/charts/issues/5893)
 
 ## <small>8.1.1 (2021-03-23)</small>
 
-* [bitnami/airflow] Apply securityContext & resources on git init & sidecar containers (#5863) ([0799ac5](https://github.com/bitnami/charts/commit/0799ac5)), closes [#5863](https://github.com/bitnami/charts/issues/5863)
+* [bitnami/airflow] Apply securityContext & resources on git init & sidecar containers (#5863) ([0799ac5](https://github.com/bitnami/charts/commit/0799ac5155b469409da00665e11da9e0a48a9500)), closes [#5863](https://github.com/bitnami/charts/issues/5863)
 
 ## 8.1.0 (2021-03-22)
 
-* [bitnami/airflow] Allow using custom secret key with external database. (#5848) ([da1831e](https://github.com/bitnami/charts/commit/da1831e)), closes [#5848](https://github.com/bitnami/charts/issues/5848)
+* [bitnami/airflow] Allow using custom secret key with external database. (#5848) ([da1831e](https://github.com/bitnami/charts/commit/da1831e8d090e3f81f441904480186ab9f044486)), closes [#5848](https://github.com/bitnami/charts/issues/5848)
 
 ## <small>8.0.11 (2021-03-19)</small>
 
-* [bitnami/*] Allow git ssh connections (#5814) ([c9adeff](https://github.com/bitnami/charts/commit/c9adeff)), closes [#5814](https://github.com/bitnami/charts/issues/5814)
+* [bitnami/*] Allow git ssh connections (#5814) ([c9adeff](https://github.com/bitnami/charts/commit/c9adefff010b9d421a1d6041216100e6621c8221)), closes [#5814](https://github.com/bitnami/charts/issues/5814)
 
 ## <small>8.0.10 (2021-03-18)</small>
 
-* [bitnami/airflow] Release 8.0.10 updating components versions ([86be269](https://github.com/bitnami/charts/commit/86be269))
+* [bitnami/airflow] Release 8.0.10 updating components versions ([86be269](https://github.com/bitnami/charts/commit/86be269708b18a4f39c7b36c379eeb92392d071b))
 
 ## <small>8.0.9 (2021-03-14)</small>
 
-* [bitnami/airflow] Release 8.0.9 updating components versions ([7dead2c](https://github.com/bitnami/charts/commit/7dead2c))
+* [bitnami/airflow] Release 8.0.9 updating components versions ([7dead2c](https://github.com/bitnami/charts/commit/7dead2c0a145706b278d43c1ccac7bd84e64a166))
 
 ## <small>8.0.8 (2021-03-11)</small>
 
-* Airflow fix Kubernetes Executor initContainer envs (#5722) ([4a50f53](https://github.com/bitnami/charts/commit/4a50f53)), closes [#5722](https://github.com/bitnami/charts/issues/5722)
+* Airflow fix Kubernetes Executor initContainer envs (#5722) ([4a50f53](https://github.com/bitnami/charts/commit/4a50f53f55a243008ca604ccedc655fa0dbcb0cd)), closes [#5722](https://github.com/bitnami/charts/issues/5722)
 
 ## <small>8.0.7 (2021-03-05)</small>
 
-* [bitnami/airflow] Add missing parameters to the worker template (#5675) ([3b855cf](https://github.com/bitnami/charts/commit/3b855cf)), closes [#5675](https://github.com/bitnami/charts/issues/5675)
+* [bitnami/airflow] Add missing parameters to the worker template (#5675) ([3b855cf](https://github.com/bitnami/charts/commit/3b855cfd6c0ba65a0c211636c3d9cbde769a910f)), closes [#5675](https://github.com/bitnami/charts/issues/5675)
 
 ## <small>8.0.6 (2021-03-04)</small>
 
-* [bitnami/*] Remove minideb mentions (#5677) ([870bc4d](https://github.com/bitnami/charts/commit/870bc4d)), closes [#5677](https://github.com/bitnami/charts/issues/5677)
-* [bitnami/harbor]: redis sentinel support in harbor (#5586) ([fa61b9c](https://github.com/bitnami/charts/commit/fa61b9c)), closes [#5586](https://github.com/bitnami/charts/issues/5586)
+* [bitnami/*] Remove minideb mentions (#5677) ([870bc4d](https://github.com/bitnami/charts/commit/870bc4dba1fc3aa55dd157da6687b25e8d352206)), closes [#5677](https://github.com/bitnami/charts/issues/5677)
+* [bitnami/harbor]: redis sentinel support in harbor (#5586) ([fa61b9c](https://github.com/bitnami/charts/commit/fa61b9c66b22668619d1029856a4d90101cbf196)), closes [#5586](https://github.com/bitnami/charts/issues/5586)
 
 ## <small>8.0.5 (2021-02-22)</small>
 
-* [bitnami/*] Use common macro to define RBAC apiVersion (#5585) ([71fb99f](https://github.com/bitnami/charts/commit/71fb99f)), closes [#5585](https://github.com/bitnami/charts/issues/5585)
+* [bitnami/*] Use common macro to define RBAC apiVersion (#5585) ([71fb99f](https://github.com/bitnami/charts/commit/71fb99f541e971b1daafaa20ffb7d18b153b8d60)), closes [#5585](https://github.com/bitnami/charts/issues/5585)
 
 ## <small>8.0.4 (2021-02-12)</small>
 
-* [bitnami/*] Add notice regarding parameters immutability after chart installation (#4853) ([5f09573](https://github.com/bitnami/charts/commit/5f09573)), closes [#4853](https://github.com/bitnami/charts/issues/4853)
-* [bitnami/airflow] Release 8.0.4 updating components versions ([7c5c92e](https://github.com/bitnami/charts/commit/7c5c92e))
+* [bitnami/*] Add notice regarding parameters immutability after chart installation (#4853) ([5f09573](https://github.com/bitnami/charts/commit/5f095734f92555dec7cd0e3ee961f315eac170ff)), closes [#4853](https://github.com/bitnami/charts/issues/4853)
+* [bitnami/airflow] Release 8.0.4 updating components versions ([7c5c92e](https://github.com/bitnami/charts/commit/7c5c92ec310c7ef7abb1ffa1427139d5e26cc98d))
 
 ## <small>8.0.3 (2021-02-09)</small>
 
-* [bitnami/airflow] Release 8.0.3 updating components versions ([15c7d15](https://github.com/bitnami/charts/commit/15c7d15))
+* [bitnami/airflow] Release 8.0.3 updating components versions ([15c7d15](https://github.com/bitnami/charts/commit/15c7d151892faed9a6cd75cf22d1ef28b31b11d2))
 
 ## <small>8.0.2 (2021-02-03)</small>
 
-* [bitnami/airflow] Fix indentation (#5354) ([0f29afc](https://github.com/bitnami/charts/commit/0f29afc)), closes [#5354](https://github.com/bitnami/charts/issues/5354)
-* [bitnami/several] Monthly trademark review (#5375) ([307a73d](https://github.com/bitnami/charts/commit/307a73d)), closes [#5375](https://github.com/bitnami/charts/issues/5375)
+* [bitnami/airflow] Fix indentation (#5354) ([0f29afc](https://github.com/bitnami/charts/commit/0f29afcb16e74d5b9ad87c23bfaad3efadea1f5d)), closes [#5354](https://github.com/bitnami/charts/issues/5354)
+* [bitnami/several] Monthly trademark review (#5375) ([307a73d](https://github.com/bitnami/charts/commit/307a73dcca857e4b567113113142c68b6eaf85e0)), closes [#5375](https://github.com/bitnami/charts/issues/5375)
 
 ## <small>8.0.1 (2021-01-29)</small>
 
-* [bitnami/airflow] fix: not to use redis when KubernetesExecutor (#5244) ([ecd6662](https://github.com/bitnami/charts/commit/ecd6662)), closes [#5244](https://github.com/bitnami/charts/issues/5244)
+* [bitnami/airflow] fix: not to use redis when KubernetesExecutor (#5244) ([ecd6662](https://github.com/bitnami/charts/commit/ecd6662b0e448f391444541392108d34b048b1f2)), closes [#5244](https://github.com/bitnami/charts/issues/5244)
 
 ## 8.0.0 (2021-01-29)
 
-* [bitnami/airflow] Release 8.0.0 updating components versions ([f31afeb](https://github.com/bitnami/charts/commit/f31afeb))
+* [bitnami/airflow] Release 8.0.0 updating components versions ([f31afeb](https://github.com/bitnami/charts/commit/f31afeb8df5a9dcc1fc63e0c18d375a22ce44509))
 
 ## <small>7.3.1 (2021-01-27)</small>
 
-* [bitnami/airflow] Release 7.3.1 updating components versions ([76b7432](https://github.com/bitnami/charts/commit/76b7432))
+* [bitnami/airflow] Release 7.3.1 updating components versions ([76b7432](https://github.com/bitnami/charts/commit/76b743217df1e6f9f92d39db545ba57775e454b1))
 
 ## 7.3.0 (2021-01-25)
 
-* [bitnami/airflow] Add hostAliases (#5193) ([db8e7c3](https://github.com/bitnami/charts/commit/db8e7c3)), closes [#5193](https://github.com/bitnami/charts/issues/5193)
+* [bitnami/airflow] Add hostAliases (#5193) ([db8e7c3](https://github.com/bitnami/charts/commit/db8e7c3f7b999e48e5831d9b15bdfcc9c7f264af)), closes [#5193](https://github.com/bitnami/charts/issues/5193)
 
 ## <small>7.2.1 (2021-01-25)</small>
 
-* [bitnami/*] Unify icons in Chart.yaml and add missing fields (#5206) ([0462921](https://github.com/bitnami/charts/commit/0462921)), closes [#5206](https://github.com/bitnami/charts/issues/5206)
+* [bitnami/*] Unify icons in Chart.yaml and add missing fields (#5206) ([0462921](https://github.com/bitnami/charts/commit/0462921418ca8d54308b7466197a6d53ffae4628)), closes [#5206](https://github.com/bitnami/charts/issues/5206)
 
 ## 7.2.0 (2021-01-22)
 
-* [bitnami/airflow]: add component wise nodeselector support (#5053) ([91f0a2d](https://github.com/bitnami/charts/commit/91f0a2d)), closes [#5053](https://github.com/bitnami/charts/issues/5053)
+* [bitnami/airflow]: add component wise nodeselector support (#5053) ([91f0a2d](https://github.com/bitnami/charts/commit/91f0a2d52882a688bbea2c70a738e39a5c1ca3d6)), closes [#5053](https://github.com/bitnami/charts/issues/5053)
 
 ## <small>7.1.4 (2021-01-19)</small>
 
-* [bitnami/*] Change helm version in the prerequisites (#5090) ([c5e67a3](https://github.com/bitnami/charts/commit/c5e67a3)), closes [#5090](https://github.com/bitnami/charts/issues/5090)
-* [bitnami/airflow] Drop values-production.yaml support (#5096) ([efd45e6](https://github.com/bitnami/charts/commit/efd45e6)), closes [#5096](https://github.com/bitnami/charts/issues/5096)
+* [bitnami/*] Change helm version in the prerequisites (#5090) ([c5e67a3](https://github.com/bitnami/charts/commit/c5e67a388743cbee28439d2cabca27884b9daf97)), closes [#5090](https://github.com/bitnami/charts/issues/5090)
+* [bitnami/airflow] Drop values-production.yaml support (#5096) ([efd45e6](https://github.com/bitnami/charts/commit/efd45e688d40b448018293faa3a15a92c0b2fb65)), closes [#5096](https://github.com/bitnami/charts/issues/5096)
 
 ## <small>7.1.3 (2021-01-14)</small>
 
-* [bitnami/airflow] Fix initContainers typo (#5024) ([85dc27c](https://github.com/bitnami/charts/commit/85dc27c)), closes [#5024](https://github.com/bitnami/charts/issues/5024)
-* [bitnami/several] Add Redis trademark (#5023) ([dfa89b8](https://github.com/bitnami/charts/commit/dfa89b8)), closes [#5023](https://github.com/bitnami/charts/issues/5023)
+* [bitnami/airflow] Fix initContainers typo (#5024) ([85dc27c](https://github.com/bitnami/charts/commit/85dc27c9e156ee17ad9b623efa4519163d6d54eb)), closes [#5024](https://github.com/bitnami/charts/issues/5024)
+* [bitnami/several] Add Redis trademark (#5023) ([dfa89b8](https://github.com/bitnami/charts/commit/dfa89b865989da26a3c73f397fd3c402dd56ebe8)), closes [#5023](https://github.com/bitnami/charts/issues/5023)
 
 ## <small>7.1.2 (2021-01-14)</small>
 
-* [bitnami/airflow] fix priorityClassName for all components (#4982) ([1a68174](https://github.com/bitnami/charts/commit/1a68174)), closes [#4982](https://github.com/bitnami/charts/issues/4982)
+* [bitnami/airflow] fix priorityClassName for all components (#4982) ([1a68174](https://github.com/bitnami/charts/commit/1a681744b96b9e603a59473a2efb9d16284bcde3)), closes [#4982](https://github.com/bitnami/charts/issues/4982)
 
 ## <small>7.1.1 (2021-01-09)</small>
 
-* [bitnami/airflow] Release 7.1.1 updating components versions ([4b4dc8b](https://github.com/bitnami/charts/commit/4b4dc8b))
+* [bitnami/airflow] Release 7.1.1 updating components versions ([4b4dc8b](https://github.com/bitnami/charts/commit/4b4dc8b8744fd445a4eedd51e97213578a17cd0b))
 
 ## 7.1.0 (2020-12-31)
 
-* [bitnami/*] fix typos (#4699) ([49adc63](https://github.com/bitnami/charts/commit/49adc63)), closes [#4699](https://github.com/bitnami/charts/issues/4699)
-* [bitnami/*] Update ingress rules (batch 1) (#4870) ([2f3e2be](https://github.com/bitnami/charts/commit/2f3e2be)), closes [#4870](https://github.com/bitnami/charts/issues/4870)
+* [bitnami/*] fix typos (#4699) ([49adc63](https://github.com/bitnami/charts/commit/49adc63b672da976c55af2e077aa5648a357b77f)), closes [#4699](https://github.com/bitnami/charts/issues/4699)
+* [bitnami/*] Update ingress rules (batch 1) (#4870) ([2f3e2be](https://github.com/bitnami/charts/commit/2f3e2beea845c8403fc33b5a75f57909bb63037a)), closes [#4870](https://github.com/bitnami/charts/issues/4870)
 
 ## <small>7.0.5 (2020-12-11)</small>
 
-* [bitnami/*] Update dependencies (#4694) ([2826c12](https://github.com/bitnami/charts/commit/2826c12)), closes [#4694](https://github.com/bitnami/charts/issues/4694)
+* [bitnami/*] Update dependencies (#4694) ([2826c12](https://github.com/bitnami/charts/commit/2826c125b42505f28431301e3c1bbe5366e47a01)), closes [#4694](https://github.com/bitnami/charts/issues/4694)
 
 ## <small>7.0.4 (2020-12-10)</small>
 
-* [bitnami/airflow] Release 7.0.4 updating components versions ([3d7140c](https://github.com/bitnami/charts/commit/3d7140c))
+* [bitnami/airflow] Release 7.0.4 updating components versions ([3d7140c](https://github.com/bitnami/charts/commit/3d7140c34f03540b39827dbc2197c03ba0b9e718))
 
 ## <small>7.0.3 (2020-11-27)</small>
 
-* [bitnami/airflow] fix: use loadBalancerIP as a fallback for baseUrl (#4493) ([5d431c8](https://github.com/bitnami/charts/commit/5d431c8)), closes [#4493](https://github.com/bitnami/charts/issues/4493)
+* [bitnami/airflow] fix: use loadBalancerIP as a fallback for baseUrl (#4493) ([5d431c8](https://github.com/bitnami/charts/commit/5d431c8dd6236bd5e51448a1b1df58900bc39169)), closes [#4493](https://github.com/bitnami/charts/issues/4493)
 
 ## <small>7.0.2 (2020-11-25)</small>
 
-* [bitnami/*] Add upgrade details to README (#4480) ([10bd8e1](https://github.com/bitnami/charts/commit/10bd8e1)), closes [#4480](https://github.com/bitnami/charts/issues/4480)
-* [bitnami/airflow] Release 7.0.2 updating components versions ([47cb09b](https://github.com/bitnami/charts/commit/47cb09b))
+* [bitnami/*] Add upgrade details to README (#4480) ([10bd8e1](https://github.com/bitnami/charts/commit/10bd8e1fbbe69461a5d90ba61562f72b526c9caf)), closes [#4480](https://github.com/bitnami/charts/issues/4480)
+* [bitnami/airflow] Release 7.0.2 updating components versions ([47cb09b](https://github.com/bitnami/charts/commit/47cb09bdfda46a41e38561887ac2ad28fb68f3d5))
 
 ## <small>7.0.1 (2020-11-24)</small>
 
-* [bitnami/airflow] hostfix: upgrade common version ([53b7580](https://github.com/bitnami/charts/commit/53b7580))
-* [bitnami/airflow] Release 7.0.1 updating components versions ([895cae9](https://github.com/bitnami/charts/commit/895cae9))
+* [bitnami/airflow] hostfix: upgrade common version ([53b7580](https://github.com/bitnami/charts/commit/53b75809e1fc14af0eac46f64122cf46649e49fb))
+* [bitnami/airflow] Release 7.0.1 updating components versions ([895cae9](https://github.com/bitnami/charts/commit/895cae97d5e956d71b52e6ec930b82a81d6727fd))
 
 ## 7.0.0 (2020-11-23)
 
-* [bitnami/airflow] MAJOR: refactor, standards, apiVersion: v2, and adding functionalities (#4069) ([166ac3f](https://github.com/bitnami/charts/commit/166ac3f)), closes [#4069](https://github.com/bitnami/charts/issues/4069)
+* [bitnami/airflow] MAJOR: refactor, standards, apiVersion: v2, and adding functionalities (#4069) ([166ac3f](https://github.com/bitnami/charts/commit/166ac3fa7c489fbe7d41e790c882ea9daf87869e)), closes [#4069](https://github.com/bitnami/charts/issues/4069)
 
 ## <small>6.7.2 (2020-11-20)</small>
 
-* [bitnami/*] Include link to Troubleshootin guide on README.md (#4136) ([c08a20e](https://github.com/bitnami/charts/commit/c08a20e)), closes [#4136](https://github.com/bitnami/charts/issues/4136)
-* [bitnami/airflow] Release 6.7.2 updating components versions ([3780c49](https://github.com/bitnami/charts/commit/3780c49))
-* [bitnami/airflow]: add documentation on python package installation into airflow containers (#4117) ([3f06a0c](https://github.com/bitnami/charts/commit/3f06a0c)), closes [#4117](https://github.com/bitnami/charts/issues/4117)
+* [bitnami/*] Include link to Troubleshootin guide on README.md (#4136) ([c08a20e](https://github.com/bitnami/charts/commit/c08a20e3db004215383004ff023a73fcc2522e72)), closes [#4136](https://github.com/bitnami/charts/issues/4136)
+* [bitnami/airflow] Release 6.7.2 updating components versions ([3780c49](https://github.com/bitnami/charts/commit/3780c49375c68dd68efb13a392043082ba9b172a))
+* [bitnami/airflow]: add documentation on python package installation into airflow containers (#4117) ([3f06a0c](https://github.com/bitnami/charts/commit/3f06a0c6883cff98a47ecaeba9f9ae07a87d908a)), closes [#4117](https://github.com/bitnami/charts/issues/4117)
 
 ## <small>6.7.1 (2020-10-21)</small>
 
-* [bitnami/airflow] Release 6.7.1 updating components versions ([3e14a96](https://github.com/bitnami/charts/commit/3e14a96))
+* [bitnami/airflow] Release 6.7.1 updating components versions ([3e14a96](https://github.com/bitnami/charts/commit/3e14a96f0c86e8dc39b5f2c2db19e276eb7fe2ed))
 
 ## 6.7.0 (2020-10-20)
 
-* [bitnami/airflow] add service-account and role creation (#3898) ([f8e72e8](https://github.com/bitnami/charts/commit/f8e72e8)), closes [#3898](https://github.com/bitnami/charts/issues/3898)
+* [bitnami/airflow] add service-account and role creation (#3898) ([f8e72e8](https://github.com/bitnami/charts/commit/f8e72e8e996afbebce68601db0e06b4c21b9d030)), closes [#3898](https://github.com/bitnami/charts/issues/3898)
 
 ## <small>6.6.1 (2020-10-06)</small>
 
-* [bitnami/airflow] fix typo in tests (#3907) ([71a2b05](https://github.com/bitnami/charts/commit/71a2b05)), closes [#3907](https://github.com/bitnami/charts/issues/3907)
+* [bitnami/airflow] fix typo in tests (#3907) ([71a2b05](https://github.com/bitnami/charts/commit/71a2b05b45b238907d1bf8fd7ffffd1289a8c441)), closes [#3907](https://github.com/bitnami/charts/issues/3907)
 
 ## 6.6.0 (2020-10-05)
 
-* [bitnami/airflow] add support for fetching dags from multiple git repo (#3804) ([9c532b6](https://github.com/bitnami/charts/commit/9c532b6)), closes [#3804](https://github.com/bitnami/charts/issues/3804)
+* [bitnami/airflow] add support for fetching dags from multiple git repo (#3804) ([9c532b6](https://github.com/bitnami/charts/commit/9c532b62059196a708903c5adf5bead2d08d4cf2)), closes [#3804](https://github.com/bitnami/charts/issues/3804)
 
 ## <small>6.5.1 (2020-09-28)</small>
 
-* [bitnami/airflow] Fix ingress labels (#3790) ([ed7318e](https://github.com/bitnami/charts/commit/ed7318e)), closes [#3790](https://github.com/bitnami/charts/issues/3790)
+* [bitnami/airflow] Fix ingress labels (#3790) ([ed7318e](https://github.com/bitnami/charts/commit/ed7318eaf92bf60a0d15c102f3ec007bad86d480)), closes [#3790](https://github.com/bitnami/charts/issues/3790)
 
 ## 6.5.0 (2020-09-24)
 
-* [bitnami/*] Affinity based on common presets (#3746) ([01884c7](https://github.com/bitnami/charts/commit/01884c7)), closes [#3746](https://github.com/bitnami/charts/issues/3746)
+* [bitnami/*] Affinity based on common presets (#3746) ([01884c7](https://github.com/bitnami/charts/commit/01884c767c48c38e6fa4c2984bd1acd5d6d81f9e)), closes [#3746](https://github.com/bitnami/charts/issues/3746)
 
 ## <small>6.4.2 (2020-09-21)</small>
 
-* [bitnami/airflow] Release 6.4.2 updating components versions ([9c90fdc](https://github.com/bitnami/charts/commit/9c90fdc))
-* [bitnami/metrics-server] Add source repo (#3577) ([1ed12f9](https://github.com/bitnami/charts/commit/1ed12f9)), closes [#3577](https://github.com/bitnami/charts/issues/3577)
+* [bitnami/airflow] Release 6.4.2 updating components versions ([9c90fdc](https://github.com/bitnami/charts/commit/9c90fdc59ec841235dbec74e8ada92bec356306b))
+* [bitnami/metrics-server] Add source repo (#3577) ([1ed12f9](https://github.com/bitnami/charts/commit/1ed12f96af75322b46afdb2b3d9907c11b13f765)), closes [#3577](https://github.com/bitnami/charts/issues/3577)
 
 ## <small>6.4.1 (2020-09-01)</small>
 
-* [bitnami/airflow] Release 6.4.1 updating components versions ([cb81f05](https://github.com/bitnami/charts/commit/cb81f05))
+* [bitnami/airflow] Release 6.4.1 updating components versions ([cb81f05](https://github.com/bitnami/charts/commit/cb81f05eddf407737b4a451e30488a11253c5b99))
 
 ## 6.4.0 (2020-08-26)
 
-* [bitnami/airflow] Allow pod annotations for Airflow workers (#3514) ([c1a145d](https://github.com/bitnami/charts/commit/c1a145d)), closes [#3514](https://github.com/bitnami/charts/issues/3514)
+* [bitnami/airflow] Allow pod annotations for Airflow workers (#3514) ([c1a145d](https://github.com/bitnami/charts/commit/c1a145d49e8a25194552ae4f20644ccf6edb3ab2)), closes [#3514](https://github.com/bitnami/charts/issues/3514)
 
 ## <small>6.3.10 (2020-08-26)</small>
 
-* [bitnami/airflow] Release 6.3.10 updating components versions ([1680b99](https://github.com/bitnami/charts/commit/1680b99))
+* [bitnami/airflow] Release 6.3.10 updating components versions ([1680b99](https://github.com/bitnami/charts/commit/1680b992b6605379abf24e801726d7d712f6459a))
 
 ## <small>6.3.9 (2020-08-07)</small>
 
-* [bitnami/airflow] Release 6.3.9 updating components versions ([9d913c6](https://github.com/bitnami/charts/commit/9d913c6))
+* [bitnami/airflow] Release 6.3.9 updating components versions ([9d913c6](https://github.com/bitnami/charts/commit/9d913c671a3a6c39f4d57f910671d0172366c486))
 
 ## <small>6.3.8 (2020-08-06)</small>
 
-* [bitnami/*] Fix TL;DR typo in READMEs (#3280) ([3d7ab40](https://github.com/bitnami/charts/commit/3d7ab40)), closes [#3280](https://github.com/bitnami/charts/issues/3280)
-* [bitnami/airflow] Release 6.3.8 updating components versions ([03be6af](https://github.com/bitnami/charts/commit/03be6af))
-* Add info for cloning private repositories ([989107d](https://github.com/bitnami/charts/commit/989107d))
+* [bitnami/*] Fix TL;DR typo in READMEs (#3280) ([3d7ab40](https://github.com/bitnami/charts/commit/3d7ab406fecd64f1af25f53e7d27f03ec95b29a4)), closes [#3280](https://github.com/bitnami/charts/issues/3280)
+* [bitnami/airflow] Release 6.3.8 updating components versions ([03be6af](https://github.com/bitnami/charts/commit/03be6afe95de9b995c2d2f5e5524f7f31a7f5127))
+* Add info for cloning private repositories ([989107d](https://github.com/bitnami/charts/commit/989107dd0f27b8651cf15658e8f7d6f930d28de8))
 
 ## <small>6.3.7 (2020-07-28)</small>
 
-* [bitnami/airflow] Fix LDAP when tls is not enabled (#3244) ([717eb47](https://github.com/bitnami/charts/commit/717eb47)), closes [#3244](https://github.com/bitnami/charts/issues/3244)
+* [bitnami/airflow] Fix LDAP when tls is not enabled (#3244) ([717eb47](https://github.com/bitnami/charts/commit/717eb4755122d93460a4505df75bca487d0ca0e1)), closes [#3244](https://github.com/bitnami/charts/issues/3244)
 
 ## <small>6.3.6 (2020-07-22)</small>
 
-* [bitnami/airflow] Fix wrong indentation of airflow.scheduler.extraVolumes (#2979) ([85d5092](https://github.com/bitnami/charts/commit/85d5092)), closes [#2979](https://github.com/bitnami/charts/issues/2979)
-* [bitnami/airflow] Release 6.3.6 updating components versions ([9ad8fe6](https://github.com/bitnami/charts/commit/9ad8fe6))
-* [bitnami/all] Add categories (#3075) ([63bde06](https://github.com/bitnami/charts/commit/63bde06)), closes [#3075](https://github.com/bitnami/charts/issues/3075)
+* [bitnami/airflow] Fix wrong indentation of airflow.scheduler.extraVolumes (#2979) ([85d5092](https://github.com/bitnami/charts/commit/85d5092c7b31992b2315be34961926991680c518)), closes [#2979](https://github.com/bitnami/charts/issues/2979)
+* [bitnami/airflow] Release 6.3.6 updating components versions ([9ad8fe6](https://github.com/bitnami/charts/commit/9ad8fe64fea6941529acd3417410109eb9403b29))
+* [bitnami/all] Add categories (#3075) ([63bde06](https://github.com/bitnami/charts/commit/63bde066b87a140fab52264d0522401ab3d63509)), closes [#3075](https://github.com/bitnami/charts/issues/3075)
 
 ## <small>6.3.5 (2020-07-02)</small>
 
-* [bitnami/airflow] Release 6.3.5 updating components versions ([b7947af](https://github.com/bitnami/charts/commit/b7947af))
+* [bitnami/airflow] Release 6.3.5 updating components versions ([b7947af](https://github.com/bitnami/charts/commit/b7947af9bab19a8e09563cc5d9f315abaca6179e))
 
 ## <small>6.3.4 (2020-06-28)</small>
 
-* [bitnami/airflow] Indentation fix in yaml output (#2685) ([131bab1](https://github.com/bitnami/charts/commit/131bab1)), closes [#2685](https://github.com/bitnami/charts/issues/2685)
-* [bitnami/airflow] Release 6.3.4 updating components versions ([ab025e5](https://github.com/bitnami/charts/commit/ab025e5))
+* [bitnami/airflow] Indentation fix in yaml output (#2685) ([131bab1](https://github.com/bitnami/charts/commit/131bab1ee084a5821f32c0430c3a10d14644871b)), closes [#2685](https://github.com/bitnami/charts/issues/2685)
+* [bitnami/airflow] Release 6.3.4 updating components versions ([ab025e5](https://github.com/bitnami/charts/commit/ab025e559e46c41574134ac0d60cb909b6a2d73c))
 
 ## <small>6.3.3 (2020-05-29)</small>
 
-* [bitnami/airflow] Release 6.3.3 updating components versions ([5d7a18a](https://github.com/bitnami/charts/commit/5d7a18a))
+* [bitnami/airflow] Release 6.3.3 updating components versions ([5d7a18a](https://github.com/bitnami/charts/commit/5d7a18acd1f4a666070e5b56fb2245c0d7fd173a))
 
 ## <small>6.3.2 (2020-05-28)</small>
 
-* [bitnami/airflow] Release 6.3.2 updating components versions ([837e9a7](https://github.com/bitnami/charts/commit/837e9a7))
+* [bitnami/airflow] Release 6.3.2 updating components versions ([837e9a7](https://github.com/bitnami/charts/commit/837e9a7a405826fe113fe881bb55d5f4fbbf76a3))
 
 ## <small>6.3.1 (2020-05-28)</small>
 
-* [bitnami/airflow] Release 6.3.1 updating components versions ([505e7c0](https://github.com/bitnami/charts/commit/505e7c0))
+* [bitnami/airflow] Release 6.3.1 updating components versions ([505e7c0](https://github.com/bitnami/charts/commit/505e7c0c80174c6717a21f0290ec3d6eabe74a47))
 
 ## 6.3.0 (2020-05-21)
 
-* [bitnami/airflow] Allow using extra env vars, extra volumes and extra volume mounts (#2595) ([0df8528](https://github.com/bitnami/charts/commit/0df8528)), closes [#2595](https://github.com/bitnami/charts/issues/2595)
-* update bitnami/common to be compatible with helm v2.12+ (#2615) ([c7751eb](https://github.com/bitnami/charts/commit/c7751eb)), closes [#2615](https://github.com/bitnami/charts/issues/2615)
+* [bitnami/airflow] Allow using extra env vars, extra volumes and extra volume mounts (#2595) ([0df8528](https://github.com/bitnami/charts/commit/0df85289a1b2e39b386a3967fa8e47a836e4a21a)), closes [#2595](https://github.com/bitnami/charts/issues/2595)
+* update bitnami/common to be compatible with helm v2.12+ (#2615) ([c7751eb](https://github.com/bitnami/charts/commit/c7751eb5764e468e1854b58a1b8491d2b13e0a4a)), closes [#2615](https://github.com/bitnami/charts/issues/2615)
 
 ## <small>6.2.2 (2020-05-15)</small>
 
-* [bitnami/airflow] Release 6.2.2 updating components versions ([905ac73](https://github.com/bitnami/charts/commit/905ac73))
+* [bitnami/airflow] Release 6.2.2 updating components versions ([905ac73](https://github.com/bitnami/charts/commit/905ac73478d9955d9afe2a4b4014caa2eca4a53c))
 
 ## <small>6.2.1 (2020-05-14)</small>
 
-* [bitnami/airflow] Release 6.2.1 updating components versions ([3108a1b](https://github.com/bitnami/charts/commit/3108a1b))
+* [bitnami/airflow] Release 6.2.1 updating components versions ([3108a1b](https://github.com/bitnami/charts/commit/3108a1b2188ea40c02e45b9110b9c94e38c68b30))
 
 ## 6.2.0 (2020-05-01)
 
-* [bitnami/airflow] add podManagementPolicy support for workers (#2420) ([2daa78e](https://github.com/bitnami/charts/commit/2daa78e)), closes [#2420](https://github.com/bitnami/charts/issues/2420)
+* [bitnami/airflow] add podManagementPolicy support for workers (#2420) ([2daa78e](https://github.com/bitnami/charts/commit/2daa78ee94bd3a2040fa940e22dcdf9383fd629f)), closes [#2420](https://github.com/bitnami/charts/issues/2420)
 
 ## <small>6.1.9 (2020-04-30)</small>
 
-* [bitnami/airflow] Release 6.1.9 updating components versions ([304b1e6](https://github.com/bitnami/charts/commit/304b1e6))
+* [bitnami/airflow] Release 6.1.9 updating components versions ([304b1e6](https://github.com/bitnami/charts/commit/304b1e6a8e2ecdc8453bbb845064ee21e6d53040))
 
 ## <small>6.1.8 (2020-04-23)</small>
 
-* [bitnami/airflow] Do not hardcode service port to 8080 (#2387) ([cfc60ae](https://github.com/bitnami/charts/commit/cfc60ae)), closes [#2387](https://github.com/bitnami/charts/issues/2387)
+* [bitnami/airflow] Do not hardcode service port to 8080 (#2387) ([cfc60ae](https://github.com/bitnami/charts/commit/cfc60ae12f7bdc04a4934e9557f4ebc9012a70a6)), closes [#2387](https://github.com/bitnami/charts/issues/2387)
 
 ## <small>6.1.7 (2020-04-22)</small>
 
-* [bitnami/airflow] Release 6.1.7 updating components versions ([6b97ceb](https://github.com/bitnami/charts/commit/6b97ceb))
+* [bitnami/airflow] Release 6.1.7 updating components versions ([6b97ceb](https://github.com/bitnami/charts/commit/6b97ceb18d88a17bc10129bc8428544333fc9245))
 
 ## <small>6.1.6 (2020-04-22)</small>
 
-* [bitnami/airflow] Release 6.1.6 updating components versions ([30be20f](https://github.com/bitnami/charts/commit/30be20f))
+* [bitnami/airflow] Release 6.1.6 updating components versions ([30be20f](https://github.com/bitnami/charts/commit/30be20ff06b4decb11e92cdfb59cadf5c292a563))
 
 ## <small>6.1.5 (2020-04-17)</small>
 
-* [bitnami/airflow] Release 6.1.5 updating components versions ([3b900e8](https://github.com/bitnami/charts/commit/3b900e8))
+* [bitnami/airflow] Release 6.1.5 updating components versions ([3b900e8](https://github.com/bitnami/charts/commit/3b900e83f98764a569320c746571229b96a47c2d))
 
 ## <small>6.1.4 (2020-04-17)</small>
 
-* fix wrong value reference (#2197) ([afabaef](https://github.com/bitnami/charts/commit/afabaef)), closes [#2197](https://github.com/bitnami/charts/issues/2197)
+* fix wrong value reference (#2197) ([afabaef](https://github.com/bitnami/charts/commit/afabaef0a6989adf1493a466c140828e9dc6d4a5)), closes [#2197](https://github.com/bitnami/charts/issues/2197)
 
 ## <small>6.1.3 (2020-04-16)</small>
 
-* [bitnami/airflow] Release 6.1.3 updating components versions ([91f4b33](https://github.com/bitnami/charts/commit/91f4b33))
+* [bitnami/airflow] Release 6.1.3 updating components versions ([91f4b33](https://github.com/bitnami/charts/commit/91f4b3377ebd2727e92724433093ad02476707be))
 
 ## <small>6.1.2 (2020-04-15)</small>
 
-* [bitnami/airflow] Release 6.1.2 updating components versions ([16f6d0e](https://github.com/bitnami/charts/commit/16f6d0e))
+* [bitnami/airflow] Release 6.1.2 updating components versions ([16f6d0e](https://github.com/bitnami/charts/commit/16f6d0ee6b28a71bb313902a13a33dc011c53821))
 
 ## <small>6.1.1 (2020-04-10)</small>
 
-* [bitnami/airflow] Release 6.1.1 updating components versions ([ff1eaf8](https://github.com/bitnami/charts/commit/ff1eaf8))
+* [bitnami/airflow] Release 6.1.1 updating components versions ([ff1eaf8](https://github.com/bitnami/charts/commit/ff1eaf8b60262d7cbcb497f869cf1a8ca716daf7))
 
 ## 6.1.0 (2020-04-10)
 
-* [bitnami/airflow] Allow existingSecret for redis/postgresql .enabled = true (#2279) ([d5dba30](https://github.com/bitnami/charts/commit/d5dba30)), closes [#2279](https://github.com/bitnami/charts/issues/2279)
+* [bitnami/airflow] Allow existingSecret for redis/postgresql .enabled = true (#2279) ([d5dba30](https://github.com/bitnami/charts/commit/d5dba30a8c4eb6b20fae925a30530cbc86e6e212)), closes [#2279](https://github.com/bitnami/charts/issues/2279)
 
 ## 6.0.0 (2020-04-10)
 
-* [bitnami/airflow] Adds support for LDAP configuration (#2174) ([958b35e](https://github.com/bitnami/charts/commit/958b35e)), closes [#2174](https://github.com/bitnami/charts/issues/2174)
+* [bitnami/airflow] Adds support for LDAP configuration (#2174) ([958b35e](https://github.com/bitnami/charts/commit/958b35ec9485ba33650f29cca0f361ec42baa94c)), closes [#2174](https://github.com/bitnami/charts/issues/2174)
 
 ## <small>5.0.6 (2020-04-09)</small>
 
-* [bitnami/airflow] Release 5.0.6 updating components versions ([c0e45c9](https://github.com/bitnami/charts/commit/c0e45c9))
+* [bitnami/airflow] Release 5.0.6 updating components versions ([c0e45c9](https://github.com/bitnami/charts/commit/c0e45c9da668b047868b38841bae204a885a36dc))
 
 ## <small>5.0.5 (2020-03-26)</small>
 
-* [bitnami/airflow] Release 5.0.5 updating components versions ([1151a91](https://github.com/bitnami/charts/commit/1151a91))
+* [bitnami/airflow] Release 5.0.5 updating components versions ([1151a91](https://github.com/bitnami/charts/commit/1151a91e41fe975e019cae82d36e4a25da1a5f5f))
 
 ## <small>5.0.4 (2020-03-20)</small>
 
-* [bitnami/airflow] Release 5.0.4 updating components versions ([2a56d35](https://github.com/bitnami/charts/commit/2a56d35))
+* [bitnami/airflow] Release 5.0.4 updating components versions ([2a56d35](https://github.com/bitnami/charts/commit/2a56d35a1147a1355fb409239d7e7c46e356b438))
 
 ## <small>5.0.3 (2020-03-11)</small>
 
-* [bitnami/airflow] Release 5.0.3 updating components versions ([2d364c8](https://github.com/bitnami/charts/commit/2d364c8))
+* [bitnami/airflow] Release 5.0.3 updating components versions ([2d364c8](https://github.com/bitnami/charts/commit/2d364c8e7ea58efac60b24311e904bf4917e6b53))
 
 ## <small>5.0.2 (2020-03-11)</small>
 
-* Move charts from upstreamed folder to bitnami (#2032) ([a0e44f7](https://github.com/bitnami/charts/commit/a0e44f7)), closes [#2032](https://github.com/bitnami/charts/issues/2032)
+* Move charts from upstreamed folder to bitnami (#2032) ([a0e44f7](https://github.com/bitnami/charts/commit/a0e44f7d6a10b8b5643186130ea420887cb72c7c)), closes [#2032](https://github.com/bitnami/charts/issues/2032)
 
 ## <small>5.0.1 (2020-03-05)</small>
 
-* [bitnami/airflow] Release 5.0.1 updating components versions ([3af6738](https://github.com/bitnami/charts/commit/3af6738))
+* [bitnami/airflow] Release 5.0.1 updating components versions ([3af6738](https://github.com/bitnami/charts/commit/3af67388df1e13ac4bbeec972d908e813be141ce))
 
 ## 5.0.0 (2020-02-26)
 
-* [bitnami/{airflow|harbor}] Update dependencies (#1980) ([69335d9](https://github.com/bitnami/charts/commit/69335d9)), closes [#1980](https://github.com/bitnami/charts/issues/1980)
+* [bitnami/{airflow|harbor}] Update dependencies (#1980) ([69335d9](https://github.com/bitnami/charts/commit/69335d950507ccd6de437e3a38bcbce10121bf71)), closes [#1980](https://github.com/bitnami/charts/issues/1980)
 
 ## <small>4.4.4 (2020-02-26)</small>
 
-* [bitnami/airflow] Release 4.4.4 updating components versions ([b734235](https://github.com/bitnami/charts/commit/b734235))
+* [bitnami/airflow] Release 4.4.4 updating components versions ([b734235](https://github.com/bitnami/charts/commit/b73423564fa4ca6e5a64510b0dc2ec426327c5d1))
 
 ## <small>4.4.3 (2020-02-25)</small>
 
-* 🐛 [bitnami/airflow] - fixing node selector, toleration and affinity (#1960) ([e9e21f0](https://github.com/bitnami/charts/commit/e9e21f0)), closes [#1960](https://github.com/bitnami/charts/issues/1960)
+* 🐛 [bitnami/airflow] - fixing node selector, toleration and affinity (#1960) ([e9e21f0](https://github.com/bitnami/charts/commit/e9e21f06f38e239df16e47750ea2617ab709969e)), closes [#1960](https://github.com/bitnami/charts/issues/1960)
 
 ## <small>4.4.2 (2020-02-20)</small>
 
-* [bitnami/airflow] Release 4.4.2 updating components versions ([5783159](https://github.com/bitnami/charts/commit/5783159))
+* [bitnami/airflow] Release 4.4.2 updating components versions ([5783159](https://github.com/bitnami/charts/commit/57831591e48c738c185772d0c8ca081a0e2c199d))
 
 ## <small>4.4.1 (2020-02-20)</small>
 
-* [bitnami/airflow] Release 4.4.1 updating components versions ([a842710](https://github.com/bitnami/charts/commit/a842710))
-* [bitnami/airflow] separate resources (#1951) ([d7a0ac8](https://github.com/bitnami/charts/commit/d7a0ac8)), closes [#1951](https://github.com/bitnami/charts/issues/1951)
+* [bitnami/airflow] Release 4.4.1 updating components versions ([a842710](https://github.com/bitnami/charts/commit/a842710b246c762221680a0ccb18b9b0a8b3fe57))
+* [bitnami/airflow] separate resources (#1951) ([d7a0ac8](https://github.com/bitnami/charts/commit/d7a0ac8fb0171c1cd18faeeb3e16d672f35bc169)), closes [#1951](https://github.com/bitnami/charts/issues/1951)
 
 ## 4.4.0 (2020-02-20)
 
-* [bitnami/airflow] adds support for retrieving the password for external Postgres and Redis from an e ([fdd9687](https://github.com/bitnami/charts/commit/fdd9687)), closes [#1917](https://github.com/bitnami/charts/issues/1917)
+* [bitnami/airflow] adds support for retrieving the password for external Postgres and Redis from an e ([fdd9687](https://github.com/bitnami/charts/commit/fdd9687070b5fd98b8ca1d607037c0b386bc968d)), closes [#1917](https://github.com/bitnami/charts/issues/1917)
 
 ## <small>4.3.4 (2020-02-20)</small>
 
-* [bitnami/airflow] Unify both values files ([6072df4](https://github.com/bitnami/charts/commit/6072df4))
+* [bitnami/airflow] Unify both values files ([6072df4](https://github.com/bitnami/charts/commit/6072df405d9c1582096784c5019c642b2dd3827d))
 
 ## <small>4.3.3 (2020-02-17)</small>
 
-* bitnami/airflow: fix nodeSelector for web and scheduler deployments (#1929) ([8aa56ac](https://github.com/bitnami/charts/commit/8aa56ac)), closes [#1929](https://github.com/bitnami/charts/issues/1929)
+* bitnami/airflow: fix nodeSelector for web and scheduler deployments (#1929) ([8aa56ac](https://github.com/bitnami/charts/commit/8aa56acf3f2499b0be43cd8517ac7a1d440b51b2)), closes [#1929](https://github.com/bitnami/charts/issues/1929)
 
 ## <small>4.3.2 (2020-02-17)</small>
 
-* [bitnami/airflow] Fix typo. (#1931) ([2219ebb](https://github.com/bitnami/charts/commit/2219ebb)), closes [#1931](https://github.com/bitnami/charts/issues/1931)
+* [bitnami/airflow] Fix typo. (#1931) ([2219ebb](https://github.com/bitnami/charts/commit/2219ebb83d3d607dfb8bc332ada60ac4cf0f6636)), closes [#1931](https://github.com/bitnami/charts/issues/1931)
 
 ## <small>4.3.1 (2020-02-11)</small>
 
-* [bitnami/several] Adapt READMEs and helpers to Helm 3 (#1911) ([40ee57c](https://github.com/bitnami/charts/commit/40ee57c)), closes [#1911](https://github.com/bitnami/charts/issues/1911)
+* [bitnami/several] Adapt READMEs and helpers to Helm 3 (#1911) ([40ee57c](https://github.com/bitnami/charts/commit/40ee57cf5164717357e1627b55bf25f59c40fbd1)), closes [#1911](https://github.com/bitnami/charts/issues/1911)
 
 ## 4.3.0 (2020-02-11)
 
-* [bitnami/airflow] Add support for plugins loaded from a git repo (#1898) ([f3cbda9](https://github.com/bitnami/charts/commit/f3cbda9)), closes [#1898](https://github.com/bitnami/charts/issues/1898)
+* [bitnami/airflow] Add support for plugins loaded from a git repo (#1898) ([f3cbda9](https://github.com/bitnami/charts/commit/f3cbda95e41a89889b4def933de776dd2626c02f)), closes [#1898](https://github.com/bitnami/charts/issues/1898)
 
 ## <small>4.2.1 (2020-02-08)</small>
 
-* [bitnami/airflow] Release 4.2.1 updating components versions ([d345a61](https://github.com/bitnami/charts/commit/d345a61))
+* [bitnami/airflow] Release 4.2.1 updating components versions ([d345a61](https://github.com/bitnami/charts/commit/d345a610ffdd4dbcb87a8909bf90e96631930990))
 
 ## 4.2.0 (2020-02-06)
 
-* [bitnami/airflow] Allow setting Redis username on external redis ([6f78e81](https://github.com/bitnami/charts/commit/6f78e81))
+* [bitnami/airflow] Allow setting Redis username on external redis ([6f78e81](https://github.com/bitnami/charts/commit/6f78e816c51f52efbfd49cac3271cc873989e71e))
 
 ## <small>4.1.3 (2020-01-24)</small>
 
-* [bitnami/airflow] Release 4.1.3 updating components versions ([70c8787](https://github.com/bitnami/charts/commit/70c8787))
+* [bitnami/airflow] Release 4.1.3 updating components versions ([70c8787](https://github.com/bitnami/charts/commit/70c878751d315f64bd05bf347ba0108957cc83fb))
 
 ## <small>4.1.2 (2020-01-21)</small>
 
-* Airflow: Bump chart version ([7bd0b08](https://github.com/bitnami/charts/commit/7bd0b08))
-* Update README.md ([ddb3312](https://github.com/bitnami/charts/commit/ddb3312))
+* Airflow: Bump chart version ([7bd0b08](https://github.com/bitnami/charts/commit/7bd0b08705c8fc42816d44cd19a208b1564b3f49))
+* Update README.md ([ddb3312](https://github.com/bitnami/charts/commit/ddb331282c886171176ecc15a751b704e1a1ffca))
 
 ## <small>4.1.1 (2020-01-14)</small>
 
-* [bitnami/airflow] Release 4.1.1 updating components versions ([6733b9d](https://github.com/bitnami/charts/commit/6733b9d))
+* [bitnami/airflow] Release 4.1.1 updating components versions ([6733b9d](https://github.com/bitnami/charts/commit/6733b9d479c26fd595a2aef8fc9f0648720721d4))
 
 ## 4.1.0 (2020-01-12)
 
-* added option to load DAGs from a specified subfolder in the git repo ([8bec104](https://github.com/bitnami/charts/commit/8bec104))
+* added option to load DAGs from a specified subfolder in the git repo ([8bec104](https://github.com/bitnami/charts/commit/8bec104c36059d97641736137f9a026b86f12e50))
 
 ## <small>4.0.20 (2019-12-27)</small>
 
-* [bitnami/airflow] Release 4.0.20 updating components versions ([22492af](https://github.com/bitnami/charts/commit/22492af))
-* Update bitnami/airflow/templates/deployment-web.yaml ([50a51aa](https://github.com/bitnami/charts/commit/50a51aa))
-* Update README.md ([f3b8cfc](https://github.com/bitnami/charts/commit/f3b8cfc))
+* [bitnami/airflow] Release 4.0.20 updating components versions ([22492af](https://github.com/bitnami/charts/commit/22492af71eef6c3f2c0bda9d1786c1f769f8dc19))
+* Update bitnami/airflow/templates/deployment-web.yaml ([50a51aa](https://github.com/bitnami/charts/commit/50a51aa6f8d7e930f4314a5551c1085d17aafb8e))
+* Update README.md ([f3b8cfc](https://github.com/bitnami/charts/commit/f3b8cfcb3c09fc6f51c89230601545a204c5cd42))
 
 ## <small>4.0.19 (2019-12-25)</small>
 
-* Add wirflow.webserverConfigMap to allow overide ~/airflow/webserver_config.py ([3f469dc](https://github.com/bitnami/charts/commit/3f469dc))
-* Update Chart.yaml ([ffe6c85](https://github.com/bitnami/charts/commit/ffe6c85))
+* Add wirflow.webserverConfigMap to allow overide ~/airflow/webserver_config.py ([3f469dc](https://github.com/bitnami/charts/commit/3f469dc5b23824a9c805c75203ac8fd4303352f2))
+* Update Chart.yaml ([ffe6c85](https://github.com/bitnami/charts/commit/ffe6c850bd92dd30b3ed3f96b16814a1cabd7ee1))
 
 ## <small>4.0.18 (2019-12-11)</small>
 
-* Update Chart.yaml ([95e2689](https://github.com/bitnami/charts/commit/95e2689))
-* Update statefulset-worker.yaml ([716cd04](https://github.com/bitnami/charts/commit/716cd04))
+* Update Chart.yaml ([95e2689](https://github.com/bitnami/charts/commit/95e26891830923fad8b3db622a948663111d4fc4))
+* Update statefulset-worker.yaml ([716cd04](https://github.com/bitnami/charts/commit/716cd04b92e8711bce2bd0d163de48acfda35c81))
 
 ## <small>4.0.17 (2019-12-10)</small>
 
-* [bitnami/airflow] fix resource template in `statefulset-worker.yaml` ([d1a986e](https://github.com/bitnami/charts/commit/d1a986e)), closes [#1686](https://github.com/bitnami/charts/issues/1686)
+* [bitnami/airflow] fix resource template in `statefulset-worker.yaml` ([d1a986e](https://github.com/bitnami/charts/commit/d1a986eac9391cd336cc55acc8f53f6e1a481b67)), closes [#1686](https://github.com/bitnami/charts/issues/1686)
 
 ## <small>4.0.16 (2019-11-15)</small>
 
-* [bitnami/airflow] Release 4.0.16 updating components versions ([20355af](https://github.com/bitnami/charts/commit/20355af))
+* [bitnami/airflow] Release 4.0.16 updating components versions ([20355af](https://github.com/bitnami/charts/commit/20355afb53e87e81396a668368cf5d19868cc095))
 
 ## <small>4.0.15 (2019-11-12)</small>
 
-* [bitnami/airflow] Release 4.0.15 updating components versions ([b594e92](https://github.com/bitnami/charts/commit/b594e92))
+* [bitnami/airflow] Release 4.0.15 updating components versions ([b594e92](https://github.com/bitnami/charts/commit/b594e9225adec33bd40b61307d06078bafbedfc0))
 
 ## <small>4.0.14 (2019-11-11)</small>
 
-* [bitnami/airflow] Release 4.0.14 updating components versions ([c9e6bdc](https://github.com/bitnami/charts/commit/c9e6bdc))
+* [bitnami/airflow] Release 4.0.14 updating components versions ([c9e6bdc](https://github.com/bitnami/charts/commit/c9e6bdc182f4e48b34e15345f9284b5827d7c7c7))
 
 ## <small>4.0.13 (2019-11-09)</small>
 
-* [bitnami/airflow] Release 4.0.13 updating components versions ([fe23688](https://github.com/bitnami/charts/commit/fe23688))
+* [bitnami/airflow] Release 4.0.13 updating components versions ([fe23688](https://github.com/bitnami/charts/commit/fe236882745e07e6a2310202aeb9405944e20ebf))
 
 ## <small>4.0.12 (2019-11-07)</small>
 
-* [bitnami/airflow] Release 4.0.12 updating components versions ([8959645](https://github.com/bitnami/charts/commit/8959645))
+* [bitnami/airflow] Release 4.0.12 updating components versions ([8959645](https://github.com/bitnami/charts/commit/895964572ecf336d4a3c43bf68baa93c3b84bea8))
 
 ## <small>3.1.12 (2019-10-15)</small>
 
-* [bitnami/airflow] Lint chart ([5579be9](https://github.com/bitnami/charts/commit/5579be9))
+* [bitnami/airflow] Lint chart ([5579be9](https://github.com/bitnami/charts/commit/5579be97c7c3727b4f8345c8e1357bec13c4553f7c7c3727b4f8345c8e1357bec13c4553f))
 
 ## <small>4.0.10 (2019-11-06)</small>
 
-* [bitnami/airflow] Release 4.0.10 updating components versions ([02020d7](https://github.com/bitnami/charts/commit/02020d7))
+* [bitnami/airflow] Release 4.0.10 updating components versions ([02020d7](https://github.com/bitnami/charts/commit/02020d748b6a697cb51a7926b9f99896130b7b18))
 
 ## <small>4.0.9 (2019-11-04)</small>
 
-* [bitnami/airflow] Release 4.0.9 updating components versions ([9580a53](https://github.com/bitnami/charts/commit/9580a53))
+* [bitnami/airflow] Release 4.0.9 updating components versions ([9580a53](https://github.com/bitnami/charts/commit/9580a535d3249ef83bd72caecf3851d0a46ee1da))
 
 ## <small>4.0.8 (2019-11-03)</small>
 
-* [bitnami/airflow] Release 4.0.8 updating components versions ([5aa7821](https://github.com/bitnami/charts/commit/5aa7821))
+* [bitnami/airflow] Release 4.0.8 updating components versions ([5aa7821](https://github.com/bitnami/charts/commit/5aa782199ddbdb80d492b10153d39508241ea211))
 
 ## <small>4.0.7 (2019-11-02)</small>
 
-* [bitnami/airflow] Release 4.0.7 updating components versions ([f445333](https://github.com/bitnami/charts/commit/f445333))
+* [bitnami/airflow] Release 4.0.7 updating components versions ([f445333](https://github.com/bitnami/charts/commit/f445333d73c78588afbaac9d01ade1494624a92c))
 
 ## <small>4.0.6 (2019-10-31)</small>
 
-* [bitnami/airflow] Release 4.0.6 updating components versions ([9ef393c](https://github.com/bitnami/charts/commit/9ef393c))
+* [bitnami/airflow] Release 4.0.6 updating components versions ([9ef393c](https://github.com/bitnami/charts/commit/9ef393c8f7e69bf6d03e3b64b0e669642dc0ea86))
 
 ## <small>4.0.5 (2019-10-30)</small>
 
-* [bitnami/airflow] Release 4.0.5 updating components versions ([fe0aafb](https://github.com/bitnami/charts/commit/fe0aafb))
+* [bitnami/airflow] Release 4.0.5 updating components versions ([fe0aafb](https://github.com/bitnami/charts/commit/fe0aafb1bba15386362addbe3f501817b30967b8))
 
 ## <small>4.0.4 (2019-10-30)</small>
 
-* [bitnami/airflow] Release 4.0.4 updating components versions ([c647a50](https://github.com/bitnami/charts/commit/c647a50))
+* [bitnami/airflow] Release 4.0.4 updating components versions ([c647a50](https://github.com/bitnami/charts/commit/c647a50ab115fe8f644c628b6efc434d20dd0ed6))
 
 ## <small>4.0.3 (2019-10-24)</small>
 
-* Fix links because of section renaming ([8e6fa3b](https://github.com/bitnami/charts/commit/8e6fa3b))
+* Fix links because of section renaming ([8e6fa3b](https://github.com/bitnami/charts/commit/8e6fa3bf7e3198954b6af507cf143fd4870c1c33))
 
 ## <small>4.0.2 (2019-10-23)</small>
 
-* Adapt README in charts (I) ([eb80a7e](https://github.com/bitnami/charts/commit/eb80a7e))
-* Update values-production ([3812d2f](https://github.com/bitnami/charts/commit/3812d2f))
+* Adapt README in charts (I) ([eb80a7e](https://github.com/bitnami/charts/commit/eb80a7eadd32e55caaa9aa3b1b7741e02f2648c7))
+* Update values-production ([3812d2f](https://github.com/bitnami/charts/commit/3812d2ffda292c25496fd5fe0a256c170365e451))
 
 ## <small>4.0.1 (2019-10-22)</small>
 
-* [bitnami/airflow] Fix wrong image tag ([cc887e9](https://github.com/bitnami/charts/commit/cc887e9))
-* [bitnami/airflow] Update components versions ([5271af8](https://github.com/bitnami/charts/commit/5271af8))
-* Indentation ([aed87c7](https://github.com/bitnami/charts/commit/aed87c7))
+* [bitnami/airflow] Fix wrong image tag ([cc887e9](https://github.com/bitnami/charts/commit/cc887e9d804e5b652205b8ce59716437eb01c9b8))
+* [bitnami/airflow] Update components versions ([5271af8](https://github.com/bitnami/charts/commit/5271af8e872802ab68d441b968fe192a438f7049))
+* Indentation ([aed87c7](https://github.com/bitnami/charts/commit/aed87c72f829e667001fa5a3b62ef8059c711ef7))
 
 ## 4.0.0 (2019-10-17)
 
-* Fix Airflow Ingress ([ff7109b](https://github.com/bitnami/charts/commit/ff7109b))
+* Fix Airflow Ingress ([ff7109b](https://github.com/bitnami/charts/commit/ff7109bfe0ad0ef9a2c339db8c571218aa2a22fb))
 
 ## <small>3.1.12 (2019-10-15)</small>
 
-* [bitnami/airflow] Lint chart ([5579be9](https://github.com/bitnami/charts/commit/5579be9))
+* [bitnami/airflow] Lint chart ([5579be9](https://github.com/bitnami/charts/commit/5579be97c7c3727b4f8345c8e1357bec13c4553f7c7c3727b4f8345c8e1357bec13c4553f))
 
 ## <small>3.1.11 (2019-10-09)</small>
 
-* [bitnami/airflow] Release 3.1.11 updating components versions ([4c48c87](https://github.com/bitnami/charts/commit/4c48c87))
+* [bitnami/airflow] Release 3.1.11 updating components versions ([4c48c87](https://github.com/bitnami/charts/commit/4c48c87e29145d4a66e69565bd45834d1fb6e7cf))
 
 ## <small>3.1.10 (2019-10-03)</small>
 
-* [bitnami/*] Fix broken links to NGINX Ingress Annotations docs ([42a2f47](https://github.com/bitnami/charts/commit/42a2f47))
+* [bitnami/*] Fix broken links to NGINX Ingress Annotations docs ([42a2f47](https://github.com/bitnami/charts/commit/42a2f476bdc0f4960ad15d9a8e2fca8cef684b8f))
 
 ## <small>3.1.9 (2019-09-27)</small>
 
-* [bitnami/airflow] [bitnami/nginx-ingress-controller] Change apps/v1beta* to apps/v1 ([186648f](https://github.com/bitnami/charts/commit/186648f))
+* [bitnami/airflow] [bitnami/nginx-ingress-controller] Change apps/v1beta* to apps/v1 ([186648f](https://github.com/bitnami/charts/commit/186648f53daf4cc23a03f11bd46c66d9a7031675))
 
 ## <small>3.1.8 (2019-09-20)</small>
 
-* [bitnami/*] Update apiVersion on sts, deployments, daemonsets and podsecuritypolicies ([4dfac07](https://github.com/bitnami/charts/commit/4dfac07))
+* [bitnami/*] Update apiVersion on sts, deployments, daemonsets and podsecuritypolicies ([4dfac07](https://github.com/bitnami/charts/commit/4dfac075aacf74405e31ae5b27df4369e84eb0b0))
 
 ## <small>3.1.7 (2019-09-09)</small>
 
-* Update postgresql dependency in Harbor and Airflow ([a0d2b4c](https://github.com/bitnami/charts/commit/a0d2b4c))
+* Update postgresql dependency in Harbor and Airflow ([a0d2b4c](https://github.com/bitnami/charts/commit/a0d2b4cf1938b6cff2b920d9e9f5c7e2593fa9f2))
 
 ## <small>3.1.6 (2019-09-09)</small>
 
-* [bitnami/airflow] Release 3.1.6 updating components versions ([0f1cee9](https://github.com/bitnami/charts/commit/0f1cee9))
+* [bitnami/airflow] Release 3.1.6 updating components versions ([0f1cee9](https://github.com/bitnami/charts/commit/0f1cee975f595e575e6c76d827265762962aa9d3))
 
 ## <small>3.1.5 (2019-09-05)</small>
 
-* [bitnami/airflow] Release 3.1.5 updating components versions ([b11df44](https://github.com/bitnami/charts/commit/b11df44))
+* [bitnami/airflow] Release 3.1.5 updating components versions ([b11df44](https://github.com/bitnami/charts/commit/b11df440764904a00085b2db0cc1de247cd4684b))
 
 ## <small>3.1.4 (2019-09-05)</small>
 
-* [bitnami/airflow] Release 3.1.4 updating components versions ([ac6301f](https://github.com/bitnami/charts/commit/ac6301f))
+* [bitnami/airflow] Release 3.1.4 updating components versions ([ac6301f](https://github.com/bitnami/charts/commit/ac6301fed9966310a838ac462459b9443ebbe921))
 
 ## <small>3.1.3 (2019-09-04)</small>
 
-* [bitnami/airflow] Release 3.1.3 updating components versions ([b4c5c7a](https://github.com/bitnami/charts/commit/b4c5c7a))
+* [bitnami/airflow] Release 3.1.3 updating components versions ([b4c5c7a](https://github.com/bitnami/charts/commit/b4c5c7a20a7f5012ff645da41c422c2d8c65e878))
 
 ## <small>3.1.2 (2019-09-03)</small>
 
-* [bitnami/airflow] Release 3.1.2 updating components versions ([b870354](https://github.com/bitnami/charts/commit/b870354))
+* [bitnami/airflow] Release 3.1.2 updating components versions ([b870354](https://github.com/bitnami/charts/commit/b870354cebe84da511ad59474ead1a13c3c12386))
 
 ## <small>3.1.1 (2019-09-02)</small>
 
-* [bitnami/airflow] Release 3.1.1 updating components versions ([dde9b77](https://github.com/bitnami/charts/commit/dde9b77))
-* Delete global storageClass when the chart has not dependencies and delete template for storageClass  ([2b5302c](https://github.com/bitnami/charts/commit/2b5302c))
-* Refactor storageClassTemplate ([1872215](https://github.com/bitnami/charts/commit/1872215))
+* [bitnami/airflow] Release 3.1.1 updating components versions ([dde9b77](https://github.com/bitnami/charts/commit/dde9b77e3123eef2f82a33cc51ec6a335db4acea))
+* Delete global storageClass when the chart has not dependencies and delete template for storageClass  ([2b5302c](https://github.com/bitnami/charts/commit/2b5302cf7c5053ba4a51fe21fb7fee16d2866a18))
+* Refactor storageClassTemplate ([1872215](https://github.com/bitnami/charts/commit/1872215effe0a6ff672537387684c8a97fb3093c))
 
 ## 3.1.0 (2019-08-19)
 
-* [bitnami/airflow] Update components versions ([6580dad](https://github.com/bitnami/charts/commit/6580dad))
-* Add global variable to set the storage class to all of the Hekm Charts ([cdb4bdc](https://github.com/bitnami/charts/commit/cdb4bdc))
-* Update charts versions ([9459dbb](https://github.com/bitnami/charts/commit/9459dbb))
+* [bitnami/airflow] Update components versions ([6580dad](https://github.com/bitnami/charts/commit/6580dad9f6a14d17e3ec13dc35958662a78338b2))
+* Add global variable to set the storage class to all of the Hekm Charts ([cdb4bdc](https://github.com/bitnami/charts/commit/cdb4bdceda07e03f3902ec2796eab54d2c6f1650))
+* Update charts versions ([9459dbb](https://github.com/bitnami/charts/commit/9459dbbf98c5572f0b92cd3eef8e12ec83a48397))
 
 ## 3.0.0 (2019-08-19)
 
-* [bitnami/node][bitnami/airflow] Update dependencies] ([a0326b1](https://github.com/bitnami/charts/commit/a0326b1))
+* [bitnami/node][bitnami/airflow] Update dependencies] ([a0326b1](https://github.com/bitnami/charts/commit/a0326b1e611937e2f94981f8b73861f6e2045bd5))
 
 ## <small>2.1.1 (2019-08-13)</small>
 
-* Update README.md ([37aede4](https://github.com/bitnami/charts/commit/37aede4))
-* Updated version numbers ([aa0294b](https://github.com/bitnami/charts/commit/aa0294b))
+* Update README.md ([37aede4](https://github.com/bitnami/charts/commit/37aede488948b199ce6cb7151d9bbec6f61687b8))
+* Updated version numbers ([aa0294b](https://github.com/bitnami/charts/commit/aa0294b246340ed44d76f8cac59338ee685fab5e))
 
 ## 2.1.0 (2019-08-12)
 
-* [bitnami/airflow] Use bitnami/airflow-exporter ([1081095](https://github.com/bitnami/charts/commit/1081095))
+* [bitnami/airflow] Use bitnami/airflow-exporter ([1081095](https://github.com/bitnami/charts/commit/1081095b3b233152fd3a0ab3822b99ec97487345))
 
 ## 2.0.0 (2019-07-17)
 
-* Implement again #1283 changes but bumping the major version ([1ce079c](https://github.com/bitnami/charts/commit/1ce079c)), closes [#1283](https://github.com/bitnami/charts/issues/1283)
+* Implement again #1283 changes but bumping the major version ([1ce079c](https://github.com/bitnami/charts/commit/1ce079c789a6c0f5174094af3ea6fb67b6c926fd)), closes [#1283](https://github.com/bitnami/charts/issues/1283)
 
 ## <small>1.0.3 (2019-07-17)</small>
 
-* Revert pull request #1283 ([8e5940a](https://github.com/bitnami/charts/commit/8e5940a)), closes [#1283](https://github.com/bitnami/charts/issues/1283)
+* Revert pull request #1283 ([8e5940a](https://github.com/bitnami/charts/commit/8e5940a9260dc722ae1a630a6b6e21df2502323f)), closes [#1283](https://github.com/bitnami/charts/issues/1283)
 
 ## <small>1.0.2 (2019-07-11)</small>
 
-* Standardize component.name & component.fullname functions ([775948e](https://github.com/bitnami/charts/commit/775948e))
+* Standardize component.name & component.fullname functions ([775948e](https://github.com/bitnami/charts/commit/775948eb27ccc5599262002b71f4982cc2b2dc8d))
 
 ## <small>1.0.1 (2019-07-01)</small>
 
-* [bitnami/airflow] Release 1.0.1 updating components versions ([b45387f](https://github.com/bitnami/charts/commit/b45387f))
+* [bitnami/airflow] Release 1.0.1 updating components versions ([b45387f](https://github.com/bitnami/charts/commit/b45387f5c73fd8a130142cc47f13859eafe03ec2))
 
 ## 1.0.0 (2019-06-28)
 
-* [bitnami/airflow] Update Airflow redis dependency ([d8b57b4](https://github.com/bitnami/charts/commit/d8b57b4))
-* Changes in README ([7ac4ec0](https://github.com/bitnami/charts/commit/7ac4ec0))
+* [bitnami/airflow] Update Airflow redis dependency ([d8b57b4](https://github.com/bitnami/charts/commit/d8b57b4eb1c66cf1ca3ab4cb1679790532ea9e08))
+* Changes in README ([7ac4ec0](https://github.com/bitnami/charts/commit/7ac4ec09a0113aae7d39173f52fb11c55f27cde5))
 
 ## <small>0.1.6 (2019-06-10)</small>
 
-* bitnami/airflow: update to 1.10.3 ([edefdf7](https://github.com/bitnami/charts/commit/edefdf7))
-* Bump version ([a672193](https://github.com/bitnami/charts/commit/a672193))
+* bitnami/airflow: update to 1.10.3 ([edefdf7](https://github.com/bitnami/charts/commit/edefdf7f240562554a3ae5f49d119e2b9055d8e0))
+* Bump version ([a672193](https://github.com/bitnami/charts/commit/a67219387480695cdd7e4dd2a7f5443ed8093a11))
 
 ## <small>0.1.5 (2019-06-10)</small>
 
-* Add command ([0d05d59](https://github.com/bitnami/charts/commit/0d05d59))
-* Use IfNotPresent as imagePullPolicy since we are using immutable tags ([53247da](https://github.com/bitnami/charts/commit/53247da))
+* Add command ([0d05d59](https://github.com/bitnami/charts/commit/0d05d591ce989ee2cd9cfeec8f2691c2bd74ba6c))
+* Use IfNotPresent as imagePullPolicy since we are using immutable tags ([53247da](https://github.com/bitnami/charts/commit/53247da385b3bed19f02505b059591869893ecbb))
 
 ## <small>0.1.4 (2019-06-07)</small>
 
-* [bitnami/airflow] Unify and document production values ([27f9b73](https://github.com/bitnami/charts/commit/27f9b73))
+* [bitnami/airflow] Unify and document production values ([27f9b73](https://github.com/bitnami/charts/commit/27f9b732ffc56801bacecc8156c038a48c5d1cb2))
 
 ## <small>0.1.3 (2019-06-07)</small>
 
-* bitnami/airflow: update to 1.10.3 ([fb3fdd5](https://github.com/bitnami/charts/commit/fb3fdd5))
+* bitnami/airflow: update to 1.10.3 ([fb3fdd5](https://github.com/bitnami/charts/commit/fb3fdd50b2dc459d080d70d5b7295ff588108e1e))
 
 ## <small>0.1.2 (2019-05-29)</small>
 
-* Check secondary images ([5327cfa](https://github.com/bitnami/charts/commit/5327cfa))
-* Fix https://github.com/helm/charts/pull/14199\#issuecomment-496883321 and support _sha256_ as an imm ([95957ea](https://github.com/bitnami/charts/commit/95957ea)), closes [#issuecomment-496883321](https://github.com/bitnami/charts/issues/issuecomment-496883321)
-* Use immutable tags in the main images ([17ca4f5](https://github.com/bitnami/charts/commit/17ca4f5))
+* Check secondary images ([5327cfa](https://github.com/bitnami/charts/commit/5327cfa319191dd8067ce538d53f4c44edfdc012))
+* Fix https://github.com/helm/charts/pull/14199\#issuecomment-496883321 and support _sha256_ as an imm ([95957ea](https://github.com/bitnami/charts/commit/95957ea6430f28ec3593053afb0bfccb75703c79)), closes [#issuecomment-496883321](https://github.com/bitnami/charts/issues/issuecomment-496883321)
+* Use immutable tags in the main images ([17ca4f5](https://github.com/bitnami/charts/commit/17ca4f5c91da33da03f9e2d411fe5e004e825c4d))
 
 ## <small>0.1.1 (2019-05-28)</small>
 
-* Prepare immutable tags ([f9093c1](https://github.com/bitnami/charts/commit/f9093c1))
-* Rename sidecar container to 'git-repo-syncer' ([60c9085](https://github.com/bitnami/charts/commit/60c9085))
-* Use 60 seconds as default interval ([305dda2](https://github.com/bitnami/charts/commit/305dda2))
+* Prepare immutable tags ([f9093c1](https://github.com/bitnami/charts/commit/f9093c1aaa9cde25a042c3d62f7873385447cbf7))
+* Rename sidecar container to 'git-repo-syncer' ([60c9085](https://github.com/bitnami/charts/commit/60c90851d887a5af14c67757a6f2fac7a823075f))
+* Use 60 seconds as default interval ([305dda2](https://github.com/bitnami/charts/commit/305dda20292afd5e1ddc2e5a08f195fa5ddeb3ad))
 
 ## 0.1.0 (2019-05-24)
 
-* [bitnami/airflow] Add sidecar container to update git repository periodically ([492c2c3](https://github.com/bitnami/charts/commit/492c2c3))
+* [bitnami/airflow] Add sidecar container to update git repository periodically ([492c2c3](https://github.com/bitnami/charts/commit/492c2c386600875498da2900605cc074ebdf0564))
 
 ## <small>0.0.4 (2019-05-13)</small>
 
-* Change gitImage to git ([7dc72b5](https://github.com/bitnami/charts/commit/7dc72b5))
-* Change gitImage to git ([37bf5f5](https://github.com/bitnami/charts/commit/37bf5f5))
+* Change gitImage to git ([7dc72b5](https://github.com/bitnami/charts/commit/7dc72b59443a3b8544888ec68ae842cb99b3cee2))
+* Change gitImage to git ([37bf5f5](https://github.com/bitnami/charts/commit/37bf5f53db3b49d5c55cdd3d8ca05fb23812a8ca))
 
 ## <small>0.0.3 (2019-05-09)</small>
 
-* [bitnami/airflow] Update Airflow dependencies ([439cb34](https://github.com/bitnami/charts/commit/439cb34))
-* Update 'patch' version instead ([fa577bc](https://github.com/bitnami/charts/commit/fa577bc))
+* [bitnami/airflow] Update Airflow dependencies ([439cb34](https://github.com/bitnami/charts/commit/439cb34962eeb74a481cc2906058b4759fd1ec48))
+* Update 'patch' version instead ([fa577bc](https://github.com/bitnami/charts/commit/fa577bc2cc74618c821a89e9d08690305e801fcc))
 
 ## <small>0.0.2 (2019-05-07)</small>
 
-* [bitnami/airflow] Remove testing value ([96beb09](https://github.com/bitnami/charts/commit/96beb09))
-* Add javsalgar feedback ([6750e89](https://github.com/bitnami/charts/commit/6750e89))
-* Add metrics exporter ([811b29c](https://github.com/bitnami/charts/commit/811b29c))
-* Delete extra blank line ([aaa4e46](https://github.com/bitnami/charts/commit/aaa4e46))
-* Fix imagePullSecret template ([9e5b51c](https://github.com/bitnami/charts/commit/9e5b51c))
-* Fix imagePullSecret template for metrics image ([5893c2b](https://github.com/bitnami/charts/commit/5893c2b))
-* Rename volume ([edd83e9](https://github.com/bitnami/charts/commit/edd83e9))
-* Truncate several names to 63 chars instead of 24 ([fe9e6ee](https://github.com/bitnami/charts/commit/fe9e6ee))
-* Update imagePullSecrets helper ([34bd725](https://github.com/bitnami/charts/commit/34bd725))
-* Update NOTES.txt and other fixes ([77c87c4](https://github.com/bitnami/charts/commit/77c87c4))
+* [bitnami/airflow] Remove testing value ([96beb09](https://github.com/bitnami/charts/commit/96beb0918d5fa032e509f2cfade872d5eba27921))
+* Add javsalgar feedback ([6750e89](https://github.com/bitnami/charts/commit/6750e8940f4eaa3943edaac87de62fcb98afe395))
+* Add metrics exporter ([811b29c](https://github.com/bitnami/charts/commit/811b29c17046d97490eafe4beaf8f57a42d85abe))
+* Delete extra blank line ([aaa4e46](https://github.com/bitnami/charts/commit/aaa4e4688a5bfc9895da242f61df9354b8572d5d))
+* Fix imagePullSecret template ([9e5b51c](https://github.com/bitnami/charts/commit/9e5b51cb110080a755e0cc2128d5ec378bca2b08))
+* Fix imagePullSecret template for metrics image ([5893c2b](https://github.com/bitnami/charts/commit/5893c2bea2c5d0e7dc6f1377978f3ac2f7d7b5e0))
+* Rename volume ([edd83e9](https://github.com/bitnami/charts/commit/edd83e9c2ab0b61164ed13a10e75e577224a2f68))
+* Truncate several names to 63 chars instead of 24 ([fe9e6ee](https://github.com/bitnami/charts/commit/fe9e6ee946bcb2713a01ac38f5ab7a65bb20728c))
+* Update imagePullSecrets helper ([34bd725](https://github.com/bitnami/charts/commit/34bd72591e15c7ad80a458ea53be1866672a365c))
+* Update NOTES.txt and other fixes ([77c87c4](https://github.com/bitnami/charts/commit/77c87c49376b68b0aa70a916d7a722c1779e7cc0))
 
 ## <small>0.0.1 (2019-04-30)</small>
 
-* Add airflow chart ([55e58ce](https://github.com/bitnami/charts/commit/55e58ce))
+* Add airflow chart ([55e58ce](https://github.com/bitnami/charts/commit/55e58ce45682451dfdc9b3f62bd142af46d937f4))

--- a/bitnami/airflow/CHANGELOG.md
+++ b/bitnami/airflow/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 18.2.1 (2024-05-22)
+## 18.2.1 (2024-05-27)
 
 * [bitnami/airflow] Fix Airflow k8s config generation in the initContainer and filesystem writability ([#26341](https://github.com/bitnami/charts/pull/26341))
 

--- a/bitnami/airflow/Chart.yaml
+++ b/bitnami/airflow/Chart.yaml
@@ -47,4 +47,4 @@ maintainers:
 name: airflow
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/airflow
-version: 18.2.0
+version: 18.2.1

--- a/bitnami/airflow/templates/config/configmap.yaml
+++ b/bitnami/airflow/templates/config/configmap.yaml
@@ -83,8 +83,9 @@ data:
                 . /opt/bitnami/scripts/airflow-worker-env.sh
                 . /opt/bitnami/scripts/libairflowworker.sh
 
+                export AIRFLOW_CONF_FILE=/tmp/airflow.cfg
                 airflow_generate_config # Generate the config file
-                cp /opt/bitnami/airflow/airflow.cfg /opt/bitnami/airflow/k8s-executor-config/airflow.cfg
+                cp /tmp/airflow.cfg /k8s-executor-config/airflow.cfg
           env:
             {{- include "airflow.configure.airflow.common" . | nindent 12 }}
             {{- include "airflow.configure.database" . | nindent 12 }}
@@ -103,7 +104,10 @@ data:
           {{- end }}
           volumeMounts:
             - name: empty-dir
-              mountPath: /opt/bitnami/airflow/k8s-executor-config
+              mountPath: /tmp
+              subPath: tmp-dir
+            - name: empty-dir
+              mountPath: /k8s-executor-conf
               subPath: app-k8s-executor-conf-dir
         {{- if .Values.initContainers }}
         {{- include "common.tplvalues.render" (dict "value" .Values.initContainers "context" $) | trim | nindent 8 }}
@@ -210,8 +214,20 @@ data:
           {{- end }}
           volumeMounts:
             - name: empty-dir
+              mountPath: /opt/bitnami/airflow/nss-wrapper
+              subPath: app-nss-wrapper-dir
+            - name: empty-dir
               mountPath: /tmp
               subPath: tmp-dir
+            - name: empty-dir
+              mountPath: /opt/bitnami/airflow/logs
+              subPath: app-logs-dir
+            - name: empty-dir
+              mountPath: /opt/bitnami/airflow/tmp
+              subPath: app-tmp-dir
+            - name: empty-dir
+              mountPath: /opt/bitnami/airflow/airflow.db
+              subPath: app-default-conf-dir/airflow.db
             {{- if .Files.Glob "files/dags/*.py" }}
             - name: local-dag-files
               mountPath: /opt/bitnami/airflow/dags/local

--- a/bitnami/airflow/templates/config/configmap.yaml
+++ b/bitnami/airflow/templates/config/configmap.yaml
@@ -85,7 +85,7 @@ data:
 
                 export AIRFLOW_CONF_FILE=/tmp/airflow.cfg
                 airflow_generate_config # Generate the config file
-                cp /tmp/airflow.cfg /k8s-executor-config/airflow.cfg
+                cp /tmp/airflow.cfg /k8s-executor-conf/airflow.cfg
           env:
             {{- include "airflow.configure.airflow.common" . | nindent 12 }}
             {{- include "airflow.configure.database" . | nindent 12 }}


### PR DESCRIPTION
### Description of the change
- Fix config generation and volume mounts
- Bump chart version

### Benefits
Airfow properly initializes configuration in a volume that is accessible by the initContainer

### Possible drawbacks
Not that I can see

### Applicable issues
- fixes [25367](https://github.com/bitnami/charts/issues/25367)

### Additional information
- Based on contribution from the amazing @[MarijnMB](https://github.com/MarijnMB)

### Checklist
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
