### PR TITLE
[bitnami/tensorflow-resnet] Use different liveness/readiness probes

### DIFF
--- a/bitnami/tensorflow-resnet/CHANGELOG.md
+++ b/bitnami/tensorflow-resnet/CHANGELOG.md
@@ -1,817 +1,822 @@
 # Changelog
 
+## 4.1.1 (2024-05-22)
+
+* [bitnami/tensorflow-resnet] Use different liveness/readiness probes ([#26347](https://github.com/bitnami/charts/pull/26347))
+
 ## 4.1.0 (2024-05-21)
 
-* [bitnami/tensorflow-resnet] feat: :sparkles: :lock: Add warning when original images are replaced ([#26282](https://github.com/bitnami/charts/pulls/26282))
+* [bitnami/*] ci: :construction_worker: Add tag and changelog support (#25359) ([91c707c](https://github.com/bitnami/charts/commit/91c707c9e4e574725a09505d2d313fb93f1b4c0a)), closes [#25359](https://github.com/bitnami/charts/issues/25359)
+* [bitnami/tensorflow-resnet] feat: :sparkles: :lock: Add warning when original images are replaced (# ([8414670](https://github.com/bitnami/charts/commit/841467028ced000a7399a8e9191d8ee58db0f678)), closes [#26282](https://github.com/bitnami/charts/issues/26282)
 
 ## <small>4.0.5 (2024-05-18)</small>
 
-* [bitnami/tensorflow-resnet] Release 4.0.5 updating components versions (#26081) ([3132729](https://github.com/bitnami/charts/commit/3132729)), closes [#26081](https://github.com/bitnami/charts/issues/26081)
+* [bitnami/tensorflow-resnet] Release 4.0.5 updating components versions (#26081) ([3132729](https://github.com/bitnami/charts/commit/3132729f26995dedba5e438bb13db1f3729a1e5e)), closes [#26081](https://github.com/bitnami/charts/issues/26081)
 
 ## <small>4.0.4 (2024-05-14)</small>
 
-* [bitnami/*] Change non-root and rolling-tags doc URLs (#25628) ([b067c94](https://github.com/bitnami/charts/commit/b067c94)), closes [#25628](https://github.com/bitnami/charts/issues/25628)
-* [bitnami/*] Set new header/owner (#25558) ([8d1dc11](https://github.com/bitnami/charts/commit/8d1dc11)), closes [#25558](https://github.com/bitnami/charts/issues/25558)
-* [bitnami/multiple charts] Fix typo: "NetworkPolice" vs "NetworkPolicy" (#25348) ([6970c1b](https://github.com/bitnami/charts/commit/6970c1b)), closes [#25348](https://github.com/bitnami/charts/issues/25348)
-* [bitnami/tensorflow-resnet] Release 4.0.4 updating components versions (#25826) ([934d790](https://github.com/bitnami/charts/commit/934d790)), closes [#25826](https://github.com/bitnami/charts/issues/25826)
-* Replace VMware by Broadcom copyright text (#25306) ([a5e4bd0](https://github.com/bitnami/charts/commit/a5e4bd0)), closes [#25306](https://github.com/bitnami/charts/issues/25306)
+* [bitnami/*] Change non-root and rolling-tags doc URLs (#25628) ([b067c94](https://github.com/bitnami/charts/commit/b067c94f6bcde427863c197fd355f0b5ba12ff5b)), closes [#25628](https://github.com/bitnami/charts/issues/25628)
+* [bitnami/*] Set new header/owner (#25558) ([8d1dc11](https://github.com/bitnami/charts/commit/8d1dc11f5fb30db6fba50c43d7af59d2f79deed3)), closes [#25558](https://github.com/bitnami/charts/issues/25558)
+* [bitnami/multiple charts] Fix typo: "NetworkPolice" vs "NetworkPolicy" (#25348) ([6970c1b](https://github.com/bitnami/charts/commit/6970c1ba245873506e73d459c6eac1e4919b778f)), closes [#25348](https://github.com/bitnami/charts/issues/25348)
+* [bitnami/tensorflow-resnet] Release 4.0.4 updating components versions (#25826) ([934d790](https://github.com/bitnami/charts/commit/934d79012a629e7fad3a9d1a0e1ebf3beba15925)), closes [#25826](https://github.com/bitnami/charts/issues/25826)
+* Replace VMware by Broadcom copyright text (#25306) ([a5e4bd0](https://github.com/bitnami/charts/commit/a5e4bd0e35e419203793976a78d9d0a13de92c76)), closes [#25306](https://github.com/bitnami/charts/issues/25306)
 
 ## <small>4.0.3 (2024-04-13)</small>
 
-* [bitnami/tensorflow-resnet] Release 4.0.3 updating components versions (#25162) ([94ce52a](https://github.com/bitnami/charts/commit/94ce52a)), closes [#25162](https://github.com/bitnami/charts/issues/25162)
+* [bitnami/tensorflow-resnet] Release 4.0.3 updating components versions (#25162) ([94ce52a](https://github.com/bitnami/charts/commit/94ce52ab08a89a7881e8d443f153e284a3f65229)), closes [#25162](https://github.com/bitnami/charts/issues/25162)
 
 ## <small>4.0.2 (2024-04-11)</small>
 
-* [bitnami/tensorflow-resnet] Release 4.0.2 (#25146) ([6d7323c](https://github.com/bitnami/charts/commit/6d7323c)), closes [#25146](https://github.com/bitnami/charts/issues/25146)
-* Update resourcesPreset comments (#24467) ([92e3e8a](https://github.com/bitnami/charts/commit/92e3e8a)), closes [#24467](https://github.com/bitnami/charts/issues/24467)
+* [bitnami/tensorflow-resnet] Release 4.0.2 (#25146) ([6d7323c](https://github.com/bitnami/charts/commit/6d7323ca5cf08762d7ff5e35869f58ff82d16cb3)), closes [#25146](https://github.com/bitnami/charts/issues/25146)
+* Update resourcesPreset comments (#24467) ([92e3e8a](https://github.com/bitnami/charts/commit/92e3e8a507326d2a20a8f10ab3e7746a2ec5c554)), closes [#24467](https://github.com/bitnami/charts/issues/24467)
 
 ## <small>4.0.1 (2024-04-02)</small>
 
-* [bitnami/*] Reorder Chart sections (#24455) ([0cf4048](https://github.com/bitnami/charts/commit/0cf4048)), closes [#24455](https://github.com/bitnami/charts/issues/24455)
-* [bitnami/tensorflow-resnet] Release 4.0.1 updating components versions (#24808) ([064335b](https://github.com/bitnami/charts/commit/064335b)), closes [#24808](https://github.com/bitnami/charts/issues/24808)
+* [bitnami/*] Reorder Chart sections (#24455) ([0cf4048](https://github.com/bitnami/charts/commit/0cf4048e8743f70a9753d460655bd030cbff6824)), closes [#24455](https://github.com/bitnami/charts/issues/24455)
+* [bitnami/tensorflow-resnet] Release 4.0.1 updating components versions (#24808) ([064335b](https://github.com/bitnami/charts/commit/064335b230b01181cfc0970714ea74a780db2985)), closes [#24808](https://github.com/bitnami/charts/issues/24808)
 
 ## 4.0.0 (2024-03-15)
 
-* [bitnami/tensorflow-resnet] feat: :sparkles: :lock: Add automatic adaptation for Openshift restricte ([13a2823](https://github.com/bitnami/charts/commit/13a2823)), closes [#24160](https://github.com/bitnami/charts/issues/24160)
-* [bitnami/tensorflow-resnet] feat!: 🔒 💥 Improve security defaults (#24277) ([bba8fd9](https://github.com/bitnami/charts/commit/bba8fd9)), closes [#24277](https://github.com/bitnami/charts/issues/24277)
+* [bitnami/tensorflow-resnet] feat: :sparkles: :lock: Add automatic adaptation for Openshift restricte ([13a2823](https://github.com/bitnami/charts/commit/13a2823a986ca71905141d3e9ebbcf6d407e5e2e)), closes [#24160](https://github.com/bitnami/charts/issues/24160)
+* [bitnami/tensorflow-resnet] feat!: 🔒 💥 Improve security defaults (#24277) ([bba8fd9](https://github.com/bitnami/charts/commit/bba8fd94e7c858de8bb74c85851c6eca20925bba)), closes [#24277](https://github.com/bitnami/charts/issues/24277)
 
 ## 3.17.0 (2024-03-06)
 
-* [bitnami/tensorflow-resnet] feat: :sparkles: :lock: Add readOnlyRootFilesystem support (#23843) ([3abf973](https://github.com/bitnami/charts/commit/3abf973)), closes [#23843](https://github.com/bitnami/charts/issues/23843)
+* [bitnami/tensorflow-resnet] feat: :sparkles: :lock: Add readOnlyRootFilesystem support (#23843) ([3abf973](https://github.com/bitnami/charts/commit/3abf97369cb48e2ec2023c7cc2e8973b34ab4171)), closes [#23843](https://github.com/bitnami/charts/issues/23843)
 
 ## <small>3.16.2 (2024-02-22)</small>
 
-* [bitnami/tensorflow-resnet] Release 3.16.2 updating components versions (#23832) ([68c7ad0](https://github.com/bitnami/charts/commit/68c7ad0)), closes [#23832](https://github.com/bitnami/charts/issues/23832)
+* [bitnami/tensorflow-resnet] Release 3.16.2 updating components versions (#23832) ([68c7ad0](https://github.com/bitnami/charts/commit/68c7ad06bb367dc674de1fa49d32843965c8fbce)), closes [#23832](https://github.com/bitnami/charts/issues/23832)
 
 ## <small>3.16.1 (2024-02-21)</small>
 
-* [bitnami/tensorflow-resnet] Release 3.16.1 updating components versions (#23698) ([146e37b](https://github.com/bitnami/charts/commit/146e37b)), closes [#23698](https://github.com/bitnami/charts/issues/23698)
+* [bitnami/tensorflow-resnet] Release 3.16.1 updating components versions (#23698) ([146e37b](https://github.com/bitnami/charts/commit/146e37b27e2572239ce7e4295e7bf7c1897e075e)), closes [#23698](https://github.com/bitnami/charts/issues/23698)
 
 ## 3.16.0 (2024-02-20)
 
-* [bitnami/*] Bump all versions (#23602) ([b70ee2a](https://github.com/bitnami/charts/commit/b70ee2a)), closes [#23602](https://github.com/bitnami/charts/issues/23602)
+* [bitnami/*] Bump all versions (#23602) ([b70ee2a](https://github.com/bitnami/charts/commit/b70ee2a30e4dc256bf0ac52928fb2fa7a70f049b)), closes [#23602](https://github.com/bitnami/charts/issues/23602)
 
 ## 3.15.0 (2024-02-15)
 
-* [bitnami/tensorflow-resnet] feat: :sparkles: :lock: Add resource preset support (#23526) ([581011c](https://github.com/bitnami/charts/commit/581011c)), closes [#23526](https://github.com/bitnami/charts/issues/23526)
+* [bitnami/tensorflow-resnet] feat: :sparkles: :lock: Add resource preset support (#23526) ([581011c](https://github.com/bitnami/charts/commit/581011c53528e7361cb9abc5446b16e115241331)), closes [#23526](https://github.com/bitnami/charts/issues/23526)
 
 ## <small>3.14.1 (2024-02-03)</small>
 
-* [bitnami/tensorflow-resnet] Release 3.14.1 updating components versions (#23144) ([02ccfe3](https://github.com/bitnami/charts/commit/02ccfe3)), closes [#23144](https://github.com/bitnami/charts/issues/23144)
+* [bitnami/tensorflow-resnet] Release 3.14.1 updating components versions (#23144) ([02ccfe3](https://github.com/bitnami/charts/commit/02ccfe3598b0caed9342884be7bb618b0d35e8d5)), closes [#23144](https://github.com/bitnami/charts/issues/23144)
 
 ## 3.14.0 (2024-02-01)
 
-* [bitnami/tensorflow-resnet] feat: :sparkles: Add allowExternalEgress (#22967) ([f40111a](https://github.com/bitnami/charts/commit/f40111a)), closes [#22967](https://github.com/bitnami/charts/issues/22967)
+* [bitnami/tensorflow-resnet] feat: :sparkles: Add allowExternalEgress (#22967) ([f40111a](https://github.com/bitnami/charts/commit/f40111a812d50237db3b46674fcfeb165c3e9880)), closes [#22967](https://github.com/bitnami/charts/issues/22967)
 
 ## 3.13.0 (2024-01-30)
 
-* [bitnami/*] Move documentation sections from docs.bitnami.com back to the README (#22203) ([7564f36](https://github.com/bitnami/charts/commit/7564f36)), closes [#22203](https://github.com/bitnami/charts/issues/22203)
-* [bitnami/tensorflow-resnet] feat: :lock: Enable networkPolicy (#22692) ([e20ea75](https://github.com/bitnami/charts/commit/e20ea75)), closes [#22692](https://github.com/bitnami/charts/issues/22692)
+* [bitnami/*] Move documentation sections from docs.bitnami.com back to the README (#22203) ([7564f36](https://github.com/bitnami/charts/commit/7564f36ca1e95ff30ee686652b7ab8690561a707)), closes [#22203](https://github.com/bitnami/charts/issues/22203)
+* [bitnami/tensorflow-resnet] feat: :lock: Enable networkPolicy (#22692) ([e20ea75](https://github.com/bitnami/charts/commit/e20ea75ec03138ee294a0eb4c844efad6b9952e3)), closes [#22692](https://github.com/bitnami/charts/issues/22692)
 
 ## <small>3.12.1 (2024-01-24)</small>
 
-* [bitnami/tensorflow-resnet] fix: :bug: Set seLinuxOptions to null for Openshift compatibility (#2266 ([c74750c](https://github.com/bitnami/charts/commit/c74750c)), closes [#22663](https://github.com/bitnami/charts/issues/22663)
+* [bitnami/tensorflow-resnet] fix: :bug: Set seLinuxOptions to null for Openshift compatibility (#2266 ([c74750c](https://github.com/bitnami/charts/commit/c74750c58184de8c2810f1f8ad5cf3dcbae8c1ca)), closes [#22663](https://github.com/bitnami/charts/issues/22663)
 
 ## 3.12.0 (2024-01-22)
 
-* [bitnami/tensorflow-resnet] fix: :lock: Move service-account token auto-mount to pod declaration (#2 ([02b736f](https://github.com/bitnami/charts/commit/02b736f)), closes [#22500](https://github.com/bitnami/charts/issues/22500)
+* [bitnami/tensorflow-resnet] fix: :lock: Move service-account token auto-mount to pod declaration (#2 ([02b736f](https://github.com/bitnami/charts/commit/02b736f28a2f4d5903313fb88d12aa668cd38f7f)), closes [#22500](https://github.com/bitnami/charts/issues/22500)
 
 ## <small>3.11.1 (2024-01-17)</small>
 
-* [bitnami/tensorflow-resnet] Release 3.11.1 updating components versions (#22330) ([4c35162](https://github.com/bitnami/charts/commit/4c35162)), closes [#22330](https://github.com/bitnami/charts/issues/22330)
+* [bitnami/tensorflow-resnet] Release 3.11.1 updating components versions (#22330) ([4c35162](https://github.com/bitnami/charts/commit/4c35162f2390c91c8a029fe2e2308bb55b195519)), closes [#22330](https://github.com/bitnami/charts/issues/22330)
 
 ## 3.11.0 (2024-01-17)
 
-* [bitnami/*] Fix docs.bitnami.com broken links (#21901) ([f35506d](https://github.com/bitnami/charts/commit/f35506d)), closes [#21901](https://github.com/bitnami/charts/issues/21901)
-* [bitnami/*] Fix ref links (in comments) (#21822) ([e4fa296](https://github.com/bitnami/charts/commit/e4fa296)), closes [#21822](https://github.com/bitnami/charts/issues/21822)
-* [bitnami/tensorflow-resnet] fix: :lock: Improve podSecurityContext and containerSecurityContext with ([8d83e19](https://github.com/bitnami/charts/commit/8d83e19)), closes [#22194](https://github.com/bitnami/charts/issues/22194)
+* [bitnami/*] Fix docs.bitnami.com broken links (#21901) ([f35506d](https://github.com/bitnami/charts/commit/f35506d2dadee4f097986e7792df1f53ab215b5d)), closes [#21901](https://github.com/bitnami/charts/issues/21901)
+* [bitnami/*] Fix ref links (in comments) (#21822) ([e4fa296](https://github.com/bitnami/charts/commit/e4fa296106b225cf8c82445727c675c7c725e380)), closes [#21822](https://github.com/bitnami/charts/issues/21822)
+* [bitnami/tensorflow-resnet] fix: :lock: Improve podSecurityContext and containerSecurityContext with ([8d83e19](https://github.com/bitnami/charts/commit/8d83e19a892c294646748c913b8d699f778eeae6)), closes [#22194](https://github.com/bitnami/charts/issues/22194)
 
 ## <small>3.10.9 (2024-01-02)</small>
 
-* [bitnami/*] Update copyright: Year and company (#21815) ([6c4bf75](https://github.com/bitnami/charts/commit/6c4bf75)), closes [#21815](https://github.com/bitnami/charts/issues/21815)
-* [bitnami/tensorflow-resnet] Add security context to 'seed' container (#21816) ([d4fcadb](https://github.com/bitnami/charts/commit/d4fcadb)), closes [#21816](https://github.com/bitnami/charts/issues/21816)
+* [bitnami/*] Update copyright: Year and company (#21815) ([6c4bf75](https://github.com/bitnami/charts/commit/6c4bf75dec58fc7c9aee9f089777b1a858c17d5b)), closes [#21815](https://github.com/bitnami/charts/issues/21815)
+* [bitnami/tensorflow-resnet] Add security context to 'seed' container (#21816) ([d4fcadb](https://github.com/bitnami/charts/commit/d4fcadb5cbe64d26ced5205938fb9ed473cb59c3)), closes [#21816](https://github.com/bitnami/charts/issues/21816)
 
 ## <small>3.10.8 (2023-12-26)</small>
 
-* [bitnami/tensorflow-resnet] Release 3.10.8 updating components versions (#21760) ([21d7d1a](https://github.com/bitnami/charts/commit/21d7d1a)), closes [#21760](https://github.com/bitnami/charts/issues/21760)
+* [bitnami/tensorflow-resnet] Release 3.10.8 updating components versions (#21760) ([21d7d1a](https://github.com/bitnami/charts/commit/21d7d1aa49e65397296c0d1a1e974a26bcaa570f)), closes [#21760](https://github.com/bitnami/charts/issues/21760)
 
 ## <small>3.10.7 (2023-12-26)</small>
 
-* [bitnami/tensorflow-resnet] Release 3.10.7 updating components versions (#21759) ([41ef447](https://github.com/bitnami/charts/commit/41ef447)), closes [#21759](https://github.com/bitnami/charts/issues/21759)
+* [bitnami/tensorflow-resnet] Release 3.10.7 updating components versions (#21759) ([41ef447](https://github.com/bitnami/charts/commit/41ef447af706aa92d011112e954277c0c8099a77)), closes [#21759](https://github.com/bitnami/charts/issues/21759)
 
 ## <small>3.10.6 (2023-12-26)</small>
 
-* [bitnami/tensorflow-resnet] Release 3.10.6 updating components versions (#21756) ([0691571](https://github.com/bitnami/charts/commit/0691571)), closes [#21756](https://github.com/bitnami/charts/issues/21756)
+* [bitnami/tensorflow-resnet] Release 3.10.6 updating components versions (#21756) ([0691571](https://github.com/bitnami/charts/commit/06915712757866a648225b8762dca4cc769a1c29)), closes [#21756](https://github.com/bitnami/charts/issues/21756)
 
 ## <small>3.10.5 (2023-11-22)</small>
 
-* [bitnami/tensorflow-resnet] Release 3.10.5 updating components versions (#21193) ([e7850b6](https://github.com/bitnami/charts/commit/e7850b6)), closes [#21193](https://github.com/bitnami/charts/issues/21193)
+* [bitnami/tensorflow-resnet] Release 3.10.5 updating components versions (#21193) ([e7850b6](https://github.com/bitnami/charts/commit/e7850b6779fbe0500bb7d23e13695e88c232fa9b)), closes [#21193](https://github.com/bitnami/charts/issues/21193)
 
 ## <small>3.10.4 (2023-11-21)</small>
 
-* [bitnami/*] Remove relative links to non-README sections, add verification for that and update TL;DR ([1103633](https://github.com/bitnami/charts/commit/1103633)), closes [#20967](https://github.com/bitnami/charts/issues/20967)
-* [bitnami/*] Rename solutions to "Bitnami package for ..." (#21038) ([b82f979](https://github.com/bitnami/charts/commit/b82f979)), closes [#21038](https://github.com/bitnami/charts/issues/21038)
-* [bitnami/tensorflow-resnet] Release 3.10.4 updating components versions (#21179) ([4d4ae15](https://github.com/bitnami/charts/commit/4d4ae15)), closes [#21179](https://github.com/bitnami/charts/issues/21179)
+* [bitnami/*] Remove relative links to non-README sections, add verification for that and update TL;DR ([1103633](https://github.com/bitnami/charts/commit/11036334d82df0490aa4abdb591543cab6cf7d7f)), closes [#20967](https://github.com/bitnami/charts/issues/20967)
+* [bitnami/*] Rename solutions to "Bitnami package for ..." (#21038) ([b82f979](https://github.com/bitnami/charts/commit/b82f979e4fb63423fe6e2192c946d09d79c944fc)), closes [#21038](https://github.com/bitnami/charts/issues/21038)
+* [bitnami/tensorflow-resnet] Release 3.10.4 updating components versions (#21179) ([4d4ae15](https://github.com/bitnami/charts/commit/4d4ae1559d2c0168c7a3feaf9e1e1fb8c2eb411a)), closes [#21179](https://github.com/bitnami/charts/issues/21179)
 
 ## <small>3.10.3 (2023-11-16)</small>
 
-* [bitnami/tensorflow-resnet] Release 3.10.3 updating components versions (#20990) ([39c6dcd](https://github.com/bitnami/charts/commit/39c6dcd)), closes [#20990](https://github.com/bitnami/charts/issues/20990)
+* [bitnami/tensorflow-resnet] Release 3.10.3 updating components versions (#20990) ([39c6dcd](https://github.com/bitnami/charts/commit/39c6dcd761cb9d7a02d4193ea6849b7d132eb6a7)), closes [#20990](https://github.com/bitnami/charts/issues/20990)
 
 ## <small>3.10.2 (2023-11-08)</small>
 
-* [bitnami/tensorflow-resnet] Release 3.10.2 updating components versions (#20714) ([5b5689d](https://github.com/bitnami/charts/commit/5b5689d)), closes [#20714](https://github.com/bitnami/charts/issues/20714)
+* [bitnami/tensorflow-resnet] Release 3.10.2 updating components versions (#20714) ([5b5689d](https://github.com/bitnami/charts/commit/5b5689de16f89337055a1c4b6fe5c2172cace9ba)), closes [#20714](https://github.com/bitnami/charts/issues/20714)
 
 ## <small>3.10.1 (2023-11-06)</small>
 
-* [bitnami/tensorflow-resnet] Release 3.10.1 updating components versions (#20645) ([a0c8648](https://github.com/bitnami/charts/commit/a0c8648)), closes [#20645](https://github.com/bitnami/charts/issues/20645)
+* [bitnami/tensorflow-resnet] Release 3.10.1 updating components versions (#20645) ([a0c8648](https://github.com/bitnami/charts/commit/a0c864858860f6874c3d5549f7473027db084afc)), closes [#20645](https://github.com/bitnami/charts/issues/20645)
 
 ## 3.10.0 (2023-11-06)
 
-* [bitnami/tensorflow-resnet] feat: :sparkles: Add support for PSA restricted policy (#20552) ([b3c01f0](https://github.com/bitnami/charts/commit/b3c01f0)), closes [#20552](https://github.com/bitnami/charts/issues/20552)
+* [bitnami/tensorflow-resnet] feat: :sparkles: Add support for PSA restricted policy (#20552) ([b3c01f0](https://github.com/bitnami/charts/commit/b3c01f04130ff28e35bc989549cad3ccfa93fdb6)), closes [#20552](https://github.com/bitnami/charts/issues/20552)
 
 ## <small>3.9.9 (2023-10-26)</small>
 
-* [bitnami/tensorflow-resnet] Release 3.9.9 updating components versions (#20473) ([6eb4add](https://github.com/bitnami/charts/commit/6eb4add)), closes [#20473](https://github.com/bitnami/charts/issues/20473)
+* [bitnami/tensorflow-resnet] Release 3.9.9 updating components versions (#20473) ([6eb4add](https://github.com/bitnami/charts/commit/6eb4adde49030f2547b54a50b9feccfc334ceabf)), closes [#20473](https://github.com/bitnami/charts/issues/20473)
 
 ## <small>3.9.8 (2023-10-26)</small>
 
-* [bitnami/tensorflow-resnet] Release 3.9.8 updating components versions (#20471) ([3611ffc](https://github.com/bitnami/charts/commit/3611ffc)), closes [#20471](https://github.com/bitnami/charts/issues/20471)
+* [bitnami/tensorflow-resnet] Release 3.9.8 updating components versions (#20471) ([3611ffc](https://github.com/bitnami/charts/commit/3611ffca3fcbef3b5bdbd7c24575c07534de8a36)), closes [#20471](https://github.com/bitnami/charts/issues/20471)
 
 ## <small>3.9.7 (2023-10-26)</small>
 
-* [bitnami/tensorflow-resnet] Release 3.9.7 updating components versions (#20462) ([8e0866d](https://github.com/bitnami/charts/commit/8e0866d)), closes [#20462](https://github.com/bitnami/charts/issues/20462)
+* [bitnami/tensorflow-resnet] Release 3.9.7 updating components versions (#20462) ([8e0866d](https://github.com/bitnami/charts/commit/8e0866d3034763ec73d05e5226553d0c58ec23fe)), closes [#20462](https://github.com/bitnami/charts/issues/20462)
 
 ## <small>3.9.6 (2023-10-26)</small>
 
-* [bitnami/*] Rename VMware Application Catalog (#20361) ([3acc734](https://github.com/bitnami/charts/commit/3acc734)), closes [#20361](https://github.com/bitnami/charts/issues/20361)
-* [bitnami/*] Skip image's tag in the README files of the Bitnami Charts (#19841) ([bb9a01b](https://github.com/bitnami/charts/commit/bb9a01b)), closes [#19841](https://github.com/bitnami/charts/issues/19841)
-* [bitnami/*] Standardize documentation (#19835) ([af5f753](https://github.com/bitnami/charts/commit/af5f753)), closes [#19835](https://github.com/bitnami/charts/issues/19835)
-* [bitnami/tensorflow-resnet] Release 3.9.6 updating components versions (#20455) ([20f2be7](https://github.com/bitnami/charts/commit/20f2be7)), closes [#20455](https://github.com/bitnami/charts/issues/20455)
+* [bitnami/*] Rename VMware Application Catalog (#20361) ([3acc734](https://github.com/bitnami/charts/commit/3acc73472beb6fb56c4d99f929061001205bc57e)), closes [#20361](https://github.com/bitnami/charts/issues/20361)
+* [bitnami/*] Skip image's tag in the README files of the Bitnami Charts (#19841) ([bb9a01b](https://github.com/bitnami/charts/commit/bb9a01b65911c87e48318db922cc05eb42785e42)), closes [#19841](https://github.com/bitnami/charts/issues/19841)
+* [bitnami/*] Standardize documentation (#19835) ([af5f753](https://github.com/bitnami/charts/commit/af5f7530c1bc8c5ded53a6c4f7b8f384ac1804f2)), closes [#19835](https://github.com/bitnami/charts/issues/19835)
+* [bitnami/tensorflow-resnet] Release 3.9.6 updating components versions (#20455) ([20f2be7](https://github.com/bitnami/charts/commit/20f2be7e5cb7df1f0e761d977153eb662970b8e2)), closes [#20455](https://github.com/bitnami/charts/issues/20455)
 
 ## <small>3.9.5 (2023-10-12)</small>
 
-* [bitnami/*] Update Helm charts prerequisites (#19745) ([eb755dd](https://github.com/bitnami/charts/commit/eb755dd)), closes [#19745](https://github.com/bitnami/charts/issues/19745)
-* [bitnami/tensorflow-resnet] Release 3.9.5 (#20199) ([af88aa1](https://github.com/bitnami/charts/commit/af88aa1)), closes [#20199](https://github.com/bitnami/charts/issues/20199)
+* [bitnami/*] Update Helm charts prerequisites (#19745) ([eb755dd](https://github.com/bitnami/charts/commit/eb755dd36a4dd3cf6635be8e0598f9a7f4c4a554)), closes [#19745](https://github.com/bitnami/charts/issues/19745)
+* [bitnami/tensorflow-resnet] Release 3.9.5 (#20199) ([af88aa1](https://github.com/bitnami/charts/commit/af88aa16511239d81bfb272ecef87f97d274eb6e)), closes [#20199](https://github.com/bitnami/charts/issues/20199)
 
 ## <small>3.9.4 (2023-09-30)</small>
 
-* [bitnami/tensorflow-resnet] Release 3.9.4 (#19662) ([c67762b](https://github.com/bitnami/charts/commit/c67762b)), closes [#19662](https://github.com/bitnami/charts/issues/19662)
+* [bitnami/tensorflow-resnet] Release 3.9.4 (#19662) ([c67762b](https://github.com/bitnami/charts/commit/c67762bb6bcc7e95ac209df73abfc624a65ee838)), closes [#19662](https://github.com/bitnami/charts/issues/19662)
 
 ## <small>3.9.3 (2023-09-21)</small>
 
-* [bitnami/tensorflow-resnet] Release 3.9.3 (#19454) ([8fc31e2](https://github.com/bitnami/charts/commit/8fc31e2)), closes [#19454](https://github.com/bitnami/charts/issues/19454)
+* [bitnami/tensorflow-resnet] Release 3.9.3 (#19454) ([8fc31e2](https://github.com/bitnami/charts/commit/8fc31e2d60e13e921e87b529e8a0d69f3fbcc87f)), closes [#19454](https://github.com/bitnami/charts/issues/19454)
 
 ## <small>3.9.2 (2023-09-20)</small>
 
-* [bitnami/tensorflow-resnet] Release 3.9.2 (#19414) ([93e0a55](https://github.com/bitnami/charts/commit/93e0a55)), closes [#19414](https://github.com/bitnami/charts/issues/19414)
-* Autogenerate schema files (#19194) ([a2c2090](https://github.com/bitnami/charts/commit/a2c2090)), closes [#19194](https://github.com/bitnami/charts/issues/19194)
-* Revert "Autogenerate schema files (#19194)" (#19335) ([73d80be](https://github.com/bitnami/charts/commit/73d80be)), closes [#19194](https://github.com/bitnami/charts/issues/19194) [#19335](https://github.com/bitnami/charts/issues/19335)
+* [bitnami/tensorflow-resnet] Release 3.9.2 (#19414) ([93e0a55](https://github.com/bitnami/charts/commit/93e0a5505ad385a8ce4075dcd3305d560b53d1a2)), closes [#19414](https://github.com/bitnami/charts/issues/19414)
+* Autogenerate schema files (#19194) ([a2c2090](https://github.com/bitnami/charts/commit/a2c2090b5ac97f47b745c8028c6452bf99739772)), closes [#19194](https://github.com/bitnami/charts/issues/19194)
+* Revert "Autogenerate schema files (#19194)" (#19335) ([73d80be](https://github.com/bitnami/charts/commit/73d80be525c88fb4b8a54451a55acd506e337062)), closes [#19194](https://github.com/bitnami/charts/issues/19194) [#19335](https://github.com/bitnami/charts/issues/19335)
 
 ## <small>3.9.1 (2023-09-06)</small>
 
-* [bitnami/tensorflow-resnet: Use merge helper]: (#19112) ([61c9eab](https://github.com/bitnami/charts/commit/61c9eab)), closes [#19112](https://github.com/bitnami/charts/issues/19112)
+* [bitnami/tensorflow-resnet: Use merge helper]: (#19112) ([61c9eab](https://github.com/bitnami/charts/commit/61c9eab3604f34728fc3c499de9ea8f8938cf100)), closes [#19112](https://github.com/bitnami/charts/issues/19112)
 
 ## 3.9.0 (2023-08-22)
 
-* [bitnami/tensorflow-resnet] Support for customizing standard labels (#18441) ([cfcd012](https://github.com/bitnami/charts/commit/cfcd012)), closes [#18441](https://github.com/bitnami/charts/issues/18441)
+* [bitnami/tensorflow-resnet] Support for customizing standard labels (#18441) ([cfcd012](https://github.com/bitnami/charts/commit/cfcd0129571bed7560f9508c4fe8d248bbb063f4)), closes [#18441](https://github.com/bitnami/charts/issues/18441)
 
 ## <small>3.8.10 (2023-08-21)</small>
 
-* [bitnami/tensorflow-resnet] Release 3.8.10 (#18723) ([bc06446](https://github.com/bitnami/charts/commit/bc06446)), closes [#18723](https://github.com/bitnami/charts/issues/18723)
+* [bitnami/tensorflow-resnet] Release 3.8.10 (#18723) ([bc06446](https://github.com/bitnami/charts/commit/bc06446cb4a1e84e0bc278d093a5410210e85329)), closes [#18723](https://github.com/bitnami/charts/issues/18723)
 
 ## <small>3.8.9 (2023-08-17)</small>
 
-* [bitnami/tensorflow-resnet] Release 3.8.9 (#18598) ([ec09fc7](https://github.com/bitnami/charts/commit/ec09fc7)), closes [#18598](https://github.com/bitnami/charts/issues/18598)
+* [bitnami/tensorflow-resnet] Release 3.8.9 (#18598) ([ec09fc7](https://github.com/bitnami/charts/commit/ec09fc7dd86ac86791f0cf3268c99f8fb9703d1d)), closes [#18598](https://github.com/bitnami/charts/issues/18598)
 
 ## <small>3.8.8 (2023-07-26)</small>
 
-* [bitnami/tensorflow-resnet] Release 3.8.8 (#17975) ([6db4874](https://github.com/bitnami/charts/commit/6db4874)), closes [#17975](https://github.com/bitnami/charts/issues/17975)
+* [bitnami/tensorflow-resnet] Release 3.8.8 (#17975) ([6db4874](https://github.com/bitnami/charts/commit/6db48744eef035db9b27dcf1230cbd457c6a7295)), closes [#17975](https://github.com/bitnami/charts/issues/17975)
 
 ## <small>3.8.7 (2023-07-24)</small>
 
-* [bitnami/tensorflow-resnet] Release 3.8.7 (#17842) ([76ff613](https://github.com/bitnami/charts/commit/76ff613)), closes [#17842](https://github.com/bitnami/charts/issues/17842)
+* [bitnami/tensorflow-resnet] Release 3.8.7 (#17842) ([76ff613](https://github.com/bitnami/charts/commit/76ff613cbba472de5f04293aad5bbf3828816300)), closes [#17842](https://github.com/bitnami/charts/issues/17842)
 
 ## <small>3.8.6 (2023-07-22)</small>
 
-* [bitnami/tensorflow-resnet] Release 3.8.6 (#17822) ([40e5249](https://github.com/bitnami/charts/commit/40e5249)), closes [#17822](https://github.com/bitnami/charts/issues/17822)
+* [bitnami/tensorflow-resnet] Release 3.8.6 (#17822) ([40e5249](https://github.com/bitnami/charts/commit/40e52491e4fffa4c746755e36a98c09ea09c0b68)), closes [#17822](https://github.com/bitnami/charts/issues/17822)
 
 ## <small>3.8.5 (2023-07-19)</small>
 
-* [bitnami/tensorflow-resnet] Release 3.8.5 (#17770) ([e701da5](https://github.com/bitnami/charts/commit/e701da5)), closes [#17770](https://github.com/bitnami/charts/issues/17770)
+* [bitnami/tensorflow-resnet] Release 3.8.5 (#17770) ([e701da5](https://github.com/bitnami/charts/commit/e701da5c69c8f1ea6adb71eedf8ecd60d719ae57)), closes [#17770](https://github.com/bitnami/charts/issues/17770)
 
 ## <small>3.8.4 (2023-07-15)</small>
 
-* [bitnami/tensorflow-resnet] Release 3.8.4 (#17668) ([001b5c7](https://github.com/bitnami/charts/commit/001b5c7)), closes [#17668](https://github.com/bitnami/charts/issues/17668)
-* Add copyright header (#17300) ([da68be8](https://github.com/bitnami/charts/commit/da68be8)), closes [#17300](https://github.com/bitnami/charts/issues/17300)
-* Update charts readme (#17217) ([31b3c0a](https://github.com/bitnami/charts/commit/31b3c0a)), closes [#17217](https://github.com/bitnami/charts/issues/17217)
+* [bitnami/tensorflow-resnet] Release 3.8.4 (#17668) ([001b5c7](https://github.com/bitnami/charts/commit/001b5c7733c7f27d2e18c30859da8b7acda4fd03)), closes [#17668](https://github.com/bitnami/charts/issues/17668)
+* Add copyright header (#17300) ([da68be8](https://github.com/bitnami/charts/commit/da68be8e951225133c7dfb572d5101ca3d61c5ae)), closes [#17300](https://github.com/bitnami/charts/issues/17300)
+* Update charts readme (#17217) ([31b3c0a](https://github.com/bitnami/charts/commit/31b3c0afd968ff4429107e34101f7509e6a0e913)), closes [#17217](https://github.com/bitnami/charts/issues/17217)
 
 ## <small>3.8.3 (2023-06-20)</small>
 
-* [bitnami/*] Change copyright section in READMEs (#17006) ([ef986a1](https://github.com/bitnami/charts/commit/ef986a1)), closes [#17006](https://github.com/bitnami/charts/issues/17006)
-* [bitnami/several] Change copyright section in READMEs (#16989) ([5b6a5cf](https://github.com/bitnami/charts/commit/5b6a5cf)), closes [#16989](https://github.com/bitnami/charts/issues/16989)
-* [bitnami/tensorflow-resnet] Release 3.8.3 (#17228) ([d65b94a](https://github.com/bitnami/charts/commit/d65b94a)), closes [#17228](https://github.com/bitnami/charts/issues/17228)
+* [bitnami/*] Change copyright section in READMEs (#17006) ([ef986a1](https://github.com/bitnami/charts/commit/ef986a1605241102b3dcafe9fd8089e6fc1201ad)), closes [#17006](https://github.com/bitnami/charts/issues/17006)
+* [bitnami/several] Change copyright section in READMEs (#16989) ([5b6a5cf](https://github.com/bitnami/charts/commit/5b6a5cfb7625a751848a2e5cd796bd7278f406ca)), closes [#16989](https://github.com/bitnami/charts/issues/16989)
+* [bitnami/tensorflow-resnet] Release 3.8.3 (#17228) ([d65b94a](https://github.com/bitnami/charts/commit/d65b94abc5579d6109d5ac324f7da069df77fe34)), closes [#17228](https://github.com/bitnami/charts/issues/17228)
 
 ## <small>3.8.2 (2023-05-21)</small>
 
-* [bitnami/tensorflow-resnet] Release 3.8.2 (#16808) ([88328b7](https://github.com/bitnami/charts/commit/88328b7)), closes [#16808](https://github.com/bitnami/charts/issues/16808)
+* [bitnami/tensorflow-resnet] Release 3.8.2 (#16808) ([88328b7](https://github.com/bitnami/charts/commit/88328b757fe9ad9b4f63294c24dd2cb8774d0677)), closes [#16808](https://github.com/bitnami/charts/issues/16808)
 
 ## <small>3.8.1 (2023-05-17)</small>
 
-* [bitnami/tensorflow-resnet] Release 3.8.1 (#16705) ([0caa4af](https://github.com/bitnami/charts/commit/0caa4af)), closes [#16705](https://github.com/bitnami/charts/issues/16705)
-* Add wording for enterprise page (#16560) ([8f22774](https://github.com/bitnami/charts/commit/8f22774)), closes [#16560](https://github.com/bitnami/charts/issues/16560)
+* [bitnami/tensorflow-resnet] Release 3.8.1 (#16705) ([0caa4af](https://github.com/bitnami/charts/commit/0caa4af56467147ca182e915f80306b7aebe8509)), closes [#16705](https://github.com/bitnami/charts/issues/16705)
+* Add wording for enterprise page (#16560) ([8f22774](https://github.com/bitnami/charts/commit/8f2277440b976d52785ba9149762ad8620a73d1f)), closes [#16560](https://github.com/bitnami/charts/issues/16560)
 
 ## 3.8.0 (2023-05-09)
 
-* [bitnami/several] Adapt Chart.yaml to set desired OCI annotations (#16546) ([fc9b18f](https://github.com/bitnami/charts/commit/fc9b18f)), closes [#16546](https://github.com/bitnami/charts/issues/16546)
+* [bitnami/several] Adapt Chart.yaml to set desired OCI annotations (#16546) ([fc9b18f](https://github.com/bitnami/charts/commit/fc9b18f2e98805d4df629acbcde696f44f973344)), closes [#16546](https://github.com/bitnami/charts/issues/16546)
 
 ## <small>3.7.1 (2023-05-01)</small>
 
-* [bitnami/tensorflow-resnet] Release 3.7.1 (#16317) ([946e818](https://github.com/bitnami/charts/commit/946e818)), closes [#16317](https://github.com/bitnami/charts/issues/16317)
+* [bitnami/tensorflow-resnet] Release 3.7.1 (#16317) ([946e818](https://github.com/bitnami/charts/commit/946e818517183654a14e6f327c80d4ddc1d260d5)), closes [#16317](https://github.com/bitnami/charts/issues/16317)
 
 ## 3.7.0 (2023-04-20)
 
-* [bitnami/*] Make Helm charts 100% OCI (#15998) ([8841510](https://github.com/bitnami/charts/commit/8841510)), closes [#15998](https://github.com/bitnami/charts/issues/15998)
+* [bitnami/*] Make Helm charts 100% OCI (#15998) ([8841510](https://github.com/bitnami/charts/commit/884151035efcbf2e1b3206e7def85511073fb57d)), closes [#15998](https://github.com/bitnami/charts/issues/15998)
 
 ## <small>3.6.16 (2023-04-01)</small>
 
-* [bitnami/tensorflow-resnet] Release 3.6.16 (#15906) ([8fa502e](https://github.com/bitnami/charts/commit/8fa502e)), closes [#15906](https://github.com/bitnami/charts/issues/15906)
+* [bitnami/tensorflow-resnet] Release 3.6.16 (#15906) ([8fa502e](https://github.com/bitnami/charts/commit/8fa502e5077e5b6e19d4bcc78ffcda6231877d98)), closes [#15906](https://github.com/bitnami/charts/issues/15906)
 
 ## <small>3.6.15 (2023-03-24)</small>
 
-* [bitnami/tensorflow-resnet] Release 3.6.15 (#15713) ([b2d3f8d](https://github.com/bitnami/charts/commit/b2d3f8d)), closes [#15713](https://github.com/bitnami/charts/issues/15713)
+* [bitnami/tensorflow-resnet] Release 3.6.15 (#15713) ([b2d3f8d](https://github.com/bitnami/charts/commit/b2d3f8d8b982511cf177e86604d14a498c593c42)), closes [#15713](https://github.com/bitnami/charts/issues/15713)
 
 ## <small>3.6.14 (2023-03-20)</small>
 
-* [bitnami/charts] Apply linter to README files (#15357) ([0e29e60](https://github.com/bitnami/charts/commit/0e29e60)), closes [#15357](https://github.com/bitnami/charts/issues/15357)
-* [bitnami/tensorflow-resnet] Release 3.6.14 (#15623) ([2ed11a7](https://github.com/bitnami/charts/commit/2ed11a7)), closes [#15623](https://github.com/bitnami/charts/issues/15623)
+* [bitnami/charts] Apply linter to README files (#15357) ([0e29e60](https://github.com/bitnami/charts/commit/0e29e600d3adc8b1b46e506eccb3decfab3b4e63)), closes [#15357](https://github.com/bitnami/charts/issues/15357)
+* [bitnami/tensorflow-resnet] Release 3.6.14 (#15623) ([2ed11a7](https://github.com/bitnami/charts/commit/2ed11a7bf0d39abd6e060da046d7c29b88a3ca25)), closes [#15623](https://github.com/bitnami/charts/issues/15623)
 
 ## <small>3.6.13 (2023-03-01)</small>
 
-* [bitnami/tensorflow-resnet] Release 3.6.13 (#15227) ([96e2452](https://github.com/bitnami/charts/commit/96e2452)), closes [#15227](https://github.com/bitnami/charts/issues/15227)
+* [bitnami/tensorflow-resnet] Release 3.6.13 (#15227) ([96e2452](https://github.com/bitnami/charts/commit/96e2452960df60e84edd03c6940dda1603422b32)), closes [#15227](https://github.com/bitnami/charts/issues/15227)
 
 ## <small>3.6.12 (2023-02-17)</small>
 
-* [bitnami/*] Change copyright date (#14682) ([add4ec7](https://github.com/bitnami/charts/commit/add4ec7)), closes [#14682](https://github.com/bitnami/charts/issues/14682)
-* [bitnami/*] Fix markdown linter issues (#14874) ([a51e0e8](https://github.com/bitnami/charts/commit/a51e0e8)), closes [#14874](https://github.com/bitnami/charts/issues/14874)
-* [bitnami/*] Remove unexpected extra spaces (#14873) ([c97c714](https://github.com/bitnami/charts/commit/c97c714)), closes [#14873](https://github.com/bitnami/charts/issues/14873)
-* [bitnami/tensorflow-resnet] Release 3.6.12 (#15020) ([5d437fc](https://github.com/bitnami/charts/commit/5d437fc)), closes [#15020](https://github.com/bitnami/charts/issues/15020)
+* [bitnami/*] Change copyright date (#14682) ([add4ec7](https://github.com/bitnami/charts/commit/add4ec701108ac36ed4de2dffbdf407a0d091067)), closes [#14682](https://github.com/bitnami/charts/issues/14682)
+* [bitnami/*] Fix markdown linter issues (#14874) ([a51e0e8](https://github.com/bitnami/charts/commit/a51e0e8d35495b907f3e70dd2f8e7c3bcbf4166a)), closes [#14874](https://github.com/bitnami/charts/issues/14874)
+* [bitnami/*] Remove unexpected extra spaces (#14873) ([c97c714](https://github.com/bitnami/charts/commit/c97c714887380d47eae7bfeff316bf01595ecd1d)), closes [#14873](https://github.com/bitnami/charts/issues/14873)
+* [bitnami/tensorflow-resnet] Release 3.6.12 (#15020) ([5d437fc](https://github.com/bitnami/charts/commit/5d437fcf2b93b16618d1ea99a2f4d1bf3516ca02)), closes [#15020](https://github.com/bitnami/charts/issues/15020)
 
 ## <small>3.6.11 (2023-01-23)</small>
 
-* [bitnami/*] Add license annotation and remove obsolete engine parameter (#14293) ([da2a794](https://github.com/bitnami/charts/commit/da2a794)), closes [#14293](https://github.com/bitnami/charts/issues/14293)
-* [bitnami/*] Change licenses annotation format (#14377) ([0ab7608](https://github.com/bitnami/charts/commit/0ab7608)), closes [#14377](https://github.com/bitnami/charts/issues/14377)
-* [bitnami/*] Unify READMEs (#14472) ([2064fb8](https://github.com/bitnami/charts/commit/2064fb8)), closes [#14472](https://github.com/bitnami/charts/issues/14472)
-* [bitnami/tensorflow-resnet] Release 3.6.11 (#14499) ([9ffd0ff](https://github.com/bitnami/charts/commit/9ffd0ff)), closes [#14499](https://github.com/bitnami/charts/issues/14499)
+* [bitnami/*] Add license annotation and remove obsolete engine parameter (#14293) ([da2a794](https://github.com/bitnami/charts/commit/da2a7943bae95b6e9b5b4ed972c15e990b69fdb0)), closes [#14293](https://github.com/bitnami/charts/issues/14293)
+* [bitnami/*] Change licenses annotation format (#14377) ([0ab7608](https://github.com/bitnami/charts/commit/0ab760862c660fcc78cffadf8e1d8cdd70881473)), closes [#14377](https://github.com/bitnami/charts/issues/14377)
+* [bitnami/*] Unify READMEs (#14472) ([2064fb8](https://github.com/bitnami/charts/commit/2064fb8dcc78a845cdede8211af8c3cc52551161)), closes [#14472](https://github.com/bitnami/charts/issues/14472)
+* [bitnami/tensorflow-resnet] Release 3.6.11 (#14499) ([9ffd0ff](https://github.com/bitnami/charts/commit/9ffd0ffbad794e28665d1ad1a424c4df48b46a80)), closes [#14499](https://github.com/bitnami/charts/issues/14499)
 
 ## <small>3.6.10 (2022-12-24)</small>
 
-* [bitnami/tensorflow-resnet] Release 3.6.10 (#14094) ([30d333b](https://github.com/bitnami/charts/commit/30d333b)), closes [#14094](https://github.com/bitnami/charts/issues/14094)
+* [bitnami/tensorflow-resnet] Release 3.6.10 (#14094) ([30d333b](https://github.com/bitnami/charts/commit/30d333b01f5013a988670a8356befb5102b412c9)), closes [#14094](https://github.com/bitnami/charts/issues/14094)
 
 ## <small>3.6.9 (2022-11-24)</small>
 
-* [bitnami/tensorflow-resnet] Release 3.6.9 (#13685) ([70ceb81](https://github.com/bitnami/charts/commit/70ceb81)), closes [#13685](https://github.com/bitnami/charts/issues/13685)
+* [bitnami/tensorflow-resnet] Release 3.6.9 (#13685) ([70ceb81](https://github.com/bitnami/charts/commit/70ceb810ff19b2d0a9ca8e3af3f91230245cc5a8)), closes [#13685](https://github.com/bitnami/charts/issues/13685)
 
 ## <small>3.6.8 (2022-11-23)</small>
 
-* [bitnami/tensorflow-resnet] Release 3.6.8 (#13652) ([fd70471](https://github.com/bitnami/charts/commit/fd70471)), closes [#13652](https://github.com/bitnami/charts/issues/13652)
+* [bitnami/tensorflow-resnet] Release 3.6.8 (#13652) ([fd70471](https://github.com/bitnami/charts/commit/fd70471cdf8ad624d9b73ce91f84fd6ae75f7195)), closes [#13652](https://github.com/bitnami/charts/issues/13652)
 
 ## <small>3.6.7 (2022-11-09)</small>
 
-* [bitnami/*] Use new default branch name in links (#12943) ([a529e02](https://github.com/bitnami/charts/commit/a529e02)), closes [#12943](https://github.com/bitnami/charts/issues/12943)
-* [bitnami/tensorflow-resnet] Release 3.6.7 (#13433) ([f606604](https://github.com/bitnami/charts/commit/f606604)), closes [#13433](https://github.com/bitnami/charts/issues/13433)
+* [bitnami/*] Use new default branch name in links (#12943) ([a529e02](https://github.com/bitnami/charts/commit/a529e02597d49d944eba1eb0f190713293247176)), closes [#12943](https://github.com/bitnami/charts/issues/12943)
+* [bitnami/tensorflow-resnet] Release 3.6.7 (#13433) ([f606604](https://github.com/bitnami/charts/commit/f606604a600a7e14c87d53241c404d5a8a7a324b)), closes [#13433](https://github.com/bitnami/charts/issues/13433)
 
 ## <small>3.6.6 (2022-10-10)</small>
 
-* [bitnami/tensorflow-resnet] Release 3.6.6 (#12888) ([dfc7113](https://github.com/bitnami/charts/commit/dfc7113)), closes [#12888](https://github.com/bitnami/charts/issues/12888)
-* Generic README instructions related to the repo (#12792) ([3cf6b10](https://github.com/bitnami/charts/commit/3cf6b10)), closes [#12792](https://github.com/bitnami/charts/issues/12792)
+* [bitnami/tensorflow-resnet] Release 3.6.6 (#12888) ([dfc7113](https://github.com/bitnami/charts/commit/dfc7113db953557c99dc97c48fe68b1db27bfe4d)), closes [#12888](https://github.com/bitnami/charts/issues/12888)
+* Generic README instructions related to the repo (#12792) ([3cf6b10](https://github.com/bitnami/charts/commit/3cf6b10e10e60df4b3e191d6b99aa99a9f597755)), closes [#12792](https://github.com/bitnami/charts/issues/12792)
 
 ## <small>3.6.5 (2022-09-21)</small>
 
-* [bitnami/tensorflow-resnet] Release 3.6.5 updating components versions ([91f02f5](https://github.com/bitnami/charts/commit/91f02f5))
-* [bitnami/tensorflow-resnet] Use custom probes if given (#12562) ([5c86bb0](https://github.com/bitnami/charts/commit/5c86bb0)), closes [#12562](https://github.com/bitnami/charts/issues/12562) [#12354](https://github.com/bitnami/charts/issues/12354)
+* [bitnami/tensorflow-resnet] Release 3.6.5 updating components versions ([91f02f5](https://github.com/bitnami/charts/commit/91f02f58f506fcb80e10685ff80904bc57025e1a))
+* [bitnami/tensorflow-resnet] Use custom probes if given (#12562) ([5c86bb0](https://github.com/bitnami/charts/commit/5c86bb07121efd7cddbd79647e5a6113c68aea84)), closes [#12562](https://github.com/bitnami/charts/issues/12562) [#12354](https://github.com/bitnami/charts/issues/12354)
 
 ## <small>3.6.4 (2022-09-19)</small>
 
-* [bitnami/tensorflow-resnet] Release 3.6.4 updating components versions ([3e63f24](https://github.com/bitnami/charts/commit/3e63f24))
+* [bitnami/tensorflow-resnet] Release 3.6.4 updating components versions ([3e63f24](https://github.com/bitnami/charts/commit/3e63f24cca3c296f1f05546f78cf65c732489df9))
 
 ## <small>3.6.3 (2022-09-13)</small>
 
-* [bitnami/tensorflow-resnet] Release 3.6.3 updating components versions ([aece640](https://github.com/bitnami/charts/commit/aece640))
+* [bitnami/tensorflow-resnet] Release 3.6.3 updating components versions ([aece640](https://github.com/bitnami/charts/commit/aece6403b990dd5db57e13022417d1d5eb675663))
 
 ## <small>3.6.2 (2022-09-08)</small>
 
-* [bitnami/tensorflow-resnet] Release 3.6.2 updating components versions ([3a0ab18](https://github.com/bitnami/charts/commit/3a0ab18))
+* [bitnami/tensorflow-resnet] Release 3.6.2 updating components versions ([3a0ab18](https://github.com/bitnami/charts/commit/3a0ab18b451bad05c324e07570c41fdd5eaebb08))
 
 ## <small>3.6.1 (2022-08-23)</small>
 
-* [bitnami/tensorflow-resnet] Update Chart.lock (#12065) ([d89f36b](https://github.com/bitnami/charts/commit/d89f36b)), closes [#12065](https://github.com/bitnami/charts/issues/12065)
+* [bitnami/tensorflow-resnet] Update Chart.lock (#12065) ([d89f36b](https://github.com/bitnami/charts/commit/d89f36bee2e8ba053d276c07ceed4bb6ce9eea1b)), closes [#12065](https://github.com/bitnami/charts/issues/12065)
 
 ## 3.6.0 (2022-08-22)
 
-* [bitnami/tensorflow-resnet] Add support for image digest apart from tag (#11956) ([ff1678b](https://github.com/bitnami/charts/commit/ff1678b)), closes [#11956](https://github.com/bitnami/charts/issues/11956)
+* [bitnami/tensorflow-resnet] Add support for image digest apart from tag (#11956) ([ff1678b](https://github.com/bitnami/charts/commit/ff1678bdeaf544a86f26b89a8e37b4bb0c703994)), closes [#11956](https://github.com/bitnami/charts/issues/11956)
 
 ## <small>3.5.22 (2022-08-09)</small>
 
-* [bitnami/tensorflow-resnet] Release 3.5.22 updating components versions ([8a6b58a](https://github.com/bitnami/charts/commit/8a6b58a))
+* [bitnami/tensorflow-resnet] Release 3.5.22 updating components versions ([8a6b58a](https://github.com/bitnami/charts/commit/8a6b58a80feeed0015acd0cfd91d3aa5212480ca))
 
 ## <small>3.5.21 (2022-08-04)</small>
 
-* [bitnami/tensorflow-resnet] Release 3.5.21 updating components versions ([2df6ffc](https://github.com/bitnami/charts/commit/2df6ffc))
+* [bitnami/tensorflow-resnet] Release 3.5.21 updating components versions ([2df6ffc](https://github.com/bitnami/charts/commit/2df6ffc159454d104dcd419f807df40802ff0def))
 
 ## <small>3.5.20 (2022-08-04)</small>
 
-* [bitnami/tensorflow-resnet] Release 3.5.20 updating components versions ([d9c6702](https://github.com/bitnami/charts/commit/d9c6702))
+* [bitnami/tensorflow-resnet] Release 3.5.20 updating components versions ([d9c6702](https://github.com/bitnami/charts/commit/d9c67020536d44a0a421e4ccd7fc24500ba08d93))
 
 ## <small>3.5.19 (2022-08-02)</small>
 
-* [bitnami/*] Update URLs to point to the new bitnami/containers monorepo (#11352) ([d665af0](https://github.com/bitnami/charts/commit/d665af0)), closes [#11352](https://github.com/bitnami/charts/issues/11352)
-* [bitnami/tensorflow-resnet] Release 3.5.19 updating components versions ([8e9acf2](https://github.com/bitnami/charts/commit/8e9acf2))
+* [bitnami/*] Update URLs to point to the new bitnami/containers monorepo (#11352) ([d665af0](https://github.com/bitnami/charts/commit/d665af0c708846192d8d5fb2f5f9ea65dd464ab0)), closes [#11352](https://github.com/bitnami/charts/issues/11352)
+* [bitnami/tensorflow-resnet] Release 3.5.19 updating components versions ([8e9acf2](https://github.com/bitnami/charts/commit/8e9acf242817d2af20d3cb2c6caf70e7e633774c))
 
 ## <small>3.5.18 (2022-07-12)</small>
 
-* [bitnami/tensorflow-resnet] Release 3.5.18 updating components versions ([5fe84d4](https://github.com/bitnami/charts/commit/5fe84d4))
+* [bitnami/tensorflow-resnet] Release 3.5.18 updating components versions ([5fe84d4](https://github.com/bitnami/charts/commit/5fe84d4148b107f2991d4be22fe5a15b346ef14d))
 
 ## <small>3.5.17 (2022-06-30)</small>
 
-* [bitnami/tensorflow-resnet] Release 3.5.17 updating components versions ([9f0b4fe](https://github.com/bitnami/charts/commit/9f0b4fe))
+* [bitnami/tensorflow-resnet] Release 3.5.17 updating components versions ([9f0b4fe](https://github.com/bitnami/charts/commit/9f0b4fe89f6033cbf250023e1fc6eb20c649dd7f))
 
 ## <small>3.5.16 (2022-06-27)</small>
 
-* [bitnami/tensorflow-resnet] Release 3.5.16 updating components versions ([9ca329c](https://github.com/bitnami/charts/commit/9ca329c))
+* [bitnami/tensorflow-resnet] Release 3.5.16 updating components versions ([9ca329c](https://github.com/bitnami/charts/commit/9ca329cef1dfb036fcaadabd2e52163c4eb4b67e))
 
 ## <small>3.5.15 (2022-06-10)</small>
 
-* [bitnami/tensorflow-resnet] Release 3.5.15 updating components versions ([f173c58](https://github.com/bitnami/charts/commit/f173c58))
+* [bitnami/tensorflow-resnet] Release 3.5.15 updating components versions ([f173c58](https://github.com/bitnami/charts/commit/f173c5863b8804a7884eafa6bc59b73493b23cc0))
 
 ## <small>3.5.14 (2022-06-08)</small>
 
-* [bitnami/*] Replace Kubeapps URL in READMEs (and kubeapps Chart.yaml) and remove BKPR references (#1 ([c6a7914](https://github.com/bitnami/charts/commit/c6a7914)), closes [#10600](https://github.com/bitnami/charts/issues/10600)
-* [bitnami/tensorflow-resnet] Release 3.5.14 updating components versions ([f2a879c](https://github.com/bitnami/charts/commit/f2a879c))
+* [bitnami/*] Replace Kubeapps URL in READMEs (and kubeapps Chart.yaml) and remove BKPR references (#1 ([c6a7914](https://github.com/bitnami/charts/commit/c6a7914361e5aea6016fb45bf4d621edfd111d32)), closes [#10600](https://github.com/bitnami/charts/issues/10600)
+* [bitnami/tensorflow-resnet] Release 3.5.14 updating components versions ([f2a879c](https://github.com/bitnami/charts/commit/f2a879c89f14fd774e9582ce3cc62555a5702fcf))
 
 ## <small>3.5.13 (2022-06-06)</small>
 
-* [bitnami/tensorflow-resnet] Release 3.5.13 updating components versions ([765b7e1](https://github.com/bitnami/charts/commit/765b7e1))
+* [bitnami/tensorflow-resnet] Release 3.5.13 updating components versions ([765b7e1](https://github.com/bitnami/charts/commit/765b7e170e6738294e1d6cded6d02254efa81348))
 
 ## <small>3.5.12 (2022-06-01)</small>
 
-* [bitnami/several] Replace maintainers email by url (#10523) ([ff3cf61](https://github.com/bitnami/charts/commit/ff3cf61)), closes [#10523](https://github.com/bitnami/charts/issues/10523)
+* [bitnami/several] Replace maintainers email by url (#10523) ([ff3cf61](https://github.com/bitnami/charts/commit/ff3cf617a1680509b0f3855d17c4ccff7b29a0ff)), closes [#10523](https://github.com/bitnami/charts/issues/10523)
 
 ## <small>3.5.11 (2022-05-22)</small>
 
-* [bitnami/tensorflow-resnet] Release 3.5.11 updating components versions ([f1d387a](https://github.com/bitnami/charts/commit/f1d387a))
+* [bitnami/tensorflow-resnet] Release 3.5.11 updating components versions ([f1d387a](https://github.com/bitnami/charts/commit/f1d387ab7d0c0fd8852031776042d007eb63eeba))
 
 ## <small>3.5.10 (2022-05-20)</small>
 
-* [bitnami/tensorflow-resnet] Release 3.5.10 updating components versions ([53a72ec](https://github.com/bitnami/charts/commit/53a72ec))
+* [bitnami/tensorflow-resnet] Release 3.5.10 updating components versions ([53a72ec](https://github.com/bitnami/charts/commit/53a72ecd0006a3641e5f873ab6163bb691097a34))
 
 ## <small>3.5.9 (2022-05-19)</small>
 
-* [bitnami/tensorflow-resnet] Release 3.5.9 updating components versions ([efd3903](https://github.com/bitnami/charts/commit/efd3903))
+* [bitnami/tensorflow-resnet] Release 3.5.9 updating components versions ([efd3903](https://github.com/bitnami/charts/commit/efd3903047d3580fcbcd3c95eb48c91074185863))
 
 ## <small>3.5.8 (2022-05-18)</small>
 
-* [bitnami/*] Remove old 'ci' files (#10171) ([5df30c4](https://github.com/bitnami/charts/commit/5df30c4)), closes [#10171](https://github.com/bitnami/charts/issues/10171)
-* [bitnami/tensorflow-resnet] Release 3.5.8 updating components versions ([a22c9a8](https://github.com/bitnami/charts/commit/a22c9a8))
+* [bitnami/*] Remove old 'ci' files (#10171) ([5df30c4](https://github.com/bitnami/charts/commit/5df30c44dbd1812da8786579ce4a94917d46a6ad)), closes [#10171](https://github.com/bitnami/charts/issues/10171)
+* [bitnami/tensorflow-resnet] Release 3.5.8 updating components versions ([a22c9a8](https://github.com/bitnami/charts/commit/a22c9a8a964ac123bdaad058105621e1b476ebd2))
 
 ## <small>3.5.7 (2022-04-20)</small>
 
-* [bitnami/tensorflow-resnet] Release 3.5.7 updating components versions ([7b86f9f](https://github.com/bitnami/charts/commit/7b86f9f))
+* [bitnami/tensorflow-resnet] Release 3.5.7 updating components versions ([7b86f9f](https://github.com/bitnami/charts/commit/7b86f9f0a1982e3d229235162ca95b48058a24f0))
 
 ## <small>3.5.6 (2022-04-19)</small>
 
-* [bitnami/tensorflow-resnet] Release 3.5.6 updating components versions ([ae295e0](https://github.com/bitnami/charts/commit/ae295e0))
+* [bitnami/tensorflow-resnet] Release 3.5.6 updating components versions ([ae295e0](https://github.com/bitnami/charts/commit/ae295e0f9befe195042af0834bf915f51f317b97))
 
 ## <small>3.5.5 (2022-04-07)</small>
 
-* [bitnami/tensorflow-resnet] Release 3.5.5 updating components versions ([446886c](https://github.com/bitnami/charts/commit/446886c))
+* [bitnami/tensorflow-resnet] Release 3.5.5 updating components versions ([446886c](https://github.com/bitnami/charts/commit/446886cf9548f3f2f54cdf072a493ca17651b338))
 
 ## <small>3.5.4 (2022-04-03)</small>
 
-* [bitnami/tensorflow-resnet] Release 3.5.4 updating components versions ([2beb4a7](https://github.com/bitnami/charts/commit/2beb4a7))
+* [bitnami/tensorflow-resnet] Release 3.5.4 updating components versions ([2beb4a7](https://github.com/bitnami/charts/commit/2beb4a7eaa4316b802e72a9439fee1ed60b154e7))
 
 ## <small>3.5.3 (2022-04-02)</small>
 
-* [bitnami/tensorflow-resnet] Release 3.5.3 updating components versions ([9b9772c](https://github.com/bitnami/charts/commit/9b9772c))
+* [bitnami/tensorflow-resnet] Release 3.5.3 updating components versions ([9b9772c](https://github.com/bitnami/charts/commit/9b9772cdfa06b091ab5cdcd0f41a837b5664a3c3))
 
 ## <small>3.5.2 (2022-03-27)</small>
 
-* [bitnami/tensorflow-resnet] Release 3.5.2 updating components versions ([b11b15b](https://github.com/bitnami/charts/commit/b11b15b))
+* [bitnami/tensorflow-resnet] Release 3.5.2 updating components versions ([b11b15b](https://github.com/bitnami/charts/commit/b11b15b4d8beb57cf951db9f54c5851de85d1920))
 
 ## <small>3.5.1 (2022-03-16)</small>
 
-* [bitnami/tensorflow-resnet] Release 3.5.1 updating components versions ([b58ac82](https://github.com/bitnami/charts/commit/b58ac82))
+* [bitnami/tensorflow-resnet] Release 3.5.1 updating components versions ([b58ac82](https://github.com/bitnami/charts/commit/b58ac8240f0189105b6e693f012050318fa00089))
 
 ## 3.5.0 (2022-03-04)
 
-* [bitnami/tensorflow-resnet] Chart standardised (#9208) ([c8b99a2](https://github.com/bitnami/charts/commit/c8b99a2)), closes [#9208](https://github.com/bitnami/charts/issues/9208)
+* [bitnami/tensorflow-resnet] Chart standardised (#9208) ([c8b99a2](https://github.com/bitnami/charts/commit/c8b99a2d9f1249cbf13fdd24542be01c2531cbb1)), closes [#9208](https://github.com/bitnami/charts/issues/9208)
 
 ## <small>3.4.5 (2022-02-28)</small>
 
-* [bitnami/tensorflow-resnet] Release 3.4.5 updating components versions ([175a516](https://github.com/bitnami/charts/commit/175a516))
+* [bitnami/tensorflow-resnet] Release 3.4.5 updating components versions ([175a516](https://github.com/bitnami/charts/commit/175a51636da1dcee70cf402ed93d592fb196c754))
 
 ## <small>3.4.4 (2022-02-24)</small>
 
-* [bitnami/tensorflow-resnet] Release 3.4.4 updating components versions ([6c698df](https://github.com/bitnami/charts/commit/6c698df))
+* [bitnami/tensorflow-resnet] Release 3.4.4 updating components versions ([6c698df](https://github.com/bitnami/charts/commit/6c698dfcf39233b54139661458f0813a8df60e6a))
 
 ## <small>3.4.3 (2022-02-12)</small>
 
-* [bitnami/tensorflow-resnet] Release 3.4.3 updating components versions ([904242b](https://github.com/bitnami/charts/commit/904242b))
-* Non utf8 chars (#8923) ([6ffd18f](https://github.com/bitnami/charts/commit/6ffd18f)), closes [#8923](https://github.com/bitnami/charts/issues/8923)
+* [bitnami/tensorflow-resnet] Release 3.4.3 updating components versions ([904242b](https://github.com/bitnami/charts/commit/904242b64179ef03bfbcfbe71b230a93085dec50))
+* Non utf8 chars (#8923) ([6ffd18f](https://github.com/bitnami/charts/commit/6ffd18fbbdf10e94ea1a90cf5b84ef610ac2a72d)), closes [#8923](https://github.com/bitnami/charts/issues/8923)
 
 ## <small>3.4.2 (2022-01-20)</small>
 
-* [bitnami/*] Readme automation (#8579) ([78d1938](https://github.com/bitnami/charts/commit/78d1938)), closes [#8579](https://github.com/bitnami/charts/issues/8579)
-* [bitnami/*] Update READMEs (#8716) ([b9a9533](https://github.com/bitnami/charts/commit/b9a9533)), closes [#8716](https://github.com/bitnami/charts/issues/8716)
-* [bitnami/several] Change prerequisites (#8725) ([8d740c5](https://github.com/bitnami/charts/commit/8d740c5)), closes [#8725](https://github.com/bitnami/charts/issues/8725)
+* [bitnami/*] Readme automation (#8579) ([78d1938](https://github.com/bitnami/charts/commit/78d193831c900d178198491ffd08fa2217a64ecd)), closes [#8579](https://github.com/bitnami/charts/issues/8579)
+* [bitnami/*] Update READMEs (#8716) ([b9a9533](https://github.com/bitnami/charts/commit/b9a953337590eb2979453385874a267bacf50936)), closes [#8716](https://github.com/bitnami/charts/issues/8716)
+* [bitnami/several] Change prerequisites (#8725) ([8d740c5](https://github.com/bitnami/charts/commit/8d740c566cfdb7e2d933c40128b4e919fce953a5)), closes [#8725](https://github.com/bitnami/charts/issues/8725)
 
 ## <small>3.4.1 (2022-01-12)</small>
 
-* [bitnami/tensorflow-resnet] Release 3.4.1 updating components versions ([74e5881](https://github.com/bitnami/charts/commit/74e5881))
+* [bitnami/tensorflow-resnet] Release 3.4.1 updating components versions ([74e5881](https://github.com/bitnami/charts/commit/74e58810562cde23d19f8d00bef3b921d99482c1))
 
 ## 3.4.0 (2022-01-05)
 
-* [bitnami/several] Adapt templating format (#8562) ([8cad18a](https://github.com/bitnami/charts/commit/8cad18a)), closes [#8562](https://github.com/bitnami/charts/issues/8562)
-* [bitnami/several] Add license to the README ([05f7633](https://github.com/bitnami/charts/commit/05f7633))
-* [bitnami/several] Add license to the README ([32fb238](https://github.com/bitnami/charts/commit/32fb238))
-* [bitnami/several] Add license to the README ([b87c2f7](https://github.com/bitnami/charts/commit/b87c2f7))
+* [bitnami/several] Adapt templating format (#8562) ([8cad18a](https://github.com/bitnami/charts/commit/8cad18aed9966a6f0208e5ad6cee46cb217f47ab)), closes [#8562](https://github.com/bitnami/charts/issues/8562)
+* [bitnami/several] Add license to the README ([05f7633](https://github.com/bitnami/charts/commit/05f763372501d596e57db713dd53ff4ff3027cc4))
+* [bitnami/several] Add license to the README ([32fb238](https://github.com/bitnami/charts/commit/32fb238e60a0affc6debd3142eaa3c3d9089ec2a))
+* [bitnami/several] Add license to the README ([b87c2f7](https://github.com/bitnami/charts/commit/b87c2f7899d48a8b02c506765e6ae82937e9ba3f))
 
 ## 3.3.0 (2021-12-31)
 
-* [bitnami/tensorflow-resnet] Update TF ResNet version (#8510) ([780fb90](https://github.com/bitnami/charts/commit/780fb90)), closes [#8510](https://github.com/bitnami/charts/issues/8510)
+* [bitnami/tensorflow-resnet] Update TF ResNet version (#8510) ([780fb90](https://github.com/bitnami/charts/commit/780fb908f2230906ee80673fb7c136ffae41acb4)), closes [#8510](https://github.com/bitnami/charts/issues/8510)
 
 ## <small>3.2.22 (2021-12-05)</small>
 
-* [bitnami/tensorflow-resnet] Release 3.2.22 updating components versions ([f85a194](https://github.com/bitnami/charts/commit/f85a194))
+* [bitnami/tensorflow-resnet] Release 3.2.22 updating components versions ([f85a194](https://github.com/bitnami/charts/commit/f85a194a243fecce649381a1b6e2cb0794339e8a))
 
 ## <small>3.2.21 (2021-11-29)</small>
 
-* [bitnami/several] Fix deadlinks in README.md (#8215) ([99e90d2](https://github.com/bitnami/charts/commit/99e90d2)), closes [#8215](https://github.com/bitnami/charts/issues/8215)
-* [bitnami/several] Replace HTTP by HTTPS when possible (#8259) ([eafb5bd](https://github.com/bitnami/charts/commit/eafb5bd)), closes [#8259](https://github.com/bitnami/charts/issues/8259)
+* [bitnami/several] Fix deadlinks in README.md (#8215) ([99e90d2](https://github.com/bitnami/charts/commit/99e90d244b3244e059a42f72dcbecd3cda2b66bb)), closes [#8215](https://github.com/bitnami/charts/issues/8215)
+* [bitnami/several] Replace HTTP by HTTPS when possible (#8259) ([eafb5bd](https://github.com/bitnami/charts/commit/eafb5bd5a2cc3aaf04fc1e8ebedd73f420d76864)), closes [#8259](https://github.com/bitnami/charts/issues/8259)
 
 ## <small>3.2.20 (2021-11-17)</small>
 
-* [bitnami/several] Add extraDeploy feature to the pending charts (#8164) ([d812a24](https://github.com/bitnami/charts/commit/d812a24)), closes [#8164](https://github.com/bitnami/charts/issues/8164)
-* [bitnami/several] Regenerate README tables ([ef52074](https://github.com/bitnami/charts/commit/ef52074))
+* [bitnami/several] Add extraDeploy feature to the pending charts (#8164) ([d812a24](https://github.com/bitnami/charts/commit/d812a243cb1bba69c67ac22cfce1f7999848ef74)), closes [#8164](https://github.com/bitnami/charts/issues/8164)
+* [bitnami/several] Regenerate README tables ([ef52074](https://github.com/bitnami/charts/commit/ef52074d5f3dd00218322cd201f83ee55f9dd1e6))
 
 ## <small>3.2.19 (2021-11-05)</small>
 
-* [bitnami/several] Regenerate README tables ([412cf6a](https://github.com/bitnami/charts/commit/412cf6a))
-* [bitnami/tensorflow-resnet] Release 3.2.19 updating components versions ([bf0f363](https://github.com/bitnami/charts/commit/bf0f363))
+* [bitnami/several] Regenerate README tables ([412cf6a](https://github.com/bitnami/charts/commit/412cf6a513cb0c03444a6e7811c6f27193239a10))
+* [bitnami/tensorflow-resnet] Release 3.2.19 updating components versions ([bf0f363](https://github.com/bitnami/charts/commit/bf0f36390ee7a0e4c8e3c5bc54774061051139a4))
 
 ## <small>3.2.18 (2021-10-26)</small>
 
-* [bitnami/several] Regenerate README tables ([c82619f](https://github.com/bitnami/charts/commit/c82619f))
-* [bitnami/tensorflow-resnet] Release 3.2.18 updating components versions ([0ab1da1](https://github.com/bitnami/charts/commit/0ab1da1))
+* [bitnami/several] Regenerate README tables ([c82619f](https://github.com/bitnami/charts/commit/c82619f4141cd18e1b6079fdd84eb5b7bb47d819))
+* [bitnami/tensorflow-resnet] Release 3.2.18 updating components versions ([0ab1da1](https://github.com/bitnami/charts/commit/0ab1da179e4132627be35c5ad1c967fe0e2d6371))
 
 ## <small>3.2.17 (2021-10-24)</small>
 
-* [bitnami/tensorflow-resnet] Release 3.2.17 updating components versions ([b239bf7](https://github.com/bitnami/charts/commit/b239bf7))
+* [bitnami/tensorflow-resnet] Release 3.2.17 updating components versions ([b239bf7](https://github.com/bitnami/charts/commit/b239bf758d9d70e5292d6b4789b45388a21f92c7))
 
 ## <small>3.2.16 (2021-10-22)</small>
 
-* [bitnami/several] Add chart info to NOTES.txt (#7889) ([a6751cd](https://github.com/bitnami/charts/commit/a6751cd)), closes [#7889](https://github.com/bitnami/charts/issues/7889)
+* [bitnami/several] Add chart info to NOTES.txt (#7889) ([a6751cd](https://github.com/bitnami/charts/commit/a6751cdd33c461fabbc459fbea6f219ec64ab6b2)), closes [#7889](https://github.com/bitnami/charts/issues/7889)
 
 ## <small>3.2.15 (2021-09-30)</small>
 
-* [bitnami/several] Regenerate README tables ([ff170d1](https://github.com/bitnami/charts/commit/ff170d1))
-* T41225 Updated README (#7652) ([0207590](https://github.com/bitnami/charts/commit/0207590)), closes [#7652](https://github.com/bitnami/charts/issues/7652)
+* [bitnami/several] Regenerate README tables ([ff170d1](https://github.com/bitnami/charts/commit/ff170d10f8aa6dae0f1e5c3f7d1c69fcec96b731))
+* T41225 Updated README (#7652) ([0207590](https://github.com/bitnami/charts/commit/020759085076c39b31ae2dd4d44cc06d90e84812)), closes [#7652](https://github.com/bitnami/charts/issues/7652)
 
 ## <small>3.2.14 (2021-09-24)</small>
 
-* [bitnami/several] Regenerate README tables ([da2513b](https://github.com/bitnami/charts/commit/da2513b))
-* [bitnami/tensorflow-resnet] Release 3.2.14 updating components versions ([a9df28e](https://github.com/bitnami/charts/commit/a9df28e))
+* [bitnami/several] Regenerate README tables ([da2513b](https://github.com/bitnami/charts/commit/da2513bf0a33819f3b1151d387c631a9ffdb03e2))
+* [bitnami/tensorflow-resnet] Release 3.2.14 updating components versions ([a9df28e](https://github.com/bitnami/charts/commit/a9df28e6b79aef20906804d531596be1eaa62afd))
 
 ## <small>3.2.13 (2021-08-25)</small>
 
-* [bitnami/tensorflow-resnet] Release 3.2.13 updating components versions ([86f713a](https://github.com/bitnami/charts/commit/86f713a))
+* [bitnami/tensorflow-resnet] Release 3.2.13 updating components versions ([86f713a](https://github.com/bitnami/charts/commit/86f713a6b84615cd8798aa7e9196b72c4501c950))
 
 ## <small>3.2.12 (2021-08-25)</small>
 
-* [bitnami/several] Regenerate README tables ([6c107e8](https://github.com/bitnami/charts/commit/6c107e8))
-* [bitnami/tensorflow-resnet] Release 3.2.12 updating components versions ([60aa3d3](https://github.com/bitnami/charts/commit/60aa3d3))
+* [bitnami/several] Regenerate README tables ([6c107e8](https://github.com/bitnami/charts/commit/6c107e835d6caf8db2e8b17dcd48c5971637e013))
+* [bitnami/tensorflow-resnet] Release 3.2.12 updating components versions ([60aa3d3](https://github.com/bitnami/charts/commit/60aa3d359a65e8bb19385cc7edf0ef306c577de4))
 
 ## <small>3.2.11 (2021-08-04)</small>
 
-* [bitnami/several] Upadte READMEs ([eb3c291](https://github.com/bitnami/charts/commit/eb3c291))
-* [bitnami/tensorflow-resnet] Release 3.2.11 updating components versions ([cec07e2](https://github.com/bitnami/charts/commit/cec07e2))
+* [bitnami/several] Upadte READMEs ([eb3c291](https://github.com/bitnami/charts/commit/eb3c2916be233280f2226d9cdceb57b08ab4a23b))
+* [bitnami/tensorflow-resnet] Release 3.2.11 updating components versions ([cec07e2](https://github.com/bitnami/charts/commit/cec07e2717e0e323e7016f6bedf4130c6e6b6e5a))
 
 ## <small>3.2.10 (2021-07-21)</small>
 
-* [bitnami/*] Replace nil values (#6993) ([2be11a7](https://github.com/bitnami/charts/commit/2be11a7)), closes [#6993](https://github.com/bitnami/charts/issues/6993)
+* [bitnami/*] Replace nil values (#6993) ([2be11a7](https://github.com/bitnami/charts/commit/2be11a70b92a01603c1f079eeaff4b00dc4796d6)), closes [#6993](https://github.com/bitnami/charts/issues/6993)
 
 ## <small>3.2.9 (2021-07-21)</small>
 
-* [bitnami/tensorflow-resnet] Release 3.2.9 updating components versions ([c939410](https://github.com/bitnami/charts/commit/c939410))
+* [bitnami/tensorflow-resnet] Release 3.2.9 updating components versions ([c939410](https://github.com/bitnami/charts/commit/c9394106d4c08852d30fc645c75ee8e9287c0987))
 
 ## <small>3.2.8 (2021-07-19)</small>
 
-* [bitnami/*] Adapt values.yaml of TensorFlow, TestLink and Thanos charts (#6965) ([71a2668](https://github.com/bitnami/charts/commit/71a2668)), closes [#6965](https://github.com/bitnami/charts/issues/6965)
+* [bitnami/*] Adapt values.yaml of TensorFlow, TestLink and Thanos charts (#6965) ([71a2668](https://github.com/bitnami/charts/commit/71a2668d72cbec381a006dab16622f19e64e1290)), closes [#6965](https://github.com/bitnami/charts/issues/6965)
 
 ## <small>3.2.7 (2021-06-21)</small>
 
-* [bitnami/tensorflow-resnet] Release 3.2.7 updating components versions ([8d92beb](https://github.com/bitnami/charts/commit/8d92beb))
+* [bitnami/tensorflow-resnet] Release 3.2.7 updating components versions ([8d92beb](https://github.com/bitnami/charts/commit/8d92beb87e6a6137789b7540152c2e1a087c72cd))
 
 ## <small>3.2.6 (2021-06-19)</small>
 
-* [bitnami/tensorflow-resnet] Release 3.2.6 updating components versions ([ccfdab5](https://github.com/bitnami/charts/commit/ccfdab5))
+* [bitnami/tensorflow-resnet] Release 3.2.6 updating components versions ([ccfdab5](https://github.com/bitnami/charts/commit/ccfdab5d12ccd54856de548265209c109907c967))
 
 ## <small>3.2.5 (2021-06-18)</small>
 
-* [bitnami/tensorflow-resnet] Release 3.2.5 updating components versions ([9ef0435](https://github.com/bitnami/charts/commit/9ef0435))
+* [bitnami/tensorflow-resnet] Release 3.2.5 updating components versions ([9ef0435](https://github.com/bitnami/charts/commit/9ef0435a2eb5d39da7bb24ca5e52fd5ec9539462))
 
 ## <small>3.2.4 (2021-05-22)</small>
 
-* [bitnami/tensorflow-resnet] Release 3.2.4 updating components versions ([e3ebd18](https://github.com/bitnami/charts/commit/e3ebd18))
+* [bitnami/tensorflow-resnet] Release 3.2.4 updating components versions ([e3ebd18](https://github.com/bitnami/charts/commit/e3ebd181deec6fc7a323999dc20e52fc89a30472))
 
 ## <small>3.2.3 (2021-04-27)</small>
 
-* [bitnami/tensorflow-resnet] Release 3.2.3 updating components versions ([a639850](https://github.com/bitnami/charts/commit/a639850))
+* [bitnami/tensorflow-resnet] Release 3.2.3 updating components versions ([a639850](https://github.com/bitnami/charts/commit/a63985094f29a26c9270742cc4be2771713fb486))
 
 ## <small>3.2.2 (2021-03-28)</small>
 
-* [bitnami/tensorflow-resnet] Release 3.2.2 updating components versions ([e4fb5eb](https://github.com/bitnami/charts/commit/e4fb5eb))
+* [bitnami/tensorflow-resnet] Release 3.2.2 updating components versions ([e4fb5eb](https://github.com/bitnami/charts/commit/e4fb5eb37b2c7269b4610e0ede71eff1db1d218f))
 
 ## <small>3.2.1 (2021-02-26)</small>
 
-* [bitnami/tensorflow-resnet] Release 3.2.1 updating components versions ([b0257f4](https://github.com/bitnami/charts/commit/b0257f4))
+* [bitnami/tensorflow-resnet] Release 3.2.1 updating components versions ([b0257f4](https://github.com/bitnami/charts/commit/b0257f4afce20dcbc3876ffd0a1c5bfd72bb88de))
 
 ## 3.2.0 (2021-01-29)
 
-* [bitnami/tensorflow-resnet] Add hostAliases (#5311) ([7aaf281](https://github.com/bitnami/charts/commit/7aaf281)), closes [#5311](https://github.com/bitnami/charts/issues/5311)
+* [bitnami/tensorflow-resnet] Add hostAliases (#5311) ([7aaf281](https://github.com/bitnami/charts/commit/7aaf2815a65fa01824bfca2f13c4181636e3ab4a)), closes [#5311](https://github.com/bitnami/charts/issues/5311)
 
 ## <small>3.1.3 (2021-01-27)</small>
 
-* [bitnami/*] Change helm version in the prerequisites (#5090) ([c5e67a3](https://github.com/bitnami/charts/commit/c5e67a3)), closes [#5090](https://github.com/bitnami/charts/issues/5090)
-* [bitnami/tensorflow-resnet] Release 3.1.3 updating components versions ([e49b3b5](https://github.com/bitnami/charts/commit/e49b3b5))
+* [bitnami/*] Change helm version in the prerequisites (#5090) ([c5e67a3](https://github.com/bitnami/charts/commit/c5e67a388743cbee28439d2cabca27884b9daf97)), closes [#5090](https://github.com/bitnami/charts/issues/5090)
+* [bitnami/tensorflow-resnet] Release 3.1.3 updating components versions ([e49b3b5](https://github.com/bitnami/charts/commit/e49b3b5f6c0f8952ff95c8507e034e5c23e38b91))
 
 ## <small>3.1.2 (2021-01-14)</small>
 
-* [bitnami/tensorflow-resnet] Release 3.1.2 updating components versions ([a11fadd](https://github.com/bitnami/charts/commit/a11fadd))
+* [bitnami/tensorflow-resnet] Release 3.1.2 updating components versions ([a11fadd](https://github.com/bitnami/charts/commit/a11fadd9afe128d66fb08e1f9d5d476f17504662))
 
 ## <small>3.1.1 (2020-12-16)</small>
 
-* [bitnami/tensorflow-resnet] Release 3.1.1 updating components versions ([cee0de0](https://github.com/bitnami/charts/commit/cee0de0))
+* [bitnami/tensorflow-resnet] Release 3.1.1 updating components versions ([cee0de0](https://github.com/bitnami/charts/commit/cee0de0d13383d8f1a103e7923851115ce2b6707))
 
 ## 3.1.0 (2020-12-15)
 
-* [bitnami/*] Affinity based on common presets (viii) (#4721) ([950ac9c](https://github.com/bitnami/charts/commit/950ac9c)), closes [#4721](https://github.com/bitnami/charts/issues/4721)
+* [bitnami/*] Affinity based on common presets (viii) (#4721) ([950ac9c](https://github.com/bitnami/charts/commit/950ac9cd4d3914b7ffe7966b75876f416e479883)), closes [#4721](https://github.com/bitnami/charts/issues/4721)
 
 ## <small>3.0.1 (2020-12-10)</small>
 
-* [bitnami/tensorflow-resnet] Release 3.0.1 updating components versions ([e762ebf](https://github.com/bitnami/charts/commit/e762ebf))
+* [bitnami/tensorflow-resnet] Release 3.0.1 updating components versions ([e762ebf](https://github.com/bitnami/charts/commit/e762ebf3262bb460ad6537223c0934e7daf19930))
 
 ## 3.0.0 (2020-11-10)
 
-* [bitnami/*] Include link to Troubleshootin guide on README.md (#4136) ([c08a20e](https://github.com/bitnami/charts/commit/c08a20e)), closes [#4136](https://github.com/bitnami/charts/issues/4136)
-* [bitnami/tensorflow-resnet] Major version. Adapt Chart to apiVersion: v2 (#4264) ([2179b1d](https://github.com/bitnami/charts/commit/2179b1d)), closes [#4264](https://github.com/bitnami/charts/issues/4264)
+* [bitnami/*] Include link to Troubleshootin guide on README.md (#4136) ([c08a20e](https://github.com/bitnami/charts/commit/c08a20e3db004215383004ff023a73fcc2522e72)), closes [#4136](https://github.com/bitnami/charts/issues/4136)
+* [bitnami/tensorflow-resnet] Major version. Adapt Chart to apiVersion: v2 (#4264) ([2179b1d](https://github.com/bitnami/charts/commit/2179b1dccceb378dea383a374089acf1f58a4a55)), closes [#4264](https://github.com/bitnami/charts/issues/4264)
 
 ## <small>2.0.20 (2020-10-22)</small>
 
-* [bitnami/tensorflow-resnet] Release 2.0.20 updating components versions ([1a753ce](https://github.com/bitnami/charts/commit/1a753ce))
+* [bitnami/tensorflow-resnet] Release 2.0.20 updating components versions ([1a753ce](https://github.com/bitnami/charts/commit/1a753ceaadf5a94eab95b0a7f57c125e090b621e))
 
 ## <small>2.0.19 (2020-09-22)</small>
 
-* [bitnami/metrics-server] Add source repo (#3577) ([1ed12f9](https://github.com/bitnami/charts/commit/1ed12f9)), closes [#3577](https://github.com/bitnami/charts/issues/3577)
-* [bitnami/tensorflow-resnet] Release 2.0.19 updating components versions ([edb215f](https://github.com/bitnami/charts/commit/edb215f))
+* [bitnami/metrics-server] Add source repo (#3577) ([1ed12f9](https://github.com/bitnami/charts/commit/1ed12f96af75322b46afdb2b3d9907c11b13f765)), closes [#3577](https://github.com/bitnami/charts/issues/3577)
+* [bitnami/tensorflow-resnet] Release 2.0.19 updating components versions ([edb215f](https://github.com/bitnami/charts/commit/edb215fb697886f3c128ab8fc7e482e0b35c01e3))
 
 ## <small>2.0.18 (2020-08-26)</small>
 
-* [bitnami/tensorflow-resnet] Release 2.0.18 updating components versions ([3a9fce7](https://github.com/bitnami/charts/commit/3a9fce7))
+* [bitnami/tensorflow-resnet] Release 2.0.18 updating components versions ([3a9fce7](https://github.com/bitnami/charts/commit/3a9fce740daf081db3d785ec78fcdd7e1906378f))
 
 ## <small>2.0.17 (2020-08-01)</small>
 
-* [bitnami/*] Fix TL;DR typo in READMEs (#3280) ([3d7ab40](https://github.com/bitnami/charts/commit/3d7ab40)), closes [#3280](https://github.com/bitnami/charts/issues/3280)
-* [bitnami/tensorflow-resnet] Release 2.0.17 updating components versions ([122ceeb](https://github.com/bitnami/charts/commit/122ceeb))
+* [bitnami/*] Fix TL;DR typo in READMEs (#3280) ([3d7ab40](https://github.com/bitnami/charts/commit/3d7ab406fecd64f1af25f53e7d27f03ec95b29a4)), closes [#3280](https://github.com/bitnami/charts/issues/3280)
+* [bitnami/tensorflow-resnet] Release 2.0.17 updating components versions ([122ceeb](https://github.com/bitnami/charts/commit/122ceeb14c5c7f282f655d3927aee2d364fb9385))
 
 ## <small>2.0.16 (2020-07-12)</small>
 
-* [bitnami/all] Add categories (#3075) ([63bde06](https://github.com/bitnami/charts/commit/63bde06)), closes [#3075](https://github.com/bitnami/charts/issues/3075)
-* [bitnami/tensorflow-resnet] Release 2.0.16 updating components versions ([931ca4b](https://github.com/bitnami/charts/commit/931ca4b))
+* [bitnami/all] Add categories (#3075) ([63bde06](https://github.com/bitnami/charts/commit/63bde066b87a140fab52264d0522401ab3d63509)), closes [#3075](https://github.com/bitnami/charts/issues/3075)
+* [bitnami/tensorflow-resnet] Release 2.0.16 updating components versions ([931ca4b](https://github.com/bitnami/charts/commit/931ca4ba2d569a72969691ee04f8f37b0d585502))
 
 ## <small>2.0.15 (2020-06-12)</small>
 
-* [bitnami/tensorflow-resnet] Release 2.0.15 updating components versions ([0cf8094](https://github.com/bitnami/charts/commit/0cf8094))
-* Add support for helm lint and helm install in PRs via GH Actions (#2721) ([5ed97f0](https://github.com/bitnami/charts/commit/5ed97f0)), closes [#2721](https://github.com/bitnami/charts/issues/2721)
+* [bitnami/tensorflow-resnet] Release 2.0.15 updating components versions ([0cf8094](https://github.com/bitnami/charts/commit/0cf8094d68e6a1179678b32ec12441a2fbdeab67))
+* Add support for helm lint and helm install in PRs via GH Actions (#2721) ([5ed97f0](https://github.com/bitnami/charts/commit/5ed97f0c1ab49e7c7c3af81b888f41f50a7cfbab)), closes [#2721](https://github.com/bitnami/charts/issues/2721)
 
 ## <small>2.0.14 (2020-05-22)</small>
 
-* [bitnami/tensorflow-resnet] Release 2.0.14 updating components versions ([e28d8bd](https://github.com/bitnami/charts/commit/e28d8bd))
-* update bitnami/common to be compatible with helm v2.12+ (#2615) ([c7751eb](https://github.com/bitnami/charts/commit/c7751eb)), closes [#2615](https://github.com/bitnami/charts/issues/2615)
+* [bitnami/tensorflow-resnet] Release 2.0.14 updating components versions ([e28d8bd](https://github.com/bitnami/charts/commit/e28d8bd6883587d9153a7fd706289b1482e0f53d))
+* update bitnami/common to be compatible with helm v2.12+ (#2615) ([c7751eb](https://github.com/bitnami/charts/commit/c7751eb5764e468e1854b58a1b8491d2b13e0a4a)), closes [#2615](https://github.com/bitnami/charts/issues/2615)
 
 ## <small>2.0.13 (2020-04-22)</small>
 
-* [bitnami/tensorflow-resnet] Release 2.0.13 updating components versions ([b4c761f](https://github.com/bitnami/charts/commit/b4c761f))
+* [bitnami/tensorflow-resnet] Release 2.0.13 updating components versions ([b4c761f](https://github.com/bitnami/charts/commit/b4c761fcedc1c37464194c43cd2287cbbf2570fe))
 
 ## <small>2.0.12 (2020-04-16)</small>
 
-* [bitnami/tensorflow-resnet] Release 2.0.12 updating components versions ([beeff1f](https://github.com/bitnami/charts/commit/beeff1f))
+* [bitnami/tensorflow-resnet] Release 2.0.12 updating components versions ([beeff1f](https://github.com/bitnami/charts/commit/beeff1f01644660c64a4e4f2611b8fc5f4b1c670))
 
 ## <small>2.0.11 (2020-03-26)</small>
 
-* [bitnami/tensorflow-resnet] Release 2.0.11 updating components versions ([9b14859](https://github.com/bitnami/charts/commit/9b14859))
+* [bitnami/tensorflow-resnet] Release 2.0.11 updating components versions ([9b14859](https://github.com/bitnami/charts/commit/9b148593ad33b56cef3f7ff76b6ff99c25d2799e))
 
 ## <small>2.0.10 (2020-03-20)</small>
 
-* [bitnami/tensorflow-resnet] Release 2.0.10 updating components versions ([d4d294e](https://github.com/bitnami/charts/commit/d4d294e))
+* [bitnami/tensorflow-resnet] Release 2.0.10 updating components versions ([d4d294e](https://github.com/bitnami/charts/commit/d4d294edbe78ca9b902f8fc0447d56c5036926b6))
 
 ## <small>2.0.9 (2020-03-12)</small>
 
-* [bitnami/tensorflow-resnet] Release 2.0.9 updating components versions ([fd04ef5](https://github.com/bitnami/charts/commit/fd04ef5))
+* [bitnami/tensorflow-resnet] Release 2.0.9 updating components versions ([fd04ef5](https://github.com/bitnami/charts/commit/fd04ef5f66813293a0123737b46b689fa83b6aad))
 
 ## <small>2.0.8 (2020-03-11)</small>
 
-* Move charts from upstreamed folder to bitnami (#2032) ([a0e44f7](https://github.com/bitnami/charts/commit/a0e44f7)), closes [#2032](https://github.com/bitnami/charts/issues/2032)
+* Move charts from upstreamed folder to bitnami (#2032) ([a0e44f7](https://github.com/bitnami/charts/commit/a0e44f7d6a10b8b5643186130ea420887cb72c7c)), closes [#2032](https://github.com/bitnami/charts/issues/2032)
 
 ## <small>2.0.7 (2020-02-27)</small>
 
-* [bitnami/tensorflow-resnet] Release 2.0.7 updating components versions ([0bc6f6a](https://github.com/bitnami/charts/commit/0bc6f6a))
+* [bitnami/tensorflow-resnet] Release 2.0.7 updating components versions ([0bc6f6a](https://github.com/bitnami/charts/commit/0bc6f6a420fc71e3ae48e8595c76cae57e018a52))
 
 ## <small>2.0.6 (2020-02-26)</small>
 
-* [bitnami/tensorflow-resnet] Release 2.0.6 updating components versions ([ae26675](https://github.com/bitnami/charts/commit/ae26675))
+* [bitnami/tensorflow-resnet] Release 2.0.6 updating components versions ([ae26675](https://github.com/bitnami/charts/commit/ae2667599d734c40d6014b93b144ffb251998418))
 
 ## <small>2.0.5 (2020-02-20)</small>
 
-* [bitnami/tensorflow-resnet] Release 2.0.5 updating components versions ([3d6265c](https://github.com/bitnami/charts/commit/3d6265c))
+* [bitnami/tensorflow-resnet] Release 2.0.5 updating components versions ([3d6265c](https://github.com/bitnami/charts/commit/3d6265c8c063f8b219498f9fef5bc3a5ad484c6a))
 
 ## <small>2.0.4 (2020-02-11)</small>
 
-* [bitnami/several] Adapt READMEs and helpers to Helm 3 (#1911) ([40ee57c](https://github.com/bitnami/charts/commit/40ee57c)), closes [#1911](https://github.com/bitnami/charts/issues/1911)
+* [bitnami/several] Adapt READMEs and helpers to Helm 3 (#1911) ([40ee57c](https://github.com/bitnami/charts/commit/40ee57cf5164717357e1627b55bf25f59c40fbd1)), closes [#1911](https://github.com/bitnami/charts/issues/1911)
 
 ## <small>2.0.3 (2020-01-16)</small>
 
-* [bitnami/tensorflow-resnet] Release 2.0.3 updating components versions ([946f866](https://github.com/bitnami/charts/commit/946f866))
+* [bitnami/tensorflow-resnet] Release 2.0.3 updating components versions ([946f866](https://github.com/bitnami/charts/commit/946f86641af2dbae76be5ea8a779a8543fc0cefa))
 
 ## <small>2.0.2 (2020-01-14)</small>
 
-* [bitnami/tensorflow-resnet] Release 2.0.2 updating components versions ([daf72df](https://github.com/bitnami/charts/commit/daf72df))
+* [bitnami/tensorflow-resnet] Release 2.0.2 updating components versions ([daf72df](https://github.com/bitnami/charts/commit/daf72dfe33a88e4e54fda9316cd890d92a8314b3))
 
 ## <small>2.0.1 (2020-01-10)</small>
 
-* [bitnami/tensorflow-resnet] Release 2.0.1 updating components versions ([1584ad7](https://github.com/bitnami/charts/commit/1584ad7))
-* [bitnami/tensorflow-resnet] Update components versions ([16ff628](https://github.com/bitnami/charts/commit/16ff628))
+* [bitnami/tensorflow-resnet] Release 2.0.1 updating components versions ([1584ad7](https://github.com/bitnami/charts/commit/1584ad75fe972ffc0bc9fec7d31a8219a8854ea3))
+* [bitnami/tensorflow-resnet] Update components versions ([16ff628](https://github.com/bitnami/charts/commit/16ff6287933e3e34481a3c8cda66a87ba4875166))
 
 ## 2.0.0 (2019-11-27)
 
-* [bitnami/tensorflow-resnet] Lint chart + standardisation ([6e89ea0](https://github.com/bitnami/charts/commit/6e89ea0))
+* [bitnami/tensorflow-resnet] Lint chart + standardisation ([6e89ea0](https://github.com/bitnami/charts/commit/6e89ea01431cf8850f3327d1a260fa5a18e94131))
 
 ## <small>1.2.14 (2019-11-13)</small>
 
-* [bitnami/tensorflow-resnet] Release 1.2.14 updating components versions ([27a2d07](https://github.com/bitnami/charts/commit/27a2d07))
+* [bitnami/tensorflow-resnet] Release 1.2.14 updating components versions ([27a2d07](https://github.com/bitnami/charts/commit/27a2d073b7e8ab6e8737aa8fdb1c5c02fd9df3d2))
 
 ## <small>1.2.13 (2019-11-11)</small>
 
-* [bitnami/tensorflow-resnet] Release 1.2.13 updating components versions ([2fead46](https://github.com/bitnami/charts/commit/2fead46))
+* [bitnami/tensorflow-resnet] Release 1.2.13 updating components versions ([2fead46](https://github.com/bitnami/charts/commit/2fead467d169c5f736b8a9d103253e813f0c4360))
 
 ## <small>1.2.12 (2019-11-10)</small>
 
-* [bitnami/tensorflow-resnet] Release 1.2.12 updating components versions ([60c7f2e](https://github.com/bitnami/charts/commit/60c7f2e))
+* [bitnami/tensorflow-resnet] Release 1.2.12 updating components versions ([60c7f2e](https://github.com/bitnami/charts/commit/60c7f2ecaf91ee609c025bb99bab8b43ce346391))
 
 ## <small>1.2.11 (2019-11-09)</small>
 
-* [bitnami/tensorflow-resnet] Release 1.2.11 updating components versions ([8bd72d0](https://github.com/bitnami/charts/commit/8bd72d0))
+* [bitnami/tensorflow-resnet] Release 1.2.11 updating components versions ([8bd72d0](https://github.com/bitnami/charts/commit/8bd72d0e04d6e2ee59158e799381d74fee7914a5))
 
 ## <small>1.2.10 (2019-11-07)</small>
 
-* [bitnami/tensorflow-resnet] Release 1.2.10 updating components versions ([5006e8c](https://github.com/bitnami/charts/commit/5006e8c))
+* [bitnami/tensorflow-resnet] Release 1.2.10 updating components versions ([5006e8c](https://github.com/bitnami/charts/commit/5006e8ca32939c0fe0cf988ff338de5ec4971317))
 
 ## <small>1.2.9 (2019-11-06)</small>
 
-* [bitnami/tensorflow-resnet] Release 1.2.9 updating components versions ([8dfff8a](https://github.com/bitnami/charts/commit/8dfff8a))
+* [bitnami/tensorflow-resnet] Release 1.2.9 updating components versions ([8dfff8a](https://github.com/bitnami/charts/commit/8dfff8a60482934119ef080619702371c444f593))
 
 ## <small>1.2.8 (2019-11-05)</small>
 
-* [bitnami/tensorflow-resnet] Release 1.2.8 updating components versions ([ae780f8](https://github.com/bitnami/charts/commit/ae780f8))
+* [bitnami/tensorflow-resnet] Release 1.2.8 updating components versions ([ae780f8](https://github.com/bitnami/charts/commit/ae780f8cf2187f4e039e95e65b37e82d33ed2ab3))
 
 ## <small>1.2.7 (2019-11-04)</small>
 
-* [bitnami/tensorflow-resnet] Release 1.2.7 updating components versions ([5bac3bf](https://github.com/bitnami/charts/commit/5bac3bf))
+* [bitnami/tensorflow-resnet] Release 1.2.7 updating components versions ([5bac3bf](https://github.com/bitnami/charts/commit/5bac3bf37bff9745273a1b03c027ac4aa34afc79))
 
 ## <small>1.2.6 (2019-10-24)</small>
 
-* Fix links because of section renaming ([8e6fa3b](https://github.com/bitnami/charts/commit/8e6fa3b))
+* Fix links because of section renaming ([8e6fa3b](https://github.com/bitnami/charts/commit/8e6fa3bf7e3198954b6af507cf143fd4870c1c33))
 
 ## <small>1.2.5 (2019-10-23)</small>
 
-* Adapt README in charts (III) ([98eadc4](https://github.com/bitnami/charts/commit/98eadc4))
+* Adapt README in charts (III) ([98eadc4](https://github.com/bitnami/charts/commit/98eadc4fd0578e60f966a66c12d531d722ec6435))
 
 ## <small>1.2.4 (2019-10-15)</small>
 
-* [bitnami/tensorflow-resnet] Update prerequisites ([3048967](https://github.com/bitnami/charts/commit/3048967))
+* [bitnami/tensorflow-resnet] Update prerequisites ([3048967](https://github.com/bitnami/charts/commit/304896759f2854fd3df9b78c6dc4928aeaf01415))
 
 ## <small>1.2.3 (2019-10-05)</small>
 
-* [bitnami/tensorflow-resnet] Release 1.2.3 updating components versions ([f503557](https://github.com/bitnami/charts/commit/f503557))
+* [bitnami/tensorflow-resnet] Release 1.2.3 updating components versions ([f503557](https://github.com/bitnami/charts/commit/f503557d81cddf98df22a5b7c3e269d8b12609eb))
 
 ## <small>1.2.2 (2019-09-20)</small>
 
-* [bitnami/*] Update apiVersion on sts, deployments, daemonsets and podsecuritypolicies ([4dfac07](https://github.com/bitnami/charts/commit/4dfac07))
+* [bitnami/*] Update apiVersion on sts, deployments, daemonsets and podsecuritypolicies ([4dfac07](https://github.com/bitnami/charts/commit/4dfac075aacf74405e31ae5b27df4369e84eb0b0))
 
 ## <small>1.2.1 (2019-09-05)</small>
 
-* [bitnami/tensorflow-resnet] Release 1.2.1 updating components versions ([e8c82d0](https://github.com/bitnami/charts/commit/e8c82d0))
+* [bitnami/tensorflow-resnet] Release 1.2.1 updating components versions ([e8c82d0](https://github.com/bitnami/charts/commit/e8c82d027cda27a18c25a73afecc53b1bc1d58f6))
 
 ## 1.2.0 (2019-09-04)
 
-* Bump minor version ([10f1738](https://github.com/bitnami/charts/commit/10f1738))
+* Bump minor version ([10f1738](https://github.com/bitnami/charts/commit/10f173888cd7001e8e7b857b30d80fd58de48b48))
 
 ## <small>1.1.2 (2019-09-04)</small>
 
-* Add affinity to tensorflow-resnet ([1cecb50](https://github.com/bitnami/charts/commit/1cecb50))
+* Add affinity to tensorflow-resnet ([1cecb50](https://github.com/bitnami/charts/commit/1cecb50e351e739626c970a142b626464144ace3))
 
 ## <small>1.1.1 (2019-09-02)</small>
 
-* [bitnami/tensorflow-resnet] Release 1.1.1 updating components versions ([bccccfc](https://github.com/bitnami/charts/commit/bccccfc))
-* Add env-var if metrics enabled only ([e5d52bb](https://github.com/bitnami/charts/commit/e5d52bb))
-* Fix port definitions ([e564367](https://github.com/bitnami/charts/commit/e564367))
-* Update serving image ([e124c42](https://github.com/bitnami/charts/commit/e124c42))
+* [bitnami/tensorflow-resnet] Release 1.1.1 updating components versions ([bccccfc](https://github.com/bitnami/charts/commit/bccccfcb7303d4cd4402c62bea2a7a93b134c950))
+* Add env-var if metrics enabled only ([e5d52bb](https://github.com/bitnami/charts/commit/e5d52bb5c8f1ecdb9e9f366f1ff664355d4140df))
+* Fix port definitions ([e564367](https://github.com/bitnami/charts/commit/e564367212bf80e28ba63a31deb26513fa2084e9))
+* Update serving image ([e124c42](https://github.com/bitnami/charts/commit/e124c42a0c8d6a1a6b78bb457fa9cd1142959832))
 
 ## 1.1.0 (2019-08-14)
 
-* [bitnami/tensorflow-resnet] Enable Rest API and configure metrics ([30cf08d](https://github.com/bitnami/charts/commit/30cf08d))
+* [bitnami/tensorflow-resnet] Enable Rest API and configure metrics ([30cf08d](https://github.com/bitnami/charts/commit/30cf08dc9af2e3414039d6d7b01b44a0e9f1c688))
 
 ## <small>1.0.2 (2019-08-13)</small>
 
-* Update README.md ([d0e7aaf](https://github.com/bitnami/charts/commit/d0e7aaf))
-* Updated version numbers ([aa0294b](https://github.com/bitnami/charts/commit/aa0294b))
+* Update README.md ([d0e7aaf](https://github.com/bitnami/charts/commit/d0e7aaf9ad6aa5511dc2844285ad2232a45cd591))
+* Updated version numbers ([aa0294b](https://github.com/bitnami/charts/commit/aa0294b246340ed44d76f8cac59338ee685fab5e))
 
 ## <small>1.0.1 (2019-07-30)</small>
 
-* [bitnami/tensorflow-resnet] Change container name to tensorflow-serving ([44f83fd](https://github.com/bitnami/charts/commit/44f83fd))
+* [bitnami/tensorflow-resnet] Change container name to tensorflow-serving ([44f83fd](https://github.com/bitnami/charts/commit/44f83fd6085cf3656137b0d8fc0d5fe29670c9cb))
 
 ## 1.0.0 (2019-07-17)
 
-* Implement again #1283 changes but bumping the major version ([1ce079c](https://github.com/bitnami/charts/commit/1ce079c)), closes [#1283](https://github.com/bitnami/charts/issues/1283)
+* Implement again #1283 changes but bumping the major version ([1ce079c](https://github.com/bitnami/charts/commit/1ce079c789a6c0f5174094af3ea6fb67b6c926fd)), closes [#1283](https://github.com/bitnami/charts/issues/1283)
 
 ## <small>0.1.9 (2019-07-17)</small>
 
-* Revert pull request #1283 ([8e5940a](https://github.com/bitnami/charts/commit/8e5940a)), closes [#1283](https://github.com/bitnami/charts/issues/1283)
+* Revert pull request #1283 ([8e5940a](https://github.com/bitnami/charts/commit/8e5940a9260dc722ae1a630a6b6e21df2502323f)), closes [#1283](https://github.com/bitnami/charts/issues/1283)
 
 ## <small>0.1.8 (2019-07-11)</small>
 
-* Standardize component.name & component.fullname functions ([775948e](https://github.com/bitnami/charts/commit/775948e))
+* Standardize component.name & component.fullname functions ([775948e](https://github.com/bitnami/charts/commit/775948eb27ccc5599262002b71f4982cc2b2dc8d))
 
 ## <small>0.1.7 (2019-07-10)</small>
 
-* [bitnami/tensorflow-resnet] Release 0.1.7 updating components versions ([0c624ec](https://github.com/bitnami/charts/commit/0c624ec))
+* [bitnami/tensorflow-resnet] Release 0.1.7 updating components versions ([0c624ec](https://github.com/bitnami/charts/commit/0c624ecd314dc2d46ffc23e9a52de5f660e25171))
 
 ## <small>0.1.6 (2019-06-10)</small>
 
-* Changes in README ([7ac4ec0](https://github.com/bitnami/charts/commit/7ac4ec0))
+* Changes in README ([7ac4ec0](https://github.com/bitnami/charts/commit/7ac4ec09a0113aae7d39173f52fb11c55f27cde5))
 
 ## <small>0.1.5 (2019-06-10)</small>
 
-* bitnami/tensorflow-resnet: update to 1.13.0 ([5a9fbb6](https://github.com/bitnami/charts/commit/5a9fbb6))
+* bitnami/tensorflow-resnet: update to 1.13.0 ([5a9fbb6](https://github.com/bitnami/charts/commit/5a9fbb6c7d2d6dd261541e9190f2840873ae4962))
 
 ## <small>0.1.4 (2019-05-29)</small>
 
-* Check secondary images ([5327cfa](https://github.com/bitnami/charts/commit/5327cfa))
-* Fix https://github.com/helm/charts/pull/14199\#issuecomment-496883321 and support _sha256_ as an imm ([95957ea](https://github.com/bitnami/charts/commit/95957ea)), closes [#issuecomment-496883321](https://github.com/bitnami/charts/issues/issuecomment-496883321)
-* Fix tensorflow and others ([6252f12](https://github.com/bitnami/charts/commit/6252f12))
-* Use immutable tags in the main images ([17ca4f5](https://github.com/bitnami/charts/commit/17ca4f5))
+* Check secondary images ([5327cfa](https://github.com/bitnami/charts/commit/5327cfa319191dd8067ce538d53f4c44edfdc012))
+* Fix https://github.com/helm/charts/pull/14199\#issuecomment-496883321 and support _sha256_ as an imm ([95957ea](https://github.com/bitnami/charts/commit/95957ea6430f28ec3593053afb0bfccb75703c79)), closes [#issuecomment-496883321](https://github.com/bitnami/charts/issues/issuecomment-496883321)
+* Fix tensorflow and others ([6252f12](https://github.com/bitnami/charts/commit/6252f125d307e55fd638687eac09f1df8451f22f))
+* Use immutable tags in the main images ([17ca4f5](https://github.com/bitnami/charts/commit/17ca4f5c91da33da03f9e2d411fe5e004e825c4d))
 
 ## <small>0.1.3 (2019-05-28)</small>
 
-* Prepare immutable tags ([f9093c1](https://github.com/bitnami/charts/commit/f9093c1))
+* Prepare immutable tags ([f9093c1](https://github.com/bitnami/charts/commit/f9093c1aaa9cde25a042c3d62f7873385447cbf7))
 
 ## <small>0.1.2 (2019-03-14)</small>
 
-* Update Chart.yaml ([4884aba](https://github.com/bitnami/charts/commit/4884aba))
-* Use global registry in secondary, metrics and other non-default images ([5d216bf](https://github.com/bitnami/charts/commit/5d216bf))
-* Use namespaces ([8c80056](https://github.com/bitnami/charts/commit/8c80056))
+* Update Chart.yaml ([4884aba](https://github.com/bitnami/charts/commit/4884aba4b5a80a2b10b5a6e5d43d6022d2d47d19))
+* Use global registry in secondary, metrics and other non-default images ([5d216bf](https://github.com/bitnami/charts/commit/5d216bfea23f62aae825e733a9e37e936f14c310))
+* Use namespaces ([8c80056](https://github.com/bitnami/charts/commit/8c80056d5526875b7b350128de0f8fb6e8e3bfa2))
 
 ## <small>0.1.1 (2019-03-14)</small>
 
-* bitnami/tensorflow-resnet: update to 1.13.0 ([d30adc3](https://github.com/bitnami/charts/commit/d30adc3))
-* Fix typo ([76e0d39](https://github.com/bitnami/charts/commit/76e0d39))
-* Fix typo in helpers ([081e077](https://github.com/bitnami/charts/commit/081e077))
-* Use server and client values ([1476cd6](https://github.com/bitnami/charts/commit/1476cd6))
+* bitnami/tensorflow-resnet: update to 1.13.0 ([d30adc3](https://github.com/bitnami/charts/commit/d30adc3c222494ba557a9ba2cbe58d3762f90bb5))
+* Fix typo ([76e0d39](https://github.com/bitnami/charts/commit/76e0d39898eed996a7a92eef3ec871b68e077f0c))
+* Fix typo in helpers ([081e077](https://github.com/bitnami/charts/commit/081e077ec7901751b3b953b33731c5ef22148b6f))
+* Use server and client values ([1476cd6](https://github.com/bitnami/charts/commit/1476cd6bd6432fa63205bd4baef49f6a202a0cc8))
 
 ## 0.1.0 (2019-03-11)
 
-* [bitnami/tensorflow-resnet] Add global imagePullSecrets to overwrite any other existing one ([65df076](https://github.com/bitnami/charts/commit/65df076))
+* [bitnami/tensorflow-resnet] Add global imagePullSecrets to overwrite any other existing one ([65df076](https://github.com/bitnami/charts/commit/65df076ea9ef62ada1e178168400b9b683fa72e8))
 
 ## <small>0.0.5 (2019-02-27)</small>
 
-* Add appiVersion to Chart.yaml ([08704a5](https://github.com/bitnami/charts/commit/08704a5))
+* Add appiVersion to Chart.yaml ([08704a5](https://github.com/bitnami/charts/commit/08704a55fa287f8da2e680344163b65863959329))
 
 ## <small>0.0.4 (2019-02-21)</small>
 
-* Update Chart.yaml ([0e49b12](https://github.com/bitnami/charts/commit/0e49b12))
-* Update README.md ([a1cb686](https://github.com/bitnami/charts/commit/a1cb686))
+* Update Chart.yaml ([0e49b12](https://github.com/bitnami/charts/commit/0e49b1233f6cdf2558c78c05889929435fa8f620))
+* Update README.md ([a1cb686](https://github.com/bitnami/charts/commit/a1cb686781ddae72add8c5943973de12211440de))
 
 ## <small>0.0.3 (2019-01-25)</small>
 
-* Add source ([0b0da5a](https://github.com/bitnami/charts/commit/0b0da5a))
-* Document the correct format for pullSecrets in READMEs ([9a2cf81](https://github.com/bitnami/charts/commit/9a2cf81))
-* Update Chart.yaml ([3ece412](https://github.com/bitnami/charts/commit/3ece412))
+* Add source ([0b0da5a](https://github.com/bitnami/charts/commit/0b0da5a5759278be1e24eacf4a34fc4edba452bd))
+* Document the correct format for pullSecrets in READMEs ([9a2cf81](https://github.com/bitnami/charts/commit/9a2cf81399905b7b3190bbc35a8d554f94014ce8))
+* Update Chart.yaml ([3ece412](https://github.com/bitnami/charts/commit/3ece412a6e49a10c2acff151562e451ec5e7d9dc))
 
 ## <small>0.0.2 (2018-12-31)</small>
 
-* [bitnami/tensorflow-resnet] Add icon and change URL ([ca958a3](https://github.com/bitnami/charts/commit/ca958a3))
-* Implemented Juan's suggested changes ([5c22212](https://github.com/bitnami/charts/commit/5c22212))
+* [bitnami/tensorflow-resnet] Add icon and change URL ([ca958a3](https://github.com/bitnami/charts/commit/ca958a370401985fd40cc8951633a7a1d2158f66))
+* Implemented Juan's suggested changes ([5c22212](https://github.com/bitnami/charts/commit/5c2221227d47bbb82091c528c4e09f9b039013d9))
 
 ## <small>0.0.1 (2018-11-29)</small>
 
-* Add new TensorFlow ResNet helm chart ([067e70d](https://github.com/bitnami/charts/commit/067e70d))
-* Fix chart metadata ([4165112](https://github.com/bitnami/charts/commit/4165112))
+* Add new TensorFlow ResNet helm chart ([067e70d](https://github.com/bitnami/charts/commit/067e70d558867bd23d0877d29333f215c03ca78e))
+* Fix chart metadata ([4165112](https://github.com/bitnami/charts/commit/416511276310a8f8763c1e2b84644e9df6787d7b))

--- a/bitnami/tensorflow-resnet/Chart.yaml
+++ b/bitnami/tensorflow-resnet/Chart.yaml
@@ -33,4 +33,4 @@ maintainers:
 name: tensorflow-resnet
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/tensorflow-resnet
-version: 4.1.0
+version: 4.1.1

--- a/bitnami/tensorflow-resnet/templates/deployment.yaml
+++ b/bitnami/tensorflow-resnet/templates/deployment.yaml
@@ -147,8 +147,10 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.livenessProbe "enabled") "context" $) | nindent 12 }}
-            tcpSocket:
-              port: tf-serving
+            exec:
+              command:
+                - pgrep
+                - tensorflow
           {{- end }}
           {{- if .Values.customReadinessProbe }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customReadinessProbe "context" $) | nindent 12 }}


### PR DESCRIPTION
### Description of the change
This PR aims to use different liveness/readiness probes to improve overall security and avoid unnecessary container restarts. [More info](https://github.com/zegl/kube-score/blob/master/README_PROBES.md).

### Benefits

Increase availability and resilience.

### Possible drawbacks

N/A

### Applicable issues

- fixes #

### Additional information

- Related to #23537

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- ~[X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)~
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
