### PR TITLE
[bitnami/kafka] Fix linter rules after deprecating Kafka Exporter

### DIFF
--- a/bitnami/kafka/README.md
+++ b/bitnami/kafka/README.md
@@ -154,12 +154,6 @@ By setting the following parameter: `listeners.client.protocol=SSL` and `listene
 
 As result, we will be able to see in kafka-authorizer.log the events specific Subject: `[...] Principal = User:CN=kafka,OU=...,O=...,L=...,C=..,ST=... is [...]`.
 
-If you also enable exposing metrics using the Kafka exporter, and you are using `SSL` or `SASL_SSL` security protocols protocols, you need to mount the CA certificated used to sign the brokers certificates in the exporter so it can validate the Kafka brokers. To do so, create a secret containing the CA, and set the `metrics.certificatesSecret` parameter. As an alternative, you can skip TLS validation using extra flags:
-
-```console
-metrics.kafka.extraFlags={tls.insecure-skip-tls-verify: ""}
-```
-
 ### Accessing Kafka brokers from outside the cluster
 
 In order to access Kafka Brokers from outside the cluster, an additional listener and advertised listener must be configured. Additionally, a specific service per kafka pod will be created.
@@ -284,14 +278,8 @@ externalAccess:
 
 The chart can optionally start two metrics exporters:
 
-- Kafka exporter, to expose Kafka metrics. By default, it uses port 9308.
 - JMX exporter, to expose JMX metrics. By default, it uses port 5556.
-
-To create a separate Kafka exporter, use the parameter below:
-
-```text
-metrics.kafka.enabled: true
-```
+- Zookeeper exporter, to expose Zookeeper metrics. By default, it uses port 9141.
 
 To expose JMX metrics to Prometheus, use the parameter below:
 

--- a/bitnami/kafka/templates/NOTES.txt
+++ b/bitnami/kafka/templates/NOTES.txt
@@ -331,5 +331,5 @@ ssl.endpoint.identification.algorithm=
 
 {{- include "kafka.checkRollingTags" . }}
 {{- include "kafka.validateValues" . }}
-{{- include "common.warnings.resources" (dict "sections" (list "broker" "controller" "externalAccess.autoDiscovery" "metrics.jmx" "metrics.kafka" "provisioning" "volumePermissions") "context" $) }}
+{{- include "common.warnings.resources" (dict "sections" (list "broker" "controller" "externalAccess.autoDiscovery" "metrics.jmx" "provisioning" "volumePermissions") "context" $) }}
 {{- include "common.warnings.modifiedImages" (dict "images" (list .Values.image .Values.externalAccess.autoDiscovery.image .Values.volumePermissions.image .Values.metrics.jmx.image) "context" $) }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->

Continuation of https://github.com/bitnami/charts/pull/26395

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [NA] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [NA] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
