### PR TITLE
[bitnami/mlflow] Use different liveness/readiness probes (part 2)

### DIFF
--- a/bitnami/mlflow/Chart.yaml
+++ b/bitnami/mlflow/Chart.yaml
@@ -43,4 +43,4 @@ name: mlflow
 sources:
 - https://github.com/bitnami/containers/tree/main/bitnami/mlflow
 - https://github.com/mlflow/mlflow
-version: 1.2.0
+version: 1.2.1

--- a/bitnami/mlflow/templates/tracking/deployment.yaml
+++ b/bitnami/mlflow/templates/tracking/deployment.yaml
@@ -215,8 +215,11 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.tracking.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.tracking.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.tracking.livenessProbe "enabled") "context" $) | nindent 12 }}
-            tcpSocket:
-              port: {{ include "mlflow.v0.tracking.portName" . }}
+            exec:
+              command:
+                - pgrep
+                - f
+                - mlflow.server
           {{- end }}
           {{- if .Values.tracking.customReadinessProbe }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.tracking.customReadinessProbe "context" $) | nindent 12 }}


### PR DESCRIPTION
### Description of the change
This PR aims to use different liveness/readiness probes to improve overall security and avoid unnecessary container restarts. [More info](https://github.com/zegl/kube-score/blob/master/README_PROBES.md).

### Benefits

Increase availability and resilience.

### Possible drawbacks

N/A

### Applicable issues

- fixes #

### Additional information

- Related to #23537

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- ~[X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)~
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
