### PR TITLE
[bitnami/nginx-ingress-controller] Use different liveness/readiness pending probe

### DIFF
--- a/bitnami/nginx-ingress-controller/CHANGELOG.md
+++ b/bitnami/nginx-ingress-controller/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 11.3.0 (2024-05-23)
+## 11.3.1 (2024-05-24)
 
-* [bitnami/nginx-ingress-controller] Enable PodDisruptionBudgets ([#26160](https://github.com/bitnami/charts/pull/26160))
+* [bitnami/nginx-ingress-controller] Use different liveness/readiness pending probe ([#26412](https://github.com/bitnami/charts/pull/26412))
+
+## 11.3.0 (2024-05-24)
+
+* [bitnami/nginx-ingress-controller] Enable PodDisruptionBudgets (#26160) ([923b570](https://github.com/bitnami/charts/commit/923b5701f21060df0ee5b17b0c2f706f9337efb3)), closes [#26160](https://github.com/bitnami/charts/issues/26160)
 
 ## <small>11.2.1 (2024-05-22)</small>
 

--- a/bitnami/nginx-ingress-controller/Chart.yaml
+++ b/bitnami/nginx-ingress-controller/Chart.yaml
@@ -34,4 +34,4 @@ maintainers:
 name: nginx-ingress-controller
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/nginx-ingress-controller
-version: 11.3.0
+version: 11.3.1

--- a/bitnami/nginx-ingress-controller/templates/controller-deployment.yaml
+++ b/bitnami/nginx-ingress-controller/templates/controller-deployment.yaml
@@ -180,10 +180,8 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.livenessProbe "enabled") "context" $) | nindent 12 }}
-            httpGet:
-              path: /healthz
+            tcpSocket:
               port: metrics
-              scheme: HTTP
           {{- end }}
           {{- if .Values.customReadinessProbe }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customReadinessProbe "context" $) | nindent 12 }}


### PR DESCRIPTION
### Description of the change
This PR aims to use different liveness/readiness probes to improve overall security and avoid unnecessary container restarts. [More info](https://github.com/zegl/kube-score/blob/master/README_PROBES.md).

### Benefits

Increase availability and resilience.

### Possible drawbacks

N/A

### Applicable issues

- fixes #

### Additional information

- Related to #23537

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- ~[X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)~
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
