### PR TITLE
[bitnami/nginx] Fix readiness probe

### DIFF
--- a/bitnami/nginx/CHANGELOG.md
+++ b/bitnami/nginx/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
+## 17.2.1 (2024-05-24)
+
+* [bitnami/nginx] Fix readiness probe ([#26394](https://github.com/bitnami/charts/pull/26394))
+
 ## 17.2.0 (2024-05-23)
 
-* [bitnami/nginx] Allow custom path for readinessProbe and update startupProbe ([#26362](https://github.com/bitnami/charts/pull/26362))
+* [bitnami/nginx] Allow custom path for readinessProbe and update startupProbe (#26362) ([24fcc5a](https://github.com/bitnami/charts/commit/24fcc5a3e6872c599d6eafdf6df531dde7272a32)), closes [#26362](https://github.com/bitnami/charts/issues/26362)
 
 ## 17.1.0 (2024-05-21)
 

--- a/bitnami/nginx/Chart.yaml
+++ b/bitnami/nginx/Chart.yaml
@@ -34,4 +34,4 @@ maintainers:
 name: nginx
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/nginx
-version: 17.2.0
+version: 17.2.1

--- a/bitnami/nginx/templates/deployment.yaml
+++ b/bitnami/nginx/templates/deployment.yaml
@@ -269,7 +269,7 @@ spec:
           {{- if .Values.customReadinessProbe }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customReadinessProbe "context" $) | nindent 12 }}
           {{- else if .Values.readinessProbe.enabled }}
-          readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.readinessProbe "enabled") "context" $) | nindent 12 }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.readinessProbe "enabled" "path") "context" $) | nindent 12 }}
             httpGet:
               path: {{ .Values.readinessProbe.path }}
               port: {{ ternary "https" "http" (and (empty .Values.containerPorts.http) (not (empty .Values.containerPorts.https))) }}


### PR DESCRIPTION
### Description of the change

This PR fixes a bug introduced at https://github.com/bitnami/charts/pull/26362 by applying the change below:

```diff
          readinessProbe:
            failureThreshold: 3
            initialDelaySeconds: 5
-           path: /
            periodSeconds: 5
            successThreshold: 1
            timeoutSeconds: 3
            httpGet:
              path: /
              port: http
```

### Benefits

Probes are correct.

### Possible drawbacks

None

### Applicable issues

None

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
