### PR TITLE
[bitnami/rabbitmq-cluster-operator] Use different liveness/readiness probes

### DIFF
--- a/bitnami/rabbitmq-cluster-operator/CHANGELOG.md
+++ b/bitnami/rabbitmq-cluster-operator/CHANGELOG.md
@@ -1,687 +1,692 @@
 # Changelog
 
+## 4.3.1 (2024-05-22)
+
+* [bitnami/rabbitmq-cluster-operator] Use different liveness/readiness probes ([#26346](https://github.com/bitnami/charts/pull/26346))
+
 ## 4.3.0 (2024-05-21)
 
-* [bitnami/rabbitmq-cluster-operator] feat: :sparkles: :lock: Add warning when original images are replaced ([#26270](https://github.com/bitnami/charts/pulls/26270))
+* [bitnami/*] ci: :construction_worker: Add tag and changelog support (#25359) ([91c707c](https://github.com/bitnami/charts/commit/91c707c9e4e574725a09505d2d313fb93f1b4c0a)), closes [#25359](https://github.com/bitnami/charts/issues/25359)
+* [bitnami/rabbitmq-cluster-operator] feat: :sparkles: :lock: Add warning when original images are rep ([5a6b027](https://github.com/bitnami/charts/commit/5a6b027237f115e14e032f4cdf78198937cfaa4a)), closes [#26270](https://github.com/bitnami/charts/issues/26270)
 
 ## <small>4.2.10 (2024-05-18)</small>
 
-* [bitnami/rabbitmq-cluster-operator] Release 4.2.10 updating components versions (#26070) ([4c35e16](https://github.com/bitnami/charts/commit/4c35e16)), closes [#26070](https://github.com/bitnami/charts/issues/26070)
+* [bitnami/rabbitmq-cluster-operator] Release 4.2.10 updating components versions (#26070) ([4c35e16](https://github.com/bitnami/charts/commit/4c35e16c11dbe171e80c9d81d1392c019b2da41c)), closes [#26070](https://github.com/bitnami/charts/issues/26070)
 
 ## <small>4.2.9 (2024-05-14)</small>
 
-* [bitnami/rabbitmq-cluster-operator] Release 4.2.9 updating components versions (#25818) ([fc54fa8](https://github.com/bitnami/charts/commit/fc54fa8)), closes [#25818](https://github.com/bitnami/charts/issues/25818)
+* [bitnami/rabbitmq-cluster-operator] Release 4.2.9 updating components versions (#25818) ([fc54fa8](https://github.com/bitnami/charts/commit/fc54fa830893fff247cbf849dbe1d3cd5b2c4531)), closes [#25818](https://github.com/bitnami/charts/issues/25818)
 
 ## <small>4.2.8 (2024-05-13)</small>
 
-* [bitnami/*] Change non-root and rolling-tags doc URLs (#25628) ([b067c94](https://github.com/bitnami/charts/commit/b067c94)), closes [#25628](https://github.com/bitnami/charts/issues/25628)
-* [bitnami/rabbitmq-cluster-operator] Release 4.2.8 (#25693) ([0f510f4](https://github.com/bitnami/charts/commit/0f510f4)), closes [#25693](https://github.com/bitnami/charts/issues/25693)
+* [bitnami/*] Change non-root and rolling-tags doc URLs (#25628) ([b067c94](https://github.com/bitnami/charts/commit/b067c94f6bcde427863c197fd355f0b5ba12ff5b)), closes [#25628](https://github.com/bitnami/charts/issues/25628)
+* [bitnami/rabbitmq-cluster-operator] Release 4.2.8 (#25693) ([0f510f4](https://github.com/bitnami/charts/commit/0f510f44297bd86c56dd4a5c627364c21cc4f668)), closes [#25693](https://github.com/bitnami/charts/issues/25693)
 
 ## <small>4.2.7 (2024-05-08)</small>
 
-* [bitnami/rabbitmq-cluster-operator] Release 4.2.7 (#25619) ([0d2dd50](https://github.com/bitnami/charts/commit/0d2dd50)), closes [#25619](https://github.com/bitnami/charts/issues/25619)
+* [bitnami/rabbitmq-cluster-operator] Release 4.2.7 (#25619) ([0d2dd50](https://github.com/bitnami/charts/commit/0d2dd50ad440d5c17716b536c12987fa864386a5)), closes [#25619](https://github.com/bitnami/charts/issues/25619)
 
 ## <small>4.2.6 (2024-05-07)</small>
 
-* [bitnami/*] Set new header/owner (#25558) ([8d1dc11](https://github.com/bitnami/charts/commit/8d1dc11)), closes [#25558](https://github.com/bitnami/charts/issues/25558)
-* [bitnami/multiple charts] Fix typo: "NetworkPolice" vs "NetworkPolicy" (#25348) ([6970c1b](https://github.com/bitnami/charts/commit/6970c1b)), closes [#25348](https://github.com/bitnami/charts/issues/25348)
-* rabbitmq-cluster-operator: rename http-webhook port to https-webhook (#25552) ([d81d3e9](https://github.com/bitnami/charts/commit/d81d3e9)), closes [#25552](https://github.com/bitnami/charts/issues/25552)
-* Replace VMware by Broadcom copyright text (#25306) ([a5e4bd0](https://github.com/bitnami/charts/commit/a5e4bd0)), closes [#25306](https://github.com/bitnami/charts/issues/25306)
+* [bitnami/*] Set new header/owner (#25558) ([8d1dc11](https://github.com/bitnami/charts/commit/8d1dc11f5fb30db6fba50c43d7af59d2f79deed3)), closes [#25558](https://github.com/bitnami/charts/issues/25558)
+* [bitnami/multiple charts] Fix typo: "NetworkPolice" vs "NetworkPolicy" (#25348) ([6970c1b](https://github.com/bitnami/charts/commit/6970c1ba245873506e73d459c6eac1e4919b778f)), closes [#25348](https://github.com/bitnami/charts/issues/25348)
+* rabbitmq-cluster-operator: rename http-webhook port to https-webhook (#25552) ([d81d3e9](https://github.com/bitnami/charts/commit/d81d3e95763b10b80d7bba8dc71a0ec1ea2fc42b)), closes [#25552](https://github.com/bitnami/charts/issues/25552)
+* Replace VMware by Broadcom copyright text (#25306) ([a5e4bd0](https://github.com/bitnami/charts/commit/a5e4bd0e35e419203793976a78d9d0a13de92c76)), closes [#25306](https://github.com/bitnami/charts/issues/25306)
 
 ## <small>4.2.5 (2024-04-23)</small>
 
-* Don't declare ClusterRoleBinding of a disabled operator (#24734) ([171b9aa](https://github.com/bitnami/charts/commit/171b9aa)), closes [#24734](https://github.com/bitnami/charts/issues/24734)
+* Don't declare ClusterRoleBinding of a disabled operator (#24734) ([171b9aa](https://github.com/bitnami/charts/commit/171b9aad59478c8fa3b0c905d39f0fd77906c240)), closes [#24734](https://github.com/bitnami/charts/issues/24734)
 
 ## <small>4.2.4 (2024-04-10)</small>
 
-* [bitnami/rabbitmq-cluster-operator] Release 4.2.4 updating components versions (#25094) ([90c6c38](https://github.com/bitnami/charts/commit/90c6c38)), closes [#25094](https://github.com/bitnami/charts/issues/25094)
+* [bitnami/rabbitmq-cluster-operator] Release 4.2.4 updating components versions (#25094) ([90c6c38](https://github.com/bitnami/charts/commit/90c6c38b327ef65f58b26aaaeef0443d4858b9df)), closes [#25094](https://github.com/bitnami/charts/issues/25094)
 
 ## <small>4.2.3 (2024-04-05)</small>
 
-* [bitnami/rabbitmq-cluster-operator] Release 4.2.3 updating components versions (#25001) ([87e38cf](https://github.com/bitnami/charts/commit/87e38cf)), closes [#25001](https://github.com/bitnami/charts/issues/25001)
+* [bitnami/rabbitmq-cluster-operator] Release 4.2.3 updating components versions (#25001) ([87e38cf](https://github.com/bitnami/charts/commit/87e38cf98c38cb6551527d4df82936eff1f4d467)), closes [#25001](https://github.com/bitnami/charts/issues/25001)
 
 ## <small>4.2.2 (2024-04-04)</small>
 
-* [bitnami/rabbitmq-cluster-operator] Release 4.2.2 updating components versions (#24915) ([5be5b4e](https://github.com/bitnami/charts/commit/5be5b4e)), closes [#24915](https://github.com/bitnami/charts/issues/24915)
+* [bitnami/rabbitmq-cluster-operator] Release 4.2.2 updating components versions (#24915) ([5be5b4e](https://github.com/bitnami/charts/commit/5be5b4e4d5932be5e05d10cb112dd3949c64e529)), closes [#24915](https://github.com/bitnami/charts/issues/24915)
 
 ## <small>4.2.1 (2024-04-03)</small>
 
-* [bitnami/rabbitmq-cluster-operator] Release 4.2.1 (#24858) ([dd58652](https://github.com/bitnami/charts/commit/dd58652)), closes [#24858](https://github.com/bitnami/charts/issues/24858)
+* [bitnami/rabbitmq-cluster-operator] Release 4.2.1 (#24858) ([dd58652](https://github.com/bitnami/charts/commit/dd58652ddbacaa716eb434e6b7ad66b0cb751bbb)), closes [#24858](https://github.com/bitnami/charts/issues/24858)
 
 ## 4.2.0 (2024-04-03)
 
-* [bitnami/rabbitmq-cluster-operator] feat: add revisionHistoryLimit (#24839) ([76826d1](https://github.com/bitnami/charts/commit/76826d1)), closes [#24839](https://github.com/bitnami/charts/issues/24839)
-* Update resourcesPreset comments (#24467) ([92e3e8a](https://github.com/bitnami/charts/commit/92e3e8a)), closes [#24467](https://github.com/bitnami/charts/issues/24467)
+* [bitnami/rabbitmq-cluster-operator] feat: add revisionHistoryLimit (#24839) ([76826d1](https://github.com/bitnami/charts/commit/76826d1d1e25bec20357c170f02bff37a8b363d0)), closes [#24839](https://github.com/bitnami/charts/issues/24839)
+* Update resourcesPreset comments (#24467) ([92e3e8a](https://github.com/bitnami/charts/commit/92e3e8a507326d2a20a8f10ab3e7746a2ec5c554)), closes [#24467](https://github.com/bitnami/charts/issues/24467)
 
 ## 4.1.0 (2024-03-21)
 
-* [bitnami/*] Reorder Chart sections (#24455) ([0cf4048](https://github.com/bitnami/charts/commit/0cf4048)), closes [#24455](https://github.com/bitnami/charts/issues/24455)
-* [bitnami/rabbitmq-cluster-operator] Add aggregate cluster roles #24563 (#24563) ([96cdf99](https://github.com/bitnami/charts/commit/96cdf99)), closes [#24563](https://github.com/bitnami/charts/issues/24563) [#24563](https://github.com/bitnami/charts/issues/24563)
+* [bitnami/*] Reorder Chart sections (#24455) ([0cf4048](https://github.com/bitnami/charts/commit/0cf4048e8743f70a9753d460655bd030cbff6824)), closes [#24455](https://github.com/bitnami/charts/issues/24455)
+* [bitnami/rabbitmq-cluster-operator] Add aggregate cluster roles #24563 (#24563) ([96cdf99](https://github.com/bitnami/charts/commit/96cdf9923a67bfa944fd1c5fc6b6c5264f39d16a)), closes [#24563](https://github.com/bitnami/charts/issues/24563) [#24563](https://github.com/bitnami/charts/issues/24563)
 
 ## 4.0.0 (2024-03-15)
 
-* [bitnami/rabbitmq-cluster-operator] feat!: 🔒 💥 Improve security defaults (#24335) ([043a43b](https://github.com/bitnami/charts/commit/043a43b)), closes [#24335](https://github.com/bitnami/charts/issues/24335)
+* [bitnami/rabbitmq-cluster-operator] feat!: 🔒 💥 Improve security defaults (#24335) ([043a43b](https://github.com/bitnami/charts/commit/043a43b64db9212e610de44aad02865c021ec3ce)), closes [#24335](https://github.com/bitnami/charts/issues/24335)
 
 ## <small>3.20.1 (2024-03-06)</small>
 
-* [bitnami/rabbitmq-cluster-operator] Release 3.20.1 updating components versions (#24216) ([6baa026](https://github.com/bitnami/charts/commit/6baa026)), closes [#24216](https://github.com/bitnami/charts/issues/24216)
+* [bitnami/rabbitmq-cluster-operator] Release 3.20.1 updating components versions (#24216) ([6baa026](https://github.com/bitnami/charts/commit/6baa026a9f2e55666126ec049ab1b446b1a7fd8d)), closes [#24216](https://github.com/bitnami/charts/issues/24216)
 
 ## 3.20.0 (2024-03-06)
 
-* [bitnami/rabbitmq-cluster-operator] feat: :sparkles: :lock: Add automatic adaptation for Openshift r ([715be15](https://github.com/bitnami/charts/commit/715be15)), closes [#24147](https://github.com/bitnami/charts/issues/24147)
+* [bitnami/rabbitmq-cluster-operator] feat: :sparkles: :lock: Add automatic adaptation for Openshift r ([715be15](https://github.com/bitnami/charts/commit/715be159a933d3af790ee6974c387eb8ee5d3466)), closes [#24147](https://github.com/bitnami/charts/issues/24147)
 
 ## <small>3.19.1 (2024-03-04)</small>
 
-* [bitnami/rabbitmq-cluster-operator] fix: correct network policy port for metrics (#23987) ([f5c9683](https://github.com/bitnami/charts/commit/f5c9683)), closes [#23987](https://github.com/bitnami/charts/issues/23987)
+* [bitnami/rabbitmq-cluster-operator] fix: correct network policy port for metrics (#23987) ([f5c9683](https://github.com/bitnami/charts/commit/f5c9683718d55e37021d3371e432904dd094a77a)), closes [#23987](https://github.com/bitnami/charts/issues/23987)
 
 ## 3.19.0 (2024-02-23)
 
-* [bitnami/rabbitmq-cluster-operator] feat: :sparkles: :lock: Add runAsGroup (#23844) ([d7d5572](https://github.com/bitnami/charts/commit/d7d5572)), closes [#23844](https://github.com/bitnami/charts/issues/23844)
+* [bitnami/rabbitmq-cluster-operator] feat: :sparkles: :lock: Add runAsGroup (#23844) ([d7d5572](https://github.com/bitnami/charts/commit/d7d5572386ce52212d60d09c13be00616fbb62f1)), closes [#23844](https://github.com/bitnami/charts/issues/23844)
 
 ## <small>3.18.2 (2024-02-22)</small>
 
-* [bitnami/rabbitmq-cluster-operator] Release 3.18.2 updating components versions (#23821) ([5ae0c9c](https://github.com/bitnami/charts/commit/5ae0c9c)), closes [#23821](https://github.com/bitnami/charts/issues/23821)
+* [bitnami/rabbitmq-cluster-operator] Release 3.18.2 updating components versions (#23821) ([5ae0c9c](https://github.com/bitnami/charts/commit/5ae0c9c4e7449a83f757a53a94f2a34f071e3e7d)), closes [#23821](https://github.com/bitnami/charts/issues/23821)
 
 ## <small>3.18.1 (2024-02-21)</small>
 
-* [bitnami/rabbitmq-cluster-operator] Release 3.18.1 updating components versions (#23687) ([a1db2cb](https://github.com/bitnami/charts/commit/a1db2cb)), closes [#23687](https://github.com/bitnami/charts/issues/23687)
+* [bitnami/rabbitmq-cluster-operator] Release 3.18.1 updating components versions (#23687) ([a1db2cb](https://github.com/bitnami/charts/commit/a1db2cbbd5487209481fdebc0767f68632632ba3)), closes [#23687](https://github.com/bitnami/charts/issues/23687)
 
 ## 3.18.0 (2024-02-20)
 
-* [bitnami/*] Bump all versions (#23602) ([b70ee2a](https://github.com/bitnami/charts/commit/b70ee2a)), closes [#23602](https://github.com/bitnami/charts/issues/23602)
+* [bitnami/*] Bump all versions (#23602) ([b70ee2a](https://github.com/bitnami/charts/commit/b70ee2a30e4dc256bf0ac52928fb2fa7a70f049b)), closes [#23602](https://github.com/bitnami/charts/issues/23602)
 
 ## <small>3.17.1 (2024-02-19)</small>
 
-* [bitnami/rabbitmq-cluster-operator] Metrics service name exceed 63 characters (#23013) ([a7a57c8](https://github.com/bitnami/charts/commit/a7a57c8)), closes [#23013](https://github.com/bitnami/charts/issues/23013)
+* [bitnami/rabbitmq-cluster-operator] Metrics service name exceed 63 characters (#23013) ([a7a57c8](https://github.com/bitnami/charts/commit/a7a57c87135d2d469b14fc63a2c604ddd774508c)), closes [#23013](https://github.com/bitnami/charts/issues/23013)
 
 ## 3.17.0 (2024-02-15)
 
-* [bitnami/rabbitmq-cluster-operator] feat: :sparkles: :lock: Add resource preset support (#23515) ([7444af2](https://github.com/bitnami/charts/commit/7444af2)), closes [#23515](https://github.com/bitnami/charts/issues/23515)
+* [bitnami/rabbitmq-cluster-operator] feat: :sparkles: :lock: Add resource preset support (#23515) ([7444af2](https://github.com/bitnami/charts/commit/7444af26e1e4e45a2127e6e475ce75ea5e2abc23)), closes [#23515](https://github.com/bitnami/charts/issues/23515)
 
 ## <small>3.16.1 (2024-02-14)</small>
 
-* [bitnami/rabbitmq-cluster-operator] fix: 🐛 Add RabbitMQ port to NetworkPolicy for topology operator ([0622181](https://github.com/bitnami/charts/commit/0622181)), closes [#23426](https://github.com/bitnami/charts/issues/23426)
+* [bitnami/rabbitmq-cluster-operator] fix: 🐛 Add RabbitMQ port to NetworkPolicy for topology operator ([0622181](https://github.com/bitnami/charts/commit/0622181fe58bda823b2c444a27652837203ebb99)), closes [#23426](https://github.com/bitnami/charts/issues/23426)
 
 ## 3.16.0 (2024-02-14)
 
-* [bitnami/rabbitmq-cluster-operator] fix: :bug: Add allowExternalEgress to avoid breaking istio (#234 ([56ceae7](https://github.com/bitnami/charts/commit/56ceae7)), closes [#23409](https://github.com/bitnami/charts/issues/23409)
+* [bitnami/rabbitmq-cluster-operator] fix: :bug: Add allowExternalEgress to avoid breaking istio (#234 ([56ceae7](https://github.com/bitnami/charts/commit/56ceae75b9c58cc7a2b19cb9e5fb6b787a47a3fe)), closes [#23409](https://github.com/bitnami/charts/issues/23409)
 
 ## <small>3.15.7 (2024-02-12)</small>
 
-* [bitnami/rabbitmq-cluster-operator] Release 3.15.7 updating components versions (#23398) ([ecc1ff9](https://github.com/bitnami/charts/commit/ecc1ff9)), closes [#23398](https://github.com/bitnami/charts/issues/23398)
+* [bitnami/rabbitmq-cluster-operator] Release 3.15.7 updating components versions (#23398) ([ecc1ff9](https://github.com/bitnami/charts/commit/ecc1ff96235132195ad5f5ff652563bb65ec106d)), closes [#23398](https://github.com/bitnami/charts/issues/23398)
 
 ## <small>3.15.6 (2024-02-09)</small>
 
-* [bitnami/rabbitmq-cluster-operator] fix: :bug: Add webhook port to network policy (#23200) ([ca03588](https://github.com/bitnami/charts/commit/ca03588)), closes [#23200](https://github.com/bitnami/charts/issues/23200)
-* [bitnami/rabbitmq-cluster-operator] Release 3.15.6 updating components versions (#23360) ([a72f2c5](https://github.com/bitnami/charts/commit/a72f2c5)), closes [#23360](https://github.com/bitnami/charts/issues/23360)
+* [bitnami/rabbitmq-cluster-operator] fix: :bug: Add webhook port to network policy (#23200) ([ca03588](https://github.com/bitnami/charts/commit/ca03588e0e522566ecc01e14ce29c54ca931e501)), closes [#23200](https://github.com/bitnami/charts/issues/23200)
+* [bitnami/rabbitmq-cluster-operator] Release 3.15.6 updating components versions (#23360) ([a72f2c5](https://github.com/bitnami/charts/commit/a72f2c5f56d3bb24724290ef49c412849731a6f2)), closes [#23360](https://github.com/bitnami/charts/issues/23360)
 
 ## <small>3.15.5 (2024-02-07)</small>
 
-* [bitnami/rabbitmq-cluster-operator] Release 3.15.5 updating components versions (#23276) ([803eaea](https://github.com/bitnami/charts/commit/803eaea)), closes [#23276](https://github.com/bitnami/charts/issues/23276)
+* [bitnami/rabbitmq-cluster-operator] Release 3.15.5 updating components versions (#23276) ([803eaea](https://github.com/bitnami/charts/commit/803eaea3c328751799f78403e3e5fefa1eea4881)), closes [#23276](https://github.com/bitnami/charts/issues/23276)
 
 ## <small>3.15.4 (2024-02-06)</small>
 
-* [bitnami/rabbitmq-cluster-operator] add missing operatorpolicies crd (#23037) ([b139daf](https://github.com/bitnami/charts/commit/b139daf)), closes [#23037](https://github.com/bitnami/charts/issues/23037)
+* [bitnami/rabbitmq-cluster-operator] add missing operatorpolicies crd (#23037) ([b139daf](https://github.com/bitnami/charts/commit/b139daf6f7bd792d64bf1c9e5f0ec168c8fb89e3)), closes [#23037](https://github.com/bitnami/charts/issues/23037)
 
 ## <small>3.15.3 (2024-02-03)</small>
 
-* [bitnami/rabbitmq-cluster-operator] Release 3.15.3 updating components versions (#23132) ([540b932](https://github.com/bitnami/charts/commit/540b932)), closes [#23132](https://github.com/bitnami/charts/issues/23132)
+* [bitnami/rabbitmq-cluster-operator] Release 3.15.3 updating components versions (#23132) ([540b932](https://github.com/bitnami/charts/commit/540b9321e1b3abc99c54ff4cccfa14557f8e3d2f)), closes [#23132](https://github.com/bitnami/charts/issues/23132)
 
 ## <small>3.15.2 (2024-02-01)</small>
 
-* [bitnami/rabbitmq-cluster-operator] Release 3.15.2 (#23006) ([3fb8508](https://github.com/bitnami/charts/commit/3fb8508)), closes [#23006](https://github.com/bitnami/charts/issues/23006)
+* [bitnami/rabbitmq-cluster-operator] Release 3.15.2 (#23006) ([3fb8508](https://github.com/bitnami/charts/commit/3fb850829a39d26d9e21644f799a5352f4a5db13)), closes [#23006](https://github.com/bitnami/charts/issues/23006)
 
 ## <small>3.15.1 (2024-01-31)</small>
 
-* [bitnami/rabbitmq-cluster-operator] Update CRDs and add headers for automatic update (#22892) ([351ac0a](https://github.com/bitnami/charts/commit/351ac0a)), closes [#22892](https://github.com/bitnami/charts/issues/22892)
+* [bitnami/rabbitmq-cluster-operator] Update CRDs and add headers for automatic update (#22892) ([351ac0a](https://github.com/bitnami/charts/commit/351ac0a8acd74c4cdf3d130c3e370824f00ecc4a)), closes [#22892](https://github.com/bitnami/charts/issues/22892)
 
 ## 3.15.0 (2024-01-30)
 
-* [bitnami/rabbitmq-cluster-operator] feat: 🔒 Enable networkPolicy  (#22739) ([a5af5d8](https://github.com/bitnami/charts/commit/a5af5d8)), closes [#22739](https://github.com/bitnami/charts/issues/22739)
+* [bitnami/rabbitmq-cluster-operator] feat: 🔒 Enable networkPolicy  (#22739) ([a5af5d8](https://github.com/bitnami/charts/commit/a5af5d850c060597b6fe6accde8eeab679378470)), closes [#22739](https://github.com/bitnami/charts/issues/22739)
 
 ## <small>3.14.1 (2024-01-29)</small>
 
-* [bitnami/rabbitmq-cluster-operator] Release 3.14.1 updating components versions (#22836) ([af09bb1](https://github.com/bitnami/charts/commit/af09bb1)), closes [#22836](https://github.com/bitnami/charts/issues/22836)
+* [bitnami/rabbitmq-cluster-operator] Release 3.14.1 updating components versions (#22836) ([af09bb1](https://github.com/bitnami/charts/commit/af09bb148a8e0fe286be81f64acde5009b4b52e4)), closes [#22836](https://github.com/bitnami/charts/issues/22836)
 
 ## 3.14.0 (2024-01-26)
 
-* [bitnami/rabbitmq-cluster-operator] feat: 🔒 support for extra rules (#22723) ([5162d80](https://github.com/bitnami/charts/commit/5162d80)), closes [#22723](https://github.com/bitnami/charts/issues/22723) [#22248](https://github.com/bitnami/charts/issues/22248)
+* [bitnami/rabbitmq-cluster-operator] feat: 🔒 support for extra rules (#22723) ([5162d80](https://github.com/bitnami/charts/commit/5162d8034ca0460f33925099b7c03237d715183e)), closes [#22723](https://github.com/bitnami/charts/issues/22723) [#22248](https://github.com/bitnami/charts/issues/22248)
 
 ## <small>3.13.1 (2024-01-25)</small>
 
-* [bitnami/*] Move documentation sections from docs.bitnami.com back to the README (#22203) ([7564f36](https://github.com/bitnami/charts/commit/7564f36)), closes [#22203](https://github.com/bitnami/charts/issues/22203)
-* [bitnami/rabbitmq-cluster-operator] fix: :bug: Set seLinuxOptions to null for Openshift compatibilit ([89ede0d](https://github.com/bitnami/charts/commit/89ede0d)), closes [#22652](https://github.com/bitnami/charts/issues/22652)
+* [bitnami/*] Move documentation sections from docs.bitnami.com back to the README (#22203) ([7564f36](https://github.com/bitnami/charts/commit/7564f36ca1e95ff30ee686652b7ab8690561a707)), closes [#22203](https://github.com/bitnami/charts/issues/22203)
+* [bitnami/rabbitmq-cluster-operator] fix: :bug: Set seLinuxOptions to null for Openshift compatibilit ([89ede0d](https://github.com/bitnami/charts/commit/89ede0d19443fbb05336c2c04891ec565fc4abbb)), closes [#22652](https://github.com/bitnami/charts/issues/22652)
 
 ## 3.13.0 (2024-01-19)
 
-* [bitnami/rabbitmq-cluster-operator] feat: :lock: Allow limit access to namespaces (#22251) ([09708d4](https://github.com/bitnami/charts/commit/09708d4)), closes [#22251](https://github.com/bitnami/charts/issues/22251)
+* [bitnami/rabbitmq-cluster-operator] feat: :lock: Allow limit access to namespaces (#22251) ([09708d4](https://github.com/bitnami/charts/commit/09708d4231e7b08bb6857191f6903306693c8247)), closes [#22251](https://github.com/bitnami/charts/issues/22251)
 
 ## 3.12.0 (2024-01-19)
 
-* [bitnami/rabbitmq-cluster-operator] fix: :lock: Move service-account token auto-mount to pod declara ([6028359](https://github.com/bitnami/charts/commit/6028359)), closes [#22454](https://github.com/bitnami/charts/issues/22454)
+* [bitnami/rabbitmq-cluster-operator] fix: :lock: Move service-account token auto-mount to pod declara ([6028359](https://github.com/bitnami/charts/commit/60283596bc3a2ba4218b3537b6e5f37edc9bb50b)), closes [#22454](https://github.com/bitnami/charts/issues/22454)
 
 ## <small>3.11.2 (2024-01-18)</small>
 
-* [bitnami/rabbitmq-cluster-operator] Update CRDs and add source header (#22379) ([0e96c3a](https://github.com/bitnami/charts/commit/0e96c3a)), closes [#22379](https://github.com/bitnami/charts/issues/22379)
+* [bitnami/rabbitmq-cluster-operator] Update CRDs and add source header (#22379) ([0e96c3a](https://github.com/bitnami/charts/commit/0e96c3ac0485d8349df6e7c0ce2f5b4634c9d88e)), closes [#22379](https://github.com/bitnami/charts/issues/22379)
 
 ## <small>3.11.1 (2024-01-17)</small>
 
-* [bitnami/rabbitmq-cluster-operator] Release 3.11.1 updating components versions (#22334) ([f2da243](https://github.com/bitnami/charts/commit/f2da243)), closes [#22334](https://github.com/bitnami/charts/issues/22334)
+* [bitnami/rabbitmq-cluster-operator] Release 3.11.1 updating components versions (#22334) ([f2da243](https://github.com/bitnami/charts/commit/f2da24303821ddac16894570105532a5838fc8ba)), closes [#22334](https://github.com/bitnami/charts/issues/22334)
 
 ## 3.11.0 (2024-01-17)
 
-* [bitnami/rabbitmq-cluster-operator] fix: :lock: Improve podSecurityContext and containerSecurityCont ([0dc9f53](https://github.com/bitnami/charts/commit/0dc9f53)), closes [#22183](https://github.com/bitnami/charts/issues/22183)
+* [bitnami/rabbitmq-cluster-operator] fix: :lock: Improve podSecurityContext and containerSecurityCont ([0dc9f53](https://github.com/bitnami/charts/commit/0dc9f530375ddcf28b30ec776c7f1e057b5cbb6c)), closes [#22183](https://github.com/bitnami/charts/issues/22183)
 
 ## <small>3.10.10 (2024-01-12)</small>
 
-* [bitnami/*] Fix ref links (in comments) (#21822) ([e4fa296](https://github.com/bitnami/charts/commit/e4fa296)), closes [#21822](https://github.com/bitnami/charts/issues/21822)
-* [bitnami/rabbitmq-cluster-operator] Set default SecurityContext readOnlyRootFilesystem to true (#220 ([7cf9be3](https://github.com/bitnami/charts/commit/7cf9be3)), closes [#22004](https://github.com/bitnami/charts/issues/22004)
+* [bitnami/*] Fix ref links (in comments) (#21822) ([e4fa296](https://github.com/bitnami/charts/commit/e4fa296106b225cf8c82445727c675c7c725e380)), closes [#21822](https://github.com/bitnami/charts/issues/21822)
+* [bitnami/rabbitmq-cluster-operator] Set default SecurityContext readOnlyRootFilesystem to true (#220 ([7cf9be3](https://github.com/bitnami/charts/commit/7cf9be3bbaf419b5ba4f9ad8f5ff8f54a152c90d)), closes [#22004](https://github.com/bitnami/charts/issues/22004)
 
 ## <small>3.10.9 (2024-01-10)</small>
 
-* [bitnami/rabbitmq-cluster-operator] Release 3.10.9 updating components versions (#21971) ([ec47536](https://github.com/bitnami/charts/commit/ec47536)), closes [#21971](https://github.com/bitnami/charts/issues/21971)
+* [bitnami/rabbitmq-cluster-operator] Release 3.10.9 updating components versions (#21971) ([ec47536](https://github.com/bitnami/charts/commit/ec47536b483ba51c839d81bb6a8c1c63023d029c)), closes [#21971](https://github.com/bitnami/charts/issues/21971)
 
 ## <small>3.10.8 (2024-01-09)</small>
 
-* [bitnami/*] Fix docs.bitnami.com broken links (#21901) ([f35506d](https://github.com/bitnami/charts/commit/f35506d)), closes [#21901](https://github.com/bitnami/charts/issues/21901)
-* [bitnami/*] Update copyright: Year and company (#21815) ([6c4bf75](https://github.com/bitnami/charts/commit/6c4bf75)), closes [#21815](https://github.com/bitnami/charts/issues/21815)
-* [bitnami/rabbitmq-cluster-operator] Release 3.10.8 updating components versions (#21920) ([f7ab989](https://github.com/bitnami/charts/commit/f7ab989)), closes [#21920](https://github.com/bitnami/charts/issues/21920)
+* [bitnami/*] Fix docs.bitnami.com broken links (#21901) ([f35506d](https://github.com/bitnami/charts/commit/f35506d2dadee4f097986e7792df1f53ab215b5d)), closes [#21901](https://github.com/bitnami/charts/issues/21901)
+* [bitnami/*] Update copyright: Year and company (#21815) ([6c4bf75](https://github.com/bitnami/charts/commit/6c4bf75dec58fc7c9aee9f089777b1a858c17d5b)), closes [#21815](https://github.com/bitnami/charts/issues/21815)
+* [bitnami/rabbitmq-cluster-operator] Release 3.10.8 updating components versions (#21920) ([f7ab989](https://github.com/bitnami/charts/commit/f7ab9895af61ba7b7e38b018d1a911c12648f957)), closes [#21920](https://github.com/bitnami/charts/issues/21920)
 
 ## <small>3.10.7 (2023-12-07)</small>
 
-* [bitnami/rabbitmq-cluster-operator] Release 3.10.7 updating components versions (#21440) ([de4dd99](https://github.com/bitnami/charts/commit/de4dd99)), closes [#21440](https://github.com/bitnami/charts/issues/21440)
+* [bitnami/rabbitmq-cluster-operator] Release 3.10.7 updating components versions (#21440) ([de4dd99](https://github.com/bitnami/charts/commit/de4dd998feee803d20a5a1d90c09770c6ae41ecc)), closes [#21440](https://github.com/bitnami/charts/issues/21440)
 
 ## <small>3.10.6 (2023-11-23)</small>
 
-* [bitnami/rabbitmq-cluster-operator] Release 3.10.6 updating components versions (#21224) ([bcf4d25](https://github.com/bitnami/charts/commit/bcf4d25)), closes [#21224](https://github.com/bitnami/charts/issues/21224)
+* [bitnami/rabbitmq-cluster-operator] Release 3.10.6 updating components versions (#21224) ([bcf4d25](https://github.com/bitnami/charts/commit/bcf4d25cfec85eb70c2fd5e62932b250cbe96639)), closes [#21224](https://github.com/bitnami/charts/issues/21224)
 
 ## <small>3.10.5 (2023-11-21)</small>
 
-* [bitnami/*] Rename solutions to "Bitnami package for ..." (#21038) ([b82f979](https://github.com/bitnami/charts/commit/b82f979)), closes [#21038](https://github.com/bitnami/charts/issues/21038)
-* [bitnami/rabbitmq-cluster-operator] Release 3.10.5 updating components versions (#21169) ([7607fb8](https://github.com/bitnami/charts/commit/7607fb8)), closes [#21169](https://github.com/bitnami/charts/issues/21169)
+* [bitnami/*] Rename solutions to "Bitnami package for ..." (#21038) ([b82f979](https://github.com/bitnami/charts/commit/b82f979e4fb63423fe6e2192c946d09d79c944fc)), closes [#21038](https://github.com/bitnami/charts/issues/21038)
+* [bitnami/rabbitmq-cluster-operator] Release 3.10.5 updating components versions (#21169) ([7607fb8](https://github.com/bitnami/charts/commit/7607fb851293a24097fa762447a554aec76530a0)), closes [#21169](https://github.com/bitnami/charts/issues/21169)
 
 ## <small>3.10.4 (2023-11-20)</small>
 
-* [bitnami/*] Remove relative links to non-README sections, add verification for that and update TL;DR ([1103633](https://github.com/bitnami/charts/commit/1103633)), closes [#20967](https://github.com/bitnami/charts/issues/20967)
-* [bitnami/rabbitmq-cluster-operator] refresh messaging-topology-operator crds (#20982) ([7c398ff](https://github.com/bitnami/charts/commit/7c398ff)), closes [#20982](https://github.com/bitnami/charts/issues/20982)
+* [bitnami/*] Remove relative links to non-README sections, add verification for that and update TL;DR ([1103633](https://github.com/bitnami/charts/commit/11036334d82df0490aa4abdb591543cab6cf7d7f)), closes [#20967](https://github.com/bitnami/charts/issues/20967)
+* [bitnami/rabbitmq-cluster-operator] refresh messaging-topology-operator crds (#20982) ([7c398ff](https://github.com/bitnami/charts/commit/7c398ff3ce40b665d464f9c5f0139031460d452b)), closes [#20982](https://github.com/bitnami/charts/issues/20982)
 
 ## <small>3.10.3 (2023-11-09)</small>
 
-* [bitnami/rabbitmq-cluster-operator] Release 3.10.3 updating components versions (#20868) ([bff0813](https://github.com/bitnami/charts/commit/bff0813)), closes [#20868](https://github.com/bitnami/charts/issues/20868)
+* [bitnami/rabbitmq-cluster-operator] Release 3.10.3 updating components versions (#20868) ([bff0813](https://github.com/bitnami/charts/commit/bff0813d12ea07dd0b77a3232677771a5e971809)), closes [#20868](https://github.com/bitnami/charts/issues/20868)
 
 ## <small>3.10.2 (2023-11-09)</small>
 
-* [bitnami/rabbitmq-cluster-operator] Release 3.10.2 updating components versions (#20826) ([848ca6d](https://github.com/bitnami/charts/commit/848ca6d)), closes [#20826](https://github.com/bitnami/charts/issues/20826)
+* [bitnami/rabbitmq-cluster-operator] Release 3.10.2 updating components versions (#20826) ([848ca6d](https://github.com/bitnami/charts/commit/848ca6d85b51af1f40be7b4c1a85baf3c50dc130)), closes [#20826](https://github.com/bitnami/charts/issues/20826)
 
 ## <small>3.10.1 (2023-11-08)</small>
 
-* [bitnami/rabbitmq-cluster-operator] Release 3.10.1 updating components versions (#20780) ([2e50df7](https://github.com/bitnami/charts/commit/2e50df7)), closes [#20780](https://github.com/bitnami/charts/issues/20780)
+* [bitnami/rabbitmq-cluster-operator] Release 3.10.1 updating components versions (#20780) ([2e50df7](https://github.com/bitnami/charts/commit/2e50df738d956a69cfee1d3f483774b01bb494d3)), closes [#20780](https://github.com/bitnami/charts/issues/20780)
 
 ## 3.10.0 (2023-10-31)
 
-* [bitnami/*] Rename VMware Application Catalog (#20361) ([3acc734](https://github.com/bitnami/charts/commit/3acc734)), closes [#20361](https://github.com/bitnami/charts/issues/20361)
-* [bitnami/rabbitmq-cluster-operator] feat: :sparkles: Add support for PSA restricted policy (#20532) ([f5bb49c](https://github.com/bitnami/charts/commit/f5bb49c)), closes [#20532](https://github.com/bitnami/charts/issues/20532)
+* [bitnami/*] Rename VMware Application Catalog (#20361) ([3acc734](https://github.com/bitnami/charts/commit/3acc73472beb6fb56c4d99f929061001205bc57e)), closes [#20361](https://github.com/bitnami/charts/issues/20361)
+* [bitnami/rabbitmq-cluster-operator] feat: :sparkles: Add support for PSA restricted policy (#20532) ([f5bb49c](https://github.com/bitnami/charts/commit/f5bb49c45f2d774b5d6a02896cc6c48e9ef0c1b5)), closes [#20532](https://github.com/bitnami/charts/issues/20532)
 
 ## 3.9.0 (2023-10-20)
 
-* [bitnami/*] Skip image's tag in the README files of the Bitnami Charts (#19841) ([bb9a01b](https://github.com/bitnami/charts/commit/bb9a01b)), closes [#19841](https://github.com/bitnami/charts/issues/19841)
-* [bitnami/*] Standardize documentation (#19835) ([af5f753](https://github.com/bitnami/charts/commit/af5f753)), closes [#19835](https://github.com/bitnami/charts/issues/19835)
-* [bitnami/rabbitmq-cluster-operator] Add support for PodMonitor (#20326) ([000105a](https://github.com/bitnami/charts/commit/000105a)), closes [#20326](https://github.com/bitnami/charts/issues/20326)
+* [bitnami/*] Skip image's tag in the README files of the Bitnami Charts (#19841) ([bb9a01b](https://github.com/bitnami/charts/commit/bb9a01b65911c87e48318db922cc05eb42785e42)), closes [#19841](https://github.com/bitnami/charts/issues/19841)
+* [bitnami/*] Standardize documentation (#19835) ([af5f753](https://github.com/bitnami/charts/commit/af5f7530c1bc8c5ded53a6c4f7b8f384ac1804f2)), closes [#19835](https://github.com/bitnami/charts/issues/19835)
+* [bitnami/rabbitmq-cluster-operator] Add support for PodMonitor (#20326) ([000105a](https://github.com/bitnami/charts/commit/000105a9e5f42bf29e5ccd7f67ef746cb0bb7410)), closes [#20326](https://github.com/bitnami/charts/issues/20326)
 
 ## <small>3.8.9 (2023-10-17)</small>
 
-* add-support-for-metrics-endpoint (#19661) ([dceeb50](https://github.com/bitnami/charts/commit/dceeb50)), closes [#19661](https://github.com/bitnami/charts/issues/19661)
+* add-support-for-metrics-endpoint (#19661) ([dceeb50](https://github.com/bitnami/charts/commit/dceeb500a15f7b9580f39a519ccbbba8a787c683)), closes [#19661](https://github.com/bitnami/charts/issues/19661)
 
 ## <small>3.8.8 (2023-10-12)</small>
 
-* [bitnami/rabbitmq-cluster-operator] Release 3.8.8 (#20121) ([7b34f99](https://github.com/bitnami/charts/commit/7b34f99)), closes [#20121](https://github.com/bitnami/charts/issues/20121)
+* [bitnami/rabbitmq-cluster-operator] Release 3.8.8 (#20121) ([7b34f99](https://github.com/bitnami/charts/commit/7b34f991bb53eb0f3c919c9e37dc1e03a4980819)), closes [#20121](https://github.com/bitnami/charts/issues/20121)
 
 ## <small>3.8.7 (2023-10-11)</small>
 
-* [bitnami/rabbitmq-cluster-operator] Release 3.8.7 (#20063) ([840e093](https://github.com/bitnami/charts/commit/840e093)), closes [#20063](https://github.com/bitnami/charts/issues/20063)
+* [bitnami/rabbitmq-cluster-operator] Release 3.8.7 (#20063) ([840e093](https://github.com/bitnami/charts/commit/840e093e2188f3e57ecee925887660fcf1e8b13b)), closes [#20063](https://github.com/bitnami/charts/issues/20063)
 
 ## <small>3.8.6 (2023-10-10)</small>
 
-* [bitnami/rabbitmq-cluster-operator] Release 3.8.6 (#19996) ([924f738](https://github.com/bitnami/charts/commit/924f738)), closes [#19996](https://github.com/bitnami/charts/issues/19996)
+* [bitnami/rabbitmq-cluster-operator] Release 3.8.6 (#19996) ([924f738](https://github.com/bitnami/charts/commit/924f7381204e15471cb6d8f85ff3cb2f1c2918ab)), closes [#19996](https://github.com/bitnami/charts/issues/19996)
 
 ## <small>3.8.5 (2023-10-09)</small>
 
-* [bitnami/*] Update Helm charts prerequisites (#19745) ([eb755dd](https://github.com/bitnami/charts/commit/eb755dd)), closes [#19745](https://github.com/bitnami/charts/issues/19745)
-* [bitnami/rabbitmq-cluster-operator] Release 3.8.5 (#19890) ([add487f](https://github.com/bitnami/charts/commit/add487f)), closes [#19890](https://github.com/bitnami/charts/issues/19890)
+* [bitnami/*] Update Helm charts prerequisites (#19745) ([eb755dd](https://github.com/bitnami/charts/commit/eb755dd36a4dd3cf6635be8e0598f9a7f4c4a554)), closes [#19745](https://github.com/bitnami/charts/issues/19745)
+* [bitnami/rabbitmq-cluster-operator] Release 3.8.5 (#19890) ([add487f](https://github.com/bitnami/charts/commit/add487f6befd6854f19e99d4ccd65c40a599a47a)), closes [#19890](https://github.com/bitnami/charts/issues/19890)
 
 ## <small>3.8.4 (2023-10-04)</small>
 
-* [bitnami/rabbitmq-cluster-operator] Release 3.8.4 (#19743) ([cec625c](https://github.com/bitnami/charts/commit/cec625c)), closes [#19743](https://github.com/bitnami/charts/issues/19743)
+* [bitnami/rabbitmq-cluster-operator] Release 3.8.4 (#19743) ([cec625c](https://github.com/bitnami/charts/commit/cec625c3c0a2629652012a3b7f823fcc6904d7b1)), closes [#19743](https://github.com/bitnami/charts/issues/19743)
 
 ## <small>3.8.3 (2023-09-28)</small>
 
-* [bitnami/rabbitmq-cluster-operator] Update Container security context (#19568) ([839b08d](https://github.com/bitnami/charts/commit/839b08d)), closes [#19568](https://github.com/bitnami/charts/issues/19568)
+* [bitnami/rabbitmq-cluster-operator] Update Container security context (#19568) ([839b08d](https://github.com/bitnami/charts/commit/839b08d1ec81937947c38a7487bdc3b1234051b5)), closes [#19568](https://github.com/bitnami/charts/issues/19568)
 
 ## <small>3.8.2 (2023-09-27)</small>
 
-* [bitnami/rabbitmq-cluster-operator] Release 3.8.2 (#19578) ([49e52ae](https://github.com/bitnami/charts/commit/49e52ae)), closes [#19578](https://github.com/bitnami/charts/issues/19578)
+* [bitnami/rabbitmq-cluster-operator] Release 3.8.2 (#19578) ([49e52ae](https://github.com/bitnami/charts/commit/49e52aec2726511280c06114724067ca88df4d13)), closes [#19578](https://github.com/bitnami/charts/issues/19578)
 
 ## <small>3.8.1 (2023-09-20)</small>
 
-* [bitnami/rabbitmq-cluster-operator] Use different app.kubernetes.io/version label on subcomponents ( ([73d5f41](https://github.com/bitnami/charts/commit/73d5f41)), closes [#19353](https://github.com/bitnami/charts/issues/19353)
-* Autogenerate schema files (#19194) ([a2c2090](https://github.com/bitnami/charts/commit/a2c2090)), closes [#19194](https://github.com/bitnami/charts/issues/19194)
-* Revert "Autogenerate schema files (#19194)" (#19335) ([73d80be](https://github.com/bitnami/charts/commit/73d80be)), closes [#19194](https://github.com/bitnami/charts/issues/19194) [#19335](https://github.com/bitnami/charts/issues/19335)
+* [bitnami/rabbitmq-cluster-operator] Use different app.kubernetes.io/version label on subcomponents ( ([73d5f41](https://github.com/bitnami/charts/commit/73d5f410a258835151aaf002a5be854f35d2918b)), closes [#19353](https://github.com/bitnami/charts/issues/19353)
+* Autogenerate schema files (#19194) ([a2c2090](https://github.com/bitnami/charts/commit/a2c2090b5ac97f47b745c8028c6452bf99739772)), closes [#19194](https://github.com/bitnami/charts/issues/19194)
+* Revert "Autogenerate schema files (#19194)" (#19335) ([73d80be](https://github.com/bitnami/charts/commit/73d80be525c88fb4b8a54451a55acd506e337062)), closes [#19194](https://github.com/bitnami/charts/issues/19194) [#19335](https://github.com/bitnami/charts/issues/19335)
 
 ## 3.8.0 (2023-09-08)
 
-* [bitnami/rabbitmq-cluster-operator] Add clusterrole customrules parameter (#19203) ([2cdd0fb](https://github.com/bitnami/charts/commit/2cdd0fb)), closes [#19203](https://github.com/bitnami/charts/issues/19203)
+* [bitnami/rabbitmq-cluster-operator] Add clusterrole customrules parameter (#19203) ([2cdd0fb](https://github.com/bitnami/charts/commit/2cdd0fb5e8587e0296bdcd875cec33c04291cdb8)), closes [#19203](https://github.com/bitnami/charts/issues/19203)
 
 ## <small>3.7.4 (2023-09-07)</small>
 
-* [bitnami/rabbitmq-cluster-operator] Fix indentation typo in msgTopologyOperator metrics service sele ([fc0df59](https://github.com/bitnami/charts/commit/fc0df59)), closes [#18929](https://github.com/bitnami/charts/issues/18929)
+* [bitnami/rabbitmq-cluster-operator] Fix indentation typo in msgTopologyOperator metrics service sele ([fc0df59](https://github.com/bitnami/charts/commit/fc0df5939290471f90689c78a11ff02820d17994)), closes [#18929](https://github.com/bitnami/charts/issues/18929)
 
 ## <small>3.7.3 (2023-09-06)</small>
 
-* [bitnami/rabbitmq-cluster-operator: Use merge helper]: (#19099) ([5beecb6](https://github.com/bitnami/charts/commit/5beecb6)), closes [#19099](https://github.com/bitnami/charts/issues/19099)
+* [bitnami/rabbitmq-cluster-operator: Use merge helper]: (#19099) ([5beecb6](https://github.com/bitnami/charts/commit/5beecb60192d689cc3970bfd4100716c341aee16)), closes [#19099](https://github.com/bitnami/charts/issues/19099)
 
 ## <small>3.7.2 (2023-08-28)</small>
 
-* [bitnami/rabbitmq-cluster-operator] Release 3.7.2 (#18912) ([0fb788e](https://github.com/bitnami/charts/commit/0fb788e)), closes [#18912](https://github.com/bitnami/charts/issues/18912)
+* [bitnami/rabbitmq-cluster-operator] Release 3.7.2 (#18912) ([0fb788e](https://github.com/bitnami/charts/commit/0fb788e6351c386e37ce34cea03875fe9fead5f5)), closes [#18912](https://github.com/bitnami/charts/issues/18912)
 
 ## <small>3.7.1 (2023-08-25)</small>
 
-* [bitnami/rabbitmq-cluster-operator] Bugfix for servicemonitor.yaml template (#18848) ([9de9350](https://github.com/bitnami/charts/commit/9de9350)), closes [#18848](https://github.com/bitnami/charts/issues/18848)
+* [bitnami/rabbitmq-cluster-operator] Bugfix for servicemonitor.yaml template (#18848) ([9de9350](https://github.com/bitnami/charts/commit/9de935089dba8d00edf5adb3d26ec637943d8f79)), closes [#18848](https://github.com/bitnami/charts/issues/18848)
 
 ## 3.7.0 (2023-08-24)
 
-* [bitnami/rabbitmq-cluster-operator] Support for customizing standard labels (#18417) ([d69f57b](https://github.com/bitnami/charts/commit/d69f57b)), closes [#18417](https://github.com/bitnami/charts/issues/18417)
+* [bitnami/rabbitmq-cluster-operator] Support for customizing standard labels (#18417) ([d69f57b](https://github.com/bitnami/charts/commit/d69f57b0cdb7f062838744d70ebd00f8d9256d1f)), closes [#18417](https://github.com/bitnami/charts/issues/18417)
 
 ## <small>3.6.7 (2023-08-20)</small>
 
-* [bitnami/rabbitmq-cluster-operator] Release 3.6.7 (#18710) ([81faee9](https://github.com/bitnami/charts/commit/81faee9)), closes [#18710](https://github.com/bitnami/charts/issues/18710)
+* [bitnami/rabbitmq-cluster-operator] Release 3.6.7 (#18710) ([81faee9](https://github.com/bitnami/charts/commit/81faee955242311c756531ef73c8cfe2b0456dfc)), closes [#18710](https://github.com/bitnami/charts/issues/18710)
 
 ## <small>3.6.6 (2023-08-17)</small>
 
-* [bitnami/rabbitmq-cluster-operator] Release 3.6.6 (#18493) ([1f339b9](https://github.com/bitnami/charts/commit/1f339b9)), closes [#18493](https://github.com/bitnami/charts/issues/18493)
+* [bitnami/rabbitmq-cluster-operator] Release 3.6.6 (#18493) ([1f339b9](https://github.com/bitnami/charts/commit/1f339b9991a5bb9ba5e58929be99460e2ff47a25)), closes [#18493](https://github.com/bitnami/charts/issues/18493)
 
 ## <small>3.6.5 (2023-08-08)</small>
 
-* [bitnami/rabbitmq-cluster-operator] chore: :page_facing_up: Remove license in CRDs (#18268) ([7b01734](https://github.com/bitnami/charts/commit/7b01734)), closes [#18268](https://github.com/bitnami/charts/issues/18268)
+* [bitnami/rabbitmq-cluster-operator] chore: :page_facing_up: Remove license in CRDs (#18268) ([7b01734](https://github.com/bitnami/charts/commit/7b017344e519d0e1263d9c6a683d6d3cc494ada6)), closes [#18268](https://github.com/bitnami/charts/issues/18268)
 
 ## <small>3.6.4 (2023-07-26)</small>
 
-* [bitnami/rabbitmq-cluster-operator] Release 3.6.4 (#17947) ([ea9fb8a](https://github.com/bitnami/charts/commit/ea9fb8a)), closes [#17947](https://github.com/bitnami/charts/issues/17947)
+* [bitnami/rabbitmq-cluster-operator] Release 3.6.4 (#17947) ([ea9fb8a](https://github.com/bitnami/charts/commit/ea9fb8a2610a30ee3e9bbf04910ac9b50169affa)), closes [#17947](https://github.com/bitnami/charts/issues/17947)
 
 ## <small>3.6.3 (2023-07-20)</small>
 
-* [bitnami/rabbitmq-cluster-operator] Release 3.6.3 (#17799) ([e274a79](https://github.com/bitnami/charts/commit/e274a79)), closes [#17799](https://github.com/bitnami/charts/issues/17799)
+* [bitnami/rabbitmq-cluster-operator] Release 3.6.3 (#17799) ([e274a79](https://github.com/bitnami/charts/commit/e274a79d85ef6abe97bd3ebb9182fe549692829b)), closes [#17799](https://github.com/bitnami/charts/issues/17799)
 
 ## <small>3.6.2 (2023-07-17)</small>
 
-* [bitnami/rabbitmq-cluster-operator] Release 3.6.2 (#17741) ([b93ede9](https://github.com/bitnami/charts/commit/b93ede9)), closes [#17741](https://github.com/bitnami/charts/issues/17741)
+* [bitnami/rabbitmq-cluster-operator] Release 3.6.2 (#17741) ([b93ede9](https://github.com/bitnami/charts/commit/b93ede9bbeafb93edd1ff8fbd2326f7362ece43e)), closes [#17741](https://github.com/bitnami/charts/issues/17741)
 
 ## <small>3.6.1 (2023-07-16)</small>
 
-* [bitnami/rabbitmq-cluster-operator] Release 3.6.1 (#17706) ([b932dcf](https://github.com/bitnami/charts/commit/b932dcf)), closes [#17706](https://github.com/bitnami/charts/issues/17706)
+* [bitnami/rabbitmq-cluster-operator] Release 3.6.1 (#17706) ([b932dcf](https://github.com/bitnami/charts/commit/b932dcfa6f1057207371b03d39a079319573391b)), closes [#17706](https://github.com/bitnami/charts/issues/17706)
 
 ## 3.6.0 (2023-07-14)
 
-* [bitnami/rabbitmq-cluster-operator] Support toggle to disable rabbitmq messaging topology operator i ([fc34693](https://github.com/bitnami/charts/commit/fc34693)), closes [#17539](https://github.com/bitnami/charts/issues/17539)
+* [bitnami/rabbitmq-cluster-operator] Support toggle to disable rabbitmq messaging topology operator i ([fc34693](https://github.com/bitnami/charts/commit/fc34693b20902c33811a65cc1ae983b9b5368e3e)), closes [#17539](https://github.com/bitnami/charts/issues/17539)
 
 ## 3.5.0 (2023-07-11)
 
-* [bitnami/rabbitmq-cluster-operator] update CRDs (#17551) ([f7b8618](https://github.com/bitnami/charts/commit/f7b8618)), closes [#17551](https://github.com/bitnami/charts/issues/17551)
+* [bitnami/rabbitmq-cluster-operator] update CRDs (#17551) ([f7b8618](https://github.com/bitnami/charts/commit/f7b861870b553175e81f2ecb1c54a63323173ae5)), closes [#17551](https://github.com/bitnami/charts/issues/17551)
 
 ## <small>3.4.3 (2023-07-09)</small>
 
-* [bitnami/rabbitmq-cluster-operator] Release 3.4.3 (#17535) ([764c3aa](https://github.com/bitnami/charts/commit/764c3aa)), closes [#17535](https://github.com/bitnami/charts/issues/17535)
-* Add copyright header (#17300) ([da68be8](https://github.com/bitnami/charts/commit/da68be8)), closes [#17300](https://github.com/bitnami/charts/issues/17300)
-* Update charts readme (#17217) ([31b3c0a](https://github.com/bitnami/charts/commit/31b3c0a)), closes [#17217](https://github.com/bitnami/charts/issues/17217)
+* [bitnami/rabbitmq-cluster-operator] Release 3.4.3 (#17535) ([764c3aa](https://github.com/bitnami/charts/commit/764c3aaa5d1da41bc7f172b859850f9057fae75f)), closes [#17535](https://github.com/bitnami/charts/issues/17535)
+* Add copyright header (#17300) ([da68be8](https://github.com/bitnami/charts/commit/da68be8e951225133c7dfb572d5101ca3d61c5ae)), closes [#17300](https://github.com/bitnami/charts/issues/17300)
+* Update charts readme (#17217) ([31b3c0a](https://github.com/bitnami/charts/commit/31b3c0afd968ff4429107e34101f7509e6a0e913)), closes [#17217](https://github.com/bitnami/charts/issues/17217)
 
 ## <small>3.4.2 (2023-06-08)</small>
 
-* [bitnami/*] Change copyright section in READMEs (#17006) ([ef986a1](https://github.com/bitnami/charts/commit/ef986a1)), closes [#17006](https://github.com/bitnami/charts/issues/17006)
-* [bitnami/rabbitmq-cluster-operator] Release 3.4.2 (#17074) ([bb3d1c6](https://github.com/bitnami/charts/commit/bb3d1c6)), closes [#17074](https://github.com/bitnami/charts/issues/17074)
-* [bitnami/several] Change copyright section in READMEs (#16989) ([5b6a5cf](https://github.com/bitnami/charts/commit/5b6a5cf)), closes [#16989](https://github.com/bitnami/charts/issues/16989)
+* [bitnami/*] Change copyright section in READMEs (#17006) ([ef986a1](https://github.com/bitnami/charts/commit/ef986a1605241102b3dcafe9fd8089e6fc1201ad)), closes [#17006](https://github.com/bitnami/charts/issues/17006)
+* [bitnami/rabbitmq-cluster-operator] Release 3.4.2 (#17074) ([bb3d1c6](https://github.com/bitnami/charts/commit/bb3d1c606fe2d5c11d7f513c609d1b3dd82324c5)), closes [#17074](https://github.com/bitnami/charts/issues/17074)
+* [bitnami/several] Change copyright section in READMEs (#16989) ([5b6a5cf](https://github.com/bitnami/charts/commit/5b6a5cfb7625a751848a2e5cd796bd7278f406ca)), closes [#16989](https://github.com/bitnami/charts/issues/16989)
 
 ## <small>3.4.1 (2023-05-21)</small>
 
-* [bitnami/rabbitmq-cluster-operator] Release 3.4.1 (#16807) ([1137f10](https://github.com/bitnami/charts/commit/1137f10)), closes [#16807](https://github.com/bitnami/charts/issues/16807)
-* Add wording for enterprise page (#16560) ([8f22774](https://github.com/bitnami/charts/commit/8f22774)), closes [#16560](https://github.com/bitnami/charts/issues/16560)
+* [bitnami/rabbitmq-cluster-operator] Release 3.4.1 (#16807) ([1137f10](https://github.com/bitnami/charts/commit/1137f10d940d4d48a9f459296e530a1444395c8e)), closes [#16807](https://github.com/bitnami/charts/issues/16807)
+* Add wording for enterprise page (#16560) ([8f22774](https://github.com/bitnami/charts/commit/8f2277440b976d52785ba9149762ad8620a73d1f)), closes [#16560](https://github.com/bitnami/charts/issues/16560)
 
 ## 3.4.0 (2023-05-09)
 
-* [bitnami/several] Adapt Chart.yaml to set desired OCI annotations (#16546) ([fc9b18f](https://github.com/bitnami/charts/commit/fc9b18f)), closes [#16546](https://github.com/bitnami/charts/issues/16546)
+* [bitnami/several] Adapt Chart.yaml to set desired OCI annotations (#16546) ([fc9b18f](https://github.com/bitnami/charts/commit/fc9b18f2e98805d4df629acbcde696f44f973344)), closes [#16546](https://github.com/bitnami/charts/issues/16546)
 
 ## <small>3.3.2 (2023-05-09)</small>
 
-* [bitnami/rabbitmq-cluster-operator] Release 3.3.2 (#16538) ([7d7e9ea](https://github.com/bitnami/charts/commit/7d7e9ea)), closes [#16538](https://github.com/bitnami/charts/issues/16538)
-* Typo fix (#16373) ([d911ef1](https://github.com/bitnami/charts/commit/d911ef1)), closes [#16373](https://github.com/bitnami/charts/issues/16373)
+* [bitnami/rabbitmq-cluster-operator] Release 3.3.2 (#16538) ([7d7e9ea](https://github.com/bitnami/charts/commit/7d7e9eab2771303d09bb942731ca7883902eb2f1)), closes [#16538](https://github.com/bitnami/charts/issues/16538)
+* Typo fix (#16373) ([d911ef1](https://github.com/bitnami/charts/commit/d911ef1147a99aa648cbb72dd34d3dff11dbbb1c)), closes [#16373](https://github.com/bitnami/charts/issues/16373)
 
 ## <small>3.3.1 (2023-05-02)</small>
 
-* [bitnami/rabbitmq-cluster-operator] Release 3.3.1 (#16330) ([2fa577a](https://github.com/bitnami/charts/commit/2fa577a)), closes [#16330](https://github.com/bitnami/charts/issues/16330)
+* [bitnami/rabbitmq-cluster-operator] Release 3.3.1 (#16330) ([2fa577a](https://github.com/bitnami/charts/commit/2fa577a043d2b5ae07cca52728d88a5ba02271b2)), closes [#16330](https://github.com/bitnami/charts/issues/16330)
 
 ## 3.3.0 (2023-04-20)
 
-* [bitnami/*] Make Helm charts 100% OCI (#15998) ([8841510](https://github.com/bitnami/charts/commit/8841510)), closes [#15998](https://github.com/bitnami/charts/issues/15998)
+* [bitnami/*] Make Helm charts 100% OCI (#15998) ([8841510](https://github.com/bitnami/charts/commit/884151035efcbf2e1b3206e7def85511073fb57d)), closes [#15998](https://github.com/bitnami/charts/issues/15998)
 
 ## <small>3.2.10 (2023-04-01)</small>
 
-* [bitnami/rabbitmq-cluster-operator] Release 3.2.10 (#15889) ([e886f36](https://github.com/bitnami/charts/commit/e886f36)), closes [#15889](https://github.com/bitnami/charts/issues/15889)
+* [bitnami/rabbitmq-cluster-operator] Release 3.2.10 (#15889) ([e886f36](https://github.com/bitnami/charts/commit/e886f36b891e86a87332a6a730de1a64696f7144)), closes [#15889](https://github.com/bitnami/charts/issues/15889)
 
 ## <small>3.2.9 (2023-03-31)</small>
 
-* [bitnami/rabbitmq-cluster-operator] Release 3.2.9 (#15825) ([17574a2](https://github.com/bitnami/charts/commit/17574a2)), closes [#15825](https://github.com/bitnami/charts/issues/15825)
+* [bitnami/rabbitmq-cluster-operator] Release 3.2.9 (#15825) ([17574a2](https://github.com/bitnami/charts/commit/17574a223a48eb842b0a2a9a6a284c7a51591bc4)), closes [#15825](https://github.com/bitnami/charts/issues/15825)
 
 ## <small>3.2.8 (2023-03-28)</small>
 
-* [bitnami/rabbitmq-cluster-operator] Update CRDs (#15744) ([1ecb473](https://github.com/bitnami/charts/commit/1ecb473)), closes [#15744](https://github.com/bitnami/charts/issues/15744)
-* Fix Error: INSTALLATION FAILED: chart "rabbitmq-cluster-operators" matching  not found in bitnami in ([8cf1506](https://github.com/bitnami/charts/commit/8cf1506)), closes [#15700](https://github.com/bitnami/charts/issues/15700)
+* [bitnami/rabbitmq-cluster-operator] Update CRDs (#15744) ([1ecb473](https://github.com/bitnami/charts/commit/1ecb473a73e83f93c28abef516b28b722c014852)), closes [#15744](https://github.com/bitnami/charts/issues/15744)
+* Fix Error: INSTALLATION FAILED: chart "rabbitmq-cluster-operators" matching  not found in bitnami in ([8cf1506](https://github.com/bitnami/charts/commit/8cf150696e022d5c7c2aa41530dcb725bdcaf0e5)), closes [#15700](https://github.com/bitnami/charts/issues/15700)
 
 ## <small>3.2.7 (2023-03-19)</small>
 
-* [bitnami/rabbitmq-cluster-operator] Release 3.2.7 (#15598) ([a4fc050](https://github.com/bitnami/charts/commit/a4fc050)), closes [#15598](https://github.com/bitnami/charts/issues/15598)
+* [bitnami/rabbitmq-cluster-operator] Release 3.2.7 (#15598) ([a4fc050](https://github.com/bitnami/charts/commit/a4fc050831ee5e72573e734a6baf4bb87e15c57c)), closes [#15598](https://github.com/bitnami/charts/issues/15598)
 
 ## <small>3.2.6 (2023-03-18)</small>
 
-* [bitnami/rabbitmq-cluster-operator] Release 3.2.6 (#15551) ([1948a68](https://github.com/bitnami/charts/commit/1948a68)), closes [#15551](https://github.com/bitnami/charts/issues/15551)
+* [bitnami/rabbitmq-cluster-operator] Release 3.2.6 (#15551) ([1948a68](https://github.com/bitnami/charts/commit/1948a6859b75351828a4a4e8394784b4b2a5133b)), closes [#15551](https://github.com/bitnami/charts/issues/15551)
 
 ## <small>3.2.5 (2023-03-15)</small>
 
-* [bitnami/charts] Apply linter to README files (#15357) ([0e29e60](https://github.com/bitnami/charts/commit/0e29e60)), closes [#15357](https://github.com/bitnami/charts/issues/15357)
-* [bitnami/rabbitmq-cluster-operator] Release 3.2.5 (#15278) ([de8ca59](https://github.com/bitnami/charts/commit/de8ca59)), closes [#15278](https://github.com/bitnami/charts/issues/15278)
+* [bitnami/charts] Apply linter to README files (#15357) ([0e29e60](https://github.com/bitnami/charts/commit/0e29e600d3adc8b1b46e506eccb3decfab3b4e63)), closes [#15357](https://github.com/bitnami/charts/issues/15357)
+* [bitnami/rabbitmq-cluster-operator] Release 3.2.5 (#15278) ([de8ca59](https://github.com/bitnami/charts/commit/de8ca594aa222a3714974c4c1ce5f9cf470cf846)), closes [#15278](https://github.com/bitnami/charts/issues/15278)
 
 ## <small>3.2.4 (2023-02-17)</small>
 
-* [bitnami/rabbitmq-cluster-operator] Release 3.2.4 (#15002) ([eb8f920](https://github.com/bitnami/charts/commit/eb8f920)), closes [#15002](https://github.com/bitnami/charts/issues/15002)
+* [bitnami/rabbitmq-cluster-operator] Release 3.2.4 (#15002) ([eb8f920](https://github.com/bitnami/charts/commit/eb8f92006a1a889fff4e942d77d9429a1bc1db13)), closes [#15002](https://github.com/bitnami/charts/issues/15002)
 
 ## <small>3.2.3 (2023-02-16)</small>
 
-* [bitnami/*] Fix markdown linter issues (#14874) ([a51e0e8](https://github.com/bitnami/charts/commit/a51e0e8)), closes [#14874](https://github.com/bitnami/charts/issues/14874)
-* [bitnami/*] Fix markdown linter issues 2 (#14890) ([aa96572](https://github.com/bitnami/charts/commit/aa96572)), closes [#14890](https://github.com/bitnami/charts/issues/14890)
-* [bitnami/*] Remove unexpected extra spaces (#14873) ([c97c714](https://github.com/bitnami/charts/commit/c97c714)), closes [#14873](https://github.com/bitnami/charts/issues/14873)
-* [rabbitmq-cluster-operator] Fix issue with caBundle not using existing CA certificate (#14909) ([e51a5cb](https://github.com/bitnami/charts/commit/e51a5cb)), closes [#14909](https://github.com/bitnami/charts/issues/14909)
+* [bitnami/*] Fix markdown linter issues (#14874) ([a51e0e8](https://github.com/bitnami/charts/commit/a51e0e8d35495b907f3e70dd2f8e7c3bcbf4166a)), closes [#14874](https://github.com/bitnami/charts/issues/14874)
+* [bitnami/*] Fix markdown linter issues 2 (#14890) ([aa96572](https://github.com/bitnami/charts/commit/aa9657237ee8df4a46db0d7fdf8a23230dd6902a)), closes [#14890](https://github.com/bitnami/charts/issues/14890)
+* [bitnami/*] Remove unexpected extra spaces (#14873) ([c97c714](https://github.com/bitnami/charts/commit/c97c714887380d47eae7bfeff316bf01595ecd1d)), closes [#14873](https://github.com/bitnami/charts/issues/14873)
+* [rabbitmq-cluster-operator] Fix issue with caBundle not using existing CA certificate (#14909) ([e51a5cb](https://github.com/bitnami/charts/commit/e51a5cb69d25a795808c0ce8b53b85e79a226df5)), closes [#14909](https://github.com/bitnami/charts/issues/14909)
 
 ## <small>3.2.2 (2023-02-04)</small>
 
-* [bitnami/*] Change copyright date (#14682) ([add4ec7](https://github.com/bitnami/charts/commit/add4ec7)), closes [#14682](https://github.com/bitnami/charts/issues/14682)
-* [bitnami/rabbitmq-cluster-operator] Release 3.2.2 (#14748) ([5267f24](https://github.com/bitnami/charts/commit/5267f24)), closes [#14748](https://github.com/bitnami/charts/issues/14748)
+* [bitnami/*] Change copyright date (#14682) ([add4ec7](https://github.com/bitnami/charts/commit/add4ec701108ac36ed4de2dffbdf407a0d091067)), closes [#14682](https://github.com/bitnami/charts/issues/14682)
+* [bitnami/rabbitmq-cluster-operator] Release 3.2.2 (#14748) ([5267f24](https://github.com/bitnami/charts/commit/5267f241a9c839256786b2a308296418bf0275b2)), closes [#14748](https://github.com/bitnami/charts/issues/14748)
 
 ## <small>3.2.1 (2023-01-31)</small>
 
-* [bitnami/*] Add license annotation and remove obsolete engine parameter (#14293) ([da2a794](https://github.com/bitnami/charts/commit/da2a794)), closes [#14293](https://github.com/bitnami/charts/issues/14293)
-* [bitnami/*] Change licenses annotation format (#14377) ([0ab7608](https://github.com/bitnami/charts/commit/0ab7608)), closes [#14377](https://github.com/bitnami/charts/issues/14377)
-* [bitnami/*] Unify READMEs (#14472) ([2064fb8](https://github.com/bitnami/charts/commit/2064fb8)), closes [#14472](https://github.com/bitnami/charts/issues/14472)
-* [bitnami/rabbitmq-cluster-operator] Don't regenerate self-signed certs on upgrade (#14654) ([d8da225](https://github.com/bitnami/charts/commit/d8da225)), closes [#14654](https://github.com/bitnami/charts/issues/14654)
+* [bitnami/*] Add license annotation and remove obsolete engine parameter (#14293) ([da2a794](https://github.com/bitnami/charts/commit/da2a7943bae95b6e9b5b4ed972c15e990b69fdb0)), closes [#14293](https://github.com/bitnami/charts/issues/14293)
+* [bitnami/*] Change licenses annotation format (#14377) ([0ab7608](https://github.com/bitnami/charts/commit/0ab760862c660fcc78cffadf8e1d8cdd70881473)), closes [#14377](https://github.com/bitnami/charts/issues/14377)
+* [bitnami/*] Unify READMEs (#14472) ([2064fb8](https://github.com/bitnami/charts/commit/2064fb8dcc78a845cdede8211af8c3cc52551161)), closes [#14472](https://github.com/bitnami/charts/issues/14472)
+* [bitnami/rabbitmq-cluster-operator] Don't regenerate self-signed certs on upgrade (#14654) ([d8da225](https://github.com/bitnami/charts/commit/d8da225bdab70026763a8077e4f103295ecb7ea7)), closes [#14654](https://github.com/bitnami/charts/issues/14654)
 
 ## 3.2.0 (2023-01-09)
 
-* bitnami/rabbitmq-cluster-operator : Configurable `dnsPolicy` / `hostNetwork` on `msgTopologyOperator ([5656d04](https://github.com/bitnami/charts/commit/5656d04)), closes [#14152](https://github.com/bitnami/charts/issues/14152)
+* bitnami/rabbitmq-cluster-operator : Configurable `dnsPolicy` / `hostNetwork` on `msgTopologyOperator ([5656d04](https://github.com/bitnami/charts/commit/5656d04fa3827fe049ed673b3a7293ed9dac3ded)), closes [#14152](https://github.com/bitnami/charts/issues/14152)
 
 ## <small>3.1.6 (2023-01-05)</small>
 
-* [bitnami/rabbitmq-cluster-operator] Release 3.1.6 (#14192) ([33481c3](https://github.com/bitnami/charts/commit/33481c3)), closes [#14192](https://github.com/bitnami/charts/issues/14192)
+* [bitnami/rabbitmq-cluster-operator] Release 3.1.6 (#14192) ([33481c3](https://github.com/bitnami/charts/commit/33481c3a4315a4046c54964802743628ad912e68)), closes [#14192](https://github.com/bitnami/charts/issues/14192)
 
 ## <small>3.1.5 (2022-12-29)</small>
 
-* [bitnami/rabbitmq-cluster-operator] Release 3.1.5 (#14129) ([6be1a60](https://github.com/bitnami/charts/commit/6be1a60)), closes [#14129](https://github.com/bitnami/charts/issues/14129)
+* [bitnami/rabbitmq-cluster-operator] Release 3.1.5 (#14129) ([6be1a60](https://github.com/bitnami/charts/commit/6be1a60f0213c8ae658bb056fd4c54c5a04fb633)), closes [#14129](https://github.com/bitnami/charts/issues/14129)
 
 ## <small>3.1.4 (2022-11-26)</small>
 
-* [bitnami/rabbitmq-cluster-operator] Release 3.1.4 (#13710) ([b0fbb2e](https://github.com/bitnami/charts/commit/b0fbb2e)), closes [#13710](https://github.com/bitnami/charts/issues/13710)
+* [bitnami/rabbitmq-cluster-operator] Release 3.1.4 (#13710) ([b0fbb2e](https://github.com/bitnami/charts/commit/b0fbb2e888427aeba7ea3f784c23f3578bc18237)), closes [#13710](https://github.com/bitnami/charts/issues/13710)
 
 ## <small>3.1.3 (2022-11-23)</small>
 
-* [bitnami/rabbitmq-cluster-operator] RabbitMQ messaging topology operator allow edit secrets in clust ([8d2125c](https://github.com/bitnami/charts/commit/8d2125c)), closes [bitnami#13497](https://github.com/bitnami/issues/13497) [#13613](https://github.com/bitnami/charts/issues/13613)
+* [bitnami/rabbitmq-cluster-operator] RabbitMQ messaging topology operator allow edit secrets in clust ([8d2125c](https://github.com/bitnami/charts/commit/8d2125c489d82e3c56e76daaa62114aaf507a1c0)), closes [bitnami#13497](https://github.com/bitnami/issues/13497) [#13613](https://github.com/bitnami/charts/issues/13613)
 
 ## <small>3.1.2 (2022-11-07)</small>
 
-* [bitnami/rabbitmq-cluster-operator] update the rabbitmq operator CRDs (#13289) ([043d85d](https://github.com/bitnami/charts/commit/043d85d)), closes [#13289](https://github.com/bitnami/charts/issues/13289)
+* [bitnami/rabbitmq-cluster-operator] update the rabbitmq operator CRDs (#13289) ([043d85d](https://github.com/bitnami/charts/commit/043d85dd783f8692a03e9dc8ccfacac5999fbf5e)), closes [#13289](https://github.com/bitnami/charts/issues/13289)
 
 ## <small>3.1.1 (2022-10-27)</small>
 
-* [bitnami/*] Use new default branch name in links (#12943) ([a529e02](https://github.com/bitnami/charts/commit/a529e02)), closes [#12943](https://github.com/bitnami/charts/issues/12943)
-* [bitnami/rabbitmq-cluster-operator] Release 3.1.1 (#13205) ([cccdab7](https://github.com/bitnami/charts/commit/cccdab7)), closes [#13205](https://github.com/bitnami/charts/issues/13205)
-* Generic README instructions related to the repo (#12792) ([3cf6b10](https://github.com/bitnami/charts/commit/3cf6b10)), closes [#12792](https://github.com/bitnami/charts/issues/12792)
+* [bitnami/*] Use new default branch name in links (#12943) ([a529e02](https://github.com/bitnami/charts/commit/a529e02597d49d944eba1eb0f190713293247176)), closes [#12943](https://github.com/bitnami/charts/issues/12943)
+* [bitnami/rabbitmq-cluster-operator] Release 3.1.1 (#13205) ([cccdab7](https://github.com/bitnami/charts/commit/cccdab709eebb87681a668846f29ba9a85fdc51d)), closes [#13205](https://github.com/bitnami/charts/issues/13205)
+* Generic README instructions related to the repo (#12792) ([3cf6b10](https://github.com/bitnami/charts/commit/3cf6b10e10e60df4b3e191d6b99aa99a9f597755)), closes [#12792](https://github.com/bitnami/charts/issues/12792)
 
 ## 3.1.0 (2022-09-30)
 
-* [bitnami/rabbitmq-cluster-operator] Add tests and publishing using VIB (#12772) ([927ffad](https://github.com/bitnami/charts/commit/927ffad)), closes [#12772](https://github.com/bitnami/charts/issues/12772)
+* [bitnami/rabbitmq-cluster-operator] Add tests and publishing using VIB (#12772) ([927ffad](https://github.com/bitnami/charts/commit/927ffada3875558d8891c0e1eed0007c3a7fc0c2)), closes [#12772](https://github.com/bitnami/charts/issues/12772)
 
 ## 3.0.0 (2022-09-27)
 
-* [bitnami/rabbitmq-cluster-operator] Release 3.0.0 updating components versions ([a13363e](https://github.com/bitnami/charts/commit/a13363e))
+* [bitnami/rabbitmq-cluster-operator] Release 3.0.0 updating components versions ([a13363e](https://github.com/bitnami/charts/commit/a13363eac3b7d8abccbba97e909c903edcf07ba1))
 
 ## <small>2.7.4 (2022-09-20)</small>
 
-* [bitnami/rabbitmq-cluster-operator] Use custom probes if given (#12552) ([b600e48](https://github.com/bitnami/charts/commit/b600e48)), closes [#12552](https://github.com/bitnami/charts/issues/12552) [#12354](https://github.com/bitnami/charts/issues/12354)
+* [bitnami/rabbitmq-cluster-operator] Use custom probes if given (#12552) ([b600e48](https://github.com/bitnami/charts/commit/b600e48ab59343183feae38742f3c71aa10171f3)), closes [#12552](https://github.com/bitnami/charts/issues/12552) [#12354](https://github.com/bitnami/charts/issues/12354)
 
 ## <small>2.7.3 (2022-09-14)</small>
 
-* fix(rabbitmq-operator): allow to change webhook port (#12414) ([fbbbdbd](https://github.com/bitnami/charts/commit/fbbbdbd)), closes [#12414](https://github.com/bitnami/charts/issues/12414)
+* fix(rabbitmq-operator): allow to change webhook port (#12414) ([fbbbdbd](https://github.com/bitnami/charts/commit/fbbbdbd28a3180b78efa279a9d970c4b72002961)), closes [#12414](https://github.com/bitnami/charts/issues/12414)
 
 ## <small>2.7.2 (2022-09-08)</small>
 
-* [bitnami/rabbitmq-cluster-operator] Release 2.7.2 updating components versions ([3349a81](https://github.com/bitnami/charts/commit/3349a81))
+* [bitnami/rabbitmq-cluster-operator] Release 2.7.2 updating components versions ([3349a81](https://github.com/bitnami/charts/commit/3349a81add2d9419208af4a4cc52f191319a64dd))
 
 ## <small>2.7.1 (2022-08-23)</small>
 
-* [bitnami/rabbitmq-cluster-operator] docs: :memo: Add CRD upgrade instructions (#12021) ([be91dea](https://github.com/bitnami/charts/commit/be91dea)), closes [#12021](https://github.com/bitnami/charts/issues/12021)
-* [bitnami/rabbitmq-cluster-operator] Update Chart.lock (#12071) ([bf0093a](https://github.com/bitnami/charts/commit/bf0093a)), closes [#12071](https://github.com/bitnami/charts/issues/12071)
+* [bitnami/rabbitmq-cluster-operator] docs: :memo: Add CRD upgrade instructions (#12021) ([be91dea](https://github.com/bitnami/charts/commit/be91dea4a9ef76867f203d555fb58b2787067bfd)), closes [#12021](https://github.com/bitnami/charts/issues/12021)
+* [bitnami/rabbitmq-cluster-operator] Update Chart.lock (#12071) ([bf0093a](https://github.com/bitnami/charts/commit/bf0093acb3d909a163ca3e8dcfea09f9597a849d)), closes [#12071](https://github.com/bitnami/charts/issues/12071)
 
 ## 2.7.0 (2022-08-22)
 
-* [bitnami/rabbitmq-cluster-operator] Add support for image digest apart from tag (#11939) ([d7283d3](https://github.com/bitnami/charts/commit/d7283d3)), closes [#11939](https://github.com/bitnami/charts/issues/11939)
+* [bitnami/rabbitmq-cluster-operator] Add support for image digest apart from tag (#11939) ([d7283d3](https://github.com/bitnami/charts/commit/d7283d3a718a51cc50379d0eed71e6aa8e7cd18e)), closes [#11939](https://github.com/bitnami/charts/issues/11939)
 
 ## <small>2.6.12 (2022-08-09)</small>
 
-* [bitnami/rabbitmq-cluster-operator] Release 2.6.12 updating components versions ([0bc84d9](https://github.com/bitnami/charts/commit/0bc84d9))
+* [bitnami/rabbitmq-cluster-operator] Release 2.6.12 updating components versions ([0bc84d9](https://github.com/bitnami/charts/commit/0bc84d98a62c1f1ac2d11cd78912539928ef3e18))
 
 ## <small>2.6.11 (2022-08-04)</small>
 
-* [bitnami/rabbitmq-cluster-operator] Release 2.6.11 updating components versions ([64eccf4](https://github.com/bitnami/charts/commit/64eccf4))
+* [bitnami/rabbitmq-cluster-operator] Release 2.6.11 updating components versions ([64eccf4](https://github.com/bitnami/charts/commit/64eccf41e7e8a6c3f045f6daee1997463da2db32))
 
 ## <small>2.6.10 (2022-07-29)</small>
 
-* [bitnami/*] Update URLs to point to the new bitnami/containers monorepo (#11352) ([d665af0](https://github.com/bitnami/charts/commit/d665af0)), closes [#11352](https://github.com/bitnami/charts/issues/11352)
-* [bitnami/rabbitmq-cluster-operator] Release 2.6.10 updating components versions ([6e5afa3](https://github.com/bitnami/charts/commit/6e5afa3))
+* [bitnami/*] Update URLs to point to the new bitnami/containers monorepo (#11352) ([d665af0](https://github.com/bitnami/charts/commit/d665af0c708846192d8d5fb2f5f9ea65dd464ab0)), closes [#11352](https://github.com/bitnami/charts/issues/11352)
+* [bitnami/rabbitmq-cluster-operator] Release 2.6.10 updating components versions ([6e5afa3](https://github.com/bitnami/charts/commit/6e5afa3937e9dfe08adf297ab7f56762e19372ea))
 
 ## <small>2.6.9 (2022-07-15)</small>
 
-* added commonName to the rabbitmq-operator certificate when using cert-manager (#11133) ([96d5db1](https://github.com/bitnami/charts/commit/96d5db1)), closes [#11133](https://github.com/bitnami/charts/issues/11133)
+* added commonName to the rabbitmq-operator certificate when using cert-manager (#11133) ([96d5db1](https://github.com/bitnami/charts/commit/96d5db1dade4797538c36306cd937ba28961a01c)), closes [#11133](https://github.com/bitnami/charts/issues/11133)
 
 ## <small>2.6.8 (2022-06-29)</small>
 
-* [bitnami/rabbitmq-cluster-operator] Release 2.6.8 updating components versions ([772f855](https://github.com/bitnami/charts/commit/772f855))
+* [bitnami/rabbitmq-cluster-operator] Release 2.6.8 updating components versions ([772f855](https://github.com/bitnami/charts/commit/772f855cfa770670e67297fddf7bf0be03e1a731))
 
 ## <small>2.6.7 (2022-06-15)</small>
 
-* [bitnami/rabbitmq-cluster-operator] Release 2.6.7 updating components versions ([a77db35](https://github.com/bitnami/charts/commit/a77db35))
+* [bitnami/rabbitmq-cluster-operator] Release 2.6.7 updating components versions ([a77db35](https://github.com/bitnami/charts/commit/a77db3566e8cb216e651244b1d0a45f553f29ee3))
 
 ## <small>2.6.6 (2022-06-09)</small>
 
-* [bitnami/*] Replace Kubeapps URL in READMEs (and kubeapps Chart.yaml) and remove BKPR references (#1 ([c6a7914](https://github.com/bitnami/charts/commit/c6a7914)), closes [#10600](https://github.com/bitnami/charts/issues/10600)
-* [bitnami/rabbitmq-cluster-operator] Release 2.6.6 updating components versions ([18740b3](https://github.com/bitnami/charts/commit/18740b3))
+* [bitnami/*] Replace Kubeapps URL in READMEs (and kubeapps Chart.yaml) and remove BKPR references (#1 ([c6a7914](https://github.com/bitnami/charts/commit/c6a7914361e5aea6016fb45bf4d621edfd111d32)), closes [#10600](https://github.com/bitnami/charts/issues/10600)
+* [bitnami/rabbitmq-cluster-operator] Release 2.6.6 updating components versions ([18740b3](https://github.com/bitnami/charts/commit/18740b37fa6e8cfb58891f162f9360635b5d36d5))
 
 ## <small>2.6.5 (2022-06-01)</small>
 
-* [bitnami/several] Replace maintainers email by url (#10523) ([ff3cf61](https://github.com/bitnami/charts/commit/ff3cf61)), closes [#10523](https://github.com/bitnami/charts/issues/10523)
+* [bitnami/several] Replace maintainers email by url (#10523) ([ff3cf61](https://github.com/bitnami/charts/commit/ff3cf617a1680509b0f3855d17c4ccff7b29a0ff)), closes [#10523](https://github.com/bitnami/charts/issues/10523)
 
 ## <small>2.6.4 (2022-05-26)</small>
 
-* [bitnami/rabbitmq-cluster-operator] Release 2.6.4 updating components versions ([cf3305f](https://github.com/bitnami/charts/commit/cf3305f))
+* [bitnami/rabbitmq-cluster-operator] Release 2.6.4 updating components versions ([cf3305f](https://github.com/bitnami/charts/commit/cf3305fb24452e0ee159dfb1851c9cd3648df972))
 
 ## <small>2.6.3 (2022-05-23)</small>
 
-* [bitnami/rabbitmq-cluster-operator] Release 2.6.3 updating components versions ([ec840aa](https://github.com/bitnami/charts/commit/ec840aa))
+* [bitnami/rabbitmq-cluster-operator] Release 2.6.3 updating components versions ([ec840aa](https://github.com/bitnami/charts/commit/ec840aa904d293360639bcfc22b3bc1636cf150f))
 
 ## <small>2.6.2 (2022-05-18)</small>
 
-* [bitnami/rabbitmq-cluster-operator] Release 2.6.2 updating components versions ([5dbe569](https://github.com/bitnami/charts/commit/5dbe569))
+* [bitnami/rabbitmq-cluster-operator] Release 2.6.2 updating components versions ([5dbe569](https://github.com/bitnami/charts/commit/5dbe56904b6aeaebcc3d9b74939d811257286766))
 
 ## <small>2.6.1 (2022-04-29)</small>
 
-* [bitnami/rabbitmq-cluster-operator] Release 2.6.1 updating components versions ([edd38ad](https://github.com/bitnami/charts/commit/edd38ad))
+* [bitnami/rabbitmq-cluster-operator] Release 2.6.1 updating components versions ([edd38ad](https://github.com/bitnami/charts/commit/edd38adcc32cde000a530e3e5d998a86a9b03eed))
 
 ## 2.6.0 (2022-04-21)
 
-* [bitnami/rabbitmq-cluster-operator] Chart standardised (#9819) ([513af35](https://github.com/bitnami/charts/commit/513af35)), closes [#9819](https://github.com/bitnami/charts/issues/9819)
+* [bitnami/rabbitmq-cluster-operator] Chart standardised (#9819) ([513af35](https://github.com/bitnami/charts/commit/513af35f36993d20de7307086ec38b4dbcc8acc7)), closes [#9819](https://github.com/bitnami/charts/issues/9819)
 
 ## <small>2.5.2 (2022-04-07)</small>
 
-* [bitnami/rabbitmq-cluster-operator] Update kubeVersion regex to work with GKE (#9718) ([dd85045](https://github.com/bitnami/charts/commit/dd85045)), closes [#9718](https://github.com/bitnami/charts/issues/9718)
+* [bitnami/rabbitmq-cluster-operator] Update kubeVersion regex to work with GKE (#9718) ([dd85045](https://github.com/bitnami/charts/commit/dd850457c01a1a0e6a24fe6bfd225c7259e3c4b8)), closes [#9718](https://github.com/bitnami/charts/issues/9718)
 
 ## <small>2.5.1 (2022-04-05)</small>
 
-* [bitnami/rabbitmq-cluster-operator] Add kubeVersion to Chart.yaml (#9657) ([3c9d687](https://github.com/bitnami/charts/commit/3c9d687)), closes [#9657](https://github.com/bitnami/charts/issues/9657)
+* [bitnami/rabbitmq-cluster-operator] Add kubeVersion to Chart.yaml (#9657) ([3c9d687](https://github.com/bitnami/charts/commit/3c9d6879c3e0c33d4e46c1460e68c55973f91897)), closes [#9657](https://github.com/bitnami/charts/issues/9657)
 
 ## 2.5.0 (2022-03-24)
 
-* [bitnami/rabbitmq-operator] Sync CRDs (#9547) ([54a5f82](https://github.com/bitnami/charts/commit/54a5f82)), closes [#9547](https://github.com/bitnami/charts/issues/9547)
+* [bitnami/rabbitmq-operator] Sync CRDs (#9547) ([54a5f82](https://github.com/bitnami/charts/commit/54a5f82ad48698d0c8bfc056e32f2cc951c254bf)), closes [#9547](https://github.com/bitnami/charts/issues/9547)
 
 ## 2.4.0 (2022-03-18)
 
-* [bitnami/rabbitmq-cluster-operator] Set readOnlyRootFileSystem by default (#9460) ([693ef41](https://github.com/bitnami/charts/commit/693ef41)), closes [#9460](https://github.com/bitnami/charts/issues/9460)
+* [bitnami/rabbitmq-cluster-operator] Set readOnlyRootFileSystem by default (#9460) ([693ef41](https://github.com/bitnami/charts/commit/693ef41b0f75a7e8c5374405ccbdc7b522914b2e)), closes [#9460](https://github.com/bitnami/charts/issues/9460)
 
 ## <small>2.3.4 (2022-03-09)</small>
 
-* [bitnami/rabbitmq-cluster-operator] Release 2.3.4 updating components versions ([2499e00](https://github.com/bitnami/charts/commit/2499e00))
+* [bitnami/rabbitmq-cluster-operator] Release 2.3.4 updating components versions ([2499e00](https://github.com/bitnami/charts/commit/2499e00e422c86d7799be83a2136306ec5db603e))
 
 ## <small>2.3.3 (2022-03-02)</small>
 
-* [bitnami/rabbitmq-cluster-operator] Release 2.3.3 updating components versions ([0ec51b7](https://github.com/bitnami/charts/commit/0ec51b7))
+* [bitnami/rabbitmq-cluster-operator] Release 2.3.3 updating components versions ([0ec51b7](https://github.com/bitnami/charts/commit/0ec51b7e3d66ba4c91ec72ec686b739799e1d00d))
 
 ## <small>2.3.2 (2022-03-01)</small>
 
-* [bitnami/several] Prettify Chart.yaml ([a056e06](https://github.com/bitnami/charts/commit/a056e06))
+* [bitnami/several] Prettify Chart.yaml ([a056e06](https://github.com/bitnami/charts/commit/a056e061fb6541870ea8d9d0a715315f1ec3bcbc))
 
 ## <small>2.3.1 (2022-02-09)</small>
 
-* [bitnami/rabbitmq-cluster-operator] Release 2.3.1 updating components versions ([de0b5b8](https://github.com/bitnami/charts/commit/de0b5b8))
+* [bitnami/rabbitmq-cluster-operator] Release 2.3.1 updating components versions ([de0b5b8](https://github.com/bitnami/charts/commit/de0b5b89ac6b32a75e52da341b2516d536b64e5b))
 
 ## 2.3.0 (2022-02-09)
 
-* [bitnami/rabbitmq-cluster-operator] feat: :wrench: Update CRDs (#8956) ([86bf708](https://github.com/bitnami/charts/commit/86bf708)), closes [#8956](https://github.com/bitnami/charts/issues/8956)
-* Non utf8 chars (#8923) ([6ffd18f](https://github.com/bitnami/charts/commit/6ffd18f)), closes [#8923](https://github.com/bitnami/charts/issues/8923)
+* [bitnami/rabbitmq-cluster-operator] feat: :wrench: Update CRDs (#8956) ([86bf708](https://github.com/bitnami/charts/commit/86bf708170e803992878b54c4bb026c73bccbf49)), closes [#8956](https://github.com/bitnami/charts/issues/8956)
+* Non utf8 chars (#8923) ([6ffd18f](https://github.com/bitnami/charts/commit/6ffd18fbbdf10e94ea1a90cf5b84ef610ac2a72d)), closes [#8923](https://github.com/bitnami/charts/issues/8923)
 
 ## <small>2.2.4 (2022-02-01)</small>
 
-* [bitnami/several] Prettify Chart.yaml (#8858) ([10e49fd](https://github.com/bitnami/charts/commit/10e49fd)), closes [#8858](https://github.com/bitnami/charts/issues/8858)
+* [bitnami/several] Prettify Chart.yaml (#8858) ([10e49fd](https://github.com/bitnami/charts/commit/10e49fdd6843558762daff0a1f96b9162bb78321)), closes [#8858](https://github.com/bitnami/charts/issues/8858)
 
 ## <small>2.2.3 (2022-01-30)</small>
 
-* [bitnami/rabbitmq-cluster-operator] Release 2.2.3 updating components versions ([9548e24](https://github.com/bitnami/charts/commit/9548e24))
+* [bitnami/rabbitmq-cluster-operator] Release 2.2.3 updating components versions ([9548e24](https://github.com/bitnami/charts/commit/9548e2478970b4f53b4e0dcfaa5b144149f9b187))
 
 ## <small>2.2.2 (2022-01-26)</small>
 
-* [bitnami/rabbitmq-cluster-operator] fix: use consistent labeling and label selectors (#8784) ([3043189](https://github.com/bitnami/charts/commit/3043189)), closes [#8784](https://github.com/bitnami/charts/issues/8784)
+* [bitnami/rabbitmq-cluster-operator] fix: use consistent labeling and label selectors (#8784) ([3043189](https://github.com/bitnami/charts/commit/30431891762eb2193e87486d4ddfb48a0e9ef553)), closes [#8784](https://github.com/bitnami/charts/issues/8784)
 
 ## <small>2.2.1 (2022-01-20)</small>
 
-* [bitnami/*] Readme automation (#8579) ([78d1938](https://github.com/bitnami/charts/commit/78d1938)), closes [#8579](https://github.com/bitnami/charts/issues/8579)
-* [bitnami/*] Update READMEs (#8716) ([b9a9533](https://github.com/bitnami/charts/commit/b9a9533)), closes [#8716](https://github.com/bitnami/charts/issues/8716)
-* [bitnami/several] Change prerequisites (#8725) ([8d740c5](https://github.com/bitnami/charts/commit/8d740c5)), closes [#8725](https://github.com/bitnami/charts/issues/8725)
+* [bitnami/*] Readme automation (#8579) ([78d1938](https://github.com/bitnami/charts/commit/78d193831c900d178198491ffd08fa2217a64ecd)), closes [#8579](https://github.com/bitnami/charts/issues/8579)
+* [bitnami/*] Update READMEs (#8716) ([b9a9533](https://github.com/bitnami/charts/commit/b9a953337590eb2979453385874a267bacf50936)), closes [#8716](https://github.com/bitnami/charts/issues/8716)
+* [bitnami/several] Change prerequisites (#8725) ([8d740c5](https://github.com/bitnami/charts/commit/8d740c566cfdb7e2d933c40128b4e919fce953a5)), closes [#8725](https://github.com/bitnami/charts/issues/8725)
 
 ## 2.2.0 (2022-01-17)
 
-* [bitnami/rabbitmq-cluster-operator] Specify default image pull secrets for the operator (#8658) ([cf6c0a3](https://github.com/bitnami/charts/commit/cf6c0a3)), closes [#8658](https://github.com/bitnami/charts/issues/8658)
+* [bitnami/rabbitmq-cluster-operator] Specify default image pull secrets for the operator (#8658) ([cf6c0a3](https://github.com/bitnami/charts/commit/cf6c0a3b3b601f51b51f040151a02273aa13fa28)), closes [#8658](https://github.com/bitnami/charts/issues/8658)
 
 ## 2.1.0 (2022-01-12)
 
-* [bitnami/rabbitmq-cluster-operator] Add value to fully override rmqco.msgTopologyOperator.fullname t ([0e5d274](https://github.com/bitnami/charts/commit/0e5d274)), closes [#8610](https://github.com/bitnami/charts/issues/8610)
+* [bitnami/rabbitmq-cluster-operator] Add value to fully override rmqco.msgTopologyOperator.fullname t ([0e5d274](https://github.com/bitnami/charts/commit/0e5d27467a51cecf44613920ae1514f6e1923d7e)), closes [#8610](https://github.com/bitnami/charts/issues/8610)
 
 ## <small>2.0.10 (2022-01-11)</small>
 
-* [bitnami/rabbitmq-cluster-operator] fix: remove namespace from non-namespaced cluster resources (#84 ([242483e](https://github.com/bitnami/charts/commit/242483e)), closes [#8414](https://github.com/bitnami/charts/issues/8414)
-* [bitnami/several] Add license to the README ([05f7633](https://github.com/bitnami/charts/commit/05f7633))
-* [bitnami/several] Add license to the README ([32fb238](https://github.com/bitnami/charts/commit/32fb238))
-* [bitnami/several] Add license to the README ([b87c2f7](https://github.com/bitnami/charts/commit/b87c2f7))
+* [bitnami/rabbitmq-cluster-operator] fix: remove namespace from non-namespaced cluster resources (#84 ([242483e](https://github.com/bitnami/charts/commit/242483e8cbe9555b683ff78decb7427e7ec22d19)), closes [#8414](https://github.com/bitnami/charts/issues/8414)
+* [bitnami/several] Add license to the README ([05f7633](https://github.com/bitnami/charts/commit/05f763372501d596e57db713dd53ff4ff3027cc4))
+* [bitnami/several] Add license to the README ([32fb238](https://github.com/bitnami/charts/commit/32fb238e60a0affc6debd3142eaa3c3d9089ec2a))
+* [bitnami/several] Add license to the README ([b87c2f7](https://github.com/bitnami/charts/commit/b87c2f7899d48a8b02c506765e6ae82937e9ba3f))
 
 ## <small>2.0.9 (2021-12-17)</small>
 
-* [bitnami/rabbitmq-cluster-operator] Release 2.0.9 updating components versions ([3838af2](https://github.com/bitnami/charts/commit/3838af2))
+* [bitnami/rabbitmq-cluster-operator] Release 2.0.9 updating components versions ([3838af2](https://github.com/bitnami/charts/commit/3838af21e44dca84a4ee6ecdc0f714348ad7d3fc))
 
 ## <small>2.0.8 (2021-12-16)</small>
 
-* [bitnami/rabbitmq-cluster-operator] Release 2.0.8 updating components versions ([ad2fc12](https://github.com/bitnami/charts/commit/ad2fc12))
+* [bitnami/rabbitmq-cluster-operator] Release 2.0.8 updating components versions ([ad2fc12](https://github.com/bitnami/charts/commit/ad2fc1273cf43b940587257488d6c6a3889c85b2))
 
 ## <small>2.0.7 (2021-12-16)</small>
 
-* [bitnami/rabbitmq-cluster-operator] fix: use the correct component for messaging-topology-operator p ([d8973be](https://github.com/bitnami/charts/commit/d8973be)), closes [#8412](https://github.com/bitnami/charts/issues/8412)
+* [bitnami/rabbitmq-cluster-operator] fix: use the correct component for messaging-topology-operator p ([d8973be](https://github.com/bitnami/charts/commit/d8973beb5aac604ebeb63f36efc9fa2dacf0bc42)), closes [#8412](https://github.com/bitnami/charts/issues/8412)
 
 ## <small>2.0.6 (2021-12-15)</small>
 
-* [bitnami/rabbitmq-cluster-operator] fix: use consistent naming for ServiceMonitor (#8407) ([ea9130e](https://github.com/bitnami/charts/commit/ea9130e)), closes [#8407](https://github.com/bitnami/charts/issues/8407)
+* [bitnami/rabbitmq-cluster-operator] fix: use consistent naming for ServiceMonitor (#8407) ([ea9130e](https://github.com/bitnami/charts/commit/ea9130ec11989db5cec875a9e02f12e1ac04dfdd)), closes [#8407](https://github.com/bitnami/charts/issues/8407)
 
 ## <small>2.0.5 (2021-12-15)</small>
 
-* [bitnami/rabbitmq-cluster-operator] fix: ServiceMonitor port must be the Service port name (#8413) ([1f90dc9](https://github.com/bitnami/charts/commit/1f90dc9)), closes [#8413](https://github.com/bitnami/charts/issues/8413)
+* [bitnami/rabbitmq-cluster-operator] fix: ServiceMonitor port must be the Service port name (#8413) ([1f90dc9](https://github.com/bitnami/charts/commit/1f90dc9154d85bc0e17b5c3e815bc5b23e251b28)), closes [#8413](https://github.com/bitnami/charts/issues/8413)
 
 ## <small>2.0.4 (2021-12-08)</small>
 
-* [bitnami/rabbitmq-cluster-operator] Release 2.0.4 updating components versions ([44833d2](https://github.com/bitnami/charts/commit/44833d2))
+* [bitnami/rabbitmq-cluster-operator] Release 2.0.4 updating components versions ([44833d2](https://github.com/bitnami/charts/commit/44833d2794851199db21ff16c8e730bf64e8d23c))
 
 ## <small>2.0.3 (2021-12-02)</small>
 
-* [bitnami/*] Fix parameters for schema generation (#8297) ([d7d52ac](https://github.com/bitnami/charts/commit/d7d52ac)), closes [#8297](https://github.com/bitnami/charts/issues/8297)
-* [bitnami/rabbitmq-cluster-operator] Fix reference to metrics ports in values.yaml and metrics servic ([fe5fa10](https://github.com/bitnami/charts/commit/fe5fa10)), closes [#8261](https://github.com/bitnami/charts/issues/8261)
+* [bitnami/*] Fix parameters for schema generation (#8297) ([d7d52ac](https://github.com/bitnami/charts/commit/d7d52acdbd1b0629e4e5295652fa6f5830daf2af)), closes [#8297](https://github.com/bitnami/charts/issues/8297)
+* [bitnami/rabbitmq-cluster-operator] Fix reference to metrics ports in values.yaml and metrics servic ([fe5fa10](https://github.com/bitnami/charts/commit/fe5fa10334febb84a5a0fd31550121618dd2a51e)), closes [#8261](https://github.com/bitnami/charts/issues/8261)
 
 ## <small>2.0.2 (2021-11-30)</small>
 
-* [bitnami/rabbitmq-cluster-operator] Make ServiceMonitor names unique (#8264) ([9d67db0](https://github.com/bitnami/charts/commit/9d67db0)), closes [#8264](https://github.com/bitnami/charts/issues/8264)
+* [bitnami/rabbitmq-cluster-operator] Make ServiceMonitor names unique (#8264) ([9d67db0](https://github.com/bitnami/charts/commit/9d67db0f871e866471c49c86ee3a1b8dc244e41f)), closes [#8264](https://github.com/bitnami/charts/issues/8264)
 
 ## <small>2.0.1 (2021-11-29)</small>
 
-* [bitnami/several] Fix deadlinks in README.md (#8215) ([99e90d2](https://github.com/bitnami/charts/commit/99e90d2)), closes [#8215](https://github.com/bitnami/charts/issues/8215)
-* [bitnami/several] Regenerate README tables ([ef52074](https://github.com/bitnami/charts/commit/ef52074))
-* [bitnami/several] Replace HTTP by HTTPS when possible (#8259) ([eafb5bd](https://github.com/bitnami/charts/commit/eafb5bd)), closes [#8259](https://github.com/bitnami/charts/issues/8259)
+* [bitnami/several] Fix deadlinks in README.md (#8215) ([99e90d2](https://github.com/bitnami/charts/commit/99e90d244b3244e059a42f72dcbecd3cda2b66bb)), closes [#8215](https://github.com/bitnami/charts/issues/8215)
+* [bitnami/several] Regenerate README tables ([ef52074](https://github.com/bitnami/charts/commit/ef52074d5f3dd00218322cd201f83ee55f9dd1e6))
+* [bitnami/several] Replace HTTP by HTTPS when possible (#8259) ([eafb5bd](https://github.com/bitnami/charts/commit/eafb5bd5a2cc3aaf04fc1e8ebedd73f420d76864)), closes [#8259](https://github.com/bitnami/charts/issues/8259)
 
 ## 2.0.0 (2021-11-04)
 
-* [bitnami/rabbitmq-cluster-operator] MAJOR: Add rabbitmq-messaging-topology-operator and rabbitmq-def ([a9b3672](https://github.com/bitnami/charts/commit/a9b3672)), closes [#7965](https://github.com/bitnami/charts/issues/7965)
+* [bitnami/rabbitmq-cluster-operator] MAJOR: Add rabbitmq-messaging-topology-operator and rabbitmq-def ([a9b3672](https://github.com/bitnami/charts/commit/a9b367272e8313b7412e4d14927b7838bfedbee5)), closes [#7965](https://github.com/bitnami/charts/issues/7965)
 
 ## <small>1.0.2 (2021-10-25)</small>
 
-* Set namespace for all resources in rabbitmq-cluster-operator chart (#7911) ([8519512](https://github.com/bitnami/charts/commit/8519512)), closes [#7911](https://github.com/bitnami/charts/issues/7911)
+* Set namespace for all resources in rabbitmq-cluster-operator chart (#7911) ([8519512](https://github.com/bitnami/charts/commit/85195124588212ba9f28650cacb7a72db96afea6)), closes [#7911](https://github.com/bitnami/charts/issues/7911)
 
 ## <small>1.0.1 (2021-10-22)</small>
 
-* [bitnami/several] Add chart info to NOTES.txt (#7889) ([a6751cd](https://github.com/bitnami/charts/commit/a6751cd)), closes [#7889](https://github.com/bitnami/charts/issues/7889)
-* [bitnami/several] Regenerate README tables ([d8e471f](https://github.com/bitnami/charts/commit/d8e471f))
+* [bitnami/several] Add chart info to NOTES.txt (#7889) ([a6751cd](https://github.com/bitnami/charts/commit/a6751cdd33c461fabbc459fbea6f219ec64ab6b2)), closes [#7889](https://github.com/bitnami/charts/issues/7889)
+* [bitnami/several] Regenerate README tables ([d8e471f](https://github.com/bitnami/charts/commit/d8e471fea607ff755d06b8c7dffb98008ea34a53))
 
 ## 1.0.0 (2021-10-14)
 
-* [bitnami/rabbitmq-cluster-operator] Adapt CRDS for 1.10.0 version (#7813) ([117e129](https://github.com/bitnami/charts/commit/117e129)), closes [#7813](https://github.com/bitnami/charts/issues/7813)
+* [bitnami/rabbitmq-cluster-operator] Adapt CRDS for 1.10.0 version (#7813) ([117e129](https://github.com/bitnami/charts/commit/117e129a1b61dbb05ffc6a112b81f6eee892a293)), closes [#7813](https://github.com/bitnami/charts/issues/7813)
 
 ## <small>0.1.7 (2021-10-14)</small>
 
-* [bitnami/rabbitmq-cluster-operator] Release 0.1.7 updating components versions ([80f7e9c](https://github.com/bitnami/charts/commit/80f7e9c))
+* [bitnami/rabbitmq-cluster-operator] Release 0.1.7 updating components versions ([80f7e9c](https://github.com/bitnami/charts/commit/80f7e9c522af1f80740056082712e87f03f59685))
 
 ## <small>0.1.6 (2021-10-01)</small>
 
-* [bitnami/rabbitmq-cluster-operator & mongodb-sharded] Fix Chart.yaml format (#7672) ([732b749](https://github.com/bitnami/charts/commit/732b749)), closes [#7672](https://github.com/bitnami/charts/issues/7672)
-* [bitnami/several] Regenerate README tables ([17dd6c4](https://github.com/bitnami/charts/commit/17dd6c4))
+* [bitnami/rabbitmq-cluster-operator & mongodb-sharded] Fix Chart.yaml format (#7672) ([732b749](https://github.com/bitnami/charts/commit/732b74986440835a93a75ef0fc93b105d0418cfe)), closes [#7672](https://github.com/bitnami/charts/issues/7672)
+* [bitnami/several] Regenerate README tables ([17dd6c4](https://github.com/bitnami/charts/commit/17dd6c43f181ba1d44429db86f6b1100f9b4c636))
 
 ## <small>0.1.5 (2021-09-29)</small>
 
-* [bitnami/rabbitmq-cluster-operator] Release 0.1.5 updating components versions ([55bc8d1](https://github.com/bitnami/charts/commit/55bc8d1))
+* [bitnami/rabbitmq-cluster-operator] Release 0.1.5 updating components versions ([55bc8d1](https://github.com/bitnami/charts/commit/55bc8d109aadad0102f70a7760b7d552dd442a2d))
 
 ## <small>0.1.4 (2021-09-22)</small>
 
-* [bitnami/rabbitmq-cluster-operator] Add missing extra-list.yaml (#7574) ([a77684b](https://github.com/bitnami/charts/commit/a77684b)), closes [#7574](https://github.com/bitnami/charts/issues/7574)
-* [bitnami/several] Regenerate README tables ([dcb935c](https://github.com/bitnami/charts/commit/dcb935c))
-* Update README.md ([b766180](https://github.com/bitnami/charts/commit/b766180))
+* [bitnami/rabbitmq-cluster-operator] Add missing extra-list.yaml (#7574) ([a77684b](https://github.com/bitnami/charts/commit/a77684b26fc1b51c2d9b19eada07c2f1cce30043)), closes [#7574](https://github.com/bitnami/charts/issues/7574)
+* [bitnami/several] Regenerate README tables ([dcb935c](https://github.com/bitnami/charts/commit/dcb935c1bf066b6d8988f3b0dbe85d01aa01b215))
+* Update README.md ([b766180](https://github.com/bitnami/charts/commit/b766180b06c36b275c2f228a7da3c93018669ca6))
 
 ## <small>0.1.3 (2021-09-08)</small>
 
-* [bitnami/rabbitmq-cluster-operator] Release 0.1.3 updating components versions ([80a02ad](https://github.com/bitnami/charts/commit/80a02ad))
-* [bitnami/several] Regenerate README tables ([e0a27b4](https://github.com/bitnami/charts/commit/e0a27b4))
+* [bitnami/rabbitmq-cluster-operator] Release 0.1.3 updating components versions ([80a02ad](https://github.com/bitnami/charts/commit/80a02ada45e6250f0c5b9a62c52c6b54ee9d1261))
+* [bitnami/several] Regenerate README tables ([e0a27b4](https://github.com/bitnami/charts/commit/e0a27b4c05c509da51859373dad032294438af74))
 
 ## <small>0.1.2 (2021-09-03)</small>
 
-* [bitnami/rabbitmq-cluster-operator] Release 0.1.2 updating components versions ([c3e887d](https://github.com/bitnami/charts/commit/c3e887d))
+* [bitnami/rabbitmq-cluster-operator] Release 0.1.2 updating components versions ([c3e887d](https://github.com/bitnami/charts/commit/c3e887d475de6b4cd2ac8d3e699f9466ead95d49))
 
 ## <small>0.1.1 (2021-08-24)</small>
 
-* [bitnami/rabbitmq-cluster-operator] Fix metadata (#7303) ([e6614b8](https://github.com/bitnami/charts/commit/e6614b8)), closes [#7303](https://github.com/bitnami/charts/issues/7303)
-* [bitnami/several] Regenerate README tables ([04e7724](https://github.com/bitnami/charts/commit/04e7724))
+* [bitnami/rabbitmq-cluster-operator] Fix metadata (#7303) ([e6614b8](https://github.com/bitnami/charts/commit/e6614b8e6e3225fdbba72c050500a278d01e8045)), closes [#7303](https://github.com/bitnami/charts/issues/7303)
+* [bitnami/several] Regenerate README tables ([04e7724](https://github.com/bitnami/charts/commit/04e77240da01c2daa3d9d8aca0cf94ddc3aaa6f0))
 
 ## 0.1.0 (2021-08-24)
 
-* [bitnami/rabbitmq-cluster-operator] Add chart (#7274) ([a5dbd74](https://github.com/bitnami/charts/commit/a5dbd74)), closes [#7274](https://github.com/bitnami/charts/issues/7274)
+* [bitnami/rabbitmq-cluster-operator] Add chart (#7274) ([a5dbd74](https://github.com/bitnami/charts/commit/a5dbd740792d121ab6167d21eeeebcf90047b644)), closes [#7274](https://github.com/bitnami/charts/issues/7274)

--- a/bitnami/rabbitmq-cluster-operator/Chart.yaml
+++ b/bitnami/rabbitmq-cluster-operator/Chart.yaml
@@ -37,4 +37,4 @@ maintainers:
 name: rabbitmq-cluster-operator
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/rabbitmq-cluster-operator
-version: 4.3.0
+version: 4.3.1

--- a/bitnami/rabbitmq-cluster-operator/templates/cluster-operator/deployment.yaml
+++ b/bitnami/rabbitmq-cluster-operator/templates/cluster-operator/deployment.yaml
@@ -131,8 +131,7 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.clusterOperator.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.clusterOperator.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.clusterOperator.livenessProbe "enabled") "context" $) | nindent 12 }}
-            httpGet:
-              path: /metrics
+            tcpSocket:
               port: http
           {{- end }}
           {{- if .Values.clusterOperator.customReadinessProbe }}

--- a/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/deployment.yaml
+++ b/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/deployment.yaml
@@ -139,8 +139,7 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.msgTopologyOperator.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.msgTopologyOperator.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.msgTopologyOperator.livenessProbe "enabled") "context" $) | nindent 12 }}
-            httpGet:
-              path: /metrics
+            tcpSocket:
               port: http-metrics
           {{- end }}
           {{- if .Values.msgTopologyOperator.customReadinessProbe }}


### PR DESCRIPTION
### Description of the change
This PR aims to use different liveness/readiness probes to improve overall security and avoid unnecessary container restarts. [More info](https://github.com/zegl/kube-score/blob/master/README_PROBES.md).

### Benefits

Increase availability and resilience.

### Possible drawbacks

N/A

### Applicable issues

- fixes #

### Additional information

- Related to #23537

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- ~[X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)~
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
