### PR TITLE
[bitnami/clickhouse] Enable PodDisruptionBudgets

### DIFF
--- a/bitnami/clickhouse/Chart.lock
+++ b/bitnami/clickhouse/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: zookeeper
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 13.3.0
+  version: 13.4.0
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 2.19.3
-digest: sha256:344b1f77eb0e4dddc6962899b8cc2892c652be5b8a96c88d9ad57708f9e61b93
-generated: "2024-05-22T13:41:36.896361+02:00"
+digest: sha256:d4cf95ede3f4616d73105423fee2b123c0b9afb19bf552cef106e46152e113a7
+generated: "2024-05-24T18:18:39.965282+02:00"

--- a/bitnami/clickhouse/Chart.yaml
+++ b/bitnami/clickhouse/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: clickhouse
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/clickhouse
-version: 6.1.1
+version: 6.2.0

--- a/bitnami/clickhouse/README.md
+++ b/bitnami/clickhouse/README.md
@@ -343,56 +343,59 @@ The [Bitnami ClickHouse](https://github.com/bitnami/containers/tree/main/bitnami
 
 ### ClickHouse keeper configuration parameters
 
-| Name                            | Description                                                                                                              | Value                   |
-| ------------------------------- | ------------------------------------------------------------------------------------------------------------------------ | ----------------------- |
-| `keeper.enabled`                | Deploy ClickHouse keeper. Support is experimental.                                                                       | `false`                 |
-| `defaultConfigurationOverrides` | Default configuration overrides (evaluated as a template)                                                                | `""`                    |
-| `existingOverridesConfigmap`    | The name of an existing ConfigMap with your custom configuration for ClickHouse                                          | `""`                    |
-| `extraOverrides`                | Extra configuration overrides (evaluated as a template) apart from the default                                           | `""`                    |
-| `extraOverridesConfigmap`       | The name of an existing ConfigMap with extra configuration for ClickHouse                                                | `""`                    |
-| `extraOverridesSecret`          | The name of an existing ConfigMap with your custom configuration for ClickHouse                                          | `""`                    |
-| `usersExtraOverrides`           | Users extra configuration overrides (evaluated as a template) apart from the default                                     | `""`                    |
-| `usersExtraOverridesConfigmap`  | The name of an existing ConfigMap with users extra configuration for ClickHouse                                          | `""`                    |
-| `usersExtraOverridesSecret`     | The name of an existing ConfigMap with your custom users configuration for ClickHouse                                    | `""`                    |
-| `initdbScripts`                 | Dictionary of initdb scripts                                                                                             | `{}`                    |
-| `initdbScriptsSecret`           | ConfigMap with the initdb scripts (Note: Overrides `initdbScripts`)                                                      | `""`                    |
-| `startdbScripts`                | Dictionary of startdb scripts                                                                                            | `{}`                    |
-| `startdbScriptsSecret`          | ConfigMap with the startdb scripts (Note: Overrides `startdbScripts`)                                                    | `""`                    |
-| `command`                       | Override default container command (useful when using custom images)                                                     | `["/scripts/setup.sh"]` |
-| `args`                          | Override default container args (useful when using custom images)                                                        | `[]`                    |
-| `automountServiceAccountToken`  | Mount Service Account token in pod                                                                                       | `false`                 |
-| `hostAliases`                   | ClickHouse pods host aliases                                                                                             | `[]`                    |
-| `podLabels`                     | Extra labels for ClickHouse pods                                                                                         | `{}`                    |
-| `podAnnotations`                | Annotations for ClickHouse pods                                                                                          | `{}`                    |
-| `podAffinityPreset`             | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                      | `""`                    |
-| `podAntiAffinityPreset`         | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                 | `soft`                  |
-| `nodeAffinityPreset.type`       | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                | `""`                    |
-| `nodeAffinityPreset.key`        | Node label key to match. Ignored if `affinity` is set                                                                    | `""`                    |
-| `nodeAffinityPreset.values`     | Node label values to match. Ignored if `affinity` is set                                                                 | `[]`                    |
-| `affinity`                      | Affinity for ClickHouse pods assignment                                                                                  | `{}`                    |
-| `nodeSelector`                  | Node labels for ClickHouse pods assignment                                                                               | `{}`                    |
-| `tolerations`                   | Tolerations for ClickHouse pods assignment                                                                               | `[]`                    |
-| `updateStrategy.type`           | ClickHouse statefulset strategy type                                                                                     | `RollingUpdate`         |
-| `podManagementPolicy`           | Statefulset Pod management policy, it needs to be Parallel to be able to complete the cluster join                       | `Parallel`              |
-| `priorityClassName`             | ClickHouse pods' priorityClassName                                                                                       | `""`                    |
-| `topologySpreadConstraints`     | Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template | `[]`                    |
-| `schedulerName`                 | Name of the k8s scheduler (other than default) for ClickHouse pods                                                       | `""`                    |
-| `terminationGracePeriodSeconds` | Seconds Redmine pod needs to terminate gracefully                                                                        | `""`                    |
-| `lifecycleHooks`                | for the ClickHouse container(s) to automate configuration before or after startup                                        | `{}`                    |
-| `extraEnvVars`                  | Array with extra environment variables to add to ClickHouse nodes                                                        | `[]`                    |
-| `extraEnvVarsCM`                | Name of existing ConfigMap containing extra env vars for ClickHouse nodes                                                | `""`                    |
-| `extraEnvVarsSecret`            | Name of existing Secret containing extra env vars for ClickHouse nodes                                                   | `""`                    |
-| `extraVolumes`                  | Optionally specify extra list of additional volumes for the ClickHouse pod(s)                                            | `[]`                    |
-| `extraVolumeMounts`             | Optionally specify extra list of additional volumeMounts for the ClickHouse container(s)                                 | `[]`                    |
-| `extraVolumeClaimTemplates`     | Optionally specify extra list of additional volumeClaimTemplates for the ClickHouse container(s)                         | `[]`                    |
-| `sidecars`                      | Add additional sidecar containers to the ClickHouse pod(s)                                                               | `[]`                    |
-| `initContainers`                | Add additional init containers to the ClickHouse pod(s)                                                                  | `[]`                    |
-| `tls.enabled`                   | Enable TLS traffic support                                                                                               | `false`                 |
-| `tls.autoGenerated`             | Generate automatically self-signed TLS certificates                                                                      | `false`                 |
-| `tls.certificatesSecret`        | Name of an existing secret that contains the certificates                                                                | `""`                    |
-| `tls.certFilename`              | Certificate filename                                                                                                     | `""`                    |
-| `tls.certKeyFilename`           | Certificate key filename                                                                                                 | `""`                    |
-| `tls.certCAFilename`            | CA Certificate filename                                                                                                  | `""`                    |
+| Name                            | Description                                                                                                                                    | Value                   |
+| ------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------- |
+| `keeper.enabled`                | Deploy ClickHouse keeper. Support is experimental.                                                                                             | `false`                 |
+| `defaultConfigurationOverrides` | Default configuration overrides (evaluated as a template)                                                                                      | `""`                    |
+| `existingOverridesConfigmap`    | The name of an existing ConfigMap with your custom configuration for ClickHouse                                                                | `""`                    |
+| `extraOverrides`                | Extra configuration overrides (evaluated as a template) apart from the default                                                                 | `""`                    |
+| `extraOverridesConfigmap`       | The name of an existing ConfigMap with extra configuration for ClickHouse                                                                      | `""`                    |
+| `extraOverridesSecret`          | The name of an existing ConfigMap with your custom configuration for ClickHouse                                                                | `""`                    |
+| `usersExtraOverrides`           | Users extra configuration overrides (evaluated as a template) apart from the default                                                           | `""`                    |
+| `usersExtraOverridesConfigmap`  | The name of an existing ConfigMap with users extra configuration for ClickHouse                                                                | `""`                    |
+| `usersExtraOverridesSecret`     | The name of an existing ConfigMap with your custom users configuration for ClickHouse                                                          | `""`                    |
+| `initdbScripts`                 | Dictionary of initdb scripts                                                                                                                   | `{}`                    |
+| `initdbScriptsSecret`           | ConfigMap with the initdb scripts (Note: Overrides `initdbScripts`)                                                                            | `""`                    |
+| `startdbScripts`                | Dictionary of startdb scripts                                                                                                                  | `{}`                    |
+| `startdbScriptsSecret`          | ConfigMap with the startdb scripts (Note: Overrides `startdbScripts`)                                                                          | `""`                    |
+| `command`                       | Override default container command (useful when using custom images)                                                                           | `["/scripts/setup.sh"]` |
+| `args`                          | Override default container args (useful when using custom images)                                                                              | `[]`                    |
+| `automountServiceAccountToken`  | Mount Service Account token in pod                                                                                                             | `false`                 |
+| `hostAliases`                   | ClickHouse pods host aliases                                                                                                                   | `[]`                    |
+| `podLabels`                     | Extra labels for ClickHouse pods                                                                                                               | `{}`                    |
+| `podAnnotations`                | Annotations for ClickHouse pods                                                                                                                | `{}`                    |
+| `podAffinityPreset`             | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                                            | `""`                    |
+| `podAntiAffinityPreset`         | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                                       | `soft`                  |
+| `nodeAffinityPreset.type`       | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                                      | `""`                    |
+| `nodeAffinityPreset.key`        | Node label key to match. Ignored if `affinity` is set                                                                                          | `""`                    |
+| `nodeAffinityPreset.values`     | Node label values to match. Ignored if `affinity` is set                                                                                       | `[]`                    |
+| `affinity`                      | Affinity for ClickHouse pods assignment                                                                                                        | `{}`                    |
+| `nodeSelector`                  | Node labels for ClickHouse pods assignment                                                                                                     | `{}`                    |
+| `tolerations`                   | Tolerations for ClickHouse pods assignment                                                                                                     | `[]`                    |
+| `updateStrategy.type`           | ClickHouse statefulset strategy type                                                                                                           | `RollingUpdate`         |
+| `podManagementPolicy`           | Statefulset Pod management policy, it needs to be Parallel to be able to complete the cluster join                                             | `Parallel`              |
+| `priorityClassName`             | ClickHouse pods' priorityClassName                                                                                                             | `""`                    |
+| `topologySpreadConstraints`     | Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template                       | `[]`                    |
+| `schedulerName`                 | Name of the k8s scheduler (other than default) for ClickHouse pods                                                                             | `""`                    |
+| `terminationGracePeriodSeconds` | Seconds Redmine pod needs to terminate gracefully                                                                                              | `""`                    |
+| `lifecycleHooks`                | for the ClickHouse container(s) to automate configuration before or after startup                                                              | `{}`                    |
+| `extraEnvVars`                  | Array with extra environment variables to add to ClickHouse nodes                                                                              | `[]`                    |
+| `extraEnvVarsCM`                | Name of existing ConfigMap containing extra env vars for ClickHouse nodes                                                                      | `""`                    |
+| `extraEnvVarsSecret`            | Name of existing Secret containing extra env vars for ClickHouse nodes                                                                         | `""`                    |
+| `extraVolumes`                  | Optionally specify extra list of additional volumes for the ClickHouse pod(s)                                                                  | `[]`                    |
+| `extraVolumeMounts`             | Optionally specify extra list of additional volumeMounts for the ClickHouse container(s)                                                       | `[]`                    |
+| `extraVolumeClaimTemplates`     | Optionally specify extra list of additional volumeClaimTemplates for the ClickHouse container(s)                                               | `[]`                    |
+| `sidecars`                      | Add additional sidecar containers to the ClickHouse pod(s)                                                                                     | `[]`                    |
+| `initContainers`                | Add additional init containers to the ClickHouse pod(s)                                                                                        | `[]`                    |
+| `pdb.create`                    | Enable/disable a Pod Disruption Budget creation                                                                                                | `true`                  |
+| `pdb.minAvailable`              | Minimum number/percentage of pods that should remain scheduled                                                                                 | `""`                    |
+| `pdb.maxUnavailable`            | Maximum number/percentage of pods that may be made unavailable. Defaults to `1` if both `pdb.minAvailable` and `pdb.maxUnavailable` are empty. | `""`                    |
+| `tls.enabled`                   | Enable TLS traffic support                                                                                                                     | `false`                 |
+| `tls.autoGenerated`             | Generate automatically self-signed TLS certificates                                                                                            | `false`                 |
+| `tls.certificatesSecret`        | Name of an existing secret that contains the certificates                                                                                      | `""`                    |
+| `tls.certFilename`              | Certificate filename                                                                                                                           | `""`                    |
+| `tls.certKeyFilename`           | Certificate key filename                                                                                                                       | `""`                    |
+| `tls.certCAFilename`            | CA Certificate filename                                                                                                                        | `""`                    |
 
 ### Traffic Exposure Parameters
 

--- a/bitnami/clickhouse/templates/pdb.yaml
+++ b/bitnami/clickhouse/templates/pdb.yaml
@@ -6,28 +6,29 @@ SPDX-License-Identifier: APACHE-2.0
 {{- if .Values.pdb.create }}
 {{- $shards := .Values.shards | int }}
 {{- range $i, $e := until $shards }}
-apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
+apiVersion: {{ include "common.capabilities.policy.apiVersion" $ }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ printf "%s-shard%d" (include "common.names.fullname" $ ) $i }}
-  namespace: {{ include "common.names.namespace" . | quote }}
-  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  namespace: {{ include "common.names.namespace" $ | quote }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" $.Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: clickhouse
     shard: {{ $i | quote }}
-  {{- if .Values.commonAnnotations }}
-  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- if $.Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" $.Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
-  {{- if .Values.pdb.minAvailable }}
-  minAvailable: {{ .Values.pdb.minAvailable }}
+  {{- if $.Values.pdb.minAvailable }}
+  minAvailable: {{ $.Values.pdb.minAvailable }}
   {{- end  }}
-  {{- if or .Values.pdb.maxUnavailable (not .Values.pdb.minAvailable) }}
-  maxUnavailable: {{ .Values.pdb.maxUnavailable | default 1 }}
+  {{- if or $.Values.pdb.maxUnavailable (not $.Values.pdb.minAvailable) }}
+  maxUnavailable: {{ $.Values.pdb.maxUnavailable | default 1 }}
   {{- end  }}
-  {{- $podLabels := include "common.tplvalues.merge" (dict "values" (list .Values.podLabels .Values.commonLabels) "context" .) }}
+  {{- $podLabels := include "common.tplvalues.merge" (dict "values" (list $.Values.podLabels $.Values.commonLabels) "context" $) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: clickhouse
       shard: {{ $i | quote }}
+---
 {{- end }}
 {{- end }}

--- a/bitnami/clickhouse/templates/pdb.yaml
+++ b/bitnami/clickhouse/templates/pdb.yaml
@@ -4,13 +4,16 @@ SPDX-License-Identifier: APACHE-2.0
 */}}
 
 {{- if .Values.pdb.create }}
+{{- $shards := .Values.shards | int }}
+{{- range $i, $e := until $shards }}
 apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
-  name: {{ include "common.names.fullname" . }}
+  name: {{ printf "%s-shard%d" (include "common.names.fullname" $ ) $i }}
   namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: clickhouse
+    shard: {{ $i | quote }}
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
@@ -25,4 +28,6 @@ spec:
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: clickhouse
+      shard: {{ $i | quote }}
+{{- end }}
 {{- end }}

--- a/bitnami/clickhouse/templates/pdb.yaml
+++ b/bitnami/clickhouse/templates/pdb.yaml
@@ -1,0 +1,28 @@
+{{- /*
+Copyright Broadcom, Inc. All Rights Reserved.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+{{- if .Values.pdb.create }}
+apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "common.names.fullname" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+    app.kubernetes.io/component: clickhouse
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.pdb.minAvailable }}
+  minAvailable: {{ .Values.pdb.minAvailable }}
+  {{- end  }}
+  {{- if or .Values.pdb.maxUnavailable (not .Values.pdb.minAvailable) }}
+  maxUnavailable: {{ .Values.pdb.maxUnavailable | default 1 }}
+  {{- end  }}
+  {{- $podLabels := include "common.tplvalues.merge" (dict "values" (list .Values.podLabels .Values.commonLabels) "context" .) }}
+  selector:
+    matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
+      app.kubernetes.io/component: clickhouse
+{{- end }}

--- a/bitnami/clickhouse/values.yaml
+++ b/bitnami/clickhouse/values.yaml
@@ -585,6 +585,16 @@ sidecars: []
 ##    command: ['sh', '-c', 'echo "hello world"']
 ##
 initContainers: []
+## Pod Disruption Budget configuration
+## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb
+## @param pdb.create Enable/disable a Pod Disruption Budget creation
+## @param pdb.minAvailable Minimum number/percentage of pods that should remain scheduled
+## @param pdb.maxUnavailable Maximum number/percentage of pods that may be made unavailable. Defaults to `1` if both `pdb.minAvailable` and `pdb.maxUnavailable` are empty.
+##
+pdb:
+  create: true
+  minAvailable: ""
+  maxUnavailable: ""
 ## TLS configuration
 ##
 tls:

--- a/template/CHART_NAME/templates/pdb.yaml
+++ b/template/CHART_NAME/templates/pdb.yaml
@@ -3,14 +3,14 @@ Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- if and .Values.%%MAIN_OBJECT_BLOCK%%.pdb.create }}
+{{- if .Values.%%MAIN_OBJECT_BLOCK%%.pdb.create }}
 apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "common.names.fullname" . }}
   namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
-    app.kubernetes.io/component: %%COMPONENT_NAME%%
+    app.kubernetes.io/component: %%MAIN_OBJECT_BLOCK%%
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
@@ -18,11 +18,11 @@ spec:
   {{- if .Values.%%MAIN_OBJECT_BLOCK%%.pdb.minAvailable }}
   minAvailable: {{ .Values.%%MAIN_OBJECT_BLOCK%%.pdb.minAvailable }}
   {{- end  }}
-  {{- if .Values.%%MAIN_OBJECT_BLOCK%%.pdb.maxUnavailable }}
-  maxUnavailable: {{ .Values.%%MAIN_OBJECT_BLOCK%%.pdb.maxUnavailable }}
+  {{- if or .Values.%%MAIN_OBJECT_BLOCK%%.pdb.maxUnavailable (not .Values.%%MAIN_OBJECT_BLOCK%%.pdb.minAvailable) }}
+  maxUnavailable: {{ .Values.%%MAIN_OBJECT_BLOCK%%.pdb.maxUnavailable | default 1 }}
   {{- end  }}
   {{- $podLabels := include "common.tplvalues.merge" (dict "values" (list .Values.%%MAIN_OBJECT_BLOCK%%.podLabels .Values.commonLabels) "context" .) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
-      app.kubernetes.io/component: %%COMPONENT_NAME%%
+      app.kubernetes.io/component: %%MAIN_OBJECT_BLOCK%%
 {{- end }}

--- a/template/CHART_NAME/templates/pdb.yaml
+++ b/template/CHART_NAME/templates/pdb.yaml
@@ -3,14 +3,14 @@ Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- if .Values.%%MAIN_OBJECT_BLOCK%%.pdb.create }}
+{{- if and .Values.%%MAIN_OBJECT_BLOCK%%.pdb.create }}
 apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "common.names.fullname" . }}
   namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
-    app.kubernetes.io/component: %%MAIN_OBJECT_BLOCK%%
+    app.kubernetes.io/component: %%COMPONENT_NAME%%
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
@@ -18,11 +18,11 @@ spec:
   {{- if .Values.%%MAIN_OBJECT_BLOCK%%.pdb.minAvailable }}
   minAvailable: {{ .Values.%%MAIN_OBJECT_BLOCK%%.pdb.minAvailable }}
   {{- end  }}
-  {{- if or .Values.%%MAIN_OBJECT_BLOCK%%.pdb.maxUnavailable (not .Values.%%MAIN_OBJECT_BLOCK%%.pdb.minAvailable) }}
-  maxUnavailable: {{ .Values.%%MAIN_OBJECT_BLOCK%%.pdb.maxUnavailable | default 1 }}
+  {{- if .Values.%%MAIN_OBJECT_BLOCK%%.pdb.maxUnavailable }}
+  maxUnavailable: {{ .Values.%%MAIN_OBJECT_BLOCK%%.pdb.maxUnavailable }}
   {{- end  }}
   {{- $podLabels := include "common.tplvalues.merge" (dict "values" (list .Values.%%MAIN_OBJECT_BLOCK%%.podLabels .Values.commonLabels) "context" .) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
-      app.kubernetes.io/component: %%MAIN_OBJECT_BLOCK%%
+      app.kubernetes.io/component: %%COMPONENT_NAME%%
 {{- end }}

--- a/template/CHART_NAME/values.yaml
+++ b/template/CHART_NAME/values.yaml
@@ -379,11 +379,11 @@ diagnosticMode:
   ## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb
   ## @param %%MAIN_OBJECT_BLOCK%%.pdb.create Enable/disable a Pod Disruption Budget creation
   ## @param %%MAIN_OBJECT_BLOCK%%.pdb.minAvailable Minimum number/percentage of pods that should remain scheduled
-  ## @param %%MAIN_OBJECT_BLOCK%%.pdb.maxUnavailable Maximum number/percentage of pods that may be made unavailable
+  ## @param %%MAIN_OBJECT_BLOCK%%.pdb.maxUnavailable Maximum number/percentage of pods that may be made unavailable. Defaults to `1` if both `%%MAIN_OBJECT_BLOCK%%.pdb.minAvailable` and `%%MAIN_OBJECT_BLOCK%%.pdb.maxUnavailable` are empty.
   ##
   pdb:
-    create: false
-    minAvailable: 1
+    create: true
+    minAvailable: ""
     maxUnavailable: ""
   ## Autoscaling configuration
   ## ref: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/

--- a/template/CHART_NAME/values.yaml
+++ b/template/CHART_NAME/values.yaml
@@ -379,11 +379,11 @@ diagnosticMode:
   ## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb
   ## @param %%MAIN_OBJECT_BLOCK%%.pdb.create Enable/disable a Pod Disruption Budget creation
   ## @param %%MAIN_OBJECT_BLOCK%%.pdb.minAvailable Minimum number/percentage of pods that should remain scheduled
-  ## @param %%MAIN_OBJECT_BLOCK%%.pdb.maxUnavailable Maximum number/percentage of pods that may be made unavailable. Defaults to `1` if both `%%MAIN_OBJECT_BLOCK%%.pdb.minAvailable` and `%%MAIN_OBJECT_BLOCK%%.pdb.maxUnavailable` are empty.
+  ## @param %%MAIN_OBJECT_BLOCK%%.pdb.maxUnavailable Maximum number/percentage of pods that may be made unavailable
   ##
   pdb:
-    create: true
-    minAvailable: ""
+    create: false
+    minAvailable: 1
     maxUnavailable: ""
   ## Autoscaling configuration
   ## ref: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/


### PR DESCRIPTION
### Description of the change

Enabled PodDisruptionBudget by default and little fixes in PDB configuration to keep it aligned with current templates.

### Benefits

PDB protects our applications from voluntary disruption initiated by cluster administrators.
Keep our charts up to date according to our templates.

### Possible drawbacks

None

### Adition information

* [Pod disruption budgets](https://kubernetes.io/docs/concepts/workloads/pods/disruptions/#pod-disruption-budgets)
* [Specifying a Disruption Budget for your Application](https://kubernetes.io/docs/tasks/run-application/configure-pdb/)

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
