### PR TITLE
[bitnami/kiam] Use different liveness/readiness probes

### DIFF
--- a/bitnami/kiam/CHANGELOG.md
+++ b/bitnami/kiam/CHANGELOG.md
@@ -1,565 +1,570 @@
 # Changelog
 
+## 2.1.1 (2024-05-23)
+
+* [bitnami/kiam] Use different liveness/readiness probes ([#26370](https://github.com/bitnami/charts/pull/26370))
+
 ## 2.1.0 (2024-05-21)
 
-* [bitnami/kiam] feat: :sparkles: :lock: Add warning when original images are replaced ([#26226](https://github.com/bitnami/charts/pulls/26226))
+* [bitnami/*] ci: :construction_worker: Add tag and changelog support (#25359) ([91c707c](https://github.com/bitnami/charts/commit/91c707c9e4e574725a09505d2d313fb93f1b4c0a)), closes [#25359](https://github.com/bitnami/charts/issues/25359)
+* [bitnami/kiam] feat: :sparkles: :lock: Add warning when original images are replaced (#26226) ([4e05399](https://github.com/bitnami/charts/commit/4e05399835e520cae4299f4cbb635adc9725ce1a)), closes [#26226](https://github.com/bitnami/charts/issues/26226)
 
 ## <small>2.0.5 (2024-05-18)</small>
 
-* [bitnami/kiam] Release 2.0.5 updating components versions (#26032) ([485070e](https://github.com/bitnami/charts/commit/485070e)), closes [#26032](https://github.com/bitnami/charts/issues/26032)
+* [bitnami/kiam] Release 2.0.5 updating components versions (#26032) ([485070e](https://github.com/bitnami/charts/commit/485070e83bd00753f24b41c1840651b00083016a)), closes [#26032](https://github.com/bitnami/charts/issues/26032)
 
 ## <small>2.0.4 (2024-05-14)</small>
 
-* [bitnami/*] Change non-root and rolling-tags doc URLs (#25628) ([b067c94](https://github.com/bitnami/charts/commit/b067c94)), closes [#25628](https://github.com/bitnami/charts/issues/25628)
-* [bitnami/kiam] Release 2.0.4 updating components versions (#25776) ([6002973](https://github.com/bitnami/charts/commit/6002973)), closes [#25776](https://github.com/bitnami/charts/issues/25776)
+* [bitnami/*] Change non-root and rolling-tags doc URLs (#25628) ([b067c94](https://github.com/bitnami/charts/commit/b067c94f6bcde427863c197fd355f0b5ba12ff5b)), closes [#25628](https://github.com/bitnami/charts/issues/25628)
+* [bitnami/kiam] Release 2.0.4 updating components versions (#25776) ([6002973](https://github.com/bitnami/charts/commit/600297334718366743da73596f3c936ed76c9521)), closes [#25776](https://github.com/bitnami/charts/issues/25776)
 
 ## <small>2.0.3 (2024-05-08)</small>
 
-* [bitnami/*] Set new header/owner (#25558) ([8d1dc11](https://github.com/bitnami/charts/commit/8d1dc11)), closes [#25558](https://github.com/bitnami/charts/issues/25558)
-* [bitnami/kiam] Release 2.0.3 updating components versions (#25602) ([b19865c](https://github.com/bitnami/charts/commit/b19865c)), closes [#25602](https://github.com/bitnami/charts/issues/25602)
-* [bitnami/multiple charts] Fix typo: "NetworkPolice" vs "NetworkPolicy" (#25348) ([6970c1b](https://github.com/bitnami/charts/commit/6970c1b)), closes [#25348](https://github.com/bitnami/charts/issues/25348)
-* Replace VMware by Broadcom copyright text (#25306) ([a5e4bd0](https://github.com/bitnami/charts/commit/a5e4bd0)), closes [#25306](https://github.com/bitnami/charts/issues/25306)
+* [bitnami/*] Set new header/owner (#25558) ([8d1dc11](https://github.com/bitnami/charts/commit/8d1dc11f5fb30db6fba50c43d7af59d2f79deed3)), closes [#25558](https://github.com/bitnami/charts/issues/25558)
+* [bitnami/kiam] Release 2.0.3 updating components versions (#25602) ([b19865c](https://github.com/bitnami/charts/commit/b19865c2358841a9c22de86877ee13ce734f5de8)), closes [#25602](https://github.com/bitnami/charts/issues/25602)
+* [bitnami/multiple charts] Fix typo: "NetworkPolice" vs "NetworkPolicy" (#25348) ([6970c1b](https://github.com/bitnami/charts/commit/6970c1ba245873506e73d459c6eac1e4919b778f)), closes [#25348](https://github.com/bitnami/charts/issues/25348)
+* Replace VMware by Broadcom copyright text (#25306) ([a5e4bd0](https://github.com/bitnami/charts/commit/a5e4bd0e35e419203793976a78d9d0a13de92c76)), closes [#25306](https://github.com/bitnami/charts/issues/25306)
 
 ## <small>2.0.2 (2024-04-05)</small>
 
-* [bitnami/kiam] Release 2.0.2 updating components versions (#24990) ([8cc7a00](https://github.com/bitnami/charts/commit/8cc7a00)), closes [#24990](https://github.com/bitnami/charts/issues/24990)
+* [bitnami/kiam] Release 2.0.2 updating components versions (#24990) ([8cc7a00](https://github.com/bitnami/charts/commit/8cc7a008fe813f0d6e8a400267a28dd8f0646abe)), closes [#24990](https://github.com/bitnami/charts/issues/24990)
 
 ## <small>2.0.1 (2024-04-04)</small>
 
-* [bitnami/*] Reorder Chart sections (#24455) ([0cf4048](https://github.com/bitnami/charts/commit/0cf4048)), closes [#24455](https://github.com/bitnami/charts/issues/24455)
-* [bitnami/kiam] Release 2.0.1 (#24889) ([18a3e4f](https://github.com/bitnami/charts/commit/18a3e4f)), closes [#24889](https://github.com/bitnami/charts/issues/24889)
-* Update resourcesPreset comments (#24467) ([92e3e8a](https://github.com/bitnami/charts/commit/92e3e8a)), closes [#24467](https://github.com/bitnami/charts/issues/24467)
+* [bitnami/*] Reorder Chart sections (#24455) ([0cf4048](https://github.com/bitnami/charts/commit/0cf4048e8743f70a9753d460655bd030cbff6824)), closes [#24455](https://github.com/bitnami/charts/issues/24455)
+* [bitnami/kiam] Release 2.0.1 (#24889) ([18a3e4f](https://github.com/bitnami/charts/commit/18a3e4f597b7c592cea84f077448f93d6e5f6692)), closes [#24889](https://github.com/bitnami/charts/issues/24889)
+* Update resourcesPreset comments (#24467) ([92e3e8a](https://github.com/bitnami/charts/commit/92e3e8a507326d2a20a8f10ab3e7746a2ec5c554)), closes [#24467](https://github.com/bitnami/charts/issues/24467)
 
 ## 2.0.0 (2024-03-12)
 
-* [bitnami/kiam] feat!: :lock: :boom: Improve security defaults (#24343) ([03396c6](https://github.com/bitnami/charts/commit/03396c6)), closes [#24343](https://github.com/bitnami/charts/issues/24343)
+* [bitnami/kiam] feat!: :lock: :boom: Improve security defaults (#24343) ([03396c6](https://github.com/bitnami/charts/commit/03396c6155b9bfb0307c8efb6d540ece8e8dba7c)), closes [#24343](https://github.com/bitnami/charts/issues/24343)
 
 ## <small>1.11.1 (2024-03-06)</small>
 
-* [bitnami/kiam] Release 1.11.1 updating components versions (#24221) ([5bcefb9](https://github.com/bitnami/charts/commit/5bcefb9)), closes [#24221](https://github.com/bitnami/charts/issues/24221)
+* [bitnami/kiam] Release 1.11.1 updating components versions (#24221) ([5bcefb9](https://github.com/bitnami/charts/commit/5bcefb93598fa46b98e523dbd667b4715e847983)), closes [#24221](https://github.com/bitnami/charts/issues/24221)
 
 ## 1.11.0 (2024-03-06)
 
-* [bitnami/kiam] feat: :sparkles: :lock: Add automatic adaptation for Openshift restricted-v2 SCC (#24 ([574caf8](https://github.com/bitnami/charts/commit/574caf8)), closes [#24102](https://github.com/bitnami/charts/issues/24102)
+* [bitnami/kiam] feat: :sparkles: :lock: Add automatic adaptation for Openshift restricted-v2 SCC (#24 ([574caf8](https://github.com/bitnami/charts/commit/574caf8bc62b18a9c54dc032ee21810200ecd6b5)), closes [#24102](https://github.com/bitnami/charts/issues/24102)
 
 ## 1.10.0 (2024-02-29)
 
-* [bitnami/kiam] feat: :sparkles: :lock: Add readOnlyRootFilesystem support (#23946) ([25fa32f](https://github.com/bitnami/charts/commit/25fa32f)), closes [#23946](https://github.com/bitnami/charts/issues/23946)
+* [bitnami/kiam] feat: :sparkles: :lock: Add readOnlyRootFilesystem support (#23946) ([25fa32f](https://github.com/bitnami/charts/commit/25fa32f2245cfbe1fa099890ca660e131fd692e1)), closes [#23946](https://github.com/bitnami/charts/issues/23946)
 
 ## <small>1.9.2 (2024-02-22)</small>
 
-* [bitnami/kiam] Release 1.9.2 updating components versions (#23793) ([6b7905d](https://github.com/bitnami/charts/commit/6b7905d)), closes [#23793](https://github.com/bitnami/charts/issues/23793)
+* [bitnami/kiam] Release 1.9.2 updating components versions (#23793) ([6b7905d](https://github.com/bitnami/charts/commit/6b7905d825d8a057c9e651fb15088dcd16a01c9e)), closes [#23793](https://github.com/bitnami/charts/issues/23793)
 
 ## <small>1.9.1 (2024-02-21)</small>
 
-* [bitnami/kiam] feat: :sparkles: :lock: Add resource preset support (#23470) ([173dd13](https://github.com/bitnami/charts/commit/173dd13)), closes [#23470](https://github.com/bitnami/charts/issues/23470)
-* [bitnami/kiam] Release 1.9.1 updating components versions (#23705) ([bd9e73b](https://github.com/bitnami/charts/commit/bd9e73b)), closes [#23705](https://github.com/bitnami/charts/issues/23705)
+* [bitnami/kiam] feat: :sparkles: :lock: Add resource preset support (#23470) ([173dd13](https://github.com/bitnami/charts/commit/173dd13878004df35747503a9edac913ba301d92)), closes [#23470](https://github.com/bitnami/charts/issues/23470)
+* [bitnami/kiam] Release 1.9.1 updating components versions (#23705) ([bd9e73b](https://github.com/bitnami/charts/commit/bd9e73bfb10540ef3c22ccbe315d333114b6e615)), closes [#23705](https://github.com/bitnami/charts/issues/23705)
 
 ## 1.9.0 (2024-02-20)
 
-* [bitnami/*] Bump all versions (#23602) ([b70ee2a](https://github.com/bitnami/charts/commit/b70ee2a)), closes [#23602](https://github.com/bitnami/charts/issues/23602)
+* [bitnami/*] Bump all versions (#23602) ([b70ee2a](https://github.com/bitnami/charts/commit/b70ee2a30e4dc256bf0ac52928fb2fa7a70f049b)), closes [#23602](https://github.com/bitnami/charts/issues/23602)
 
 ## 1.8.0 (2024-02-13)
 
-* [bitnami/kiam] feat: :lock: Enable networkPolicy (#23187) ([ee8c5a5](https://github.com/bitnami/charts/commit/ee8c5a5)), closes [#23187](https://github.com/bitnami/charts/issues/23187)
+* [bitnami/kiam] feat: :lock: Enable networkPolicy (#23187) ([ee8c5a5](https://github.com/bitnami/charts/commit/ee8c5a5dd987a486d4628624024f0bc3346996b9)), closes [#23187](https://github.com/bitnami/charts/issues/23187)
 
 ## <small>1.7.5 (2024-02-07)</small>
 
-* [bitnami/kiam] Release 1.7.5 updating components versions (#23297) ([e694312](https://github.com/bitnami/charts/commit/e694312)), closes [#23297](https://github.com/bitnami/charts/issues/23297)
+* [bitnami/kiam] Release 1.7.5 updating components versions (#23297) ([e694312](https://github.com/bitnami/charts/commit/e69431219eee1366444f8a5b2c3142912bf85071)), closes [#23297](https://github.com/bitnami/charts/issues/23297)
 
 ## <small>1.7.4 (2024-02-07)</small>
 
-* [bitnami/kiam] Release 1.7.4 updating components versions (#23251) ([086ea28](https://github.com/bitnami/charts/commit/086ea28)), closes [#23251](https://github.com/bitnami/charts/issues/23251)
+* [bitnami/kiam] Release 1.7.4 updating components versions (#23251) ([086ea28](https://github.com/bitnami/charts/commit/086ea281fef35174dd527d7837571e77fe061d7f)), closes [#23251](https://github.com/bitnami/charts/issues/23251)
 
 ## <small>1.7.3 (2024-02-02)</small>
 
-* [bitnami/kiam] Release 1.7.3 updating components versions (#23088) ([399fc3a](https://github.com/bitnami/charts/commit/399fc3a)), closes [#23088](https://github.com/bitnami/charts/issues/23088)
+* [bitnami/kiam] Release 1.7.3 updating components versions (#23088) ([399fc3a](https://github.com/bitnami/charts/commit/399fc3a21a21e5078a5304528b59475f7d94abd6)), closes [#23088](https://github.com/bitnami/charts/issues/23088)
 
 ## <small>1.7.2 (2024-01-30)</small>
 
-* [bitnami/kiam] Release 1.7.2 updating components versions (#22933) ([8ea52e7](https://github.com/bitnami/charts/commit/8ea52e7)), closes [#22933](https://github.com/bitnami/charts/issues/22933)
+* [bitnami/kiam] Release 1.7.2 updating components versions (#22933) ([8ea52e7](https://github.com/bitnami/charts/commit/8ea52e7a9e25e307585a6b243b7316ee3c3ad3de)), closes [#22933](https://github.com/bitnami/charts/issues/22933)
 
 ## <small>1.7.1 (2024-01-26)</small>
 
-* [bitnami/*] Move documentation sections from docs.bitnami.com back to the README (#22203) ([7564f36](https://github.com/bitnami/charts/commit/7564f36)), closes [#22203](https://github.com/bitnami/charts/issues/22203)
-* [bitnami/kiam] fix: :bug: Set seLinuxOptions to null for Openshift compatibility (#22607) ([cb6c28e](https://github.com/bitnami/charts/commit/cb6c28e)), closes [#22607](https://github.com/bitnami/charts/issues/22607)
+* [bitnami/*] Move documentation sections from docs.bitnami.com back to the README (#22203) ([7564f36](https://github.com/bitnami/charts/commit/7564f36ca1e95ff30ee686652b7ab8690561a707)), closes [#22203](https://github.com/bitnami/charts/issues/22203)
+* [bitnami/kiam] fix: :bug: Set seLinuxOptions to null for Openshift compatibility (#22607) ([cb6c28e](https://github.com/bitnami/charts/commit/cb6c28e612faab44e9798deb59bf1340b36b7557)), closes [#22607](https://github.com/bitnami/charts/issues/22607)
 
 ## 1.7.0 (2024-01-19)
 
-* [bitnami/kiam] fix: :lock: Move service-account token auto-mount to pod declaration (#22417) ([03715c5](https://github.com/bitnami/charts/commit/03715c5)), closes [#22417](https://github.com/bitnami/charts/issues/22417)
+* [bitnami/kiam] fix: :lock: Move service-account token auto-mount to pod declaration (#22417) ([03715c5](https://github.com/bitnami/charts/commit/03715c5a9151380bce27ac4776ecbc998ea7c015)), closes [#22417](https://github.com/bitnami/charts/issues/22417)
 
 ## <small>1.6.1 (2024-01-18)</small>
 
-* [bitnami/kiam] Release 1.6.1 updating components versions (#22285) ([0a282f1](https://github.com/bitnami/charts/commit/0a282f1)), closes [#22285](https://github.com/bitnami/charts/issues/22285)
+* [bitnami/kiam] Release 1.6.1 updating components versions (#22285) ([0a282f1](https://github.com/bitnami/charts/commit/0a282f146d058e9412960d32e09636fe28320ea7)), closes [#22285](https://github.com/bitnami/charts/issues/22285)
 
 ## 1.6.0 (2024-01-16)
 
-* [bitnami/kiam] fix: :lock: Improve podSecurityContext and containerSecurityContext with essential se ([fd003d0](https://github.com/bitnami/charts/commit/fd003d0)), closes [#22138](https://github.com/bitnami/charts/issues/22138)
+* [bitnami/kiam] fix: :lock: Improve podSecurityContext and containerSecurityContext with essential se ([fd003d0](https://github.com/bitnami/charts/commit/fd003d018cea367015b9ce630eb939afe5218eed)), closes [#22138](https://github.com/bitnami/charts/issues/22138)
 
 ## <small>1.5.2 (2024-01-15)</small>
 
-* [bitnami/*] Fix ref links (in comments) (#21822) ([e4fa296](https://github.com/bitnami/charts/commit/e4fa296)), closes [#21822](https://github.com/bitnami/charts/issues/21822)
-* [bitnami/kiam] fix: :lock: Do not automount the service account token unless necessary (#22048) ([d8d9cf3](https://github.com/bitnami/charts/commit/d8d9cf3)), closes [#22048](https://github.com/bitnami/charts/issues/22048)
+* [bitnami/*] Fix ref links (in comments) (#21822) ([e4fa296](https://github.com/bitnami/charts/commit/e4fa296106b225cf8c82445727c675c7c725e380)), closes [#21822](https://github.com/bitnami/charts/issues/21822)
+* [bitnami/kiam] fix: :lock: Do not automount the service account token unless necessary (#22048) ([d8d9cf3](https://github.com/bitnami/charts/commit/d8d9cf32c0562cd6d853270a70d76e77e456aa43)), closes [#22048](https://github.com/bitnami/charts/issues/22048)
 
 ## <small>1.5.1 (2024-01-10)</small>
 
-* [bitnami/kiam] Release 1.5.1 updating components versions (#21948) ([e3a85e3](https://github.com/bitnami/charts/commit/e3a85e3)), closes [#21948](https://github.com/bitnami/charts/issues/21948)
+* [bitnami/kiam] Release 1.5.1 updating components versions (#21948) ([e3a85e3](https://github.com/bitnami/charts/commit/e3a85e30c1feba2153a4a7b6b9664c702f446006)), closes [#21948](https://github.com/bitnami/charts/issues/21948)
 
 ## 1.5.0 (2024-01-10)
 
-* [bitnami/*] Fix docs.bitnami.com broken links (#21901) ([f35506d](https://github.com/bitnami/charts/commit/f35506d)), closes [#21901](https://github.com/bitnami/charts/issues/21901)
-* [bitnami/*] Update copyright: Year and company (#21815) ([6c4bf75](https://github.com/bitnami/charts/commit/6c4bf75)), closes [#21815](https://github.com/bitnami/charts/issues/21815)
-* [bitnami/kiam] feat: :sparkles: Add seccompProfile to containerSecurityContext (#21900) ([6aefe24](https://github.com/bitnami/charts/commit/6aefe24)), closes [#21900](https://github.com/bitnami/charts/issues/21900)
+* [bitnami/*] Fix docs.bitnami.com broken links (#21901) ([f35506d](https://github.com/bitnami/charts/commit/f35506d2dadee4f097986e7792df1f53ab215b5d)), closes [#21901](https://github.com/bitnami/charts/issues/21901)
+* [bitnami/*] Update copyright: Year and company (#21815) ([6c4bf75](https://github.com/bitnami/charts/commit/6c4bf75dec58fc7c9aee9f089777b1a858c17d5b)), closes [#21815](https://github.com/bitnami/charts/issues/21815)
+* [bitnami/kiam] feat: :sparkles: Add seccompProfile to containerSecurityContext (#21900) ([6aefe24](https://github.com/bitnami/charts/commit/6aefe24962f16169b0a3deb387198e927b7ffe32)), closes [#21900](https://github.com/bitnami/charts/issues/21900)
 
 ## <small>1.4.10 (2023-12-07)</small>
 
-* [bitnami/kiam] Release 1.4.10 updating components versions (#21447) ([e304629](https://github.com/bitnami/charts/commit/e304629)), closes [#21447](https://github.com/bitnami/charts/issues/21447)
+* [bitnami/kiam] Release 1.4.10 updating components versions (#21447) ([e304629](https://github.com/bitnami/charts/commit/e3046299818c79aad3dea4c70985b53052ebed73)), closes [#21447](https://github.com/bitnami/charts/issues/21447)
 
 ## <small>1.4.9 (2023-11-21)</small>
 
-* [bitnami/*] Remove relative links to non-README sections, add verification for that and update TL;DR ([1103633](https://github.com/bitnami/charts/commit/1103633)), closes [#20967](https://github.com/bitnami/charts/issues/20967)
-* [bitnami/*] Rename solutions to "Bitnami package for ..." (#21038) ([b82f979](https://github.com/bitnami/charts/commit/b82f979)), closes [#21038](https://github.com/bitnami/charts/issues/21038)
-* [bitnami/kiam] Release 1.4.9 updating components versions (#21129) ([b850e3d](https://github.com/bitnami/charts/commit/b850e3d)), closes [#21129](https://github.com/bitnami/charts/issues/21129)
+* [bitnami/*] Remove relative links to non-README sections, add verification for that and update TL;DR ([1103633](https://github.com/bitnami/charts/commit/11036334d82df0490aa4abdb591543cab6cf7d7f)), closes [#20967](https://github.com/bitnami/charts/issues/20967)
+* [bitnami/*] Rename solutions to "Bitnami package for ..." (#21038) ([b82f979](https://github.com/bitnami/charts/commit/b82f979e4fb63423fe6e2192c946d09d79c944fc)), closes [#21038](https://github.com/bitnami/charts/issues/21038)
+* [bitnami/kiam] Release 1.4.9 updating components versions (#21129) ([b850e3d](https://github.com/bitnami/charts/commit/b850e3da36240cec5627fb777e3f8b6944ea8e3c)), closes [#21129](https://github.com/bitnami/charts/issues/21129)
 
 ## <small>1.4.8 (2023-11-08)</small>
 
-* [bitnami/kiam] Release 1.4.8 updating components versions (#20811) ([14aa495](https://github.com/bitnami/charts/commit/14aa495)), closes [#20811](https://github.com/bitnami/charts/issues/20811)
+* [bitnami/kiam] Release 1.4.8 updating components versions (#20811) ([14aa495](https://github.com/bitnami/charts/commit/14aa495141d844b523515b5bff21d3e6f614f07b)), closes [#20811](https://github.com/bitnami/charts/issues/20811)
 
 ## <small>1.4.7 (2023-11-08)</small>
 
-* [bitnami/*] Rename VMware Application Catalog (#20361) ([3acc734](https://github.com/bitnami/charts/commit/3acc734)), closes [#20361](https://github.com/bitnami/charts/issues/20361)
-* [bitnami/*] Skip image's tag in the README files of the Bitnami Charts (#19841) ([bb9a01b](https://github.com/bitnami/charts/commit/bb9a01b)), closes [#19841](https://github.com/bitnami/charts/issues/19841)
-* [bitnami/*] Standardize documentation (#19835) ([af5f753](https://github.com/bitnami/charts/commit/af5f753)), closes [#19835](https://github.com/bitnami/charts/issues/19835)
-* [bitnami/kiam] Release 1.4.7 updating components versions (#20735) ([1e22cb6](https://github.com/bitnami/charts/commit/1e22cb6)), closes [#20735](https://github.com/bitnami/charts/issues/20735)
+* [bitnami/*] Rename VMware Application Catalog (#20361) ([3acc734](https://github.com/bitnami/charts/commit/3acc73472beb6fb56c4d99f929061001205bc57e)), closes [#20361](https://github.com/bitnami/charts/issues/20361)
+* [bitnami/*] Skip image's tag in the README files of the Bitnami Charts (#19841) ([bb9a01b](https://github.com/bitnami/charts/commit/bb9a01b65911c87e48318db922cc05eb42785e42)), closes [#19841](https://github.com/bitnami/charts/issues/19841)
+* [bitnami/*] Standardize documentation (#19835) ([af5f753](https://github.com/bitnami/charts/commit/af5f7530c1bc8c5ded53a6c4f7b8f384ac1804f2)), closes [#19835](https://github.com/bitnami/charts/issues/19835)
+* [bitnami/kiam] Release 1.4.7 updating components versions (#20735) ([1e22cb6](https://github.com/bitnami/charts/commit/1e22cb6eea2fa29c9f9a9e9b2782491c145ffc95)), closes [#20735](https://github.com/bitnami/charts/issues/20735)
 
 ## <small>1.4.6 (2023-10-11)</small>
 
-* [bitnami/kiam] Release 1.4.6 (#20046) ([3ce70f4](https://github.com/bitnami/charts/commit/3ce70f4)), closes [#20046](https://github.com/bitnami/charts/issues/20046)
+* [bitnami/kiam] Release 1.4.6 (#20046) ([3ce70f4](https://github.com/bitnami/charts/commit/3ce70f40ad0454a9878b0d06ac8597033b7a8b1a)), closes [#20046](https://github.com/bitnami/charts/issues/20046)
 
 ## <small>1.4.5 (2023-10-09)</small>
 
-* [bitnami/*] Update Helm charts prerequisites (#19745) ([eb755dd](https://github.com/bitnami/charts/commit/eb755dd)), closes [#19745](https://github.com/bitnami/charts/issues/19745)
-* [bitnami/kiam] Release 1.4.5 (#19855) ([cdd3bf1](https://github.com/bitnami/charts/commit/cdd3bf1)), closes [#19855](https://github.com/bitnami/charts/issues/19855)
+* [bitnami/*] Update Helm charts prerequisites (#19745) ([eb755dd](https://github.com/bitnami/charts/commit/eb755dd36a4dd3cf6635be8e0598f9a7f4c4a554)), closes [#19745](https://github.com/bitnami/charts/issues/19745)
+* [bitnami/kiam] Release 1.4.5 (#19855) ([cdd3bf1](https://github.com/bitnami/charts/commit/cdd3bf1ef8b0cc00653d955de0d1c26f3ef3f134)), closes [#19855](https://github.com/bitnami/charts/issues/19855)
 
 ## <small>1.4.4 (2023-10-03)</small>
 
-* [bitnami/kiam] Release 1.4.4 (#19714) ([9840a3d](https://github.com/bitnami/charts/commit/9840a3d)), closes [#19714](https://github.com/bitnami/charts/issues/19714)
+* [bitnami/kiam] Release 1.4.4 (#19714) ([9840a3d](https://github.com/bitnami/charts/commit/9840a3dc00d8ed3fa00a8b8d740bff61264d7065)), closes [#19714](https://github.com/bitnami/charts/issues/19714)
 
 ## <small>1.4.3 (2023-10-02)</small>
 
-* [bitnami/kiam] Use common capabilities for PSP (#19629) ([f916fe0](https://github.com/bitnami/charts/commit/f916fe0)), closes [#19629](https://github.com/bitnami/charts/issues/19629)
+* [bitnami/kiam] Use common capabilities for PSP (#19629) ([f916fe0](https://github.com/bitnami/charts/commit/f916fe09e23819d9ce98b481549bcbe368b7cc64)), closes [#19629](https://github.com/bitnami/charts/issues/19629)
 
 ## <small>1.4.2 (2023-09-20)</small>
 
-* [bitnami/kiam] Release 1.4.2 (#19440) ([0f334d7](https://github.com/bitnami/charts/commit/0f334d7)), closes [#19440](https://github.com/bitnami/charts/issues/19440)
-* Autogenerate schema files (#19194) ([a2c2090](https://github.com/bitnami/charts/commit/a2c2090)), closes [#19194](https://github.com/bitnami/charts/issues/19194)
-* Revert "Autogenerate schema files (#19194)" (#19335) ([73d80be](https://github.com/bitnami/charts/commit/73d80be)), closes [#19194](https://github.com/bitnami/charts/issues/19194) [#19335](https://github.com/bitnami/charts/issues/19335)
+* [bitnami/kiam] Release 1.4.2 (#19440) ([0f334d7](https://github.com/bitnami/charts/commit/0f334d785e0d72f169ead7e9606c4290389f9f65)), closes [#19440](https://github.com/bitnami/charts/issues/19440)
+* Autogenerate schema files (#19194) ([a2c2090](https://github.com/bitnami/charts/commit/a2c2090b5ac97f47b745c8028c6452bf99739772)), closes [#19194](https://github.com/bitnami/charts/issues/19194)
+* Revert "Autogenerate schema files (#19194)" (#19335) ([73d80be](https://github.com/bitnami/charts/commit/73d80be525c88fb4b8a54451a55acd506e337062)), closes [#19194](https://github.com/bitnami/charts/issues/19194) [#19335](https://github.com/bitnami/charts/issues/19335)
 
 ## <small>1.4.1 (2023-09-06)</small>
 
-* [bitnami/kiam: Use merge helper]: (#19056) ([0d8251d](https://github.com/bitnami/charts/commit/0d8251d)), closes [#19056](https://github.com/bitnami/charts/issues/19056)
+* [bitnami/kiam: Use merge helper]: (#19056) ([0d8251d](https://github.com/bitnami/charts/commit/0d8251d95126e902606e1c2e2621b9fcd920cb3b)), closes [#19056](https://github.com/bitnami/charts/issues/19056)
 
 ## 1.4.0 (2023-08-24)
 
-* [bitnami/kiam] Support for customizing standard labels (#18313) ([e008ebc](https://github.com/bitnami/charts/commit/e008ebc)), closes [#18313](https://github.com/bitnami/charts/issues/18313)
+* [bitnami/kiam] Support for customizing standard labels (#18313) ([e008ebc](https://github.com/bitnami/charts/commit/e008ebc7ab08e29c8e63c57ceb8ee339922210f2)), closes [#18313](https://github.com/bitnami/charts/issues/18313)
 
 ## <small>1.3.9 (2023-08-21)</small>
 
-* [bitnami/kiam] Release 1.3.9 (#18766) ([2108527](https://github.com/bitnami/charts/commit/2108527)), closes [#18766](https://github.com/bitnami/charts/issues/18766)
+* [bitnami/kiam] Release 1.3.9 (#18766) ([2108527](https://github.com/bitnami/charts/commit/2108527844a57cd9b9c6e31d2dc8c4239da20cd3)), closes [#18766](https://github.com/bitnami/charts/issues/18766)
 
 ## <small>1.3.8 (2023-08-19)</small>
 
-* [bitnami/kiam] Release 1.3.8 (#18672) ([564e8b3](https://github.com/bitnami/charts/commit/564e8b3)), closes [#18672](https://github.com/bitnami/charts/issues/18672)
+* [bitnami/kiam] Release 1.3.8 (#18672) ([564e8b3](https://github.com/bitnami/charts/commit/564e8b364aa9d75943a659746e8ebdb0c8eca00b)), closes [#18672](https://github.com/bitnami/charts/issues/18672)
 
 ## <small>1.3.7 (2023-08-17)</small>
 
-* [bitnami/kiam] Release 1.3.7 (#18534) ([34f2309](https://github.com/bitnami/charts/commit/34f2309)), closes [#18534](https://github.com/bitnami/charts/issues/18534)
+* [bitnami/kiam] Release 1.3.7 (#18534) ([34f2309](https://github.com/bitnami/charts/commit/34f23092eaf2ea1d8d17d2559e1bd2a1d74434c5)), closes [#18534](https://github.com/bitnami/charts/issues/18534)
 
 ## <small>1.3.6 (2023-07-25)</small>
 
-* [bitnami/kiam] Release 1.3.6 (#17894) ([54b3349](https://github.com/bitnami/charts/commit/54b3349)), closes [#17894](https://github.com/bitnami/charts/issues/17894)
+* [bitnami/kiam] Release 1.3.6 (#17894) ([54b3349](https://github.com/bitnami/charts/commit/54b3349c165b616737ddfa54f6f10d400ed51234)), closes [#17894](https://github.com/bitnami/charts/issues/17894)
 
 ## <small>1.3.5 (2023-07-13)</small>
 
-* [bitnami/kiam] Release 1 (#17611) ([f1b8206](https://github.com/bitnami/charts/commit/f1b8206)), closes [#17611](https://github.com/bitnami/charts/issues/17611)
-* Add copyright header (#17300) ([da68be8](https://github.com/bitnami/charts/commit/da68be8)), closes [#17300](https://github.com/bitnami/charts/issues/17300)
+* [bitnami/kiam] Release 1 (#17611) ([f1b8206](https://github.com/bitnami/charts/commit/f1b820622525519e58a07d97d7d7051df976ed6b)), closes [#17611](https://github.com/bitnami/charts/issues/17611)
+* Add copyright header (#17300) ([da68be8](https://github.com/bitnami/charts/commit/da68be8e951225133c7dfb572d5101ca3d61c5ae)), closes [#17300](https://github.com/bitnami/charts/issues/17300)
 
 ## <small>1.3.4 (2023-06-22)</small>
 
-* [bitnami/kiam] Release 1.3.4 (#17308) ([f6222e7](https://github.com/bitnami/charts/commit/f6222e7)), closes [#17308](https://github.com/bitnami/charts/issues/17308)
-* Update charts readme (#17217) ([31b3c0a](https://github.com/bitnami/charts/commit/31b3c0a)), closes [#17217](https://github.com/bitnami/charts/issues/17217)
+* [bitnami/kiam] Release 1.3.4 (#17308) ([f6222e7](https://github.com/bitnami/charts/commit/f6222e7564f14971c80eb32a258fbba234fa896d)), closes [#17308](https://github.com/bitnami/charts/issues/17308)
+* Update charts readme (#17217) ([31b3c0a](https://github.com/bitnami/charts/commit/31b3c0afd968ff4429107e34101f7509e6a0e913)), closes [#17217](https://github.com/bitnami/charts/issues/17217)
 
 ## <small>1.3.3 (2023-06-21)</small>
 
-* [bitnami/kiam] Remove namespace field for cluster wide resources (#17271) ([4507089](https://github.com/bitnami/charts/commit/4507089)), closes [#17271](https://github.com/bitnami/charts/issues/17271)
+* [bitnami/kiam] Remove namespace field for cluster wide resources (#17271) ([4507089](https://github.com/bitnami/charts/commit/45070893fbeefb794fa10460a0c475c3e78a7ce4)), closes [#17271](https://github.com/bitnami/charts/issues/17271)
 
 ## <small>1.3.2 (2023-06-20)</small>
 
-* [bitnami/*] Change copyright section in READMEs (#17006) ([ef986a1](https://github.com/bitnami/charts/commit/ef986a1)), closes [#17006](https://github.com/bitnami/charts/issues/17006)
-* [bitnami/kiam] Release 1.3.2 (#17211) ([85f926b](https://github.com/bitnami/charts/commit/85f926b)), closes [#17211](https://github.com/bitnami/charts/issues/17211)
-* [bitnami/several] Change copyright section in READMEs (#16989) ([5b6a5cf](https://github.com/bitnami/charts/commit/5b6a5cf)), closes [#16989](https://github.com/bitnami/charts/issues/16989)
+* [bitnami/*] Change copyright section in READMEs (#17006) ([ef986a1](https://github.com/bitnami/charts/commit/ef986a1605241102b3dcafe9fd8089e6fc1201ad)), closes [#17006](https://github.com/bitnami/charts/issues/17006)
+* [bitnami/kiam] Release 1.3.2 (#17211) ([85f926b](https://github.com/bitnami/charts/commit/85f926b0d9996a49a7ef71433be5ca6ee08405f0)), closes [#17211](https://github.com/bitnami/charts/issues/17211)
+* [bitnami/several] Change copyright section in READMEs (#16989) ([5b6a5cf](https://github.com/bitnami/charts/commit/5b6a5cfb7625a751848a2e5cd796bd7278f406ca)), closes [#16989](https://github.com/bitnami/charts/issues/16989)
 
 ## <small>1.3.1 (2023-05-21)</small>
 
-* [bitnami/kiam] Release 1.3.1 (#16776) ([ca57eb9](https://github.com/bitnami/charts/commit/ca57eb9)), closes [#16776](https://github.com/bitnami/charts/issues/16776)
-* Add wording for enterprise page (#16560) ([8f22774](https://github.com/bitnami/charts/commit/8f22774)), closes [#16560](https://github.com/bitnami/charts/issues/16560)
+* [bitnami/kiam] Release 1.3.1 (#16776) ([ca57eb9](https://github.com/bitnami/charts/commit/ca57eb91c60484db5d9f649afcddbee142f88b9e)), closes [#16776](https://github.com/bitnami/charts/issues/16776)
+* Add wording for enterprise page (#16560) ([8f22774](https://github.com/bitnami/charts/commit/8f2277440b976d52785ba9149762ad8620a73d1f)), closes [#16560](https://github.com/bitnami/charts/issues/16560)
 
 ## 1.3.0 (2023-05-09)
 
-* [bitnami/several] Adapt Chart.yaml to set desired OCI annotations (#16546) ([fc9b18f](https://github.com/bitnami/charts/commit/fc9b18f)), closes [#16546](https://github.com/bitnami/charts/issues/16546)
+* [bitnami/several] Adapt Chart.yaml to set desired OCI annotations (#16546) ([fc9b18f](https://github.com/bitnami/charts/commit/fc9b18f2e98805d4df629acbcde696f44f973344)), closes [#16546](https://github.com/bitnami/charts/issues/16546)
 
 ## <small>1.2.2 (2023-05-09)</small>
 
-* [bitnami/kiam] Release 1.2.2 (#16462) ([2a6eb71](https://github.com/bitnami/charts/commit/2a6eb71)), closes [#16462](https://github.com/bitnami/charts/issues/16462)
+* [bitnami/kiam] Release 1.2.2 (#16462) ([2a6eb71](https://github.com/bitnami/charts/commit/2a6eb714d8afe029469deea1daf01f5eb0ca5fd1)), closes [#16462](https://github.com/bitnami/charts/issues/16462)
 
 ## <small>1.2.1 (2023-05-01)</small>
 
-* [bitnami/kiam] Release 1.2.1 (#16295) ([d6a79a5](https://github.com/bitnami/charts/commit/d6a79a5)), closes [#16295](https://github.com/bitnami/charts/issues/16295)
+* [bitnami/kiam] Release 1.2.1 (#16295) ([d6a79a5](https://github.com/bitnami/charts/commit/d6a79a59a649ede7e2d4241fc339cb6ea8b24e37)), closes [#16295](https://github.com/bitnami/charts/issues/16295)
 
 ## 1.2.0 (2023-04-20)
 
-* [bitnami/*] Make Helm charts 100% OCI (#15998) ([8841510](https://github.com/bitnami/charts/commit/8841510)), closes [#15998](https://github.com/bitnami/charts/issues/15998)
+* [bitnami/*] Make Helm charts 100% OCI (#15998) ([8841510](https://github.com/bitnami/charts/commit/884151035efcbf2e1b3206e7def85511073fb57d)), closes [#15998](https://github.com/bitnami/charts/issues/15998)
 
 ## <small>1.1.14 (2023-04-04)</small>
 
-* [bitnami/kiam] Release 1.1.14 (#15855) ([5161517](https://github.com/bitnami/charts/commit/5161517)), closes [#15855](https://github.com/bitnami/charts/issues/15855)
+* [bitnami/kiam] Release 1.1.14 (#15855) ([5161517](https://github.com/bitnami/charts/commit/5161517a58c5cf0f23501eeeac475ebf20b53fe4)), closes [#15855](https://github.com/bitnami/charts/issues/15855)
 
 ## <small>1.1.13 (2023-03-22)</small>
 
-* [bitnami/charts] Apply linter to README files (#15357) ([0e29e60](https://github.com/bitnami/charts/commit/0e29e60)), closes [#15357](https://github.com/bitnami/charts/issues/15357)
-* [bitnami/kiam] Release 1.1.13 (#15662) ([193e46e](https://github.com/bitnami/charts/commit/193e46e)), closes [#15662](https://github.com/bitnami/charts/issues/15662)
+* [bitnami/charts] Apply linter to README files (#15357) ([0e29e60](https://github.com/bitnami/charts/commit/0e29e600d3adc8b1b46e506eccb3decfab3b4e63)), closes [#15357](https://github.com/bitnami/charts/issues/15357)
+* [bitnami/kiam] Release 1.1.13 (#15662) ([193e46e](https://github.com/bitnami/charts/commit/193e46eb1f016c2f64112108e2f7f3a3e63b5537)), closes [#15662](https://github.com/bitnami/charts/issues/15662)
 
 ## <small>1.1.12 (2023-03-01)</small>
 
-* [bitnami/kiam] Release 1.1.12 (#15270) ([fe1b130](https://github.com/bitnami/charts/commit/fe1b130)), closes [#15270](https://github.com/bitnami/charts/issues/15270)
+* [bitnami/kiam] Release 1.1.12 (#15270) ([fe1b130](https://github.com/bitnami/charts/commit/fe1b130d164883e1e9fd0a0b7fbc5e43bc6c0bb1)), closes [#15270](https://github.com/bitnami/charts/issues/15270)
 
 ## <small>1.1.11 (2023-02-17)</small>
 
-* [bitnami/*] Fix markdown linter issues (#14874) ([a51e0e8](https://github.com/bitnami/charts/commit/a51e0e8)), closes [#14874](https://github.com/bitnami/charts/issues/14874)
-* [bitnami/*] Remove unexpected extra spaces (#14873) ([c97c714](https://github.com/bitnami/charts/commit/c97c714)), closes [#14873](https://github.com/bitnami/charts/issues/14873)
-* [bitnami/kiam] Release 1.1.11 (#14958) ([9051c7c](https://github.com/bitnami/charts/commit/9051c7c)), closes [#14958](https://github.com/bitnami/charts/issues/14958)
+* [bitnami/*] Fix markdown linter issues (#14874) ([a51e0e8](https://github.com/bitnami/charts/commit/a51e0e8d35495b907f3e70dd2f8e7c3bcbf4166a)), closes [#14874](https://github.com/bitnami/charts/issues/14874)
+* [bitnami/*] Remove unexpected extra spaces (#14873) ([c97c714](https://github.com/bitnami/charts/commit/c97c714887380d47eae7bfeff316bf01595ecd1d)), closes [#14873](https://github.com/bitnami/charts/issues/14873)
+* [bitnami/kiam] Release 1.1.11 (#14958) ([9051c7c](https://github.com/bitnami/charts/commit/9051c7c10595bdf48dda8d015823280ecae78958)), closes [#14958](https://github.com/bitnami/charts/issues/14958)
 
 ## <small>1.1.10 (2023-02-05)</small>
 
-* [bitnami/kiam] Release 1.1.10 (#14750) ([c0b2c0d](https://github.com/bitnami/charts/commit/c0b2c0d)), closes [#14750](https://github.com/bitnami/charts/issues/14750)
+* [bitnami/kiam] Release 1.1.10 (#14750) ([c0b2c0d](https://github.com/bitnami/charts/commit/c0b2c0d5543c65174d6a64966b1df48e9c859160)), closes [#14750](https://github.com/bitnami/charts/issues/14750)
 
 ## <small>1.1.9 (2023-02-02)</small>
 
-* [bitnami/kiam] Hotfix kiam certificates (#14685) ([0788e25](https://github.com/bitnami/charts/commit/0788e25)), closes [#14685](https://github.com/bitnami/charts/issues/14685)
+* [bitnami/kiam] Hotfix kiam certificates (#14685) ([0788e25](https://github.com/bitnami/charts/commit/0788e258fa7b5c1ac063826ac6a1e4fd9e73ec45)), closes [#14685](https://github.com/bitnami/charts/issues/14685)
 
 ## <small>1.1.8 (2023-01-31)</small>
 
-* [bitnami/*] Add license annotation and remove obsolete engine parameter (#14293) ([da2a794](https://github.com/bitnami/charts/commit/da2a794)), closes [#14293](https://github.com/bitnami/charts/issues/14293)
-* [bitnami/*] Change copyright date (#14682) ([add4ec7](https://github.com/bitnami/charts/commit/add4ec7)), closes [#14682](https://github.com/bitnami/charts/issues/14682)
-* [bitnami/*] Change licenses annotation format (#14377) ([0ab7608](https://github.com/bitnami/charts/commit/0ab7608)), closes [#14377](https://github.com/bitnami/charts/issues/14377)
-* [bitnami/*] Unify READMEs (#14472) ([2064fb8](https://github.com/bitnami/charts/commit/2064fb8)), closes [#14472](https://github.com/bitnami/charts/issues/14472)
-* [bitnami/kiam] Don't regenerate self-signed certs on upgrade (#14631) ([8773e5a](https://github.com/bitnami/charts/commit/8773e5a)), closes [#14631](https://github.com/bitnami/charts/issues/14631)
+* [bitnami/*] Add license annotation and remove obsolete engine parameter (#14293) ([da2a794](https://github.com/bitnami/charts/commit/da2a7943bae95b6e9b5b4ed972c15e990b69fdb0)), closes [#14293](https://github.com/bitnami/charts/issues/14293)
+* [bitnami/*] Change copyright date (#14682) ([add4ec7](https://github.com/bitnami/charts/commit/add4ec701108ac36ed4de2dffbdf407a0d091067)), closes [#14682](https://github.com/bitnami/charts/issues/14682)
+* [bitnami/*] Change licenses annotation format (#14377) ([0ab7608](https://github.com/bitnami/charts/commit/0ab760862c660fcc78cffadf8e1d8cdd70881473)), closes [#14377](https://github.com/bitnami/charts/issues/14377)
+* [bitnami/*] Unify READMEs (#14472) ([2064fb8](https://github.com/bitnami/charts/commit/2064fb8dcc78a845cdede8211af8c3cc52551161)), closes [#14472](https://github.com/bitnami/charts/issues/14472)
+* [bitnami/kiam] Don't regenerate self-signed certs on upgrade (#14631) ([8773e5a](https://github.com/bitnami/charts/commit/8773e5aa16404f7201d9e28c7c6d9d7329cfb8f7)), closes [#14631](https://github.com/bitnami/charts/issues/14631)
 
 ## <small>1.1.7 (2023-01-06)</small>
 
-* [bitnami/kiam] Release 1.1.7 (#14199) ([c9e4581](https://github.com/bitnami/charts/commit/c9e4581)), closes [#14199](https://github.com/bitnami/charts/issues/14199)
+* [bitnami/kiam] Release 1.1.7 (#14199) ([c9e4581](https://github.com/bitnami/charts/commit/c9e4581a091574101a43f991f328916ce23f7f6c)), closes [#14199](https://github.com/bitnami/charts/issues/14199)
 
 ## <small>1.1.6 (2022-12-07)</small>
 
-* [bitnami/kiam] Release 1.1.6 (#13856) ([62c040e](https://github.com/bitnami/charts/commit/62c040e)), closes [#13856](https://github.com/bitnami/charts/issues/13856)
+* [bitnami/kiam] Release 1.1.6 (#13856) ([62c040e](https://github.com/bitnami/charts/commit/62c040ecf8bfd3dc2640a0bee67a8cd1e9722aea)), closes [#13856](https://github.com/bitnami/charts/issues/13856)
 
 ## <small>1.1.5 (2022-11-07)</small>
 
-* [bitnami/*] Use new default branch name in links (#12943) ([a529e02](https://github.com/bitnami/charts/commit/a529e02)), closes [#12943](https://github.com/bitnami/charts/issues/12943)
-* [bitnami/kiam] Release 1.1.5 updating components versions ([16864e6](https://github.com/bitnami/charts/commit/16864e6))
+* [bitnami/*] Use new default branch name in links (#12943) ([a529e02](https://github.com/bitnami/charts/commit/a529e02597d49d944eba1eb0f190713293247176)), closes [#12943](https://github.com/bitnami/charts/issues/12943)
+* [bitnami/kiam] Release 1.1.5 updating components versions ([16864e6](https://github.com/bitnami/charts/commit/16864e6d84b6be5cfa7ce73cb3fb982acd00e544))
 
 ## <small>1.1.4 (2022-10-08)</small>
 
-* [bitnami/kiam] Release 1.1.4 updating components versions ([bec2b10](https://github.com/bitnami/charts/commit/bec2b10))
-* Generic README instructions related to the repo (#12792) ([3cf6b10](https://github.com/bitnami/charts/commit/3cf6b10)), closes [#12792](https://github.com/bitnami/charts/issues/12792)
+* [bitnami/kiam] Release 1.1.4 updating components versions ([bec2b10](https://github.com/bitnami/charts/commit/bec2b10e3baff337177ba241079f0eb07c8e27d0))
+* Generic README instructions related to the repo (#12792) ([3cf6b10](https://github.com/bitnami/charts/commit/3cf6b10e10e60df4b3e191d6b99aa99a9f597755)), closes [#12792](https://github.com/bitnami/charts/issues/12792)
 
 ## <small>1.1.3 (2022-09-20)</small>
 
-* [bitnami/kiam] Use custom probes if given (#12512) ([53f68b5](https://github.com/bitnami/charts/commit/53f68b5)), closes [#12512](https://github.com/bitnami/charts/issues/12512) [#12354](https://github.com/bitnami/charts/issues/12354)
+* [bitnami/kiam] Use custom probes if given (#12512) ([53f68b5](https://github.com/bitnami/charts/commit/53f68b5b2391378c848ce4db3caca87f689a992b)), closes [#12512](https://github.com/bitnami/charts/issues/12512) [#12354](https://github.com/bitnami/charts/issues/12354)
 
 ## <small>1.1.2 (2022-09-08)</small>
 
-* [bitnami/kiam] Release 1.1.2 updating components versions ([81d0d39](https://github.com/bitnami/charts/commit/81d0d39))
+* [bitnami/kiam] Release 1.1.2 updating components versions ([81d0d39](https://github.com/bitnami/charts/commit/81d0d3901ca4afd297fcbdfedcbc9b4909363092))
 
 ## <small>1.1.1 (2022-08-23)</small>
 
-* [bitnami/kiam] Update Chart.lock (#12055) ([6829141](https://github.com/bitnami/charts/commit/6829141)), closes [#12055](https://github.com/bitnami/charts/issues/12055)
+* [bitnami/kiam] Update Chart.lock (#12055) ([6829141](https://github.com/bitnami/charts/commit/6829141e784bcbb6617f9148c11a8a746cb8e90d)), closes [#12055](https://github.com/bitnami/charts/issues/12055)
 
 ## 1.1.0 (2022-08-22)
 
-* [bitnami/kiam] Add support for image digest apart from tag (#11906) ([2c8fd9d](https://github.com/bitnami/charts/commit/2c8fd9d)), closes [#11906](https://github.com/bitnami/charts/issues/11906)
+* [bitnami/kiam] Add support for image digest apart from tag (#11906) ([2c8fd9d](https://github.com/bitnami/charts/commit/2c8fd9d1fa9be5731f9cd47876d7f0fc67346638)), closes [#11906](https://github.com/bitnami/charts/issues/11906)
 
 ## <small>1.0.18 (2022-08-09)</small>
 
-* [bitnami/kiam] Release 1.0.18 updating components versions ([d089250](https://github.com/bitnami/charts/commit/d089250))
+* [bitnami/kiam] Release 1.0.18 updating components versions ([d089250](https://github.com/bitnami/charts/commit/d0892508e8b31470e766eb68f0b414ce5c730c6d))
 
 ## <small>1.0.17 (2022-08-04)</small>
 
-* [bitnami/kiam] Release 1.0.17 updating components versions ([3d9004f](https://github.com/bitnami/charts/commit/3d9004f))
+* [bitnami/kiam] Release 1.0.17 updating components versions ([3d9004f](https://github.com/bitnami/charts/commit/3d9004fc6463184e09c8850184835725ebcdc9d4))
 
 ## <small>1.0.16 (2022-08-02)</small>
 
-* [bitnami/kiam] Release 1.0.16 updating components versions ([d20853e](https://github.com/bitnami/charts/commit/d20853e))
+* [bitnami/kiam] Release 1.0.16 updating components versions ([d20853e](https://github.com/bitnami/charts/commit/d20853e1244abd2e52ec810740ab1a4ef091fc44))
 
 ## <small>1.0.15 (2022-07-30)</small>
 
-* [bitnami/*] Update URLs to point to the new bitnami/containers monorepo (#11352) ([d665af0](https://github.com/bitnami/charts/commit/d665af0)), closes [#11352](https://github.com/bitnami/charts/issues/11352)
-* [bitnami/kiam] Release 1.0.15 updating components versions ([24b0726](https://github.com/bitnami/charts/commit/24b0726))
+* [bitnami/*] Update URLs to point to the new bitnami/containers monorepo (#11352) ([d665af0](https://github.com/bitnami/charts/commit/d665af0c708846192d8d5fb2f5f9ea65dd464ab0)), closes [#11352](https://github.com/bitnami/charts/issues/11352)
+* [bitnami/kiam] Release 1.0.15 updating components versions ([24b0726](https://github.com/bitnami/charts/commit/24b07264b6cf877ea3bc8755d3c39330e29aafbd))
 
 ## <small>1.0.14 (2022-06-30)</small>
 
-* [bitnami/kiam] Release 1.0.14 updating components versions ([84e14eb](https://github.com/bitnami/charts/commit/84e14eb))
+* [bitnami/kiam] Release 1.0.14 updating components versions ([84e14eb](https://github.com/bitnami/charts/commit/84e14ebd785e07d50bb1e1d16272839339e3de55))
 
 ## <small>1.0.13 (2022-06-10)</small>
 
-* [bitnami/*] Replace Kubeapps URL in READMEs (and kubeapps Chart.yaml) and remove BKPR references (#1 ([c6a7914](https://github.com/bitnami/charts/commit/c6a7914)), closes [#10600](https://github.com/bitnami/charts/issues/10600)
-* [bitnami/kiam] Release 1.0.13 updating components versions ([25a15df](https://github.com/bitnami/charts/commit/25a15df))
+* [bitnami/*] Replace Kubeapps URL in READMEs (and kubeapps Chart.yaml) and remove BKPR references (#1 ([c6a7914](https://github.com/bitnami/charts/commit/c6a7914361e5aea6016fb45bf4d621edfd111d32)), closes [#10600](https://github.com/bitnami/charts/issues/10600)
+* [bitnami/kiam] Release 1.0.13 updating components versions ([25a15df](https://github.com/bitnami/charts/commit/25a15df6fe81c1babd9382d55e928842b0807213))
 
 ## <small>1.0.12 (2022-06-06)</small>
 
-* [bitnami/kiam] Release 1.0.12 updating components versions ([e870226](https://github.com/bitnami/charts/commit/e870226))
+* [bitnami/kiam] Release 1.0.12 updating components versions ([e870226](https://github.com/bitnami/charts/commit/e870226874800a0e71d5f59fdbced872a341522f))
 
 ## <small>1.0.11 (2022-06-01)</small>
 
-* [bitnami/several] Replace maintainers email by url (#10523) ([ff3cf61](https://github.com/bitnami/charts/commit/ff3cf61)), closes [#10523](https://github.com/bitnami/charts/issues/10523)
+* [bitnami/several] Replace maintainers email by url (#10523) ([ff3cf61](https://github.com/bitnami/charts/commit/ff3cf617a1680509b0f3855d17c4ccff7b29a0ff)), closes [#10523](https://github.com/bitnami/charts/issues/10523)
 
 ## <small>1.0.10 (2022-05-26)</small>
 
-* [bitnami/kiam] Add missing service parameter (#10419) ([4017ca6](https://github.com/bitnami/charts/commit/4017ca6)), closes [#10419](https://github.com/bitnami/charts/issues/10419)
+* [bitnami/kiam] Add missing service parameter (#10419) ([4017ca6](https://github.com/bitnami/charts/commit/4017ca6cdd0ead17255e6d0fc1dd089742bbb6d4)), closes [#10419](https://github.com/bitnami/charts/issues/10419)
 
 ## <small>1.0.9 (2022-05-21)</small>
 
-* [bitnami/kiam] Release 1.0.9 updating components versions ([18fd680](https://github.com/bitnami/charts/commit/18fd680))
+* [bitnami/kiam] Release 1.0.9 updating components versions ([18fd680](https://github.com/bitnami/charts/commit/18fd6800382f13496921969d14ca4126bd4eeb7c))
 
 ## <small>1.0.8 (2022-05-20)</small>
 
-* [bitnami/kiam] Release 1.0.8 updating components versions ([a053dc9](https://github.com/bitnami/charts/commit/a053dc9))
+* [bitnami/kiam] Release 1.0.8 updating components versions ([a053dc9](https://github.com/bitnami/charts/commit/a053dc91480db76dc6fdfe329a915ad19fe71fe7))
 
 ## <small>1.0.7 (2022-05-19)</small>
 
-* [bitnami/kiam] Release 1.0.7 updating components versions ([d198953](https://github.com/bitnami/charts/commit/d198953))
+* [bitnami/kiam] Release 1.0.7 updating components versions ([d198953](https://github.com/bitnami/charts/commit/d19895306b5d16649b273c39faa6b6fbdc3189ff))
 
 ## <small>1.0.6 (2022-05-18)</small>
 
-* [bitnami/kiam] Release 1.0.6 updating components versions ([c1b113e](https://github.com/bitnami/charts/commit/c1b113e))
+* [bitnami/kiam] Release 1.0.6 updating components versions ([c1b113e](https://github.com/bitnami/charts/commit/c1b113ee3faf740c5bb5ba1eaadab5611bc17c9c))
 
 ## <small>1.0.5 (2022-05-11)</small>
 
-* [bitnami/kiam] Add missing namespace metadata (#10130) ([8b1ff8b](https://github.com/bitnami/charts/commit/8b1ff8b)), closes [#10130](https://github.com/bitnami/charts/issues/10130)
+* [bitnami/kiam] Add missing namespace metadata (#10130) ([8b1ff8b](https://github.com/bitnami/charts/commit/8b1ff8b9ff14011dcd98edca6d264a74e4b6b378)), closes [#10130](https://github.com/bitnami/charts/issues/10130)
 
 ## <small>1.0.4 (2022-04-19)</small>
 
-* [bitnami/kiam] Release 1.0.4 updating components versions ([cfd4206](https://github.com/bitnami/charts/commit/cfd4206))
-* Update README.md ([5878c9e](https://github.com/bitnami/charts/commit/5878c9e))
+* [bitnami/kiam] Release 1.0.4 updating components versions ([cfd4206](https://github.com/bitnami/charts/commit/cfd420682cce92502f3c7e89f8131a5ff4d1209d))
+* Update README.md ([5878c9e](https://github.com/bitnami/charts/commit/5878c9ecfaf51a7f5e03e7797e6b7e00b051bf5d))
 
 ## <small>1.0.3 (2022-04-02)</small>
 
-* [bitnami/kiam] Release 1.0.3 updating components versions ([f819e31](https://github.com/bitnami/charts/commit/f819e31))
+* [bitnami/kiam] Release 1.0.3 updating components versions ([f819e31](https://github.com/bitnami/charts/commit/f819e31b0e5f3d0fb2d36ae6aa8b67a3cdf08314))
 
 ## <small>1.0.2 (2022-03-27)</small>
 
-* [bitnami/kiam] Release 1.0.2 updating components versions ([3540db7](https://github.com/bitnami/charts/commit/3540db7))
+* [bitnami/kiam] Release 1.0.2 updating components versions ([3540db7](https://github.com/bitnami/charts/commit/3540db75609db05f0fe6944ba86f3a63417080df))
 
 ## <small>1.0.1 (2022-03-16)</small>
 
-* [bitnami/kiam] Release 1.0.1 updating components versions ([e2738ba](https://github.com/bitnami/charts/commit/e2738ba))
+* [bitnami/kiam] Release 1.0.1 updating components versions ([e2738ba](https://github.com/bitnami/charts/commit/e2738ba257e4efe023342b5d7ac7248e44b2ec81))
 
 ## 1.0.0 (2022-03-02)
 
-* [bitnami/kiam] MAJOR - Update Kiam to v4 + agent root permissions (#9058) ([b4029a8](https://github.com/bitnami/charts/commit/b4029a8)), closes [#9058](https://github.com/bitnami/charts/issues/9058)
+* [bitnami/kiam] MAJOR - Update Kiam to v4 + agent root permissions (#9058) ([b4029a8](https://github.com/bitnami/charts/commit/b4029a835d77eeee69d6712b504da39520674670)), closes [#9058](https://github.com/bitnami/charts/issues/9058)
 
 ## <small>0.4.5 (2022-02-27)</small>
 
-* [bitnami/kiam] Release 0.4.5 updating components versions ([8815c81](https://github.com/bitnami/charts/commit/8815c81))
+* [bitnami/kiam] Release 0.4.5 updating components versions ([8815c81](https://github.com/bitnami/charts/commit/8815c817fe05b964a3e1cd9cd4a9915425aaa347))
 
 ## <small>0.4.4 (2022-02-22)</small>
 
-* [bitnami/kiam] Release 0.4.4 updating components versions ([819d214](https://github.com/bitnami/charts/commit/819d214))
+* [bitnami/kiam] Release 0.4.4 updating components versions ([819d214](https://github.com/bitnami/charts/commit/819d21434dcfa0be47b1b98a68614a8b03e62e32))
 
 ## <small>0.4.3 (2022-02-10)</small>
 
-* [bitnami/kiam] Release 0.4.3 updating components versions ([6f0bee9](https://github.com/bitnami/charts/commit/6f0bee9))
-* Non utf8 chars (#8923) ([6ffd18f](https://github.com/bitnami/charts/commit/6ffd18f)), closes [#8923](https://github.com/bitnami/charts/issues/8923)
+* [bitnami/kiam] Release 0.4.3 updating components versions ([6f0bee9](https://github.com/bitnami/charts/commit/6f0bee9f5f19f0f5e5eb4709bd17a65eed27e098))
+* Non utf8 chars (#8923) ([6ffd18f](https://github.com/bitnami/charts/commit/6ffd18fbbdf10e94ea1a90cf5b84ef610ac2a72d)), closes [#8923](https://github.com/bitnami/charts/issues/8923)
 
 ## <small>0.4.2 (2022-01-20)</small>
 
-* [bitnami/*] Readme automation (#8579) ([78d1938](https://github.com/bitnami/charts/commit/78d1938)), closes [#8579](https://github.com/bitnami/charts/issues/8579)
-* [bitnami/*] Update READMEs (#8716) ([b9a9533](https://github.com/bitnami/charts/commit/b9a9533)), closes [#8716](https://github.com/bitnami/charts/issues/8716)
-* [bitnami/several] Change prerequisites (#8725) ([8d740c5](https://github.com/bitnami/charts/commit/8d740c5)), closes [#8725](https://github.com/bitnami/charts/issues/8725)
+* [bitnami/*] Readme automation (#8579) ([78d1938](https://github.com/bitnami/charts/commit/78d193831c900d178198491ffd08fa2217a64ecd)), closes [#8579](https://github.com/bitnami/charts/issues/8579)
+* [bitnami/*] Update READMEs (#8716) ([b9a9533](https://github.com/bitnami/charts/commit/b9a953337590eb2979453385874a267bacf50936)), closes [#8716](https://github.com/bitnami/charts/issues/8716)
+* [bitnami/several] Change prerequisites (#8725) ([8d740c5](https://github.com/bitnami/charts/commit/8d740c566cfdb7e2d933c40128b4e919fce953a5)), closes [#8725](https://github.com/bitnami/charts/issues/8725)
 
 ## <small>0.4.1 (2022-01-11)</small>
 
-* [bitnami/kiam] Release 0.4.1 updating components versions ([bf07fc7](https://github.com/bitnami/charts/commit/bf07fc7))
+* [bitnami/kiam] Release 0.4.1 updating components versions ([bf07fc7](https://github.com/bitnami/charts/commit/bf07fc77d257fa2e41e625c4b36d6687668c6e40))
 
 ## 0.4.0 (2022-01-05)
 
-* [bitnami/several] Adapt templating format (#8562) ([8cad18a](https://github.com/bitnami/charts/commit/8cad18a)), closes [#8562](https://github.com/bitnami/charts/issues/8562)
-* [bitnami/several] Add license to the README ([05f7633](https://github.com/bitnami/charts/commit/05f7633))
-* [bitnami/several] Add license to the README ([32fb238](https://github.com/bitnami/charts/commit/32fb238))
-* [bitnami/several] Add license to the README ([b87c2f7](https://github.com/bitnami/charts/commit/b87c2f7))
+* [bitnami/several] Adapt templating format (#8562) ([8cad18a](https://github.com/bitnami/charts/commit/8cad18aed9966a6f0208e5ad6cee46cb217f47ab)), closes [#8562](https://github.com/bitnami/charts/issues/8562)
+* [bitnami/several] Add license to the README ([05f7633](https://github.com/bitnami/charts/commit/05f763372501d596e57db713dd53ff4ff3027cc4))
+* [bitnami/several] Add license to the README ([32fb238](https://github.com/bitnami/charts/commit/32fb238e60a0affc6debd3142eaa3c3d9089ec2a))
+* [bitnami/several] Add license to the README ([b87c2f7](https://github.com/bitnami/charts/commit/b87c2f7899d48a8b02c506765e6ae82937e9ba3f))
 
 ## <small>0.3.24 (2021-12-17)</small>
 
-* [bitnami/kiam] Release 0.3.24 updating components versions ([e2a410a](https://github.com/bitnami/charts/commit/e2a410a))
+* [bitnami/kiam] Release 0.3.24 updating components versions ([e2a410a](https://github.com/bitnami/charts/commit/e2a410a16967ff216311b8b1c2c6e0cc1fb630ff))
 
 ## <small>0.3.23 (2021-12-16)</small>
 
-* [bitnami/kiam] Release 0.3.23 updating components versions ([bec76e4](https://github.com/bitnami/charts/commit/bec76e4))
+* [bitnami/kiam] Release 0.3.23 updating components versions ([bec76e4](https://github.com/bitnami/charts/commit/bec76e4bbc888790b2a775dbed13fbd8264461d3))
 
 ## <small>0.3.22 (2021-12-02)</small>
 
-* [bitnami/*] Fix parameters for schema generation (#8297) ([d7d52ac](https://github.com/bitnami/charts/commit/d7d52ac)), closes [#8297](https://github.com/bitnami/charts/issues/8297)
+* [bitnami/*] Fix parameters for schema generation (#8297) ([d7d52ac](https://github.com/bitnami/charts/commit/d7d52acdbd1b0629e4e5295652fa6f5830daf2af)), closes [#8297](https://github.com/bitnami/charts/issues/8297)
 
 ## <small>0.3.21 (2021-11-29)</small>
 
-* [bitnami/several] Regenerate README tables ([ac75243](https://github.com/bitnami/charts/commit/ac75243))
-* [bitnami/several] Replace HTTP by HTTPS when possible (#8259) ([eafb5bd](https://github.com/bitnami/charts/commit/eafb5bd)), closes [#8259](https://github.com/bitnami/charts/issues/8259)
+* [bitnami/several] Regenerate README tables ([ac75243](https://github.com/bitnami/charts/commit/ac752431b90e935d0a4dbfef70dc44f24f3d3dd2))
+* [bitnami/several] Replace HTTP by HTTPS when possible (#8259) ([eafb5bd](https://github.com/bitnami/charts/commit/eafb5bd5a2cc3aaf04fc1e8ebedd73f420d76864)), closes [#8259](https://github.com/bitnami/charts/issues/8259)
 
 ## <small>0.3.20 (2021-11-25)</small>
 
-* [bitnami/kiam] Release 0.3.20 updating components versions ([5a8676e](https://github.com/bitnami/charts/commit/5a8676e))
+* [bitnami/kiam] Release 0.3.20 updating components versions ([5a8676e](https://github.com/bitnami/charts/commit/5a8676e8e3584340ce56ab89b4b68b1e82e51cfa))
 
 ## <small>0.3.19 (2021-10-27)</small>
 
-* [bitnami/*] Mark PodSecurityPolicy resources as deprecated (#7948) ([5cac753](https://github.com/bitnami/charts/commit/5cac753)), closes [#7948](https://github.com/bitnami/charts/issues/7948)
-* [bitnami/several] Regenerate README tables ([412cf6a](https://github.com/bitnami/charts/commit/412cf6a))
+* [bitnami/*] Mark PodSecurityPolicy resources as deprecated (#7948) ([5cac753](https://github.com/bitnami/charts/commit/5cac7539dcb6c3baef06ed6676bfa99c16fdb5fe)), closes [#7948](https://github.com/bitnami/charts/issues/7948)
+* [bitnami/several] Regenerate README tables ([412cf6a](https://github.com/bitnami/charts/commit/412cf6a513cb0c03444a6e7811c6f27193239a10))
 
 ## <small>0.3.18 (2021-10-26)</small>
 
-* [bitnami/kiam] Release 0.3.18 updating components versions ([c4e2b0c](https://github.com/bitnami/charts/commit/c4e2b0c))
-* [bitnami/several] Regenerate README tables ([c82619f](https://github.com/bitnami/charts/commit/c82619f))
+* [bitnami/kiam] Release 0.3.18 updating components versions ([c4e2b0c](https://github.com/bitnami/charts/commit/c4e2b0c660e365dce31d575478704cbd365afb44))
+* [bitnami/several] Regenerate README tables ([c82619f](https://github.com/bitnami/charts/commit/c82619f4141cd18e1b6079fdd84eb5b7bb47d819))
 
 ## <small>0.3.17 (2021-10-24)</small>
 
-* [bitnami/kiam] Release 0.3.17 updating components versions ([ff49629](https://github.com/bitnami/charts/commit/ff49629))
+* [bitnami/kiam] Release 0.3.17 updating components versions ([ff49629](https://github.com/bitnami/charts/commit/ff4962931cd00dac273e59cb5789bbdecaa69c54))
 
 ## <small>0.3.16 (2021-10-22)</small>
 
-* [bitnami/several] Add chart info to NOTES.txt (#7889) ([a6751cd](https://github.com/bitnami/charts/commit/a6751cd)), closes [#7889](https://github.com/bitnami/charts/issues/7889)
+* [bitnami/several] Add chart info to NOTES.txt (#7889) ([a6751cd](https://github.com/bitnami/charts/commit/a6751cdd33c461fabbc459fbea6f219ec64ab6b2)), closes [#7889](https://github.com/bitnami/charts/issues/7889)
 
 ## <small>0.3.15 (2021-10-07)</small>
 
-* [bitnami/*] Fix service monitors selectors (#7720) ([1279593](https://github.com/bitnami/charts/commit/1279593)), closes [#7720](https://github.com/bitnami/charts/issues/7720)
-* [bitnami/*] Generate READMEs with new generator version (#7614) ([e5ab2e6](https://github.com/bitnami/charts/commit/e5ab2e6)), closes [#7614](https://github.com/bitnami/charts/issues/7614)
+* [bitnami/*] Fix service monitors selectors (#7720) ([1279593](https://github.com/bitnami/charts/commit/1279593765044df99902bfee8dcfaeb60e95f125)), closes [#7720](https://github.com/bitnami/charts/issues/7720)
+* [bitnami/*] Generate READMEs with new generator version (#7614) ([e5ab2e6](https://github.com/bitnami/charts/commit/e5ab2e6ecdd6bce800863f154cda524ff9f6c117)), closes [#7614](https://github.com/bitnami/charts/issues/7614)
 
 ## <small>0.3.14 (2021-09-24)</small>
 
-* [bitnami/kiam] Release 0.3.14 updating components versions ([ec25397](https://github.com/bitnami/charts/commit/ec25397))
-* [bitnami/several] Regenerate README tables ([da2513b](https://github.com/bitnami/charts/commit/da2513b))
+* [bitnami/kiam] Release 0.3.14 updating components versions ([ec25397](https://github.com/bitnami/charts/commit/ec25397107eec7520d58b876fbee113344b41dfc))
+* [bitnami/several] Regenerate README tables ([da2513b](https://github.com/bitnami/charts/commit/da2513bf0a33819f3b1151d387c631a9ffdb03e2))
 
 ## <small>0.3.13 (2021-08-25)</small>
 
-* [bitnami/kiam] Release 0.3.13 updating components versions ([65dfeb5](https://github.com/bitnami/charts/commit/65dfeb5))
-* [bitnami/several] Regenerate README tables ([6c107e8](https://github.com/bitnami/charts/commit/6c107e8))
+* [bitnami/kiam] Release 0.3.13 updating components versions ([65dfeb5](https://github.com/bitnami/charts/commit/65dfeb5b1091117ad681de58e9dbb7f9b549ae48))
+* [bitnami/several] Regenerate README tables ([6c107e8](https://github.com/bitnami/charts/commit/6c107e835d6caf8db2e8b17dcd48c5971637e013))
 
 ## <small>0.3.12 (2021-08-04)</small>
 
-* [bitnami/kiam] Release 0.3.12 updating components versions ([42efe42](https://github.com/bitnami/charts/commit/42efe42))
+* [bitnami/kiam] Release 0.3.12 updating components versions ([42efe42](https://github.com/bitnami/charts/commit/42efe4241513e9d013f1660431591cde443b2085))
 
 ## <small>0.3.11 (2021-07-27)</small>
 
-* [bitnami/several] Fix default values and regenerate README (#7024) ([4c86733](https://github.com/bitnami/charts/commit/4c86733)), closes [#7024](https://github.com/bitnami/charts/issues/7024)
+* [bitnami/several] Fix default values and regenerate README (#7024) ([4c86733](https://github.com/bitnami/charts/commit/4c867335c5c9c5aba041868df16ebb8f64ac68bd)), closes [#7024](https://github.com/bitnami/charts/issues/7024)
 
 ## <small>0.3.10 (2021-07-18)</small>
 
-* [bitnami/kiam] Release 0.3.10 updating components versions ([2a70031](https://github.com/bitnami/charts/commit/2a70031))
+* [bitnami/kiam] Release 0.3.10 updating components versions ([2a70031](https://github.com/bitnami/charts/commit/2a7003154f50945ef4f5bafcb331473881ca88b3))
 
 ## <small>0.3.9 (2021-07-12)</small>
 
-* [bitnami/kiam] Updated README (#6893) ([dd59157](https://github.com/bitnami/charts/commit/dd59157)), closes [#6893](https://github.com/bitnami/charts/issues/6893)
+* [bitnami/kiam] Updated README (#6893) ([dd59157](https://github.com/bitnami/charts/commit/dd591577983795227746728c87a8147df3c0c2f7)), closes [#6893](https://github.com/bitnami/charts/issues/6893)
 
 ## <small>0.3.8 (2021-07-08)</small>
 
-* [bitnami/*] Adapt values.yaml of Keykloak, Kiam and Kibana charts (#6858) ([1c52336](https://github.com/bitnami/charts/commit/1c52336)), closes [#6858](https://github.com/bitnami/charts/issues/6858)
+* [bitnami/*] Adapt values.yaml of Keykloak, Kiam and Kibana charts (#6858) ([1c52336](https://github.com/bitnami/charts/commit/1c523366e09a2e62b34aab0a4962e4d5d5bb0199)), closes [#6858](https://github.com/bitnami/charts/issues/6858)
 
 ## <small>0.3.7 (2021-06-18)</small>
 
-* [bitnami/kiam] Release 0.3.7 updating components versions ([947dd5f](https://github.com/bitnami/charts/commit/947dd5f))
+* [bitnami/kiam] Release 0.3.7 updating components versions ([947dd5f](https://github.com/bitnami/charts/commit/947dd5ffaa649578e290b7298e061f42859c9425))
 
 ## <small>0.3.6 (2021-05-19)</small>
 
-* [bitnami/kiam] Release 0.3.6 updating components versions ([8fc5b89](https://github.com/bitnami/charts/commit/8fc5b89))
+* [bitnami/kiam] Release 0.3.6 updating components versions ([8fc5b89](https://github.com/bitnami/charts/commit/8fc5b89aea63a00d5e354e6788241815477751d7))
 
 ## <small>0.3.5 (2021-04-30)</small>
 
-* Fix typos in several README files (#6252) ([fd16565](https://github.com/bitnami/charts/commit/fd16565)), closes [#6252](https://github.com/bitnami/charts/issues/6252)
+* Fix typos in several README files (#6252) ([fd16565](https://github.com/bitnami/charts/commit/fd1656587a007ac9b8e9d895f6b99607fb225f7c)), closes [#6252](https://github.com/bitnami/charts/issues/6252)
 
 ## <small>0.3.4 (2021-04-19)</small>
 
-* [bitnami/kiam] Release 0.3.4 updating components versions ([09febb6](https://github.com/bitnami/charts/commit/09febb6))
+* [bitnami/kiam] Release 0.3.4 updating components versions ([09febb6](https://github.com/bitnami/charts/commit/09febb6d56c960a83cb1b00d796b02ef964fed91))
 
 ## <small>0.3.3 (2021-03-20)</small>
 
-* [bitnami/kiam] Release 0.3.3 updating components versions ([63a72f9](https://github.com/bitnami/charts/commit/63a72f9))
+* [bitnami/kiam] Release 0.3.3 updating components versions ([63a72f9](https://github.com/bitnami/charts/commit/63a72f9b14354fda5aa967464ae7d5e384323132))
 
 ## <small>0.3.2 (2021-02-22)</small>
 
-* [bitnami/*] Use common macro to define RBAC apiVersion (#5585) ([71fb99f](https://github.com/bitnami/charts/commit/71fb99f)), closes [#5585](https://github.com/bitnami/charts/issues/5585)
+* [bitnami/*] Use common macro to define RBAC apiVersion (#5585) ([71fb99f](https://github.com/bitnami/charts/commit/71fb99f541e971b1daafaa20ffb7d18b153b8d60)), closes [#5585](https://github.com/bitnami/charts/issues/5585)
 
 ## <small>0.3.1 (2021-02-18)</small>
 
-* [bitnami/kiam] Release 0.3.1 updating components versions ([e404d31](https://github.com/bitnami/charts/commit/e404d31))
+* [bitnami/kiam] Release 0.3.1 updating components versions ([e404d31](https://github.com/bitnami/charts/commit/e404d31ee800fb85432e93d6c6ff00806b31746a))
 
 ## 0.3.0 (2021-01-27)
 
-* [bitnami/kiam] Add hostAliases (#5250) ([ef0ea05](https://github.com/bitnami/charts/commit/ef0ea05)), closes [#5250](https://github.com/bitnami/charts/issues/5250)
+* [bitnami/kiam] Add hostAliases (#5250) ([ef0ea05](https://github.com/bitnami/charts/commit/ef0ea0507b2cd831bd9c11eb27e66312f27e7f88)), closes [#5250](https://github.com/bitnami/charts/issues/5250)
 
 ## <small>0.2.4 (2021-01-25)</small>
 
-* [bitnami/*] Unify icons in Chart.yaml and add missing fields (#5206) ([0462921](https://github.com/bitnami/charts/commit/0462921)), closes [#5206](https://github.com/bitnami/charts/issues/5206)
+* [bitnami/*] Unify icons in Chart.yaml and add missing fields (#5206) ([0462921](https://github.com/bitnami/charts/commit/0462921418ca8d54308b7466197a6d53ffae4628)), closes [#5206](https://github.com/bitnami/charts/issues/5206)
 
 ## <small>0.2.3 (2021-01-19)</small>
 
-* [bitnami/*] Change helm version in the prerequisites (#5090) ([c5e67a3](https://github.com/bitnami/charts/commit/c5e67a3)), closes [#5090](https://github.com/bitnami/charts/issues/5090)
-* [bitnami/kiam] Release 0.2.3 updating components versions ([152afd9](https://github.com/bitnami/charts/commit/152afd9))
+* [bitnami/*] Change helm version in the prerequisites (#5090) ([c5e67a3](https://github.com/bitnami/charts/commit/c5e67a388743cbee28439d2cabca27884b9daf97)), closes [#5090](https://github.com/bitnami/charts/issues/5090)
+* [bitnami/kiam] Release 0.2.3 updating components versions ([152afd9](https://github.com/bitnami/charts/commit/152afd99edf61b03f7ed6ab4ab1e79207c34ceb3))
 
 ## <small>0.2.2 (2021-01-17)</small>
 
-* [bitnami/kiam] Release 0.2.2 updating components versions ([a10fecc](https://github.com/bitnami/charts/commit/a10fecc))
+* [bitnami/kiam] Release 0.2.2 updating components versions ([a10fecc](https://github.com/bitnami/charts/commit/a10fecce6b4fa0960a8b3f742d2cc5323e436d4c))
 
 ## <small>0.2.1 (2021-01-12)</small>
 
-* [bitnami/kiam] Improve note for the chart requirements in AWS (#4913) ([932a515](https://github.com/bitnami/charts/commit/932a515)), closes [#4913](https://github.com/bitnami/charts/issues/4913)
-* [bitnami/several] Prettify Chart.yaml following bitnami standards (#4954) ([cd897df](https://github.com/bitnami/charts/commit/cd897df)), closes [#4954](https://github.com/bitnami/charts/issues/4954)
+* [bitnami/kiam] Improve note for the chart requirements in AWS (#4913) ([932a515](https://github.com/bitnami/charts/commit/932a5153804b9c84e6d5c94d444a211d8eb08135)), closes [#4913](https://github.com/bitnami/charts/issues/4913)
+* [bitnami/several] Prettify Chart.yaml following bitnami standards (#4954) ([cd897df](https://github.com/bitnami/charts/commit/cd897dfb0697e2c81329435b38eaf5ae52e1dc09)), closes [#4954](https://github.com/bitnami/charts/issues/4954)
 
 ## 0.2.0 (2020-12-18)
 
-* [bitnami/kiam] Resolves problems with the kiam chart. (#4780) ([aac5443](https://github.com/bitnami/charts/commit/aac5443)), closes [#4780](https://github.com/bitnami/charts/issues/4780)
+* [bitnami/kiam] Resolves problems with the kiam chart. (#4780) ([aac5443](https://github.com/bitnami/charts/commit/aac54433b8ab8b80d46abf6eca98fed76eeed2a1)), closes [#4780](https://github.com/bitnami/charts/issues/4780)
 
 ## <small>0.1.9 (2020-12-17)</small>
 
-* [bitnami/kiam] Release 0.1.9 updating components versions ([9b003fd](https://github.com/bitnami/charts/commit/9b003fd))
+* [bitnami/kiam] Release 0.1.9 updating components versions ([9b003fd](https://github.com/bitnami/charts/commit/9b003fd3383058311db20136e276cc1a6855fcef))
 
 ## <small>0.1.8 (2020-12-16)</small>
 
-* [bitnami/*] fix typos (#4699) ([49adc63](https://github.com/bitnami/charts/commit/49adc63)), closes [#4699](https://github.com/bitnami/charts/issues/4699)
-* [bitnami/kiam] Release 0.1.8 updating components versions ([4345f45](https://github.com/bitnami/charts/commit/4345f45))
+* [bitnami/*] fix typos (#4699) ([49adc63](https://github.com/bitnami/charts/commit/49adc63b672da976c55af2e077aa5648a357b77f)), closes [#4699](https://github.com/bitnami/charts/issues/4699)
+* [bitnami/kiam] Release 0.1.8 updating components versions ([4345f45](https://github.com/bitnami/charts/commit/4345f450e4ecfa4afa40abff46d870ccf0bc2e4e))
 
 ## <small>0.1.7 (2020-12-11)</small>
 
-* [bitnami/*] Update dependencies (#4694) ([2826c12](https://github.com/bitnami/charts/commit/2826c12)), closes [#4694](https://github.com/bitnami/charts/issues/4694)
+* [bitnami/*] Update dependencies (#4694) ([2826c12](https://github.com/bitnami/charts/commit/2826c125b42505f28431301e3c1bbe5366e47a01)), closes [#4694](https://github.com/bitnami/charts/issues/4694)
 
 ## <small>0.1.5 (2020-11-16)</small>
 
-* [bitnami/kiam] Release 0.1.5 updating components versions ([826b40f](https://github.com/bitnami/charts/commit/826b40f))
+* [bitnami/kiam] Release 0.1.5 updating components versions ([826b40f](https://github.com/bitnami/charts/commit/826b40f0bef522d63cbc5ed3014ec7c843f89f4a))
 
 ## <small>0.1.4 (2020-11-16)</small>
 
-* [bitnami/kiam] Fix KIAM package (#4372) ([40cf9b6](https://github.com/bitnami/charts/commit/40cf9b6)), closes [#4372](https://github.com/bitnami/charts/issues/4372)
+* [bitnami/kiam] Fix KIAM package (#4372) ([40cf9b6](https://github.com/bitnami/charts/commit/40cf9b6cc4fc0c30e5219add9486f56e14580e2b)), closes [#4372](https://github.com/bitnami/charts/issues/4372)
 
 ## <small>0.1.3 (2020-11-14)</small>
 
-* [bitnami/kiam] Release 0.1.3 updating components versions ([43fb598](https://github.com/bitnami/charts/commit/43fb598))
-* Bump kiam origin ([7892e62](https://github.com/bitnami/charts/commit/7892e62))
+* [bitnami/kiam] Release 0.1.3 updating components versions ([43fb598](https://github.com/bitnami/charts/commit/43fb5980e35789ae243e5a58c5b8006cf62bc686))
+* Bump kiam origin ([7892e62](https://github.com/bitnami/charts/commit/7892e6290cdbb97514d3b0e15ec6c6e616f80326))
 
 ## <small>0.1.2 (2020-11-13)</small>
 
-* [bitnami/kiam] Release 0.1.2 updating components versions ([eb27a7a](https://github.com/bitnami/charts/commit/eb27a7a))
+* [bitnami/kiam] Release 0.1.2 updating components versions ([eb27a7a](https://github.com/bitnami/charts/commit/eb27a7aa61b1b790d1fce56ad86b013a0b984374))
 
 ## <small>0.1.1 (2020-11-12)</small>
 
-* [bitnami/kiam] Use latest common version and update prerequisites (#4349) ([d574e1f](https://github.com/bitnami/charts/commit/d574e1f)), closes [#4349](https://github.com/bitnami/charts/issues/4349)
+* [bitnami/kiam] Use latest common version and update prerequisites (#4349) ([d574e1f](https://github.com/bitnami/charts/commit/d574e1f6d724cbb4d053518dd1b81e6a7c95cf3d)), closes [#4349](https://github.com/bitnami/charts/issues/4349)
 
 ## 0.1.0 (2020-11-12)
 
-* [bitnami/kiam] Add kiam helm chart (#4313) ([2a66fcb](https://github.com/bitnami/charts/commit/2a66fcb)), closes [#4313](https://github.com/bitnami/charts/issues/4313)
+* [bitnami/kiam] Add kiam helm chart (#4313) ([2a66fcb](https://github.com/bitnami/charts/commit/2a66fcbe791014cb2c70bbdeb853665590db39c9)), closes [#4313](https://github.com/bitnami/charts/issues/4313)

--- a/bitnami/kiam/Chart.yaml
+++ b/bitnami/kiam/Chart.yaml
@@ -28,4 +28,4 @@ maintainers:
 name: kiam
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/kiam
-version: 2.1.0
+version: 2.1.1

--- a/bitnami/kiam/templates/agent/agent-daemonset.yaml
+++ b/bitnami/kiam/templates/agent/agent-daemonset.yaml
@@ -182,7 +182,7 @@ spec:
               {{- if .Values.agent.enableDeepProbe }}
               path: /health?deep=1
               {{- else }}
-              path: /ping
+              path: /health
               {{- end }}
               port: {{ .Values.agent.containerPort }}
             initialDelaySeconds: {{ .Values.agent.livenessProbe.initialDelaySeconds }}
@@ -196,11 +196,7 @@ spec:
           {{- else if .Values.agent.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
-              {{- if .Values.agent.enableDeepProbe }}
-              path: /health?deep=1
-              {{- else }}
               path: /ping
-              {{- end }}
               port: {{ .Values.agent.containerPort }}
             initialDelaySeconds: {{ .Values.agent.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.agent.readinessProbe.periodSeconds }}

--- a/bitnami/kiam/templates/server/server-daemonset.yaml
+++ b/bitnami/kiam/templates/server/server-daemonset.yaml
@@ -173,8 +173,8 @@ spec:
                 - --key=/bitnami/kiam/tls/{{ .Values.server.tlsCerts.keyFileName }}
                 - --ca=/bitnami/kiam/tls/{{ .Values.server.tlsCerts.caFileName }}
                 - --server-address=127.0.0.1:{{ .Values.server.containerPort }}
-                - --server-address-refresh=2s
-                - --timeout=5s
+                - --server-address-refresh=4s
+                - --timeout=10s
                 - --gateway-timeout-creation={{ .Values.server.gatewayTimeoutCreation }}
             initialDelaySeconds: {{ .Values.server.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.server.livenessProbe.periodSeconds }}

--- a/bitnami/kiam/templates/server/server-deployment.yaml
+++ b/bitnami/kiam/templates/server/server-deployment.yaml
@@ -174,8 +174,8 @@ spec:
                 - --key=/bitnami/kiam/tls/{{ .Values.server.tlsCerts.keyFileName }}
                 - --ca=/bitnami/kiam/tls/{{ .Values.server.tlsCerts.caFileName }}
                 - --server-address=127.0.0.1:{{ .Values.server.containerPort }}
-                - --server-address-refresh=2s
-                - --timeout=5s
+                - --server-address-refresh=4s
+                - --timeout=10s
                 - --gateway-timeout-creation={{ .Values.server.gatewayTimeoutCreation }}
             initialDelaySeconds: {{ .Values.server.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.server.livenessProbe.periodSeconds }}


### PR DESCRIPTION
### Description of the change
This PR aims to use different liveness/readiness probes to improve overall security and avoid unnecessary container restarts. [More info](https://github.com/zegl/kube-score/blob/master/README_PROBES.md).

### Benefits

Increase availability and resilience.

### Possible drawbacks

N/A

### Applicable issues

- fixes #

### Additional information

- Related to #23537

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- ~[X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)~
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
