### PR TITLE
[bitnami/redmine] Enable PodDisruptionBudgets

### DIFF
--- a/bitnami/redmine/CHANGELOG.md
+++ b/bitnami/redmine/CHANGELOG.md
@@ -1,955 +1,960 @@
 # Changelog
 
+## 28.2.0 (2024-05-23)
+
+* [bitnami/redmine] Enable PodDisruptionBudgets ([#26376](https://github.com/bitnami/charts/pull/26376))
+
 ## 28.1.0 (2024-05-21)
 
-* [bitnami/redmine] feat: :sparkles: :lock: Add warning when original images are replaced ([#26273](https://github.com/bitnami/charts/pulls/26273))
+* [bitnami/*] ci: :construction_worker: Add tag and changelog support (#25359) ([91c707c](https://github.com/bitnami/charts/commit/91c707c9e4e574725a09505d2d313fb93f1b4c0a)), closes [#25359](https://github.com/bitnami/charts/issues/25359)
+* [bitnami/redmine] feat: :sparkles: :lock: Add warning when original images are replaced (#26273) ([82df93d](https://github.com/bitnami/charts/commit/82df93d23c4b3781ab45fd78fabd542506f38284)), closes [#26273](https://github.com/bitnami/charts/issues/26273)
 
 ## <small>28.0.5 (2024-05-18)</small>
 
-* [bitnami/redmine] Release 28.0.5 updating components versions (#26074) ([8ced0fe](https://github.com/bitnami/charts/commit/8ced0fe)), closes [#26074](https://github.com/bitnami/charts/issues/26074)
+* [bitnami/redmine] Release 28.0.5 updating components versions (#26074) ([8ced0fe](https://github.com/bitnami/charts/commit/8ced0fe67d7a9432feb480bafccef90dca406dfd)), closes [#26074](https://github.com/bitnami/charts/issues/26074)
 
 ## <small>28.0.4 (2024-05-17)</small>
 
-* [bitnami/redmine] Use different liveness/readiness probes (#25955) ([bd49fad](https://github.com/bitnami/charts/commit/bd49fad)), closes [#25955](https://github.com/bitnami/charts/issues/25955)
+* [bitnami/redmine] Use different liveness/readiness probes (#25955) ([bd49fad](https://github.com/bitnami/charts/commit/bd49fad34dee0f596fdca8da935afe7577f22085)), closes [#25955](https://github.com/bitnami/charts/issues/25955)
 
 ## <small>28.0.3 (2024-05-14)</small>
 
-* [bitnami/*] Change non-root and rolling-tags doc URLs (#25628) ([b067c94](https://github.com/bitnami/charts/commit/b067c94)), closes [#25628](https://github.com/bitnami/charts/issues/25628)
-* [bitnami/*] Set new header/owner (#25558) ([8d1dc11](https://github.com/bitnami/charts/commit/8d1dc11)), closes [#25558](https://github.com/bitnami/charts/issues/25558)
-* [bitnami/multiple charts] Fix typo: "NetworkPolice" vs "NetworkPolicy" (#25348) ([6970c1b](https://github.com/bitnami/charts/commit/6970c1b)), closes [#25348](https://github.com/bitnami/charts/issues/25348)
-* [bitnami/redmine] Release 28.0.3 updating components versions (#25820) ([ebe9d70](https://github.com/bitnami/charts/commit/ebe9d70)), closes [#25820](https://github.com/bitnami/charts/issues/25820)
-* Replace VMware by Broadcom copyright text (#25306) ([a5e4bd0](https://github.com/bitnami/charts/commit/a5e4bd0)), closes [#25306](https://github.com/bitnami/charts/issues/25306)
+* [bitnami/*] Change non-root and rolling-tags doc URLs (#25628) ([b067c94](https://github.com/bitnami/charts/commit/b067c94f6bcde427863c197fd355f0b5ba12ff5b)), closes [#25628](https://github.com/bitnami/charts/issues/25628)
+* [bitnami/*] Set new header/owner (#25558) ([8d1dc11](https://github.com/bitnami/charts/commit/8d1dc11f5fb30db6fba50c43d7af59d2f79deed3)), closes [#25558](https://github.com/bitnami/charts/issues/25558)
+* [bitnami/multiple charts] Fix typo: "NetworkPolice" vs "NetworkPolicy" (#25348) ([6970c1b](https://github.com/bitnami/charts/commit/6970c1ba245873506e73d459c6eac1e4919b778f)), closes [#25348](https://github.com/bitnami/charts/issues/25348)
+* [bitnami/redmine] Release 28.0.3 updating components versions (#25820) ([ebe9d70](https://github.com/bitnami/charts/commit/ebe9d707ada7ad7c5e147f4528235317422b153a)), closes [#25820](https://github.com/bitnami/charts/issues/25820)
+* Replace VMware by Broadcom copyright text (#25306) ([a5e4bd0](https://github.com/bitnami/charts/commit/a5e4bd0e35e419203793976a78d9d0a13de92c76)), closes [#25306](https://github.com/bitnami/charts/issues/25306)
 
 ## <small>28.0.2 (2024-04-18)</small>
 
-* [bitnami/redmine] fix: :bug: Remove incorrect CHMOD capability (#24933) ([004945b](https://github.com/bitnami/charts/commit/004945b)), closes [#24933](https://github.com/bitnami/charts/issues/24933)
+* [bitnami/redmine] fix: :bug: Remove incorrect CHMOD capability (#24933) ([004945b](https://github.com/bitnami/charts/commit/004945bd892147af3bad6c135c3255d04b62ad22)), closes [#24933](https://github.com/bitnami/charts/issues/24933)
 
 ## <small>28.0.1 (2024-04-05)</small>
 
-* [bitnami/redmine] Release 28.0.1 (#25013) ([30dd397](https://github.com/bitnami/charts/commit/30dd397)), closes [#25013](https://github.com/bitnami/charts/issues/25013)
+* [bitnami/redmine] Release 28.0.1 (#25013) ([30dd397](https://github.com/bitnami/charts/commit/30dd39716e4a99e415b69b66c1a80c51729c1a66)), closes [#25013](https://github.com/bitnami/charts/issues/25013)
 
 ## 28.0.0 (2024-04-03)
 
-* [bitnami/redmine] feat!: :lock: :boom: Improve security defaults (#24830) ([01706d7](https://github.com/bitnami/charts/commit/01706d7)), closes [#24830](https://github.com/bitnami/charts/issues/24830)
-* Update resourcesPreset comments (#24467) ([92e3e8a](https://github.com/bitnami/charts/commit/92e3e8a)), closes [#24467](https://github.com/bitnami/charts/issues/24467)
+* [bitnami/redmine] feat!: :lock: :boom: Improve security defaults (#24830) ([01706d7](https://github.com/bitnami/charts/commit/01706d725a049827b324b04dbfcfbddb9900a41a)), closes [#24830](https://github.com/bitnami/charts/issues/24830)
+* Update resourcesPreset comments (#24467) ([92e3e8a](https://github.com/bitnami/charts/commit/92e3e8a507326d2a20a8f10ab3e7746a2ec5c554)), closes [#24467](https://github.com/bitnami/charts/issues/24467)
 
 ## <small>27.1.1 (2024-04-02)</small>
 
-* [bitnami/*] Reorder Chart sections (#24455) ([0cf4048](https://github.com/bitnami/charts/commit/0cf4048)), closes [#24455](https://github.com/bitnami/charts/issues/24455)
-* [bitnami/redmine] Release 27.1.1 updating components versions (#24798) ([a204d30](https://github.com/bitnami/charts/commit/a204d30)), closes [#24798](https://github.com/bitnami/charts/issues/24798)
+* [bitnami/*] Reorder Chart sections (#24455) ([0cf4048](https://github.com/bitnami/charts/commit/0cf4048e8743f70a9753d460655bd030cbff6824)), closes [#24455](https://github.com/bitnami/charts/issues/24455)
+* [bitnami/redmine] Release 27.1.1 updating components versions (#24798) ([a204d30](https://github.com/bitnami/charts/commit/a204d301cb5317db6c9ab325d1a13a53d4659c7f)), closes [#24798](https://github.com/bitnami/charts/issues/24798)
 
 ## 27.1.0 (2024-03-06)
 
-* [bitnami/redmine] feat: :sparkles: :lock: Add automatic adaptation for Openshift restricted-v2 SCC ( ([4e52724](https://github.com/bitnami/charts/commit/4e52724)), closes [#24151](https://github.com/bitnami/charts/issues/24151)
+* [bitnami/redmine] feat: :sparkles: :lock: Add automatic adaptation for Openshift restricted-v2 SCC ( ([4e52724](https://github.com/bitnami/charts/commit/4e52724a1e3c2695b5945478b7552c21607f31b8)), closes [#24151](https://github.com/bitnami/charts/issues/24151)
 
 ## <small>27.0.1 (2024-03-04)</small>
 
-* [bitnami/redmine] Release 27.0.1 updating components versions (#24052) ([9b039be](https://github.com/bitnami/charts/commit/9b039be)), closes [#24052](https://github.com/bitnami/charts/issues/24052)
+* [bitnami/redmine] Release 27.0.1 updating components versions (#24052) ([9b039be](https://github.com/bitnami/charts/commit/9b039bed01fcd32880a44e2a52b8fd583b4c4de6)), closes [#24052](https://github.com/bitnami/charts/issues/24052)
 
 ## 27.0.0 (2024-03-04)
 
-* [bitnami/redmine] Update bundled PostgreSQL and MariaDB (#24029) ([a5a7515](https://github.com/bitnami/charts/commit/a5a7515)), closes [#24029](https://github.com/bitnami/charts/issues/24029)
+* [bitnami/redmine] Update bundled PostgreSQL and MariaDB (#24029) ([a5a7515](https://github.com/bitnami/charts/commit/a5a7515699942c47dd1aee7921869b2feacb22d9)), closes [#24029](https://github.com/bitnami/charts/issues/24029)
 
 ## <small>26.5.2 (2024-02-22)</small>
 
-* [bitnami/redmine] Release 26.5.2 updating components versions (#23827) ([382aef3](https://github.com/bitnami/charts/commit/382aef3)), closes [#23827](https://github.com/bitnami/charts/issues/23827)
+* [bitnami/redmine] Release 26.5.2 updating components versions (#23827) ([382aef3](https://github.com/bitnami/charts/commit/382aef39c031d759f446d634d71f29b2cba5675c)), closes [#23827](https://github.com/bitnami/charts/issues/23827)
 
 ## <small>26.5.1 (2024-02-21)</small>
 
-* [bitnami/redmine] Release 26.5.1 updating components versions (#23693) ([e2ede51](https://github.com/bitnami/charts/commit/e2ede51)), closes [#23693](https://github.com/bitnami/charts/issues/23693)
+* [bitnami/redmine] Release 26.5.1 updating components versions (#23693) ([e2ede51](https://github.com/bitnami/charts/commit/e2ede51f3c4c449ee7ff9e6e82a4eae26f6b6400)), closes [#23693](https://github.com/bitnami/charts/issues/23693)
 
 ## 26.5.0 (2024-02-20)
 
-* [bitnami/*] Bump all versions (#23602) ([b70ee2a](https://github.com/bitnami/charts/commit/b70ee2a)), closes [#23602](https://github.com/bitnami/charts/issues/23602)
+* [bitnami/*] Bump all versions (#23602) ([b70ee2a](https://github.com/bitnami/charts/commit/b70ee2a30e4dc256bf0ac52928fb2fa7a70f049b)), closes [#23602](https://github.com/bitnami/charts/issues/23602)
 
 ## 26.4.0 (2024-02-20)
 
-* [bitnami/redmine] feat: :sparkles: :lock: Add resource preset support (#23518) ([323e57c](https://github.com/bitnami/charts/commit/323e57c)), closes [#23518](https://github.com/bitnami/charts/issues/23518)
+* [bitnami/redmine] feat: :sparkles: :lock: Add resource preset support (#23518) ([323e57c](https://github.com/bitnami/charts/commit/323e57cfc4391d928baff50116880c981a6737ae)), closes [#23518](https://github.com/bitnami/charts/issues/23518)
 
 ## <small>26.3.3 (2024-02-03)</small>
 
-* [bitnami/redmine] Release 26.3.3 updating components versions (#23138) ([c976825](https://github.com/bitnami/charts/commit/c976825)), closes [#23138](https://github.com/bitnami/charts/issues/23138)
+* [bitnami/redmine] Release 26.3.3 updating components versions (#23138) ([c976825](https://github.com/bitnami/charts/commit/c9768253c4a01397cdfbffb0d5677c67ca3a876a)), closes [#23138](https://github.com/bitnami/charts/issues/23138)
 
 ## <small>26.3.2 (2024-01-27)</small>
 
-* [bitnami/redmine] Release 26.3.2 updating components versions (#22787) ([5b73acd](https://github.com/bitnami/charts/commit/5b73acd)), closes [#22787](https://github.com/bitnami/charts/issues/22787)
+* [bitnami/redmine] Release 26.3.2 updating components versions (#22787) ([5b73acd](https://github.com/bitnami/charts/commit/5b73acd6cbf0700d52af7a8ad3612c9d7bf035c2)), closes [#22787](https://github.com/bitnami/charts/issues/22787)
 
 ## <small>26.3.1 (2024-01-25)</small>
 
-* [bitnami/*] Move documentation sections from docs.bitnami.com back to the README (#22203) ([7564f36](https://github.com/bitnami/charts/commit/7564f36)), closes [#22203](https://github.com/bitnami/charts/issues/22203)
-* [bitnami/redmine] fix: :bug: Set seLinuxOptions to null for Openshift compatibility (#22655) ([aedab13](https://github.com/bitnami/charts/commit/aedab13)), closes [#22655](https://github.com/bitnami/charts/issues/22655)
+* [bitnami/*] Move documentation sections from docs.bitnami.com back to the README (#22203) ([7564f36](https://github.com/bitnami/charts/commit/7564f36ca1e95ff30ee686652b7ab8690561a707)), closes [#22203](https://github.com/bitnami/charts/issues/22203)
+* [bitnami/redmine] fix: :bug: Set seLinuxOptions to null for Openshift compatibility (#22655) ([aedab13](https://github.com/bitnami/charts/commit/aedab1318888f3ebff12a3ff7f41d861f2543251)), closes [#22655](https://github.com/bitnami/charts/issues/22655)
 
 ## 26.3.0 (2024-01-19)
 
-* [bitnami/redmine] fix: :lock: Move service-account token auto-mount to pod declaration (#22457) ([11e4371](https://github.com/bitnami/charts/commit/11e4371)), closes [#22457](https://github.com/bitnami/charts/issues/22457)
+* [bitnami/redmine] fix: :lock: Move service-account token auto-mount to pod declaration (#22457) ([11e4371](https://github.com/bitnami/charts/commit/11e4371f6fec57514c1de1350e01d5f9627709ba)), closes [#22457](https://github.com/bitnami/charts/issues/22457)
 
 ## <small>26.2.1 (2024-01-18)</small>
 
-* [bitnami/redmine] Release 26.2.1 updating components versions (#22340) ([a584208](https://github.com/bitnami/charts/commit/a584208)), closes [#22340](https://github.com/bitnami/charts/issues/22340)
+* [bitnami/redmine] Release 26.2.1 updating components versions (#22340) ([a584208](https://github.com/bitnami/charts/commit/a584208f97224477e42519cf46a121bb813d8bb0)), closes [#22340](https://github.com/bitnami/charts/issues/22340)
 
 ## 26.2.0 (2024-01-16)
 
-* [bitnami/redmine] fix: :lock: Improve podSecurityContext and containerSecurityContext with essential ([d0a32ab](https://github.com/bitnami/charts/commit/d0a32ab)), closes [#22186](https://github.com/bitnami/charts/issues/22186)
+* [bitnami/redmine] fix: :lock: Improve podSecurityContext and containerSecurityContext with essential ([d0a32ab](https://github.com/bitnami/charts/commit/d0a32ab0f7f4ca3944db4915830089b9ea839989)), closes [#22186](https://github.com/bitnami/charts/issues/22186)
 
 ## <small>26.1.3 (2024-01-12)</small>
 
-* [bitnami/redmine] Release 26.1.3 updating components versions (#22074) ([afef76e](https://github.com/bitnami/charts/commit/afef76e)), closes [#22074](https://github.com/bitnami/charts/issues/22074)
+* [bitnami/redmine] Release 26.1.3 updating components versions (#22074) ([afef76e](https://github.com/bitnami/charts/commit/afef76e1a67449e9cf068da0148fce6a000aaa10)), closes [#22074](https://github.com/bitnami/charts/issues/22074)
 
 ## <small>26.1.2 (2024-01-11)</small>
 
-* [bitnami/redmine] Release 26.1.2 updating components versions (#21996) ([11c4ffd](https://github.com/bitnami/charts/commit/11c4ffd)), closes [#21996](https://github.com/bitnami/charts/issues/21996)
+* [bitnami/redmine] Release 26.1.2 updating components versions (#21996) ([11c4ffd](https://github.com/bitnami/charts/commit/11c4ffd6e87bd742203f28b50d87474142f2922e)), closes [#21996](https://github.com/bitnami/charts/issues/21996)
 
 ## <small>26.1.1 (2024-01-11)</small>
 
-* [bitnami/*] Fix ref links (in comments) (#21822) ([e4fa296](https://github.com/bitnami/charts/commit/e4fa296)), closes [#21822](https://github.com/bitnami/charts/issues/21822)
-* [bitnami/redmine] Release 26.1.1 updating components versions (#21993) ([c8e6af8](https://github.com/bitnami/charts/commit/c8e6af8)), closes [#21993](https://github.com/bitnami/charts/issues/21993)
+* [bitnami/*] Fix ref links (in comments) (#21822) ([e4fa296](https://github.com/bitnami/charts/commit/e4fa296106b225cf8c82445727c675c7c725e380)), closes [#21822](https://github.com/bitnami/charts/issues/21822)
+* [bitnami/redmine] Release 26.1.1 updating components versions (#21993) ([c8e6af8](https://github.com/bitnami/charts/commit/c8e6af8eb72b6c52cf44f5a172ea23fb4704d222)), closes [#21993](https://github.com/bitnami/charts/issues/21993)
 
 ## 26.1.0 (2024-01-10)
 
-* [bitnami/*] Fix docs.bitnami.com broken links (#21901) ([f35506d](https://github.com/bitnami/charts/commit/f35506d)), closes [#21901](https://github.com/bitnami/charts/issues/21901)
-* [bitnami/redmine] feat: :sparkles: Add seccompProfile to containerSecurityContext (#21912) ([11bf7a1](https://github.com/bitnami/charts/commit/11bf7a1)), closes [#21912](https://github.com/bitnami/charts/issues/21912)
+* [bitnami/*] Fix docs.bitnami.com broken links (#21901) ([f35506d](https://github.com/bitnami/charts/commit/f35506d2dadee4f097986e7792df1f53ab215b5d)), closes [#21901](https://github.com/bitnami/charts/issues/21901)
+* [bitnami/redmine] feat: :sparkles: Add seccompProfile to containerSecurityContext (#21912) ([11bf7a1](https://github.com/bitnami/charts/commit/11bf7a1283bfbfbacbb058b3f61ecfd2d975d943)), closes [#21912](https://github.com/bitnami/charts/issues/21912)
 
 ## <small>26.0.1 (2024-01-03)</small>
 
-* [bitnami/*] Update copyright: Year and company (#21815) ([6c4bf75](https://github.com/bitnami/charts/commit/6c4bf75)), closes [#21815](https://github.com/bitnami/charts/issues/21815)
-* [bitnami/redmine] Release 26.0.1 updating components versions (#21827) ([05c4216](https://github.com/bitnami/charts/commit/05c4216)), closes [#21827](https://github.com/bitnami/charts/issues/21827)
+* [bitnami/*] Update copyright: Year and company (#21815) ([6c4bf75](https://github.com/bitnami/charts/commit/6c4bf75dec58fc7c9aee9f089777b1a858c17d5b)), closes [#21815](https://github.com/bitnami/charts/issues/21815)
+* [bitnami/redmine] Release 26.0.1 updating components versions (#21827) ([05c4216](https://github.com/bitnami/charts/commit/05c42162ed61e358cff65cd2a18a28448218c391)), closes [#21827](https://github.com/bitnami/charts/issues/21827)
 
 ## 26.0.0 (2023-12-20)
 
-* [bitnami/redmine] Upgrade MariaDB 11.2 (#21693) ([3912649](https://github.com/bitnami/charts/commit/3912649)), closes [#21693](https://github.com/bitnami/charts/issues/21693)
+* [bitnami/redmine] Upgrade MariaDB 11.2 (#21693) ([3912649](https://github.com/bitnami/charts/commit/3912649deba567a55a9029f0f856749a8ad14e53)), closes [#21693](https://github.com/bitnami/charts/issues/21693)
 
 ## <small>25.0.8 (2023-12-20)</small>
 
-* [bitnami/redmine] Release 25.0.8 updating components versions (#21676) ([305212b](https://github.com/bitnami/charts/commit/305212b)), closes [#21676](https://github.com/bitnami/charts/issues/21676)
+* [bitnami/redmine] Release 25.0.8 updating components versions (#21676) ([305212b](https://github.com/bitnami/charts/commit/305212bffc10174e6d18b3b118d097c372ccb888)), closes [#21676](https://github.com/bitnami/charts/issues/21676)
 
 ## <small>25.0.7 (2023-11-27)</small>
 
-* [bitnami/redmine] Release 25.0.7 updating components versions (#21279) ([8350105](https://github.com/bitnami/charts/commit/8350105)), closes [#21279](https://github.com/bitnami/charts/issues/21279)
+* [bitnami/redmine] Release 25.0.7 updating components versions (#21279) ([8350105](https://github.com/bitnami/charts/commit/83501052e0e3827dade31b755e173823f1d7ea1f)), closes [#21279](https://github.com/bitnami/charts/issues/21279)
 
 ## <small>25.0.6 (2023-11-21)</small>
 
-* [bitnami/*] Remove relative links to non-README sections, add verification for that and update TL;DR ([1103633](https://github.com/bitnami/charts/commit/1103633)), closes [#20967](https://github.com/bitnami/charts/issues/20967)
-* [bitnami/*] Rename solutions to "Bitnami package for ..." (#21038) ([b82f979](https://github.com/bitnami/charts/commit/b82f979)), closes [#21038](https://github.com/bitnami/charts/issues/21038)
-* [bitnami/redmine] Release 25.0.6 updating components versions (#21171) ([6bb7a4f](https://github.com/bitnami/charts/commit/6bb7a4f)), closes [#21171](https://github.com/bitnami/charts/issues/21171)
+* [bitnami/*] Remove relative links to non-README sections, add verification for that and update TL;DR ([1103633](https://github.com/bitnami/charts/commit/11036334d82df0490aa4abdb591543cab6cf7d7f)), closes [#20967](https://github.com/bitnami/charts/issues/20967)
+* [bitnami/*] Rename solutions to "Bitnami package for ..." (#21038) ([b82f979](https://github.com/bitnami/charts/commit/b82f979e4fb63423fe6e2192c946d09d79c944fc)), closes [#21038](https://github.com/bitnami/charts/issues/21038)
+* [bitnami/redmine] Release 25.0.6 updating components versions (#21171) ([6bb7a4f](https://github.com/bitnami/charts/commit/6bb7a4fd50be5413d8ea6bfc74689289fdb8c844)), closes [#21171](https://github.com/bitnami/charts/issues/21171)
 
 ## <small>25.0.5 (2023-11-08)</small>
 
-* [bitnami/redmine] Release 25.0.5 updating components versions (#20712) ([e6c59e3](https://github.com/bitnami/charts/commit/e6c59e3)), closes [#20712](https://github.com/bitnami/charts/issues/20712)
+* [bitnami/redmine] Release 25.0.5 updating components versions (#20712) ([e6c59e3](https://github.com/bitnami/charts/commit/e6c59e34f0584dde49e0341b1c3f0aa05a25f853)), closes [#20712](https://github.com/bitnami/charts/issues/20712)
 
 ## <small>25.0.4 (2023-11-06)</small>
 
-* [bitnami/redmine] Release 25.0.4 updating components versions (#20636) ([27c357f](https://github.com/bitnami/charts/commit/27c357f)), closes [#20636](https://github.com/bitnami/charts/issues/20636)
+* [bitnami/redmine] Release 25.0.4 updating components versions (#20636) ([27c357f](https://github.com/bitnami/charts/commit/27c357f1b8639c6878104bf30857079a4c1678a3)), closes [#20636](https://github.com/bitnami/charts/issues/20636)
 
 ## <small>25.0.3 (2023-11-02)</small>
 
-* [bitnami/redmine] Release 25.0.3 updating components versions (#20592) ([86ea264](https://github.com/bitnami/charts/commit/86ea264)), closes [#20592](https://github.com/bitnami/charts/issues/20592)
+* [bitnami/redmine] Release 25.0.3 updating components versions (#20592) ([86ea264](https://github.com/bitnami/charts/commit/86ea26405dbf6e76ffb9c4430c77607614fd4b93)), closes [#20592](https://github.com/bitnami/charts/issues/20592)
 
 ## <small>25.0.2 (2023-10-31)</small>
 
-* [bitnami/*] Rename VMware Application Catalog (#20361) ([3acc734](https://github.com/bitnami/charts/commit/3acc734)), closes [#20361](https://github.com/bitnami/charts/issues/20361)
-* [bitnami/*] Skip image's tag in the README files of the Bitnami Charts (#19841) ([bb9a01b](https://github.com/bitnami/charts/commit/bb9a01b)), closes [#19841](https://github.com/bitnami/charts/issues/19841)
-* [bitnami/*] Standardize documentation (#19835) ([af5f753](https://github.com/bitnami/charts/commit/af5f753)), closes [#19835](https://github.com/bitnami/charts/issues/19835)
-* [bitnami/redmine] Release 25.0.2 updating components versions (#20543) ([025a995](https://github.com/bitnami/charts/commit/025a995)), closes [#20543](https://github.com/bitnami/charts/issues/20543)
+* [bitnami/*] Rename VMware Application Catalog (#20361) ([3acc734](https://github.com/bitnami/charts/commit/3acc73472beb6fb56c4d99f929061001205bc57e)), closes [#20361](https://github.com/bitnami/charts/issues/20361)
+* [bitnami/*] Skip image's tag in the README files of the Bitnami Charts (#19841) ([bb9a01b](https://github.com/bitnami/charts/commit/bb9a01b65911c87e48318db922cc05eb42785e42)), closes [#19841](https://github.com/bitnami/charts/issues/19841)
+* [bitnami/*] Standardize documentation (#19835) ([af5f753](https://github.com/bitnami/charts/commit/af5f7530c1bc8c5ded53a6c4f7b8f384ac1804f2)), closes [#19835](https://github.com/bitnami/charts/issues/19835)
+* [bitnami/redmine] Release 25.0.2 updating components versions (#20543) ([025a995](https://github.com/bitnami/charts/commit/025a995cd3a092705e91c58eda01120f608a7c4e)), closes [#20543](https://github.com/bitnami/charts/issues/20543)
 
 ## <small>25.0.1 (2023-10-12)</small>
 
-* [bitnami/redmine] Release 25.0.1 (#20172) ([d43a356](https://github.com/bitnami/charts/commit/d43a356)), closes [#20172](https://github.com/bitnami/charts/issues/20172)
+* [bitnami/redmine] Release 25.0.1 (#20172) ([d43a356](https://github.com/bitnami/charts/commit/d43a356c4940bd066060b1594d936e51c574cd40)), closes [#20172](https://github.com/bitnami/charts/issues/20172)
 
 ## 25.0.0 (2023-10-11)
 
-* [bitnami/redmine] Update MariaDB to 14.x.x (#20009) ([825f828](https://github.com/bitnami/charts/commit/825f828)), closes [#20009](https://github.com/bitnami/charts/issues/20009)
+* [bitnami/redmine] Update MariaDB to 14.x.x (#20009) ([825f828](https://github.com/bitnami/charts/commit/825f828f87dd88db7d96d1f71a71c470f7546aec)), closes [#20009](https://github.com/bitnami/charts/issues/20009)
 
 ## <small>24.0.3 (2023-10-09)</small>
 
-* [bitnami/redmine] Release 24.0.3 (#19909) ([cfe38d9](https://github.com/bitnami/charts/commit/cfe38d9)), closes [#19909](https://github.com/bitnami/charts/issues/19909)
+* [bitnami/redmine] Release 24.0.3 (#19909) ([cfe38d9](https://github.com/bitnami/charts/commit/cfe38d936a999046f06add8a97c17ffc1381ffd7)), closes [#19909](https://github.com/bitnami/charts/issues/19909)
 
 ## <small>24.0.2 (2023-10-09)</small>
 
-* [bitnami/*] Update Helm charts prerequisites (#19745) ([eb755dd](https://github.com/bitnami/charts/commit/eb755dd)), closes [#19745](https://github.com/bitnami/charts/issues/19745)
-* [bitnami/redmine] Release 24.0.2 (#19807) ([0b1198f](https://github.com/bitnami/charts/commit/0b1198f)), closes [#19807](https://github.com/bitnami/charts/issues/19807)
+* [bitnami/*] Update Helm charts prerequisites (#19745) ([eb755dd](https://github.com/bitnami/charts/commit/eb755dd36a4dd3cf6635be8e0598f9a7f4c4a554)), closes [#19745](https://github.com/bitnami/charts/issues/19745)
+* [bitnami/redmine] Release 24.0.2 (#19807) ([0b1198f](https://github.com/bitnami/charts/commit/0b1198fdcc20e784d74e49d7d0341f524dc4ec75)), closes [#19807](https://github.com/bitnami/charts/issues/19807)
 
 ## <small>24.0.1 (2023-09-30)</small>
 
-* [bitnami/redmine] Release 24.0.1 (#19664) ([fcde31e](https://github.com/bitnami/charts/commit/fcde31e)), closes [#19664](https://github.com/bitnami/charts/issues/19664)
+* [bitnami/redmine] Release 24.0.1 (#19664) ([fcde31e](https://github.com/bitnami/charts/commit/fcde31e937e8cb5effa2256fe805311afe5d1361)), closes [#19664](https://github.com/bitnami/charts/issues/19664)
 
 ## 24.0.0 (2023-09-29)
 
-* [bitnami/redmine] Update dependencies (#19621) ([132b78d](https://github.com/bitnami/charts/commit/132b78d)), closes [#19621](https://github.com/bitnami/charts/issues/19621)
+* [bitnami/redmine] Update dependencies (#19621) ([132b78d](https://github.com/bitnami/charts/commit/132b78d8f43bf2253fcee04ca01617273270c769)), closes [#19621](https://github.com/bitnami/charts/issues/19621)
 
 ## <small>23.1.3 (2023-09-26)</small>
 
-* [bitnami/redmine] Release 23.1.3 (#19545) ([f07c752](https://github.com/bitnami/charts/commit/f07c752)), closes [#19545](https://github.com/bitnami/charts/issues/19545)
+* [bitnami/redmine] Release 23.1.3 (#19545) ([f07c752](https://github.com/bitnami/charts/commit/f07c75285d8c3b88d4affb5671ff788d91c9b70f)), closes [#19545](https://github.com/bitnami/charts/issues/19545)
 
 ## <small>23.1.2 (2023-09-20)</small>
 
-* [bitnami/redmine] Release 23.1.2 (#19408) ([16448d7](https://github.com/bitnami/charts/commit/16448d7)), closes [#19408](https://github.com/bitnami/charts/issues/19408)
-* Autogenerate schema files (#19194) ([a2c2090](https://github.com/bitnami/charts/commit/a2c2090)), closes [#19194](https://github.com/bitnami/charts/issues/19194)
-* Revert "Autogenerate schema files (#19194)" (#19335) ([73d80be](https://github.com/bitnami/charts/commit/73d80be)), closes [#19194](https://github.com/bitnami/charts/issues/19194) [#19335](https://github.com/bitnami/charts/issues/19335)
+* [bitnami/redmine] Release 23.1.2 (#19408) ([16448d7](https://github.com/bitnami/charts/commit/16448d7b9a72d357c1b4ef51326ce16ef4e3f625)), closes [#19408](https://github.com/bitnami/charts/issues/19408)
+* Autogenerate schema files (#19194) ([a2c2090](https://github.com/bitnami/charts/commit/a2c2090b5ac97f47b745c8028c6452bf99739772)), closes [#19194](https://github.com/bitnami/charts/issues/19194)
+* Revert "Autogenerate schema files (#19194)" (#19335) ([73d80be](https://github.com/bitnami/charts/commit/73d80be525c88fb4b8a54451a55acd506e337062)), closes [#19194](https://github.com/bitnami/charts/issues/19194) [#19335](https://github.com/bitnami/charts/issues/19335)
 
 ## <small>23.1.1 (2023-09-07)</small>
 
-* [bitnami/redmine: Use merge helper]: (#19100) ([3b8b1b3](https://github.com/bitnami/charts/commit/3b8b1b3)), closes [#19100](https://github.com/bitnami/charts/issues/19100)
+* [bitnami/redmine: Use merge helper]: (#19100) ([3b8b1b3](https://github.com/bitnami/charts/commit/3b8b1b3b5d55644b8fe22d12a39e09a178ce9b15)), closes [#19100](https://github.com/bitnami/charts/issues/19100)
 
 ## 23.1.0 (2023-08-23)
 
-* [bitnami/redmine] Support for customizing standard labels (#18744) ([c7eb5bc](https://github.com/bitnami/charts/commit/c7eb5bc)), closes [#18744](https://github.com/bitnami/charts/issues/18744)
+* [bitnami/redmine] Support for customizing standard labels (#18744) ([c7eb5bc](https://github.com/bitnami/charts/commit/c7eb5bc00478fd21589816268fdb4015b16b50ce)), closes [#18744](https://github.com/bitnami/charts/issues/18744)
 
 ## <small>23.0.2 (2023-08-21)</small>
 
-* [bitnami/redmine] Release 23.0.2 (#18714) ([a9b92c6](https://github.com/bitnami/charts/commit/a9b92c6)), closes [#18714](https://github.com/bitnami/charts/issues/18714)
+* [bitnami/redmine] Release 23.0.2 (#18714) ([a9b92c6](https://github.com/bitnami/charts/commit/a9b92c68d8f4ad0a19479741308cd4c1ec10079a)), closes [#18714](https://github.com/bitnami/charts/issues/18714)
 
 ## <small>23.0.1 (2023-08-17)</small>
 
-* [bitnami/redmine] Release 23.0.1 (#18590) ([ceaba85](https://github.com/bitnami/charts/commit/ceaba85)), closes [#18590](https://github.com/bitnami/charts/issues/18590)
+* [bitnami/redmine] Release 23.0.1 (#18590) ([ceaba85](https://github.com/bitnami/charts/commit/ceaba85a82058ac43150eac638fd232086ad0c96)), closes [#18590](https://github.com/bitnami/charts/issues/18590)
 
 ## 23.0.0 (2023-08-01)
 
-* [bitnami/redmine] Update MariaDB chart to 13.0 (#18116) ([25c51d8](https://github.com/bitnami/charts/commit/25c51d8)), closes [#18116](https://github.com/bitnami/charts/issues/18116)
+* [bitnami/redmine] Update MariaDB chart to 13.0 (#18116) ([25c51d8](https://github.com/bitnami/charts/commit/25c51d8ddb6fe57227d3743b0d5c50a681e9b7fe)), closes [#18116](https://github.com/bitnami/charts/issues/18116)
 
 ## <small>22.1.9 (2023-08-01)</small>
 
-* [bitnami/redmine] Release 22.1.9 (#18085) ([9535ecd](https://github.com/bitnami/charts/commit/9535ecd)), closes [#18085](https://github.com/bitnami/charts/issues/18085)
+* [bitnami/redmine] Release 22.1.9 (#18085) ([9535ecd](https://github.com/bitnami/charts/commit/9535ecd0df5989d92b03b3f29f278f57b5b80fe9)), closes [#18085](https://github.com/bitnami/charts/issues/18085)
 
 ## <small>22.1.8 (2023-07-27)</small>
 
-* [bitnami/redmine] Release 22.1.8 (#17959) ([7619518](https://github.com/bitnami/charts/commit/7619518)), closes [#17959](https://github.com/bitnami/charts/issues/17959)
+* [bitnami/redmine] Release 22.1.8 (#17959) ([7619518](https://github.com/bitnami/charts/commit/7619518aa285239abd1a3d014a70ad472c7657ed)), closes [#17959](https://github.com/bitnami/charts/issues/17959)
 
 ## <small>22.1.7 (2023-07-17)</small>
 
-* [bitnami/redmine] Release 22.1.7 (#17748) ([8df9819](https://github.com/bitnami/charts/commit/8df9819)), closes [#17748](https://github.com/bitnami/charts/issues/17748)
+* [bitnami/redmine] Release 22.1.7 (#17748) ([8df9819](https://github.com/bitnami/charts/commit/8df9819f0e43ab5b70096a7ed1b213ae6fcc74ca)), closes [#17748](https://github.com/bitnami/charts/issues/17748)
 
 ## <small>22.1.6 (2023-07-13)</small>
 
-* [bitnami/redmine] Release 22.1.6 updating components versions (#17662) ([1a82cf1](https://github.com/bitnami/charts/commit/1a82cf1)), closes [#17662](https://github.com/bitnami/charts/issues/17662)
+* [bitnami/redmine] Release 22.1.6 updating components versions (#17662) ([1a82cf1](https://github.com/bitnami/charts/commit/1a82cf19b469f139aad9fd4b53f2067e2fbe8cda)), closes [#17662](https://github.com/bitnami/charts/issues/17662)
 
 ## <small>22.1.5 (2023-07-11)</small>
 
-* [bitnami/redmine] Release 22.1.5 (#17565) ([b359695](https://github.com/bitnami/charts/commit/b359695)), closes [#17565](https://github.com/bitnami/charts/issues/17565)
-* Add copyright header (#17300) ([da68be8](https://github.com/bitnami/charts/commit/da68be8)), closes [#17300](https://github.com/bitnami/charts/issues/17300)
-* Update charts readme (#17217) ([31b3c0a](https://github.com/bitnami/charts/commit/31b3c0a)), closes [#17217](https://github.com/bitnami/charts/issues/17217)
+* [bitnami/redmine] Release 22.1.5 (#17565) ([b359695](https://github.com/bitnami/charts/commit/b359695638d0ea9e38d65f699b00e6b921abec3f)), closes [#17565](https://github.com/bitnami/charts/issues/17565)
+* Add copyright header (#17300) ([da68be8](https://github.com/bitnami/charts/commit/da68be8e951225133c7dfb572d5101ca3d61c5ae)), closes [#17300](https://github.com/bitnami/charts/issues/17300)
+* Update charts readme (#17217) ([31b3c0a](https://github.com/bitnami/charts/commit/31b3c0afd968ff4429107e34101f7509e6a0e913)), closes [#17217](https://github.com/bitnami/charts/issues/17217)
 
 ## <small>22.1.4 (2023-06-20)</small>
 
-* [bitnami/*] Change copyright section in READMEs (#17006) ([ef986a1](https://github.com/bitnami/charts/commit/ef986a1)), closes [#17006](https://github.com/bitnami/charts/issues/17006)
-* [bitnami/redmine] Release 22.1.4 (#17242) ([0aef9ba](https://github.com/bitnami/charts/commit/0aef9ba)), closes [#17242](https://github.com/bitnami/charts/issues/17242)
-* [bitnami/several] Change copyright section in READMEs (#16989) ([5b6a5cf](https://github.com/bitnami/charts/commit/5b6a5cf)), closes [#16989](https://github.com/bitnami/charts/issues/16989)
-* [bitnami/several] Remove 'Community supported solution' section from READMEs (#17119) ([4531d57](https://github.com/bitnami/charts/commit/4531d57)), closes [#17119](https://github.com/bitnami/charts/issues/17119)
+* [bitnami/*] Change copyright section in READMEs (#17006) ([ef986a1](https://github.com/bitnami/charts/commit/ef986a1605241102b3dcafe9fd8089e6fc1201ad)), closes [#17006](https://github.com/bitnami/charts/issues/17006)
+* [bitnami/redmine] Release 22.1.4 (#17242) ([0aef9ba](https://github.com/bitnami/charts/commit/0aef9ba1fb5979b9ceafb68e1a5689a466e2bbff)), closes [#17242](https://github.com/bitnami/charts/issues/17242)
+* [bitnami/several] Change copyright section in READMEs (#16989) ([5b6a5cf](https://github.com/bitnami/charts/commit/5b6a5cfb7625a751848a2e5cd796bd7278f406ca)), closes [#16989](https://github.com/bitnami/charts/issues/16989)
+* [bitnami/several] Remove 'Community supported solution' section from READMEs (#17119) ([4531d57](https://github.com/bitnami/charts/commit/4531d571914e970fe4cef19ae00a9fa4cc038f47)), closes [#17119](https://github.com/bitnami/charts/issues/17119)
 
 ## <small>22.1.3 (2023-05-21)</small>
 
-* [bitnami/redmine] Release 22.1.3 (#16832) ([af874ad](https://github.com/bitnami/charts/commit/af874ad)), closes [#16832](https://github.com/bitnami/charts/issues/16832)
+* [bitnami/redmine] Release 22.1.3 (#16832) ([af874ad](https://github.com/bitnami/charts/commit/af874ad020cc68efdf97239736972b66e111d431)), closes [#16832](https://github.com/bitnami/charts/issues/16832)
 
 ## <small>22.1.2 (2023-05-17)</small>
 
-* [bitnami/redmine] Release 22.1.2 (#16712) ([3a77bdb](https://github.com/bitnami/charts/commit/3a77bdb)), closes [#16712](https://github.com/bitnami/charts/issues/16712)
+* [bitnami/redmine] Release 22.1.2 (#16712) ([3a77bdb](https://github.com/bitnami/charts/commit/3a77bdb503af9e713c85b623da28b6c30db69cc2)), closes [#16712](https://github.com/bitnami/charts/issues/16712)
 
 ## <small>22.1.1 (2023-05-12)</small>
 
-* [bitnami/redmine] Release 22.1.1 (#16622) ([ca2bb7d](https://github.com/bitnami/charts/commit/ca2bb7d)), closes [#16622](https://github.com/bitnami/charts/issues/16622)
-* Add wording for enterprise page (#16560) ([8f22774](https://github.com/bitnami/charts/commit/8f22774)), closes [#16560](https://github.com/bitnami/charts/issues/16560)
+* [bitnami/redmine] Release 22.1.1 (#16622) ([ca2bb7d](https://github.com/bitnami/charts/commit/ca2bb7d12f7fc824a2c0f144c7aae277003da2d8)), closes [#16622](https://github.com/bitnami/charts/issues/16622)
+* Add wording for enterprise page (#16560) ([8f22774](https://github.com/bitnami/charts/commit/8f2277440b976d52785ba9149762ad8620a73d1f)), closes [#16560](https://github.com/bitnami/charts/issues/16560)
 
 ## 22.1.0 (2023-05-09)
 
-* [bitnami/several] Adapt Chart.yaml to set desired OCI annotations (#16546) ([fc9b18f](https://github.com/bitnami/charts/commit/fc9b18f)), closes [#16546](https://github.com/bitnami/charts/issues/16546)
+* [bitnami/several] Adapt Chart.yaml to set desired OCI annotations (#16546) ([fc9b18f](https://github.com/bitnami/charts/commit/fc9b18f2e98805d4df629acbcde696f44f973344)), closes [#16546](https://github.com/bitnami/charts/issues/16546)
 
 ## <small>22.0.2 (2023-05-09)</small>
 
-* [bitnami/redmine] Release 22.0.2 (#16494) ([56a9ec1](https://github.com/bitnami/charts/commit/56a9ec1)), closes [#16494](https://github.com/bitnami/charts/issues/16494)
+* [bitnami/redmine] Release 22.0.2 (#16494) ([56a9ec1](https://github.com/bitnami/charts/commit/56a9ec18beeb9179dbf5d20f3abdb2c81394cb6a)), closes [#16494](https://github.com/bitnami/charts/issues/16494)
 
 ## <small>22.0.1 (2023-05-01)</small>
 
-* [bitnami/redmine] Release 22.0.1 (#16321) ([b43f278](https://github.com/bitnami/charts/commit/b43f278)), closes [#16321](https://github.com/bitnami/charts/issues/16321)
+* [bitnami/redmine] Release 22.0.1 (#16321) ([b43f278](https://github.com/bitnami/charts/commit/b43f27843c0a3b5e61ed029c600564da7c1d3e75)), closes [#16321](https://github.com/bitnami/charts/issues/16321)
 
 ## 22.0.0 (2023-04-22)
 
-* [bitnami/redmine] Upgrade MariaDB to version 10.11 (#16179) ([e7fc23a](https://github.com/bitnami/charts/commit/e7fc23a)), closes [#16179](https://github.com/bitnami/charts/issues/16179)
+* [bitnami/redmine] Upgrade MariaDB to version 10.11 (#16179) ([e7fc23a](https://github.com/bitnami/charts/commit/e7fc23a3828596f0a17019799c9487a7f5648aae)), closes [#16179](https://github.com/bitnami/charts/issues/16179)
 
 ## 21.2.0 (2023-04-20)
 
-* [bitnami/*] Make Helm charts 100% OCI (#15998) ([8841510](https://github.com/bitnami/charts/commit/8841510)), closes [#15998](https://github.com/bitnami/charts/issues/15998)
+* [bitnami/*] Make Helm charts 100% OCI (#15998) ([8841510](https://github.com/bitnami/charts/commit/884151035efcbf2e1b3206e7def85511073fb57d)), closes [#15998](https://github.com/bitnami/charts/issues/15998)
 
 ## <small>21.1.1 (2023-04-01)</small>
 
-* [bitnami/redmine] Release 21.1.1 (#15917) ([11fd162](https://github.com/bitnami/charts/commit/11fd162)), closes [#15917](https://github.com/bitnami/charts/issues/15917)
+* [bitnami/redmine] Release 21.1.1 (#15917) ([11fd162](https://github.com/bitnami/charts/commit/11fd162931158a59af54a00d9caf9ae543c47d8c)), closes [#15917](https://github.com/bitnami/charts/issues/15917)
 
 ## 21.1.0 (2023-03-21)
 
-* [bitnami/redmine] Run initContainer as privileged user (#15496) ([8f0f5db](https://github.com/bitnami/charts/commit/8f0f5db)), closes [#15496](https://github.com/bitnami/charts/issues/15496)
+* [bitnami/redmine] Run initContainer as privileged user (#15496) ([8f0f5db](https://github.com/bitnami/charts/commit/8f0f5db9ee3a0158daf3558a93688a59c7452181)), closes [#15496](https://github.com/bitnami/charts/issues/15496)
 
 ## <small>21.0.10 (2023-03-19)</small>
 
-* [bitnami/charts] Apply linter to README files (#15357) ([0e29e60](https://github.com/bitnami/charts/commit/0e29e60)), closes [#15357](https://github.com/bitnami/charts/issues/15357)
-* [bitnami/redmine] Release 21.0.10 (#15607) ([7cfc2a3](https://github.com/bitnami/charts/commit/7cfc2a3)), closes [#15607](https://github.com/bitnami/charts/issues/15607)
+* [bitnami/charts] Apply linter to README files (#15357) ([0e29e60](https://github.com/bitnami/charts/commit/0e29e600d3adc8b1b46e506eccb3decfab3b4e63)), closes [#15357](https://github.com/bitnami/charts/issues/15357)
+* [bitnami/redmine] Release 21.0.10 (#15607) ([7cfc2a3](https://github.com/bitnami/charts/commit/7cfc2a3ba1e283ac2e6fbd7a51fddb681f01a4c3)), closes [#15607](https://github.com/bitnami/charts/issues/15607)
 
 ## <small>21.0.9 (2023-03-06)</small>
 
-* [bitnami/redmine] Release 21.0.9 (#15331) ([3d0ba88](https://github.com/bitnami/charts/commit/3d0ba88)), closes [#15331](https://github.com/bitnami/charts/issues/15331)
+* [bitnami/redmine] Release 21.0.9 (#15331) ([3d0ba88](https://github.com/bitnami/charts/commit/3d0ba888886990a5eb15104d424a5dfcf9aa9ba9)), closes [#15331](https://github.com/bitnami/charts/issues/15331)
 
 ## <small>21.0.8 (2023-03-01)</small>
 
-* [bitnami/redmine] Release 21.0.8 (#15225) ([fffb47c](https://github.com/bitnami/charts/commit/fffb47c)), closes [#15225](https://github.com/bitnami/charts/issues/15225)
+* [bitnami/redmine] Release 21.0.8 (#15225) ([fffb47c](https://github.com/bitnami/charts/commit/fffb47cfc1a1efad1232a15a713d56d5c5fb636c)), closes [#15225](https://github.com/bitnami/charts/issues/15225)
 
 ## <small>21.0.7 (2023-02-17)</small>
 
-* [bitnami/*] Fix markdown linter issues (#14874) ([a51e0e8](https://github.com/bitnami/charts/commit/a51e0e8)), closes [#14874](https://github.com/bitnami/charts/issues/14874)
-* [bitnami/*] Fix markdown linter issues 2 (#14890) ([aa96572](https://github.com/bitnami/charts/commit/aa96572)), closes [#14890](https://github.com/bitnami/charts/issues/14890)
-* [bitnami/*] Remove unexpected extra spaces (#14873) ([c97c714](https://github.com/bitnami/charts/commit/c97c714)), closes [#14873](https://github.com/bitnami/charts/issues/14873)
-* [bitnami/redmine] Release 21.0.7 (#15016) ([27656fe](https://github.com/bitnami/charts/commit/27656fe)), closes [#15016](https://github.com/bitnami/charts/issues/15016)
+* [bitnami/*] Fix markdown linter issues (#14874) ([a51e0e8](https://github.com/bitnami/charts/commit/a51e0e8d35495b907f3e70dd2f8e7c3bcbf4166a)), closes [#14874](https://github.com/bitnami/charts/issues/14874)
+* [bitnami/*] Fix markdown linter issues 2 (#14890) ([aa96572](https://github.com/bitnami/charts/commit/aa9657237ee8df4a46db0d7fdf8a23230dd6902a)), closes [#14890](https://github.com/bitnami/charts/issues/14890)
+* [bitnami/*] Remove unexpected extra spaces (#14873) ([c97c714](https://github.com/bitnami/charts/commit/c97c714887380d47eae7bfeff316bf01595ecd1d)), closes [#14873](https://github.com/bitnami/charts/issues/14873)
+* [bitnami/redmine] Release 21.0.7 (#15016) ([27656fe](https://github.com/bitnami/charts/commit/27656fe22aae76fe3f49e285fadc458ce7cf723e)), closes [#15016](https://github.com/bitnami/charts/issues/15016)
 
 ## <small>21.0.6 (2023-02-02)</small>
 
-* [bitnami/*] Change copyright date (#14682) ([add4ec7](https://github.com/bitnami/charts/commit/add4ec7)), closes [#14682](https://github.com/bitnami/charts/issues/14682)
-* [bitnami/redmine] Don't regenerate self-signed certs on upgrade (#14657) ([3ce31ca](https://github.com/bitnami/charts/commit/3ce31ca)), closes [#14657](https://github.com/bitnami/charts/issues/14657)
-* [bitnami/redmine] Release 21.0.6 (#14718) ([c2c88be](https://github.com/bitnami/charts/commit/c2c88be)), closes [#14718](https://github.com/bitnami/charts/issues/14718)
+* [bitnami/*] Change copyright date (#14682) ([add4ec7](https://github.com/bitnami/charts/commit/add4ec701108ac36ed4de2dffbdf407a0d091067)), closes [#14682](https://github.com/bitnami/charts/issues/14682)
+* [bitnami/redmine] Don't regenerate self-signed certs on upgrade (#14657) ([3ce31ca](https://github.com/bitnami/charts/commit/3ce31ca0847f72d27c8280529008b79ee1de6b06)), closes [#14657](https://github.com/bitnami/charts/issues/14657)
+* [bitnami/redmine] Release 21.0.6 (#14718) ([c2c88be](https://github.com/bitnami/charts/commit/c2c88be48ba78bdf30e4a5cc1b6a5b8b311ac590)), closes [#14718](https://github.com/bitnami/charts/issues/14718)
 
 ## <small>21.0.5 (2023-01-30)</small>
 
-* [bitnami/*] Add license annotation and remove obsolete engine parameter (#14293) ([da2a794](https://github.com/bitnami/charts/commit/da2a794)), closes [#14293](https://github.com/bitnami/charts/issues/14293)
-* [bitnami/*] Change licenses annotation format (#14377) ([0ab7608](https://github.com/bitnami/charts/commit/0ab7608)), closes [#14377](https://github.com/bitnami/charts/issues/14377)
-* [bitnami/*] Unify READMEs (#14472) ([2064fb8](https://github.com/bitnami/charts/commit/2064fb8)), closes [#14472](https://github.com/bitnami/charts/issues/14472)
-* [bitnami/redmine] Release 21.0.5 (#14670) ([88f7b44](https://github.com/bitnami/charts/commit/88f7b44)), closes [#14670](https://github.com/bitnami/charts/issues/14670)
+* [bitnami/*] Add license annotation and remove obsolete engine parameter (#14293) ([da2a794](https://github.com/bitnami/charts/commit/da2a7943bae95b6e9b5b4ed972c15e990b69fdb0)), closes [#14293](https://github.com/bitnami/charts/issues/14293)
+* [bitnami/*] Change licenses annotation format (#14377) ([0ab7608](https://github.com/bitnami/charts/commit/0ab760862c660fcc78cffadf8e1d8cdd70881473)), closes [#14377](https://github.com/bitnami/charts/issues/14377)
+* [bitnami/*] Unify READMEs (#14472) ([2064fb8](https://github.com/bitnami/charts/commit/2064fb8dcc78a845cdede8211af8c3cc52551161)), closes [#14472](https://github.com/bitnami/charts/issues/14472)
+* [bitnami/redmine] Release 21.0.5 (#14670) ([88f7b44](https://github.com/bitnami/charts/commit/88f7b44278a795d50c26bbf6a657cca9c926f1b9)), closes [#14670](https://github.com/bitnami/charts/issues/14670)
 
 ## <small>21.0.4 (2022-12-31)</small>
 
-* [bitnami/redmine] Release 21.0.4 (#14146) ([a091f55](https://github.com/bitnami/charts/commit/a091f55)), closes [#14146](https://github.com/bitnami/charts/issues/14146)
+* [bitnami/redmine] Release 21.0.4 (#14146) ([a091f55](https://github.com/bitnami/charts/commit/a091f5561c373ca84387e161218f36a49de37295)), closes [#14146](https://github.com/bitnami/charts/issues/14146)
 
 ## <small>21.0.3 (2022-12-01)</small>
 
-* [bitnami/redmine] Release 21.0.3 (#13796) ([acb9842](https://github.com/bitnami/charts/commit/acb9842)), closes [#13796](https://github.com/bitnami/charts/issues/13796)
+* [bitnami/redmine] Release 21.0.3 (#13796) ([acb9842](https://github.com/bitnami/charts/commit/acb984227719fe8b48db8eb79b781d18d6b7e817)), closes [#13796](https://github.com/bitnami/charts/issues/13796)
 
 ## <small>21.0.2 (2022-11-29)</small>
 
-* [bitnami/redmine] Release 21.0.2 (#13737) ([5f55a4c](https://github.com/bitnami/charts/commit/5f55a4c)), closes [#13737](https://github.com/bitnami/charts/issues/13737)
+* [bitnami/redmine] Release 21.0.2 (#13737) ([5f55a4c](https://github.com/bitnami/charts/commit/5f55a4c1b6d497f7accc01ffa4e91319393c5146)), closes [#13737](https://github.com/bitnami/charts/issues/13737)
 
 ## <small>21.0.1 (2022-11-01)</small>
 
-* [bitnami/redmine] Release 21.0.1 (#13298) ([14a5191](https://github.com/bitnami/charts/commit/14a5191)), closes [#13298](https://github.com/bitnami/charts/issues/13298)
+* [bitnami/redmine] Release 21.0.1 (#13298) ([14a5191](https://github.com/bitnami/charts/commit/14a51915fa900ee761fff62cfb0ab34dfc0f18cc)), closes [#13298](https://github.com/bitnami/charts/issues/13298)
 
 ## 21.0.0 (2022-10-28)
 
-* [bitnami/redmine] Update dependencies (#13222) ([4ec4833](https://github.com/bitnami/charts/commit/4ec4833)), closes [#13222](https://github.com/bitnami/charts/issues/13222)
+* [bitnami/redmine] Update dependencies (#13222) ([4ec4833](https://github.com/bitnami/charts/commit/4ec48338b88c1247596b9ffb0c041f3310fa8063)), closes [#13222](https://github.com/bitnami/charts/issues/13222)
 
 ## <small>20.3.8 (2022-10-26)</small>
 
-* [bitnami/*] Use new default branch name in links (#12943) ([a529e02](https://github.com/bitnami/charts/commit/a529e02)), closes [#12943](https://github.com/bitnami/charts/issues/12943)
-* fix apiversion hardcode for cronjob (#13111) ([a9f7f3d](https://github.com/bitnami/charts/commit/a9f7f3d)), closes [#13111](https://github.com/bitnami/charts/issues/13111)
+* [bitnami/*] Use new default branch name in links (#12943) ([a529e02](https://github.com/bitnami/charts/commit/a529e02597d49d944eba1eb0f190713293247176)), closes [#12943](https://github.com/bitnami/charts/issues/12943)
+* fix apiversion hardcode for cronjob (#13111) ([a9f7f3d](https://github.com/bitnami/charts/commit/a9f7f3d20cfe6d58bf9ed9f6cdafa7cdf6074167)), closes [#13111](https://github.com/bitnami/charts/issues/13111)
 
 ## <small>20.3.7 (2022-10-06)</small>
 
-* [bitnami/redmine] Use custom probes if given (#12554) ([23320a4](https://github.com/bitnami/charts/commit/23320a4)), closes [#12554](https://github.com/bitnami/charts/issues/12554) [#12354](https://github.com/bitnami/charts/issues/12354)
-* Generic README instructions related to the repo (#12792) ([3cf6b10](https://github.com/bitnami/charts/commit/3cf6b10)), closes [#12792](https://github.com/bitnami/charts/issues/12792)
+* [bitnami/redmine] Use custom probes if given (#12554) ([23320a4](https://github.com/bitnami/charts/commit/23320a44277861cd8ad03ae5f5e943411f20d109)), closes [#12554](https://github.com/bitnami/charts/issues/12554) [#12354](https://github.com/bitnami/charts/issues/12354)
+* Generic README instructions related to the repo (#12792) ([3cf6b10](https://github.com/bitnami/charts/commit/3cf6b10e10e60df4b3e191d6b99aa99a9f597755)), closes [#12792](https://github.com/bitnami/charts/issues/12792)
 
 ## <small>20.3.6 (2022-10-04)</small>
 
-* [bitnami/redmine]  External MariaDB secret name is wrong (#12384) (#12779) ([64cd330](https://github.com/bitnami/charts/commit/64cd330)), closes [#12384](https://github.com/bitnami/charts/issues/12384) [#12779](https://github.com/bitnami/charts/issues/12779) [#12384](https://github.com/bitnami/charts/issues/12384) [#12384](https://github.com/bitnami/charts/issues/12384)
+* [bitnami/redmine]  External MariaDB secret name is wrong (#12384) (#12779) ([64cd330](https://github.com/bitnami/charts/commit/64cd330ae000f848c0ab51f6ec51ef5bb088a740)), closes [#12384](https://github.com/bitnami/charts/issues/12384) [#12779](https://github.com/bitnami/charts/issues/12779) [#12384](https://github.com/bitnami/charts/issues/12384) [#12384](https://github.com/bitnami/charts/issues/12384)
 
 ## <small>20.3.5 (2022-10-02)</small>
 
-* [bitnami/redmine] Release 20.3.5 (#12788) ([7edec0d](https://github.com/bitnami/charts/commit/7edec0d)), closes [#12788](https://github.com/bitnami/charts/issues/12788)
+* [bitnami/redmine] Release 20.3.5 (#12788) ([7edec0d](https://github.com/bitnami/charts/commit/7edec0dfec40937925581e45159a0627e3d1edad)), closes [#12788](https://github.com/bitnami/charts/issues/12788)
 
 ## <small>20.3.4 (2022-09-24)</small>
 
-* [bitnami/redmine] Release 20.3.4 (#12662) ([9e15346](https://github.com/bitnami/charts/commit/9e15346)), closes [#12662](https://github.com/bitnami/charts/issues/12662)
+* [bitnami/redmine] Release 20.3.4 (#12662) ([9e15346](https://github.com/bitnami/charts/commit/9e15346368a58970bfe079d242e8ea78bc2618ef)), closes [#12662](https://github.com/bitnami/charts/issues/12662)
 
 ## <small>20.3.3 (2022-08-25)</small>
 
-* [bitnami/redmine] Release 20.3.3 (#12147) ([2f6e01e](https://github.com/bitnami/charts/commit/2f6e01e)), closes [#12147](https://github.com/bitnami/charts/issues/12147)
+* [bitnami/redmine] Release 20.3.3 (#12147) ([2f6e01e](https://github.com/bitnami/charts/commit/2f6e01ef0389bfb7a681930204fc59bc6463cd8e)), closes [#12147](https://github.com/bitnami/charts/issues/12147)
 
 ## <small>20.3.2 (2022-08-23)</small>
 
-* [bitnami/redmine] Update Chart.lock (#12113) ([8b72a4e](https://github.com/bitnami/charts/commit/8b72a4e)), closes [#12113](https://github.com/bitnami/charts/issues/12113)
+* [bitnami/redmine] Update Chart.lock (#12113) ([8b72a4e](https://github.com/bitnami/charts/commit/8b72a4e811abcb46f00f5cc75d993c052e30bc7d)), closes [#12113](https://github.com/bitnami/charts/issues/12113)
 
 ## <small>20.3.1 (2022-08-22)</small>
 
-* [bitnami/redmine] Update Chart.lock (#11983) ([e85b19f](https://github.com/bitnami/charts/commit/e85b19f)), closes [#11983](https://github.com/bitnami/charts/issues/11983)
+* [bitnami/redmine] Update Chart.lock (#11983) ([e85b19f](https://github.com/bitnami/charts/commit/e85b19f992271b3f4c89f76b88b869b2341f0133)), closes [#11983](https://github.com/bitnami/charts/issues/11983)
 
 ## 20.3.0 (2022-08-22)
 
-* [bitnami/redmine] Add support for image digest apart from tag (#11935) ([4c55205](https://github.com/bitnami/charts/commit/4c55205)), closes [#11935](https://github.com/bitnami/charts/issues/11935)
+* [bitnami/redmine] Add support for image digest apart from tag (#11935) ([4c55205](https://github.com/bitnami/charts/commit/4c55205fbe7eb7baec6acbccd93f35ce2b3447db)), closes [#11935](https://github.com/bitnami/charts/issues/11935)
 
 ## <small>20.2.20 (2022-08-17)</small>
 
-* [bitnami/redmine] Release 20.2.20 (#11815) ([d15a210](https://github.com/bitnami/charts/commit/d15a210)), closes [#11815](https://github.com/bitnami/charts/issues/11815)
+* [bitnami/redmine] Release 20.2.20 (#11815) ([d15a210](https://github.com/bitnami/charts/commit/d15a21036e8c03edb419d9829df1fa4a66ca9d47)), closes [#11815](https://github.com/bitnami/charts/issues/11815)
 
 ## <small>20.2.19 (2022-08-09)</small>
 
-* [bitnami/redmine] Release 20.2.19 (#11695) ([04e63e3](https://github.com/bitnami/charts/commit/04e63e3)), closes [#11695](https://github.com/bitnami/charts/issues/11695)
+* [bitnami/redmine] Release 20.2.19 (#11695) ([04e63e3](https://github.com/bitnami/charts/commit/04e63e3ec626c7213c4051a6f106d1fb7f376f96)), closes [#11695](https://github.com/bitnami/charts/issues/11695)
 
 ## <small>20.2.18 (2022-08-08)</small>
 
-* Fix helm syntax error (#11628) ([2ff96cc](https://github.com/bitnami/charts/commit/2ff96cc)), closes [#11628](https://github.com/bitnami/charts/issues/11628)
+* Fix helm syntax error (#11628) ([2ff96cc](https://github.com/bitnami/charts/commit/2ff96ccef60900a6c22a9e5bd2f6f8af71f55572)), closes [#11628](https://github.com/bitnami/charts/issues/11628)
 
 ## <small>20.2.17 (2022-08-03)</small>
 
-* [bitnami/redmine] Release 20.2.17 (#11539) ([3c7d65a](https://github.com/bitnami/charts/commit/3c7d65a)), closes [#11539](https://github.com/bitnami/charts/issues/11539)
+* [bitnami/redmine] Release 20.2.17 (#11539) ([3c7d65a](https://github.com/bitnami/charts/commit/3c7d65a91d0a2acccfe74807a6d2974eea0706fd)), closes [#11539](https://github.com/bitnami/charts/issues/11539)
 
 ## <small>20.2.16 (2022-07-27)</small>
 
-* [bitnami/redmine] Release 20.2.16 (#11388) ([6da3db6](https://github.com/bitnami/charts/commit/6da3db6)), closes [#11388](https://github.com/bitnami/charts/issues/11388)
+* [bitnami/redmine] Release 20.2.16 (#11388) ([6da3db6](https://github.com/bitnami/charts/commit/6da3db6aec5d8a1de5ce38b77c5bb4ccc21885a7)), closes [#11388](https://github.com/bitnami/charts/issues/11388)
 
 ## <small>20.2.15 (2022-07-27)</small>
 
-* [bitnami/*] Update URLs to point to the new bitnami/containers monorepo (#11352) ([d665af0](https://github.com/bitnami/charts/commit/d665af0)), closes [#11352](https://github.com/bitnami/charts/issues/11352)
-* [bitnami/redmine] Release 20.2.15 (#11365) ([9e584a9](https://github.com/bitnami/charts/commit/9e584a9)), closes [#11365](https://github.com/bitnami/charts/issues/11365)
+* [bitnami/*] Update URLs to point to the new bitnami/containers monorepo (#11352) ([d665af0](https://github.com/bitnami/charts/commit/d665af0c708846192d8d5fb2f5f9ea65dd464ab0)), closes [#11352](https://github.com/bitnami/charts/issues/11352)
+* [bitnami/redmine] Release 20.2.15 (#11365) ([9e584a9](https://github.com/bitnami/charts/commit/9e584a9f05e0ae38394f6393e05ae29cd2203308)), closes [#11365](https://github.com/bitnami/charts/issues/11365)
 
 ## <small>20.2.14 (2022-07-12)</small>
 
-* [bitnami/redmine] Release 20.2.14 (#11148) ([cc02072](https://github.com/bitnami/charts/commit/cc02072)), closes [#11148](https://github.com/bitnami/charts/issues/11148)
+* [bitnami/redmine] Release 20.2.14 (#11148) ([cc02072](https://github.com/bitnami/charts/commit/cc02072a8917a09309ad2d4f9f330d57145416ad)), closes [#11148](https://github.com/bitnami/charts/issues/11148)
 
 ## <small>20.2.13 (2022-07-09)</small>
 
-* [bitnami/redmine] Release 20.2.13 (#11102) ([4268874](https://github.com/bitnami/charts/commit/4268874)), closes [#11102](https://github.com/bitnami/charts/issues/11102)
+* [bitnami/redmine] Release 20.2.13 (#11102) ([4268874](https://github.com/bitnami/charts/commit/4268874d94b00f7f40c68084b9279b1fdcc9526c)), closes [#11102](https://github.com/bitnami/charts/issues/11102)
 
 ## <small>20.2.12 (2022-07-06)</small>
 
-* [bitnami/redmine] Release 20.2.12 (#11058) ([10ac6ea](https://github.com/bitnami/charts/commit/10ac6ea)), closes [#11058](https://github.com/bitnami/charts/issues/11058)
+* [bitnami/redmine] Release 20.2.12 (#11058) ([10ac6ea](https://github.com/bitnami/charts/commit/10ac6ea9a866ece29c4dd781811e2756ea9ff0f4)), closes [#11058](https://github.com/bitnami/charts/issues/11058)
 
 ## <small>20.2.11 (2022-07-04)</small>
 
-* [bitnami/redmine] Release 20.2.11 (#11022) ([8afdcfe](https://github.com/bitnami/charts/commit/8afdcfe)), closes [#11022](https://github.com/bitnami/charts/issues/11022)
+* [bitnami/redmine] Release 20.2.11 (#11022) ([8afdcfe](https://github.com/bitnami/charts/commit/8afdcfe9f3e276b0cd3b85d0a6326f314b424ab2)), closes [#11022](https://github.com/bitnami/charts/issues/11022)
 
 ## <small>20.2.10 (2022-06-30)</small>
 
-* [bitnami/redmine] Release 20.2.10 (#10955) ([c664ad9](https://github.com/bitnami/charts/commit/c664ad9)), closes [#10955](https://github.com/bitnami/charts/issues/10955)
+* [bitnami/redmine] Release 20.2.10 (#10955) ([c664ad9](https://github.com/bitnami/charts/commit/c664ad9f9c290efca321d047107b57d953476dd6)), closes [#10955](https://github.com/bitnami/charts/issues/10955)
 
 ## <small>20.2.9 (2022-06-21)</small>
 
-* [bitnami/redmine] Release 20.2.9 updating components versions ([e1efdc5](https://github.com/bitnami/charts/commit/e1efdc5))
+* [bitnami/redmine] Release 20.2.9 updating components versions ([e1efdc5](https://github.com/bitnami/charts/commit/e1efdc5f29a1ebfd581be41ec530dbd001bbfb50))
 
 ## <small>20.2.8 (2022-06-13)</small>
 
-* [bitnami/redmine] Release 20.2.8 updating components versions ([b3b16c8](https://github.com/bitnami/charts/commit/b3b16c8))
+* [bitnami/redmine] Release 20.2.8 updating components versions ([b3b16c8](https://github.com/bitnami/charts/commit/b3b16c8802ea97b4e74d418977c6fe770c611925))
 
 ## <small>20.2.7 (2022-06-11)</small>
 
-* [bitnami/redmine] Release 20.2.7 updating components versions ([4a718e8](https://github.com/bitnami/charts/commit/4a718e8))
+* [bitnami/redmine] Release 20.2.7 updating components versions ([4a718e8](https://github.com/bitnami/charts/commit/4a718e857e4a35254ee718967590ab96bc310910))
 
 ## <small>20.2.6 (2022-06-10)</small>
 
-* [bitnami/redmine] Release 20.2.6 updating components versions ([6815165](https://github.com/bitnami/charts/commit/6815165))
+* [bitnami/redmine] Release 20.2.6 updating components versions ([6815165](https://github.com/bitnami/charts/commit/6815165afc4138e35532fe2f67ac713c6e4cd122))
 
 ## <small>20.2.5 (2022-06-07)</small>
 
-* [bitnami/*] Replace Kubeapps URL in READMEs (and kubeapps Chart.yaml) and remove BKPR references (#1 ([c6a7914](https://github.com/bitnami/charts/commit/c6a7914)), closes [#10600](https://github.com/bitnami/charts/issues/10600)
-* Fix tolerations and topologySpreadConstraints default values (#10642) ([8183cf9](https://github.com/bitnami/charts/commit/8183cf9)), closes [#10642](https://github.com/bitnami/charts/issues/10642)
+* [bitnami/*] Replace Kubeapps URL in READMEs (and kubeapps Chart.yaml) and remove BKPR references (#1 ([c6a7914](https://github.com/bitnami/charts/commit/c6a7914361e5aea6016fb45bf4d621edfd111d32)), closes [#10600](https://github.com/bitnami/charts/issues/10600)
+* Fix tolerations and topologySpreadConstraints default values (#10642) ([8183cf9](https://github.com/bitnami/charts/commit/8183cf9caa6f490ee5053b75df397164e498c483)), closes [#10642](https://github.com/bitnami/charts/issues/10642)
 
 ## <small>20.2.4 (2022-06-07)</small>
 
-* [bitnami/redmine] Release 20.2.4 updating components versions ([7d2684f](https://github.com/bitnami/charts/commit/7d2684f))
+* [bitnami/redmine] Release 20.2.4 updating components versions ([7d2684f](https://github.com/bitnami/charts/commit/7d2684fee594c87dd2fd7fb8afce8be381e35205))
 
 ## <small>20.2.3 (2022-06-01)</small>
 
-* [bitnami/several] Replace maintainers email by url (#10523) ([ff3cf61](https://github.com/bitnami/charts/commit/ff3cf61)), closes [#10523](https://github.com/bitnami/charts/issues/10523)
+* [bitnami/several] Replace maintainers email by url (#10523) ([ff3cf61](https://github.com/bitnami/charts/commit/ff3cf617a1680509b0f3855d17c4ccff7b29a0ff)), closes [#10523](https://github.com/bitnami/charts/issues/10523)
 
 ## <small>20.2.2 (2022-05-28)</small>
 
-* [bitnami/redmine] Release 20.2.2 updating components versions ([26f9b78](https://github.com/bitnami/charts/commit/26f9b78))
+* [bitnami/redmine] Release 20.2.2 updating components versions ([26f9b78](https://github.com/bitnami/charts/commit/26f9b78a4a76a4c0f171918f4e4706e0d9b767a8))
 
 ## <small>20.2.1 (2022-05-27)</small>
 
-* [bitnami/redmine] Release 20.2.1 updating components versions ([4329e8d](https://github.com/bitnami/charts/commit/4329e8d))
+* [bitnami/redmine] Release 20.2.1 updating components versions ([4329e8d](https://github.com/bitnami/charts/commit/4329e8d138445335746c5664ee2d41e8bd59eb46))
 
 ## 20.2.0 (2022-05-26)
 
-* [bitnami/redmine] Add missing service parameter (#10432) ([6dae995](https://github.com/bitnami/charts/commit/6dae995)), closes [#10432](https://github.com/bitnami/charts/issues/10432)
+* [bitnami/redmine] Add missing service parameter (#10432) ([6dae995](https://github.com/bitnami/charts/commit/6dae99541e917cb7c568362eb3f4421ff9da883e)), closes [#10432](https://github.com/bitnami/charts/issues/10432)
 
 ## <small>20.1.5 (2022-05-25)</small>
 
-* [bitnami/redmine] Release 20.1.5 updating components versions ([d615697](https://github.com/bitnami/charts/commit/d615697))
+* [bitnami/redmine] Release 20.1.5 updating components versions ([d615697](https://github.com/bitnami/charts/commit/d615697468fc86c5913e59a6808934cbe76bc1e0))
 
 ## <small>20.1.4 (2022-05-21)</small>
 
-* [bitnami/redmine] Release 20.1.4 updating components versions ([098a24b](https://github.com/bitnami/charts/commit/098a24b))
+* [bitnami/redmine] Release 20.1.4 updating components versions ([098a24b](https://github.com/bitnami/charts/commit/098a24b8fa65b2f5da90c785e6ed9885bedd9e54))
 
 ## <small>20.1.3 (2022-05-20)</small>
 
-* [bitnami/redmine] Release 20.1.3 updating components versions ([f53ce5b](https://github.com/bitnami/charts/commit/f53ce5b))
+* [bitnami/redmine] Release 20.1.3 updating components versions ([f53ce5b](https://github.com/bitnami/charts/commit/f53ce5b0c70c6c273b723fab95be24762195e4ba))
 
 ## <small>20.1.2 (2022-05-18)</small>
 
-* [bitnami/redmine] Release 20.1.2 updating components versions ([0fafe93](https://github.com/bitnami/charts/commit/0fafe93))
+* [bitnami/redmine] Release 20.1.2 updating components versions ([0fafe93](https://github.com/bitnami/charts/commit/0fafe9357c2224e9eaf27ef26aa20873d07d31dc))
 
 ## <small>20.1.1 (2022-05-17)</small>
 
-* [bitnami/redmine] Release 20.1.1 updating components versions ([00def3c](https://github.com/bitnami/charts/commit/00def3c))
+* [bitnami/redmine] Release 20.1.1 updating components versions ([00def3c](https://github.com/bitnami/charts/commit/00def3c0b52b1d5fb0644c7955a64c7e0d7d698d))
 
 ## 20.1.0 (2022-05-16)
 
-* [bitnami/*] add ingress extraRules feature (#10253) ([0f6cbb9](https://github.com/bitnami/charts/commit/0f6cbb9)), closes [#10253](https://github.com/bitnami/charts/issues/10253)
+* [bitnami/*] add ingress extraRules feature (#10253) ([0f6cbb9](https://github.com/bitnami/charts/commit/0f6cbb9099b0e56685cc1d36ba50340f3d7278a1)), closes [#10253](https://github.com/bitnami/charts/issues/10253)
 
 ## <small>20.0.3 (2022-05-15)</small>
 
-* [bitnami/*] Fix typo in comments (relay -> rely) (#10151) ([9cfe4a4](https://github.com/bitnami/charts/commit/9cfe4a4)), closes [#10151](https://github.com/bitnami/charts/issues/10151)
-* [bitnami/*] Remove old 'ci' files (#10171) ([5df30c4](https://github.com/bitnami/charts/commit/5df30c4)), closes [#10171](https://github.com/bitnami/charts/issues/10171)
-* [bitnami/redmine] Release 20.0.3 updating components versions ([4d7e4c4](https://github.com/bitnami/charts/commit/4d7e4c4))
+* [bitnami/*] Fix typo in comments (relay -> rely) (#10151) ([9cfe4a4](https://github.com/bitnami/charts/commit/9cfe4a48cc35851faea6be7ffb2a978d223befa0)), closes [#10151](https://github.com/bitnami/charts/issues/10151)
+* [bitnami/*] Remove old 'ci' files (#10171) ([5df30c4](https://github.com/bitnami/charts/commit/5df30c44dbd1812da8786579ce4a94917d46a6ad)), closes [#10171](https://github.com/bitnami/charts/issues/10171)
+* [bitnami/redmine] Release 20.0.3 updating components versions ([4d7e4c4](https://github.com/bitnami/charts/commit/4d7e4c471d4893ff484c741b4a6af28d9c9db3b0))
 
 ## <small>20.0.2 (2022-05-11)</small>
 
-* [bitnami/redmine] Add missing namespace metadata (#10157) ([6841683](https://github.com/bitnami/charts/commit/6841683)), closes [#10157](https://github.com/bitnami/charts/issues/10157)
+* [bitnami/redmine] Add missing namespace metadata (#10157) ([6841683](https://github.com/bitnami/charts/commit/6841683ecb1ea20581c028946112945e5920d751)), closes [#10157](https://github.com/bitnami/charts/issues/10157)
 
 ## <small>20.0.1 (2022-04-21)</small>
 
-* [bitnami/redmine] Release 20.0.1 updating components versions ([a4a1d9b](https://github.com/bitnami/charts/commit/a4a1d9b))
+* [bitnami/redmine] Release 20.0.1 updating components versions ([a4a1d9b](https://github.com/bitnami/charts/commit/a4a1d9ba657f49efaaade45b39f37eb3c3f57979))
 
 ## 20.0.0 (2022-04-21)
 
-* [bitnami/redmine] feat!: :arrow_up: Bump MariaDB version to 10.6 (#9859) ([2924e5a](https://github.com/bitnami/charts/commit/2924e5a)), closes [#9859](https://github.com/bitnami/charts/issues/9859)
+* [bitnami/redmine] feat!: :arrow_up: Bump MariaDB version to 10.6 (#9859) ([2924e5a](https://github.com/bitnami/charts/commit/2924e5a631c1f85f5b849abd2d9f3fbf536a4c85)), closes [#9859](https://github.com/bitnami/charts/issues/9859)
 
 ## <small>19.0.1 (2022-04-19)</small>
 
-* [bitnami/redmine] Release 19.0.1 updating components versions ([9bd36eb](https://github.com/bitnami/charts/commit/9bd36eb))
+* [bitnami/redmine] Release 19.0.1 updating components versions ([9bd36eb](https://github.com/bitnami/charts/commit/9bd36eb3d47847699aa021cee31edbb9d2f77498))
 
 ## 19.0.0 (2022-04-18)
 
-* [bitnami/redmine] Release 19.0.0 updating components versions ([d731c1c](https://github.com/bitnami/charts/commit/d731c1c))
+* [bitnami/redmine] Release 19.0.0 updating components versions ([d731c1c](https://github.com/bitnami/charts/commit/d731c1c164d3bea67ebb6824cd6c480116a98e56))
 
 ## <small>18.1.11 (2022-04-08)</small>
 
-* [bitnami/redmine] Release 18.1.11 updating components versions ([c88223c](https://github.com/bitnami/charts/commit/c88223c))
+* [bitnami/redmine] Release 18.1.11 updating components versions ([c88223c](https://github.com/bitnami/charts/commit/c88223c39c61a16e2c4857f9472019ed495a1f8b))
 
 ## <small>18.1.10 (2022-04-06)</small>
 
-* [bitnami/redmine] Release 18.1.10 updating components versions ([3224051](https://github.com/bitnami/charts/commit/3224051))
+* [bitnami/redmine] Release 18.1.10 updating components versions ([3224051](https://github.com/bitnami/charts/commit/32240513e86595ca26ea532a8f5cca2081a2b8a0))
 
 ## <small>18.1.9 (2022-04-02)</small>
 
-* [bitnami/redmine] Release 18.1.9 updating components versions ([be9866a](https://github.com/bitnami/charts/commit/be9866a))
+* [bitnami/redmine] Release 18.1.9 updating components versions ([be9866a](https://github.com/bitnami/charts/commit/be9866a2c69557e1f4954507c82a420abc10591d))
 
 ## <small>18.1.8 (2022-03-29)</small>
 
-* [bitnami/redmine] Release 18.1.8 updating components versions ([1e5031e](https://github.com/bitnami/charts/commit/1e5031e))
+* [bitnami/redmine] Release 18.1.8 updating components versions ([1e5031e](https://github.com/bitnami/charts/commit/1e5031e93ae17ad9190310557d43614afe65f5bc))
 
 ## <small>18.1.7 (2022-03-28)</small>
 
-* [bitnami/redmine] Release 18.1.7 updating components versions ([8660331](https://github.com/bitnami/charts/commit/8660331))
+* [bitnami/redmine] Release 18.1.7 updating components versions ([8660331](https://github.com/bitnami/charts/commit/866033187b40ee9cc78c7d94373764276b62ee3a))
 
 ## <small>18.1.6 (2022-03-28)</small>
 
-* [bitnami/redmine] Release 18.1.6 updating components versions ([7950746](https://github.com/bitnami/charts/commit/7950746))
+* [bitnami/redmine] Release 18.1.6 updating components versions ([7950746](https://github.com/bitnami/charts/commit/7950746456b739f8d96ddce787f6b046c625dccd))
 
 ## <small>18.1.5 (2022-03-27)</small>
 
-* [bitnami/redmine] Release 18.1.5 updating components versions ([b0f0ebb](https://github.com/bitnami/charts/commit/b0f0ebb))
+* [bitnami/redmine] Release 18.1.5 updating components versions ([b0f0ebb](https://github.com/bitnami/charts/commit/b0f0ebb07118db4802b9f3c5f9f9c37cb914c5bd))
 
 ## <small>18.1.4 (2022-03-25)</small>
 
-* [bitnami/redmine] Release 18.1.4 updating components versions ([483771f](https://github.com/bitnami/charts/commit/483771f))
+* [bitnami/redmine] Release 18.1.4 updating components versions ([483771f](https://github.com/bitnami/charts/commit/483771fa45d728055d12b291efd2d3a9666f4503))
 
 ## <small>18.1.3 (2022-03-18)</small>
 
-* [bitnami/redmine] Release 18.1.3 updating components versions ([eb45bde](https://github.com/bitnami/charts/commit/eb45bde))
+* [bitnami/redmine] Release 18.1.3 updating components versions ([eb45bde](https://github.com/bitnami/charts/commit/eb45bde99f2a867b14d9cd6dd4f8a63fdf35c49b))
 
 ## <small>18.1.2 (2022-03-17)</small>
 
-* [bitnami/redmine] Release 18.1.2 updating components versions ([052d796](https://github.com/bitnami/charts/commit/052d796))
+* [bitnami/redmine] Release 18.1.2 updating components versions ([052d796](https://github.com/bitnami/charts/commit/052d7967105a90cc78434d2e85a0b142f0c5d76f))
 
 ## <small>18.1.1 (2022-03-16)</small>
 
-* [bitnami/redmine] Release 18.1.1 updating components versions ([730b935](https://github.com/bitnami/charts/commit/730b935))
+* [bitnami/redmine] Release 18.1.1 updating components versions ([730b935](https://github.com/bitnami/charts/commit/730b935313c510b463df19e0ca003c558f4fe4ea))
 
 ## 18.1.0 (2022-03-11)
 
-* [bitnami/redmine] Chart standardized (#9356) ([228286b](https://github.com/bitnami/charts/commit/228286b)), closes [#9356](https://github.com/bitnami/charts/issues/9356)
+* [bitnami/redmine] Chart standardized (#9356) ([228286b](https://github.com/bitnami/charts/commit/228286b12885a06947e57bbb08a229ecce0b1d54)), closes [#9356](https://github.com/bitnami/charts/issues/9356)
 
 ## <small>18.0.5 (2022-03-10)</small>
 
-* [bitnami/redmine] Release 18.0.5 updating components versions ([55fc409](https://github.com/bitnami/charts/commit/55fc409))
+* [bitnami/redmine] Release 18.0.5 updating components versions ([55fc409](https://github.com/bitnami/charts/commit/55fc409892217fc5fc0c8a37d2cd29609327a0e4))
 
 ## <small>18.0.4 (2022-03-10)</small>
 
-* [bitnami/redmine] Release 18.0.4 updating components versions ([feb8ce1](https://github.com/bitnami/charts/commit/feb8ce1))
+* [bitnami/redmine] Release 18.0.4 updating components versions ([feb8ce1](https://github.com/bitnami/charts/commit/feb8ce1cc5daa99b1a845a9e8734d29933b019f5))
 
 ## <small>18.0.3 (2022-03-07)</small>
 
-* [bitnami/*] Take 'global.postgresql' values into account (#9314) ([dd428a0](https://github.com/bitnami/charts/commit/dd428a0)), closes [#9314](https://github.com/bitnami/charts/issues/9314)
+* [bitnami/*] Take 'global.postgresql' values into account (#9314) ([dd428a0](https://github.com/bitnami/charts/commit/dd428a06614551c92500afa84ce9750c4d8b90c9)), closes [#9314](https://github.com/bitnami/charts/issues/9314)
 
 ## <small>18.0.2 (2022-03-04)</small>
 
-* [bitnami/several] Reorder subcharts (#9299) ([a041f6b](https://github.com/bitnami/charts/commit/a041f6b)), closes [#9299](https://github.com/bitnami/charts/issues/9299)
+* [bitnami/several] Reorder subcharts (#9299) ([a041f6b](https://github.com/bitnami/charts/commit/a041f6b0ff2dea82b3d030cb99454cede94dbc9a)), closes [#9299](https://github.com/bitnami/charts/issues/9299)
 
 ## <small>18.0.1 (2022-03-02)</small>
 
-* [bitnami/redmine] Release 18.0.1 updating components versions ([eec9a5c](https://github.com/bitnami/charts/commit/eec9a5c))
+* [bitnami/redmine] Release 18.0.1 updating components versions ([eec9a5c](https://github.com/bitnami/charts/commit/eec9a5ce8752f6cc5f100a9e2eae5c8905134597))
 
 ## 18.0.0 (2022-03-02)
 
-* [bitnami/redmine] feat!: :arrow_up: Bump PostgreSQL and MariaDB Dependencies (#9262) ([4c6e1e1](https://github.com/bitnami/charts/commit/4c6e1e1)), closes [#9262](https://github.com/bitnami/charts/issues/9262)
+* [bitnami/redmine] feat!: :arrow_up: Bump PostgreSQL and MariaDB Dependencies (#9262) ([4c6e1e1](https://github.com/bitnami/charts/commit/4c6e1e18aaf8d9f59fb8957aa26ca385cea7bc10)), closes [#9262](https://github.com/bitnami/charts/issues/9262)
 
 ## <small>17.2.10 (2022-03-02)</small>
 
-* [bitnami/redmine] Release 17.2.10 updating components versions ([618fb84](https://github.com/bitnami/charts/commit/618fb84))
+* [bitnami/redmine] Release 17.2.10 updating components versions ([618fb84](https://github.com/bitnami/charts/commit/618fb84cf7207c03f98cba8f01330b04cce0b5d6))
 
 ## <small>17.2.9 (2022-02-27)</small>
 
-* [bitnami/redmine] Release 17.2.9 updating components versions ([0ee0ba7](https://github.com/bitnami/charts/commit/0ee0ba7))
+* [bitnami/redmine] Release 17.2.9 updating components versions ([0ee0ba7](https://github.com/bitnami/charts/commit/0ee0ba7a3b756fcd6ed5d9890d08a320e8af7644))
 
 ## <small>17.2.8 (2022-02-23)</small>
 
-* [bitnami/redmine] Release 17.2.8 updating components versions ([eb9018b](https://github.com/bitnami/charts/commit/eb9018b))
+* [bitnami/redmine] Release 17.2.8 updating components versions ([eb9018b](https://github.com/bitnami/charts/commit/eb9018beb19b45b15f83e46a1ca06b095eadc54a))
 
 ## <small>17.2.7 (2022-02-23)</small>
 
-* [bitnami/redmine] Release 17.2.7 updating components versions ([df75d3e](https://github.com/bitnami/charts/commit/df75d3e))
+* [bitnami/redmine] Release 17.2.7 updating components versions ([df75d3e](https://github.com/bitnami/charts/commit/df75d3eb5738234ded8735535322778c08ce74ca))
 
 ## <small>17.2.6 (2022-02-21)</small>
 
-* [bitnami/redmine] Do not hardcode PDB apiVersion (#9116) ([aaea440](https://github.com/bitnami/charts/commit/aaea440)), closes [#9116](https://github.com/bitnami/charts/issues/9116)
+* [bitnami/redmine] Do not hardcode PDB apiVersion (#9116) ([aaea440](https://github.com/bitnami/charts/commit/aaea440c9e1dda73fccf40ac6a169e87e94e6d1a)), closes [#9116](https://github.com/bitnami/charts/issues/9116)
 
 ## <small>17.2.5 (2022-02-13)</small>
 
-* [bitnami/redmine] Release 17.2.5 updating components versions ([45a4333](https://github.com/bitnami/charts/commit/45a4333))
-* Non utf8 chars (#8923) ([6ffd18f](https://github.com/bitnami/charts/commit/6ffd18f)), closes [#8923](https://github.com/bitnami/charts/issues/8923)
+* [bitnami/redmine] Release 17.2.5 updating components versions ([45a4333](https://github.com/bitnami/charts/commit/45a433346bb9e907a2df4b501e912605066f3970))
+* Non utf8 chars (#8923) ([6ffd18f](https://github.com/bitnami/charts/commit/6ffd18fbbdf10e94ea1a90cf5b84ef610ac2a72d)), closes [#8923](https://github.com/bitnami/charts/issues/8923)
 
 ## <small>17.2.4 (2022-02-02)</small>
 
-* [bitnami/*] Make use of new "common.ingress.certManagerRequest" helper (#8862) ([12e4c37](https://github.com/bitnami/charts/commit/12e4c37)), closes [#8862](https://github.com/bitnami/charts/issues/8862)
+* [bitnami/*] Make use of new "common.ingress.certManagerRequest" helper (#8862) ([12e4c37](https://github.com/bitnami/charts/commit/12e4c3733eaeaa9a5579fdf917fa098a0f2aae23)), closes [#8862](https://github.com/bitnami/charts/issues/8862)
 
 ## <small>17.2.3 (2022-01-25)</small>
 
-* [bitnami/redmine] Add IngressClassName (#8758) ([241e4ca](https://github.com/bitnami/charts/commit/241e4ca)), closes [#8758](https://github.com/bitnami/charts/issues/8758)
+* [bitnami/redmine] Add IngressClassName (#8758) ([241e4ca](https://github.com/bitnami/charts/commit/241e4caaaca1a1cdfb5090e4ce69e4af6ba96491)), closes [#8758](https://github.com/bitnami/charts/issues/8758)
 
 ## <small>17.2.2 (2022-01-20)</small>
 
-* [bitnami/*] Readme automation (#8579) ([78d1938](https://github.com/bitnami/charts/commit/78d1938)), closes [#8579](https://github.com/bitnami/charts/issues/8579)
-* [bitnami/*] Update READMEs (#8716) ([b9a9533](https://github.com/bitnami/charts/commit/b9a9533)), closes [#8716](https://github.com/bitnami/charts/issues/8716)
-* [bitnami/redmine] Change default updateStrategy.rollingUpdate from {} to null (#8678) ([7413d5c](https://github.com/bitnami/charts/commit/7413d5c)), closes [#8678](https://github.com/bitnami/charts/issues/8678) [#8539](https://github.com/bitnami/charts/issues/8539)
-* [bitnami/several] Change prerequisites (#8725) ([8d740c5](https://github.com/bitnami/charts/commit/8d740c5)), closes [#8725](https://github.com/bitnami/charts/issues/8725)
+* [bitnami/*] Readme automation (#8579) ([78d1938](https://github.com/bitnami/charts/commit/78d193831c900d178198491ffd08fa2217a64ecd)), closes [#8579](https://github.com/bitnami/charts/issues/8579)
+* [bitnami/*] Update READMEs (#8716) ([b9a9533](https://github.com/bitnami/charts/commit/b9a953337590eb2979453385874a267bacf50936)), closes [#8716](https://github.com/bitnami/charts/issues/8716)
+* [bitnami/redmine] Change default updateStrategy.rollingUpdate from {} to null (#8678) ([7413d5c](https://github.com/bitnami/charts/commit/7413d5c167b36bb366bac3a7779dc4b6fe23787b)), closes [#8678](https://github.com/bitnami/charts/issues/8678) [#8539](https://github.com/bitnami/charts/issues/8539)
+* [bitnami/several] Change prerequisites (#8725) ([8d740c5](https://github.com/bitnami/charts/commit/8d740c566cfdb7e2d933c40128b4e919fce953a5)), closes [#8725](https://github.com/bitnami/charts/issues/8725)
 
 ## <small>17.2.1 (2022-01-16)</small>
 
-* [bitnami/redmine] Release 17.2.1 updating components versions ([263a20e](https://github.com/bitnami/charts/commit/263a20e))
+* [bitnami/redmine] Release 17.2.1 updating components versions ([263a20e](https://github.com/bitnami/charts/commit/263a20efe48be1f152f0ed4d6a2e1b16a0f25d2a))
 
 ## 17.2.0 (2022-01-05)
 
-* [bitnami/several] Adapt templating format (#8562) ([8cad18a](https://github.com/bitnami/charts/commit/8cad18a)), closes [#8562](https://github.com/bitnami/charts/issues/8562)
-* [bitnami/several] Add license to the README ([05f7633](https://github.com/bitnami/charts/commit/05f7633))
-* [bitnami/several] Add license to the README ([32fb238](https://github.com/bitnami/charts/commit/32fb238))
-* [bitnami/several] Add license to the README ([b87c2f7](https://github.com/bitnami/charts/commit/b87c2f7))
+* [bitnami/several] Adapt templating format (#8562) ([8cad18a](https://github.com/bitnami/charts/commit/8cad18aed9966a6f0208e5ad6cee46cb217f47ab)), closes [#8562](https://github.com/bitnami/charts/issues/8562)
+* [bitnami/several] Add license to the README ([05f7633](https://github.com/bitnami/charts/commit/05f763372501d596e57db713dd53ff4ff3027cc4))
+* [bitnami/several] Add license to the README ([32fb238](https://github.com/bitnami/charts/commit/32fb238e60a0affc6debd3142eaa3c3d9089ec2a))
+* [bitnami/several] Add license to the README ([b87c2f7](https://github.com/bitnami/charts/commit/b87c2f7899d48a8b02c506765e6ae82937e9ba3f))
 
 ## <small>17.1.3 (2021-12-17)</small>
 
-* [bitnami/redmine] Release 17.1.3 updating components versions ([b6df613](https://github.com/bitnami/charts/commit/b6df613))
+* [bitnami/redmine] Release 17.1.3 updating components versions ([b6df613](https://github.com/bitnami/charts/commit/b6df6139b9001c110bc94bcaeee19a3146ea0f78))
 
 ## <small>17.1.2 (2021-12-13)</small>
 
-* bitnami/redmine Fixing 8314: point to correct externalDatabase name (#8315) ([6b5efeb](https://github.com/bitnami/charts/commit/6b5efeb)), closes [#8315](https://github.com/bitnami/charts/issues/8315)
+* bitnami/redmine Fixing 8314: point to correct externalDatabase name (#8315) ([6b5efeb](https://github.com/bitnami/charts/commit/6b5efeb05b01d2c2ed2a6d324669f76e18bd73e2)), closes [#8315](https://github.com/bitnami/charts/issues/8315)
 
 ## <small>17.1.1 (2021-11-29)</small>
 
-* [bitnami/several] Add 'community support' note to some Helm chart READMEs (#8148) ([ce6b838](https://github.com/bitnami/charts/commit/ce6b838)), closes [#8148](https://github.com/bitnami/charts/issues/8148)
-* [bitnami/several] Fix deadlinks in README.md (#8215) ([99e90d2](https://github.com/bitnami/charts/commit/99e90d2)), closes [#8215](https://github.com/bitnami/charts/issues/8215)
-* [bitnami/several] Regenerate README tables ([7b091c0](https://github.com/bitnami/charts/commit/7b091c0))
-* [bitnami/several] Replace HTTP by HTTPS when possible (#8259) ([eafb5bd](https://github.com/bitnami/charts/commit/eafb5bd)), closes [#8259](https://github.com/bitnami/charts/issues/8259)
+* [bitnami/several] Add 'community support' note to some Helm chart READMEs (#8148) ([ce6b838](https://github.com/bitnami/charts/commit/ce6b83829ac261c04784d7818c9cfa844f403213)), closes [#8148](https://github.com/bitnami/charts/issues/8148)
+* [bitnami/several] Fix deadlinks in README.md (#8215) ([99e90d2](https://github.com/bitnami/charts/commit/99e90d244b3244e059a42f72dcbecd3cda2b66bb)), closes [#8215](https://github.com/bitnami/charts/issues/8215)
+* [bitnami/several] Regenerate README tables ([7b091c0](https://github.com/bitnami/charts/commit/7b091c0808ef00425c404cb97fe73c0578ccf1a3))
+* [bitnami/several] Replace HTTP by HTTPS when possible (#8259) ([eafb5bd](https://github.com/bitnami/charts/commit/eafb5bd5a2cc3aaf04fc1e8ebedd73f420d76864)), closes [#8259](https://github.com/bitnami/charts/issues/8259)
 
 ## 17.1.0 (2021-11-17)
 
-* [bitnami/*] Add network policies - fourth batch (#8154) ([5816c03](https://github.com/bitnami/charts/commit/5816c03)), closes [#8154](https://github.com/bitnami/charts/issues/8154)
-* [bitnami/several] Regenerate README tables ([1cde837](https://github.com/bitnami/charts/commit/1cde837))
+* [bitnami/*] Add network policies - fourth batch (#8154) ([5816c03](https://github.com/bitnami/charts/commit/5816c036207fdd537d76278adff4342cbc35dc52)), closes [#8154](https://github.com/bitnami/charts/issues/8154)
+* [bitnami/several] Regenerate README tables ([1cde837](https://github.com/bitnami/charts/commit/1cde8378b3ee2e825ac07bb0266a988b95b8dbce))
 
 ## <small>17.0.13 (2021-11-17)</small>
 
-* [bitnami/redmine] Release 17.0.13 updating components versions ([4ae8a6d](https://github.com/bitnami/charts/commit/4ae8a6d))
-* [bitnami/several] Regenerate README tables ([6e3fb95](https://github.com/bitnami/charts/commit/6e3fb95))
+* [bitnami/redmine] Release 17.0.13 updating components versions ([4ae8a6d](https://github.com/bitnami/charts/commit/4ae8a6d83bc6eee88e80758f91240e67c97027e0))
+* [bitnami/several] Regenerate README tables ([6e3fb95](https://github.com/bitnami/charts/commit/6e3fb954296a91f83fc1654d77109e5ef4fb6dc0))
 
 ## <small>17.0.12 (2021-10-27)</small>
 
-* [bitnami/redmine] Release 17.0.12 updating components versions ([d198c10](https://github.com/bitnami/charts/commit/d198c10))
+* [bitnami/redmine] Release 17.0.12 updating components versions ([d198c10](https://github.com/bitnami/charts/commit/d198c10246216c6e1e5304ce66fad65d9456160e))
 
 ## <small>17.0.11 (2021-10-22)</small>
 
-* [bitnami/several] Add chart info to NOTES.txt (#7889) ([a6751cd](https://github.com/bitnami/charts/commit/a6751cd)), closes [#7889](https://github.com/bitnami/charts/issues/7889)
-* [bitnami/several] Regenerate README tables ([194a909](https://github.com/bitnami/charts/commit/194a909))
+* [bitnami/several] Add chart info to NOTES.txt (#7889) ([a6751cd](https://github.com/bitnami/charts/commit/a6751cdd33c461fabbc459fbea6f219ec64ab6b2)), closes [#7889](https://github.com/bitnami/charts/issues/7889)
+* [bitnami/several] Regenerate README tables ([194a909](https://github.com/bitnami/charts/commit/194a909268377a6820d91f788c0380f427637ce6))
 
 ## <small>17.0.10 (2021-10-10)</small>
 
-* [bitnami/redmine] Release 17.0.10 updating components versions ([4026954](https://github.com/bitnami/charts/commit/4026954))
+* [bitnami/redmine] Release 17.0.10 updating components versions ([4026954](https://github.com/bitnami/charts/commit/402695402158fdf2fc767f4b356f509855da3ce1))
 
 ## <small>17.0.9 (2021-09-30)</small>
 
-* [bitnami/*] Drop support for deprecated cert-manager annotation (#7656) ([bbf403b](https://github.com/bitnami/charts/commit/bbf403b)), closes [#7656](https://github.com/bitnami/charts/issues/7656)
-* [bitnami/several] Regenerate README tables ([ff170d1](https://github.com/bitnami/charts/commit/ff170d1))
+* [bitnami/*] Drop support for deprecated cert-manager annotation (#7656) ([bbf403b](https://github.com/bitnami/charts/commit/bbf403bae78be53430fbf13e462f9bd1eeb5bf04)), closes [#7656](https://github.com/bitnami/charts/issues/7656)
+* [bitnami/several] Regenerate README tables ([ff170d1](https://github.com/bitnami/charts/commit/ff170d10f8aa6dae0f1e5c3f7d1c69fcec96b731))
 
 ## <small>17.0.8 (2021-09-26)</small>
 
-* [bitnami/*] Generate READMEs with new generator version (#7614) ([e5ab2e6](https://github.com/bitnami/charts/commit/e5ab2e6)), closes [#7614](https://github.com/bitnami/charts/issues/7614)
-* [bitnami/redmine] Release 17.0.8 updating components versions ([2177e5f](https://github.com/bitnami/charts/commit/2177e5f))
+* [bitnami/*] Generate READMEs with new generator version (#7614) ([e5ab2e6](https://github.com/bitnami/charts/commit/e5ab2e6ecdd6bce800863f154cda524ff9f6c117)), closes [#7614](https://github.com/bitnami/charts/issues/7614)
+* [bitnami/redmine] Release 17.0.8 updating components versions ([2177e5f](https://github.com/bitnami/charts/commit/2177e5fd2063a621602df2352d097c023f42114c))
 
 ## <small>17.0.7 (2021-09-07)</small>
 
-* [bitnami/redmine] Missing env var in cronjob.yaml (#7386) ([04f41bd](https://github.com/bitnami/charts/commit/04f41bd)), closes [#7386](https://github.com/bitnami/charts/issues/7386)
-* [bitnami/several] Regenerate README tables ([64d5d74](https://github.com/bitnami/charts/commit/64d5d74))
+* [bitnami/redmine] Missing env var in cronjob.yaml (#7386) ([04f41bd](https://github.com/bitnami/charts/commit/04f41bda9c2cc83a62601c4014dd2173fa350ece)), closes [#7386](https://github.com/bitnami/charts/issues/7386)
+* [bitnami/several] Regenerate README tables ([64d5d74](https://github.com/bitnami/charts/commit/64d5d747b84299ca9f63ea8a586b13870abe31a6))
 
 ## <small>17.0.6 (2021-08-27)</small>
 
-* [bitnami/redmine] Release 17.0.6 updating components versions ([8cfde20](https://github.com/bitnami/charts/commit/8cfde20))
-* [bitnami/several] Regenerate README tables ([da2513b](https://github.com/bitnami/charts/commit/da2513b))
+* [bitnami/redmine] Release 17.0.6 updating components versions ([8cfde20](https://github.com/bitnami/charts/commit/8cfde20c341e804573bec1ea06d8b0d984b6e20c))
+* [bitnami/several] Regenerate README tables ([da2513b](https://github.com/bitnami/charts/commit/da2513bf0a33819f3b1151d387c631a9ffdb03e2))
 
 ## <small>17.0.5 (2021-08-26)</small>
 
-* [bitnami/redmine] Release 17.0.5 updating components versions ([a964260](https://github.com/bitnami/charts/commit/a964260))
-* [bitnami/several] Regenerate README tables ([6c9124f](https://github.com/bitnami/charts/commit/6c9124f))
+* [bitnami/redmine] Release 17.0.5 updating components versions ([a964260](https://github.com/bitnami/charts/commit/a9642603c4e7289db13bb2d940cdafeb1a087740))
+* [bitnami/several] Regenerate README tables ([6c9124f](https://github.com/bitnami/charts/commit/6c9124f79491aa65f53a87c1ed598b47ffa8b411))
 
 ## <small>17.0.4 (2021-08-18)</small>
 
-* [bitnami/redmine] Release 17.0.4 updating components versions ([303634a](https://github.com/bitnami/charts/commit/303634a))
+* [bitnami/redmine] Release 17.0.4 updating components versions ([303634a](https://github.com/bitnami/charts/commit/303634a2030582e8ff3501d9124ce0f924ad41c3))
 
 ## <small>17.0.3 (2021-08-17)</small>
 
-* [bitnami/redmine] fix port number setting for postgresql (#7236) ([2eaee0e](https://github.com/bitnami/charts/commit/2eaee0e)), closes [#7236](https://github.com/bitnami/charts/issues/7236)
-* [bitnami/several] Regenerate README tables ([6c107e8](https://github.com/bitnami/charts/commit/6c107e8))
+* [bitnami/redmine] fix port number setting for postgresql (#7236) ([2eaee0e](https://github.com/bitnami/charts/commit/2eaee0e4b6e26d88b326354fe2118fa1787f8cc1)), closes [#7236](https://github.com/bitnami/charts/issues/7236)
+* [bitnami/several] Regenerate README tables ([6c107e8](https://github.com/bitnami/charts/commit/6c107e835d6caf8db2e8b17dcd48c5971637e013))
 
 ## <small>17.0.2 (2021-08-05)</small>
 
-* [charts/redmine] Fix example for customPostInitScripts (#7112) ([c10c7f4](https://github.com/bitnami/charts/commit/c10c7f4)), closes [#7112](https://github.com/bitnami/charts/issues/7112)
+* [charts/redmine] Fix example for customPostInitScripts (#7112) ([c10c7f4](https://github.com/bitnami/charts/commit/c10c7f4015d1ed0bf52ed10f9cd0cc6fb7d94910)), closes [#7112](https://github.com/bitnami/charts/issues/7112)
 
 ## <small>17.0.1 (2021-08-02)</small>
 
-* [bitnami/redmine] Release 17.0.1 updating components versions ([6b55d22](https://github.com/bitnami/charts/commit/6b55d22))
+* [bitnami/redmine] Release 17.0.1 updating components versions ([6b55d22](https://github.com/bitnami/charts/commit/6b55d2232c0d8f15f7e9537cfc6034d91b7d92f9))
 
 ## 17.0.0 (2021-08-02)
 
-* [bitnami/several] Simplify image definition logic removing duplications (#7114) ([43e4eee](https://github.com/bitnami/charts/commit/43e4eee)), closes [#7114](https://github.com/bitnami/charts/issues/7114)
+* [bitnami/several] Simplify image definition logic removing duplications (#7114) ([43e4eee](https://github.com/bitnami/charts/commit/43e4eee921209ca662c7902668b09b3b1a1d28a9)), closes [#7114](https://github.com/bitnami/charts/issues/7114)
 
 ## <small>16.0.2 (2021-08-01)</small>
 
-* [bitnami/redmine] add postinint configmap (#6998) ([9d3c782](https://github.com/bitnami/charts/commit/9d3c782)), closes [#6998](https://github.com/bitnami/charts/issues/6998)
-* [bitnami/redmine] Release 16.0.2 updating components versions ([2a1c85c](https://github.com/bitnami/charts/commit/2a1c85c))
+* [bitnami/redmine] add postinint configmap (#6998) ([9d3c782](https://github.com/bitnami/charts/commit/9d3c782170b0fefe5d8b42a5af37348ff0163b2d)), closes [#6998](https://github.com/bitnami/charts/issues/6998)
+* [bitnami/redmine] Release 16.0.2 updating components versions ([2a1c85c](https://github.com/bitnami/charts/commit/2a1c85c4906c5918493c357d3e404b400a1efd02))
 
 ## <small>16.0.1 (2021-07-21)</small>
 
-* [bitnami/*] Replace nil values (#6993) ([2be11a7](https://github.com/bitnami/charts/commit/2be11a7)), closes [#6993](https://github.com/bitnami/charts/issues/6993)
+* [bitnami/*] Replace nil values (#6993) ([2be11a7](https://github.com/bitnami/charts/commit/2be11a70b92a01603c1f079eeaff4b00dc4796d6)), closes [#6993](https://github.com/bitnami/charts/issues/6993)
 
 ## 16.0.0 (2021-07-16)
 
-* [bitnami/redmine] MAJOR: Redmine image refactor (#6739) ([31bcd6c](https://github.com/bitnami/charts/commit/31bcd6c)), closes [#6739](https://github.com/bitnami/charts/issues/6739)
+* [bitnami/redmine] MAJOR: Redmine image refactor (#6739) ([31bcd6c](https://github.com/bitnami/charts/commit/31bcd6c169b666d618feb5aa8dc5df7decf5a0d9)), closes [#6739](https://github.com/bitnami/charts/issues/6739)
 
 ## <small>15.2.21 (2021-06-21)</small>
 
-* [bitnami/redmine] Release 15.2.21 updating components versions ([8cbd555](https://github.com/bitnami/charts/commit/8cbd555))
+* [bitnami/redmine] Release 15.2.21 updating components versions ([8cbd555](https://github.com/bitnami/charts/commit/8cbd555bf33e2c621febe35e9e7bda309b9cefa3))
 
 ## <small>15.2.20 (2021-06-14)</small>
 
-* [bitnami/redmine] Update mail-receiver-configmap.yaml (#6655) ([5821f57](https://github.com/bitnami/charts/commit/5821f57)), closes [#6655](https://github.com/bitnami/charts/issues/6655)
+* [bitnami/redmine] Update mail-receiver-configmap.yaml (#6655) ([5821f57](https://github.com/bitnami/charts/commit/5821f57a76cdf7992dededef45977c3021fa195f)), closes [#6655](https://github.com/bitnami/charts/issues/6655)
 
 ## <small>15.2.19 (2021-05-31)</small>
 
-* [bitnami/redmine] Release 15.2.19 updating components versions ([9c3d785](https://github.com/bitnami/charts/commit/9c3d785))
+* [bitnami/redmine] Release 15.2.19 updating components versions ([9c3d785](https://github.com/bitnami/charts/commit/9c3d7855e085cf5a072907fbd2785bb34a141aca))
 
 ## <small>15.2.18 (2021-05-26)</small>
 
-* [bitnami/redmine] Release 15.2.18 updating components versions ([b05da7c](https://github.com/bitnami/charts/commit/b05da7c))
+* [bitnami/redmine] Release 15.2.18 updating components versions ([b05da7c](https://github.com/bitnami/charts/commit/b05da7c20acdded70bb0f96b557b675a084245f0))
 
 ## <small>15.2.17 (2021-05-25)</small>
 
-* [bitnami/redmine] Release 15.2.17 updating components versions ([d3831fd](https://github.com/bitnami/charts/commit/d3831fd))
+* [bitnami/redmine] Release 15.2.17 updating components versions ([d3831fd](https://github.com/bitnami/charts/commit/d3831fd1c318d2062e1b5f23f2c618f86cf333b9))
 
 ## <small>15.2.16 (2021-05-24)</small>
 
-* [bitnami/redmine] Release 15.2.16 updating components versions ([57b5615](https://github.com/bitnami/charts/commit/57b5615))
+* [bitnami/redmine] Release 15.2.16 updating components versions ([57b5615](https://github.com/bitnami/charts/commit/57b561536b763f77741a1a5a917e240daa2dab62))
 
 ## <small>15.2.15 (2021-05-23)</small>
 
-* [bitnami/redmine] Release 15.2.15 updating components versions ([c2a097f](https://github.com/bitnami/charts/commit/c2a097f))
+* [bitnami/redmine] Release 15.2.15 updating components versions ([c2a097f](https://github.com/bitnami/charts/commit/c2a097fbec1ffa66bca002ca0d3bac433a02d4ea))
 
 ## <small>15.2.14 (2021-04-30)</small>
 
-* [bitnami/redmine] Release 15.2.14 updating components versions ([0a93c63](https://github.com/bitnami/charts/commit/0a93c63))
+* [bitnami/redmine] Release 15.2.14 updating components versions ([0a93c63](https://github.com/bitnami/charts/commit/0a93c63c8e2136951fb5d054e1b02f7470fb4723))
 
 ## <small>15.2.13 (2021-04-29)</small>
 
-* [bitnami/redmine] Release 15.2.13 updating components versions ([32dc1a8](https://github.com/bitnami/charts/commit/32dc1a8))
+* [bitnami/redmine] Release 15.2.13 updating components versions ([32dc1a8](https://github.com/bitnami/charts/commit/32dc1a86239da05d78b81d3c46ee3177155e9d08))
 
 ## <small>15.2.12 (2021-04-28)</small>
 
-* [bitnami/redmine] Release 15.2.12 updating components versions ([5e7eed6](https://github.com/bitnami/charts/commit/5e7eed6))
+* [bitnami/redmine] Release 15.2.12 updating components versions ([5e7eed6](https://github.com/bitnami/charts/commit/5e7eed675e79d2ba94625856ec1158e8a029e46e))
 
 ## <small>15.2.11 (2021-04-27)</small>
 
-* [bitnami/redmine] Release 15.2.11 updating components versions ([bad030c](https://github.com/bitnami/charts/commit/bad030c))
+* [bitnami/redmine] Release 15.2.11 updating components versions ([bad030c](https://github.com/bitnami/charts/commit/bad030c1c03ba5d745b6932d928e8dcbd565c83d))
 
 ## <small>15.2.10 (2021-04-09)</small>
 
-* [bitnami/redmine] Release 15.2.10 updating components versions ([6130650](https://github.com/bitnami/charts/commit/6130650))
+* [bitnami/redmine] Release 15.2.10 updating components versions ([6130650](https://github.com/bitnami/charts/commit/613065093bfa57f0f98285c6ac99bdb2d62f0da8))
 
 ## <small>15.2.9 (2021-04-07)</small>
 
-* [bitnami/redmine] fix indent in cronjob.yml (#6031) ([71df259](https://github.com/bitnami/charts/commit/71df259)), closes [#6031](https://github.com/bitnami/charts/issues/6031)
+* [bitnami/redmine] fix indent in cronjob.yml (#6031) ([71df259](https://github.com/bitnami/charts/commit/71df259eb1ea31191f2e9fcaa91d3378cfe2a953)), closes [#6031](https://github.com/bitnami/charts/issues/6031)
 
 ## <small>15.2.8 (2021-03-29)</small>
 
-* [bitnami/redmine] Add info on how to run redmine with multiple replicas to Readme (#5941) ([02c9648](https://github.com/bitnami/charts/commit/02c9648)), closes [#5941](https://github.com/bitnami/charts/issues/5941)
+* [bitnami/redmine] Add info on how to run redmine with multiple replicas to Readme (#5941) ([02c9648](https://github.com/bitnami/charts/commit/02c9648be18b57a107baf98b4cf75f9caf791546)), closes [#5941](https://github.com/bitnami/charts/issues/5941)
 
 ## <small>15.2.7 (2021-03-28)</small>
 
-* [bitnami/redmine] Release 15.2.7 updating components versions ([ccc973e](https://github.com/bitnami/charts/commit/ccc973e))
+* [bitnami/redmine] Release 15.2.7 updating components versions ([ccc973e](https://github.com/bitnami/charts/commit/ccc973ef7e6bc5bb513fd47dfc8543e6c6be36d2))
 
 ## <small>15.2.6 (2021-03-21)</small>
 
-* [bitnami/redmine] Release 15.2.6 updating components versions ([1f96950](https://github.com/bitnami/charts/commit/1f96950))
+* [bitnami/redmine] Release 15.2.6 updating components versions ([1f96950](https://github.com/bitnami/charts/commit/1f96950c22336be2bd20ea0c184d420426c4903e))
 
 ## <small>15.2.5 (2021-03-05)</small>
 
-* [bitnami/*] Adapt certificates initContainer to the new image (#5684) ([5d59d2f](https://github.com/bitnami/charts/commit/5d59d2f)), closes [#5684](https://github.com/bitnami/charts/issues/5684)
+* [bitnami/*] Adapt certificates initContainer to the new image (#5684) ([5d59d2f](https://github.com/bitnami/charts/commit/5d59d2f21e0aaf95c8a5d24f13804f4062e1fc75)), closes [#5684](https://github.com/bitnami/charts/issues/5684)
 
 ## <small>15.2.4 (2021-03-04)</small>
 
-* [bitnami/*] Remove minideb mentions (#5677) ([870bc4d](https://github.com/bitnami/charts/commit/870bc4d)), closes [#5677](https://github.com/bitnami/charts/issues/5677)
+* [bitnami/*] Remove minideb mentions (#5677) ([870bc4d](https://github.com/bitnami/charts/commit/870bc4dba1fc3aa55dd157da6687b25e8d352206)), closes [#5677](https://github.com/bitnami/charts/issues/5677)
 
 ## <small>15.2.3 (2021-02-22)</small>
 
-* [bitnami/*] Add notice regarding parameters immutability after chart installation (#4853) ([5f09573](https://github.com/bitnami/charts/commit/5f09573)), closes [#4853](https://github.com/bitnami/charts/issues/4853)
-* [bitnami/redmine] Release 15.2.3 updating components versions ([dad9bf7](https://github.com/bitnami/charts/commit/dad9bf7))
+* [bitnami/*] Add notice regarding parameters immutability after chart installation (#4853) ([5f09573](https://github.com/bitnami/charts/commit/5f095734f92555dec7cd0e3ee961f315eac170ff)), closes [#4853](https://github.com/bitnami/charts/issues/4853)
+* [bitnami/redmine] Release 15.2.3 updating components versions ([dad9bf7](https://github.com/bitnami/charts/commit/dad9bf73fc062892826d4c7efb0b3dccaa4c9939))
 
 ## <small>15.2.2 (2021-02-04)</small>
 
-* [bitnami/several] Fix template issue when using ingress secrets (#5373) ([7fd5ea5](https://github.com/bitnami/charts/commit/7fd5ea5)), closes [#5373](https://github.com/bitnami/charts/issues/5373)
+* [bitnami/several] Fix template issue when using ingress secrets (#5373) ([7fd5ea5](https://github.com/bitnami/charts/commit/7fd5ea5ad2d46f5bad85585e04844add77cc4885)), closes [#5373](https://github.com/bitnami/charts/issues/5373)
 
 ## <small>15.2.1 (2021-01-27)</small>
 
-* [bitnami/redmine] Release 15.2.1 updating components versions ([112b68b](https://github.com/bitnami/charts/commit/112b68b))
+* [bitnami/redmine] Release 15.2.1 updating components versions ([112b68b](https://github.com/bitnami/charts/commit/112b68bfc249f59e955f2da7880c3dfa5bcee7c8))
 
 ## 15.2.0 (2021-01-25)
 
-* [bitnami/redmine] Add hostAliases support (#5163) ([af4f408](https://github.com/bitnami/charts/commit/af4f408)), closes [#5163](https://github.com/bitnami/charts/issues/5163)
+* [bitnami/redmine] Add hostAliases support (#5163) ([af4f408](https://github.com/bitnami/charts/commit/af4f4083922dad78816ac0fed84099a6e58b7008)), closes [#5163](https://github.com/bitnami/charts/issues/5163)
 
 ## <small>15.1.2 (2021-01-24)</small>
 
-* [bitnami/*] Change helm version in the prerequisites (#5090) ([c5e67a3](https://github.com/bitnami/charts/commit/c5e67a3)), closes [#5090](https://github.com/bitnami/charts/issues/5090)
-* [bitnami/redmine] Release 15.1.2 updating components versions ([befdec6](https://github.com/bitnami/charts/commit/befdec6))
+* [bitnami/*] Change helm version in the prerequisites (#5090) ([c5e67a3](https://github.com/bitnami/charts/commit/c5e67a388743cbee28439d2cabca27884b9daf97)), closes [#5090](https://github.com/bitnami/charts/issues/5090)
+* [bitnami/redmine] Release 15.1.2 updating components versions ([befdec6](https://github.com/bitnami/charts/commit/befdec61188eb68a60fd7619c5b6b1831c479b5c))
 
 ## <small>15.1.1 (2021-01-19)</small>
 
-* [bitnami/redmine] Fix Pod/Container SecurityContext(s) (#5084) ([8c7a079](https://github.com/bitnami/charts/commit/8c7a079)), closes [#5084](https://github.com/bitnami/charts/issues/5084)
+* [bitnami/redmine] Fix Pod/Container SecurityContext(s) (#5084) ([8c7a079](https://github.com/bitnami/charts/commit/8c7a0796cac9ae963afe82b00995b803cfdd11ee)), closes [#5084](https://github.com/bitnami/charts/issues/5084)
 
 ## 15.1.0 (2021-01-15)
 
-* [bitnami/redmine] Adapt ingress to k8s 1.20 (#5008) ([66eafb7](https://github.com/bitnami/charts/commit/66eafb7)), closes [#5008](https://github.com/bitnami/charts/issues/5008)
+* [bitnami/redmine] Adapt ingress to k8s 1.20 (#5008) ([66eafb7](https://github.com/bitnami/charts/commit/66eafb757ff9201c44a54b1b735767ad429e4884)), closes [#5008](https://github.com/bitnami/charts/issues/5008)
 
 ## <small>15.0.3 (2020-12-23)</small>
 
-* [bitnami/*] fix typos (#4699) ([49adc63](https://github.com/bitnami/charts/commit/49adc63)), closes [#4699](https://github.com/bitnami/charts/issues/4699)
-* [bitnami/redmine] Release 15.0.3 updating components versions ([427d7a0](https://github.com/bitnami/charts/commit/427d7a0))
+* [bitnami/*] fix typos (#4699) ([49adc63](https://github.com/bitnami/charts/commit/49adc63b672da976c55af2e077aa5648a357b77f)), closes [#4699](https://github.com/bitnami/charts/issues/4699)
+* [bitnami/redmine] Release 15.0.3 updating components versions ([427d7a0](https://github.com/bitnami/charts/commit/427d7a0e73109f92cca48af9b8e32a3d54f1c7af))
 
 ## <small>15.0.2 (2020-12-11)</small>
 
-* [bitnami/*] Update dependencies (#4694) ([2826c12](https://github.com/bitnami/charts/commit/2826c12)), closes [#4694](https://github.com/bitnami/charts/issues/4694)
+* [bitnami/*] Update dependencies (#4694) ([2826c12](https://github.com/bitnami/charts/commit/2826c125b42505f28431301e3c1bbe5366e47a01)), closes [#4694](https://github.com/bitnami/charts/issues/4694)
 
 ## <small>15.0.1 (2020-12-02)</small>
 
-* [bitnami/redmine] Add how to deploy in a different URI to the README.md (#4481) ([2a053fb](https://github.com/bitnami/charts/commit/2a053fb)), closes [#4481](https://github.com/bitnami/charts/issues/4481)
+* [bitnami/redmine] Add how to deploy in a different URI to the README.md (#4481) ([2a053fb](https://github.com/bitnami/charts/commit/2a053fbb7e71268973e651738418e6e6a403da9d)), closes [#4481](https://github.com/bitnami/charts/issues/4481)
 
 ## 15.0.0 (2020-11-23)
 
-* [bitnami/redmine] MAJOR - Redmine subchart bump, also apiVersion: v2 (#4159) ([0f1b1ef](https://github.com/bitnami/charts/commit/0f1b1ef)), closes [#4159](https://github.com/bitnami/charts/issues/4159)
+* [bitnami/redmine] MAJOR - Redmine subchart bump, also apiVersion: v2 (#4159) ([0f1b1ef](https://github.com/bitnami/charts/commit/0f1b1eff13365b3422a6c2d0b0c79e3ee3f827b6)), closes [#4159](https://github.com/bitnami/charts/issues/4159)
 
 ## <small>14.2.14 (2020-11-20)</small>
 
-* [bitnami/*] Expose the "service type" in the basic form for Kubeapps (#4445) ([cf3b3d3](https://github.com/bitnami/charts/commit/cf3b3d3)), closes [#4445](https://github.com/bitnami/charts/issues/4445)
+* [bitnami/*] Expose the "service type" in the basic form for Kubeapps (#4445) ([cf3b3d3](https://github.com/bitnami/charts/commit/cf3b3d3def5931883df8054806edcea9b8339c50)), closes [#4445](https://github.com/bitnami/charts/issues/4445)
 
 ## <small>14.2.13 (2020-11-06)</small>
 
-* [bitnami/redmine] Release 14.2.13 updating components versions ([a802aa7](https://github.com/bitnami/charts/commit/a802aa7))
+* [bitnami/redmine] Release 14.2.13 updating components versions ([a802aa7](https://github.com/bitnami/charts/commit/a802aa7683e11e567facf5904ac100297c4eb29e))
 
 ## <small>14.2.12 (2020-10-29)</small>
 
-* [bitnami/*] Include link to Troubleshootin guide on README.md (#4136) ([c08a20e](https://github.com/bitnami/charts/commit/c08a20e)), closes [#4136](https://github.com/bitnami/charts/issues/4136)
-* [bitnami/redmine] Release 14.2.12 updating components versions ([5f4b4b1](https://github.com/bitnami/charts/commit/5f4b4b1))
+* [bitnami/*] Include link to Troubleshootin guide on README.md (#4136) ([c08a20e](https://github.com/bitnami/charts/commit/c08a20e3db004215383004ff023a73fcc2522e72)), closes [#4136](https://github.com/bitnami/charts/issues/4136)
+* [bitnami/redmine] Release 14.2.12 updating components versions ([5f4b4b1](https://github.com/bitnami/charts/commit/5f4b4b1f9aec59371a16ead48f01c81b5cdfb09f))
 
 ## <small>14.2.11 (2020-10-21)</small>
 
-* [bitnami/redmine] Release 14.2.11 updating components versions ([ea09ec8](https://github.com/bitnami/charts/commit/ea09ec8))
+* [bitnami/redmine] Release 14.2.11 updating components versions ([ea09ec8](https://github.com/bitnami/charts/commit/ea09ec8e02fd2345d273f4a17361bfaed886e467))
 
 ## <small>14.2.10 (2020-09-21)</small>
 
-* [bitnami/metrics-server] Add source repo (#3577) ([1ed12f9](https://github.com/bitnami/charts/commit/1ed12f9)), closes [#3577](https://github.com/bitnami/charts/issues/3577)
-* [bitnami/redmine] Release 14.2.10 updating components versions ([6572761](https://github.com/bitnami/charts/commit/6572761))
+* [bitnami/metrics-server] Add source repo (#3577) ([1ed12f9](https://github.com/bitnami/charts/commit/1ed12f96af75322b46afdb2b3d9907c11b13f765)), closes [#3577](https://github.com/bitnami/charts/issues/3577)
+* [bitnami/redmine] Release 14.2.10 updating components versions ([6572761](https://github.com/bitnami/charts/commit/6572761b5274548942ced3b494b461e2f76f94ef))
 
 ## <small>14.2.9 (2020-08-27)</small>
 
-* [bitnami/*] Fix TL;DR typo in READMEs (#3280) ([3d7ab40](https://github.com/bitnami/charts/commit/3d7ab40)), closes [#3280](https://github.com/bitnami/charts/issues/3280)
-* [bitnami/redmine] Release 14.2.9 updating components versions ([a9dc996](https://github.com/bitnami/charts/commit/a9dc996))
+* [bitnami/*] Fix TL;DR typo in READMEs (#3280) ([3d7ab40](https://github.com/bitnami/charts/commit/3d7ab406fecd64f1af25f53e7d27f03ec95b29a4)), closes [#3280](https://github.com/bitnami/charts/issues/3280)
+* [bitnami/redmine] Release 14.2.9 updating components versions ([a9dc996](https://github.com/bitnami/charts/commit/a9dc9964f333e2b440d70c566a062783d14c0167))
 
 ## <small>14.2.8 (2020-07-28)</small>
 
-* [bitnami/redmine] Release 14.2.8 updating components versions ([0266b3f](https://github.com/bitnami/charts/commit/0266b3f))
+* [bitnami/redmine] Release 14.2.8 updating components versions ([0266b3f](https://github.com/bitnami/charts/commit/0266b3fc32834c5c0de8346f585fddfba4c6b7a8))
 
 ## <small>14.2.7 (2020-07-24)</small>
 
-* [bitnami/all] Add categories (#3075) ([63bde06](https://github.com/bitnami/charts/commit/63bde06)), closes [#3075](https://github.com/bitnami/charts/issues/3075)
-* [bitnami/redmine] Release 14.2.7 updating components versions ([004265b](https://github.com/bitnami/charts/commit/004265b))
+* [bitnami/all] Add categories (#3075) ([63bde06](https://github.com/bitnami/charts/commit/63bde066b87a140fab52264d0522401ab3d63509)), closes [#3075](https://github.com/bitnami/charts/issues/3075)
+* [bitnami/redmine] Release 14.2.7 updating components versions ([004265b](https://github.com/bitnami/charts/commit/004265bd58d94de910346221103446fab1c1eaf5))
 
 ## <small>14.2.6 (2020-06-30)</small>
 
-* [bitnami/redmine] Release 14.2.6 updating components versions ([80ccaa2](https://github.com/bitnami/charts/commit/80ccaa2))
+* [bitnami/redmine] Release 14.2.6 updating components versions ([80ccaa2](https://github.com/bitnami/charts/commit/80ccaa2689d5ce414d1092f7d4ff23ac1b6e9bb8))
 
 ## <small>14.2.5 (2020-06-30)</small>
 
-* [bitnami/redmine] Add updateStrategy to deployment (#2943) ([189cd7d](https://github.com/bitnami/charts/commit/189cd7d)), closes [#2943](https://github.com/bitnami/charts/issues/2943)
+* [bitnami/redmine] Add updateStrategy to deployment (#2943) ([189cd7d](https://github.com/bitnami/charts/commit/189cd7d45ea14feead6a448d74b647c807825b03)), closes [#2943](https://github.com/bitnami/charts/issues/2943)
 
 ## <small>14.2.4 (2020-06-24)</small>
 
-* [bitnami/redmine] Move certificate.extraEnvVars to certificate.image (#2907) ([64e1ab5](https://github.com/bitnami/charts/commit/64e1ab5)), closes [#2907](https://github.com/bitnami/charts/issues/2907)
-* [bitnami/redmine] Release 14.2.4 updating components versions ([0e31eaa](https://github.com/bitnami/charts/commit/0e31eaa))
+* [bitnami/redmine] Move certificate.extraEnvVars to certificate.image (#2907) ([64e1ab5](https://github.com/bitnami/charts/commit/64e1ab51711278d2493857f136d5d6be81704503)), closes [#2907](https://github.com/bitnami/charts/issues/2907)
+* [bitnami/redmine] Release 14.2.4 updating components versions ([0e31eaa](https://github.com/bitnami/charts/commit/0e31eaa23a27f1ad0f0463d14cafbdea9df161bf))
 
 ## <small>14.2.3 (2020-06-23)</small>
 
-* [bitnami/redmine] Release 14.2.3 updating components versions ([6a81e36](https://github.com/bitnami/charts/commit/6a81e36))
+* [bitnami/redmine] Release 14.2.3 updating components versions ([6a81e36](https://github.com/bitnami/charts/commit/6a81e36951973c8871b45c849a2160a2b34a7221))
 
 ## <small>14.2.2 (2020-06-22)</small>
 
-* [bitnami/redmine] Fix deployment secret when using mariadb.existingSecret (#2893) ([4d5d0e1](https://github.com/bitnami/charts/commit/4d5d0e1)), closes [#2893](https://github.com/bitnami/charts/issues/2893)
+* [bitnami/redmine] Fix deployment secret when using mariadb.existingSecret (#2893) ([4d5d0e1](https://github.com/bitnami/charts/commit/4d5d0e135a2c01bf11fb0315097aa338910bf079)), closes [#2893](https://github.com/bitnami/charts/issues/2893)
 
 ## <small>14.2.1 (2020-06-18)</small>
 
-* [bitnami/redmine] Release 14.2.1 updating components versions ([67ffee5](https://github.com/bitnami/charts/commit/67ffee5))
-* [multiple charts] Update hidden properties in the different JSON schemas (#2871) ([4cff6ba](https://github.com/bitnami/charts/commit/4cff6ba)), closes [#2871](https://github.com/bitnami/charts/issues/2871)
+* [bitnami/redmine] Release 14.2.1 updating components versions ([67ffee5](https://github.com/bitnami/charts/commit/67ffee540499832ecc9a302d8ede134a61e17d98))
+* [multiple charts] Update hidden properties in the different JSON schemas (#2871) ([4cff6ba](https://github.com/bitnami/charts/commit/4cff6ba8b0013b6dc368a1e7986c393e8447e75b)), closes [#2871](https://github.com/bitnami/charts/issues/2871)
 
 ## 14.2.0 (2020-06-17)
 
-* [bitnami/redmine] Inject Root CA into image (#2774) ([94fd9d0](https://github.com/bitnami/charts/commit/94fd9d0)), closes [#2774](https://github.com/bitnami/charts/issues/2774)
+* [bitnami/redmine] Inject Root CA into image (#2774) ([94fd9d0](https://github.com/bitnami/charts/commit/94fd9d054de059c7bd2ea9e14956fa5e5a2a9cd6)), closes [#2774](https://github.com/bitnami/charts/issues/2774)
 
 ## <small>14.1.21 (2020-06-12)</small>
 
-* [bitnami/redmine] Release 14.1.21 updating components versions ([10263d4](https://github.com/bitnami/charts/commit/10263d4))
+* [bitnami/redmine] Release 14.1.21 updating components versions ([10263d4](https://github.com/bitnami/charts/commit/10263d43ab2f2c63f1df5e7cffa9824fd525c6b2))
 
 ## <small>14.1.20 (2020-06-11)</small>
 
-* [bitnami/redmine] Release 14.1.20 updating components versions ([fc168f1](https://github.com/bitnami/charts/commit/fc168f1))
-* Add support for helm lint and helm install in PRs via GH Actions (#2721) ([5ed97f0](https://github.com/bitnami/charts/commit/5ed97f0)), closes [#2721](https://github.com/bitnami/charts/issues/2721)
+* [bitnami/redmine] Release 14.1.20 updating components versions ([fc168f1](https://github.com/bitnami/charts/commit/fc168f103982f54e7a44696bde46b3a09c7b28e8))
+* Add support for helm lint and helm install in PRs via GH Actions (#2721) ([5ed97f0](https://github.com/bitnami/charts/commit/5ed97f0c1ab49e7c7c3af81b888f41f50a7cfbab)), closes [#2721](https://github.com/bitnami/charts/issues/2721)
 
 ## <small>14.1.19 (2020-05-22)</small>
 
-* [bitnami/redmine] Release 14.1.19 updating components versions ([67cdc9c](https://github.com/bitnami/charts/commit/67cdc9c))
-* update bitnami/common to be compatible with helm v2.12+ (#2615) ([c7751eb](https://github.com/bitnami/charts/commit/c7751eb)), closes [#2615](https://github.com/bitnami/charts/issues/2615)
+* [bitnami/redmine] Release 14.1.19 updating components versions ([67cdc9c](https://github.com/bitnami/charts/commit/67cdc9ce20ad4dd554ae41a1948c888abdf75068))
+* update bitnami/common to be compatible with helm v2.12+ (#2615) ([c7751eb](https://github.com/bitnami/charts/commit/c7751eb5764e468e1854b58a1b8491d2b13e0a4a)), closes [#2615](https://github.com/bitnami/charts/issues/2615)
 
 ## <small>14.1.18 (2020-04-22)</small>
 
-* [bitnami/redmine] Release 14.1.18 updating components versions ([b5c1ffd](https://github.com/bitnami/charts/commit/b5c1ffd))
+* [bitnami/redmine] Release 14.1.18 updating components versions ([b5c1ffd](https://github.com/bitnami/charts/commit/b5c1ffdf6c2cb92bc125c62f340e964bec063219))
 
 ## <small>14.1.17 (2020-04-22)</small>
 
-* [bitnami/redmine] Release 14.1.17 updating components versions ([b9b9915](https://github.com/bitnami/charts/commit/b9b9915))
+* [bitnami/redmine] Release 14.1.17 updating components versions ([b9b9915](https://github.com/bitnami/charts/commit/b9b99154b466dfa587b149d5b7669e4790fd74ed))
 
 ## <small>14.1.16 (2020-04-16)</small>
 
-* [bitnami/redmine] Release 14.1.16 updating components versions ([82d3f2e](https://github.com/bitnami/charts/commit/82d3f2e))
+* [bitnami/redmine] Release 14.1.16 updating components versions ([82d3f2e](https://github.com/bitnami/charts/commit/82d3f2e6b195e8f34545b767231f7b8a2097c0d6))
 
 ## <small>14.1.15 (2020-04-07)</small>
 
-* [bitnami/redmine] Release 14.1.15 updating components versions ([5457033](https://github.com/bitnami/charts/commit/5457033))
+* [bitnami/redmine] Release 14.1.15 updating components versions ([5457033](https://github.com/bitnami/charts/commit/54570333a067d28c416179cf6936106bd274d089))
 
 ## <small>14.1.14 (2020-03-26)</small>
 
-* [bitnami/redmine] Release 14.1.14 updating components versions ([d17f385](https://github.com/bitnami/charts/commit/d17f385))
+* [bitnami/redmine] Release 14.1.14 updating components versions ([d17f385](https://github.com/bitnami/charts/commit/d17f385e46fa4d6418ac15540ef11c93881b100b))
 
 ## <small>14.1.13 (2020-03-20)</small>
 
-* [bitnami/redmine] Release 14.1.13 updating components versions ([5076b4e](https://github.com/bitnami/charts/commit/5076b4e))
+* [bitnami/redmine] Release 14.1.13 updating components versions ([5076b4e](https://github.com/bitnami/charts/commit/5076b4ecbecb089853b319d3ce66d28eaac95760))
 
 ## <small>14.1.12 (2020-03-11)</small>
 
-* [bitnami/redmine] Release 14.1.12 updating components versions ([fbbfae4](https://github.com/bitnami/charts/commit/fbbfae4))
+* [bitnami/redmine] Release 14.1.12 updating components versions ([fbbfae4](https://github.com/bitnami/charts/commit/fbbfae4ed8bec55559ef0936d56cb53fd9b3ef5a))
 
 ## <small>14.1.11 (2020-03-11)</small>
 
-* Move charts from upstreamed folder to bitnami (#2032) ([a0e44f7](https://github.com/bitnami/charts/commit/a0e44f7)), closes [#2032](https://github.com/bitnami/charts/issues/2032)
+* Move charts from upstreamed folder to bitnami (#2032) ([a0e44f7](https://github.com/bitnami/charts/commit/a0e44f7d6a10b8b5643186130ea420887cb72c7c)), closes [#2032](https://github.com/bitnami/charts/issues/2032)

--- a/bitnami/redmine/Chart.yaml
+++ b/bitnami/redmine/Chart.yaml
@@ -43,4 +43,4 @@ maintainers:
 name: redmine
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/redmine
-version: 28.1.0
+version: 28.2.0

--- a/bitnami/redmine/README.md
+++ b/bitnami/redmine/README.md
@@ -416,16 +416,16 @@ helm install test --set persistence.existingClaim=PVC_REDMINE,mariadb.persistenc
 
 ### Other Parameters
 
-| Name                       | Description                                                    | Value   |
-| -------------------------- | -------------------------------------------------------------- | ------- |
-| `pdb.create`               | Enable a Pod Disruption Budget creation                        | `false` |
-| `pdb.minAvailable`         | Minimum number/percentage of pods that should remain scheduled | `""`    |
-| `pdb.maxUnavailable`       | Maximum number/percentage of pods that may be made unavailable | `""`    |
-| `autoscaling.enabled`      | Enable Horizontal POD autoscaling for Redmine                  | `false` |
-| `autoscaling.minReplicas`  | Minimum number of Redmine replicas                             | `1`     |
-| `autoscaling.maxReplicas`  | Maximum number of Redmine replicas                             | `11`    |
-| `autoscaling.targetCPU`    | Target CPU utilization percentage                              | `50`    |
-| `autoscaling.targetMemory` | Target Memory utilization percentage                           | `50`    |
+| Name                       | Description                                                                                                                                                  | Value   |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------- |
+| `pdb.create`               | Enable a Pod Disruption Budget creation                                                                                                                      | `true`  |
+| `pdb.minAvailable`         | Minimum number/percentage of pods that should remain scheduled                                                                                               | `""`    |
+| `pdb.maxUnavailable`       | Maximum number/percentage of pods that may be made unavailable. Defaults to `1` if both `server.pdb.minAvailable` and `server.pdb.maxUnavailable` are empty. | `""`    |
+| `autoscaling.enabled`      | Enable Horizontal POD autoscaling for Redmine                                                                                                                | `false` |
+| `autoscaling.minReplicas`  | Minimum number of Redmine replicas                                                                                                                           | `1`     |
+| `autoscaling.maxReplicas`  | Maximum number of Redmine replicas                                                                                                                           | `11`    |
+| `autoscaling.targetCPU`    | Target CPU utilization percentage                                                                                                                            | `50`    |
+| `autoscaling.targetMemory` | Target Memory utilization percentage                                                                                                                         | `50`    |
 
 ### Database Parameters
 

--- a/bitnami/redmine/templates/pdb.yaml
+++ b/bitnami/redmine/templates/pdb.yaml
@@ -17,8 +17,8 @@ spec:
   {{- if .Values.pdb.minAvailable }}
   minAvailable: {{ .Values.pdb.minAvailable }}
   {{- end }}
-  {{- if .Values.pdb.maxUnavailable }}
-  maxUnavailable: {{ .Values.pdb.maxUnavailable }}
+  {{- if or .Values.pdb.maxUnavailable (not .Values.pdb.minAvailable) }}
+  maxUnavailable: {{ .Values.pdb.maxUnavailable | default 1 }}
   {{- end }}
   {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.podLabels .Values.commonLabels ) "context" . ) }}
   selector:

--- a/bitnami/redmine/values.yaml
+++ b/bitnami/redmine/values.yaml
@@ -655,10 +655,10 @@ serviceAccount:
 ## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
 ## @param pdb.create Enable a Pod Disruption Budget creation
 ## @param pdb.minAvailable Minimum number/percentage of pods that should remain scheduled
-## @param pdb.maxUnavailable Maximum number/percentage of pods that may be made unavailable
+## @param pdb.maxUnavailable Maximum number/percentage of pods that may be made unavailable. Defaults to `1` if both `server.pdb.minAvailable` and `server.pdb.maxUnavailable` are empty.
 ##
 pdb:
-  create: false
+  create: true
   minAvailable: ""
   maxUnavailable: ""
 ## Redmine Autoscaling configuration


### PR DESCRIPTION
### Description of the change

Enabled PodDisruptionBudget by default and little fixes in PDB configuration to keep it aligned with current templates.

### Benefits

PDB protects our applications from voluntary disruption initiated by cluster administrators.
Keep our charts up to date according to our templates.

### Possible drawbacks

None

### Adition information

* [Pod disruption budgets](https://kubernetes.io/docs/concepts/workloads/pods/disruptions/#pod-disruption-budgets)
* [Specifying a Disruption Budget for your Application](https://kubernetes.io/docs/tasks/run-application/configure-pdb/)

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
