### PR TITLE
[bitnami/janusgraph] Use different liveness/readiness probes

### DIFF
--- a/bitnami/janusgraph/CHANGELOG.md
+++ b/bitnami/janusgraph/CHANGELOG.md
@@ -1,44 +1,49 @@
 # Changelog
 
+## 0.3.1 (2024-05-22)
+
+* [bitnami/janusgraph] Use different liveness/readiness probes ([#26345](https://github.com/bitnami/charts/pull/26345))
+
 ## 0.3.0 (2024-05-21)
 
-* [bitnami/janusgraph] feat: :sparkles: :lock: Add warning when original images are replaced ([#26219](https://github.com/bitnami/charts/pulls/26219))
+* [bitnami/*] ci: :construction_worker: Add tag and changelog support (#25359) ([91c707c](https://github.com/bitnami/charts/commit/91c707c9e4e574725a09505d2d313fb93f1b4c0a)), closes [#25359](https://github.com/bitnami/charts/issues/25359)
+* [bitnami/janusgraph] feat: :sparkles: :lock: Add warning when original images are replaced (#26219) ([2de41cc](https://github.com/bitnami/charts/commit/2de41cc762de9c750213ebbe4121ef7924b01b97)), closes [#26219](https://github.com/bitnami/charts/issues/26219)
 
 ## 0.2.0 (2024-05-20)
 
-* [bitnami/janusgraph] PDB review (#25936) ([15ee760](https://github.com/bitnami/charts/commit/15ee760)), closes [#25936](https://github.com/bitnami/charts/issues/25936)
+* [bitnami/janusgraph] PDB review (#25936) ([15ee760](https://github.com/bitnami/charts/commit/15ee7604a1b1db4b1e5061b19e907194c629108e)), closes [#25936](https://github.com/bitnami/charts/issues/25936)
 
 ## <small>0.1.7 (2024-05-18)</small>
 
-* [bitnami/janusgraph] Release 0.1.7 updating components versions (#26026) ([0e800dc](https://github.com/bitnami/charts/commit/0e800dc)), closes [#26026](https://github.com/bitnami/charts/issues/26026)
+* [bitnami/janusgraph] Release 0.1.7 updating components versions (#26026) ([0e800dc](https://github.com/bitnami/charts/commit/0e800dcb83315b4a5cf883ac6486f82707a89e04)), closes [#26026](https://github.com/bitnami/charts/issues/26026)
 
 ## <small>0.1.6 (2024-05-14)</small>
 
-* [bitnami/*] Change non-root and rolling-tags doc URLs (#25628) ([b067c94](https://github.com/bitnami/charts/commit/b067c94)), closes [#25628](https://github.com/bitnami/charts/issues/25628)
-* [bitnami/*] Set new header/owner (#25558) ([8d1dc11](https://github.com/bitnami/charts/commit/8d1dc11)), closes [#25558](https://github.com/bitnami/charts/issues/25558)
-* [bitnami/janusgraph] Release 0.1.6 updating components versions (#25770) ([20c76cb](https://github.com/bitnami/charts/commit/20c76cb)), closes [#25770](https://github.com/bitnami/charts/issues/25770)
+* [bitnami/*] Change non-root and rolling-tags doc URLs (#25628) ([b067c94](https://github.com/bitnami/charts/commit/b067c94f6bcde427863c197fd355f0b5ba12ff5b)), closes [#25628](https://github.com/bitnami/charts/issues/25628)
+* [bitnami/*] Set new header/owner (#25558) ([8d1dc11](https://github.com/bitnami/charts/commit/8d1dc11f5fb30db6fba50c43d7af59d2f79deed3)), closes [#25558](https://github.com/bitnami/charts/issues/25558)
+* [bitnami/janusgraph] Release 0.1.6 updating components versions (#25770) ([20c76cb](https://github.com/bitnami/charts/commit/20c76cbf6bc61c2c73a8e6f2b11571e05863a918)), closes [#25770](https://github.com/bitnami/charts/issues/25770)
 
 ## <small>0.1.5 (2024-05-02)</small>
 
-* [bitnami/janusgraph] Add metrics port in networkPolicy ingress (#25498) ([1b280b8](https://github.com/bitnami/charts/commit/1b280b8)), closes [#25498](https://github.com/bitnami/charts/issues/25498)
-* [bitnami/janusgraph] Release 0.1.5 updating components versions (#25502) ([76d2a3e](https://github.com/bitnami/charts/commit/76d2a3e)), closes [#25502](https://github.com/bitnami/charts/issues/25502)
+* [bitnami/janusgraph] Add metrics port in networkPolicy ingress (#25498) ([1b280b8](https://github.com/bitnami/charts/commit/1b280b80efe645a602cf4b086de90756c4638aa8)), closes [#25498](https://github.com/bitnami/charts/issues/25498)
+* [bitnami/janusgraph] Release 0.1.5 updating components versions (#25502) ([76d2a3e](https://github.com/bitnami/charts/commit/76d2a3e5688ba1e69999ebcfd17ed8103f421b00)), closes [#25502](https://github.com/bitnami/charts/issues/25502)
 
 ## <small>0.1.4 (2024-05-02)</small>
 
-* [bitnami/janusgraph] Release 0.1.4 updating components versions (#25495) ([b8e7d16](https://github.com/bitnami/charts/commit/b8e7d16)), closes [#25495](https://github.com/bitnami/charts/issues/25495)
+* [bitnami/janusgraph] Release 0.1.4 updating components versions (#25495) ([b8e7d16](https://github.com/bitnami/charts/commit/b8e7d16ae35a1afe27019c5d5d4c3ab4b646c747)), closes [#25495](https://github.com/bitnami/charts/issues/25495)
 
 ## <small>0.1.3 (2024-04-30)</small>
 
-* [bitnami/janusgraph] Add vib-publish role (#25465) ([81bd3f0](https://github.com/bitnami/charts/commit/81bd3f0)), closes [#25465](https://github.com/bitnami/charts/issues/25465)
+* [bitnami/janusgraph] Add vib-publish role (#25465) ([81bd3f0](https://github.com/bitnami/charts/commit/81bd3f043fd26bfe2ff469eafea439c16ca4ee88)), closes [#25465](https://github.com/bitnami/charts/issues/25465)
 
 ## <small>0.1.2 (2024-04-30)</small>
 
-* [bitnami/janusgraph] Release 0.1.2 updating components versions (#25461) ([0de0beb](https://github.com/bitnami/charts/commit/0de0beb)), closes [#25461](https://github.com/bitnami/charts/issues/25461)
+* [bitnami/janusgraph] Release 0.1.2 updating components versions (#25461) ([0de0beb](https://github.com/bitnami/charts/commit/0de0beb72068879297a577d39568e8ccbc231bc9)), closes [#25461](https://github.com/bitnami/charts/issues/25461)
 
 ## <small>0.1.1 (2024-04-30)</small>
 
-* [bitnami/janusgraph] Release 0.1.1 updating components versions (#25458) ([352b0c3](https://github.com/bitnami/charts/commit/352b0c3)), closes [#25458](https://github.com/bitnami/charts/issues/25458)
+* [bitnami/janusgraph] Release 0.1.1 updating components versions (#25458) ([352b0c3](https://github.com/bitnami/charts/commit/352b0c3db4ddb7431d3b1c639f528066f5b5821c)), closes [#25458](https://github.com/bitnami/charts/issues/25458)
 
 ## 0.1.0 (2024-04-30)
 
-* [bitnami/janusgraph] Add chart (#24621) ([c225e73](https://github.com/bitnami/charts/commit/c225e73)), closes [#24621](https://github.com/bitnami/charts/issues/24621)
+* [bitnami/janusgraph] Add chart (#24621) ([c225e73](https://github.com/bitnami/charts/commit/c225e73a90453163a337c1c518a850e587b5b7ae)), closes [#24621](https://github.com/bitnami/charts/issues/24621)

--- a/bitnami/janusgraph/Chart.yaml
+++ b/bitnami/janusgraph/Chart.yaml
@@ -37,4 +37,4 @@ name: janusgraph
 sources:
 - https://github.com/bitnami/containers/tree/main/bitnami/janusgraph
 - https://github.com/janusgraph/janusgraph
-version: 0.3.0
+version: 0.3.1

--- a/bitnami/janusgraph/templates/deployment.yaml
+++ b/bitnami/janusgraph/templates/deployment.yaml
@@ -159,8 +159,11 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.livenessProbe "enabled") "context" $) | nindent 12 }}
-            tcpSocket:
-              port: gremlin
+            exec:
+              command:
+                - pgrep
+                - -f
+                - gremlin
           {{- end }}
           {{- if .Values.customReadinessProbe }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customReadinessProbe "context" $) | nindent 12 }}
@@ -239,8 +242,7 @@ spec:
           {{- if not .Values.diagnosticMode.enabled }}
           {{- if .Values.metrics.livenessProbe.enabled }}
           livenessProbe: {{- omit .Values.metrics.livenessProbe "enabled" | toYaml | nindent 12 }}
-            httpGet:
-              path: /metrics
+            tcpSocket:
               port: metrics
           {{- end }}
           {{- if .Values.metrics.readinessProbe.enabled }}


### PR DESCRIPTION
### Description of the change
This PR aims to use different liveness/readiness probes to improve overall security and avoid unnecessary container restarts. [More info](https://github.com/zegl/kube-score/blob/master/README_PROBES.md).

### Benefits

Increase availability and resilience.

### Possible drawbacks

N/A

### Applicable issues

- fixes #

### Additional information

- Related to #23537

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- ~[X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)~
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
