### PR TITLE
[bitnami/postgresql-ha] Fix livenessProbe for metrics

### DIFF
--- a/bitnami/postgresql-ha/CHANGELOG.md
+++ b/bitnami/postgresql-ha/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 14.1.1 (2024-05-23)
+## 14.1.2 (2024-05-24)
 
-* [bitnami/postgresql-ha] Use different liveness/readiness probes ([#26388](https://github.com/bitnami/charts/pull/26388))
+* [bitnami/postgresql-ha] Fix livenessProbe for metrics ([#26399](https://github.com/bitnami/charts/pull/26399))
+
+## <small>14.1.1 (2024-05-23)</small>
+
+* [bitnami/postgresql-ha] Use different liveness/readiness probes (#26388) ([26f7610](https://github.com/bitnami/charts/commit/26f761041f61f2a27e32813857fd40fd1fc62b74)), closes [#26388](https://github.com/bitnami/charts/issues/26388)
 
 ## 14.1.0 (2024-05-21)
 

--- a/bitnami/postgresql-ha/Chart.yaml
+++ b/bitnami/postgresql-ha/Chart.yaml
@@ -40,4 +40,4 @@ maintainers:
 name: postgresql-ha
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/postgresql-ha
-version: 14.1.1
+version: 14.1.2

--- a/bitnami/postgresql-ha/templates/postgresql/statefulset.yaml
+++ b/bitnami/postgresql-ha/templates/postgresql/statefulset.yaml
@@ -536,7 +536,7 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.metrics.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.metrics.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.metrics.livenessProbe "enabled") "context" $) | nindent 12 }}
-            tpcSocket:
+            tcpSocket:
               port: metrics
           {{- end }}
           {{- if .Values.metrics.customReadinessProbe }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change
It fixes an issue introduced in #26388.

### Benefits
Fix metrics livenessProbe.

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #26396

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- ~[ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)~
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
