### PR TITLE
[bitnami/grafana-mimir] Use different liveness/readiness probes

### DIFF
--- a/bitnami/grafana-mimir/CHANGELOG.md
+++ b/bitnami/grafana-mimir/CHANGELOG.md
@@ -1,344 +1,349 @@
 # Changelog
 
+## 1.1.1 (2024-05-22)
+
+* [bitnami/grafana-mimir] Use different liveness/readiness probes ([#26350](https://github.com/bitnami/charts/pull/26350))
+
 ## 1.1.0 (2024-05-21)
 
-* [bitnami/grafana-mimir] feat: :sparkles: :lock: Add warning when original images are replaced ([#26211](https://github.com/bitnami/charts/pulls/26211))
+* [bitnami/*] ci: :construction_worker: Add tag and changelog support (#25359) ([91c707c](https://github.com/bitnami/charts/commit/91c707c9e4e574725a09505d2d313fb93f1b4c0a)), closes [#25359](https://github.com/bitnami/charts/issues/25359)
+* [bitnami/grafana-mimir] feat: :sparkles: :lock: Add warning when original images are replaced (#2621 ([747eebb](https://github.com/bitnami/charts/commit/747eebbb49caf1baece3398d0fad3e5c1f9adc64)), closes [#26211](https://github.com/bitnami/charts/issues/26211)
 
 ## <small>1.0.8 (2024-05-18)</small>
 
-* [bitnami/grafana-mimir] Release 1.0.8 updating components versions (#26019) ([e69d268](https://github.com/bitnami/charts/commit/e69d268)), closes [#26019](https://github.com/bitnami/charts/issues/26019)
+* [bitnami/grafana-mimir] Release 1.0.8 updating components versions (#26019) ([e69d268](https://github.com/bitnami/charts/commit/e69d268f3a9f303f4e6cc9ade6f35b420578df44)), closes [#26019](https://github.com/bitnami/charts/issues/26019)
 
 ## <small>1.0.7 (2024-05-17)</small>
 
-* [bitnami/grafana-mimir] PDB review (#25935) ([cb309ce](https://github.com/bitnami/charts/commit/cb309ce)), closes [#25935](https://github.com/bitnami/charts/issues/25935)
+* [bitnami/grafana-mimir] PDB review (#25935) ([cb309ce](https://github.com/bitnami/charts/commit/cb309ce738bc2ea264a9f63e3024b933041d2b13)), closes [#25935](https://github.com/bitnami/charts/issues/25935)
 
 ## <small>1.0.6 (2024-05-13)</small>
 
-* [bitnami/grafana-mimir] Release 1.0.6 updating components versions (#25766) ([dd02a85](https://github.com/bitnami/charts/commit/dd02a85)), closes [#25766](https://github.com/bitnami/charts/issues/25766)
+* [bitnami/grafana-mimir] Release 1.0.6 updating components versions (#25766) ([dd02a85](https://github.com/bitnami/charts/commit/dd02a8567e21644bc34921e64a9a3325548521c1)), closes [#25766](https://github.com/bitnami/charts/issues/25766)
 
 ## <small>1.0.5 (2024-05-13)</small>
 
-* [bitnami/*] Change non-root and rolling-tags doc URLs (#25628) ([b067c94](https://github.com/bitnami/charts/commit/b067c94)), closes [#25628](https://github.com/bitnami/charts/issues/25628)
-* [bitnami/grafana-mimir] Release 1.0.5 updating components versions (#25717) ([6eaaaba](https://github.com/bitnami/charts/commit/6eaaaba)), closes [#25717](https://github.com/bitnami/charts/issues/25717)
+* [bitnami/*] Change non-root and rolling-tags doc URLs (#25628) ([b067c94](https://github.com/bitnami/charts/commit/b067c94f6bcde427863c197fd355f0b5ba12ff5b)), closes [#25628](https://github.com/bitnami/charts/issues/25628)
+* [bitnami/grafana-mimir] Release 1.0.5 updating components versions (#25717) ([6eaaaba](https://github.com/bitnami/charts/commit/6eaaaba9f1625f8d89cc826ae500cac42945c2f0)), closes [#25717](https://github.com/bitnami/charts/issues/25717)
 
 ## <small>1.0.4 (2024-05-08)</small>
 
-* [bitnami/*] Set new header/owner (#25558) ([8d1dc11](https://github.com/bitnami/charts/commit/8d1dc11)), closes [#25558](https://github.com/bitnami/charts/issues/25558)
-* [bitnami/grafana-mimir] Release 1.0.4 updating components versions (#25594) ([763906a](https://github.com/bitnami/charts/commit/763906a)), closes [#25594](https://github.com/bitnami/charts/issues/25594)
+* [bitnami/*] Set new header/owner (#25558) ([8d1dc11](https://github.com/bitnami/charts/commit/8d1dc11f5fb30db6fba50c43d7af59d2f79deed3)), closes [#25558](https://github.com/bitnami/charts/issues/25558)
+* [bitnami/grafana-mimir] Release 1.0.4 updating components versions (#25594) ([763906a](https://github.com/bitnami/charts/commit/763906aeb94e2580d17687ceb588577b946ace92)), closes [#25594](https://github.com/bitnami/charts/issues/25594)
 
 ## <small>1.0.3 (2024-05-06)</small>
 
-* [bitnami/grafana-mimir] Remove unicode characters (#25543) ([b6b7c42](https://github.com/bitnami/charts/commit/b6b7c42)), closes [#25543](https://github.com/bitnami/charts/issues/25543)
-* [bitnami/multiple charts] Fix typo: "NetworkPolice" vs "NetworkPolicy" (#25348) ([6970c1b](https://github.com/bitnami/charts/commit/6970c1b)), closes [#25348](https://github.com/bitnami/charts/issues/25348)
-* Replace VMware by Broadcom copyright text (#25306) ([a5e4bd0](https://github.com/bitnami/charts/commit/a5e4bd0)), closes [#25306](https://github.com/bitnami/charts/issues/25306)
+* [bitnami/grafana-mimir] Remove unicode characters (#25543) ([b6b7c42](https://github.com/bitnami/charts/commit/b6b7c421f8cbdbe7dbda9f901364626cda7add9b)), closes [#25543](https://github.com/bitnami/charts/issues/25543)
+* [bitnami/multiple charts] Fix typo: "NetworkPolice" vs "NetworkPolicy" (#25348) ([6970c1b](https://github.com/bitnami/charts/commit/6970c1ba245873506e73d459c6eac1e4919b778f)), closes [#25348](https://github.com/bitnami/charts/issues/25348)
+* Replace VMware by Broadcom copyright text (#25306) ([a5e4bd0](https://github.com/bitnami/charts/commit/a5e4bd0e35e419203793976a78d9d0a13de92c76)), closes [#25306](https://github.com/bitnami/charts/issues/25306)
 
 ## <small>1.0.2 (2024-04-05)</small>
 
-* [bitnami/grafana-mimir] Release 1.0.2 updating components versions (#25004) ([cf7a1e9](https://github.com/bitnami/charts/commit/cf7a1e9)), closes [#25004](https://github.com/bitnami/charts/issues/25004)
+* [bitnami/grafana-mimir] Release 1.0.2 updating components versions (#25004) ([cf7a1e9](https://github.com/bitnami/charts/commit/cf7a1e9cfa9ea95587725c9c33526dfcbe2b995d)), closes [#25004](https://github.com/bitnami/charts/issues/25004)
 
 ## <small>1.0.1 (2024-04-04)</small>
 
-* [bitnami/grafana-mimir] Release 1.0.1 (#24882) ([fc660e4](https://github.com/bitnami/charts/commit/fc660e4)), closes [#24882](https://github.com/bitnami/charts/issues/24882)
-* Update resourcesPreset comments (#24467) ([92e3e8a](https://github.com/bitnami/charts/commit/92e3e8a)), closes [#24467](https://github.com/bitnami/charts/issues/24467)
+* [bitnami/grafana-mimir] Release 1.0.1 (#24882) ([fc660e4](https://github.com/bitnami/charts/commit/fc660e462b6491d9019e721e6cbe70ccada4ffc8)), closes [#24882](https://github.com/bitnami/charts/issues/24882)
+* Update resourcesPreset comments (#24467) ([92e3e8a](https://github.com/bitnami/charts/commit/92e3e8a507326d2a20a8f10ab3e7746a2ec5c554)), closes [#24467](https://github.com/bitnami/charts/issues/24467)
 
 ## 1.0.0 (2024-03-18)
 
-* [bitnami/*] Reorder Chart sections (#24455) ([0cf4048](https://github.com/bitnami/charts/commit/0cf4048)), closes [#24455](https://github.com/bitnami/charts/issues/24455)
-* [bitnami/grafana-mimir] feat!: :lock: :boom: Improve security defaults (#24511) ([b156c9e](https://github.com/bitnami/charts/commit/b156c9e)), closes [#24511](https://github.com/bitnami/charts/issues/24511)
+* [bitnami/*] Reorder Chart sections (#24455) ([0cf4048](https://github.com/bitnami/charts/commit/0cf4048e8743f70a9753d460655bd030cbff6824)), closes [#24455](https://github.com/bitnami/charts/issues/24455)
+* [bitnami/grafana-mimir] feat!: :lock: :boom: Improve security defaults (#24511) ([b156c9e](https://github.com/bitnami/charts/commit/b156c9ee9da56d149aae815ffc9e84ea6070e5df)), closes [#24511](https://github.com/bitnami/charts/issues/24511)
 
 ## <small>0.14.1 (2024-03-06)</small>
 
-* [bitnami/grafana-mimir] Release 0.14.1 updating components versions (#24225) ([ba7aa54](https://github.com/bitnami/charts/commit/ba7aa54)), closes [#24225](https://github.com/bitnami/charts/issues/24225)
+* [bitnami/grafana-mimir] Release 0.14.1 updating components versions (#24225) ([ba7aa54](https://github.com/bitnami/charts/commit/ba7aa541c1cfc10929f9ec676e5fa5e3e37385e1)), closes [#24225](https://github.com/bitnami/charts/issues/24225)
 
 ## 0.14.0 (2024-03-06)
 
-* [bitnami/grafana-mimir] feat: :sparkles: :lock: Add automatic adaptation for Openshift restricted-v2 ([ce21621](https://github.com/bitnami/charts/commit/ce21621)), closes [#24089](https://github.com/bitnami/charts/issues/24089)
+* [bitnami/grafana-mimir] feat: :sparkles: :lock: Add automatic adaptation for Openshift restricted-v2 ([ce21621](https://github.com/bitnami/charts/commit/ce21621e28a227658f5647888e9df65a5ab30bcc)), closes [#24089](https://github.com/bitnami/charts/issues/24089)
 
 ## 0.13.0 (2024-02-27)
 
-* [bitnami/grafana-mimir] feat: :sparkles: :lock: Add readOnlyRootFilesystem support (#23908) ([629f25a](https://github.com/bitnami/charts/commit/629f25a)), closes [#23908](https://github.com/bitnami/charts/issues/23908)
+* [bitnami/grafana-mimir] feat: :sparkles: :lock: Add readOnlyRootFilesystem support (#23908) ([629f25a](https://github.com/bitnami/charts/commit/629f25a585d177b95d531373d58faad2efe9041b)), closes [#23908](https://github.com/bitnami/charts/issues/23908)
 
 ## <small>0.12.2 (2024-02-21)</small>
 
-* [bitnami/grafana-mimir] Release 0.12.2 updating components versions (#23761) ([69cdd90](https://github.com/bitnami/charts/commit/69cdd90)), closes [#23761](https://github.com/bitnami/charts/issues/23761)
+* [bitnami/grafana-mimir] Release 0.12.2 updating components versions (#23761) ([69cdd90](https://github.com/bitnami/charts/commit/69cdd90d5ab350755626b47ca51a1b480fb4c8dd)), closes [#23761](https://github.com/bitnami/charts/issues/23761)
 
 ## <small>0.12.1 (2024-02-21)</small>
 
-* [bitnami/grafana-mimir] Release 0.12.1 updating components versions (#23652) ([af488ff](https://github.com/bitnami/charts/commit/af488ff)), closes [#23652](https://github.com/bitnami/charts/issues/23652)
+* [bitnami/grafana-mimir] Release 0.12.1 updating components versions (#23652) ([af488ff](https://github.com/bitnami/charts/commit/af488ffb6e1bb0ac409eaa5309fba2e7e53330bc)), closes [#23652](https://github.com/bitnami/charts/issues/23652)
 
 ## 0.12.0 (2024-02-20)
 
-* [bitnami/grafana-mimir] feat: :sparkles: :lock: Add resource preset support (#23456) ([1e271a7](https://github.com/bitnami/charts/commit/1e271a7)), closes [#23456](https://github.com/bitnami/charts/issues/23456)
+* [bitnami/grafana-mimir] feat: :sparkles: :lock: Add resource preset support (#23456) ([1e271a7](https://github.com/bitnami/charts/commit/1e271a7d93207ff79857cf03570fc77576d0c316)), closes [#23456](https://github.com/bitnami/charts/issues/23456)
 
 ## 0.11.0 (2024-02-20)
 
-* [bitnami/*] Bump all versions (#23602) ([b70ee2a](https://github.com/bitnami/charts/commit/b70ee2a)), closes [#23602](https://github.com/bitnami/charts/issues/23602)
+* [bitnami/*] Bump all versions (#23602) ([b70ee2a](https://github.com/bitnami/charts/commit/b70ee2a30e4dc256bf0ac52928fb2fa7a70f049b)), closes [#23602](https://github.com/bitnami/charts/issues/23602)
 
 ## 0.10.0 (2024-02-09)
 
-* [bitnami/grafana-mimir] feat: :lock: Enable networkPolicy (#23254) ([5cad7ed](https://github.com/bitnami/charts/commit/5cad7ed)), closes [#23254](https://github.com/bitnami/charts/issues/23254)
+* [bitnami/grafana-mimir] feat: :lock: Enable networkPolicy (#23254) ([5cad7ed](https://github.com/bitnami/charts/commit/5cad7ed7370159f40d6f782580d1870046135ad3)), closes [#23254](https://github.com/bitnami/charts/issues/23254)
 
 ## <small>0.9.9 (2024-02-07)</small>
 
-* [bitnami/grafana-mimir] Release 0.9.9 updating components versions (#23290) ([29e185d](https://github.com/bitnami/charts/commit/29e185d)), closes [#23290](https://github.com/bitnami/charts/issues/23290)
+* [bitnami/grafana-mimir] Release 0.9.9 updating components versions (#23290) ([29e185d](https://github.com/bitnami/charts/commit/29e185d3ad43f297e2043fa58537dd94d5408b42)), closes [#23290](https://github.com/bitnami/charts/issues/23290)
 
 ## <small>0.9.8 (2024-02-07)</small>
 
-* [bitnami/grafana-mimir] Release 0.9.8 updating components versions (#23231) ([d31e480](https://github.com/bitnami/charts/commit/d31e480)), closes [#23231](https://github.com/bitnami/charts/issues/23231)
+* [bitnami/grafana-mimir] Release 0.9.8 updating components versions (#23231) ([d31e480](https://github.com/bitnami/charts/commit/d31e480dc07e1dc0f10be0a6ab5e60c0be3ae783)), closes [#23231](https://github.com/bitnami/charts/issues/23231)
 
 ## <small>0.9.7 (2024-02-05)</small>
 
-* [bitnami/grafana-mimir] Release 0.9.7 updating components versions (#23185) ([a42ea4a](https://github.com/bitnami/charts/commit/a42ea4a)), closes [#23185](https://github.com/bitnami/charts/issues/23185)
-* [bitnami/grafana-mimir] Replacing serviceMonitor targetPorts with the right port (#22525) ([a7eaf54](https://github.com/bitnami/charts/commit/a7eaf54)), closes [#22525](https://github.com/bitnami/charts/issues/22525)
+* [bitnami/grafana-mimir] Release 0.9.7 updating components versions (#23185) ([a42ea4a](https://github.com/bitnami/charts/commit/a42ea4a289228f2e7a1bef4363d687e34b74efa9)), closes [#23185](https://github.com/bitnami/charts/issues/23185)
+* [bitnami/grafana-mimir] Replacing serviceMonitor targetPorts with the right port (#22525) ([a7eaf54](https://github.com/bitnami/charts/commit/a7eaf54636d5faf994422d9edd7589967f4e52ce)), closes [#22525](https://github.com/bitnami/charts/issues/22525)
 
 ## <small>0.9.6 (2024-02-02)</small>
 
-* [bitnami/grafana-mimir] Release 0.9.6 updating components versions (#23070) ([b1963af](https://github.com/bitnami/charts/commit/b1963af)), closes [#23070](https://github.com/bitnami/charts/issues/23070)
+* [bitnami/grafana-mimir] Release 0.9.6 updating components versions (#23070) ([b1963af](https://github.com/bitnami/charts/commit/b1963afe91b53235a436700a0b513ae4d5e2306b)), closes [#23070](https://github.com/bitnami/charts/issues/23070)
 
 ## <small>0.9.5 (2024-01-30)</small>
 
-* [bitnami/grafana-mimir] Release 0.9.5 updating components versions (#22916) ([446e72b](https://github.com/bitnami/charts/commit/446e72b)), closes [#22916](https://github.com/bitnami/charts/issues/22916)
+* [bitnami/grafana-mimir] Release 0.9.5 updating components versions (#22916) ([446e72b](https://github.com/bitnami/charts/commit/446e72bf3353574d0183f78213f4067b8b9e7bb9)), closes [#22916](https://github.com/bitnami/charts/issues/22916)
 
 ## <small>0.9.4 (2024-01-30)</small>
 
-* [bitnami/grafana-mimir] Release 0.9.4 updating components versions (#22861) ([79b276e](https://github.com/bitnami/charts/commit/79b276e)), closes [#22861](https://github.com/bitnami/charts/issues/22861)
+* [bitnami/grafana-mimir] Release 0.9.4 updating components versions (#22861) ([79b276e](https://github.com/bitnami/charts/commit/79b276e553829ebca8db46a1b7f50f6fd34bd152)), closes [#22861](https://github.com/bitnami/charts/issues/22861)
 
 ## <small>0.9.3 (2024-01-30)</small>
 
-* [bitnami/grafana-mimir] Release 0.9.3 updating components versions (#22848) ([64787f7](https://github.com/bitnami/charts/commit/64787f7)), closes [#22848](https://github.com/bitnami/charts/issues/22848)
+* [bitnami/grafana-mimir] Release 0.9.3 updating components versions (#22848) ([64787f7](https://github.com/bitnami/charts/commit/64787f79e2a326609a4c98620d1d62de3bd1090d)), closes [#22848](https://github.com/bitnami/charts/issues/22848)
 
 ## <small>0.9.2 (2024-01-27)</small>
 
-* [bitnami/*] Move documentation sections from docs.bitnami.com back to the README (#22203) ([7564f36](https://github.com/bitnami/charts/commit/7564f36)), closes [#22203](https://github.com/bitnami/charts/issues/22203)
-* [bitnami/grafana-mimir] Release 0.9.2 updating components versions (#22794) ([2f7d46a](https://github.com/bitnami/charts/commit/2f7d46a)), closes [#22794](https://github.com/bitnami/charts/issues/22794)
+* [bitnami/*] Move documentation sections from docs.bitnami.com back to the README (#22203) ([7564f36](https://github.com/bitnami/charts/commit/7564f36ca1e95ff30ee686652b7ab8690561a707)), closes [#22203](https://github.com/bitnami/charts/issues/22203)
+* [bitnami/grafana-mimir] Release 0.9.2 updating components versions (#22794) ([2f7d46a](https://github.com/bitnami/charts/commit/2f7d46a2c8a16c5e1a754c5ffdce34fe0ffa2225)), closes [#22794](https://github.com/bitnami/charts/issues/22794)
 
 ## <small>0.9.1 (2024-01-24)</small>
 
-* [bitnami/grafana-mimir] fix: :bug: Set seLinuxOptions to null for Openshift compatibility (#22594) ([75f2fef](https://github.com/bitnami/charts/commit/75f2fef)), closes [#22594](https://github.com/bitnami/charts/issues/22594)
+* [bitnami/grafana-mimir] fix: :bug: Set seLinuxOptions to null for Openshift compatibility (#22594) ([75f2fef](https://github.com/bitnami/charts/commit/75f2fef3f25ba2fa47992363d14828e076a235c7)), closes [#22594](https://github.com/bitnami/charts/issues/22594)
 
 ## 0.9.0 (2024-01-19)
 
-* [bitnami/grafana-mimir] fix: :lock: Move service-account token auto-mount to pod declaration (#22407 ([d02b7e5](https://github.com/bitnami/charts/commit/d02b7e5)), closes [#22407](https://github.com/bitnami/charts/issues/22407)
+* [bitnami/grafana-mimir] fix: :lock: Move service-account token auto-mount to pod declaration (#22407 ([d02b7e5](https://github.com/bitnami/charts/commit/d02b7e590fcaed588630a7d9c7e54facf3b6b8ee)), closes [#22407](https://github.com/bitnami/charts/issues/22407)
 
 ## <small>0.8.1 (2024-01-18)</small>
 
-* [bitnami/grafana-mimir] Release 0.8.1 updating components versions (#22289) ([0884877](https://github.com/bitnami/charts/commit/0884877)), closes [#22289](https://github.com/bitnami/charts/issues/22289)
+* [bitnami/grafana-mimir] Release 0.8.1 updating components versions (#22289) ([0884877](https://github.com/bitnami/charts/commit/08848779c400deb3ffe1e89790f1eb26e0a565ea)), closes [#22289](https://github.com/bitnami/charts/issues/22289)
 
 ## 0.8.0 (2024-01-16)
 
-* [bitnami/grafana-mimir] fix: :lock: Improve podSecurityContext and containerSecurityContext with ess ([368af3d](https://github.com/bitnami/charts/commit/368af3d)), closes [#22125](https://github.com/bitnami/charts/issues/22125)
+* [bitnami/grafana-mimir] fix: :lock: Improve podSecurityContext and containerSecurityContext with ess ([368af3d](https://github.com/bitnami/charts/commit/368af3d48ff53866277b6f1a550be414fe701d24)), closes [#22125](https://github.com/bitnami/charts/issues/22125)
 
 ## <small>0.7.12 (2024-01-15)</small>
 
-* [bitnami/grafana-mimir] fix: :lock: Do not automount the service account token unless necessary (#22 ([202950b](https://github.com/bitnami/charts/commit/202950b)), closes [#22043](https://github.com/bitnami/charts/issues/22043)
+* [bitnami/grafana-mimir] fix: :lock: Do not automount the service account token unless necessary (#22 ([202950b](https://github.com/bitnami/charts/commit/202950bff55578164900cffab6a1aebcf0fce907)), closes [#22043](https://github.com/bitnami/charts/issues/22043)
 
 ## <small>0.7.11 (2024-01-12)</small>
 
-* [bitnami/*] Fix ref links (in comments) (#21822) ([e4fa296](https://github.com/bitnami/charts/commit/e4fa296)), closes [#21822](https://github.com/bitnami/charts/issues/21822)
-* [bitnami/grafana-mimir] Release 0.7.11 updating components versions (#22009) ([a3b6f81](https://github.com/bitnami/charts/commit/a3b6f81)), closes [#22009](https://github.com/bitnami/charts/issues/22009)
+* [bitnami/*] Fix ref links (in comments) (#21822) ([e4fa296](https://github.com/bitnami/charts/commit/e4fa296106b225cf8c82445727c675c7c725e380)), closes [#21822](https://github.com/bitnami/charts/issues/21822)
+* [bitnami/grafana-mimir] Release 0.7.11 updating components versions (#22009) ([a3b6f81](https://github.com/bitnami/charts/commit/a3b6f8144cf237ccbd9b052f91845e801bf1aec5)), closes [#22009](https://github.com/bitnami/charts/issues/22009)
 
 ## <small>0.7.10 (2024-01-10)</small>
 
-* [bitnami/*] Fix docs.bitnami.com broken links (#21901) ([f35506d](https://github.com/bitnami/charts/commit/f35506d)), closes [#21901](https://github.com/bitnami/charts/issues/21901)
-* [bitnami/grafana-mimir] Release 0.7.10 updating components versions (#21946) ([fbeeeea](https://github.com/bitnami/charts/commit/fbeeeea)), closes [#21946](https://github.com/bitnami/charts/issues/21946)
+* [bitnami/*] Fix docs.bitnami.com broken links (#21901) ([f35506d](https://github.com/bitnami/charts/commit/f35506d2dadee4f097986e7792df1f53ab215b5d)), closes [#21901](https://github.com/bitnami/charts/issues/21901)
+* [bitnami/grafana-mimir] Release 0.7.10 updating components versions (#21946) ([fbeeeea](https://github.com/bitnami/charts/commit/fbeeeeac600cfb8d6fec6db2054ea3ed7c22132d)), closes [#21946](https://github.com/bitnami/charts/issues/21946)
 
 ## <small>0.7.9 (2024-01-03)</small>
 
-* [bitnami/*] Update copyright: Year and company (#21815) ([6c4bf75](https://github.com/bitnami/charts/commit/6c4bf75)), closes [#21815](https://github.com/bitnami/charts/issues/21815)
-* [bitnami/grafana-mimir] Release 0.7.9 (#21820) ([73a409f](https://github.com/bitnami/charts/commit/73a409f)), closes [#21820](https://github.com/bitnami/charts/issues/21820)
+* [bitnami/*] Update copyright: Year and company (#21815) ([6c4bf75](https://github.com/bitnami/charts/commit/6c4bf75dec58fc7c9aee9f089777b1a858c17d5b)), closes [#21815](https://github.com/bitnami/charts/issues/21815)
+* [bitnami/grafana-mimir] Release 0.7.9 (#21820) ([73a409f](https://github.com/bitnami/charts/commit/73a409f79d9c3e0235ec67f59423201fa512eca3)), closes [#21820](https://github.com/bitnami/charts/issues/21820)
 
 ## <small>0.7.8 (2023-12-12)</small>
 
-* [bitnami/grafana-mimir] Release 0.7.8 updating components versions (#21537) ([083ca54](https://github.com/bitnami/charts/commit/083ca54)), closes [#21537](https://github.com/bitnami/charts/issues/21537)
+* [bitnami/grafana-mimir] Release 0.7.8 updating components versions (#21537) ([083ca54](https://github.com/bitnami/charts/commit/083ca54dcc27ae2961b672b5bfca9e45d2c5f5fe)), closes [#21537](https://github.com/bitnami/charts/issues/21537)
 
 ## <small>0.7.7 (2023-12-07)</small>
 
-* [bitnami/grafana-mimir] Release 0.7.7 updating components versions (#21422) ([5b3a618](https://github.com/bitnami/charts/commit/5b3a618)), closes [#21422](https://github.com/bitnami/charts/issues/21422)
+* [bitnami/grafana-mimir] Release 0.7.7 updating components versions (#21422) ([5b3a618](https://github.com/bitnami/charts/commit/5b3a61872fead2f15ae0ea2cb58f2616bafc6309)), closes [#21422](https://github.com/bitnami/charts/issues/21422)
 
 ## <small>0.7.6 (2023-11-25)</small>
 
-* [bitnami/grafana-mimir] Release 0.7.6 updating components versions (#21248) ([22dafeb](https://github.com/bitnami/charts/commit/22dafeb)), closes [#21248](https://github.com/bitnami/charts/issues/21248)
+* [bitnami/grafana-mimir] Release 0.7.6 updating components versions (#21248) ([22dafeb](https://github.com/bitnami/charts/commit/22dafeb6569379a6fda53f0a4f7cd53920e08174)), closes [#21248](https://github.com/bitnami/charts/issues/21248)
 
 ## <small>0.7.5 (2023-11-23)</small>
 
-* [bitnami/grafana-mimir] Release 0.7.5 updating components versions (#21225) ([8f6ea27](https://github.com/bitnami/charts/commit/8f6ea27)), closes [#21225](https://github.com/bitnami/charts/issues/21225)
+* [bitnami/grafana-mimir] Release 0.7.5 updating components versions (#21225) ([8f6ea27](https://github.com/bitnami/charts/commit/8f6ea27cfa9dfe27baddd57a13a0debfb07c95f1)), closes [#21225](https://github.com/bitnami/charts/issues/21225)
 
 ## <small>0.7.4 (2023-11-21)</small>
 
-* [bitnami/*] Remove relative links to non-README sections, add verification for that and update TL;DR ([1103633](https://github.com/bitnami/charts/commit/1103633)), closes [#20967](https://github.com/bitnami/charts/issues/20967)
-* [bitnami/*] Rename solutions to "Bitnami package for ..." (#21038) ([b82f979](https://github.com/bitnami/charts/commit/b82f979)), closes [#21038](https://github.com/bitnami/charts/issues/21038)
-* [bitnami/grafana-mimir] Release 0.7.4 updating components versions (#21117) ([279a03d](https://github.com/bitnami/charts/commit/279a03d)), closes [#21117](https://github.com/bitnami/charts/issues/21117)
-* Update readme-generator links (#21043) ([1581eba](https://github.com/bitnami/charts/commit/1581eba)), closes [#21043](https://github.com/bitnami/charts/issues/21043)
+* [bitnami/*] Remove relative links to non-README sections, add verification for that and update TL;DR ([1103633](https://github.com/bitnami/charts/commit/11036334d82df0490aa4abdb591543cab6cf7d7f)), closes [#20967](https://github.com/bitnami/charts/issues/20967)
+* [bitnami/*] Rename solutions to "Bitnami package for ..." (#21038) ([b82f979](https://github.com/bitnami/charts/commit/b82f979e4fb63423fe6e2192c946d09d79c944fc)), closes [#21038](https://github.com/bitnami/charts/issues/21038)
+* [bitnami/grafana-mimir] Release 0.7.4 updating components versions (#21117) ([279a03d](https://github.com/bitnami/charts/commit/279a03dccb4c747af10d5449357196f376b6c711)), closes [#21117](https://github.com/bitnami/charts/issues/21117)
+* Update readme-generator links (#21043) ([1581eba](https://github.com/bitnami/charts/commit/1581eba8044d730a763c266f279ac2ac782f764d)), closes [#21043](https://github.com/bitnami/charts/issues/21043)
 
 ## <small>0.7.3 (2023-11-09)</small>
 
-* [bitnami/grafana-mimir] Release 0.7.3 updating components versions (#20850) ([7c88528](https://github.com/bitnami/charts/commit/7c88528)), closes [#20850](https://github.com/bitnami/charts/issues/20850)
+* [bitnami/grafana-mimir] Release 0.7.3 updating components versions (#20850) ([7c88528](https://github.com/bitnami/charts/commit/7c88528a6a899cf98e16b83236d29b5bf6857be3)), closes [#20850](https://github.com/bitnami/charts/issues/20850)
 
 ## <small>0.7.2 (2023-11-09)</small>
 
-* [bitnami/grafana-mimir] Release 0.7.2 updating components versions (#20841) ([58ddb44](https://github.com/bitnami/charts/commit/58ddb44)), closes [#20841](https://github.com/bitnami/charts/issues/20841)
+* [bitnami/grafana-mimir] Release 0.7.2 updating components versions (#20841) ([58ddb44](https://github.com/bitnami/charts/commit/58ddb443758261f770762c404bf9d1260fd5a2d9)), closes [#20841](https://github.com/bitnami/charts/issues/20841)
 
 ## <small>0.7.1 (2023-11-09)</small>
 
-* [bitnami/grafana-mimir] Release 0.7.1 updating components versions (#20752) ([5efde72](https://github.com/bitnami/charts/commit/5efde72)), closes [#20752](https://github.com/bitnami/charts/issues/20752)
+* [bitnami/grafana-mimir] Release 0.7.1 updating components versions (#20752) ([5efde72](https://github.com/bitnami/charts/commit/5efde729953eb7f6f98e841d831f4991ea9d9fff)), closes [#20752](https://github.com/bitnami/charts/issues/20752)
 
 ## 0.7.0 (2023-10-31)
 
-* [bitnami/*] Rename VMware Application Catalog (#20361) ([3acc734](https://github.com/bitnami/charts/commit/3acc734)), closes [#20361](https://github.com/bitnami/charts/issues/20361)
-* [bitnami/*] Skip image's tag in the README files of the Bitnami Charts (#19841) ([bb9a01b](https://github.com/bitnami/charts/commit/bb9a01b)), closes [#19841](https://github.com/bitnami/charts/issues/19841)
-* [bitnami/*] Standardize documentation (#19835) ([af5f753](https://github.com/bitnami/charts/commit/af5f753)), closes [#19835](https://github.com/bitnami/charts/issues/19835)
-* [bitnami/grafana-mimir] feat: :sparkles: Add support for PSA restricted policy (#20444) ([3f03c1a](https://github.com/bitnami/charts/commit/3f03c1a)), closes [#20444](https://github.com/bitnami/charts/issues/20444)
+* [bitnami/*] Rename VMware Application Catalog (#20361) ([3acc734](https://github.com/bitnami/charts/commit/3acc73472beb6fb56c4d99f929061001205bc57e)), closes [#20361](https://github.com/bitnami/charts/issues/20361)
+* [bitnami/*] Skip image's tag in the README files of the Bitnami Charts (#19841) ([bb9a01b](https://github.com/bitnami/charts/commit/bb9a01b65911c87e48318db922cc05eb42785e42)), closes [#19841](https://github.com/bitnami/charts/issues/19841)
+* [bitnami/*] Standardize documentation (#19835) ([af5f753](https://github.com/bitnami/charts/commit/af5f7530c1bc8c5ded53a6c4f7b8f384ac1804f2)), closes [#19835](https://github.com/bitnami/charts/issues/19835)
+* [bitnami/grafana-mimir] feat: :sparkles: Add support for PSA restricted policy (#20444) ([3f03c1a](https://github.com/bitnami/charts/commit/3f03c1a9b7749091729b24774dba7e4419d80461)), closes [#20444](https://github.com/bitnami/charts/issues/20444)
 
 ## <small>0.6.11 (2023-10-18)</small>
 
-* [bitnami/grafana-mimir] Release 0.6.11 (#20312) ([6612ebf](https://github.com/bitnami/charts/commit/6612ebf)), closes [#20312](https://github.com/bitnami/charts/issues/20312)
+* [bitnami/grafana-mimir] Release 0.6.11 (#20312) ([6612ebf](https://github.com/bitnami/charts/commit/6612ebff362279263a35745d50332b99a96a6d01)), closes [#20312](https://github.com/bitnami/charts/issues/20312)
 
 ## <small>0.6.10 (2023-10-16)</small>
 
-* Fix alertmanager external url (#19825) ([c32bcdb](https://github.com/bitnami/charts/commit/c32bcdb)), closes [#19825](https://github.com/bitnami/charts/issues/19825)
+* Fix alertmanager external url (#19825) ([c32bcdb](https://github.com/bitnami/charts/commit/c32bcdb5a8821e3648dd39bec9939e7c177ae802)), closes [#19825](https://github.com/bitnami/charts/issues/19825)
 
 ## <small>0.6.9 (2023-10-13)</small>
 
-* [bitnami/grafana-mimir] Release 0.6.9 (#20225) ([7e87810](https://github.com/bitnami/charts/commit/7e87810)), closes [#20225](https://github.com/bitnami/charts/issues/20225)
+* [bitnami/grafana-mimir] Release 0.6.9 (#20225) ([7e87810](https://github.com/bitnami/charts/commit/7e8781048be5c4f5a32bc389f1d30fcfcd3bada6)), closes [#20225](https://github.com/bitnami/charts/issues/20225)
 
 ## <small>0.6.8 (2023-10-12)</small>
 
-* [bitnami/grafana-mimir] Release 0.6.8 (#20180) ([2f59cb5](https://github.com/bitnami/charts/commit/2f59cb5)), closes [#20180](https://github.com/bitnami/charts/issues/20180)
+* [bitnami/grafana-mimir] Release 0.6.8 (#20180) ([2f59cb5](https://github.com/bitnami/charts/commit/2f59cb5f81c2ea90796f248636a1fef00a15f647)), closes [#20180](https://github.com/bitnami/charts/issues/20180)
 
 ## <small>0.6.7 (2023-10-09)</small>
 
-* [bitnami/*] Update Helm charts prerequisites (#19745) ([eb755dd](https://github.com/bitnami/charts/commit/eb755dd)), closes [#19745](https://github.com/bitnami/charts/issues/19745)
-* [bitnami/grafana-mimir] Release 0.6.7 (#19913) ([6747c1e](https://github.com/bitnami/charts/commit/6747c1e)), closes [#19913](https://github.com/bitnami/charts/issues/19913)
+* [bitnami/*] Update Helm charts prerequisites (#19745) ([eb755dd](https://github.com/bitnami/charts/commit/eb755dd36a4dd3cf6635be8e0598f9a7f4c4a554)), closes [#19745](https://github.com/bitnami/charts/issues/19745)
+* [bitnami/grafana-mimir] Release 0.6.7 (#19913) ([6747c1e](https://github.com/bitnami/charts/commit/6747c1e164eb82ccf684804c4af3889d1ec37175)), closes [#19913](https://github.com/bitnami/charts/issues/19913)
 
 ## <small>0.6.6 (2023-10-03)</small>
 
-* [bitnami/grafana-mimir] Release 0.6.6 (#19711) ([630ee34](https://github.com/bitnami/charts/commit/630ee34)), closes [#19711](https://github.com/bitnami/charts/issues/19711)
+* [bitnami/grafana-mimir] Release 0.6.6 (#19711) ([630ee34](https://github.com/bitnami/charts/commit/630ee34574c57d319ad29d40c2d5a1b3d274cf7c)), closes [#19711](https://github.com/bitnami/charts/issues/19711)
 
 ## <small>0.6.5 (2023-09-20)</small>
 
-* [bitnami/grafana-mimir] Use different app.kubernetes.io/version label on subcomponents (#19336) ([3c88b51](https://github.com/bitnami/charts/commit/3c88b51)), closes [#19336](https://github.com/bitnami/charts/issues/19336)
+* [bitnami/grafana-mimir] Use different app.kubernetes.io/version label on subcomponents (#19336) ([3c88b51](https://github.com/bitnami/charts/commit/3c88b511169833c10f45f61154c1326e57fde300)), closes [#19336](https://github.com/bitnami/charts/issues/19336)
 
 ## <small>0.6.4 (2023-09-18)</small>
 
-* [bitnami/grafana-mimir] Release 0.6.4 (#19361) ([41a75eb](https://github.com/bitnami/charts/commit/41a75eb)), closes [#19361](https://github.com/bitnami/charts/issues/19361)
-* Revert "Autogenerate schema files (#19194)" (#19335) ([73d80be](https://github.com/bitnami/charts/commit/73d80be)), closes [#19194](https://github.com/bitnami/charts/issues/19194) [#19335](https://github.com/bitnami/charts/issues/19335)
+* [bitnami/grafana-mimir] Release 0.6.4 (#19361) ([41a75eb](https://github.com/bitnami/charts/commit/41a75eb9fe24f06a7dfbeb360f04c129309fe35b)), closes [#19361](https://github.com/bitnami/charts/issues/19361)
+* Revert "Autogenerate schema files (#19194)" (#19335) ([73d80be](https://github.com/bitnami/charts/commit/73d80be525c88fb4b8a54451a55acd506e337062)), closes [#19194](https://github.com/bitnami/charts/issues/19194) [#19335](https://github.com/bitnami/charts/issues/19335)
 
 ## <small>0.6.3 (2023-09-14)</small>
 
-* [bitnami/grafana-mimir] Release 0.6.3 (#19288) ([9b45451](https://github.com/bitnami/charts/commit/9b45451)), closes [#19288](https://github.com/bitnami/charts/issues/19288)
-* Autogenerate schema files (#19194) ([a2c2090](https://github.com/bitnami/charts/commit/a2c2090)), closes [#19194](https://github.com/bitnami/charts/issues/19194)
+* [bitnami/grafana-mimir] Release 0.6.3 (#19288) ([9b45451](https://github.com/bitnami/charts/commit/9b45451b6427ecf42b56eb613cbd3e684f27b3d1)), closes [#19288](https://github.com/bitnami/charts/issues/19288)
+* Autogenerate schema files (#19194) ([a2c2090](https://github.com/bitnami/charts/commit/a2c2090b5ac97f47b745c8028c6452bf99739772)), closes [#19194](https://github.com/bitnami/charts/issues/19194)
 
 ## <small>0.6.2 (2023-09-08)</small>
 
-* [bitnami/grafana-mimir: Use merge helper]: (#19045) ([f293cfe](https://github.com/bitnami/charts/commit/f293cfe)), closes [#19045](https://github.com/bitnami/charts/issues/19045)
+* [bitnami/grafana-mimir: Use merge helper]: (#19045) ([f293cfe](https://github.com/bitnami/charts/commit/f293cfe3e91d46e26558df8a4d48234a6d657988)), closes [#19045](https://github.com/bitnami/charts/issues/19045)
 
 ## <small>0.6.1 (2023-09-06)</small>
 
-* [bitnami/grafana-mimir] Release 0.6.1 (#19136) ([db0f0cd](https://github.com/bitnami/charts/commit/db0f0cd)), closes [#19136](https://github.com/bitnami/charts/issues/19136)
+* [bitnami/grafana-mimir] Release 0.6.1 (#19136) ([db0f0cd](https://github.com/bitnami/charts/commit/db0f0cd8e0205a9a389371c218708d747b85bf48)), closes [#19136](https://github.com/bitnami/charts/issues/19136)
 
 ## 0.6.0 (2023-08-28)
 
-* [bitnami/grafana-mimir] Support for customizing standard labels (#18488) ([deecf27](https://github.com/bitnami/charts/commit/deecf27)), closes [#18488](https://github.com/bitnami/charts/issues/18488)
+* [bitnami/grafana-mimir] Support for customizing standard labels (#18488) ([deecf27](https://github.com/bitnami/charts/commit/deecf27c7ff4e59a8e7b22d4643c5e2da7042a06)), closes [#18488](https://github.com/bitnami/charts/issues/18488)
 
 ## <small>0.5.8 (2023-08-19)</small>
 
-* [bitnami/grafana-mimir] Release 0.5.8 (#18664) ([4e21622](https://github.com/bitnami/charts/commit/4e21622)), closes [#18664](https://github.com/bitnami/charts/issues/18664)
+* [bitnami/grafana-mimir] Release 0.5.8 (#18664) ([4e21622](https://github.com/bitnami/charts/commit/4e216222a5bb705e570b8f719cb2ddefe181b4e5)), closes [#18664](https://github.com/bitnami/charts/issues/18664)
 
 ## <small>0.5.7 (2023-08-17)</small>
 
-* [bitnami/grafana-mimir] Release 0.5.7 (#18522) ([80ce6f6](https://github.com/bitnami/charts/commit/80ce6f6)), closes [#18522](https://github.com/bitnami/charts/issues/18522)
+* [bitnami/grafana-mimir] Release 0.5.7 (#18522) ([80ce6f6](https://github.com/bitnami/charts/commit/80ce6f61b7f149996c4330341030c02dbdfce8a2)), closes [#18522](https://github.com/bitnami/charts/issues/18522)
 
 ## <small>0.5.6 (2023-07-25)</small>
 
-* [bitnami/grafana-mimir] Release 0.5.6 (#17891) ([f77e83e](https://github.com/bitnami/charts/commit/f77e83e)), closes [#17891](https://github.com/bitnami/charts/issues/17891)
+* [bitnami/grafana-mimir] Release 0.5.6 (#17891) ([f77e83e](https://github.com/bitnami/charts/commit/f77e83e20cbf8e2d12d02c25fdc4b378dcee6d46)), closes [#17891](https://github.com/bitnami/charts/issues/17891)
 
 ## <small>0.5.5 (2023-07-13)</small>
 
-* [bitnami/grafana-mimir] Release 0.5.5 (#17641) ([24501f4](https://github.com/bitnami/charts/commit/24501f4)), closes [#17641](https://github.com/bitnami/charts/issues/17641)
-* Use os-shell in tempate and Jaeger runtime params (#17557) ([91a49eb](https://github.com/bitnami/charts/commit/91a49eb)), closes [#17557](https://github.com/bitnami/charts/issues/17557)
+* [bitnami/grafana-mimir] Release 0.5.5 (#17641) ([24501f4](https://github.com/bitnami/charts/commit/24501f4230cb41c962bcef368f0ed2c6ca271138)), closes [#17641](https://github.com/bitnami/charts/issues/17641)
+* Use os-shell in tempate and Jaeger runtime params (#17557) ([91a49eb](https://github.com/bitnami/charts/commit/91a49eb1e3c81c7b7c6c28d1bc5d6d6ae698c1e2)), closes [#17557](https://github.com/bitnami/charts/issues/17557)
 
 ## <small>0.5.4 (2023-07-06)</small>
 
-* [bitnami/grafana-mimir] Fix helm error when gateway.auth.existingSecret is set (#17469) ([6dcd8cd](https://github.com/bitnami/charts/commit/6dcd8cd)), closes [#17469](https://github.com/bitnami/charts/issues/17469)
+* [bitnami/grafana-mimir] Fix helm error when gateway.auth.existingSecret is set (#17469) ([6dcd8cd](https://github.com/bitnami/charts/commit/6dcd8cd210264b63427f0f1b87f75cc4640ce710)), closes [#17469](https://github.com/bitnami/charts/issues/17469)
 
 ## <small>0.5.3 (2023-06-30)</small>
 
-* [bitnami/grafana-mimir] Release 0.5.3 (#17422) ([6062eb6](https://github.com/bitnami/charts/commit/6062eb6)), closes [#17422](https://github.com/bitnami/charts/issues/17422)
-* Add copyright header (#17300) ([da68be8](https://github.com/bitnami/charts/commit/da68be8)), closes [#17300](https://github.com/bitnami/charts/issues/17300)
-* Update charts readme (#17217) ([31b3c0a](https://github.com/bitnami/charts/commit/31b3c0a)), closes [#17217](https://github.com/bitnami/charts/issues/17217)
+* [bitnami/grafana-mimir] Release 0.5.3 (#17422) ([6062eb6](https://github.com/bitnami/charts/commit/6062eb64c750831144c6aeefb8a645282ab86932)), closes [#17422](https://github.com/bitnami/charts/issues/17422)
+* Add copyright header (#17300) ([da68be8](https://github.com/bitnami/charts/commit/da68be8e951225133c7dfb572d5101ca3d61c5ae)), closes [#17300](https://github.com/bitnami/charts/issues/17300)
+* Update charts readme (#17217) ([31b3c0a](https://github.com/bitnami/charts/commit/31b3c0afd968ff4429107e34101f7509e6a0e913)), closes [#17217](https://github.com/bitnami/charts/issues/17217)
 
 ## <small>0.5.2 (2023-06-20)</small>
 
-* [bitnami/*] Change copyright section in READMEs (#17006) ([ef986a1](https://github.com/bitnami/charts/commit/ef986a1)), closes [#17006](https://github.com/bitnami/charts/issues/17006)
-* [bitnami/grafana-mimir] Release 0.5.2 (#17198) ([7b9226f](https://github.com/bitnami/charts/commit/7b9226f)), closes [#17198](https://github.com/bitnami/charts/issues/17198)
-* [bitnami/several] Change copyright section in READMEs (#16989) ([5b6a5cf](https://github.com/bitnami/charts/commit/5b6a5cf)), closes [#16989](https://github.com/bitnami/charts/issues/16989)
+* [bitnami/*] Change copyright section in READMEs (#17006) ([ef986a1](https://github.com/bitnami/charts/commit/ef986a1605241102b3dcafe9fd8089e6fc1201ad)), closes [#17006](https://github.com/bitnami/charts/issues/17006)
+* [bitnami/grafana-mimir] Release 0.5.2 (#17198) ([7b9226f](https://github.com/bitnami/charts/commit/7b9226f165ab754576daa949c973a845cf42f40f)), closes [#17198](https://github.com/bitnami/charts/issues/17198)
+* [bitnami/several] Change copyright section in READMEs (#16989) ([5b6a5cf](https://github.com/bitnami/charts/commit/5b6a5cfb7625a751848a2e5cd796bd7278f406ca)), closes [#16989](https://github.com/bitnami/charts/issues/16989)
 
 ## <small>0.5.1 (2023-05-21)</small>
 
-* [bitnami/grafana-mimir] Release 0.5.1 (#16766) ([d45f6b4](https://github.com/bitnami/charts/commit/d45f6b4)), closes [#16766](https://github.com/bitnami/charts/issues/16766)
-* Add wording for enterprise page (#16560) ([8f22774](https://github.com/bitnami/charts/commit/8f22774)), closes [#16560](https://github.com/bitnami/charts/issues/16560)
+* [bitnami/grafana-mimir] Release 0.5.1 (#16766) ([d45f6b4](https://github.com/bitnami/charts/commit/d45f6b4f771edbb2f44121cf1d76d14f28d3ff98)), closes [#16766](https://github.com/bitnami/charts/issues/16766)
+* Add wording for enterprise page (#16560) ([8f22774](https://github.com/bitnami/charts/commit/8f2277440b976d52785ba9149762ad8620a73d1f)), closes [#16560](https://github.com/bitnami/charts/issues/16560)
 
 ## 0.5.0 (2023-05-09)
 
-* [bitnami/several] Adapt Chart.yaml to set desired OCI annotations (#16546) ([fc9b18f](https://github.com/bitnami/charts/commit/fc9b18f)), closes [#16546](https://github.com/bitnami/charts/issues/16546)
+* [bitnami/several] Adapt Chart.yaml to set desired OCI annotations (#16546) ([fc9b18f](https://github.com/bitnami/charts/commit/fc9b18f2e98805d4df629acbcde696f44f973344)), closes [#16546](https://github.com/bitnami/charts/issues/16546)
 
 ## <small>0.4.4 (2023-05-09)</small>
 
-* [bitnami/grafana-mimir] Release 0.4.4 (#16515) ([831858a](https://github.com/bitnami/charts/commit/831858a)), closes [#16515](https://github.com/bitnami/charts/issues/16515)
+* [bitnami/grafana-mimir] Release 0.4.4 (#16515) ([831858a](https://github.com/bitnami/charts/commit/831858a1bd4a8a8aa72d809f25dd86b21e7031a4)), closes [#16515](https://github.com/bitnami/charts/issues/16515)
 
 ## <small>0.4.3 (2023-05-03)</small>
 
-* [bitnami/grafana-mimir] Release 0.4.3 (#16361) ([6ef2bf9](https://github.com/bitnami/charts/commit/6ef2bf9)), closes [#16361](https://github.com/bitnami/charts/issues/16361)
+* [bitnami/grafana-mimir] Release 0.4.3 (#16361) ([6ef2bf9](https://github.com/bitnami/charts/commit/6ef2bf9c8c40acaec0b63c997278e2ac9237e082)), closes [#16361](https://github.com/bitnami/charts/issues/16361)
 
 ## <small>0.4.2 (2023-05-03)</small>
 
-* [bitnami/grafana-mimir] Release 0.4.2 (#16357) ([ea6fcda](https://github.com/bitnami/charts/commit/ea6fcda)), closes [#16357](https://github.com/bitnami/charts/issues/16357)
+* [bitnami/grafana-mimir] Release 0.4.2 (#16357) ([ea6fcda](https://github.com/bitnami/charts/commit/ea6fcdac3d1b4a236a503b9f13bffa1f72c35256)), closes [#16357](https://github.com/bitnami/charts/issues/16357)
 
 ## <small>0.4.1 (2023-04-25)</small>
 
-* [bitnami/grafana-mimir] Release 0.4.1 (#16217) ([253fec3](https://github.com/bitnami/charts/commit/253fec3)), closes [#16217](https://github.com/bitnami/charts/issues/16217)
+* [bitnami/grafana-mimir] Release 0.4.1 (#16217) ([253fec3](https://github.com/bitnami/charts/commit/253fec3376c9b1a81c8c525adc88df5cc9b015d9)), closes [#16217](https://github.com/bitnami/charts/issues/16217)
 
 ## 0.4.0 (2023-04-25)
 
-* [bitnami/several] Revert changes done by mistake in Chart.yaml repo (#16211) ([3a60f4b](https://github.com/bitnami/charts/commit/3a60f4b)), closes [#16211](https://github.com/bitnami/charts/issues/16211)
+* [bitnami/several] Revert changes done by mistake in Chart.yaml repo (#16211) ([3a60f4b](https://github.com/bitnami/charts/commit/3a60f4b10d2e02dbf83fcf64906b43edb6725615)), closes [#16211](https://github.com/bitnami/charts/issues/16211)
 
 ## <small>0.3.1 (2023-04-20)</small>
 
-* [bitnami/grafana-mimir] Release 0.3.1 (#16150) ([08f1fc2](https://github.com/bitnami/charts/commit/08f1fc2)), closes [#16150](https://github.com/bitnami/charts/issues/16150)
+* [bitnami/grafana-mimir] Release 0.3.1 (#16150) ([08f1fc2](https://github.com/bitnami/charts/commit/08f1fc249221b94c4699b573e2742379e1a54fdf)), closes [#16150](https://github.com/bitnami/charts/issues/16150)
 
 ## 0.3.0 (2023-04-20)
 
-* [bitnami/*] Make Helm charts 100% OCI (#15998) ([8841510](https://github.com/bitnami/charts/commit/8841510)), closes [#15998](https://github.com/bitnami/charts/issues/15998)
+* [bitnami/*] Make Helm charts 100% OCI (#15998) ([8841510](https://github.com/bitnami/charts/commit/884151035efcbf2e1b3206e7def85511073fb57d)), closes [#15998](https://github.com/bitnami/charts/issues/15998)
 
 ## <small>0.2.3 (2023-04-01)</small>
 
-* [bitnami/grafana-mimir] Release 0.2.3 (#15865) ([3de82f2](https://github.com/bitnami/charts/commit/3de82f2)), closes [#15865](https://github.com/bitnami/charts/issues/15865)
+* [bitnami/grafana-mimir] Release 0.2.3 (#15865) ([3de82f2](https://github.com/bitnami/charts/commit/3de82f2441d768617c0f030a6982f5df44926c7d)), closes [#15865](https://github.com/bitnami/charts/issues/15865)
 
 ## <small>0.2.2 (2023-03-18)</small>
 
-* [bitnami/grafana-mimir] Release 0.2.2 (#15571) ([79bbd22](https://github.com/bitnami/charts/commit/79bbd22)), closes [#15571](https://github.com/bitnami/charts/issues/15571)
+* [bitnami/grafana-mimir] Release 0.2.2 (#15571) ([79bbd22](https://github.com/bitnami/charts/commit/79bbd22718f965c48c3925ba17aae3509abd31a9)), closes [#15571](https://github.com/bitnami/charts/issues/15571)
 
 ## <small>0.2.1 (2023-03-15)</small>
 
-* [bitnami/grafana-mimir] Fix #15369, wrong gateway configuration when alertmanager.enabled=true (#155 ([e2d1a61](https://github.com/bitnami/charts/commit/e2d1a61)), closes [#15369](https://github.com/bitnami/charts/issues/15369) [#15509](https://github.com/bitnami/charts/issues/15509)
+* [bitnami/grafana-mimir] Fix #15369, wrong gateway configuration when alertmanager.enabled=true (#155 ([e2d1a61](https://github.com/bitnami/charts/commit/e2d1a61fd06c0d2ce320f326a2d7b2fd16fd66f8)), closes [#15369](https://github.com/bitnami/charts/issues/15369) [#15509](https://github.com/bitnami/charts/issues/15509)
 
 ## 0.2.0 (2023-03-10)
 
-* [bitnami/grafana-mimir] Add support for service.headless.annotations (#15430) ([0a37caf](https://github.com/bitnami/charts/commit/0a37caf)), closes [#15430](https://github.com/bitnami/charts/issues/15430)
+* [bitnami/grafana-mimir] Add support for service.headless.annotations (#15430) ([0a37caf](https://github.com/bitnami/charts/commit/0a37cafe42bd180d0b626836e863590da4202e33)), closes [#15430](https://github.com/bitnami/charts/issues/15430)
 
 ## <small>0.1.3 (2023-03-10)</small>
 
-* [bitnami/charts] Apply linter to README files (#15357) ([0e29e60](https://github.com/bitnami/charts/commit/0e29e60)), closes [#15357](https://github.com/bitnami/charts/issues/15357)
-* [bitnami/grafana-mimir] Release 0.1.3 (#15422) ([b52404a](https://github.com/bitnami/charts/commit/b52404a)), closes [#15422](https://github.com/bitnami/charts/issues/15422)
+* [bitnami/charts] Apply linter to README files (#15357) ([0e29e60](https://github.com/bitnami/charts/commit/0e29e600d3adc8b1b46e506eccb3decfab3b4e63)), closes [#15357](https://github.com/bitnami/charts/issues/15357)
+* [bitnami/grafana-mimir] Release 0.1.3 (#15422) ([b52404a](https://github.com/bitnami/charts/commit/b52404a079d393ce4b59d7fbb3ddc3c2996b9926)), closes [#15422](https://github.com/bitnami/charts/issues/15422)
 
 ## <small>0.1.2 (2023-03-01)</small>
 
-* [bitnami/grafana-mimir] Release 0.1.2 (#15260) ([a893c52](https://github.com/bitnami/charts/commit/a893c52)), closes [#15260](https://github.com/bitnami/charts/issues/15260)
+* [bitnami/grafana-mimir] Release 0.1.2 (#15260) ([a893c52](https://github.com/bitnami/charts/commit/a893c521b25e9c7140c017d99437abf0c31c10bf)), closes [#15260](https://github.com/bitnami/charts/issues/15260)
 
 ## <small>0.1.1 (2023-02-24)</small>
 
-* [bitnami/grafana-mimir] Release 0.1.1 (#15139) ([e953034](https://github.com/bitnami/charts/commit/e953034)), closes [#15139](https://github.com/bitnami/charts/issues/15139)
+* [bitnami/grafana-mimir] Release 0.1.1 (#15139) ([e953034](https://github.com/bitnami/charts/commit/e953034d77859c841977f1707eb88beb7d3bbbf8)), closes [#15139](https://github.com/bitnami/charts/issues/15139)
 
 ## 0.1.0 (2023-02-23)
 
-* [bitnami/grafana-mimir] Add grafana-mimir to Bitnami Catalog (#14346) ([44a9669](https://github.com/bitnami/charts/commit/44a9669)), closes [#14346](https://github.com/bitnami/charts/issues/14346)
+* [bitnami/grafana-mimir] Add grafana-mimir to Bitnami Catalog (#14346) ([44a9669](https://github.com/bitnami/charts/commit/44a96694cc259f65fec4b98641e5b7ad64d70477)), closes [#14346](https://github.com/bitnami/charts/issues/14346)

--- a/bitnami/grafana-mimir/Chart.lock
+++ b/bitnami/grafana-mimir/Chart.lock
@@ -1,21 +1,21 @@
 dependencies:
 - name: minio
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 14.5.0
+  version: 14.6.0
 - name: memcached
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 7.3.0
+  version: 7.4.1
 - name: memcached
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 7.3.0
+  version: 7.4.1
 - name: memcached
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 7.3.0
+  version: 7.4.1
 - name: memcached
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 7.3.0
+  version: 7.4.1
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 2.19.3
-digest: sha256:be6119fb507c134c6168c4332dab8f397bd632957d207c9e811d2f90af8cab48
-generated: "2024-05-21T13:46:08.541176352+02:00"
+digest: sha256:5ac2c128a8a0105c56739cc9d878a950d36239f956fc7f2c29e614be1d7e7e44
+generated: "2024-05-22T17:28:30.752645+02:00"

--- a/bitnami/grafana-mimir/Chart.yaml
+++ b/bitnami/grafana-mimir/Chart.yaml
@@ -59,4 +59,4 @@ maintainers:
 name: grafana-mimir
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/grafana-mimir
-version: 1.1.0
+version: 1.1.1

--- a/bitnami/grafana-mimir/templates/alertmanager/statefulset.yaml
+++ b/bitnami/grafana-mimir/templates/alertmanager/statefulset.yaml
@@ -173,8 +173,7 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.alertmanager.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.alertmanager.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.alertmanager.livenessProbe "enabled") "context" $) | nindent 12 }}
-            httpGet:
-              path: /ready
+            tcpSocket:
               port: http
           {{- end }}
           {{- if .Values.alertmanager.customReadinessProbe }}

--- a/bitnami/grafana-mimir/templates/compactor/statefulset.yaml
+++ b/bitnami/grafana-mimir/templates/compactor/statefulset.yaml
@@ -172,8 +172,7 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.compactor.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.compactor.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.compactor.livenessProbe "enabled") "context" $) | nindent 12 }}
-            httpGet:
-              path: /ready
+            tcpSocket:
               port: http
           {{- end }}
           {{- if .Values.compactor.customReadinessProbe }}

--- a/bitnami/grafana-mimir/templates/distributor/deployment.yaml
+++ b/bitnami/grafana-mimir/templates/distributor/deployment.yaml
@@ -140,8 +140,7 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.distributor.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.distributor.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.distributor.livenessProbe "enabled") "context" $) | nindent 12 }}
-            httpGet:
-              path: /ready
+            tcpSocket:
               port: http
           {{- end }}
           {{- if .Values.distributor.customReadinessProbe }}

--- a/bitnami/grafana-mimir/templates/gateway/deployment.yaml
+++ b/bitnami/grafana-mimir/templates/gateway/deployment.yaml
@@ -130,8 +130,7 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.gateway.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.gateway.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.gateway.livenessProbe "enabled") "context" $) | nindent 12 }}
-            httpGet:
-              path: /
+            tcpSocket:
               port: http
           {{- end }}
           {{- if .Values.gateway.customReadinessProbe }}

--- a/bitnami/grafana-mimir/templates/ingester/statefulset.yaml
+++ b/bitnami/grafana-mimir/templates/ingester/statefulset.yaml
@@ -172,8 +172,7 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.ingester.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.ingester.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.ingester.livenessProbe "enabled") "context" $) | nindent 12 }}
-            httpGet:
-              path: /ready
+            tcpSocket:
               port: http
           {{- end }}
           {{- if .Values.ingester.customReadinessProbe }}

--- a/bitnami/grafana-mimir/templates/overrides-exporter/deployment.yaml
+++ b/bitnami/grafana-mimir/templates/overrides-exporter/deployment.yaml
@@ -138,8 +138,7 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.overridesExporter.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.overridesExporter.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.overridesExporter.livenessProbe "enabled") "context" $) | nindent 12 }}
-            httpGet:
-              path: /ready
+            tcpSocket:
               port: http
           {{- end }}
           {{- if .Values.overridesExporter.customReadinessProbe }}

--- a/bitnami/grafana-mimir/templates/querier/deployment.yaml
+++ b/bitnami/grafana-mimir/templates/querier/deployment.yaml
@@ -140,8 +140,7 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.querier.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.querier.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.querier.livenessProbe "enabled") "context" $) | nindent 12 }}
-            httpGet:
-              path: /ready
+            tcpSocket:
               port: http
           {{- end }}
           {{- if .Values.querier.customReadinessProbe }}

--- a/bitnami/grafana-mimir/templates/query-frontend/deployment.yaml
+++ b/bitnami/grafana-mimir/templates/query-frontend/deployment.yaml
@@ -139,8 +139,7 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.queryFrontend.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.queryFrontend.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.queryFrontend.livenessProbe "enabled") "context" $) | nindent 12 }}
-            httpGet:
-              path: /ready
+            tcpSocket:
               port: http
           {{- end }}
           {{- if .Values.queryFrontend.customReadinessProbe }}

--- a/bitnami/grafana-mimir/templates/query-scheduler/deployment.yaml
+++ b/bitnami/grafana-mimir/templates/query-scheduler/deployment.yaml
@@ -125,8 +125,7 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.queryScheduler.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.queryScheduler.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.queryScheduler.livenessProbe "enabled") "context" $) | nindent 12 }}
-            httpGet:
-              path: /ready
+            tcpSocket:
               port: http
           {{- end }}
           {{- if .Values.queryScheduler.customReadinessProbe }}

--- a/bitnami/grafana-mimir/templates/ruler/deployment.yaml
+++ b/bitnami/grafana-mimir/templates/ruler/deployment.yaml
@@ -126,8 +126,7 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.ruler.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.ruler.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.ruler.livenessProbe "enabled") "context" $) | nindent 12 }}
-            httpGet:
-              path: /ready
+            tcpSocket:
               port: http
           {{- end }}
           {{- if .Values.ruler.customReadinessProbe }}

--- a/bitnami/grafana-mimir/templates/store-gateway/statefulset.yaml
+++ b/bitnami/grafana-mimir/templates/store-gateway/statefulset.yaml
@@ -172,8 +172,7 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.storeGateway.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.storeGateway.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.storeGateway.livenessProbe "enabled") "context" $) | nindent 12 }}
-            httpGet:
-              path: /ready
+            tcpSocket:
               port: http
           {{- end }}
           {{- if .Values.storeGateway.customReadinessProbe }}


### PR DESCRIPTION
### Description of the change
This PR aims to use different liveness/readiness probes to improve overall security and avoid unnecessary container restarts. [More info](https://github.com/zegl/kube-score/blob/master/README_PROBES.md).

### Benefits

Increase availability and resilience.

### Possible drawbacks

N/A

### Applicable issues

- fixes #

### Additional information

- Related to #23537

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- ~[X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)~
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
