### PR TITLE
[bitnami/grafana-tempo] Use different liveness/readiness probes

### DIFF
--- a/bitnami/grafana-tempo/Chart.lock
+++ b/bitnami/grafana-tempo/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: memcached
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 7.3.0
+  version: 7.4.1
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 2.19.3
-digest: sha256:0ad61a98ddd8f7c0c3d509a8c5dd36d651cf13738be1959915a5d6b9df89f4e9
-generated: "2024-05-21T13:47:39.577834087+02:00"
+digest: sha256:a0552717cf259a1f11729688d45d211b1fc78f21cb6f2f8dd3792c3ab67a8788
+generated: "2024-05-22T13:37:33.641734+02:00"

--- a/bitnami/grafana-tempo/Chart.yaml
+++ b/bitnami/grafana-tempo/Chart.yaml
@@ -39,4 +39,4 @@ maintainers:
 name: grafana-tempo
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/grafana-tempo
-version: 3.4.0
+version: 3.4.1

--- a/bitnami/grafana-tempo/templates/compactor/deployment.yaml
+++ b/bitnami/grafana-tempo/templates/compactor/deployment.yaml
@@ -122,8 +122,7 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.compactor.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.compactor.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.compactor.livenessProbe "enabled") "context" $) | nindent 12 }}
-            httpGet:
-              path: /ready
+            tcpSocket:
               port: {{ .Values.tempo.containerPorts.web }}
           {{- end }}
           {{- if .Values.compactor.customReadinessProbe }}

--- a/bitnami/grafana-tempo/templates/distributor/deployment.yaml
+++ b/bitnami/grafana-tempo/templates/distributor/deployment.yaml
@@ -161,8 +161,7 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.distributor.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.distributor.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.distributor.livenessProbe "enabled") "context" $) | nindent 12 }}
-            httpGet:
-              path: /ready
+            tcpSocket:
               port: {{ .Values.tempo.containerPorts.web }}
           {{- end }}
           {{- if .Values.distributor.customReadinessProbe }}

--- a/bitnami/grafana-tempo/templates/ingester/statefulset.yaml
+++ b/bitnami/grafana-tempo/templates/ingester/statefulset.yaml
@@ -159,7 +159,8 @@ spec:
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.ingester.customReadinessProbe "context" $) | nindent 12 }}
           {{- else if .Values.ingester.readinessProbe.enabled }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.ingester.readinessProbe "enabled") "context" $) | nindent 12 }}
-            tcpSocket:
+            httpGet:
+              path: /ready
               port: http
           {{- end }}
           {{- if .Values.ingester.customStartupProbe }}

--- a/bitnami/grafana-tempo/templates/metrics-generator/deployment.yaml
+++ b/bitnami/grafana-tempo/templates/metrics-generator/deployment.yaml
@@ -121,8 +121,7 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.metricsGenerator.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.metricsGenerator.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.metricsGenerator.livenessProbe "enabled") "context" $) | nindent 12 }}
-            httpGet:
-              path: /ready
+            tcpSocket:
               port: {{ .Values.tempo.containerPorts.web }}
           {{- end }}
           {{- if .Values.metricsGenerator.customReadinessProbe }}

--- a/bitnami/grafana-tempo/templates/querier/deployment.yaml
+++ b/bitnami/grafana-tempo/templates/querier/deployment.yaml
@@ -121,8 +121,7 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.querier.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.querier.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.querier.livenessProbe "enabled") "context" $) | nindent 12 }}
-            httpGet:
-              path: /ready
+            tcpSocket:
               port: {{ .Values.tempo.containerPorts.web }}
           {{- end }}
           {{- if .Values.querier.customReadinessProbe }}

--- a/bitnami/grafana-tempo/templates/query-frontend/deployment.yaml
+++ b/bitnami/grafana-tempo/templates/query-frontend/deployment.yaml
@@ -120,8 +120,7 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.queryFrontend.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.queryFrontend.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.queryFrontend.livenessProbe "enabled") "context" $) | nindent 12 }}
-            httpGet:
-              path: /ready
+            tcpSocket:
               port: {{ .Values.tempo.containerPorts.web }}
           {{- end }}
           {{- if .Values.queryFrontend.customReadinessProbe }}
@@ -217,7 +216,8 @@ spec:
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.queryFrontend.query.customReadinessProbe "context" $) | nindent 12 }}
           {{- else if .Values.queryFrontend.query.readinessProbe.enabled }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.queryFrontend.query.readinessProbe "enabled") "context" $) | nindent 12 }}
-            tcpSocket:
+            httpGet:
+              path: /
               port: jaeger-ui
           {{- end }}
           {{- if .Values.queryFrontend.query.customStartupProbe }}

--- a/bitnami/grafana-tempo/templates/vulture/deployment.yaml
+++ b/bitnami/grafana-tempo/templates/vulture/deployment.yaml
@@ -119,8 +119,7 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.vulture.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.vulture.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.vulture.livenessProbe "enabled") "context" $) | nindent 12 }}
-            httpGet:
-              path: /metrics
+            tcpSocket:
               port: {{ .Values.vulture.containerPorts.http }}
           {{- end }}
           {{- if .Values.vulture.customReadinessProbe }}


### PR DESCRIPTION
### Description of the change
This PR aims to use different liveness/readiness probes to improve overall security and avoid unnecessary container restarts. [More info](https://github.com/zegl/kube-score/blob/master/README_PROBES.md).

### Benefits

Increase availability and resilience.

### Possible drawbacks

N/A

### Applicable issues

- fixes #

### Additional information

- Related to #23537

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- ~[X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)~
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
