### PR TITLE
[bitnami/jupyterhub] Use different liveness/readiness probes

### DIFF
--- a/bitnami/jupyterhub/CHANGELOG.md
+++ b/bitnami/jupyterhub/CHANGELOG.md
@@ -1,764 +1,769 @@
 # Changelog
 
+## 7.1.1 (2024-05-22)
+
+* [bitnami/jupyterhub] Use different liveness/readiness probes ([#26348](https://github.com/bitnami/charts/pull/26348))
+
 ## 7.1.0 (2024-05-21)
 
-* [bitnami/jupyterhub] feat: :sparkles: :lock: Add warning when original images are replaced ([#26223](https://github.com/bitnami/charts/pulls/26223))
+* [bitnami/*] ci: :construction_worker: Add tag and changelog support (#25359) ([91c707c](https://github.com/bitnami/charts/commit/91c707c9e4e574725a09505d2d313fb93f1b4c0a)), closes [#25359](https://github.com/bitnami/charts/issues/25359)
+* [bitnami/jupyterhub] feat: :sparkles: :lock: Add warning when original images are replaced (#26223) ([5669ec1](https://github.com/bitnami/charts/commit/5669ec1cd2a9a24fc9b5ea80da139c7bb23869f2)), closes [#26223](https://github.com/bitnami/charts/issues/26223)
 
 ## <small>7.0.5 (2024-05-18)</small>
 
-* [bitnami/jupyterhub] Release 7.0.5 updating components versions (#26029) ([e3d5725](https://github.com/bitnami/charts/commit/e3d5725)), closes [#26029](https://github.com/bitnami/charts/issues/26029)
+* [bitnami/jupyterhub] Release 7.0.5 updating components versions (#26029) ([e3d5725](https://github.com/bitnami/charts/commit/e3d57252dee88266a7ffd9b2abe953d0717c863c)), closes [#26029](https://github.com/bitnami/charts/issues/26029)
 
 ## <small>7.0.4 (2024-05-14)</small>
 
-* [bitnami/*] Change non-root and rolling-tags doc URLs (#25628) ([b067c94](https://github.com/bitnami/charts/commit/b067c94)), closes [#25628](https://github.com/bitnami/charts/issues/25628)
-* [bitnami/*] Set new header/owner (#25558) ([8d1dc11](https://github.com/bitnami/charts/commit/8d1dc11)), closes [#25558](https://github.com/bitnami/charts/issues/25558)
-* [bitnami/jupyterhub] Release 7.0.4 updating components versions (#25774) ([7eddc22](https://github.com/bitnami/charts/commit/7eddc22)), closes [#25774](https://github.com/bitnami/charts/issues/25774)
-* Replace VMware by Broadcom copyright text (#25306) ([a5e4bd0](https://github.com/bitnami/charts/commit/a5e4bd0)), closes [#25306](https://github.com/bitnami/charts/issues/25306)
+* [bitnami/*] Change non-root and rolling-tags doc URLs (#25628) ([b067c94](https://github.com/bitnami/charts/commit/b067c94f6bcde427863c197fd355f0b5ba12ff5b)), closes [#25628](https://github.com/bitnami/charts/issues/25628)
+* [bitnami/*] Set new header/owner (#25558) ([8d1dc11](https://github.com/bitnami/charts/commit/8d1dc11f5fb30db6fba50c43d7af59d2f79deed3)), closes [#25558](https://github.com/bitnami/charts/issues/25558)
+* [bitnami/jupyterhub] Release 7.0.4 updating components versions (#25774) ([7eddc22](https://github.com/bitnami/charts/commit/7eddc22490c0bd084eacd1cbe652a80cce99306b)), closes [#25774](https://github.com/bitnami/charts/issues/25774)
+* Replace VMware by Broadcom copyright text (#25306) ([a5e4bd0](https://github.com/bitnami/charts/commit/a5e4bd0e35e419203793976a78d9d0a13de92c76)), closes [#25306](https://github.com/bitnami/charts/issues/25306)
 
 ## <small>7.0.3 (2024-04-09)</small>
 
-* [bitnami/jupyterhub] Release 7.0.3 updating components versions (#25065) ([8df2b07](https://github.com/bitnami/charts/commit/8df2b07)), closes [#25065](https://github.com/bitnami/charts/issues/25065)
+* [bitnami/jupyterhub] Release 7.0.3 updating components versions (#25065) ([8df2b07](https://github.com/bitnami/charts/commit/8df2b07519ffe8fc4990ec334610e7d3777e0a17)), closes [#25065](https://github.com/bitnami/charts/issues/25065)
 
 ## <small>7.0.2 (2024-04-05)</small>
 
-* [bitnami/jupyterhub] Release 7.0.2 updating components versions (#24982) ([2f8627a](https://github.com/bitnami/charts/commit/2f8627a)), closes [#24982](https://github.com/bitnami/charts/issues/24982)
+* [bitnami/jupyterhub] Release 7.0.2 updating components versions (#24982) ([2f8627a](https://github.com/bitnami/charts/commit/2f8627afd1354e7f70d0655dcdb3b7c8542349ea)), closes [#24982](https://github.com/bitnami/charts/issues/24982)
 
 ## <small>7.0.1 (2024-04-05)</small>
 
-* [bitnami/jupyterhub] Release 7.0.1 (#24919) ([9dd53c5](https://github.com/bitnami/charts/commit/9dd53c5)), closes [#24919](https://github.com/bitnami/charts/issues/24919)
+* [bitnami/jupyterhub] Release 7.0.1 (#24919) ([9dd53c5](https://github.com/bitnami/charts/commit/9dd53c51e04a398cb013a634275c54f1a7d1b24d)), closes [#24919](https://github.com/bitnami/charts/issues/24919)
 
 ## 7.0.0 (2024-04-03)
 
-* [bitnami/jupyterhub] feat!: :lock: :boom: Improve security defaults (#24656) ([77560c4](https://github.com/bitnami/charts/commit/77560c4)), closes [#24656](https://github.com/bitnami/charts/issues/24656)
-* Update resourcesPreset comments (#24467) ([92e3e8a](https://github.com/bitnami/charts/commit/92e3e8a)), closes [#24467](https://github.com/bitnami/charts/issues/24467)
+* [bitnami/jupyterhub] feat!: :lock: :boom: Improve security defaults (#24656) ([77560c4](https://github.com/bitnami/charts/commit/77560c4f172e210bff37861c40d90719c58e719d)), closes [#24656](https://github.com/bitnami/charts/issues/24656)
+* Update resourcesPreset comments (#24467) ([92e3e8a](https://github.com/bitnami/charts/commit/92e3e8a507326d2a20a8f10ab3e7746a2ec5c554)), closes [#24467](https://github.com/bitnami/charts/issues/24467)
 
 ## <small>6.1.4 (2024-03-30)</small>
 
-* [bitnami/jupyterhub] Release 6.1.4 updating components versions (#24754) ([c164a5f](https://github.com/bitnami/charts/commit/c164a5f)), closes [#24754](https://github.com/bitnami/charts/issues/24754)
+* [bitnami/jupyterhub] Release 6.1.4 updating components versions (#24754) ([c164a5f](https://github.com/bitnami/charts/commit/c164a5ff193fe56dc541abaaf55b2b51c08c7626)), closes [#24754](https://github.com/bitnami/charts/issues/24754)
 
 ## <small>6.1.3 (2024-03-26)</small>
 
-* [bitnami/jupyterhub] Release 6.1.3 updating components versions (#24681) ([2c72512](https://github.com/bitnami/charts/commit/2c72512)), closes [#24681](https://github.com/bitnami/charts/issues/24681)
+* [bitnami/jupyterhub] Release 6.1.3 updating components versions (#24681) ([2c72512](https://github.com/bitnami/charts/commit/2c72512a246a16874ed6063c32db2824ae784b32)), closes [#24681](https://github.com/bitnami/charts/issues/24681)
 
 ## <small>6.1.2 (2024-03-26)</small>
 
-* [bitnami/jupyterhub] Release 6.1.2 updating components versions (#24662) ([97a7177](https://github.com/bitnami/charts/commit/97a7177)), closes [#24662](https://github.com/bitnami/charts/issues/24662)
+* [bitnami/jupyterhub] Release 6.1.2 updating components versions (#24662) ([97a7177](https://github.com/bitnami/charts/commit/97a7177aa071e6da9843af8ff5a97631d70c2082)), closes [#24662](https://github.com/bitnami/charts/issues/24662)
 
 ## <small>6.1.1 (2024-03-24)</small>
 
-* [bitnami/*] Reorder Chart sections (#24455) ([0cf4048](https://github.com/bitnami/charts/commit/0cf4048)), closes [#24455](https://github.com/bitnami/charts/issues/24455)
-* [bitnami/jupyterhub] Release 6.1.1 updating components versions (#24638) ([d454bfc](https://github.com/bitnami/charts/commit/d454bfc)), closes [#24638](https://github.com/bitnami/charts/issues/24638)
+* [bitnami/*] Reorder Chart sections (#24455) ([0cf4048](https://github.com/bitnami/charts/commit/0cf4048e8743f70a9753d460655bd030cbff6824)), closes [#24455](https://github.com/bitnami/charts/issues/24455)
+* [bitnami/jupyterhub] Release 6.1.1 updating components versions (#24638) ([d454bfc](https://github.com/bitnami/charts/commit/d454bfc7e6193297bbbb4d030701199b5c08b070)), closes [#24638](https://github.com/bitnami/charts/issues/24638)
 
 ## 6.1.0 (2024-03-06)
 
-* [bitnami/jupyterhub] feat: :sparkles: :lock: Add automatic adaptation for Openshift restricted-v2 SC ([aeef6b7](https://github.com/bitnami/charts/commit/aeef6b7)), closes [#24099](https://github.com/bitnami/charts/issues/24099)
+* [bitnami/jupyterhub] feat: :sparkles: :lock: Add automatic adaptation for Openshift restricted-v2 SC ([aeef6b7](https://github.com/bitnami/charts/commit/aeef6b7767dadc6c23774b373eec515061edd16a)), closes [#24099](https://github.com/bitnami/charts/issues/24099)
 
 ## 6.0.0 (2024-03-04)
 
-* [bitnami/jupyterhub] Update bundled PostgreSQL (#24043) ([e4b26d5](https://github.com/bitnami/charts/commit/e4b26d5)), closes [#24043](https://github.com/bitnami/charts/issues/24043)
+* [bitnami/jupyterhub] Update bundled PostgreSQL (#24043) ([e4b26d5](https://github.com/bitnami/charts/commit/e4b26d54b0f5c80d7a06f6ebc06c8b23ca0ad688)), closes [#24043](https://github.com/bitnami/charts/issues/24043)
 
 ## 5.9.0 (2024-02-27)
 
-* [bitnami/jupyterhub] feat: :sparkles: :lock: Add readOnlyRootFilesystem support (#23921) ([25c0e2d](https://github.com/bitnami/charts/commit/25c0e2d)), closes [#23921](https://github.com/bitnami/charts/issues/23921)
+* [bitnami/jupyterhub] feat: :sparkles: :lock: Add readOnlyRootFilesystem support (#23921) ([25c0e2d](https://github.com/bitnami/charts/commit/25c0e2dd2eb62a34151a9db38ee11559456a5d22)), closes [#23921](https://github.com/bitnami/charts/issues/23921)
 
 ## <small>5.8.3 (2024-02-26)</small>
 
-* [bitnami/jupyterhub] Fix global image registry not being respected in jupyterhub configuration (#238 ([0b207d3](https://github.com/bitnami/charts/commit/0b207d3)), closes [#23881](https://github.com/bitnami/charts/issues/23881)
+* [bitnami/jupyterhub] Fix global image registry not being respected in jupyterhub configuration (#238 ([0b207d3](https://github.com/bitnami/charts/commit/0b207d3efba8efea21e1619ca9ca755a301b4bf9)), closes [#23881](https://github.com/bitnami/charts/issues/23881)
 
 ## <small>5.8.2 (2024-02-22)</small>
 
-* [bitnami/jupyterhub] Release 5.8.2 updating components versions (#23788) ([26b6b6c](https://github.com/bitnami/charts/commit/26b6b6c)), closes [#23788](https://github.com/bitnami/charts/issues/23788)
+* [bitnami/jupyterhub] Release 5.8.2 updating components versions (#23788) ([26b6b6c](https://github.com/bitnami/charts/commit/26b6b6c598de347b3cf4bcc15c84d93fa976b9a4)), closes [#23788](https://github.com/bitnami/charts/issues/23788)
 
 ## <small>5.8.1 (2024-02-21)</small>
 
-* [bitnami/jupyterhub] Release 5.8.1 updating components versions (#23708) ([4a3e350](https://github.com/bitnami/charts/commit/4a3e350)), closes [#23708](https://github.com/bitnami/charts/issues/23708)
+* [bitnami/jupyterhub] Release 5.8.1 updating components versions (#23708) ([4a3e350](https://github.com/bitnami/charts/commit/4a3e3507afe9369fc9a59c6c34d47e9a327c30b3)), closes [#23708](https://github.com/bitnami/charts/issues/23708)
 
 ## 5.8.0 (2024-02-20)
 
-* [bitnami/*] Bump all versions (#23602) ([b70ee2a](https://github.com/bitnami/charts/commit/b70ee2a)), closes [#23602](https://github.com/bitnami/charts/issues/23602)
+* [bitnami/*] Bump all versions (#23602) ([b70ee2a](https://github.com/bitnami/charts/commit/b70ee2a30e4dc256bf0ac52928fb2fa7a70f049b)), closes [#23602](https://github.com/bitnami/charts/issues/23602)
 
 ## 5.7.0 (2024-02-16)
 
-* [bitnami/jupyterhub] feat: :sparkles: :lock: Add resource preset support (#23467) ([9c08219](https://github.com/bitnami/charts/commit/9c08219)), closes [#23467](https://github.com/bitnami/charts/issues/23467)
+* [bitnami/jupyterhub] feat: :sparkles: :lock: Add resource preset support (#23467) ([9c08219](https://github.com/bitnami/charts/commit/9c08219d78d27cab32385a96ae848f97903e4279)), closes [#23467](https://github.com/bitnami/charts/issues/23467)
 
 ## <small>5.6.5 (2024-02-08)</small>
 
-* [bitnami/jupyterhub] Fix securityContext in Openshift clusters (#23330) ([3369cf8](https://github.com/bitnami/charts/commit/3369cf8)), closes [#23330](https://github.com/bitnami/charts/issues/23330)
+* [bitnami/jupyterhub] Fix securityContext in Openshift clusters (#23330) ([3369cf8](https://github.com/bitnami/charts/commit/3369cf8312eca3a83e4954cf9d5b3e787e9c1c93)), closes [#23330](https://github.com/bitnami/charts/issues/23330)
 
 ## <small>5.6.4 (2024-02-02)</small>
 
-* [bitnami/jupyterhub] Release 5.6.4 updating components versions (#23086) ([0a896a9](https://github.com/bitnami/charts/commit/0a896a9)), closes [#23086](https://github.com/bitnami/charts/issues/23086)
+* [bitnami/jupyterhub] Release 5.6.4 updating components versions (#23086) ([0a896a9](https://github.com/bitnami/charts/commit/0a896a96819325504cbc359a1a87db9953f4ae7a)), closes [#23086](https://github.com/bitnami/charts/issues/23086)
 
 ## <small>5.6.3 (2024-01-31)</small>
 
-* [bitnami/jupyterhub] Bump chart version (#22974) ([7b75c7d](https://github.com/bitnami/charts/commit/7b75c7d)), closes [#22974](https://github.com/bitnami/charts/issues/22974)
-* Fixed jupyterhub external database config gen (#22735) ([df7972b](https://github.com/bitnami/charts/commit/df7972b)), closes [#22735](https://github.com/bitnami/charts/issues/22735)
+* [bitnami/jupyterhub] Bump chart version (#22974) ([7b75c7d](https://github.com/bitnami/charts/commit/7b75c7db34735a155f36ec49cc63a5416de721ae)), closes [#22974](https://github.com/bitnami/charts/issues/22974)
+* Fixed jupyterhub external database config gen (#22735) ([df7972b](https://github.com/bitnami/charts/commit/df7972b4b7911f5345f26b735696260f1eaf7c9f)), closes [#22735](https://github.com/bitnami/charts/issues/22735)
 
 ## <small>5.6.2 (2024-01-27)</small>
 
-* [bitnami/*] Move documentation sections from docs.bitnami.com back to the README (#22203) ([7564f36](https://github.com/bitnami/charts/commit/7564f36)), closes [#22203](https://github.com/bitnami/charts/issues/22203)
-* [bitnami/jupyterhub] Release 5.6.2 updating components versions (#22799) ([553cb6d](https://github.com/bitnami/charts/commit/553cb6d)), closes [#22799](https://github.com/bitnami/charts/issues/22799)
+* [bitnami/*] Move documentation sections from docs.bitnami.com back to the README (#22203) ([7564f36](https://github.com/bitnami/charts/commit/7564f36ca1e95ff30ee686652b7ab8690561a707)), closes [#22203](https://github.com/bitnami/charts/issues/22203)
+* [bitnami/jupyterhub] Release 5.6.2 updating components versions (#22799) ([553cb6d](https://github.com/bitnami/charts/commit/553cb6d5c3036ab36b2bc21ea6b8eb67f4519167)), closes [#22799](https://github.com/bitnami/charts/issues/22799)
 
 ## <small>5.6.1 (2024-01-24)</small>
 
-* [bitnami/jupyterhub] fix: :bug: Set seLinuxOptions to null for Openshift compatibility (#22604) ([424d287](https://github.com/bitnami/charts/commit/424d287)), closes [#22604](https://github.com/bitnami/charts/issues/22604)
+* [bitnami/jupyterhub] fix: :bug: Set seLinuxOptions to null for Openshift compatibility (#22604) ([424d287](https://github.com/bitnami/charts/commit/424d287eb986fa401ab9b795d01f3f16f62054c6)), closes [#22604](https://github.com/bitnami/charts/issues/22604)
 
 ## 5.6.0 (2024-01-22)
 
-* [bitnami/jupyterhub] fix: :lock: Move service-account token auto-mount to pod declaration (#22414) ([3907f6c](https://github.com/bitnami/charts/commit/3907f6c)), closes [#22414](https://github.com/bitnami/charts/issues/22414)
+* [bitnami/jupyterhub] fix: :lock: Move service-account token auto-mount to pod declaration (#22414) ([3907f6c](https://github.com/bitnami/charts/commit/3907f6c2c6463ce6c1e34d1d1d531687f1d4d62a)), closes [#22414](https://github.com/bitnami/charts/issues/22414)
 
 ## 5.5.0 (2024-01-19)
 
-* [bitnami/jupyterhub] feat: :lock: Add compatibility with PSA restricted (#22515) ([9d1b8ab](https://github.com/bitnami/charts/commit/9d1b8ab)), closes [#22515](https://github.com/bitnami/charts/issues/22515)
+* [bitnami/jupyterhub] feat: :lock: Add compatibility with PSA restricted (#22515) ([9d1b8ab](https://github.com/bitnami/charts/commit/9d1b8abb368181395fa4939adc8b5162dffd9ad5)), closes [#22515](https://github.com/bitnami/charts/issues/22515)
 
 ## <small>5.4.1 (2024-01-18)</small>
 
-* [bitnami/jupyterhub] Release 5.4.1 updating components versions (#22292) ([78ae35b](https://github.com/bitnami/charts/commit/78ae35b)), closes [#22292](https://github.com/bitnami/charts/issues/22292)
+* [bitnami/jupyterhub] Release 5.4.1 updating components versions (#22292) ([78ae35b](https://github.com/bitnami/charts/commit/78ae35b311c5b551704bfd004272557cd37d79e4)), closes [#22292](https://github.com/bitnami/charts/issues/22292)
 
 ## 5.4.0 (2024-01-17)
 
-* [bitnami/jupyterhub] fix: :lock: Improve podSecurityContext and containerSecurityContext with essent ([f2d0ab5](https://github.com/bitnami/charts/commit/f2d0ab5)), closes [#22135](https://github.com/bitnami/charts/issues/22135)
+* [bitnami/jupyterhub] fix: :lock: Improve podSecurityContext and containerSecurityContext with essent ([f2d0ab5](https://github.com/bitnami/charts/commit/f2d0ab5dba21e6e8f74c782f62f8120ac2546d83)), closes [#22135](https://github.com/bitnami/charts/issues/22135)
 
 ## <small>5.3.2 (2024-01-15)</small>
 
-* [bitnami/*] Fix docs.bitnami.com broken links (#21901) ([f35506d](https://github.com/bitnami/charts/commit/f35506d)), closes [#21901](https://github.com/bitnami/charts/issues/21901)
-* [bitnami/*] Fix ref links (in comments) (#21822) ([e4fa296](https://github.com/bitnami/charts/commit/e4fa296)), closes [#21822](https://github.com/bitnami/charts/issues/21822)
-* [bitnami/jupyterhub] fix: :lock: Do not automount the service account token unless necessary (#22047 ([c6cd517](https://github.com/bitnami/charts/commit/c6cd517)), closes [#22047](https://github.com/bitnami/charts/issues/22047)
+* [bitnami/*] Fix docs.bitnami.com broken links (#21901) ([f35506d](https://github.com/bitnami/charts/commit/f35506d2dadee4f097986e7792df1f53ab215b5d)), closes [#21901](https://github.com/bitnami/charts/issues/21901)
+* [bitnami/*] Fix ref links (in comments) (#21822) ([e4fa296](https://github.com/bitnami/charts/commit/e4fa296106b225cf8c82445727c675c7c725e380)), closes [#21822](https://github.com/bitnami/charts/issues/21822)
+* [bitnami/jupyterhub] fix: :lock: Do not automount the service account token unless necessary (#22047 ([c6cd517](https://github.com/bitnami/charts/commit/c6cd517f81d1c0d1a146a6be325c73ea5480fbb3)), closes [#22047](https://github.com/bitnami/charts/issues/22047)
 
 ## <small>5.3.1 (2024-01-03)</small>
 
-* [bitnami/jupyterhub] Release 5.3.1 updating components versions (#21842) ([cbde210](https://github.com/bitnami/charts/commit/cbde210)), closes [#21842](https://github.com/bitnami/charts/issues/21842)
+* [bitnami/jupyterhub] Release 5.3.1 updating components versions (#21842) ([cbde210](https://github.com/bitnami/charts/commit/cbde210b043f30e867df289798494900aaf93b5d)), closes [#21842](https://github.com/bitnami/charts/issues/21842)
 
 ## 5.3.0 (2024-01-03)
 
-* [bitnami/*] Update copyright: Year and company (#21815) ([6c4bf75](https://github.com/bitnami/charts/commit/6c4bf75)), closes [#21815](https://github.com/bitnami/charts/issues/21815)
-* [bitnami/jupyterhub] add missing service api tokens to hub's secret (#21784) ([5e3e637](https://github.com/bitnami/charts/commit/5e3e637)), closes [#21784](https://github.com/bitnami/charts/issues/21784)
+* [bitnami/*] Update copyright: Year and company (#21815) ([6c4bf75](https://github.com/bitnami/charts/commit/6c4bf75dec58fc7c9aee9f089777b1a858c17d5b)), closes [#21815](https://github.com/bitnami/charts/issues/21815)
+* [bitnami/jupyterhub] add missing service api tokens to hub's secret (#21784) ([5e3e637](https://github.com/bitnami/charts/commit/5e3e637ae1edf18d0a87cd29055a7490741ea5f0)), closes [#21784](https://github.com/bitnami/charts/issues/21784)
 
 ## <small>5.2.9 (2023-11-24)</small>
 
-* [bitnami/jupyterhub] Release 5.2.9 updating components versions (#21238) ([b19a6a9](https://github.com/bitnami/charts/commit/b19a6a9)), closes [#21238](https://github.com/bitnami/charts/issues/21238)
+* [bitnami/jupyterhub] Release 5.2.9 updating components versions (#21238) ([b19a6a9](https://github.com/bitnami/charts/commit/b19a6a9754ebad1ad80bb97d806091190a773ece)), closes [#21238](https://github.com/bitnami/charts/issues/21238)
 
 ## <small>5.2.8 (2023-11-24)</small>
 
-* [bitnami/jupyterhub] Release 5.2.8 updating components versions (#21236) ([90ed88b](https://github.com/bitnami/charts/commit/90ed88b)), closes [#21236](https://github.com/bitnami/charts/issues/21236)
+* [bitnami/jupyterhub] Release 5.2.8 updating components versions (#21236) ([90ed88b](https://github.com/bitnami/charts/commit/90ed88b24c3397d39d7fa02449629b4a6392861c)), closes [#21236](https://github.com/bitnami/charts/issues/21236)
 
 ## <small>5.2.7 (2023-11-21)</small>
 
-* [bitnami/*] Rename solutions to "Bitnami package for ..." (#21038) ([b82f979](https://github.com/bitnami/charts/commit/b82f979)), closes [#21038](https://github.com/bitnami/charts/issues/21038)
-* [bitnami/jupyterhub] Release 5.2.7 updating components versions (#21126) ([210ec3a](https://github.com/bitnami/charts/commit/210ec3a)), closes [#21126](https://github.com/bitnami/charts/issues/21126)
+* [bitnami/*] Rename solutions to "Bitnami package for ..." (#21038) ([b82f979](https://github.com/bitnami/charts/commit/b82f979e4fb63423fe6e2192c946d09d79c944fc)), closes [#21038](https://github.com/bitnami/charts/issues/21038)
+* [bitnami/jupyterhub] Release 5.2.7 updating components versions (#21126) ([210ec3a](https://github.com/bitnami/charts/commit/210ec3a79375856adb8426456bbbdc188e8699ff)), closes [#21126](https://github.com/bitnami/charts/issues/21126)
 
 ## <small>5.2.6 (2023-11-16)</small>
 
-* [bitnami/jupyterhub] Release 5.2.6 updating components versions (#21016) ([17712bf](https://github.com/bitnami/charts/commit/17712bf)), closes [#21016](https://github.com/bitnami/charts/issues/21016)
+* [bitnami/jupyterhub] Release 5.2.6 updating components versions (#21016) ([17712bf](https://github.com/bitnami/charts/commit/17712bfe1c6e27e68388dcf9062291209b9c16ba)), closes [#21016](https://github.com/bitnami/charts/issues/21016)
 
 ## <small>5.2.5 (2023-11-16)</small>
 
-* [bitnami/jupyterhub] Release 5.2.5 updating components versions (#21015) ([843fffa](https://github.com/bitnami/charts/commit/843fffa)), closes [#21015](https://github.com/bitnami/charts/issues/21015)
+* [bitnami/jupyterhub] Release 5.2.5 updating components versions (#21015) ([843fffa](https://github.com/bitnami/charts/commit/843fffa31b81615d316c347d17e0eea8b3543adc)), closes [#21015](https://github.com/bitnami/charts/issues/21015)
 
 ## <small>5.2.4 (2023-11-16)</small>
 
-* [bitnami/*] Remove relative links to non-README sections, add verification for that and update TL;DR ([1103633](https://github.com/bitnami/charts/commit/1103633)), closes [#20967](https://github.com/bitnami/charts/issues/20967)
-* [bitnami/jupyterhub] Release 5.2.4 updating components versions (#21014) ([434800f](https://github.com/bitnami/charts/commit/434800f)), closes [#21014](https://github.com/bitnami/charts/issues/21014)
+* [bitnami/*] Remove relative links to non-README sections, add verification for that and update TL;DR ([1103633](https://github.com/bitnami/charts/commit/11036334d82df0490aa4abdb591543cab6cf7d7f)), closes [#20967](https://github.com/bitnami/charts/issues/20967)
+* [bitnami/jupyterhub] Release 5.2.4 updating components versions (#21014) ([434800f](https://github.com/bitnami/charts/commit/434800fa12445e3a643c80233bf4979e9f8cb57c)), closes [#21014](https://github.com/bitnami/charts/issues/21014)
 
 ## <small>5.2.3 (2023-11-16)</small>
 
-* [bitnami/jupyterhub] Release 5.2.3 updating components versions (#21004) ([9c3dfb5](https://github.com/bitnami/charts/commit/9c3dfb5)), closes [#21004](https://github.com/bitnami/charts/issues/21004)
+* [bitnami/jupyterhub] Release 5.2.3 updating components versions (#21004) ([9c3dfb5](https://github.com/bitnami/charts/commit/9c3dfb522ac8b14c5325c2f4077d171d3d0c84aa)), closes [#21004](https://github.com/bitnami/charts/issues/21004)
 
 ## <small>5.2.2 (2023-11-15)</small>
 
-* [bitnami/jupyterhub] Release 5.2.2 updating components versions (#20978) ([472c3ea](https://github.com/bitnami/charts/commit/472c3ea)), closes [#20978](https://github.com/bitnami/charts/issues/20978)
+* [bitnami/jupyterhub] Release 5.2.2 updating components versions (#20978) ([472c3ea](https://github.com/bitnami/charts/commit/472c3ea90df270ad9a9a36275b21bd8bff5eea97)), closes [#20978](https://github.com/bitnami/charts/issues/20978)
 
 ## <small>5.2.1 (2023-11-15)</small>
 
-* [bitnami/jupyterhub] Release 5.2.1 updating components versions (#20973) ([fb0f9e3](https://github.com/bitnami/charts/commit/fb0f9e3)), closes [#20973](https://github.com/bitnami/charts/issues/20973)
+* [bitnami/jupyterhub] Release 5.2.1 updating components versions (#20973) ([fb0f9e3](https://github.com/bitnami/charts/commit/fb0f9e38e600317a6c65a86cb0173de61d060cdf)), closes [#20973](https://github.com/bitnami/charts/issues/20973)
 
 ## 5.2.0 (2023-11-15)
 
-* [bitnami/jupyterhub] Add support for profileList definition in singleuser (#20621) ([0992320](https://github.com/bitnami/charts/commit/0992320)), closes [#20621](https://github.com/bitnami/charts/issues/20621)
+* [bitnami/jupyterhub] Add support for profileList definition in singleuser (#20621) ([0992320](https://github.com/bitnami/charts/commit/0992320a9aaa287d4b40015930fed5d6229903c7)), closes [#20621](https://github.com/bitnami/charts/issues/20621)
 
 ## <small>5.1.3 (2023-11-08)</small>
 
-* [bitnami/jupyterhub] Release 5.1.3 updating components versions (#20706) ([8924ad7](https://github.com/bitnami/charts/commit/8924ad7)), closes [#20706](https://github.com/bitnami/charts/issues/20706)
+* [bitnami/jupyterhub] Release 5.1.3 updating components versions (#20706) ([8924ad7](https://github.com/bitnami/charts/commit/8924ad70c1dc71955559089569d4101711ef623b)), closes [#20706](https://github.com/bitnami/charts/issues/20706)
 
 ## <small>5.1.2 (2023-11-02)</small>
 
-* [bitnami/jupyterhub] Release 5.1.2 updating components versions (#20590) ([caf35f1](https://github.com/bitnami/charts/commit/caf35f1)), closes [#20590](https://github.com/bitnami/charts/issues/20590)
+* [bitnami/jupyterhub] Release 5.1.2 updating components versions (#20590) ([caf35f1](https://github.com/bitnami/charts/commit/caf35f136e3dc8fd6213079b53b7a60c0311dc4d)), closes [#20590](https://github.com/bitnami/charts/issues/20590)
 
 ## <small>5.1.1 (2023-11-02)</small>
 
-* [bitnami/jupyterhub] Release 5.1.1 updating components versions (#20588) ([6f61de2](https://github.com/bitnami/charts/commit/6f61de2)), closes [#20588](https://github.com/bitnami/charts/issues/20588)
+* [bitnami/jupyterhub] Release 5.1.1 updating components versions (#20588) ([6f61de2](https://github.com/bitnami/charts/commit/6f61de22219a00fda8481f4edb97af9d3924a548)), closes [#20588](https://github.com/bitnami/charts/issues/20588)
 
 ## 5.1.0 (2023-10-31)
 
-* [bitnami/jupyterhub] feat: :sparkles: Add support for PSA restricted policy (#20458) ([b98e0dc](https://github.com/bitnami/charts/commit/b98e0dc)), closes [#20458](https://github.com/bitnami/charts/issues/20458)
+* [bitnami/jupyterhub] feat: :sparkles: Add support for PSA restricted policy (#20458) ([b98e0dc](https://github.com/bitnami/charts/commit/b98e0dca01d8d0dfabd38273b1f9d55dd882e8dc)), closes [#20458](https://github.com/bitnami/charts/issues/20458)
 
 ## <small>5.0.3 (2023-10-25)</small>
 
-* [bitnami/*] Rename VMware Application Catalog (#20361) ([3acc734](https://github.com/bitnami/charts/commit/3acc734)), closes [#20361](https://github.com/bitnami/charts/issues/20361)
-* [bitnami/*] Skip image's tag in the README files of the Bitnami Charts (#19841) ([bb9a01b](https://github.com/bitnami/charts/commit/bb9a01b)), closes [#19841](https://github.com/bitnami/charts/issues/19841)
-* [bitnami/*] Standardize documentation (#19835) ([af5f753](https://github.com/bitnami/charts/commit/af5f753)), closes [#19835](https://github.com/bitnami/charts/issues/19835)
-* [bitnami/jupyterhub] Release 5.0.3 updating components versions (#20432) ([b7dd80a](https://github.com/bitnami/charts/commit/b7dd80a)), closes [#20432](https://github.com/bitnami/charts/issues/20432)
+* [bitnami/*] Rename VMware Application Catalog (#20361) ([3acc734](https://github.com/bitnami/charts/commit/3acc73472beb6fb56c4d99f929061001205bc57e)), closes [#20361](https://github.com/bitnami/charts/issues/20361)
+* [bitnami/*] Skip image's tag in the README files of the Bitnami Charts (#19841) ([bb9a01b](https://github.com/bitnami/charts/commit/bb9a01b65911c87e48318db922cc05eb42785e42)), closes [#19841](https://github.com/bitnami/charts/issues/19841)
+* [bitnami/*] Standardize documentation (#19835) ([af5f753](https://github.com/bitnami/charts/commit/af5f7530c1bc8c5ded53a6c4f7b8f384ac1804f2)), closes [#19835](https://github.com/bitnami/charts/issues/19835)
+* [bitnami/jupyterhub] Release 5.0.3 updating components versions (#20432) ([b7dd80a](https://github.com/bitnami/charts/commit/b7dd80a48af65113e3330b1fcac520a1ae3450b4)), closes [#20432](https://github.com/bitnami/charts/issues/20432)
 
 ## <small>5.0.2 (2023-10-12)</small>
 
-* [bitnami/jupyterhub] Release 5.0.2 (#20143) ([c1cf450](https://github.com/bitnami/charts/commit/c1cf450)), closes [#20143](https://github.com/bitnami/charts/issues/20143)
+* [bitnami/jupyterhub] Release 5.0.2 (#20143) ([c1cf450](https://github.com/bitnami/charts/commit/c1cf4505defadf5886e47a52f8800003910a7abf)), closes [#20143](https://github.com/bitnami/charts/issues/20143)
 
 ## <small>5.0.1 (2023-10-09)</small>
 
-* [bitnami/*] Update Helm charts prerequisites (#19745) ([eb755dd](https://github.com/bitnami/charts/commit/eb755dd)), closes [#19745](https://github.com/bitnami/charts/issues/19745)
-* [bitnami/jupyterhub] Release 5.0.1 (#19916) ([413c78a](https://github.com/bitnami/charts/commit/413c78a)), closes [#19916](https://github.com/bitnami/charts/issues/19916)
+* [bitnami/*] Update Helm charts prerequisites (#19745) ([eb755dd](https://github.com/bitnami/charts/commit/eb755dd36a4dd3cf6635be8e0598f9a7f4c4a554)), closes [#19745](https://github.com/bitnami/charts/issues/19745)
+* [bitnami/jupyterhub] Release 5.0.1 (#19916) ([413c78a](https://github.com/bitnami/charts/commit/413c78afc9a935c5d26a92a579bb66a6c6479c71)), closes [#19916](https://github.com/bitnami/charts/issues/19916)
 
 ## 5.0.0 (2023-09-29)
 
-* [bitnami/jupyterhub] Update dependencies (#19615) ([9d587f0](https://github.com/bitnami/charts/commit/9d587f0)), closes [#19615](https://github.com/bitnami/charts/issues/19615)
+* [bitnami/jupyterhub] Update dependencies (#19615) ([9d587f0](https://github.com/bitnami/charts/commit/9d587f0bf72688ef2d61cfdc6ff0f74a09a5fb00)), closes [#19615](https://github.com/bitnami/charts/issues/19615)
 
 ## <small>4.2.4 (2023-09-26)</small>
 
-* [bitnami/jupyterhub] Release 4.2.4 (#19549) ([f2d6821](https://github.com/bitnami/charts/commit/f2d6821)), closes [#19549](https://github.com/bitnami/charts/issues/19549)
+* [bitnami/jupyterhub] Release 4.2.4 (#19549) ([f2d6821](https://github.com/bitnami/charts/commit/f2d68215f07aa2c5bbb6aae7325e74df0fa2a4ae)), closes [#19549](https://github.com/bitnami/charts/issues/19549)
 
 ## <small>4.2.3 (2023-09-20)</small>
 
-* [bitnami/*] Update readme files (#19277) ([e56aeb2](https://github.com/bitnami/charts/commit/e56aeb2)), closes [#19277](https://github.com/bitnami/charts/issues/19277)
-* [bitnami/jupyterhub] Use different app.kubernetes.io/version label on subcomponents (#19339) ([fe3b587](https://github.com/bitnami/charts/commit/fe3b587)), closes [#19339](https://github.com/bitnami/charts/issues/19339)
-* Autogenerate schema files (#19194) ([a2c2090](https://github.com/bitnami/charts/commit/a2c2090)), closes [#19194](https://github.com/bitnami/charts/issues/19194)
-* Revert "Autogenerate schema files (#19194)" (#19335) ([73d80be](https://github.com/bitnami/charts/commit/73d80be)), closes [#19194](https://github.com/bitnami/charts/issues/19194) [#19335](https://github.com/bitnami/charts/issues/19335)
+* [bitnami/*] Update readme files (#19277) ([e56aeb2](https://github.com/bitnami/charts/commit/e56aeb2fbfbf5b6e42375db48cc7ae1ef1c3a823)), closes [#19277](https://github.com/bitnami/charts/issues/19277)
+* [bitnami/jupyterhub] Use different app.kubernetes.io/version label on subcomponents (#19339) ([fe3b587](https://github.com/bitnami/charts/commit/fe3b587ea302f2a67bc6ec5603ea99f7240cbb70)), closes [#19339](https://github.com/bitnami/charts/issues/19339)
+* Autogenerate schema files (#19194) ([a2c2090](https://github.com/bitnami/charts/commit/a2c2090b5ac97f47b745c8028c6452bf99739772)), closes [#19194](https://github.com/bitnami/charts/issues/19194)
+* Revert "Autogenerate schema files (#19194)" (#19335) ([73d80be](https://github.com/bitnami/charts/commit/73d80be525c88fb4b8a54451a55acd506e337062)), closes [#19194](https://github.com/bitnami/charts/issues/19194) [#19335](https://github.com/bitnami/charts/issues/19335)
 
 ## <small>4.2.2 (2023-09-07)</small>
 
-* [bitnami/jupyterhub: Use merge helper]: (#19055) ([f001a93](https://github.com/bitnami/charts/commit/f001a93)), closes [#19055](https://github.com/bitnami/charts/issues/19055)
+* [bitnami/jupyterhub: Use merge helper]: (#19055) ([f001a93](https://github.com/bitnami/charts/commit/f001a93d2457f783c656c878f6c2152e9b327569)), closes [#19055](https://github.com/bitnami/charts/issues/19055)
 
 ## <small>4.2.1 (2023-08-30)</small>
 
-* [bitnami/jupyterhub] Release 4.2.1 (#18949) ([8a0a391](https://github.com/bitnami/charts/commit/8a0a391)), closes [#18949](https://github.com/bitnami/charts/issues/18949)
+* [bitnami/jupyterhub] Release 4.2.1 (#18949) ([8a0a391](https://github.com/bitnami/charts/commit/8a0a391a8ad9ea7495b90b74e3d06e1385ef6482)), closes [#18949](https://github.com/bitnami/charts/issues/18949)
 
 ## 4.2.0 (2023-08-23)
 
-* [bitnami/jupyterhub] Support for customizing standard labels (#18555) ([ced91cc](https://github.com/bitnami/charts/commit/ced91cc)), closes [#18555](https://github.com/bitnami/charts/issues/18555)
+* [bitnami/jupyterhub] Support for customizing standard labels (#18555) ([ced91cc](https://github.com/bitnami/charts/commit/ced91cc89faae42e21c69c702959f1dc771e4c0b)), closes [#18555](https://github.com/bitnami/charts/issues/18555)
 
 ## <small>4.1.11 (2023-08-19)</small>
 
-* [bitnami/jupyterhub] Release 4.1.11 (#18669) ([3a67927](https://github.com/bitnami/charts/commit/3a67927)), closes [#18669](https://github.com/bitnami/charts/issues/18669)
+* [bitnami/jupyterhub] Release 4.1.11 (#18669) ([3a67927](https://github.com/bitnami/charts/commit/3a67927626f177373b2a298fd71816e9fb5f26d4)), closes [#18669](https://github.com/bitnami/charts/issues/18669)
 
 ## <small>4.1.10 (2023-08-17)</small>
 
-* [bitnami/jupyterhub] Release 4.1.10 (#18531) ([d37161b](https://github.com/bitnami/charts/commit/d37161b)), closes [#18531](https://github.com/bitnami/charts/issues/18531)
+* [bitnami/jupyterhub] Release 4.1.10 (#18531) ([d37161b](https://github.com/bitnami/charts/commit/d37161b51c5dce31baa8ef350dd2f97cd071e2e6)), closes [#18531](https://github.com/bitnami/charts/issues/18531)
 
 ## <small>4.1.9 (2023-08-10)</small>
 
-* [bitnami/jupyterhub] Release 4.1.9 (#18361) ([9ac520e](https://github.com/bitnami/charts/commit/9ac520e)), closes [#18361](https://github.com/bitnami/charts/issues/18361)
+* [bitnami/jupyterhub] Release 4.1.9 (#18361) ([9ac520e](https://github.com/bitnami/charts/commit/9ac520ed19b93d7ebc31fd130e812479972eef1c)), closes [#18361](https://github.com/bitnami/charts/issues/18361)
 
 ## <small>4.1.8 (2023-08-02)</small>
 
-* [bitnami/jupyterhub] Release 4.1.8 (#18145) ([c5e5e7e](https://github.com/bitnami/charts/commit/c5e5e7e)), closes [#18145](https://github.com/bitnami/charts/issues/18145)
+* [bitnami/jupyterhub] Release 4.1.8 (#18145) ([c5e5e7e](https://github.com/bitnami/charts/commit/c5e5e7e2f1dde06d5f77eb0daf60b7dca74672be)), closes [#18145](https://github.com/bitnami/charts/issues/18145)
 
 ## <small>4.1.7 (2023-07-13)</small>
 
-* [bitnami/charts] Automate license checks (#17421) ([8f3d7ef](https://github.com/bitnami/charts/commit/8f3d7ef)), closes [#17421](https://github.com/bitnami/charts/issues/17421)
-* [bitnami/jupyterhub] Release 4.1.7 (#17678) ([d6214e5](https://github.com/bitnami/charts/commit/d6214e5)), closes [#17678](https://github.com/bitnami/charts/issues/17678)
-* Use os-shell in tempate and Jaeger runtime params (#17557) ([91a49eb](https://github.com/bitnami/charts/commit/91a49eb)), closes [#17557](https://github.com/bitnami/charts/issues/17557)
+* [bitnami/charts] Automate license checks (#17421) ([8f3d7ef](https://github.com/bitnami/charts/commit/8f3d7ef927fb8ce998114c05d41a2302c4364d03)), closes [#17421](https://github.com/bitnami/charts/issues/17421)
+* [bitnami/jupyterhub] Release 4.1.7 (#17678) ([d6214e5](https://github.com/bitnami/charts/commit/d6214e5b420cf75dc255a570a96727859c6dc46f)), closes [#17678](https://github.com/bitnami/charts/issues/17678)
+* Use os-shell in tempate and Jaeger runtime params (#17557) ([91a49eb](https://github.com/bitnami/charts/commit/91a49eb1e3c81c7b7c6c28d1bc5d6d6ae698c1e2)), closes [#17557](https://github.com/bitnami/charts/issues/17557)
 
 ## <small>4.1.6 (2023-06-28)</small>
 
-* [bitnami/jupyterhub] Release 4.1.6 (#17386) ([87cf420](https://github.com/bitnami/charts/commit/87cf420)), closes [#17386](https://github.com/bitnami/charts/issues/17386)
-* Add copyright header (#17300) ([da68be8](https://github.com/bitnami/charts/commit/da68be8)), closes [#17300](https://github.com/bitnami/charts/issues/17300)
+* [bitnami/jupyterhub] Release 4.1.6 (#17386) ([87cf420](https://github.com/bitnami/charts/commit/87cf420ac0babb1ee018a16f9170ea857bb20fff)), closes [#17386](https://github.com/bitnami/charts/issues/17386)
+* Add copyright header (#17300) ([da68be8](https://github.com/bitnami/charts/commit/da68be8e951225133c7dfb572d5101ca3d61c5ae)), closes [#17300](https://github.com/bitnami/charts/issues/17300)
 
 ## <small>4.1.5 (2023-06-26)</small>
 
-* [bitnami/*] Change copyright section in READMEs (#17006) ([ef986a1](https://github.com/bitnami/charts/commit/ef986a1)), closes [#17006](https://github.com/bitnami/charts/issues/17006)
-* [bitnami/jupyterhub] Add jupyterhub proxy serviceAccount settings (#17279) ([e439a39](https://github.com/bitnami/charts/commit/e439a39)), closes [#17279](https://github.com/bitnami/charts/issues/17279)
-* [bitnami/several] Change copyright section in READMEs (#16989) ([5b6a5cf](https://github.com/bitnami/charts/commit/5b6a5cf)), closes [#16989](https://github.com/bitnami/charts/issues/16989)
-* Update charts readme (#17217) ([31b3c0a](https://github.com/bitnami/charts/commit/31b3c0a)), closes [#17217](https://github.com/bitnami/charts/issues/17217)
+* [bitnami/*] Change copyright section in READMEs (#17006) ([ef986a1](https://github.com/bitnami/charts/commit/ef986a1605241102b3dcafe9fd8089e6fc1201ad)), closes [#17006](https://github.com/bitnami/charts/issues/17006)
+* [bitnami/jupyterhub] Add jupyterhub proxy serviceAccount settings (#17279) ([e439a39](https://github.com/bitnami/charts/commit/e439a39376d138804e1e35676a7dd16a30a3e716)), closes [#17279](https://github.com/bitnami/charts/issues/17279)
+* [bitnami/several] Change copyright section in READMEs (#16989) ([5b6a5cf](https://github.com/bitnami/charts/commit/5b6a5cfb7625a751848a2e5cd796bd7278f406ca)), closes [#16989](https://github.com/bitnami/charts/issues/16989)
+* Update charts readme (#17217) ([31b3c0a](https://github.com/bitnami/charts/commit/31b3c0afd968ff4429107e34101f7509e6a0e913)), closes [#17217](https://github.com/bitnami/charts/issues/17217)
 
 ## <small>4.1.4 (2023-05-23)</small>
 
-* [bitnami/jupyterhub] Release 4.1.4 (#16882) ([0766be9](https://github.com/bitnami/charts/commit/0766be9)), closes [#16882](https://github.com/bitnami/charts/issues/16882)
+* [bitnami/jupyterhub] Release 4.1.4 (#16882) ([0766be9](https://github.com/bitnami/charts/commit/0766be985820efeaf5db5405cec59f205b444251)), closes [#16882](https://github.com/bitnami/charts/issues/16882)
 
 ## <small>4.1.3 (2023-05-22)</small>
 
-* [bitnami/jupyterhub] Release 4.1.3 (#16854) ([ed81d5a](https://github.com/bitnami/charts/commit/ed81d5a)), closes [#16854](https://github.com/bitnami/charts/issues/16854)
+* [bitnami/jupyterhub] Release 4.1.3 (#16854) ([ed81d5a](https://github.com/bitnami/charts/commit/ed81d5afcb655e1a435fac96aa06fe20784c5f41)), closes [#16854](https://github.com/bitnami/charts/issues/16854)
 
 ## <small>4.1.2 (2023-05-21)</small>
 
-* [bitnami/jupyterhub] Release 4.1.2 (#16775) ([2229c7e](https://github.com/bitnami/charts/commit/2229c7e)), closes [#16775](https://github.com/bitnami/charts/issues/16775)
+* [bitnami/jupyterhub] Release 4.1.2 (#16775) ([2229c7e](https://github.com/bitnami/charts/commit/2229c7e5408e78fa45990af5ac42d2160032a6a8)), closes [#16775](https://github.com/bitnami/charts/issues/16775)
 
 ## <small>4.1.1 (2023-05-16)</small>
 
-* [bitnami/jupyterhub] Release 4.1.1 (#16689) ([1313428](https://github.com/bitnami/charts/commit/1313428)), closes [#16689](https://github.com/bitnami/charts/issues/16689)
-* Add wording for enterprise page (#16560) ([8f22774](https://github.com/bitnami/charts/commit/8f22774)), closes [#16560](https://github.com/bitnami/charts/issues/16560)
+* [bitnami/jupyterhub] Release 4.1.1 (#16689) ([1313428](https://github.com/bitnami/charts/commit/13134286712854fb3e713f8fcce415462841addf)), closes [#16689](https://github.com/bitnami/charts/issues/16689)
+* Add wording for enterprise page (#16560) ([8f22774](https://github.com/bitnami/charts/commit/8f2277440b976d52785ba9149762ad8620a73d1f)), closes [#16560](https://github.com/bitnami/charts/issues/16560)
 
 ## 4.1.0 (2023-05-09)
 
-* [bitnami/several] Adapt Chart.yaml to set desired OCI annotations (#16546) ([fc9b18f](https://github.com/bitnami/charts/commit/fc9b18f)), closes [#16546](https://github.com/bitnami/charts/issues/16546)
+* [bitnami/several] Adapt Chart.yaml to set desired OCI annotations (#16546) ([fc9b18f](https://github.com/bitnami/charts/commit/fc9b18f2e98805d4df629acbcde696f44f973344)), closes [#16546](https://github.com/bitnami/charts/issues/16546)
 
 ## <small>4.0.1 (2023-05-09)</small>
 
-* [bitnami/jupyterhub] Release 4.0.1 (#16465) ([2e7d5c5](https://github.com/bitnami/charts/commit/2e7d5c5)), closes [#16465](https://github.com/bitnami/charts/issues/16465)
+* [bitnami/jupyterhub] Release 4.0.1 (#16465) ([2e7d5c5](https://github.com/bitnami/charts/commit/2e7d5c527116186c33b30d3c78cf891fd6c67139)), closes [#16465](https://github.com/bitnami/charts/issues/16465)
 
 ## 4.0.0 (2023-05-05)
 
-* [bitnami/jupyterhub] Release 4.0.0 (#16410) ([3f897d8](https://github.com/bitnami/charts/commit/3f897d8)), closes [#16410](https://github.com/bitnami/charts/issues/16410)
+* [bitnami/jupyterhub] Release 4.0.0 (#16410) ([3f897d8](https://github.com/bitnami/charts/commit/3f897d8c3bf72598815642848b10ec195344f4cb)), closes [#16410](https://github.com/bitnami/charts/issues/16410)
 
 ## <small>3.1.1 (2023-05-01)</small>
 
-* [bitnami/jupyterhub] Release 3.1.1 (#16296) ([bc37460](https://github.com/bitnami/charts/commit/bc37460)), closes [#16296](https://github.com/bitnami/charts/issues/16296)
+* [bitnami/jupyterhub] Release 3.1.1 (#16296) ([bc37460](https://github.com/bitnami/charts/commit/bc37460bf1f71029233236569a2157486f40884e)), closes [#16296](https://github.com/bitnami/charts/issues/16296)
 
 ## 3.1.0 (2023-04-20)
 
-* [bitnami/*] Make Helm charts 100% OCI (#15998) ([8841510](https://github.com/bitnami/charts/commit/8841510)), closes [#15998](https://github.com/bitnami/charts/issues/15998)
+* [bitnami/*] Make Helm charts 100% OCI (#15998) ([8841510](https://github.com/bitnami/charts/commit/884151035efcbf2e1b3206e7def85511073fb57d)), closes [#15998](https://github.com/bitnami/charts/issues/15998)
 
 ## <small>3.0.13 (2023-04-01)</small>
 
-* [bitnami/jupyterhub] Release 3.0.13 (#15858) ([da73cba](https://github.com/bitnami/charts/commit/da73cba)), closes [#15858](https://github.com/bitnami/charts/issues/15858)
+* [bitnami/jupyterhub] Release 3.0.13 (#15858) ([da73cba](https://github.com/bitnami/charts/commit/da73cbac94f8ea5411fac55ea73ddda6af6eae70)), closes [#15858](https://github.com/bitnami/charts/issues/15858)
 
 ## <small>3.0.12 (2023-03-22)</small>
 
-* [bitnami/charts] Apply linter to README files (#15357) ([0e29e60](https://github.com/bitnami/charts/commit/0e29e60)), closes [#15357](https://github.com/bitnami/charts/issues/15357)
-* [bitnami/jupyterhub] Release 3.0.12 (#15666) ([afd9c34](https://github.com/bitnami/charts/commit/afd9c34)), closes [#15666](https://github.com/bitnami/charts/issues/15666)
+* [bitnami/charts] Apply linter to README files (#15357) ([0e29e60](https://github.com/bitnami/charts/commit/0e29e600d3adc8b1b46e506eccb3decfab3b4e63)), closes [#15357](https://github.com/bitnami/charts/issues/15357)
+* [bitnami/jupyterhub] Release 3.0.12 (#15666) ([afd9c34](https://github.com/bitnami/charts/commit/afd9c346423abf1bf9857145afe7ec0bc9f1b413)), closes [#15666](https://github.com/bitnami/charts/issues/15666)
 
 ## <small>3.0.11 (2023-03-01)</small>
 
-* [bitnami/jupyterhub] Release 3.0.11 (#15273) ([648024a](https://github.com/bitnami/charts/commit/648024a)), closes [#15273](https://github.com/bitnami/charts/issues/15273)
+* [bitnami/jupyterhub] Release 3.0.11 (#15273) ([648024a](https://github.com/bitnami/charts/commit/648024a54b39b64378b43c25ed5265dfa6b5461a)), closes [#15273](https://github.com/bitnami/charts/issues/15273)
 
 ## <small>3.0.10 (2023-02-17)</small>
 
-* [bitnami/*] Fix markdown linter issues (#14874) ([a51e0e8](https://github.com/bitnami/charts/commit/a51e0e8)), closes [#14874](https://github.com/bitnami/charts/issues/14874)
-* [bitnami/*] Fix markdown linter issues 2 (#14890) ([aa96572](https://github.com/bitnami/charts/commit/aa96572)), closes [#14890](https://github.com/bitnami/charts/issues/14890)
-* [bitnami/*] Remove unexpected extra spaces (#14873) ([c97c714](https://github.com/bitnami/charts/commit/c97c714)), closes [#14873](https://github.com/bitnami/charts/issues/14873)
-* [bitnami/jupyterhub] Release 3.0.10 (#14957) ([ce2e6ea](https://github.com/bitnami/charts/commit/ce2e6ea)), closes [#14957](https://github.com/bitnami/charts/issues/14957)
+* [bitnami/*] Fix markdown linter issues (#14874) ([a51e0e8](https://github.com/bitnami/charts/commit/a51e0e8d35495b907f3e70dd2f8e7c3bcbf4166a)), closes [#14874](https://github.com/bitnami/charts/issues/14874)
+* [bitnami/*] Fix markdown linter issues 2 (#14890) ([aa96572](https://github.com/bitnami/charts/commit/aa9657237ee8df4a46db0d7fdf8a23230dd6902a)), closes [#14890](https://github.com/bitnami/charts/issues/14890)
+* [bitnami/*] Remove unexpected extra spaces (#14873) ([c97c714](https://github.com/bitnami/charts/commit/c97c714887380d47eae7bfeff316bf01595ecd1d)), closes [#14873](https://github.com/bitnami/charts/issues/14873)
+* [bitnami/jupyterhub] Release 3.0.10 (#14957) ([ce2e6ea](https://github.com/bitnami/charts/commit/ce2e6ea2d3f88f521a2fb3d28404e2cab1bf04b9)), closes [#14957](https://github.com/bitnami/charts/issues/14957)
 
 ## <small>3.0.9 (2023-02-01)</small>
 
-* [bitnami/*] Change copyright date (#14682) ([add4ec7](https://github.com/bitnami/charts/commit/add4ec7)), closes [#14682](https://github.com/bitnami/charts/issues/14682)
-* [bitnami/jupyterhub] Release 3.0.9 (#14706) ([f8de5ac](https://github.com/bitnami/charts/commit/f8de5ac)), closes [#14706](https://github.com/bitnami/charts/issues/14706)
+* [bitnami/*] Change copyright date (#14682) ([add4ec7](https://github.com/bitnami/charts/commit/add4ec701108ac36ed4de2dffbdf407a0d091067)), closes [#14682](https://github.com/bitnami/charts/issues/14682)
+* [bitnami/jupyterhub] Release 3.0.9 (#14706) ([f8de5ac](https://github.com/bitnami/charts/commit/f8de5acc0e6a69978f2b108b043b1d3f7f0cbaa5)), closes [#14706](https://github.com/bitnami/charts/issues/14706)
 
 ## <small>3.0.8 (2023-01-31)</small>
 
-* [bitnami/jupyterhub] Don't regenerate self-signed certs on upgrade (#14628) ([29563d3](https://github.com/bitnami/charts/commit/29563d3)), closes [#14628](https://github.com/bitnami/charts/issues/14628)
+* [bitnami/jupyterhub] Don't regenerate self-signed certs on upgrade (#14628) ([29563d3](https://github.com/bitnami/charts/commit/29563d3b19f6978524de7a113b87d248b9585847)), closes [#14628](https://github.com/bitnami/charts/issues/14628)
 
 ## <small>3.0.7 (2023-01-27)</small>
 
-* [bitnami/*] Unify READMEs (#14472) ([2064fb8](https://github.com/bitnami/charts/commit/2064fb8)), closes [#14472](https://github.com/bitnami/charts/issues/14472)
-* [bitnami/jupyterhub] Release 3.0.7 (#14571) ([1a137e0](https://github.com/bitnami/charts/commit/1a137e0)), closes [#14571](https://github.com/bitnami/charts/issues/14571)
+* [bitnami/*] Unify READMEs (#14472) ([2064fb8](https://github.com/bitnami/charts/commit/2064fb8dcc78a845cdede8211af8c3cc52551161)), closes [#14472](https://github.com/bitnami/charts/issues/14472)
+* [bitnami/jupyterhub] Release 3.0.7 (#14571) ([1a137e0](https://github.com/bitnami/charts/commit/1a137e0905e85fee1d24392633b04bf99e1b2ac7)), closes [#14571](https://github.com/bitnami/charts/issues/14571)
 
 ## <small>3.0.6 (2023-01-20)</small>
 
-* [bitnami/jupyterhub] Add resource specification to the initContainers of the Image Puller Job. (#144 ([a7ba8ac](https://github.com/bitnami/charts/commit/a7ba8ac)), closes [#14427](https://github.com/bitnami/charts/issues/14427)
+* [bitnami/jupyterhub] Add resource specification to the initContainers of the Image Puller Job. (#144 ([a7ba8ac](https://github.com/bitnami/charts/commit/a7ba8aca7aa0aece463df6f46f7422c61c6e57dd)), closes [#14427](https://github.com/bitnami/charts/issues/14427)
 
 ## <small>3.0.5 (2023-01-18)</small>
 
-* [bitnami/*] Add license annotation and remove obsolete engine parameter (#14293) ([da2a794](https://github.com/bitnami/charts/commit/da2a794)), closes [#14293](https://github.com/bitnami/charts/issues/14293)
-* [bitnami/*] Change licenses annotation format (#14377) ([0ab7608](https://github.com/bitnami/charts/commit/0ab7608)), closes [#14377](https://github.com/bitnami/charts/issues/14377)
-* [bitnami/jupyterhub] Release 3.0.5 (#14418) ([e5d36f2](https://github.com/bitnami/charts/commit/e5d36f2)), closes [#14418](https://github.com/bitnami/charts/issues/14418)
+* [bitnami/*] Add license annotation and remove obsolete engine parameter (#14293) ([da2a794](https://github.com/bitnami/charts/commit/da2a7943bae95b6e9b5b4ed972c15e990b69fdb0)), closes [#14293](https://github.com/bitnami/charts/issues/14293)
+* [bitnami/*] Change licenses annotation format (#14377) ([0ab7608](https://github.com/bitnami/charts/commit/0ab760862c660fcc78cffadf8e1d8cdd70881473)), closes [#14377](https://github.com/bitnami/charts/issues/14377)
+* [bitnami/jupyterhub] Release 3.0.5 (#14418) ([e5d36f2](https://github.com/bitnami/charts/commit/e5d36f261009f8d0fcbcc1ca178e762e54300e52)), closes [#14418](https://github.com/bitnami/charts/issues/14418)
 
 ## <small>3.0.4 (2022-12-29)</small>
 
-* [bitnami/jupyterhub] Release 3.0.4 (#14125) ([132c1be](https://github.com/bitnami/charts/commit/132c1be)), closes [#14125](https://github.com/bitnami/charts/issues/14125)
+* [bitnami/jupyterhub] Release 3.0.4 (#14125) ([132c1be](https://github.com/bitnami/charts/commit/132c1be713b1af366370b1d4a3d3e1b925644d08)), closes [#14125](https://github.com/bitnami/charts/issues/14125)
 
 ## <small>3.0.3 (2022-11-29)</small>
 
-* [bitnami/jupyterhub] Release 3.0.3 (#13732) ([87fa2d3](https://github.com/bitnami/charts/commit/87fa2d3)), closes [#13732](https://github.com/bitnami/charts/issues/13732)
+* [bitnami/jupyterhub] Release 3.0.3 (#13732) ([87fa2d3](https://github.com/bitnami/charts/commit/87fa2d3e5b710c91ee23401273372acea592f674)), closes [#13732](https://github.com/bitnami/charts/issues/13732)
 
 ## <small>3.0.2 (2022-11-21)</small>
 
-* [bitnami/jupyterhub] fix apiversion hardcode for NetworkPolicy (#13576) ([b52dbf2](https://github.com/bitnami/charts/commit/b52dbf2)), closes [#13576](https://github.com/bitnami/charts/issues/13576)
+* [bitnami/jupyterhub] fix apiversion hardcode for NetworkPolicy (#13576) ([b52dbf2](https://github.com/bitnami/charts/commit/b52dbf2ca348996fdabeb8a7adfce72d1f4cb04a)), closes [#13576](https://github.com/bitnami/charts/issues/13576)
 
 ## <small>3.0.1 (2022-10-30)</small>
 
-* [bitnami/jupyterhub] Release 3.0.1 updating components versions ([b69f237](https://github.com/bitnami/charts/commit/b69f237))
+* [bitnami/jupyterhub] Release 3.0.1 updating components versions ([b69f237](https://github.com/bitnami/charts/commit/b69f2372926e152b0892842a8fc638dd911bec20))
 
 ## 3.0.0 (2022-10-28)
 
-* [bitnami/jupyterhub] Update dependencies (#13223) ([6a3aebd](https://github.com/bitnami/charts/commit/6a3aebd)), closes [#13223](https://github.com/bitnami/charts/issues/13223)
+* [bitnami/jupyterhub] Update dependencies (#13223) ([6a3aebd](https://github.com/bitnami/charts/commit/6a3aebdcc6dc3a6e46e2c19bc9d6dd560a593410)), closes [#13223](https://github.com/bitnami/charts/issues/13223)
 
 ## <small>2.0.2 (2022-10-24)</small>
 
-* [bitnami/*] Use new default branch name in links (#12943) ([a529e02](https://github.com/bitnami/charts/commit/a529e02)), closes [#12943](https://github.com/bitnami/charts/issues/12943)
-* [bitnami/jupyterhub] Fix envvars render error (#13078) ([5f54916](https://github.com/bitnami/charts/commit/5f54916)), closes [#13078](https://github.com/bitnami/charts/issues/13078)
+* [bitnami/*] Use new default branch name in links (#12943) ([a529e02](https://github.com/bitnami/charts/commit/a529e02597d49d944eba1eb0f190713293247176)), closes [#12943](https://github.com/bitnami/charts/issues/12943)
+* [bitnami/jupyterhub] Fix envvars render error (#13078) ([5f54916](https://github.com/bitnami/charts/commit/5f54916bb500aca5c7e8fea32d9112d7b9d91c61)), closes [#13078](https://github.com/bitnami/charts/issues/13078)
 
 ## <small>2.0.1 (2022-10-10)</small>
 
-* [bitnami/jupyterhub] Fix test existence nested key (#12782) ([f184add](https://github.com/bitnami/charts/commit/f184add)), closes [#12782](https://github.com/bitnami/charts/issues/12782)
-* Generic README instructions related to the repo (#12792) ([3cf6b10](https://github.com/bitnami/charts/commit/3cf6b10)), closes [#12792](https://github.com/bitnami/charts/issues/12792)
+* [bitnami/jupyterhub] Fix test existence nested key (#12782) ([f184add](https://github.com/bitnami/charts/commit/f184addbc19fe2ab45234d03d7e059505385c235)), closes [#12782](https://github.com/bitnami/charts/issues/12782)
+* Generic README instructions related to the repo (#12792) ([3cf6b10](https://github.com/bitnami/charts/commit/3cf6b10e10e60df4b3e191d6b99aa99a9f597755)), closes [#12792](https://github.com/bitnami/charts/issues/12792)
 
 ## 2.0.0 (2022-09-28)
 
-* [bitnami/jupyterhub] Update chart to include Jupyterhub 3.x (#12593) ([a0fd0a4](https://github.com/bitnami/charts/commit/a0fd0a4)), closes [#12593](https://github.com/bitnami/charts/issues/12593)
+* [bitnami/jupyterhub] Update chart to include Jupyterhub 3.x (#12593) ([a0fd0a4](https://github.com/bitnami/charts/commit/a0fd0a47c6bbccb5b82e58a27bf3f5eafb0f6e3d)), closes [#12593](https://github.com/bitnami/charts/issues/12593)
 
 ## <small>1.4.6 (2022-09-26)</small>
 
-* [bitnami/jupyterhub] Release 1.4.6 updating components versions ([a79e941](https://github.com/bitnami/charts/commit/a79e941))
+* [bitnami/jupyterhub] Release 1.4.6 updating components versions ([a79e941](https://github.com/bitnami/charts/commit/a79e941767caf40a7b75d40934b4a5534bba3ed1))
 
 ## <small>1.4.5 (2022-09-22)</small>
 
-* [bitnami/jupyterhub] Release 1.4.5 updating components versions ([a4bf037](https://github.com/bitnami/charts/commit/a4bf037))
+* [bitnami/jupyterhub] Release 1.4.5 updating components versions ([a4bf037](https://github.com/bitnami/charts/commit/a4bf037707dd130179725d73093b4b216e177922))
 
 ## <small>1.4.4 (2022-09-20)</small>
 
-* [bitnami/jupyterhub] Use custom probes if given (#12509) ([f04a24d](https://github.com/bitnami/charts/commit/f04a24d)), closes [#12509](https://github.com/bitnami/charts/issues/12509) [#12354](https://github.com/bitnami/charts/issues/12354)
+* [bitnami/jupyterhub] Use custom probes if given (#12509) ([f04a24d](https://github.com/bitnami/charts/commit/f04a24d6102c25bb1cad8037844231c4d544ae65)), closes [#12509](https://github.com/bitnami/charts/issues/12509) [#12354](https://github.com/bitnami/charts/issues/12354)
 
 ## <small>1.4.3 (2022-09-08)</small>
 
-* [bitnami/jupyterhub] Release 1.4.3 updating components versions ([350a571](https://github.com/bitnami/charts/commit/350a571))
+* [bitnami/jupyterhub] Release 1.4.3 updating components versions ([350a571](https://github.com/bitnami/charts/commit/350a571ebeda7055883e071e65687690c3705796))
 
 ## <small>1.4.2 (2022-09-02)</small>
 
-* [bitnami/jupyterhub] Change type singleuser.extraEnvVars type (#12233) ([44c23b3](https://github.com/bitnami/charts/commit/44c23b3)), closes [#12233](https://github.com/bitnami/charts/issues/12233)
+* [bitnami/jupyterhub] Change type singleuser.extraEnvVars type (#12233) ([44c23b3](https://github.com/bitnami/charts/commit/44c23b37b72df22f4f2f39770592f1cd6f28b4d6)), closes [#12233](https://github.com/bitnami/charts/issues/12233)
 
 ## <small>1.4.1 (2022-08-23)</small>
 
-* [bitnami/jupyterhub] Update Chart.lock (#12123) ([fd0d72b](https://github.com/bitnami/charts/commit/fd0d72b)), closes [#12123](https://github.com/bitnami/charts/issues/12123)
+* [bitnami/jupyterhub] Update Chart.lock (#12123) ([fd0d72b](https://github.com/bitnami/charts/commit/fd0d72b30968fae8f8d6c67deaf11ad8e26f4aa5)), closes [#12123](https://github.com/bitnami/charts/issues/12123)
 
 ## 1.4.0 (2022-08-22)
 
-* [bitnami/jupyterhub] Add support for image digest apart from tag (#11888) ([99a8307](https://github.com/bitnami/charts/commit/99a8307)), closes [#11888](https://github.com/bitnami/charts/issues/11888)
+* [bitnami/jupyterhub] Add support for image digest apart from tag (#11888) ([99a8307](https://github.com/bitnami/charts/commit/99a8307ddba11454383b653663128678adce9a1d)), closes [#11888](https://github.com/bitnami/charts/issues/11888)
 
 ## <small>1.3.13 (2022-08-09)</small>
 
-* [bitnami/jupyterhub] Release 1.3.13 updating components versions ([2f53fa8](https://github.com/bitnami/charts/commit/2f53fa8))
+* [bitnami/jupyterhub] Release 1.3.13 updating components versions ([2f53fa8](https://github.com/bitnami/charts/commit/2f53fa841eb974ef533d20c8bbf7e44e1cba56e1))
 
 ## <small>1.3.12 (2022-08-04)</small>
 
-* [bitnami/jupyterhub] Release 1.3.12 updating components versions ([81cd383](https://github.com/bitnami/charts/commit/81cd383))
+* [bitnami/jupyterhub] Release 1.3.12 updating components versions ([81cd383](https://github.com/bitnami/charts/commit/81cd383bd3fb2ab7d211732711cac2158f6a1e4c))
 
 ## <small>1.3.11 (2022-08-03)</small>
 
-* [bitnami/jupyterhub] Release 1.3.11 updating components versions ([c0bebc6](https://github.com/bitnami/charts/commit/c0bebc6))
+* [bitnami/jupyterhub] Release 1.3.11 updating components versions ([c0bebc6](https://github.com/bitnami/charts/commit/c0bebc6a7e047e2827614134db4b4bba419e9f14))
 
 ## <small>1.3.10 (2022-08-02)</small>
 
-* [bitnami/*] Update URLs to point to the new bitnami/containers monorepo (#11352) ([d665af0](https://github.com/bitnami/charts/commit/d665af0)), closes [#11352](https://github.com/bitnami/charts/issues/11352)
-* [bitnami/jupyterhub] Release 1.3.10 updating components versions ([29c89b0](https://github.com/bitnami/charts/commit/29c89b0))
+* [bitnami/*] Update URLs to point to the new bitnami/containers monorepo (#11352) ([d665af0](https://github.com/bitnami/charts/commit/d665af0c708846192d8d5fb2f5f9ea65dd464ab0)), closes [#11352](https://github.com/bitnami/charts/issues/11352)
+* [bitnami/jupyterhub] Release 1.3.10 updating components versions ([29c89b0](https://github.com/bitnami/charts/commit/29c89b0044464580e9da1349ebfd9cc890415928))
 
 ## <small>1.3.9 (2022-07-18)</small>
 
-* [bitnami/jupyterhub] Prettify and unify Chart.yaml (#11218) ([9290297](https://github.com/bitnami/charts/commit/9290297)), closes [#11218](https://github.com/bitnami/charts/issues/11218)
+* [bitnami/jupyterhub] Prettify and unify Chart.yaml (#11218) ([9290297](https://github.com/bitnami/charts/commit/929029787d8b300538b3fd404a3e128bdc753828)), closes [#11218](https://github.com/bitnami/charts/issues/11218)
 
 ## <small>1.3.8 (2022-07-04)</small>
 
-* [bitnami/jupyterhub] Release 1.3.8 updating components versions ([6950080](https://github.com/bitnami/charts/commit/6950080))
+* [bitnami/jupyterhub] Release 1.3.8 updating components versions ([6950080](https://github.com/bitnami/charts/commit/6950080efed23ef75f75468e824de68507defde5))
 
 ## <small>1.3.7 (2022-06-30)</small>
 
-* [bitnami/jupyterhub] Release 1.3.7 updating components versions ([c3776f5](https://github.com/bitnami/charts/commit/c3776f5))
+* [bitnami/jupyterhub] Release 1.3.7 updating components versions ([c3776f5](https://github.com/bitnami/charts/commit/c3776f5a3cde4ce9d52f4964edc6ba7e84af6b3b))
 
 ## <small>1.3.6 (2022-06-10)</small>
 
-* [bitnami/jupyterhub] Release 1.3.6 updating components versions ([6e6693a](https://github.com/bitnami/charts/commit/6e6693a))
+* [bitnami/jupyterhub] Release 1.3.6 updating components versions ([6e6693a](https://github.com/bitnami/charts/commit/6e6693ae81e19ab7d814eae13094860a48ec24a8))
 
 ## <small>1.3.5 (2022-06-07)</small>
 
-* [bitnami/*] Replace Kubeapps URL in READMEs (and kubeapps Chart.yaml) and remove BKPR references (#1 ([c6a7914](https://github.com/bitnami/charts/commit/c6a7914)), closes [#10600](https://github.com/bitnami/charts/issues/10600)
-* Fix tolerations and topologySpreadConstraints default values (#10628) ([94402c8](https://github.com/bitnami/charts/commit/94402c8)), closes [#10628](https://github.com/bitnami/charts/issues/10628)
+* [bitnami/*] Replace Kubeapps URL in READMEs (and kubeapps Chart.yaml) and remove BKPR references (#1 ([c6a7914](https://github.com/bitnami/charts/commit/c6a7914361e5aea6016fb45bf4d621edfd111d32)), closes [#10600](https://github.com/bitnami/charts/issues/10600)
+* Fix tolerations and topologySpreadConstraints default values (#10628) ([94402c8](https://github.com/bitnami/charts/commit/94402c8ddb8a951ff5949d3855a2a1d18c684285)), closes [#10628](https://github.com/bitnami/charts/issues/10628)
 
 ## <small>1.3.4 (2022-06-07)</small>
 
-* [bitnami/jupyterhub] Release 1.3.4 updating components versions ([c6c139b](https://github.com/bitnami/charts/commit/c6c139b))
+* [bitnami/jupyterhub] Release 1.3.4 updating components versions ([c6c139b](https://github.com/bitnami/charts/commit/c6c139b6df73eae44deaca59e590bfe98914600a))
 
 ## <small>1.3.3 (2022-06-01)</small>
 
-* [bitnami/several] Replace maintainers email by url (#10523) ([ff3cf61](https://github.com/bitnami/charts/commit/ff3cf61)), closes [#10523](https://github.com/bitnami/charts/issues/10523)
+* [bitnami/several] Replace maintainers email by url (#10523) ([ff3cf61](https://github.com/bitnami/charts/commit/ff3cf617a1680509b0f3855d17c4ccff7b29a0ff)), closes [#10523](https://github.com/bitnami/charts/issues/10523)
 
 ## <small>1.3.2 (2022-05-30)</small>
 
-* [bitnami/several] Replace base64 --decode with base64 -d (#10495) ([099286a](https://github.com/bitnami/charts/commit/099286a)), closes [#10495](https://github.com/bitnami/charts/issues/10495)
+* [bitnami/several] Replace base64 --decode with base64 -d (#10495) ([099286a](https://github.com/bitnami/charts/commit/099286ae7a87784cf809df0b64ab24f7ff0144c8)), closes [#10495](https://github.com/bitnami/charts/issues/10495)
 
 ## <small>1.3.1 (2022-05-27)</small>
 
-* [bitnami/jupyterhub] Release 1.3.1 updating components versions ([c477a3a](https://github.com/bitnami/charts/commit/c477a3a))
+* [bitnami/jupyterhub] Release 1.3.1 updating components versions ([c477a3a](https://github.com/bitnami/charts/commit/c477a3a653eefcacb76fa997c1d9be1358db4447))
 
 ## 1.3.0 (2022-05-27)
 
-* [bitnami/jupyterhub] Add missing service parameter (#10416) ([9ba7262](https://github.com/bitnami/charts/commit/9ba7262)), closes [#10416](https://github.com/bitnami/charts/issues/10416)
+* [bitnami/jupyterhub] Add missing service parameter (#10416) ([9ba7262](https://github.com/bitnami/charts/commit/9ba72622648074c28c24caac7b29be5f6567a2f8)), closes [#10416](https://github.com/bitnami/charts/issues/10416)
 
 ## <small>1.2.2 (2022-05-26)</small>
 
-*  [bitnami/jupyterhub] Fix indent in annotations of hub deployment (#10395) ([1821fe4](https://github.com/bitnami/charts/commit/1821fe4)), closes [#10395](https://github.com/bitnami/charts/issues/10395)
+*  [bitnami/jupyterhub] Fix indent in annotations of hub deployment (#10395) ([1821fe4](https://github.com/bitnami/charts/commit/1821fe473b9a55368eee80fbbde5c47c1b449aa6)), closes [#10395](https://github.com/bitnami/charts/issues/10395)
 
 ## <small>1.2.1 (2022-05-18)</small>
 
-* [bitnami/jupyterhub] Release 1.2.1 updating components versions ([6c7c30b](https://github.com/bitnami/charts/commit/6c7c30b))
+* [bitnami/jupyterhub] Release 1.2.1 updating components versions ([6c7c30b](https://github.com/bitnami/charts/commit/6c7c30b578c1d0940cfc01cc64957dd0c6b4a86e))
 
 ## 1.2.0 (2022-05-16)
 
-* [bitnami/*] add ingress extraRules feature (#10253) ([0f6cbb9](https://github.com/bitnami/charts/commit/0f6cbb9)), closes [#10253](https://github.com/bitnami/charts/issues/10253)
+* [bitnami/*] add ingress extraRules feature (#10253) ([0f6cbb9](https://github.com/bitnami/charts/commit/0f6cbb9099b0e56685cc1d36ba50340f3d7278a1)), closes [#10253](https://github.com/bitnami/charts/issues/10253)
 
 ## <small>1.1.14 (2022-05-13)</small>
 
-* [bitnami/*] Remove old 'ci' files (#10171) ([5df30c4](https://github.com/bitnami/charts/commit/5df30c4)), closes [#10171](https://github.com/bitnami/charts/issues/10171)
-* [bitnami/*] Unify k8s directives separators (#10185) ([2650214](https://github.com/bitnami/charts/commit/2650214)), closes [#10185](https://github.com/bitnami/charts/issues/10185)
+* [bitnami/*] Remove old 'ci' files (#10171) ([5df30c4](https://github.com/bitnami/charts/commit/5df30c44dbd1812da8786579ce4a94917d46a6ad)), closes [#10171](https://github.com/bitnami/charts/issues/10171)
+* [bitnami/*] Unify k8s directives separators (#10185) ([2650214](https://github.com/bitnami/charts/commit/26502141d146ca3bdfb3bf744fcdec8ca5cece44)), closes [#10185](https://github.com/bitnami/charts/issues/10185)
 
 ## <small>1.1.13 (2022-05-11)</small>
 
-* [bitnami/*] Fix typo in comments (relay -> rely) (#10151) ([9cfe4a4](https://github.com/bitnami/charts/commit/9cfe4a4)), closes [#10151](https://github.com/bitnami/charts/issues/10151)
+* [bitnami/*] Fix typo in comments (relay -> rely) (#10151) ([9cfe4a4](https://github.com/bitnami/charts/commit/9cfe4a48cc35851faea6be7ffb2a978d223befa0)), closes [#10151](https://github.com/bitnami/charts/issues/10151)
 
 ## <small>1.1.12 (2022-04-22)</small>
 
-* [bitnami/jupyterhub] Release 1.1.12 updating components versions ([db9c112](https://github.com/bitnami/charts/commit/db9c112))
+* [bitnami/jupyterhub] Release 1.1.12 updating components versions ([db9c112](https://github.com/bitnami/charts/commit/db9c112cf71d63045712e5bb75420d99f16dfbfe))
 
 ## <small>1.1.11 (2022-04-20)</small>
 
-* [bitnami/jupyterhub] Release 1.1.11 updating components versions ([d6ac51a](https://github.com/bitnami/charts/commit/d6ac51a))
+* [bitnami/jupyterhub] Release 1.1.11 updating components versions ([d6ac51a](https://github.com/bitnami/charts/commit/d6ac51a35a7bf57bbd13404f3ed55dd6b7abe244))
 
 ## <small>1.1.10 (2022-04-19)</small>
 
-* [bitnami/jupyterhub] Release 1.1.10 updating components versions ([f34bd74](https://github.com/bitnami/charts/commit/f34bd74))
+* [bitnami/jupyterhub] Release 1.1.10 updating components versions ([f34bd74](https://github.com/bitnami/charts/commit/f34bd74d3b3593235ba96ed3fa056e88c2de247a))
 
 ## <small>1.1.9 (2022-04-07)</small>
 
-* [bitnami/jupyterhub] Release 1.1.9 updating components versions ([9ede2c9](https://github.com/bitnami/charts/commit/9ede2c9))
+* [bitnami/jupyterhub] Release 1.1.9 updating components versions ([9ede2c9](https://github.com/bitnami/charts/commit/9ede2c9c89cf315bbc970522eaa18bfd6ab3c0fe))
 
 ## <small>1.1.8 (2022-04-07)</small>
 
-* [bitnami/jupyterhub] Release 1.1.8 updating components versions ([9b767c2](https://github.com/bitnami/charts/commit/9b767c2))
+* [bitnami/jupyterhub] Release 1.1.8 updating components versions ([9b767c2](https://github.com/bitnami/charts/commit/9b767c2bc32d1c3e16be19ca76b12850e611768f))
 
 ## <small>1.1.7 (2022-04-03)</small>
 
-* [bitnami/jupyterhub] Release 1.1.7 updating components versions ([908d3b6](https://github.com/bitnami/charts/commit/908d3b6))
+* [bitnami/jupyterhub] Release 1.1.7 updating components versions ([908d3b6](https://github.com/bitnami/charts/commit/908d3b669834e3128d98fcb08a3efd6a1cb7d347))
 
 ## <small>1.1.6 (2022-04-02)</small>
 
-* [bitnami/jupyterhub] Release 1.1.6 updating components versions ([6bfb48d](https://github.com/bitnami/charts/commit/6bfb48d))
+* [bitnami/jupyterhub] Release 1.1.6 updating components versions ([6bfb48d](https://github.com/bitnami/charts/commit/6bfb48d9aaadd1d8ffd644cb5a5d1e752c1a8481))
 
 ## <small>1.1.5 (2022-03-29)</small>
 
-* [bitnami/jupyterhub] Release 1.1.5 updating components versions ([3bb3d03](https://github.com/bitnami/charts/commit/3bb3d03))
+* [bitnami/jupyterhub] Release 1.1.5 updating components versions ([3bb3d03](https://github.com/bitnami/charts/commit/3bb3d0334a81687122dfcf479b08da29d1f8ed10))
 
 ## <small>1.1.4 (2022-03-28)</small>
 
-* [bitnami/jupyterhub] Release 1.1.4 updating components versions ([17d4463](https://github.com/bitnami/charts/commit/17d4463))
+* [bitnami/jupyterhub] Release 1.1.4 updating components versions ([17d4463](https://github.com/bitnami/charts/commit/17d446378fc5fac83f6605b8795f93e7c0df37b6))
 
 ## <small>1.1.3 (2022-03-27)</small>
 
-* [bitnami/jupyterhub] Release 1.1.3 updating components versions ([b8cfe94](https://github.com/bitnami/charts/commit/b8cfe94))
+* [bitnami/jupyterhub] Release 1.1.3 updating components versions ([b8cfe94](https://github.com/bitnami/charts/commit/b8cfe9488c1b92d695b76f0529d66c254ea93170))
 
 ## <small>1.1.2 (2022-03-18)</small>
 
-* [bitnami/jupyterhub] Release 1.1.2 updating components versions ([76c8340](https://github.com/bitnami/charts/commit/76c8340))
+* [bitnami/jupyterhub] Release 1.1.2 updating components versions ([76c8340](https://github.com/bitnami/charts/commit/76c8340573526b8fe5076fcbd6d8e10de4e58ec9))
 
 ## <small>1.1.1 (2022-03-16)</small>
 
-* [bitnami/jupyterhub] Release 1.1.1 updating components versions ([1b32cff](https://github.com/bitnami/charts/commit/1b32cff))
+* [bitnami/jupyterhub] Release 1.1.1 updating components versions ([1b32cff](https://github.com/bitnami/charts/commit/1b32cffb6fa9dded7c88f4c8f6d6a394c535f6ac))
 
 ## 1.1.0 (2022-03-08)
 
-* [bitnami/jupyterhub] Chart standardized (#9330) ([d06594f](https://github.com/bitnami/charts/commit/d06594f)), closes [#9330](https://github.com/bitnami/charts/issues/9330)
+* [bitnami/jupyterhub] Chart standardized (#9330) ([d06594f](https://github.com/bitnami/charts/commit/d06594fb9e20e4912359ece25114ef731f966074)), closes [#9330](https://github.com/bitnami/charts/issues/9330)
 
 ## <small>1.0.2 (2022-03-07)</small>
 
-* [bitnami/*] Take 'global.postgresql' values into account (#9314) ([dd428a0](https://github.com/bitnami/charts/commit/dd428a0)), closes [#9314](https://github.com/bitnami/charts/issues/9314)
+* [bitnami/*] Take 'global.postgresql' values into account (#9314) ([dd428a0](https://github.com/bitnami/charts/commit/dd428a06614551c92500afa84ce9750c4d8b90c9)), closes [#9314](https://github.com/bitnami/charts/issues/9314)
 
 ## <small>1.0.1 (2022-03-04)</small>
 
-* [bitnami/several] Reorder subcharts (#9299) ([a041f6b](https://github.com/bitnami/charts/commit/a041f6b)), closes [#9299](https://github.com/bitnami/charts/issues/9299)
+* [bitnami/several] Reorder subcharts (#9299) ([a041f6b](https://github.com/bitnami/charts/commit/a041f6b0ff2dea82b3d030cb99454cede94dbc9a)), closes [#9299](https://github.com/bitnami/charts/issues/9299)
 
 ## 1.0.0 (2022-03-02)
 
-* [bitnami/jupyterhub] feat!: :arrow_up: Bump PostgreSQL subchart (#9258) ([4330719](https://github.com/bitnami/charts/commit/4330719)), closes [#9258](https://github.com/bitnami/charts/issues/9258)
+* [bitnami/jupyterhub] feat!: :arrow_up: Bump PostgreSQL subchart (#9258) ([4330719](https://github.com/bitnami/charts/commit/4330719acfc7a6bceedb8222e1f5448544f1b6dd)), closes [#9258](https://github.com/bitnami/charts/issues/9258)
 
 ## <small>0.4.9 (2022-03-01)</small>
 
-* [bitnami/jupyterhub] Release 0.4.9 updating components versions ([6117653](https://github.com/bitnami/charts/commit/6117653))
+* [bitnami/jupyterhub] Release 0.4.9 updating components versions ([6117653](https://github.com/bitnami/charts/commit/611765353cba943e48248fa6c618e783a29c5cba))
 
 ## <small>0.4.8 (2022-02-27)</small>
 
-* [bitnami/jupyterhub] Release 0.4.8 updating components versions ([678868e](https://github.com/bitnami/charts/commit/678868e))
+* [bitnami/jupyterhub] Release 0.4.8 updating components versions ([678868e](https://github.com/bitnami/charts/commit/678868e9599b3a380eabbd39747e524ba055fc69))
 
 ## <small>0.4.7 (2022-02-21)</small>
 
-* [bitnami/jupyterhub] Do not hardcode PDB apiVersion (#9096) ([894eb59](https://github.com/bitnami/charts/commit/894eb59)), closes [#9096](https://github.com/bitnami/charts/issues/9096)
+* [bitnami/jupyterhub] Do not hardcode PDB apiVersion (#9096) ([894eb59](https://github.com/bitnami/charts/commit/894eb595df22b29b309255b6ea2e29effa22d4b5)), closes [#9096](https://github.com/bitnami/charts/issues/9096)
 
 ## <small>0.4.6 (2022-02-11)</small>
 
-* [bitnami/jupyterhub] Release 0.4.6 updating components versions ([e1d9527](https://github.com/bitnami/charts/commit/e1d9527))
+* [bitnami/jupyterhub] Release 0.4.6 updating components versions ([e1d9527](https://github.com/bitnami/charts/commit/e1d9527ed0fa2ccf53f028ef695ed8c37b7104a0))
 
 ## <small>0.4.5 (2022-02-10)</small>
 
-* Updates values file to use singleuser.podLabels. (#8960) ([aa61c8d](https://github.com/bitnami/charts/commit/aa61c8d)), closes [#8960](https://github.com/bitnami/charts/issues/8960)
+* Updates values file to use singleuser.podLabels. (#8960) ([aa61c8d](https://github.com/bitnami/charts/commit/aa61c8d5a33e7c495fd3fbfc7c1e42f765ba54fe)), closes [#8960](https://github.com/bitnami/charts/issues/8960)
 
 ## <small>0.4.4 (2022-02-02)</small>
 
-* [bitnami/*] Make use of new "common.ingress.certManagerRequest" helper (#8862) ([12e4c37](https://github.com/bitnami/charts/commit/12e4c37)), closes [#8862](https://github.com/bitnami/charts/issues/8862)
+* [bitnami/*] Make use of new "common.ingress.certManagerRequest" helper (#8862) ([12e4c37](https://github.com/bitnami/charts/commit/12e4c3733eaeaa9a5579fdf917fa098a0f2aae23)), closes [#8862](https://github.com/bitnami/charts/issues/8862)
 
 ## <small>0.4.3 (2022-01-25)</small>
 
-* [bitnami/jupyterhub] Fix misplaced Ingress class in template file (#8761) ([29b4ba6](https://github.com/bitnami/charts/commit/29b4ba6)), closes [#8761](https://github.com/bitnami/charts/issues/8761) [#8757](https://github.com/bitnami/charts/issues/8757)
+* [bitnami/jupyterhub] Fix misplaced Ingress class in template file (#8761) ([29b4ba6](https://github.com/bitnami/charts/commit/29b4ba6c28725064cdeb1cdc7226bf8eb93975f0)), closes [#8761](https://github.com/bitnami/charts/issues/8761) [#8757](https://github.com/bitnami/charts/issues/8757)
 
 ## <small>0.4.2 (2022-01-20)</small>
 
-* [bitnami/*] Readme automation (#8579) ([78d1938](https://github.com/bitnami/charts/commit/78d1938)), closes [#8579](https://github.com/bitnami/charts/issues/8579)
-* [bitnami/*] Update READMEs (#8716) ([b9a9533](https://github.com/bitnami/charts/commit/b9a9533)), closes [#8716](https://github.com/bitnami/charts/issues/8716)
-* [bitnami/several] Change prerequisites (#8725) ([8d740c5](https://github.com/bitnami/charts/commit/8d740c5)), closes [#8725](https://github.com/bitnami/charts/issues/8725)
+* [bitnami/*] Readme automation (#8579) ([78d1938](https://github.com/bitnami/charts/commit/78d193831c900d178198491ffd08fa2217a64ecd)), closes [#8579](https://github.com/bitnami/charts/issues/8579)
+* [bitnami/*] Update READMEs (#8716) ([b9a9533](https://github.com/bitnami/charts/commit/b9a953337590eb2979453385874a267bacf50936)), closes [#8716](https://github.com/bitnami/charts/issues/8716)
+* [bitnami/several] Change prerequisites (#8725) ([8d740c5](https://github.com/bitnami/charts/commit/8d740c566cfdb7e2d933c40128b4e919fce953a5)), closes [#8725](https://github.com/bitnami/charts/issues/8725)
 
 ## <small>0.4.1 (2022-01-12)</small>
 
-* [bitnami/jupyterhub] Release 0.4.1 updating components versions ([df52d40](https://github.com/bitnami/charts/commit/df52d40))
+* [bitnami/jupyterhub] Release 0.4.1 updating components versions ([df52d40](https://github.com/bitnami/charts/commit/df52d4003e8650ac69e6bedeafe25198a5f27821))
 
 ## 0.4.0 (2022-01-05)
 
-* [bitnami/several] Adapt templating format (#8562) ([8cad18a](https://github.com/bitnami/charts/commit/8cad18a)), closes [#8562](https://github.com/bitnami/charts/issues/8562)
+* [bitnami/several] Adapt templating format (#8562) ([8cad18a](https://github.com/bitnami/charts/commit/8cad18aed9966a6f0208e5ad6cee46cb217f47ab)), closes [#8562](https://github.com/bitnami/charts/issues/8562)
 
 ## <small>0.3.7 (2022-01-04)</small>
 
-* [bitnami/several] Add license to the README ([05f7633](https://github.com/bitnami/charts/commit/05f7633))
-* [bitnami/several] Add license to the README ([32fb238](https://github.com/bitnami/charts/commit/32fb238))
-* [bitnami/several] Add license to the README ([b87c2f7](https://github.com/bitnami/charts/commit/b87c2f7))
-* [bitnami/several] Fix issue with quote when followed by }} (#8561) ([58077af](https://github.com/bitnami/charts/commit/58077af)), closes [#8561](https://github.com/bitnami/charts/issues/8561)
+* [bitnami/several] Add license to the README ([05f7633](https://github.com/bitnami/charts/commit/05f763372501d596e57db713dd53ff4ff3027cc4))
+* [bitnami/several] Add license to the README ([32fb238](https://github.com/bitnami/charts/commit/32fb238e60a0affc6debd3142eaa3c3d9089ec2a))
+* [bitnami/several] Add license to the README ([b87c2f7](https://github.com/bitnami/charts/commit/b87c2f7899d48a8b02c506765e6ae82937e9ba3f))
+* [bitnami/several] Fix issue with quote when followed by }} (#8561) ([58077af](https://github.com/bitnami/charts/commit/58077af58f40e74e7af41485bcca493e38523537)), closes [#8561](https://github.com/bitnami/charts/issues/8561)
 
 ## <small>0.3.6 (2021-12-21)</small>
 
-* [bitnami/jupyterhub] Release 0.3.6 updating components versions ([8cb0422](https://github.com/bitnami/charts/commit/8cb0422))
+* [bitnami/jupyterhub] Release 0.3.6 updating components versions ([8cb0422](https://github.com/bitnami/charts/commit/8cb0422ad2cbc58a81fa17fbfce08a7bb09d3d9b))
 
 ## <small>0.3.5 (2021-12-20)</small>
 
-* [bitnami/jupyterhub] Release 0.3.5 updating components versions ([da7bc20](https://github.com/bitnami/charts/commit/da7bc20))
+* [bitnami/jupyterhub] Release 0.3.5 updating components versions ([da7bc20](https://github.com/bitnami/charts/commit/da7bc20d343cdef705f7ebc50ef8b0046e6eb0e0))
 
 ## <small>0.3.4 (2021-12-17)</small>
 
-* [bitnami/jupyterhub] Release 0.3.4 updating components versions ([82705e1](https://github.com/bitnami/charts/commit/82705e1))
+* [bitnami/jupyterhub] Release 0.3.4 updating components versions ([82705e1](https://github.com/bitnami/charts/commit/82705e111fe4d4842bcc7ae921633e82d6e02ae2))
 
 ## <small>0.3.3 (2021-12-16)</small>
 
-* [bitnami/jupyterhub] Release 0.3.3 updating components versions ([2fcb30a](https://github.com/bitnami/charts/commit/2fcb30a))
+* [bitnami/jupyterhub] Release 0.3.3 updating components versions ([2fcb30a](https://github.com/bitnami/charts/commit/2fcb30a868e36cf6d343ad4100297bf85a114523))
 
 ## <small>0.3.2 (2021-11-29)</small>
 
-* [bitnami/several] Fix deadlinks in README.md (#8215) ([99e90d2](https://github.com/bitnami/charts/commit/99e90d2)), closes [#8215](https://github.com/bitnami/charts/issues/8215)
-* [bitnami/several] Regenerate README tables ([7b091c0](https://github.com/bitnami/charts/commit/7b091c0))
-* [bitnami/several] Replace HTTP by HTTPS when possible (#8259) ([eafb5bd](https://github.com/bitnami/charts/commit/eafb5bd)), closes [#8259](https://github.com/bitnami/charts/issues/8259)
+* [bitnami/several] Fix deadlinks in README.md (#8215) ([99e90d2](https://github.com/bitnami/charts/commit/99e90d244b3244e059a42f72dcbecd3cda2b66bb)), closes [#8215](https://github.com/bitnami/charts/issues/8215)
+* [bitnami/several] Regenerate README tables ([7b091c0](https://github.com/bitnami/charts/commit/7b091c0808ef00425c404cb97fe73c0578ccf1a3))
+* [bitnami/several] Replace HTTP by HTTPS when possible (#8259) ([eafb5bd](https://github.com/bitnami/charts/commit/eafb5bd5a2cc3aaf04fc1e8ebedd73f420d76864)), closes [#8259](https://github.com/bitnami/charts/issues/8259)
 
 ## <small>0.3.1 (2021-11-19)</small>
 
-* [bitnami/jupyterhub] Release 0.3.1 updating components versions ([6580f57](https://github.com/bitnami/charts/commit/6580f57))
+* [bitnami/jupyterhub] Release 0.3.1 updating components versions ([6580f57](https://github.com/bitnami/charts/commit/6580f572467e30426959501f30b1bedb8914f862))
 
 ## 0.3.0 (2021-11-18)
 
-* [bitnami/jupyterhub] Add ingressClassName, new cert-manager way (#8157) ([9302115](https://github.com/bitnami/charts/commit/9302115)), closes [#8157](https://github.com/bitnami/charts/issues/8157)
-* [bitnami/several] Regenerate README tables ([1cde837](https://github.com/bitnami/charts/commit/1cde837))
+* [bitnami/jupyterhub] Add ingressClassName, new cert-manager way (#8157) ([9302115](https://github.com/bitnami/charts/commit/930211569529cacc1d47e80c7fd696f7755bd7f3)), closes [#8157](https://github.com/bitnami/charts/issues/8157)
+* [bitnami/several] Regenerate README tables ([1cde837](https://github.com/bitnami/charts/commit/1cde8378b3ee2e825ac07bb0266a988b95b8dbce))
 
 ## <small>0.2.7 (2021-11-16)</small>
 
-* [bitnami/jupyterhub] Release 0.2.7 updating components versions ([4e39657](https://github.com/bitnami/charts/commit/4e39657))
-* [bitnami/several] Regenerate README tables ([14b89ea](https://github.com/bitnami/charts/commit/14b89ea))
+* [bitnami/jupyterhub] Release 0.2.7 updating components versions ([4e39657](https://github.com/bitnami/charts/commit/4e39657004c9e0af8cc07ad92363268a731d5203))
+* [bitnami/several] Regenerate README tables ([14b89ea](https://github.com/bitnami/charts/commit/14b89eadad5eaf515b99c0392eb9461fff50f4a1))
 
 ## <small>0.2.6 (2021-11-09)</small>
 
-* [bitnami/jupyterhub] Release 0.2.6 updating components versions ([3876210](https://github.com/bitnami/charts/commit/3876210))
-* [bitnami/several] Regenerate README tables ([3cefed3](https://github.com/bitnami/charts/commit/3cefed3))
+* [bitnami/jupyterhub] Release 0.2.6 updating components versions ([3876210](https://github.com/bitnami/charts/commit/387621060c51923e40920a0f49322a7bf62482ca))
+* [bitnami/several] Regenerate README tables ([3cefed3](https://github.com/bitnami/charts/commit/3cefed3ef961fbd7596242b1165bcfa229a9cadb))
 
 ## <small>0.2.5 (2021-10-28)</small>
 
-* [bitnami/jupyterhub] Release 0.2.5 updating components versions ([3b7d432](https://github.com/bitnami/charts/commit/3b7d432))
+* [bitnami/jupyterhub] Release 0.2.5 updating components versions ([3b7d432](https://github.com/bitnami/charts/commit/3b7d432606b3a09536e9e5c9128a450481f009a9))
 
 ## <small>0.2.4 (2021-10-22)</small>
 
-* [bitnami/several] Add chart info to NOTES.txt (#7889) ([a6751cd](https://github.com/bitnami/charts/commit/a6751cd)), closes [#7889](https://github.com/bitnami/charts/issues/7889)
+* [bitnami/several] Add chart info to NOTES.txt (#7889) ([a6751cd](https://github.com/bitnami/charts/commit/a6751cdd33c461fabbc459fbea6f219ec64ab6b2)), closes [#7889](https://github.com/bitnami/charts/issues/7889)
 
 ## <small>0.2.3 (2021-10-19)</small>
 
-* [bitnami/several] Change pullPolicy for bitnami-shell image (#7852) ([9711a33](https://github.com/bitnami/charts/commit/9711a33)), closes [#7852](https://github.com/bitnami/charts/issues/7852)
-* [bitnami/several] Regenerate README tables ([0a26eaa](https://github.com/bitnami/charts/commit/0a26eaa))
+* [bitnami/several] Change pullPolicy for bitnami-shell image (#7852) ([9711a33](https://github.com/bitnami/charts/commit/9711a33c6eec72ea79143c4b7574dbe6a148d6b2)), closes [#7852](https://github.com/bitnami/charts/issues/7852)
+* [bitnami/several] Regenerate README tables ([0a26eaa](https://github.com/bitnami/charts/commit/0a26eaafd6ad234046aa91c79a44a1d45f55724e))
 
 ## <small>0.2.2 (2021-10-17)</small>
 
-* [bitnami/jupyterhub] Fix proxy.service.public.type (#7731) ([0e1d0f0](https://github.com/bitnami/charts/commit/0e1d0f0)), closes [#7731](https://github.com/bitnami/charts/issues/7731)
-* [bitnami/jupyterhub] Release 0.2.2 updating components versions ([c6f5ebe](https://github.com/bitnami/charts/commit/c6f5ebe))
-* [bitnamijupyterhub] Regenerate README tables ([798dfb2](https://github.com/bitnami/charts/commit/798dfb2))
+* [bitnami/jupyterhub] Fix proxy.service.public.type (#7731) ([0e1d0f0](https://github.com/bitnami/charts/commit/0e1d0f06805f3804d2a636ede953dbde4233a55c)), closes [#7731](https://github.com/bitnami/charts/issues/7731)
+* [bitnami/jupyterhub] Release 0.2.2 updating components versions ([c6f5ebe](https://github.com/bitnami/charts/commit/c6f5ebee3cdf3077fee6d91504f64d0bde975f32))
+* [bitnamijupyterhub] Regenerate README tables ([798dfb2](https://github.com/bitnami/charts/commit/798dfb2b6604bcb22420cda1487f043d9971d113))
 
 ## <small>0.2.1 (2021-10-14)</small>
 
-* [bitnami/jupyterhub] Fix imagePullSecrets format for singleuser configuration, add security options  ([9cff860](https://github.com/bitnami/charts/commit/9cff860)), closes [#7713](https://github.com/bitnami/charts/issues/7713)
-* [bitnami/several] Regenerate README tables ([cdcf8c1](https://github.com/bitnami/charts/commit/cdcf8c1))
+* [bitnami/jupyterhub] Fix imagePullSecrets format for singleuser configuration, add security options  ([9cff860](https://github.com/bitnami/charts/commit/9cff8603312aa550cc8a8337443c8b420c74d544)), closes [#7713](https://github.com/bitnami/charts/issues/7713)
+* [bitnami/several] Regenerate README tables ([cdcf8c1](https://github.com/bitnami/charts/commit/cdcf8c1407a9a23b93fadf513be21ca1f9c7c056))
 
 ## 0.2.0 (2021-10-05)
 
-* [bitnami/jupyterhub] Add Prometheus monitoring with serviceMonitors for hub and proxy components (#7 ([d115315](https://github.com/bitnami/charts/commit/d115315)), closes [#7637](https://github.com/bitnami/charts/issues/7637)
+* [bitnami/jupyterhub] Add Prometheus monitoring with serviceMonitors for hub and proxy components (#7 ([d115315](https://github.com/bitnami/charts/commit/d1153158adb10f4579867e5ba647e1e9d5ca8012)), closes [#7637](https://github.com/bitnami/charts/issues/7637)
 
 ## <small>0.1.20 (2021-10-01)</small>
 
-* [bitnami/*] Drop support for deprecated cert-manager annotation (#7582) ([a081792](https://github.com/bitnami/charts/commit/a081792)), closes [#7582](https://github.com/bitnami/charts/issues/7582)
-* [bitnami/several] Regenerate README tables ([ff170d1](https://github.com/bitnami/charts/commit/ff170d1))
+* [bitnami/*] Drop support for deprecated cert-manager annotation (#7582) ([a081792](https://github.com/bitnami/charts/commit/a08179293543f063e5de966a9976ca967161de7b)), closes [#7582](https://github.com/bitnami/charts/issues/7582)
+* [bitnami/several] Regenerate README tables ([ff170d1](https://github.com/bitnami/charts/commit/ff170d10f8aa6dae0f1e5c3f7d1c69fcec96b731))
 
 ## <small>0.1.19 (2021-09-25)</small>
 
-* [bitnami/*] Generate READMEs with new generator version (#7614) ([e5ab2e6](https://github.com/bitnami/charts/commit/e5ab2e6)), closes [#7614](https://github.com/bitnami/charts/issues/7614)
-* [bitnami/jupyterhub] Release 0.1.19 updating components versions ([cbc32ca](https://github.com/bitnami/charts/commit/cbc32ca))
-* [bitnami/several] Regenerate README tables ([64d5d74](https://github.com/bitnami/charts/commit/64d5d74))
+* [bitnami/*] Generate READMEs with new generator version (#7614) ([e5ab2e6](https://github.com/bitnami/charts/commit/e5ab2e6ecdd6bce800863f154cda524ff9f6c117)), closes [#7614](https://github.com/bitnami/charts/issues/7614)
+* [bitnami/jupyterhub] Release 0.1.19 updating components versions ([cbc32ca](https://github.com/bitnami/charts/commit/cbc32ca236ef82c513ec25e844fec2786bd8b015))
+* [bitnami/several] Regenerate README tables ([64d5d74](https://github.com/bitnami/charts/commit/64d5d747b84299ca9f63ea8a586b13870abe31a6))
 
 ## <small>0.1.18 (2021-08-26)</small>
 
-* [bitnami/jupyterhub] Release 0.1.18 updating components versions ([c99e607](https://github.com/bitnami/charts/commit/c99e607))
-* [bitnami/several] Regenerate README tables ([da2513b](https://github.com/bitnami/charts/commit/da2513b))
+* [bitnami/jupyterhub] Release 0.1.18 updating components versions ([c99e607](https://github.com/bitnami/charts/commit/c99e6070226c34de36f92fd68c4fe758b09c00d0))
+* [bitnami/several] Regenerate README tables ([da2513b](https://github.com/bitnami/charts/commit/da2513bf0a33819f3b1151d387c631a9ffdb03e2))
 
 ## <small>0.1.17 (2021-08-25)</small>
 
-* [bitnami/jupyterhub] Release 0.1.17 updating components versions ([1c9155a](https://github.com/bitnami/charts/commit/1c9155a))
-* [bitnami/several] Regenerate README tables ([6c107e8](https://github.com/bitnami/charts/commit/6c107e8))
+* [bitnami/jupyterhub] Release 0.1.17 updating components versions ([1c9155a](https://github.com/bitnami/charts/commit/1c9155a7a55d09281954e87d82a3f44e4717c12e))
+* [bitnami/several] Regenerate README tables ([6c107e8](https://github.com/bitnami/charts/commit/6c107e835d6caf8db2e8b17dcd48c5971637e013))
 
 ## <small>0.1.16 (2021-08-04)</small>
 
-* [bitnami/jupyterhub] Release 0.1.16 updating components versions ([910a640](https://github.com/bitnami/charts/commit/910a640))
+* [bitnami/jupyterhub] Release 0.1.16 updating components versions ([910a640](https://github.com/bitnami/charts/commit/910a640529881014eb4a6a0a3a6588c2ee1675bf))
 
 ## <small>0.1.15 (2021-07-30)</small>
 
-* [bitnami/several] Fix default values when using `foo: |` (#7092) ([fe91297](https://github.com/bitnami/charts/commit/fe91297)), closes [#7092](https://github.com/bitnami/charts/issues/7092)
+* [bitnami/several] Fix default values when using `foo: |` (#7092) ([fe91297](https://github.com/bitnami/charts/commit/fe91297fdf3f6c74aee31c423912e4ac19b55c94)), closes [#7092](https://github.com/bitnami/charts/issues/7092)
 
 ## <small>0.1.14 (2021-07-29)</small>
 
-* [bitnami/jupyterhub] Fix default value for extraIngress/extraEgress (#7091) ([cfb8506](https://github.com/bitnami/charts/commit/cfb8506)), closes [#7091](https://github.com/bitnami/charts/issues/7091)
+* [bitnami/jupyterhub] Fix default value for extraIngress/extraEgress (#7091) ([cfb8506](https://github.com/bitnami/charts/commit/cfb85065978de0a6d806d69af57c62ba3b34a980)), closes [#7091](https://github.com/bitnami/charts/issues/7091)
 
 ## <small>0.1.13 (2021-07-27)</small>
 
-* [bitnami/several] Fix default values and regenerate README (#7024) ([4c86733](https://github.com/bitnami/charts/commit/4c86733)), closes [#7024](https://github.com/bitnami/charts/issues/7024)
+* [bitnami/several] Fix default values and regenerate README (#7024) ([4c86733](https://github.com/bitnami/charts/commit/4c867335c5c9c5aba041868df16ebb8f64ac68bd)), closes [#7024](https://github.com/bitnami/charts/issues/7024)
 
 ## <small>0.1.12 (2021-07-16)</small>
 
-* [bitnami/jupyterhub] Release 0.1.12 updating components versions ([ac6c377](https://github.com/bitnami/charts/commit/ac6c377))
+* [bitnami/jupyterhub] Release 0.1.12 updating components versions ([ac6c377](https://github.com/bitnami/charts/commit/ac6c3775cb19ece64788cfab139c240049e91eab))
 
 ## <small>0.1.11 (2021-07-09)</small>
 
-* [bitnami/jupyterhub] Release 0.1.11 updating components versions ([e8c0b82](https://github.com/bitnami/charts/commit/e8c0b82))
+* [bitnami/jupyterhub] Release 0.1.11 updating components versions ([e8c0b82](https://github.com/bitnami/charts/commit/e8c0b82f28ef17853f8c5bc50e6785ad67665824))
 
 ## <small>0.1.10 (2021-07-09)</small>
 
-* [bitnami/*] Adapt values.yaml of Joomla, Jupyterhub and Kafka charts (#6850) ([8ebbf6e](https://github.com/bitnami/charts/commit/8ebbf6e)), closes [#6850](https://github.com/bitnami/charts/issues/6850)
+* [bitnami/*] Adapt values.yaml of Joomla, Jupyterhub and Kafka charts (#6850) ([8ebbf6e](https://github.com/bitnami/charts/commit/8ebbf6e0af566e05e794562d9a4d1e4f73ce1502)), closes [#6850](https://github.com/bitnami/charts/issues/6850)
 
 ## <small>0.1.9 (2021-06-09)</small>
 
-* [bitnami/jupyterhub] Release 0.1.9 updating components versions ([1f103bb](https://github.com/bitnami/charts/commit/1f103bb))
-* Bug #6339 - bitnami/jupyterhub chart fix (#6388) ([d232e6b](https://github.com/bitnami/charts/commit/d232e6b)), closes [#6388](https://github.com/bitnami/charts/issues/6388)
+* [bitnami/jupyterhub] Release 0.1.9 updating components versions ([1f103bb](https://github.com/bitnami/charts/commit/1f103bbc164f51f0dd82d6b832b5c3891d0b668a))
+* Bug #6339 - bitnami/jupyterhub chart fix (#6388) ([d232e6b](https://github.com/bitnami/charts/commit/d232e6b36b7f030564198040158bb03f7049de76)), closes [#6388](https://github.com/bitnami/charts/issues/6388)
 
 ## <small>0.1.8 (2021-05-28)</small>
 
-* [bitnami/jupyterhub] Release 0.1.8 updating components versions ([e3c6ae3](https://github.com/bitnami/charts/commit/e3c6ae3))
+* [bitnami/jupyterhub] Release 0.1.8 updating components versions ([e3c6ae3](https://github.com/bitnami/charts/commit/e3c6ae3045a3723b73145239778481852d2383c4))
 
 ## <small>0.1.7 (2021-05-26)</small>
 
-* [bitnami/jupyterhub] Release 0.1.7 updating components versions ([f42af9f](https://github.com/bitnami/charts/commit/f42af9f))
+* [bitnami/jupyterhub] Release 0.1.7 updating components versions ([f42af9f](https://github.com/bitnami/charts/commit/f42af9fe85a0408e2c5f69d2345d92f407b23479))
 
 ## <small>0.1.6 (2021-05-24)</small>
 
-* [bitnami/jupyterhub] Release 0.1.6 updating components versions ([58ef7b0](https://github.com/bitnami/charts/commit/58ef7b0))
+* [bitnami/jupyterhub] Release 0.1.6 updating components versions ([58ef7b0](https://github.com/bitnami/charts/commit/58ef7b087837b31d7c6c81e5aad6c4531b61160f))
 
 ## <small>0.1.5 (2021-05-20)</small>
 
-* [bitnami/jupyterhub] Fix singleuser storage class (#6425) ([aca158e](https://github.com/bitnami/charts/commit/aca158e)), closes [#6425](https://github.com/bitnami/charts/issues/6425)
+* [bitnami/jupyterhub] Fix singleuser storage class (#6425) ([aca158e](https://github.com/bitnami/charts/commit/aca158ee4a4a990fb8127af8e8457b3bab37ff5c)), closes [#6425](https://github.com/bitnami/charts/issues/6425)
 
 ## <small>0.1.4 (2021-05-14)</small>
 
-* [bitnami/jupyterhub] Updated README (#6242) ([b5728c1](https://github.com/bitnami/charts/commit/b5728c1)), closes [#6242](https://github.com/bitnami/charts/issues/6242)
+* [bitnami/jupyterhub] Updated README (#6242) ([b5728c1](https://github.com/bitnami/charts/commit/b5728c17c6513d7e963fbedeaef763a5bc1e084e)), closes [#6242](https://github.com/bitnami/charts/issues/6242)
 
 ## <small>0.1.3 (2021-04-26)</small>
 
-* [bitnami/jupyterhub] Fixes error when using storageclass (#6205) ([7228f09](https://github.com/bitnami/charts/commit/7228f09)), closes [#6205](https://github.com/bitnami/charts/issues/6205)
+* [bitnami/jupyterhub] Fixes error when using storageclass (#6205) ([7228f09](https://github.com/bitnami/charts/commit/7228f09e648c1ec603f69ea1e8623ba8fdf94d79)), closes [#6205](https://github.com/bitnami/charts/issues/6205)
 
 ## <small>0.1.2 (2021-04-23)</small>
 
-* [bitnami/jupyterhub] Fix for TKG (#6203) ([c9a13e3](https://github.com/bitnami/charts/commit/c9a13e3)), closes [#6203](https://github.com/bitnami/charts/issues/6203)
+* [bitnami/jupyterhub] Fix for TKG (#6203) ([c9a13e3](https://github.com/bitnami/charts/commit/c9a13e39dfaf1177494b446c821e86588e0b0f04)), closes [#6203](https://github.com/bitnami/charts/issues/6203)
 
 ## <small>0.1.1 (2021-04-23)</small>
 
-* [bitnami/jupyterhub] Removes imagePullSecrets (#6201) ([834764f](https://github.com/bitnami/charts/commit/834764f)), closes [#6201](https://github.com/bitnami/charts/issues/6201)
+* [bitnami/jupyterhub] Removes imagePullSecrets (#6201) ([834764f](https://github.com/bitnami/charts/commit/834764fd1757a0a7f95c14098e2be08263b00b70)), closes [#6201](https://github.com/bitnami/charts/issues/6201)
 
 ## 0.1.0 (2021-04-23)
 
-* [bitnami/jupyterhub] Add chart (#5992) ([4845f4a](https://github.com/bitnami/charts/commit/4845f4a)), closes [#5992](https://github.com/bitnami/charts/issues/5992)
+* [bitnami/jupyterhub] Add chart (#5992) ([4845f4a](https://github.com/bitnami/charts/commit/4845f4a0ba8936a6bb35bf419ae9ddac30eb4397)), closes [#5992](https://github.com/bitnami/charts/issues/5992)

--- a/bitnami/jupyterhub/Chart.lock
+++ b/bitnami/jupyterhub/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: postgresql
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 15.3.5
+  version: 15.4.0
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 2.19.3
-digest: sha256:733f900df591c9175c755b21213ed83c02a011517e70120f4e00aa28b12397e2
-generated: "2024-05-21T13:55:01.057775148+02:00"
+digest: sha256:aef3ad652bf811a804846abc0c8355ab57e2cd668e2f28788a1ef93c0f333977
+generated: "2024-05-22T17:03:10.634654+02:00"

--- a/bitnami/jupyterhub/Chart.yaml
+++ b/bitnami/jupyterhub/Chart.yaml
@@ -37,4 +37,4 @@ maintainers:
 name: jupyterhub
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/jupyterhub
-version: 7.1.0
+version: 7.1.1

--- a/bitnami/jupyterhub/templates/hub/deployment.yaml
+++ b/bitnami/jupyterhub/templates/hub/deployment.yaml
@@ -214,8 +214,7 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.hub.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.hub.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.hub.livenessProbe "enabled") "context" $) | nindent 12 }}
-            httpGet:
-              path: {{ .Values.hub.baseUrl | trimSuffix "/" }}/hub/health
+            tcpSocket:
               port: http
           {{- end }}
           {{- if .Values.hub.customReadinessProbe }}

--- a/bitnami/jupyterhub/templates/proxy/deployment.yaml
+++ b/bitnami/jupyterhub/templates/proxy/deployment.yaml
@@ -157,8 +157,7 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.proxy.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.proxy.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.proxy.livenessProbe "enabled") "context" $) | nindent 12 }}
-            httpGet:
-              path: /_chp_healthz
+            tcpSocket:
               port: http
           {{- end }}
           {{- if .Values.proxy.customReadinessProbe }}


### PR DESCRIPTION
### Description of the change
This PR aims to use different liveness/readiness probes to improve overall security and avoid unnecessary container restarts. [More info](https://github.com/zegl/kube-score/blob/master/README_PROBES.md).

### Benefits

Increase availability and resilience.

### Possible drawbacks

N/A

### Applicable issues

- fixes #

### Additional information

- Related to #23537

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- ~[X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)~
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
