### PR TITLE
[binami/valkey] fix: wrong port set for sentinel setup

### DIFF
--- a/bitnami/valkey/CHANGELOG.md
+++ b/bitnami/valkey/CHANGELOG.md
@@ -1,21 +1,26 @@
 # Changelog
 
+## 0.2.1 (2024-05-24)
+
+* [binami/valkey] fix: wrong port set for sentinel setup ([#26392](https://github.com/bitnami/charts/pull/26392))
+
 ## 0.2.0 (2024-05-21)
 
-* [bitnami/valkey] feat: :sparkles: :lock: Add warning when original images are replaced ([#26285](https://github.com/bitnami/charts/pulls/26285))
+* [bitnami/*] ci: :construction_worker: Add tag and changelog support (#25359) ([91c707c](https://github.com/bitnami/charts/commit/91c707c9e4e574725a09505d2d313fb93f1b4c0a)), closes [#25359](https://github.com/bitnami/charts/issues/25359)
+* [bitnami/valkey] feat: :sparkles: :lock: Add warning when original images are replaced (#26285) ([6029428](https://github.com/bitnami/charts/commit/6029428e0fbc8ee4e8c47bff8134f67d60e2b523)), closes [#26285](https://github.com/bitnami/charts/issues/26285)
 
 ## <small>0.1.3 (2024-05-18)</small>
 
-* [bitnami/valkey] Release 0.1.3 updating components versions (#26085) ([356d258](https://github.com/bitnami/charts/commit/356d258)), closes [#26085](https://github.com/bitnami/charts/issues/26085)
+* [bitnami/valkey] Release 0.1.3 updating components versions (#26085) ([356d258](https://github.com/bitnami/charts/commit/356d2582f06e58cb774a0484a0af9a692a2a94c5)), closes [#26085](https://github.com/bitnami/charts/issues/26085)
 
 ## <small>0.1.2 (2024-05-14)</small>
 
-* [bitnami/valkey] Release 0.1.2 updating components versions (#25850) ([5532975](https://github.com/bitnami/charts/commit/5532975)), closes [#25850](https://github.com/bitnami/charts/issues/25850)
+* [bitnami/valkey] Release 0.1.2 updating components versions (#25850) ([5532975](https://github.com/bitnami/charts/commit/5532975a630d972508ba11d51a225ac73f975d83)), closes [#25850](https://github.com/bitnami/charts/issues/25850)
 
 ## <small>0.1.1 (2024-05-14)</small>
 
-* [bitnami/valkey] Release 0.1.1 updating components versions (#25842) ([3a607b1](https://github.com/bitnami/charts/commit/3a607b1)), closes [#25842](https://github.com/bitnami/charts/issues/25842)
+* [bitnami/valkey] Release 0.1.1 updating components versions (#25842) ([3a607b1](https://github.com/bitnami/charts/commit/3a607b18d83308b3bd45e7d7243e8d094dd454f7)), closes [#25842](https://github.com/bitnami/charts/issues/25842)
 
 ## 0.1.0 (2024-05-10)
 
-* [bitnami/valkey] Add new valkey chart (#25643) ([fae194a](https://github.com/bitnami/charts/commit/fae194a)), closes [#25643](https://github.com/bitnami/charts/issues/25643)
+* [bitnami/valkey] Add new valkey chart (#25643) ([fae194a](https://github.com/bitnami/charts/commit/fae194af0f55687e2b825e4aefd8501ed788a9fc)), closes [#25643](https://github.com/bitnami/charts/issues/25643)

--- a/bitnami/valkey/Chart.yaml
+++ b/bitnami/valkey/Chart.yaml
@@ -36,4 +36,4 @@ maintainers:
 name: valkey
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/valkey
-version: 0.2.0
+version: 0.2.1

--- a/bitnami/valkey/templates/headless-svc.yaml
+++ b/bitnami/valkey/templates/headless-svc.yaml
@@ -26,7 +26,7 @@ spec:
   {{- end }}
   ports:
     - name: tcp-redis
-      port: {{ if .Values.sentinel.enabled }}{{ .Values.sentinel.containerPorts.sentinel }}{{ else }} {{ .Values.master.containerPorts.valkey }}{{ end }}
+      port: {{ if .Values.sentinel.enabled }}{{ .Values.replica.containerPorts.valkey }}{{ else }} {{ .Values.master.containerPorts.valkey }}{{ end }}
       targetPort: redis
     {{- if .Values.sentinel.enabled }}
     - name: tcp-sentinel


### PR DESCRIPTION
### Description of the change

The port on the STS does not match the one required by the service.

### Applicable issues

- fixes #26363

### Additional information

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
