### PR TITLE
[bitnami/deepspeed] Enable PodDisruptionBudgets

### DIFF
--- a/bitnami/deepspeed/CHANGELOG.md
+++ b/bitnami/deepspeed/CHANGELOG.md
@@ -1,221 +1,225 @@
 # Changelog
 
-## 2.1.1 (2024-05-21)
+## 2.2.0 (2024-05-24)
 
-* [bitnami/deepspeed] Use different liveness/readiness probes (part 2) ([#26168](https://github.com/bitnami/charts/pulls/26168))
+* [bitnami/deepspeed] Enable PodDisruptionBudgets ([#26424](https://github.com/bitnami/charts/pull/26424))
+
+## <small>2.1.1 (2024-05-21)</small>
+
+* [bitnami/deepspeed] Use different liveness/readiness probes (part 2) (#26168) ([a2bb3bd](https://github.com/bitnami/charts/commit/a2bb3bdb5f5e623d28591052fe377dd35aacd728)), closes [#26168](https://github.com/bitnami/charts/issues/26168)
 
 ## 2.1.0 (2024-05-21)
 
-* [bitnami/*] ci: :construction_worker: Add tag and changelog support (#25359) ([91c707c](https://github.com/bitnami/charts/commit/91c707c)), closes [#25359](https://github.com/bitnami/charts/issues/25359)
-* [bitnami/deepspeed] feat: :sparkles: :lock: Add warning when original images are replaced (#26192) ([309aec1](https://github.com/bitnami/charts/commit/309aec1)), closes [#26192](https://github.com/bitnami/charts/issues/26192)
+* [bitnami/*] ci: :construction_worker: Add tag and changelog support (#25359) ([91c707c](https://github.com/bitnami/charts/commit/91c707c9e4e574725a09505d2d313fb93f1b4c0a)), closes [#25359](https://github.com/bitnami/charts/issues/25359)
+* [bitnami/deepspeed] feat: :sparkles: :lock: Add warning when original images are replaced (#26192) ([309aec1](https://github.com/bitnami/charts/commit/309aec1ef50ecd3281866feaae45e039a5b100c8)), closes [#26192](https://github.com/bitnami/charts/issues/26192)
 
 ## <small>2.0.6 (2024-05-21)</small>
 
-* [bitnami/deepspeed] Use different liveness/readiness probes (#26121) ([c4196e0](https://github.com/bitnami/charts/commit/c4196e0)), closes [#26121](https://github.com/bitnami/charts/issues/26121)
+* [bitnami/deepspeed] Use different liveness/readiness probes (#26121) ([c4196e0](https://github.com/bitnami/charts/commit/c4196e0c9a212ab3810ab85e12ed3c7fbb925a2d)), closes [#26121](https://github.com/bitnami/charts/issues/26121)
 
 ## <small>2.0.5 (2024-05-18)</small>
 
-* [bitnami/*] Change non-root and rolling-tags doc URLs (#25628) ([b067c94](https://github.com/bitnami/charts/commit/b067c94)), closes [#25628](https://github.com/bitnami/charts/issues/25628)
-* [bitnami/*] Set new header/owner (#25558) ([8d1dc11](https://github.com/bitnami/charts/commit/8d1dc11)), closes [#25558](https://github.com/bitnami/charts/issues/25558)
-* [bitnami/deepspeed] Release 2.0.5 updating components versions (#26093) ([ea8a526](https://github.com/bitnami/charts/commit/ea8a526)), closes [#26093](https://github.com/bitnami/charts/issues/26093)
-* Replace VMware by Broadcom copyright text (#25306) ([a5e4bd0](https://github.com/bitnami/charts/commit/a5e4bd0)), closes [#25306](https://github.com/bitnami/charts/issues/25306)
+* [bitnami/*] Change non-root and rolling-tags doc URLs (#25628) ([b067c94](https://github.com/bitnami/charts/commit/b067c94f6bcde427863c197fd355f0b5ba12ff5b)), closes [#25628](https://github.com/bitnami/charts/issues/25628)
+* [bitnami/*] Set new header/owner (#25558) ([8d1dc11](https://github.com/bitnami/charts/commit/8d1dc11f5fb30db6fba50c43d7af59d2f79deed3)), closes [#25558](https://github.com/bitnami/charts/issues/25558)
+* [bitnami/deepspeed] Release 2.0.5 updating components versions (#26093) ([ea8a526](https://github.com/bitnami/charts/commit/ea8a5262079be7156a35a6a5eb16dcb378ea9665)), closes [#26093](https://github.com/bitnami/charts/issues/26093)
+* Replace VMware by Broadcom copyright text (#25306) ([a5e4bd0](https://github.com/bitnami/charts/commit/a5e4bd0e35e419203793976a78d9d0a13de92c76)), closes [#25306](https://github.com/bitnami/charts/issues/25306)
 
 ## <small>2.0.4 (2024-04-24)</small>
 
-* [bitnami/deepspeed] Release 2.0.4 updating components versions (#25344) ([5161c55](https://github.com/bitnami/charts/commit/5161c55)), closes [#25344](https://github.com/bitnami/charts/issues/25344)
+* [bitnami/deepspeed] Release 2.0.4 updating components versions (#25344) ([5161c55](https://github.com/bitnami/charts/commit/5161c55bb99a4ab46911ee0a0f603812a2e84eff)), closes [#25344](https://github.com/bitnami/charts/issues/25344)
 
 ## <small>2.0.3 (2024-04-16)</small>
 
-* [bitnami/deepspeed] Release 2.0.3 updating components versions (#25187) ([50b29e6](https://github.com/bitnami/charts/commit/50b29e6)), closes [#25187](https://github.com/bitnami/charts/issues/25187)
+* [bitnami/deepspeed] Release 2.0.3 updating components versions (#25187) ([50b29e6](https://github.com/bitnami/charts/commit/50b29e671242de52f69b7f78df146436754dfaf9)), closes [#25187](https://github.com/bitnami/charts/issues/25187)
 
 ## <small>2.0.2 (2024-04-05)</small>
 
-* [bitnami/*] Reorder Chart sections (#24455) ([0cf4048](https://github.com/bitnami/charts/commit/0cf4048)), closes [#24455](https://github.com/bitnami/charts/issues/24455)
-* [bitnami/deepspeed] Release 2.0.2 (#24997) ([0a0af2d](https://github.com/bitnami/charts/commit/0a0af2d)), closes [#24997](https://github.com/bitnami/charts/issues/24997)
-* [bitnami/several] Fix comment mentioning Keycloak (#24661) ([641c546](https://github.com/bitnami/charts/commit/641c546)), closes [#24661](https://github.com/bitnami/charts/issues/24661)
-* Update resourcesPreset comments (#24467) ([92e3e8a](https://github.com/bitnami/charts/commit/92e3e8a)), closes [#24467](https://github.com/bitnami/charts/issues/24467)
+* [bitnami/*] Reorder Chart sections (#24455) ([0cf4048](https://github.com/bitnami/charts/commit/0cf4048e8743f70a9753d460655bd030cbff6824)), closes [#24455](https://github.com/bitnami/charts/issues/24455)
+* [bitnami/deepspeed] Release 2.0.2 (#24997) ([0a0af2d](https://github.com/bitnami/charts/commit/0a0af2d528567be067ed5f8cf9d45847ec97c339)), closes [#24997](https://github.com/bitnami/charts/issues/24997)
+* [bitnami/several] Fix comment mentioning Keycloak (#24661) ([641c546](https://github.com/bitnami/charts/commit/641c5468069de826c12d1e7c825807cf68b4ee96)), closes [#24661](https://github.com/bitnami/charts/issues/24661)
+* Update resourcesPreset comments (#24467) ([92e3e8a](https://github.com/bitnami/charts/commit/92e3e8a507326d2a20a8f10ab3e7746a2ec5c554)), closes [#24467](https://github.com/bitnami/charts/issues/24467)
 
 ## <small>2.0.1 (2024-03-11)</small>
 
-* [bitnami/deepspeed] chore: :arrow_up: Bump common subchart ([8167283](https://github.com/bitnami/charts/commit/8167283))
+* [bitnami/deepspeed] chore: :arrow_up: Bump common subchart ([8167283](https://github.com/bitnami/charts/commit/8167283dcf41f542c0520017e7d1f6e0f8990e83))
 
 ## 2.0.0 (2024-03-11)
 
-* [bitnami/deepspeed] feat!: :lock: :boom: Improve security defaults (#24292) ([4c045cd](https://github.com/bitnami/charts/commit/4c045cd)), closes [#24292](https://github.com/bitnami/charts/issues/24292)
+* [bitnami/deepspeed] feat!: :lock: :boom: Improve security defaults (#24292) ([4c045cd](https://github.com/bitnami/charts/commit/4c045cd751e424e862595af082bed2737a27da79)), closes [#24292](https://github.com/bitnami/charts/issues/24292)
 
 ## <small>1.8.2 (2024-03-08)</small>
 
-* [bitnami/deepspeed] Release 1.8.2 updating components versions (#24267) ([c8d0f2d](https://github.com/bitnami/charts/commit/c8d0f2d)), closes [#24267](https://github.com/bitnami/charts/issues/24267)
+* [bitnami/deepspeed] Release 1.8.2 updating components versions (#24267) ([c8d0f2d](https://github.com/bitnami/charts/commit/c8d0f2da760765b7106e33658891d65d79b03612)), closes [#24267](https://github.com/bitnami/charts/issues/24267)
 
 ## <small>1.8.1 (2024-03-07)</small>
 
-* [bitnami/deepspeed] Release 1.8.1 updating components versions (#24233) ([92caaf1](https://github.com/bitnami/charts/commit/92caaf1)), closes [#24233](https://github.com/bitnami/charts/issues/24233)
+* [bitnami/deepspeed] Release 1.8.1 updating components versions (#24233) ([92caaf1](https://github.com/bitnami/charts/commit/92caaf1fe0c980bbcb41eca9e58bbc36d6b03f0d)), closes [#24233](https://github.com/bitnami/charts/issues/24233)
 
 ## 1.8.0 (2024-03-06)
 
-* [bitnami/deepspeed] feat: :sparkles: :lock: Add automatic adaptation for Openshift restricted-v2 SCC ([0907908](https://github.com/bitnami/charts/commit/0907908)), closes [#24073](https://github.com/bitnami/charts/issues/24073)
+* [bitnami/deepspeed] feat: :sparkles: :lock: Add automatic adaptation for Openshift restricted-v2 SCC ([0907908](https://github.com/bitnami/charts/commit/0907908adc68d391fa7879c9600bfeaca4c82c25)), closes [#24073](https://github.com/bitnami/charts/issues/24073)
 
 ## <small>1.7.5 (2024-02-27)</small>
 
-* [bitnami/deepspeed] Release 1.7.5 updating components versions (#23933) ([232cf2c](https://github.com/bitnami/charts/commit/232cf2c)), closes [#23933](https://github.com/bitnami/charts/issues/23933)
+* [bitnami/deepspeed] Release 1.7.5 updating components versions (#23933) ([232cf2c](https://github.com/bitnami/charts/commit/232cf2c1071e38bbc59265a4742578394d6b1556)), closes [#23933](https://github.com/bitnami/charts/issues/23933)
 
 ## <small>1.7.4 (2024-02-24)</small>
 
-* [bitnami/deepspeed] Release 1.7.4 updating components versions (#23894) ([cc227b7](https://github.com/bitnami/charts/commit/cc227b7)), closes [#23894](https://github.com/bitnami/charts/issues/23894)
+* [bitnami/deepspeed] Release 1.7.4 updating components versions (#23894) ([cc227b7](https://github.com/bitnami/charts/commit/cc227b7663cdbec9667c781262785588eadcdfc0)), closes [#23894](https://github.com/bitnami/charts/issues/23894)
 
 ## <small>1.7.3 (2024-02-23)</small>
 
-* [bitnami/deepspeed] Release 1.7.3 updating components versions (#23870) ([de23cb0](https://github.com/bitnami/charts/commit/de23cb0)), closes [#23870](https://github.com/bitnami/charts/issues/23870)
+* [bitnami/deepspeed] Release 1.7.3 updating components versions (#23870) ([de23cb0](https://github.com/bitnami/charts/commit/de23cb0c80011c16e681fe1ae6c20e155fbc8aae)), closes [#23870](https://github.com/bitnami/charts/issues/23870)
 
 ## <small>1.7.2 (2024-02-21)</small>
 
-* [bitnami/deepspeed] Release 1.7.2 updating components versions (#23748) ([3fdd90e](https://github.com/bitnami/charts/commit/3fdd90e)), closes [#23748](https://github.com/bitnami/charts/issues/23748)
+* [bitnami/deepspeed] Release 1.7.2 updating components versions (#23748) ([3fdd90e](https://github.com/bitnami/charts/commit/3fdd90ec075502cf55f3535c30858982518b126e)), closes [#23748](https://github.com/bitnami/charts/issues/23748)
 
 ## <small>1.7.1 (2024-02-21)</small>
 
-* [bitnami/deepspeed] feat: :sparkles: :lock: Add resource preset support (#23440) ([fcfad88](https://github.com/bitnami/charts/commit/fcfad88)), closes [#23440](https://github.com/bitnami/charts/issues/23440)
-* [bitnami/deepspeed] Release 1.7.1 updating components versions (#23642) ([2005b56](https://github.com/bitnami/charts/commit/2005b56)), closes [#23642](https://github.com/bitnami/charts/issues/23642)
+* [bitnami/deepspeed] feat: :sparkles: :lock: Add resource preset support (#23440) ([fcfad88](https://github.com/bitnami/charts/commit/fcfad88e137c92a38e67adfe3b544d249924a1d0)), closes [#23440](https://github.com/bitnami/charts/issues/23440)
+* [bitnami/deepspeed] Release 1.7.1 updating components versions (#23642) ([2005b56](https://github.com/bitnami/charts/commit/2005b56cdd2b06ed94ff36772f6a3e52b7f31ebf)), closes [#23642](https://github.com/bitnami/charts/issues/23642)
 
 ## 1.7.0 (2024-02-20)
 
-* [bitnami/*] Bump all versions (#23602) ([b70ee2a](https://github.com/bitnami/charts/commit/b70ee2a)), closes [#23602](https://github.com/bitnami/charts/issues/23602)
+* [bitnami/*] Bump all versions (#23602) ([b70ee2a](https://github.com/bitnami/charts/commit/b70ee2a30e4dc256bf0ac52928fb2fa7a70f049b)), closes [#23602](https://github.com/bitnami/charts/issues/23602)
 
 ## <small>1.6.1 (2024-02-16)</small>
 
-* [bitnami/deepspeed] Release 1.6.1 updating components versions (#23573) ([d22aed4](https://github.com/bitnami/charts/commit/d22aed4)), closes [#23573](https://github.com/bitnami/charts/issues/23573)
+* [bitnami/deepspeed] Release 1.6.1 updating components versions (#23573) ([d22aed4](https://github.com/bitnami/charts/commit/d22aed47f2375af5861faa3ac2b22f1263328875)), closes [#23573](https://github.com/bitnami/charts/issues/23573)
 
 ## 1.6.0 (2024-02-14)
 
-* [bitnami/deepspeed] feat: :lock: Enable networkPolicy (#23299) ([6233419](https://github.com/bitnami/charts/commit/6233419)), closes [#23299](https://github.com/bitnami/charts/issues/23299)
+* [bitnami/deepspeed] feat: :lock: Enable networkPolicy (#23299) ([6233419](https://github.com/bitnami/charts/commit/623341908329f4dc96b0229dcd6398f560d296e1)), closes [#23299](https://github.com/bitnami/charts/issues/23299)
 
 ## <small>1.5.3 (2024-02-08)</small>
 
-* [bitnami/deepspeed] Release 1.5.3 (#23332) ([e6f3011](https://github.com/bitnami/charts/commit/e6f3011)), closes [#23332](https://github.com/bitnami/charts/issues/23332)
+* [bitnami/deepspeed] Release 1.5.3 (#23332) ([e6f3011](https://github.com/bitnami/charts/commit/e6f301116b60df8d7a11afc22428d9383c387b88)), closes [#23332](https://github.com/bitnami/charts/issues/23332)
 
 ## <small>1.5.2 (2024-01-30)</small>
 
-* [bitnami/*] Move documentation sections from docs.bitnami.com back to the README (#22203) ([7564f36](https://github.com/bitnami/charts/commit/7564f36)), closes [#22203](https://github.com/bitnami/charts/issues/22203)
-* [bitnami/deepspeed] Release 1.5.2 updating components versions (#22844) ([05570d2](https://github.com/bitnami/charts/commit/05570d2)), closes [#22844](https://github.com/bitnami/charts/issues/22844)
+* [bitnami/*] Move documentation sections from docs.bitnami.com back to the README (#22203) ([7564f36](https://github.com/bitnami/charts/commit/7564f36ca1e95ff30ee686652b7ab8690561a707)), closes [#22203](https://github.com/bitnami/charts/issues/22203)
+* [bitnami/deepspeed] Release 1.5.2 updating components versions (#22844) ([05570d2](https://github.com/bitnami/charts/commit/05570d23f7f0b8aeda4ae3e2cf601af0329ee87a)), closes [#22844](https://github.com/bitnami/charts/issues/22844)
 
 ## <small>1.5.1 (2024-01-24)</small>
 
-* [bitnami/deepspeed] fix: :bug: Set seLinuxOptions to null for Openshift compatibility (#22578) ([80cb5bb](https://github.com/bitnami/charts/commit/80cb5bb)), closes [#22578](https://github.com/bitnami/charts/issues/22578)
+* [bitnami/deepspeed] fix: :bug: Set seLinuxOptions to null for Openshift compatibility (#22578) ([80cb5bb](https://github.com/bitnami/charts/commit/80cb5bba5955ab4db7b5ef8a98950424c8a10768)), closes [#22578](https://github.com/bitnami/charts/issues/22578)
 
 ## 1.5.0 (2024-01-19)
 
-* [bitnami/deepspeed] fix: :lock: Move service-account token auto-mount to pod declaration (#22393) ([593a70d](https://github.com/bitnami/charts/commit/593a70d)), closes [#22393](https://github.com/bitnami/charts/issues/22393)
+* [bitnami/deepspeed] fix: :lock: Move service-account token auto-mount to pod declaration (#22393) ([593a70d](https://github.com/bitnami/charts/commit/593a70df63c660afa26321edc0bdce3247468a8d)), closes [#22393](https://github.com/bitnami/charts/issues/22393)
 
 ## <small>1.4.1 (2024-01-18)</small>
 
-* [bitnami/deepspeed] Release 1.3.6 updating components versions (#21838) ([827eba4](https://github.com/bitnami/charts/commit/827eba4)), closes [#21838](https://github.com/bitnami/charts/issues/21838)
+* [bitnami/deepspeed] Release 1.3.6 updating components versions (#21838) ([827eba4](https://github.com/bitnami/charts/commit/827eba4f1d12f7620ce815f6d4b68b279f2dd699)), closes [#21838](https://github.com/bitnami/charts/issues/21838)
 
 ## 1.4.0 (2024-01-16)
 
-* [bitnami/deepspeed] fix: :lock: Improve podSecurityContext and containerSecurityContext with essenti ([df53714](https://github.com/bitnami/charts/commit/df53714)), closes [#22109](https://github.com/bitnami/charts/issues/22109)
+* [bitnami/deepspeed] fix: :lock: Improve podSecurityContext and containerSecurityContext with essenti ([df53714](https://github.com/bitnami/charts/commit/df537144cd3c0da79341ee6690041cf124755c44)), closes [#22109](https://github.com/bitnami/charts/issues/22109)
 
 ## <small>1.3.6 (2024-01-15)</small>
 
-* [bitnami/*] Fix docs.bitnami.com broken links (#21901) ([f35506d](https://github.com/bitnami/charts/commit/f35506d)), closes [#21901](https://github.com/bitnami/charts/issues/21901)
-* [bitnami/*] Fix ref links (in comments) (#21822) ([e4fa296](https://github.com/bitnami/charts/commit/e4fa296)), closes [#21822](https://github.com/bitnami/charts/issues/21822)
-* [bitnami/*] Update copyright: Year and company (#21815) ([6c4bf75](https://github.com/bitnami/charts/commit/6c4bf75)), closes [#21815](https://github.com/bitnami/charts/issues/21815)
-* [bitnami/deepspeed] fix: :lock: Do not use the default service account (#21991) ([33f24b3](https://github.com/bitnami/charts/commit/33f24b3)), closes [#21991](https://github.com/bitnami/charts/issues/21991)
+* [bitnami/*] Fix docs.bitnami.com broken links (#21901) ([f35506d](https://github.com/bitnami/charts/commit/f35506d2dadee4f097986e7792df1f53ab215b5d)), closes [#21901](https://github.com/bitnami/charts/issues/21901)
+* [bitnami/*] Fix ref links (in comments) (#21822) ([e4fa296](https://github.com/bitnami/charts/commit/e4fa296106b225cf8c82445727c675c7c725e380)), closes [#21822](https://github.com/bitnami/charts/issues/21822)
+* [bitnami/*] Update copyright: Year and company (#21815) ([6c4bf75](https://github.com/bitnami/charts/commit/6c4bf75dec58fc7c9aee9f089777b1a858c17d5b)), closes [#21815](https://github.com/bitnami/charts/issues/21815)
+* [bitnami/deepspeed] fix: :lock: Do not use the default service account (#21991) ([33f24b3](https://github.com/bitnami/charts/commit/33f24b3e202f5d6bd143e054f31477870dcdaa68)), closes [#21991](https://github.com/bitnami/charts/issues/21991)
 
 ## <small>1.3.5 (2023-11-21)</small>
 
-* [bitnami/*] Remove relative links to non-README sections, add verification for that and update TL;DR ([1103633](https://github.com/bitnami/charts/commit/1103633)), closes [#20967](https://github.com/bitnami/charts/issues/20967)
-* [bitnami/*] Rename solutions to "Bitnami package for ..." (#21038) ([b82f979](https://github.com/bitnami/charts/commit/b82f979)), closes [#21038](https://github.com/bitnami/charts/issues/21038)
-* [bitnami/deepspeed] Release 1.3.5 updating components versions (#21106) ([7154d94](https://github.com/bitnami/charts/commit/7154d94)), closes [#21106](https://github.com/bitnami/charts/issues/21106)
+* [bitnami/*] Remove relative links to non-README sections, add verification for that and update TL;DR ([1103633](https://github.com/bitnami/charts/commit/11036334d82df0490aa4abdb591543cab6cf7d7f)), closes [#20967](https://github.com/bitnami/charts/issues/20967)
+* [bitnami/*] Rename solutions to "Bitnami package for ..." (#21038) ([b82f979](https://github.com/bitnami/charts/commit/b82f979e4fb63423fe6e2192c946d09d79c944fc)), closes [#21038](https://github.com/bitnami/charts/issues/21038)
+* [bitnami/deepspeed] Release 1.3.5 updating components versions (#21106) ([7154d94](https://github.com/bitnami/charts/commit/7154d943d1a13cb4c8dfeae248a5edf9bdf34a95)), closes [#21106](https://github.com/bitnami/charts/issues/21106)
 
 ## <small>1.3.4 (2023-11-16)</small>
 
-* [bitnami/deepspeed] Release 1.3.4 updating components versions (#20996) ([fd3129d](https://github.com/bitnami/charts/commit/fd3129d)), closes [#20996](https://github.com/bitnami/charts/issues/20996)
+* [bitnami/deepspeed] Release 1.3.4 updating components versions (#20996) ([fd3129d](https://github.com/bitnami/charts/commit/fd3129d80fad8a21bf172ce186808f0588344d8d)), closes [#20996](https://github.com/bitnami/charts/issues/20996)
 
 ## <small>1.3.3 (2023-11-15)</small>
 
-* [bitnami/deepspeed] Release 1.3.3 updating components versions (#20984) ([c5f6b14](https://github.com/bitnami/charts/commit/c5f6b14)), closes [#20984](https://github.com/bitnami/charts/issues/20984)
+* [bitnami/deepspeed] Release 1.3.3 updating components versions (#20984) ([c5f6b14](https://github.com/bitnami/charts/commit/c5f6b1460a66ee07933357c24b79f28aa5a15ac2)), closes [#20984](https://github.com/bitnami/charts/issues/20984)
 
 ## <small>1.3.2 (2023-11-13)</small>
 
-* [bitnami/deepspeed] Release 1.3.2 updating components versions (#20928) ([c1fcfc4](https://github.com/bitnami/charts/commit/c1fcfc4)), closes [#20928](https://github.com/bitnami/charts/issues/20928)
+* [bitnami/deepspeed] Release 1.3.2 updating components versions (#20928) ([c1fcfc4](https://github.com/bitnami/charts/commit/c1fcfc4b7ce68ef911077853795ef05a0719b5cb)), closes [#20928](https://github.com/bitnami/charts/issues/20928)
 
 ## <small>1.3.1 (2023-11-10)</small>
 
-* [bitnami/deepspeed] Release 1.3.1 (#20695) ([0d624f9](https://github.com/bitnami/charts/commit/0d624f9)), closes [#20695](https://github.com/bitnami/charts/issues/20695)
+* [bitnami/deepspeed] Release 1.3.1 (#20695) ([0d624f9](https://github.com/bitnami/charts/commit/0d624f924e7cd9c2d31a4cefbe09f548635c5e4f)), closes [#20695](https://github.com/bitnami/charts/issues/20695)
 
 ## 1.3.0 (2023-11-06)
 
-* [bitnami/deepspeed] feat: :sparkles: Add support for PSA restricted policy (#20420) ([8d63995](https://github.com/bitnami/charts/commit/8d63995)), closes [#20420](https://github.com/bitnami/charts/issues/20420)
+* [bitnami/deepspeed] feat: :sparkles: Add support for PSA restricted policy (#20420) ([8d63995](https://github.com/bitnami/charts/commit/8d639950903e0bde10810549ec45e943cb3bc585)), closes [#20420](https://github.com/bitnami/charts/issues/20420)
 
 ## <small>1.2.7 (2023-10-23)</small>
 
-* [bitnami/*] Rename VMware Application Catalog (#20361) ([3acc734](https://github.com/bitnami/charts/commit/3acc734)), closes [#20361](https://github.com/bitnami/charts/issues/20361)
-* [bitnami/*] Skip image's tag in the README files of the Bitnami Charts (#19841) ([bb9a01b](https://github.com/bitnami/charts/commit/bb9a01b)), closes [#19841](https://github.com/bitnami/charts/issues/19841)
-* [bitnami/*] Standardize documentation (#19835) ([af5f753](https://github.com/bitnami/charts/commit/af5f753)), closes [#19835](https://github.com/bitnami/charts/issues/19835)
-* [bitnami/deepspeed] Release 1.2.7 updating components versions (#20365) ([354d248](https://github.com/bitnami/charts/commit/354d248)), closes [#20365](https://github.com/bitnami/charts/issues/20365)
+* [bitnami/*] Rename VMware Application Catalog (#20361) ([3acc734](https://github.com/bitnami/charts/commit/3acc73472beb6fb56c4d99f929061001205bc57e)), closes [#20361](https://github.com/bitnami/charts/issues/20361)
+* [bitnami/*] Skip image's tag in the README files of the Bitnami Charts (#19841) ([bb9a01b](https://github.com/bitnami/charts/commit/bb9a01b65911c87e48318db922cc05eb42785e42)), closes [#19841](https://github.com/bitnami/charts/issues/19841)
+* [bitnami/*] Standardize documentation (#19835) ([af5f753](https://github.com/bitnami/charts/commit/af5f7530c1bc8c5ded53a6c4f7b8f384ac1804f2)), closes [#19835](https://github.com/bitnami/charts/issues/19835)
+* [bitnami/deepspeed] Release 1.2.7 updating components versions (#20365) ([354d248](https://github.com/bitnami/charts/commit/354d248e1404ae542db8ab3c1e90a518e86416ec)), closes [#20365](https://github.com/bitnami/charts/issues/20365)
 
 ## <small>1.2.6 (2023-10-12)</small>
 
-* [bitnami/deepspeed] Release 1.2.6 (#20201) ([bbf8671](https://github.com/bitnami/charts/commit/bbf8671)), closes [#20201](https://github.com/bitnami/charts/issues/20201)
+* [bitnami/deepspeed] Release 1.2.6 (#20201) ([bbf8671](https://github.com/bitnami/charts/commit/bbf8671f1d3a745e7839c508fa0c3be33c872402)), closes [#20201](https://github.com/bitnami/charts/issues/20201)
 
 ## <small>1.2.5 (2023-10-09)</small>
 
-* [bitnami/deepspeed] Release 1.2.5 (#19903) ([f96288d](https://github.com/bitnami/charts/commit/f96288d)), closes [#19903](https://github.com/bitnami/charts/issues/19903)
+* [bitnami/deepspeed] Release 1.2.5 (#19903) ([f96288d](https://github.com/bitnami/charts/commit/f96288d8861c25b60ced89945271b6b4a48dd7e6)), closes [#19903](https://github.com/bitnami/charts/issues/19903)
 
 ## <small>1.2.4 (2023-10-09)</small>
 
-* [bitnami/*] Update Helm charts prerequisites (#19745) ([eb755dd](https://github.com/bitnami/charts/commit/eb755dd)), closes [#19745](https://github.com/bitnami/charts/issues/19745)
-* [bitnami/deepspeed] bump bitnami/common (#19783) ([054f89a](https://github.com/bitnami/charts/commit/054f89a)), closes [#19783](https://github.com/bitnami/charts/issues/19783)
-* Revert "Autogenerate schema files (#19194)" (#19335) ([73d80be](https://github.com/bitnami/charts/commit/73d80be)), closes [#19194](https://github.com/bitnami/charts/issues/19194) [#19335](https://github.com/bitnami/charts/issues/19335)
+* [bitnami/*] Update Helm charts prerequisites (#19745) ([eb755dd](https://github.com/bitnami/charts/commit/eb755dd36a4dd3cf6635be8e0598f9a7f4c4a554)), closes [#19745](https://github.com/bitnami/charts/issues/19745)
+* [bitnami/deepspeed] bump bitnami/common (#19783) ([054f89a](https://github.com/bitnami/charts/commit/054f89a6a03da756493f9e334745138e7e0869eb)), closes [#19783](https://github.com/bitnami/charts/issues/19783)
+* Revert "Autogenerate schema files (#19194)" (#19335) ([73d80be](https://github.com/bitnami/charts/commit/73d80be525c88fb4b8a54451a55acd506e337062)), closes [#19194](https://github.com/bitnami/charts/issues/19194) [#19335](https://github.com/bitnami/charts/issues/19335)
 
 ## <small>1.2.3 (2023-09-12)</small>
 
-* [bitnami/deepspeed] Release 1.2.3 (#19243) ([0897e83](https://github.com/bitnami/charts/commit/0897e83)), closes [#19243](https://github.com/bitnami/charts/issues/19243)
-* Autogenerate schema files (#19194) ([a2c2090](https://github.com/bitnami/charts/commit/a2c2090)), closes [#19194](https://github.com/bitnami/charts/issues/19194)
+* [bitnami/deepspeed] Release 1.2.3 (#19243) ([0897e83](https://github.com/bitnami/charts/commit/0897e837e9ba11573ac9457600aa14de2ddb0a85)), closes [#19243](https://github.com/bitnami/charts/issues/19243)
+* Autogenerate schema files (#19194) ([a2c2090](https://github.com/bitnami/charts/commit/a2c2090b5ac97f47b745c8028c6452bf99739772)), closes [#19194](https://github.com/bitnami/charts/issues/19194)
 
 ## <small>1.2.2 (2023-09-06)</small>
 
-* [bitnami/deepspeed]: Use merge helper (#19061) ([a108f3b](https://github.com/bitnami/charts/commit/a108f3b)), closes [#19061](https://github.com/bitnami/charts/issues/19061)
+* [bitnami/deepspeed]: Use merge helper (#19061) ([a108f3b](https://github.com/bitnami/charts/commit/a108f3bd62b90fc0f19405c572d1f1cbbc202348)), closes [#19061](https://github.com/bitnami/charts/issues/19061)
 
 ## <small>1.2.1 (2023-08-31)</small>
 
-* [bitnami/deepspeed] Release 1.2.1 (#18970) ([8f59911](https://github.com/bitnami/charts/commit/8f59911)), closes [#18970](https://github.com/bitnami/charts/issues/18970)
+* [bitnami/deepspeed] Release 1.2.1 (#18970) ([8f59911](https://github.com/bitnami/charts/commit/8f59911b638b3222c64691b90194c0df1e1b60a0)), closes [#18970](https://github.com/bitnami/charts/issues/18970)
 
 ## 1.2.0 (2023-08-29)
 
-* [bitnami/deepspeed] Support for customizing standard labels (#18478) ([9c8407e](https://github.com/bitnami/charts/commit/9c8407e)), closes [#18478](https://github.com/bitnami/charts/issues/18478)
+* [bitnami/deepspeed] Support for customizing standard labels (#18478) ([9c8407e](https://github.com/bitnami/charts/commit/9c8407ea49c59a4fb7da91149f15cd0062ed1082)), closes [#18478](https://github.com/bitnami/charts/issues/18478)
 
 ## <small>1.1.6 (2023-08-22)</small>
 
-* [bitnami/deepspeed] Release 1.1.6 (#18781) ([75d6f29](https://github.com/bitnami/charts/commit/75d6f29)), closes [#18781](https://github.com/bitnami/charts/issues/18781)
+* [bitnami/deepspeed] Release 1.1.6 (#18781) ([75d6f29](https://github.com/bitnami/charts/commit/75d6f29a01c6dcd385ea8469eb756828f3cf9f36)), closes [#18781](https://github.com/bitnami/charts/issues/18781)
 
 ## <small>1.1.5 (2023-08-18)</small>
 
-* [bitnami/deepspeed] fix: :bug: Set HOME to /home/deepspeed (#18614) ([363051a](https://github.com/bitnami/charts/commit/363051a)), closes [#18614](https://github.com/bitnami/charts/issues/18614)
+* [bitnami/deepspeed] fix: :bug: Set HOME to /home/deepspeed (#18614) ([363051a](https://github.com/bitnami/charts/commit/363051a739d813f951ea0b165c27ca36c050b1f0)), closes [#18614](https://github.com/bitnami/charts/issues/18614)
 
 ## <small>1.1.4 (2023-08-17)</small>
 
-* [bitnami/deepspeed] Release 1.1.4 (#18508) ([e2ecd36](https://github.com/bitnami/charts/commit/e2ecd36)), closes [#18508](https://github.com/bitnami/charts/issues/18508)
+* [bitnami/deepspeed] Release 1.1.4 (#18508) ([e2ecd36](https://github.com/bitnami/charts/commit/e2ecd36a0618d02ea3a8ad6ee48508b16ee31f72)), closes [#18508](https://github.com/bitnami/charts/issues/18508)
 
 ## <small>1.1.3 (2023-08-14)</small>
 
-* [bitnami/deepspeed] Release 1.1.3 (#18394) ([2796e51](https://github.com/bitnami/charts/commit/2796e51)), closes [#18394](https://github.com/bitnami/charts/issues/18394)
+* [bitnami/deepspeed] Release 1.1.3 (#18394) ([2796e51](https://github.com/bitnami/charts/commit/2796e51b0ec5295a11772ed91e6d7d44cf756c66)), closes [#18394](https://github.com/bitnami/charts/issues/18394)
 
 ## <small>1.1.2 (2023-08-13)</small>
 
-* [bitnami/deepspeed] Release 1.1.2 (#18389) ([72fee9e](https://github.com/bitnami/charts/commit/72fee9e)), closes [#18389](https://github.com/bitnami/charts/issues/18389)
+* [bitnami/deepspeed] Release 1.1.2 (#18389) ([72fee9e](https://github.com/bitnami/charts/commit/72fee9ebfb8af8d3628bfe0b3b5c00f83cfdca62)), closes [#18389](https://github.com/bitnami/charts/issues/18389)
 
 ## <small>1.1.1 (2023-08-11)</small>
 
-* [bitnami/deepspeed] fix: :bug: Add context to init container (#18360) ([24d9de2](https://github.com/bitnami/charts/commit/24d9de2)), closes [#18360](https://github.com/bitnami/charts/issues/18360)
+* [bitnami/deepspeed] fix: :bug: Add context to init container (#18360) ([24d9de2](https://github.com/bitnami/charts/commit/24d9de2ba259e6086da7d75a8a991210771bb5ad)), closes [#18360](https://github.com/bitnami/charts/issues/18360)
 
 ## 1.1.0 (2023-08-09)
 
-* [bitnami/deepspeed] feat: :sparkles: Allow older versions of ssh (#18332) ([67d991f](https://github.com/bitnami/charts/commit/67d991f)), closes [#18332](https://github.com/bitnami/charts/issues/18332)
+* [bitnami/deepspeed] feat: :sparkles: Allow older versions of ssh (#18332) ([67d991f](https://github.com/bitnami/charts/commit/67d991f32939c0bb979449bf89f93b876adc59a1)), closes [#18332](https://github.com/bitnami/charts/issues/18332)
 
 ## 1.0.0 (2023-08-08)
 
-* [bitnami/deepspeed] Release 1.0.0 (#18256) ([c0ae702](https://github.com/bitnami/charts/commit/c0ae702)), closes [#18256](https://github.com/bitnami/charts/issues/18256)
+* [bitnami/deepspeed] Release 1.0.0 (#18256) ([c0ae702](https://github.com/bitnami/charts/commit/c0ae702a65e20b295a6c86539dd8365e1091da8d)), closes [#18256](https://github.com/bitnami/charts/issues/18256)
 
 ## 0.1.0 (2023-08-07)
 
-* [bitnami/deepspeed] feat: :tada: Add chart (#18139) ([a6e91d3](https://github.com/bitnami/charts/commit/a6e91d3)), closes [#18139](https://github.com/bitnami/charts/issues/18139)
+* [bitnami/deepspeed] feat: :tada: Add chart (#18139) ([a6e91d3](https://github.com/bitnami/charts/commit/a6e91d36d8415f9d0179e019ceba261d8b963d4e)), closes [#18139](https://github.com/bitnami/charts/issues/18139)

--- a/bitnami/deepspeed/Chart.yaml
+++ b/bitnami/deepspeed/Chart.yaml
@@ -35,5 +35,5 @@ name: deepspeed
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/deepspeed
 - https://github.com/bitnami/charts/tree/main/bitnami/pytorch
-version: 2.1.1
+version: 2.2.0
 

--- a/bitnami/deepspeed/README.md
+++ b/bitnami/deepspeed/README.md
@@ -315,18 +315,21 @@ You can enable this initContainer by setting `volumePermissions.enabled` to `tru
 
 ### Deepspeed Client persistence paramaters
 
-| Name                               | Description                                                             | Value                     |
-| ---------------------------------- | ----------------------------------------------------------------------- | ------------------------- |
-| `client.persistence.enabled`       | Use a PVC to persist data                                               | `false`                   |
-| `client.persistence.storageClass`  | discourse & sidekiq data Persistent Volume Storage Class                | `""`                      |
-| `client.persistence.existingClaim` | Use a existing PVC which must be created manually before bound          | `""`                      |
-| `client.persistence.mountPath`     | Path to mount the volume at                                             | `/bitnami/deepspeed/data` |
-| `client.persistence.accessModes`   | Persistent Volume Access Mode                                           | `["ReadWriteOnce"]`       |
-| `client.persistence.dataSource`    | Custom PVC data source                                                  | `{}`                      |
-| `client.persistence.selector`      | Selector to match an existing Persistent Volume for the client data PVC | `{}`                      |
-| `client.persistence.size`          | Size of data volume                                                     | `8Gi`                     |
-| `client.persistence.labels`        | Persistent Volume labels                                                | `{}`                      |
-| `client.persistence.annotations`   | Persistent Volume annotations                                           | `{}`                      |
+| Name                               | Description                                                                                                                                                  | Value                     |
+| ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------- |
+| `client.persistence.enabled`       | Use a PVC to persist data                                                                                                                                    | `false`                   |
+| `client.persistence.storageClass`  | discourse & sidekiq data Persistent Volume Storage Class                                                                                                     | `""`                      |
+| `client.persistence.existingClaim` | Use a existing PVC which must be created manually before bound                                                                                               | `""`                      |
+| `client.persistence.mountPath`     | Path to mount the volume at                                                                                                                                  | `/bitnami/deepspeed/data` |
+| `client.persistence.accessModes`   | Persistent Volume Access Mode                                                                                                                                | `["ReadWriteOnce"]`       |
+| `client.persistence.dataSource`    | Custom PVC data source                                                                                                                                       | `{}`                      |
+| `client.persistence.selector`      | Selector to match an existing Persistent Volume for the client data PVC                                                                                      | `{}`                      |
+| `client.persistence.size`          | Size of data volume                                                                                                                                          | `8Gi`                     |
+| `client.persistence.labels`        | Persistent Volume labels                                                                                                                                     | `{}`                      |
+| `client.persistence.annotations`   | Persistent Volume annotations                                                                                                                                | `{}`                      |
+| `client.pdb.create`                | Enable/disable a Pod Disruption Budget creation                                                                                                              | `true`                    |
+| `client.pdb.minAvailable`          | Minimum number/percentage of pods that should remain scheduled                                                                                               | `""`                      |
+| `client.pdb.maxUnavailable`        | Maximum number/percentage of pods that may be made unavailable. Defaults to `1` if both `client.pdb.minAvailable` and `client.pdb.maxUnavailable` are empty. | `""`                      |
 
 ### Worker Deployment Parameters
 
@@ -454,6 +457,9 @@ You can enable this initContainer by setting `volumePermissions.enabled` to `tru
 | `worker.persistence.size`             | Size of data volume                                                                                                                                                                                                                                   | `8Gi`                      |
 | `worker.persistence.labels`           | Persistent Volume labels                                                                                                                                                                                                                              | `{}`                       |
 | `worker.persistence.annotations`      | Persistent Volume annotations                                                                                                                                                                                                                         | `{}`                       |
+| `worker.pdb.create`                   | Enable/disable a Pod Disruption Budget creation                                                                                                                                                                                                       | `true`                     |
+| `worker.pdb.minAvailable`             | Minimum number/percentage of pods that should remain scheduled                                                                                                                                                                                        | `""`                       |
+| `worker.pdb.maxUnavailable`           | Maximum number/percentage of pods that may be made unavailable. Defaults to `1` if both `worker.pdb.minAvailable` and `worker.pdb.maxUnavailable` are empty.                                                                                          | `""`                       |
 | `gitImage.registry`                   | Git image registry                                                                                                                                                                                                                                    | `REGISTRY_NAME`            |
 | `gitImage.repository`                 | Git image repository                                                                                                                                                                                                                                  | `REPOSITORY_NAME/git`      |
 | `gitImage.digest`                     | Git image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag                                                                                                                                                   | `""`                       |

--- a/bitnami/deepspeed/templates/client/pdb.yaml
+++ b/bitnami/deepspeed/templates/client/pdb.yaml
@@ -1,0 +1,30 @@
+{{- /*
+Copyright Broadcom, Inc. All Rights Reserved.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+{{- if and .Values.client.enabled .Values.client.pdb.create (not .Values.client.useJob) }}
+apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "deepspeed.v0.client.fullname" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+    app.kubernetes.io/part-of: deepspeed
+    app.kubernetes.io/component: client
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.client.pdb.minAvailable }}
+  minAvailable: {{ .Values.client.pdb.minAvailable }}
+  {{- end  }}
+  {{- if or .Values.client.pdb.maxUnavailable (not .Values.client.pdb.minAvailable) }}
+  maxUnavailable: {{ .Values.client.pdb.maxUnavailable | default 1 }}
+  {{- end  }}
+  {{- $podLabels := include "common.tplvalues.merge" (dict "values" (list .Values.client.podLabels .Values.commonLabels) "context" .) }}
+  selector:
+    matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
+      app.kubernetes.io/part-of: deepspeed
+      app.kubernetes.io/component: client
+{{- end }}

--- a/bitnami/deepspeed/templates/worker/pdb.yaml
+++ b/bitnami/deepspeed/templates/worker/pdb.yaml
@@ -1,0 +1,30 @@
+{{- /*
+Copyright Broadcom, Inc. All Rights Reserved.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+{{- if and .Values.worker.enabled  .Values.worker.pdb.create }}
+apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "deepspeed.v0.worker.fullname" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+    app.kubernetes.io/part-of: deepspeed
+    app.kubernetes.io/component: worker
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.worker.pdb.minAvailable }}
+  minAvailable: {{ .Values.worker.pdb.minAvailable }}
+  {{- end  }}
+  {{- if or .Values.worker.pdb.maxUnavailable (not .Values.worker.pdb.minAvailable) }}
+  maxUnavailable: {{ .Values.worker.pdb.maxUnavailable | default 1 }}
+  {{- end  }}
+  {{- $podLabels := include "common.tplvalues.merge" (dict "values" (list .Values.worker.podLabels .Values.commonLabels) "context" .) }}
+  selector:
+    matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
+      app.kubernetes.io/part-of: deepspeed
+      app.kubernetes.io/component: worker
+{{- end }}

--- a/bitnami/deepspeed/values.yaml
+++ b/bitnami/deepspeed/values.yaml
@@ -543,6 +543,16 @@ client:
     ## @param client.persistence.annotations Persistent Volume annotations
     ##
     annotations: {}
+  ## Pod Disruption Budget configuration
+  ## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb
+  ## @param client.pdb.create Enable/disable a Pod Disruption Budget creation
+  ## @param client.pdb.minAvailable Minimum number/percentage of pods that should remain scheduled
+  ## @param client.pdb.maxUnavailable Maximum number/percentage of pods that may be made unavailable. Defaults to `1` if both `client.pdb.minAvailable` and `client.pdb.maxUnavailable` are empty.
+  ##
+  pdb:
+    create: true
+    minAvailable: ""
+    maxUnavailable: ""
 ## @section Worker Deployment Parameters
 ##
 worker:
@@ -1003,6 +1013,16 @@ worker:
     ## @param worker.persistence.annotations Persistent Volume annotations
     ##
     annotations: {}
+  ## Pod Disruption Budget configuration
+  ## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb
+  ## @param worker.pdb.create Enable/disable a Pod Disruption Budget creation
+  ## @param worker.pdb.minAvailable Minimum number/percentage of pods that should remain scheduled
+  ## @param worker.pdb.maxUnavailable Maximum number/percentage of pods that may be made unavailable. Defaults to `1` if both `worker.pdb.minAvailable` and `worker.pdb.maxUnavailable` are empty.
+  ##
+  pdb:
+    create: true
+    minAvailable: ""
+    maxUnavailable: ""
 ## Bitnami git image version
 ## ref: https://hub.docker.com/r/bitnami/git/tags/
 ## @param gitImage.registry [default: REGISTRY_NAME] Git image registry


### PR DESCRIPTION
### Description of the change

Enabled PodDisruptionBudget by default and little fixes in PDB configuration to keep it aligned with current templates.

### Benefits

PDB protects our applications from voluntary disruption initiated by cluster administrators.
Keep our charts up to date according to our templates.

### Possible drawbacks

None

### Adition information

* [Pod disruption budgets](https://kubernetes.io/docs/concepts/workloads/pods/disruptions/#pod-disruption-budgets)
* [Specifying a Disruption Budget for your Application](https://kubernetes.io/docs/tasks/run-application/configure-pdb/)

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
