### PR TITLE
[bitnami/discourse] Enable PodDisruptionBudgets

### DIFF
--- a/bitnami/discourse/CHANGELOG.md
+++ b/bitnami/discourse/CHANGELOG.md
@@ -1,974 +1,979 @@
 # Changelog
 
+## 13.2.0 (2024-05-24)
+
+* [bitnami/discourse] Enable PodDisruptionBudgets ([#26425](https://github.com/bitnami/charts/pull/26425))
+
 ## 13.1.0 (2024-05-21)
 
-* [bitnami/discourse] feat: :sparkles: :lock: Add warning when original images are replaced ([#26193](https://github.com/bitnami/charts/pulls/26193))
+* [bitnami/*] ci: :construction_worker: Add tag and changelog support (#25359) ([91c707c](https://github.com/bitnami/charts/commit/91c707c9e4e574725a09505d2d313fb93f1b4c0a)), closes [#25359](https://github.com/bitnami/charts/issues/25359)
+* [bitnami/discourse] feat: :sparkles: :lock: Add warning when original images are replaced (#26193) ([249c0f9](https://github.com/bitnami/charts/commit/249c0f962bbb1f423f48e84d03910eccb03dc19c)), closes [#26193](https://github.com/bitnami/charts/issues/26193)
 
 ## <small>13.0.7 (2024-05-20)</small>
 
-* [bitnami/discourse] Use different liveness/readiness probes (#26119) ([6c08d62](https://github.com/bitnami/charts/commit/6c08d62)), closes [#26119](https://github.com/bitnami/charts/issues/26119)
+* [bitnami/discourse] Use different liveness/readiness probes (#26119) ([6c08d62](https://github.com/bitnami/charts/commit/6c08d62efba3524bc16192666f13f159406e6b95)), closes [#26119](https://github.com/bitnami/charts/issues/26119)
 
 ## <small>13.0.6 (2024-05-18)</small>
 
-* [bitnami/discourse] Release 13.0.6 updating components versions (#26006) ([946cf18](https://github.com/bitnami/charts/commit/946cf18)), closes [#26006](https://github.com/bitnami/charts/issues/26006)
+* [bitnami/discourse] Release 13.0.6 updating components versions (#26006) ([946cf18](https://github.com/bitnami/charts/commit/946cf18345500b4beac3a193515d87273672e3cc)), closes [#26006](https://github.com/bitnami/charts/issues/26006)
 
 ## <small>13.0.5 (2024-05-15)</small>
 
-* [bitnami/discourse] Release 13.0.5 updating components versions (#25939) ([4b89068](https://github.com/bitnami/charts/commit/4b89068)), closes [#25939](https://github.com/bitnami/charts/issues/25939)
+* [bitnami/discourse] Release 13.0.5 updating components versions (#25939) ([4b89068](https://github.com/bitnami/charts/commit/4b89068b8267e4b115c676064d092a05813953cc)), closes [#25939](https://github.com/bitnami/charts/issues/25939)
 
 ## <small>13.0.4 (2024-05-14)</small>
 
-* [bitnami/*] Change non-root and rolling-tags doc URLs (#25628) ([b067c94](https://github.com/bitnami/charts/commit/b067c94)), closes [#25628](https://github.com/bitnami/charts/issues/25628)
-* [bitnami/*] Set new header/owner (#25558) ([8d1dc11](https://github.com/bitnami/charts/commit/8d1dc11)), closes [#25558](https://github.com/bitnami/charts/issues/25558)
-* [bitnami/discourse] Release 13.0.4 updating components versions (#25767) ([4ee56a4](https://github.com/bitnami/charts/commit/4ee56a4)), closes [#25767](https://github.com/bitnami/charts/issues/25767)
+* [bitnami/*] Change non-root and rolling-tags doc URLs (#25628) ([b067c94](https://github.com/bitnami/charts/commit/b067c94f6bcde427863c197fd355f0b5ba12ff5b)), closes [#25628](https://github.com/bitnami/charts/issues/25628)
+* [bitnami/*] Set new header/owner (#25558) ([8d1dc11](https://github.com/bitnami/charts/commit/8d1dc11f5fb30db6fba50c43d7af59d2f79deed3)), closes [#25558](https://github.com/bitnami/charts/issues/25558)
+* [bitnami/discourse] Release 13.0.4 updating components versions (#25767) ([4ee56a4](https://github.com/bitnami/charts/commit/4ee56a46786dba2b8e32934a4dc0acb399da36e0)), closes [#25767](https://github.com/bitnami/charts/issues/25767)
 
 ## <small>13.0.3 (2024-04-26)</small>
 
-* [bitnami/discourse] Release 13.0.3 updating components versions (#25409) ([a92fc24](https://github.com/bitnami/charts/commit/a92fc24)), closes [#25409](https://github.com/bitnami/charts/issues/25409)
-* [bitnami/multiple charts] Fix typo: "NetworkPolice" vs "NetworkPolicy" (#25348) ([6970c1b](https://github.com/bitnami/charts/commit/6970c1b)), closes [#25348](https://github.com/bitnami/charts/issues/25348)
-* Replace VMware by Broadcom copyright text (#25306) ([a5e4bd0](https://github.com/bitnami/charts/commit/a5e4bd0)), closes [#25306](https://github.com/bitnami/charts/issues/25306)
+* [bitnami/discourse] Release 13.0.3 updating components versions (#25409) ([a92fc24](https://github.com/bitnami/charts/commit/a92fc24193f44f3c8bfedac97173b49fc4191d09)), closes [#25409](https://github.com/bitnami/charts/issues/25409)
+* [bitnami/multiple charts] Fix typo: "NetworkPolice" vs "NetworkPolicy" (#25348) ([6970c1b](https://github.com/bitnami/charts/commit/6970c1ba245873506e73d459c6eac1e4919b778f)), closes [#25348](https://github.com/bitnami/charts/issues/25348)
+* Replace VMware by Broadcom copyright text (#25306) ([a5e4bd0](https://github.com/bitnami/charts/commit/a5e4bd0e35e419203793976a78d9d0a13de92c76)), closes [#25306](https://github.com/bitnami/charts/issues/25306)
 
 ## <small>13.0.2 (2024-04-15)</small>
 
-* [bitnami/discourse] fix: :bug: Remove incorrect CHMOD capability (#24932) ([e31f0ef](https://github.com/bitnami/charts/commit/e31f0ef)), closes [#24932](https://github.com/bitnami/charts/issues/24932)
+* [bitnami/discourse] fix: :bug: Remove incorrect CHMOD capability (#24932) ([e31f0ef](https://github.com/bitnami/charts/commit/e31f0ef3763179ce15417d6b1b8ff1848b926471)), closes [#24932](https://github.com/bitnami/charts/issues/24932)
 
 ## <small>13.0.1 (2024-04-05)</small>
 
-* [bitnami/discourse] Release 13.0.1 (#24992) ([cd036b8](https://github.com/bitnami/charts/commit/cd036b8)), closes [#24992](https://github.com/bitnami/charts/issues/24992)
+* [bitnami/discourse] Release 13.0.1 (#24992) ([cd036b8](https://github.com/bitnami/charts/commit/cd036b8ecbb8fc052f06139a3dc9da1f5876c67c)), closes [#24992](https://github.com/bitnami/charts/issues/24992)
 
 ## 13.0.0 (2024-04-04)
 
-* [bitnami/discourse] feat!: :lock: :boom: Improve security defaults (#24787) ([4a05fd0](https://github.com/bitnami/charts/commit/4a05fd0)), closes [#24787](https://github.com/bitnami/charts/issues/24787)
-* Update resourcesPreset comments (#24467) ([92e3e8a](https://github.com/bitnami/charts/commit/92e3e8a)), closes [#24467](https://github.com/bitnami/charts/issues/24467)
+* [bitnami/discourse] feat!: :lock: :boom: Improve security defaults (#24787) ([4a05fd0](https://github.com/bitnami/charts/commit/4a05fd060f4f57645e024b3ad1a435d45cb882ec)), closes [#24787](https://github.com/bitnami/charts/issues/24787)
+* Update resourcesPreset comments (#24467) ([92e3e8a](https://github.com/bitnami/charts/commit/92e3e8a507326d2a20a8f10ab3e7746a2ec5c554)), closes [#24467](https://github.com/bitnami/charts/issues/24467)
 
 ## 12.8.0 (2024-03-20)
 
-* [bitnami/*] Reorder Chart sections (#24455) ([0cf4048](https://github.com/bitnami/charts/commit/0cf4048)), closes [#24455](https://github.com/bitnami/charts/issues/24455)
-* [bitnami/discourse] Update plugins to compatible versions (#23931) ([586bbc4](https://github.com/bitnami/charts/commit/586bbc4)), closes [#23931](https://github.com/bitnami/charts/issues/23931)
+* [bitnami/*] Reorder Chart sections (#24455) ([0cf4048](https://github.com/bitnami/charts/commit/0cf4048e8743f70a9753d460655bd030cbff6824)), closes [#24455](https://github.com/bitnami/charts/issues/24455)
+* [bitnami/discourse] Update plugins to compatible versions (#23931) ([586bbc4](https://github.com/bitnami/charts/commit/586bbc45f6454291d149838a3f4e3108b5f1f583)), closes [#23931](https://github.com/bitnami/charts/issues/23931)
 
 ## <small>12.7.3 (2024-03-15)</small>
 
-* [bitnami/discourse] Release 12.7.3 updating components versions (#24476) ([e44e0f8](https://github.com/bitnami/charts/commit/e44e0f8)), closes [#24476](https://github.com/bitnami/charts/issues/24476)
+* [bitnami/discourse] Release 12.7.3 updating components versions (#24476) ([e44e0f8](https://github.com/bitnami/charts/commit/e44e0f8dafcde9fb936675d8880fdf9a5b6fe020)), closes [#24476](https://github.com/bitnami/charts/issues/24476)
 
 ## <small>12.7.2 (2024-03-13)</small>
 
-* [bitnami/discourse] Update chart deps (#24395) ([05921be](https://github.com/bitnami/charts/commit/05921be)), closes [#24395](https://github.com/bitnami/charts/issues/24395)
+* [bitnami/discourse] Update chart deps (#24395) ([05921be](https://github.com/bitnami/charts/commit/05921be438045cc18471a61c3f79c517364590c4)), closes [#24395](https://github.com/bitnami/charts/issues/24395)
 
 ## <small>12.7.1 (2024-03-08)</small>
 
-* [bitnami/discourse] Release 12.7.1 updating components versions (#24294) ([fa2e3d6](https://github.com/bitnami/charts/commit/fa2e3d6)), closes [#24294](https://github.com/bitnami/charts/issues/24294)
+* [bitnami/discourse] Release 12.7.1 updating components versions (#24294) ([fa2e3d6](https://github.com/bitnami/charts/commit/fa2e3d674bf7d509d1a3660ca0363b5f8fc138b7)), closes [#24294](https://github.com/bitnami/charts/issues/24294)
 
 ## 12.7.0 (2024-03-06)
 
-* [bitnami/discourse] feat: :sparkles: :lock: Add automatic adaptation for Openshift restricted-v2 SCC ([da4135e](https://github.com/bitnami/charts/commit/da4135e)), closes [#24074](https://github.com/bitnami/charts/issues/24074)
+* [bitnami/discourse] feat: :sparkles: :lock: Add automatic adaptation for Openshift restricted-v2 SCC ([da4135e](https://github.com/bitnami/charts/commit/da4135e242f6955a1d586a7fdbf915f885fee063)), closes [#24074](https://github.com/bitnami/charts/issues/24074)
 
 ## <small>12.6.2 (2024-02-22)</small>
 
-* [bitnami/discourse] Release 12.6.2 updating components versions (#23847) ([b8295f5](https://github.com/bitnami/charts/commit/b8295f5)), closes [#23847](https://github.com/bitnami/charts/issues/23847)
+* [bitnami/discourse] Release 12.6.2 updating components versions (#23847) ([b8295f5](https://github.com/bitnami/charts/commit/b8295f50c2015769d046f9a88381d1681f18001a)), closes [#23847](https://github.com/bitnami/charts/issues/23847)
 
 ## <small>12.6.1 (2024-02-22)</small>
 
-* [bitnami/discourse] Release 12.6.1 (#23640) ([748d938](https://github.com/bitnami/charts/commit/748d938)), closes [#23640](https://github.com/bitnami/charts/issues/23640)
+* [bitnami/discourse] Release 12.6.1 (#23640) ([748d938](https://github.com/bitnami/charts/commit/748d938e8ef8419a0c183344f384af71c93ce4e8)), closes [#23640](https://github.com/bitnami/charts/issues/23640)
 
 ## 12.6.0 (2024-02-20)
 
-* [bitnami/*] Bump all versions (#23602) ([b70ee2a](https://github.com/bitnami/charts/commit/b70ee2a)), closes [#23602](https://github.com/bitnami/charts/issues/23602)
+* [bitnami/*] Bump all versions (#23602) ([b70ee2a](https://github.com/bitnami/charts/commit/b70ee2a30e4dc256bf0ac52928fb2fa7a70f049b)), closes [#23602](https://github.com/bitnami/charts/issues/23602)
 
 ## 12.5.0 (2024-02-16)
 
-* [bitnami/discourse] feat: :sparkles: :lock: Add resource preset support (#23441) ([38b444c](https://github.com/bitnami/charts/commit/38b444c)), closes [#23441](https://github.com/bitnami/charts/issues/23441)
+* [bitnami/discourse] feat: :sparkles: :lock: Add resource preset support (#23441) ([38b444c](https://github.com/bitnami/charts/commit/38b444c6d43a0fe918c218cb959a62489345394d)), closes [#23441](https://github.com/bitnami/charts/issues/23441)
 
 ## <small>12.4.2 (2024-02-15)</small>
 
-* [bitnami/discourse] Release 12.4.2 (#23534) ([5dab0c4](https://github.com/bitnami/charts/commit/5dab0c4)), closes [#23534](https://github.com/bitnami/charts/issues/23534)
+* [bitnami/discourse] Release 12.4.2 (#23534) ([5dab0c4](https://github.com/bitnami/charts/commit/5dab0c4973c03ed42e546764d1a3d0b6a9137067)), closes [#23534](https://github.com/bitnami/charts/issues/23534)
 
 ## <small>12.4.1 (2024-01-25)</small>
 
-* [bitnami/*] Move documentation sections from docs.bitnami.com back to the README (#22203) ([7564f36](https://github.com/bitnami/charts/commit/7564f36)), closes [#22203](https://github.com/bitnami/charts/issues/22203)
-* [bitnami/discourse] fix: :bug: Set seLinuxOptions to null for Openshift compatibility (#22579) ([d616d9e](https://github.com/bitnami/charts/commit/d616d9e)), closes [#22579](https://github.com/bitnami/charts/issues/22579)
+* [bitnami/*] Move documentation sections from docs.bitnami.com back to the README (#22203) ([7564f36](https://github.com/bitnami/charts/commit/7564f36ca1e95ff30ee686652b7ab8690561a707)), closes [#22203](https://github.com/bitnami/charts/issues/22203)
+* [bitnami/discourse] fix: :bug: Set seLinuxOptions to null for Openshift compatibility (#22579) ([d616d9e](https://github.com/bitnami/charts/commit/d616d9e4df5f71b86b3a65257fc1a92816f8ba43)), closes [#22579](https://github.com/bitnami/charts/issues/22579)
 
 ## 12.4.0 (2024-01-19)
 
-* [bitnami/discourse] fix: :lock: Move service-account token auto-mount to pod declaration (#22394) ([c471e36](https://github.com/bitnami/charts/commit/c471e36)), closes [#22394](https://github.com/bitnami/charts/issues/22394)
+* [bitnami/discourse] fix: :lock: Move service-account token auto-mount to pod declaration (#22394) ([c471e36](https://github.com/bitnami/charts/commit/c471e36129129f27bd911ae0bab39af6bb0f62a0)), closes [#22394](https://github.com/bitnami/charts/issues/22394)
 
 ## 12.3.0 (2024-01-16)
 
-* [bitnami/discourse] fix: :lock: Improve podSecurityContext and containerSecurityContext with essenti ([7654446](https://github.com/bitnami/charts/commit/7654446)), closes [#22110](https://github.com/bitnami/charts/issues/22110)
+* [bitnami/discourse] fix: :lock: Improve podSecurityContext and containerSecurityContext with essenti ([7654446](https://github.com/bitnami/charts/commit/76544468d99e25e3674c32682942d7a6e280d3d4)), closes [#22110](https://github.com/bitnami/charts/issues/22110)
 
 ## <small>12.2.1 (2024-01-15)</small>
 
-* [bitnami/*] Fix ref links (in comments) (#21822) ([e4fa296](https://github.com/bitnami/charts/commit/e4fa296)), closes [#21822](https://github.com/bitnami/charts/issues/21822)
-* [bitnami/discourse] fix: :lock: Do not use the default service account (#21992) ([a9634c9](https://github.com/bitnami/charts/commit/a9634c9)), closes [#21992](https://github.com/bitnami/charts/issues/21992)
+* [bitnami/*] Fix ref links (in comments) (#21822) ([e4fa296](https://github.com/bitnami/charts/commit/e4fa296106b225cf8c82445727c675c7c725e380)), closes [#21822](https://github.com/bitnami/charts/issues/21822)
+* [bitnami/discourse] fix: :lock: Do not use the default service account (#21992) ([a9634c9](https://github.com/bitnami/charts/commit/a9634c9fc9376fb9db2c46945210f3601c79e66f)), closes [#21992](https://github.com/bitnami/charts/issues/21992)
 
 ## 12.2.0 (2024-01-10)
 
-* [bitnami/*] Fix docs.bitnami.com broken links (#21901) ([f35506d](https://github.com/bitnami/charts/commit/f35506d)), closes [#21901](https://github.com/bitnami/charts/issues/21901)
-* [bitnami/discourse] feat: :sparkles: Add seccompProfile to containerSecurityContext (#21915) ([23b82b8](https://github.com/bitnami/charts/commit/23b82b8)), closes [#21915](https://github.com/bitnami/charts/issues/21915)
+* [bitnami/*] Fix docs.bitnami.com broken links (#21901) ([f35506d](https://github.com/bitnami/charts/commit/f35506d2dadee4f097986e7792df1f53ab215b5d)), closes [#21901](https://github.com/bitnami/charts/issues/21901)
+* [bitnami/discourse] feat: :sparkles: Add seccompProfile to containerSecurityContext (#21915) ([23b82b8](https://github.com/bitnami/charts/commit/23b82b812499d52d9d3bab6798d7248bc48c1fb2)), closes [#21915](https://github.com/bitnami/charts/issues/21915)
 
 ## <small>12.1.2 (2024-01-03)</small>
 
-* [bitnami/*] Update copyright: Year and company (#21815) ([6c4bf75](https://github.com/bitnami/charts/commit/6c4bf75)), closes [#21815](https://github.com/bitnami/charts/issues/21815)
-* [bitnami/discourse] Release 12.1.2 updating components versions (#21834) ([1a307c8](https://github.com/bitnami/charts/commit/1a307c8)), closes [#21834](https://github.com/bitnami/charts/issues/21834)
+* [bitnami/*] Update copyright: Year and company (#21815) ([6c4bf75](https://github.com/bitnami/charts/commit/6c4bf75dec58fc7c9aee9f089777b1a858c17d5b)), closes [#21815](https://github.com/bitnami/charts/issues/21815)
+* [bitnami/discourse] Release 12.1.2 updating components versions (#21834) ([1a307c8](https://github.com/bitnami/charts/commit/1a307c8b5172e1854db1a1da51179d7cd06fd222)), closes [#21834](https://github.com/bitnami/charts/issues/21834)
 
 ## <small>12.1.1 (2023-12-31)</small>
 
-* [bitnami/discourse] Release 12.1.1 updating components versions (#21799) ([d8fbbdf](https://github.com/bitnami/charts/commit/d8fbbdf)), closes [#21799](https://github.com/bitnami/charts/issues/21799)
+* [bitnami/discourse] Release 12.1.1 updating components versions (#21799) ([d8fbbdf](https://github.com/bitnami/charts/commit/d8fbbdfce220fb6514db7ac79e0d4f51df6526d9)), closes [#21799](https://github.com/bitnami/charts/issues/21799)
 
 ## 12.1.0 (2023-12-15)
 
-* [bitnami/discourse] Add support for skipping to persist plugins (#21588) ([0c71c19](https://github.com/bitnami/charts/commit/0c71c19)), closes [#21588](https://github.com/bitnami/charts/issues/21588)
+* [bitnami/discourse] Add support for skipping to persist plugins (#21588) ([0c71c19](https://github.com/bitnami/charts/commit/0c71c19039f769637dfbbb1104e813896c80182e)), closes [#21588](https://github.com/bitnami/charts/issues/21588)
 
 ## <small>12.0.7 (2023-11-21)</small>
 
-* [bitnami/*] Remove relative links to non-README sections, add verification for that and update TL;DR ([1103633](https://github.com/bitnami/charts/commit/1103633)), closes [#20967](https://github.com/bitnami/charts/issues/20967)
-* [bitnami/discourse] Release 12.0.7 updating components versions (#21105) ([e700274](https://github.com/bitnami/charts/commit/e700274)), closes [#21105](https://github.com/bitnami/charts/issues/21105)
+* [bitnami/*] Remove relative links to non-README sections, add verification for that and update TL;DR ([1103633](https://github.com/bitnami/charts/commit/11036334d82df0490aa4abdb591543cab6cf7d7f)), closes [#20967](https://github.com/bitnami/charts/issues/20967)
+* [bitnami/discourse] Release 12.0.7 updating components versions (#21105) ([e700274](https://github.com/bitnami/charts/commit/e700274382af6993a10dd008e3f6093fed12f05c)), closes [#21105](https://github.com/bitnami/charts/issues/21105)
 
 ## <small>12.0.6 (2023-11-09)</small>
 
-* [bitnami/discourse] Release 12.0.6 updating components versions (#20847) ([0ce5001](https://github.com/bitnami/charts/commit/0ce5001)), closes [#20847](https://github.com/bitnami/charts/issues/20847)
+* [bitnami/discourse] Release 12.0.6 updating components versions (#20847) ([0ce5001](https://github.com/bitnami/charts/commit/0ce50017aa403205a47c1e742b8ea2bb90f1f814)), closes [#20847](https://github.com/bitnami/charts/issues/20847)
 
 ## <small>12.0.5 (2023-11-08)</small>
 
-* [bitnami/discourse] Release 12.0.5 updating components versions (#20697) ([fec90fb](https://github.com/bitnami/charts/commit/fec90fb)), closes [#20697](https://github.com/bitnami/charts/issues/20697)
+* [bitnami/discourse] Release 12.0.5 updating components versions (#20697) ([fec90fb](https://github.com/bitnami/charts/commit/fec90fbbf680f6676bc128d20658e06c84d94a5a)), closes [#20697](https://github.com/bitnami/charts/issues/20697)
 
 ## <small>12.0.4 (2023-11-02)</small>
 
-* [bitnami/*] Rename VMware Application Catalog (#20361) ([3acc734](https://github.com/bitnami/charts/commit/3acc734)), closes [#20361](https://github.com/bitnami/charts/issues/20361)
-* [bitnami/*] Skip image's tag in the README files of the Bitnami Charts (#19841) ([bb9a01b](https://github.com/bitnami/charts/commit/bb9a01b)), closes [#19841](https://github.com/bitnami/charts/issues/19841)
-* [bitnami/*] Standardize documentation (#19835) ([af5f753](https://github.com/bitnami/charts/commit/af5f753)), closes [#19835](https://github.com/bitnami/charts/issues/19835)
-* [bitnami/discourse] Release 12.0.4 updating components versions (#20599) ([2d6ac9f](https://github.com/bitnami/charts/commit/2d6ac9f)), closes [#20599](https://github.com/bitnami/charts/issues/20599)
+* [bitnami/*] Rename VMware Application Catalog (#20361) ([3acc734](https://github.com/bitnami/charts/commit/3acc73472beb6fb56c4d99f929061001205bc57e)), closes [#20361](https://github.com/bitnami/charts/issues/20361)
+* [bitnami/*] Skip image's tag in the README files of the Bitnami Charts (#19841) ([bb9a01b](https://github.com/bitnami/charts/commit/bb9a01b65911c87e48318db922cc05eb42785e42)), closes [#19841](https://github.com/bitnami/charts/issues/19841)
+* [bitnami/*] Standardize documentation (#19835) ([af5f753](https://github.com/bitnami/charts/commit/af5f7530c1bc8c5ded53a6c4f7b8f384ac1804f2)), closes [#19835](https://github.com/bitnami/charts/issues/19835)
+* [bitnami/discourse] Release 12.0.4 updating components versions (#20599) ([2d6ac9f](https://github.com/bitnami/charts/commit/2d6ac9f979a734e467c21f5a6defb4be72fe5e50)), closes [#20599](https://github.com/bitnami/charts/issues/20599)
 
 ## <small>12.0.3 (2023-10-17)</small>
 
-* [bitnami/discourse] Release 12.0.3 (#20267) ([bae41e6](https://github.com/bitnami/charts/commit/bae41e6)), closes [#20267](https://github.com/bitnami/charts/issues/20267)
+* [bitnami/discourse] Release 12.0.3 (#20267) ([bae41e6](https://github.com/bitnami/charts/commit/bae41e60e86325757b7b6456101e5d2ee59d0a26)), closes [#20267](https://github.com/bitnami/charts/issues/20267)
 
 ## <small>12.0.2 (2023-10-12)</small>
 
-* [bitnami/discourse] Release 12.0.2 (#20179) ([783e54a](https://github.com/bitnami/charts/commit/783e54a)), closes [#20179](https://github.com/bitnami/charts/issues/20179)
+* [bitnami/discourse] Release 12.0.2 (#20179) ([783e54a](https://github.com/bitnami/charts/commit/783e54a80c698a643c314e8dd9285d788101e330)), closes [#20179](https://github.com/bitnami/charts/issues/20179)
 
 ## <small>12.0.1 (2023-10-09)</small>
 
-* [bitnami/*] Update Helm charts prerequisites (#19745) ([eb755dd](https://github.com/bitnami/charts/commit/eb755dd)), closes [#19745](https://github.com/bitnami/charts/issues/19745)
-* [bitnami/discourse] Release 12.0.1 (#19796) ([dbdacc0](https://github.com/bitnami/charts/commit/dbdacc0)), closes [#19796](https://github.com/bitnami/charts/issues/19796)
+* [bitnami/*] Update Helm charts prerequisites (#19745) ([eb755dd](https://github.com/bitnami/charts/commit/eb755dd36a4dd3cf6635be8e0598f9a7f4c4a554)), closes [#19745](https://github.com/bitnami/charts/issues/19745)
+* [bitnami/discourse] Release 12.0.1 (#19796) ([dbdacc0](https://github.com/bitnami/charts/commit/dbdacc08152fd62fe97240d85bb091cb59aa2708)), closes [#19796](https://github.com/bitnami/charts/issues/19796)
 
 ## 12.0.0 (2023-09-29)
 
-* [bitnami/discourse] Update dependencies (#19612) ([c11a51f](https://github.com/bitnami/charts/commit/c11a51f)), closes [#19612](https://github.com/bitnami/charts/issues/19612)
+* [bitnami/discourse] Update dependencies (#19612) ([c11a51f](https://github.com/bitnami/charts/commit/c11a51fec406684b209297571d78500d6f365682)), closes [#19612](https://github.com/bitnami/charts/issues/19612)
 
 ## <small>11.0.5 (2023-09-26)</small>
 
-* [bitnami/discourse] Release 11.0.5 (#19557) ([72cbede](https://github.com/bitnami/charts/commit/72cbede)), closes [#19557](https://github.com/bitnami/charts/issues/19557)
+* [bitnami/discourse] Release 11.0.5 (#19557) ([72cbede](https://github.com/bitnami/charts/commit/72cbede8b291fa549b7c8de3a86541422e888ece)), closes [#19557](https://github.com/bitnami/charts/issues/19557)
 
 ## <small>11.0.4 (2023-09-26)</small>
 
-* [bitnami/*] Update readme files (#19277) ([e56aeb2](https://github.com/bitnami/charts/commit/e56aeb2)), closes [#19277](https://github.com/bitnami/charts/issues/19277)
-* [bitnami/discourse] Release 11.0.4 (#19546) ([5dd1549](https://github.com/bitnami/charts/commit/5dd1549)), closes [#19546](https://github.com/bitnami/charts/issues/19546)
-* Revert "Autogenerate schema files (#19194)" (#19335) ([73d80be](https://github.com/bitnami/charts/commit/73d80be)), closes [#19194](https://github.com/bitnami/charts/issues/19194) [#19335](https://github.com/bitnami/charts/issues/19335)
+* [bitnami/*] Update readme files (#19277) ([e56aeb2](https://github.com/bitnami/charts/commit/e56aeb2fbfbf5b6e42375db48cc7ae1ef1c3a823)), closes [#19277](https://github.com/bitnami/charts/issues/19277)
+* [bitnami/discourse] Release 11.0.4 (#19546) ([5dd1549](https://github.com/bitnami/charts/commit/5dd1549e9e0a51ff9d08b7353af9ff1194d166ae)), closes [#19546](https://github.com/bitnami/charts/issues/19546)
+* Revert "Autogenerate schema files (#19194)" (#19335) ([73d80be](https://github.com/bitnami/charts/commit/73d80be525c88fb4b8a54451a55acd506e337062)), closes [#19194](https://github.com/bitnami/charts/issues/19194) [#19335](https://github.com/bitnami/charts/issues/19335)
 
 ## <small>11.0.3 (2023-09-13)</small>
 
-* [bitnami/discourse] Release 11.0.3 (#19257) ([0ea9eb9](https://github.com/bitnami/charts/commit/0ea9eb9)), closes [#19257](https://github.com/bitnami/charts/issues/19257)
+* [bitnami/discourse] Release 11.0.3 (#19257) ([0ea9eb9](https://github.com/bitnami/charts/commit/0ea9eb93fcb9e6934935d373b9f08333dfc59e6f)), closes [#19257](https://github.com/bitnami/charts/issues/19257)
 
 ## <small>11.0.2 (2023-09-11)</small>
 
-* [bitnami/discourse] Release 11.0.2 (#19239) ([0f981c8](https://github.com/bitnami/charts/commit/0f981c8)), closes [#19239](https://github.com/bitnami/charts/issues/19239)
-* Autogenerate schema files (#19194) ([a2c2090](https://github.com/bitnami/charts/commit/a2c2090)), closes [#19194](https://github.com/bitnami/charts/issues/19194)
+* [bitnami/discourse] Release 11.0.2 (#19239) ([0f981c8](https://github.com/bitnami/charts/commit/0f981c8fab01ff658cfa386e02b01dc4271475f1)), closes [#19239](https://github.com/bitnami/charts/issues/19239)
+* Autogenerate schema files (#19194) ([a2c2090](https://github.com/bitnami/charts/commit/a2c2090b5ac97f47b745c8028c6452bf99739772)), closes [#19194](https://github.com/bitnami/charts/issues/19194)
 
 ## <small>11.0.1 (2023-09-06)</small>
 
-* [bitnami/discourse: Use merge helper]: (#19030) ([52a77ee](https://github.com/bitnami/charts/commit/52a77ee)), closes [#19030](https://github.com/bitnami/charts/issues/19030)
+* [bitnami/discourse: Use merge helper]: (#19030) ([52a77ee](https://github.com/bitnami/charts/commit/52a77ee7dbdd1d819a89da9a71901388f4baeca8)), closes [#19030](https://github.com/bitnami/charts/issues/19030)
 
 ## 11.0.0 (2023-08-28)
 
-* [bitnami/discourse] Update Redis' subchart (#18894) ([205af45](https://github.com/bitnami/charts/commit/205af45)), closes [#18894](https://github.com/bitnami/charts/issues/18894)
+* [bitnami/discourse] Update Redis' subchart (#18894) ([205af45](https://github.com/bitnami/charts/commit/205af45e578e7f94317505ac36d8c5fbf7de4540)), closes [#18894](https://github.com/bitnami/charts/issues/18894)
 
 ## 10.4.0 (2023-08-23)
 
-* [bitnami/discourse] Support for customizing standard labels (#18479) ([02497d4](https://github.com/bitnami/charts/commit/02497d4)), closes [#18479](https://github.com/bitnami/charts/issues/18479)
+* [bitnami/discourse] Support for customizing standard labels (#18479) ([02497d4](https://github.com/bitnami/charts/commit/02497d45292cdb5e7dfacb5fe11392ec00660f01)), closes [#18479](https://github.com/bitnami/charts/issues/18479)
 
 ## <small>10.3.8 (2023-08-18)</small>
 
-* [bitnami/discourse] Release 10.3.8 (#18637) ([a1917ba](https://github.com/bitnami/charts/commit/a1917ba)), closes [#18637](https://github.com/bitnami/charts/issues/18637)
+* [bitnami/discourse] Release 10.3.8 (#18637) ([a1917ba](https://github.com/bitnami/charts/commit/a1917ba9979e42752a35703f259d5ea8539e2f55)), closes [#18637](https://github.com/bitnami/charts/issues/18637)
 
 ## <small>10.3.7 (2023-07-25)</small>
 
-* [bitnami/discourse] Release 10.3.7 (#17873) ([91e3107](https://github.com/bitnami/charts/commit/91e3107)), closes [#17873](https://github.com/bitnami/charts/issues/17873)
+* [bitnami/discourse] Release 10.3.7 (#17873) ([91e3107](https://github.com/bitnami/charts/commit/91e31076cc0187b73f4400b795318d5fe43ca739)), closes [#17873](https://github.com/bitnami/charts/issues/17873)
 
 ## <small>10.3.6 (2023-07-25)</small>
 
-* [bitnami/discourse] Release 10.3.6 (#17853) ([392bb05](https://github.com/bitnami/charts/commit/392bb05)), closes [#17853](https://github.com/bitnami/charts/issues/17853)
+* [bitnami/discourse] Release 10.3.6 (#17853) ([392bb05](https://github.com/bitnami/charts/commit/392bb05279d5703e4525946fafab8bbfbe7290e2)), closes [#17853](https://github.com/bitnami/charts/issues/17853)
 
 ## <small>10.3.5 (2023-07-21)</small>
 
-* [bitnami/discourse] Release 10.3.5 (#17691) ([8ad039e](https://github.com/bitnami/charts/commit/8ad039e)), closes [#17691](https://github.com/bitnami/charts/issues/17691)
-* Add copyright header (#17300) ([da68be8](https://github.com/bitnami/charts/commit/da68be8)), closes [#17300](https://github.com/bitnami/charts/issues/17300)
+* [bitnami/discourse] Release 10.3.5 (#17691) ([8ad039e](https://github.com/bitnami/charts/commit/8ad039e36f0a8e37ee43c46a10ff2a67a9afa765)), closes [#17691](https://github.com/bitnami/charts/issues/17691)
+* Add copyright header (#17300) ([da68be8](https://github.com/bitnami/charts/commit/da68be8e951225133c7dfb572d5101ca3d61c5ae)), closes [#17300](https://github.com/bitnami/charts/issues/17300)
 
 ## <small>10.3.4 (2023-06-23)</small>
 
-* [bitnami/discourse] Release 10.3.4 (#17330) ([b04bf4f](https://github.com/bitnami/charts/commit/b04bf4f)), closes [#17330](https://github.com/bitnami/charts/issues/17330)
-* Update charts readme (#17217) ([31b3c0a](https://github.com/bitnami/charts/commit/31b3c0a)), closes [#17217](https://github.com/bitnami/charts/issues/17217)
+* [bitnami/discourse] Release 10.3.4 (#17330) ([b04bf4f](https://github.com/bitnami/charts/commit/b04bf4f93906c3c25a264ac4aa48c43cd0b8cd2d)), closes [#17330](https://github.com/bitnami/charts/issues/17330)
+* Update charts readme (#17217) ([31b3c0a](https://github.com/bitnami/charts/commit/31b3c0afd968ff4429107e34101f7509e6a0e913)), closes [#17217](https://github.com/bitnami/charts/issues/17217)
 
 ## <small>10.3.3 (2023-06-20)</small>
 
-* [bitnami/*] Change copyright section in READMEs (#17006) ([ef986a1](https://github.com/bitnami/charts/commit/ef986a1)), closes [#17006](https://github.com/bitnami/charts/issues/17006)
-* [bitnami/discourse] Release 10.3.3 (#17248) ([dac9838](https://github.com/bitnami/charts/commit/dac9838)), closes [#17248](https://github.com/bitnami/charts/issues/17248)
-* [bitnami/several] Change copyright section in READMEs (#16989) ([5b6a5cf](https://github.com/bitnami/charts/commit/5b6a5cf)), closes [#16989](https://github.com/bitnami/charts/issues/16989)
-* [bitnami/several] Remove 'Community supported solution' section from READMEs (#17119) ([4531d57](https://github.com/bitnami/charts/commit/4531d57)), closes [#17119](https://github.com/bitnami/charts/issues/17119)
+* [bitnami/*] Change copyright section in READMEs (#17006) ([ef986a1](https://github.com/bitnami/charts/commit/ef986a1605241102b3dcafe9fd8089e6fc1201ad)), closes [#17006](https://github.com/bitnami/charts/issues/17006)
+* [bitnami/discourse] Release 10.3.3 (#17248) ([dac9838](https://github.com/bitnami/charts/commit/dac98388f9b40177e57979a6ae98227a325735d2)), closes [#17248](https://github.com/bitnami/charts/issues/17248)
+* [bitnami/several] Change copyright section in READMEs (#16989) ([5b6a5cf](https://github.com/bitnami/charts/commit/5b6a5cfb7625a751848a2e5cd796bd7278f406ca)), closes [#16989](https://github.com/bitnami/charts/issues/16989)
+* [bitnami/several] Remove 'Community supported solution' section from READMEs (#17119) ([4531d57](https://github.com/bitnami/charts/commit/4531d571914e970fe4cef19ae00a9fa4cc038f47)), closes [#17119](https://github.com/bitnami/charts/issues/17119)
 
 ## <small>10.3.2 (2023-05-21)</small>
 
-* [bitnami/discourse] Release 10.3.2 (#16844) ([85029b6](https://github.com/bitnami/charts/commit/85029b6)), closes [#16844](https://github.com/bitnami/charts/issues/16844)
-* Add wording for enterprise page (#16560) ([8f22774](https://github.com/bitnami/charts/commit/8f22774)), closes [#16560](https://github.com/bitnami/charts/issues/16560)
+* [bitnami/discourse] Release 10.3.2 (#16844) ([85029b6](https://github.com/bitnami/charts/commit/85029b6ab58038d5bf8b9fee5b8c34831322c27a)), closes [#16844](https://github.com/bitnami/charts/issues/16844)
+* Add wording for enterprise page (#16560) ([8f22774](https://github.com/bitnami/charts/commit/8f2277440b976d52785ba9149762ad8620a73d1f)), closes [#16560](https://github.com/bitnami/charts/issues/16560)
 
 ## <small>10.3.1 (2023-05-09)</small>
 
-* [bitnami/discourse] Release 10.3.1 (#16551) ([0c497d1](https://github.com/bitnami/charts/commit/0c497d1)), closes [#16551](https://github.com/bitnami/charts/issues/16551)
+* [bitnami/discourse] Release 10.3.1 (#16551) ([0c497d1](https://github.com/bitnami/charts/commit/0c497d1a9a29e1fbfdc5bfcbab4569b4a1dedfec)), closes [#16551](https://github.com/bitnami/charts/issues/16551)
 
 ## 10.3.0 (2023-05-09)
 
-* [bitnami/several] Adapt Chart.yaml to set desired OCI annotations (#16546) ([fc9b18f](https://github.com/bitnami/charts/commit/fc9b18f)), closes [#16546](https://github.com/bitnami/charts/issues/16546)
+* [bitnami/several] Adapt Chart.yaml to set desired OCI annotations (#16546) ([fc9b18f](https://github.com/bitnami/charts/commit/fc9b18f2e98805d4df629acbcde696f44f973344)), closes [#16546](https://github.com/bitnami/charts/issues/16546)
 
 ## <small>10.2.1 (2023-05-09)</small>
 
-* [bitnami/discourse] Release 10.2.1 (#16450) ([1415738](https://github.com/bitnami/charts/commit/1415738)), closes [#16450](https://github.com/bitnami/charts/issues/16450)
+* [bitnami/discourse] Release 10.2.1 (#16450) ([1415738](https://github.com/bitnami/charts/commit/14157389b71e84964d1a8e7b544f55cb90905c84)), closes [#16450](https://github.com/bitnami/charts/issues/16450)
 
 ## 10.2.0 (2023-04-28)
 
-* [bitnami/discourse] Add feature discourse.plugins (#16196) ([64038e7](https://github.com/bitnami/charts/commit/64038e7)), closes [#16196](https://github.com/bitnami/charts/issues/16196)
+* [bitnami/discourse] Add feature discourse.plugins (#16196) ([64038e7](https://github.com/bitnami/charts/commit/64038e7c438c3166e28fa1e2c052c48e0fede6f6)), closes [#16196](https://github.com/bitnami/charts/issues/16196)
 
 ## 10.1.0 (2023-04-20)
 
-* [bitnami/*] Make Helm charts 100% OCI (#15998) ([8841510](https://github.com/bitnami/charts/commit/8841510)), closes [#15998](https://github.com/bitnami/charts/issues/15998)
+* [bitnami/*] Make Helm charts 100% OCI (#15998) ([8841510](https://github.com/bitnami/charts/commit/884151035efcbf2e1b3206e7def85511073fb57d)), closes [#15998](https://github.com/bitnami/charts/issues/15998)
 
 ## <small>10.0.6 (2023-04-18)</small>
 
-* [bitnami/discourse] Release 10.0.6 (#16115) ([2a1ce42](https://github.com/bitnami/charts/commit/2a1ce42)), closes [#16115](https://github.com/bitnami/charts/issues/16115)
+* [bitnami/discourse] Release 10.0.6 (#16115) ([2a1ce42](https://github.com/bitnami/charts/commit/2a1ce42112ce5984f20e53c8622b8def9f04f01f)), closes [#16115](https://github.com/bitnami/charts/issues/16115)
 
 ## <small>10.0.5 (2023-04-01)</small>
 
-* [bitnami/discourse] Release 10.0.5 (#15920) ([206a036](https://github.com/bitnami/charts/commit/206a036)), closes [#15920](https://github.com/bitnami/charts/issues/15920)
+* [bitnami/discourse] Release 10.0.5 (#15920) ([206a036](https://github.com/bitnami/charts/commit/206a036d75eb35344d55b8351a470a9d2e465f2d)), closes [#15920](https://github.com/bitnami/charts/issues/15920)
 
 ## <small>10.0.4 (2023-03-19)</small>
 
-* [bitnami/charts] Apply linter to README files (#15357) ([0e29e60](https://github.com/bitnami/charts/commit/0e29e60)), closes [#15357](https://github.com/bitnami/charts/issues/15357)
-* [bitnami/discourse] Release 10.0.4 (#15589) ([a86c136](https://github.com/bitnami/charts/commit/a86c136)), closes [#15589](https://github.com/bitnami/charts/issues/15589)
+* [bitnami/charts] Apply linter to README files (#15357) ([0e29e60](https://github.com/bitnami/charts/commit/0e29e600d3adc8b1b46e506eccb3decfab3b4e63)), closes [#15357](https://github.com/bitnami/charts/issues/15357)
+* [bitnami/discourse] Release 10.0.4 (#15589) ([a86c136](https://github.com/bitnami/charts/commit/a86c13653ef39b049e32d00684489d485e99aa7d)), closes [#15589](https://github.com/bitnami/charts/issues/15589)
 
 ## <small>10.0.3 (2023-03-01)</small>
 
-* [bitnami/discourse] Release 10.0.3 (#15194) ([233405f](https://github.com/bitnami/charts/commit/233405f)), closes [#15194](https://github.com/bitnami/charts/issues/15194)
+* [bitnami/discourse] Release 10.0.3 (#15194) ([233405f](https://github.com/bitnami/charts/commit/233405f3534d2a3130cf653e14c27871c38ac345)), closes [#15194](https://github.com/bitnami/charts/issues/15194)
 
 ## <small>10.0.2 (2023-02-23)</small>
 
-* [bitnami/discourse] Release 10.0.2 (#15099) ([eefaca2](https://github.com/bitnami/charts/commit/eefaca2)), closes [#15099](https://github.com/bitnami/charts/issues/15099)
+* [bitnami/discourse] Release 10.0.2 (#15099) ([eefaca2](https://github.com/bitnami/charts/commit/eefaca2a390be44977432666f8672d9bb927962b)), closes [#15099](https://github.com/bitnami/charts/issues/15099)
 
 ## <small>10.0.1 (2023-02-17)</small>
 
-* [bitnami/*] Fix markdown linter issues (#14874) ([a51e0e8](https://github.com/bitnami/charts/commit/a51e0e8)), closes [#14874](https://github.com/bitnami/charts/issues/14874)
-* [bitnami/*] Fix markdown linter issues 2 (#14890) ([aa96572](https://github.com/bitnami/charts/commit/aa96572)), closes [#14890](https://github.com/bitnami/charts/issues/14890)
-* [bitnami/*] Remove unexpected extra spaces (#14873) ([c97c714](https://github.com/bitnami/charts/commit/c97c714)), closes [#14873](https://github.com/bitnami/charts/issues/14873)
-* [bitnami/discourse] Release 10.0.1 (#14981) ([a336ca3](https://github.com/bitnami/charts/commit/a336ca3)), closes [#14981](https://github.com/bitnami/charts/issues/14981)
+* [bitnami/*] Fix markdown linter issues (#14874) ([a51e0e8](https://github.com/bitnami/charts/commit/a51e0e8d35495b907f3e70dd2f8e7c3bcbf4166a)), closes [#14874](https://github.com/bitnami/charts/issues/14874)
+* [bitnami/*] Fix markdown linter issues 2 (#14890) ([aa96572](https://github.com/bitnami/charts/commit/aa9657237ee8df4a46db0d7fdf8a23230dd6902a)), closes [#14890](https://github.com/bitnami/charts/issues/14890)
+* [bitnami/*] Remove unexpected extra spaces (#14873) ([c97c714](https://github.com/bitnami/charts/commit/c97c714887380d47eae7bfeff316bf01595ecd1d)), closes [#14873](https://github.com/bitnami/charts/issues/14873)
+* [bitnami/discourse] Release 10.0.1 (#14981) ([a336ca3](https://github.com/bitnami/charts/commit/a336ca3181a5ca85b4b0f939e2e36afd09580052)), closes [#14981](https://github.com/bitnami/charts/issues/14981)
 
 ## 10.0.0 (2023-02-08)
 
-* [bitnami/*] Change copyright date (#14682) ([add4ec7](https://github.com/bitnami/charts/commit/add4ec7)), closes [#14682](https://github.com/bitnami/charts/issues/14682)
-* [bitnami/discourse] Release 10.0.0 (#14743) ([a1e2d41](https://github.com/bitnami/charts/commit/a1e2d41)), closes [#14743](https://github.com/bitnami/charts/issues/14743)
+* [bitnami/*] Change copyright date (#14682) ([add4ec7](https://github.com/bitnami/charts/commit/add4ec701108ac36ed4de2dffbdf407a0d091067)), closes [#14682](https://github.com/bitnami/charts/issues/14682)
+* [bitnami/discourse] Release 10.0.0 (#14743) ([a1e2d41](https://github.com/bitnami/charts/commit/a1e2d414195798ea43cbbd7d8634ac2a0d014486)), closes [#14743](https://github.com/bitnami/charts/issues/14743)
 
 ## <small>9.0.9 (2023-01-31)</small>
 
-* [bitnami/*] Change licenses annotation format (#14377) ([0ab7608](https://github.com/bitnami/charts/commit/0ab7608)), closes [#14377](https://github.com/bitnami/charts/issues/14377)
-* [bitnami/*] Unify READMEs (#14472) ([2064fb8](https://github.com/bitnami/charts/commit/2064fb8)), closes [#14472](https://github.com/bitnami/charts/issues/14472)
-* [bitnami/discourse] Don't regenerate self-signed certs on upgrade (#14616) ([136234e](https://github.com/bitnami/charts/commit/136234e)), closes [#14616](https://github.com/bitnami/charts/issues/14616)
+* [bitnami/*] Change licenses annotation format (#14377) ([0ab7608](https://github.com/bitnami/charts/commit/0ab760862c660fcc78cffadf8e1d8cdd70881473)), closes [#14377](https://github.com/bitnami/charts/issues/14377)
+* [bitnami/*] Unify READMEs (#14472) ([2064fb8](https://github.com/bitnami/charts/commit/2064fb8dcc78a845cdede8211af8c3cc52551161)), closes [#14472](https://github.com/bitnami/charts/issues/14472)
+* [bitnami/discourse] Don't regenerate self-signed certs on upgrade (#14616) ([136234e](https://github.com/bitnami/charts/commit/136234e7ff7ce8a3e7f0138b442ef0a3a8fce3ca)), closes [#14616](https://github.com/bitnami/charts/issues/14616)
 
 ## <small>9.0.8 (2023-01-13)</small>
 
-* [bitnami/discourse] Release 9.0.8 (#14345) ([5034873](https://github.com/bitnami/charts/commit/5034873)), closes [#14345](https://github.com/bitnami/charts/issues/14345)
+* [bitnami/discourse] Release 9.0.8 (#14345) ([5034873](https://github.com/bitnami/charts/commit/5034873f2efa692db25f73361cbc936f8b16e82a)), closes [#14345](https://github.com/bitnami/charts/issues/14345)
 
 ## <small>9.0.7 (2023-01-12)</small>
 
-* [bitnami/*] Add license annotation and remove obsolete engine parameter (#14293) ([da2a794](https://github.com/bitnami/charts/commit/da2a794)), closes [#14293](https://github.com/bitnami/charts/issues/14293)
-* Bug/discourse remove redis username (#14265) ([e5c2e8c](https://github.com/bitnami/charts/commit/e5c2e8c)), closes [#14265](https://github.com/bitnami/charts/issues/14265)
+* [bitnami/*] Add license annotation and remove obsolete engine parameter (#14293) ([da2a794](https://github.com/bitnami/charts/commit/da2a7943bae95b6e9b5b4ed972c15e990b69fdb0)), closes [#14293](https://github.com/bitnami/charts/issues/14293)
+* Bug/discourse remove redis username (#14265) ([e5c2e8c](https://github.com/bitnami/charts/commit/e5c2e8c28b3dbfbd006feaec605c3ee18997ec57)), closes [#14265](https://github.com/bitnami/charts/issues/14265)
 
 ## <small>9.0.6 (2022-12-14)</small>
 
-* [bitnami/discourse] Release 9.0.6 (#13959) ([1f84c45](https://github.com/bitnami/charts/commit/1f84c45)), closes [#13959](https://github.com/bitnami/charts/issues/13959)
+* [bitnami/discourse] Release 9.0.6 (#13959) ([1f84c45](https://github.com/bitnami/charts/commit/1f84c45407c5fbb14c29893a922408cd49dcb463)), closes [#13959](https://github.com/bitnami/charts/issues/13959)
 
 ## <small>9.0.5 (2022-12-12)</small>
 
-* [bitnami/discourse] Release 9.0.5 (#13930) ([0e7c27c](https://github.com/bitnami/charts/commit/0e7c27c)), closes [#13930](https://github.com/bitnami/charts/issues/13930)
+* [bitnami/discourse] Release 9.0.5 (#13930) ([0e7c27c](https://github.com/bitnami/charts/commit/0e7c27cf328c77838cf454f84fc4ab1648e29701)), closes [#13930](https://github.com/bitnami/charts/issues/13930)
 
 ## <small>9.0.4 (2022-11-30)</small>
 
-* [bitnami/discourse] Release 9.0.4 (#13766) ([f4782b2](https://github.com/bitnami/charts/commit/f4782b2)), closes [#13766](https://github.com/bitnami/charts/issues/13766)
+* [bitnami/discourse] Release 9.0.4 (#13766) ([f4782b2](https://github.com/bitnami/charts/commit/f4782b23d9213c00ab662fa154d5bb68b74a9355)), closes [#13766](https://github.com/bitnami/charts/issues/13766)
 
 ## <small>9.0.3 (2022-11-29)</small>
 
-* [bitnami/discourse] Release 9.0.3 (#13740) ([d776600](https://github.com/bitnami/charts/commit/d776600)), closes [#13740](https://github.com/bitnami/charts/issues/13740)
+* [bitnami/discourse] Release 9.0.3 (#13740) ([d776600](https://github.com/bitnami/charts/commit/d776600cb83a01fc0b5f8241e60bc1b70d809acc)), closes [#13740](https://github.com/bitnami/charts/issues/13740)
 
 ## <small>9.0.2 (2022-11-22)</small>
 
-* [bitnami/discourse] Release 9.0.2 (#13632) ([cfac18a](https://github.com/bitnami/charts/commit/cfac18a)), closes [#13632](https://github.com/bitnami/charts/issues/13632)
+* [bitnami/discourse] Release 9.0.2 (#13632) ([cfac18a](https://github.com/bitnami/charts/commit/cfac18ab5f44e81abdfecf1382996ed52eb8092f)), closes [#13632](https://github.com/bitnami/charts/issues/13632)
 
 ## <small>9.0.1 (2022-11-21)</small>
 
-* [bitnami/discourse] Release 9.0.1 (#13614) ([a5aa552](https://github.com/bitnami/charts/commit/a5aa552)), closes [#13614](https://github.com/bitnami/charts/issues/13614)
+* [bitnami/discourse] Release 9.0.1 (#13614) ([a5aa552](https://github.com/bitnami/charts/commit/a5aa552ba06831e45ff8611898b8204bb0329226)), closes [#13614](https://github.com/bitnami/charts/issues/13614)
 
 ## 9.0.0 (2022-10-28)
 
-* [bitnami/*] Use new default branch name in links (#12943) ([a529e02](https://github.com/bitnami/charts/commit/a529e02)), closes [#12943](https://github.com/bitnami/charts/issues/12943)
-* [bitnami/discourse] Update dependencies (#13212) ([76e3c3e](https://github.com/bitnami/charts/commit/76e3c3e)), closes [#13212](https://github.com/bitnami/charts/issues/13212)
-* Generic README instructions related to the repo (#12792) ([3cf6b10](https://github.com/bitnami/charts/commit/3cf6b10)), closes [#12792](https://github.com/bitnami/charts/issues/12792)
+* [bitnami/*] Use new default branch name in links (#12943) ([a529e02](https://github.com/bitnami/charts/commit/a529e02597d49d944eba1eb0f190713293247176)), closes [#12943](https://github.com/bitnami/charts/issues/12943)
+* [bitnami/discourse] Update dependencies (#13212) ([76e3c3e](https://github.com/bitnami/charts/commit/76e3c3ebff8cc1567eb043b656353078fd69f6af)), closes [#13212](https://github.com/bitnami/charts/issues/13212)
+* Generic README instructions related to the repo (#12792) ([3cf6b10](https://github.com/bitnami/charts/commit/3cf6b10e10e60df4b3e191d6b99aa99a9f597755)), closes [#12792](https://github.com/bitnami/charts/issues/12792)
 
 ## <small>8.1.8 (2022-10-05)</small>
 
-* [bitnami/discourse] Release 8.1.8 (#12810) ([e7df0fb](https://github.com/bitnami/charts/commit/e7df0fb)), closes [#12810](https://github.com/bitnami/charts/issues/12810)
-* adjust the naming style for resources to make them not pass the length limit (#12751) ([82880bd](https://github.com/bitnami/charts/commit/82880bd)), closes [#12751](https://github.com/bitnami/charts/issues/12751)
+* [bitnami/discourse] Release 8.1.8 (#12810) ([e7df0fb](https://github.com/bitnami/charts/commit/e7df0fbd10c6036196dfa0634e8115f2a1cb6f44)), closes [#12810](https://github.com/bitnami/charts/issues/12810)
+* adjust the naming style for resources to make them not pass the length limit (#12751) ([82880bd](https://github.com/bitnami/charts/commit/82880bd34569bcc42ff44c03f578b97d4947cda5)), closes [#12751](https://github.com/bitnami/charts/issues/12751)
 
 ## <small>8.1.7 (2022-09-30)</small>
 
-* [bitnami/discourse] Release 8.1.7 (#12771) ([1b900bc](https://github.com/bitnami/charts/commit/1b900bc)), closes [#12771](https://github.com/bitnami/charts/issues/12771)
+* [bitnami/discourse] Release 8.1.7 (#12771) ([1b900bc](https://github.com/bitnami/charts/commit/1b900bcf27a01fba035e21d0aa8c2799abf0c78d)), closes [#12771](https://github.com/bitnami/charts/issues/12771)
 
 ## <small>8.1.6 (2022-09-30)</small>
 
-* [bitnami/discourse] Release 8.1.6 (#12742) ([b5f53f5](https://github.com/bitnami/charts/commit/b5f53f5)), closes [#12742](https://github.com/bitnami/charts/issues/12742)
+* [bitnami/discourse] Release 8.1.6 (#12742) ([b5f53f5](https://github.com/bitnami/charts/commit/b5f53f5a71b8c2891de2db9d40fae0b6ab7bfc58)), closes [#12742](https://github.com/bitnami/charts/issues/12742)
 
 ## <small>8.1.5 (2022-09-21)</small>
 
-* [bitnami/discourse] Use custom probes if given (#12489) ([e4a1296](https://github.com/bitnami/charts/commit/e4a1296)), closes [#12489](https://github.com/bitnami/charts/issues/12489) [#12354](https://github.com/bitnami/charts/issues/12354)
+* [bitnami/discourse] Use custom probes if given (#12489) ([e4a1296](https://github.com/bitnami/charts/commit/e4a1296a215525396946220e6d35c8ecd29a2e96)), closes [#12489](https://github.com/bitnami/charts/issues/12489) [#12354](https://github.com/bitnami/charts/issues/12354)
 
 ## <small>8.1.4 (2022-09-14)</small>
 
-* [bitnami/discourse] Release 8.1.4 (#12430) ([a27f02e](https://github.com/bitnami/charts/commit/a27f02e)), closes [#12430](https://github.com/bitnami/charts/issues/12430)
+* [bitnami/discourse] Release 8.1.4 (#12430) ([a27f02e](https://github.com/bitnami/charts/commit/a27f02ec6c38537be7ab8a0935b989ae2f417488)), closes [#12430](https://github.com/bitnami/charts/issues/12430)
 
 ## <small>8.1.3 (2022-08-30)</small>
 
-* [bitnami/discourse] Release 8.1.3 (#12205) ([adff229](https://github.com/bitnami/charts/commit/adff229)), closes [#12205](https://github.com/bitnami/charts/issues/12205)
+* [bitnami/discourse] Release 8.1.3 (#12205) ([adff229](https://github.com/bitnami/charts/commit/adff229073c1523fbd2294f236858d3ffc21b3ed)), closes [#12205](https://github.com/bitnami/charts/issues/12205)
 
 ## <small>8.1.2 (2022-08-23)</small>
 
-* [bitnami/discourse] Update Chart.lock (#12101) ([f4d162f](https://github.com/bitnami/charts/commit/f4d162f)), closes [#12101](https://github.com/bitnami/charts/issues/12101)
+* [bitnami/discourse] Update Chart.lock (#12101) ([f4d162f](https://github.com/bitnami/charts/commit/f4d162fe3d0d480f44543079598ee405d9d103e5)), closes [#12101](https://github.com/bitnami/charts/issues/12101)
 
 ## <small>8.1.1 (2022-08-23)</small>
 
-* [bitnami/discourse] Fix for #11859 remove pw from cm (#11970) ([205378b](https://github.com/bitnami/charts/commit/205378b)), closes [#11859](https://github.com/bitnami/charts/issues/11859) [#11970](https://github.com/bitnami/charts/issues/11970)
+* [bitnami/discourse] Fix for #11859 remove pw from cm (#11970) ([205378b](https://github.com/bitnami/charts/commit/205378be4b979cd806adb13389a0e6b9e311e5aa)), closes [#11859](https://github.com/bitnami/charts/issues/11859) [#11970](https://github.com/bitnami/charts/issues/11970)
 
 ## 8.1.0 (2022-08-22)
 
-* [bitnami/discourse] Add support for image digest apart from tag (#11872) ([e441402](https://github.com/bitnami/charts/commit/e441402)), closes [#11872](https://github.com/bitnami/charts/issues/11872)
+* [bitnami/discourse] Add support for image digest apart from tag (#11872) ([e441402](https://github.com/bitnami/charts/commit/e44140261ae545236c41697c385046d62c270417)), closes [#11872](https://github.com/bitnami/charts/issues/11872)
 
 ## <small>8.0.9 (2022-08-18)</small>
 
-* [bitnami/discourse] Release 8.0.9 (#11821) ([0e211f1](https://github.com/bitnami/charts/commit/0e211f1)), closes [#11821](https://github.com/bitnami/charts/issues/11821)
+* [bitnami/discourse] Release 8.0.9 (#11821) ([0e211f1](https://github.com/bitnami/charts/commit/0e211f17754cfd9b96c403fd00ce1d70601a1399)), closes [#11821](https://github.com/bitnami/charts/issues/11821)
 
 ## <small>8.0.8 (2022-08-11)</small>
 
-* [bitnami/discourse] Release 8.0.8 (#11719) ([0790c9c](https://github.com/bitnami/charts/commit/0790c9c)), closes [#11719](https://github.com/bitnami/charts/issues/11719)
+* [bitnami/discourse] Release 8.0.8 (#11719) ([0790c9c](https://github.com/bitnami/charts/commit/0790c9cf17a3ba36f62db5d6d572195e8533d3a6)), closes [#11719](https://github.com/bitnami/charts/issues/11719)
 
 ## <small>8.0.7 (2022-08-09)</small>
 
-* [bitnami/discourse] Release 8.0.7 (#11676) ([dadcec0](https://github.com/bitnami/charts/commit/dadcec0)), closes [#11676](https://github.com/bitnami/charts/issues/11676)
+* [bitnami/discourse] Release 8.0.7 (#11676) ([dadcec0](https://github.com/bitnami/charts/commit/dadcec0dabf5f9a919b55aa1f3dfaf2553eeb279)), closes [#11676](https://github.com/bitnami/charts/issues/11676)
 
 ## <small>8.0.6 (2022-08-04)</small>
 
-* [bitnami/discourse] Release 8.0.6 (#11584) ([ff973d3](https://github.com/bitnami/charts/commit/ff973d3)), closes [#11584](https://github.com/bitnami/charts/issues/11584)
+* [bitnami/discourse] Release 8.0.6 (#11584) ([ff973d3](https://github.com/bitnami/charts/commit/ff973d34d3bf7b56909395c87105769976503944)), closes [#11584](https://github.com/bitnami/charts/issues/11584)
 
 ## <small>8.0.5 (2022-08-03)</small>
 
-* [bitnami/discourse] Release 8.0.5 (#11541) ([ef1d2d8](https://github.com/bitnami/charts/commit/ef1d2d8)), closes [#11541](https://github.com/bitnami/charts/issues/11541)
+* [bitnami/discourse] Release 8.0.5 (#11541) ([ef1d2d8](https://github.com/bitnami/charts/commit/ef1d2d8ea6605ea4cda865f2b6fe4aeb1a2d00f1)), closes [#11541](https://github.com/bitnami/charts/issues/11541)
 
 ## <small>8.0.4 (2022-07-28)</small>
 
-* [bitnami/discourse] Release 8.0.4 (#11395) ([d74913f](https://github.com/bitnami/charts/commit/d74913f)), closes [#11395](https://github.com/bitnami/charts/issues/11395)
+* [bitnami/discourse] Release 8.0.4 (#11395) ([d74913f](https://github.com/bitnami/charts/commit/d74913fce97ec8505ffd10ebb27c476399b14e72)), closes [#11395](https://github.com/bitnami/charts/issues/11395)
 
 ## <small>8.0.3 (2022-07-27)</small>
 
-* [bitnami/discourse] Release 8.0.3 (#11392) ([dde21b8](https://github.com/bitnami/charts/commit/dde21b8)), closes [#11392](https://github.com/bitnami/charts/issues/11392)
+* [bitnami/discourse] Release 8.0.3 (#11392) ([dde21b8](https://github.com/bitnami/charts/commit/dde21b8fea5a7000c3d8dbee2b987fe5c2e6e262)), closes [#11392](https://github.com/bitnami/charts/issues/11392)
 
 ## <small>8.0.2 (2022-07-27)</small>
 
-* [bitnami/*] Update URLs to point to the new bitnami/containers monorepo (#11352) ([d665af0](https://github.com/bitnami/charts/commit/d665af0)), closes [#11352](https://github.com/bitnami/charts/issues/11352)
-* [bitnami/discourse] Release 8.0.2 (#11367) ([415a9f2](https://github.com/bitnami/charts/commit/415a9f2)), closes [#11367](https://github.com/bitnami/charts/issues/11367)
+* [bitnami/*] Update URLs to point to the new bitnami/containers monorepo (#11352) ([d665af0](https://github.com/bitnami/charts/commit/d665af0c708846192d8d5fb2f5f9ea65dd464ab0)), closes [#11352](https://github.com/bitnami/charts/issues/11352)
+* [bitnami/discourse] Release 8.0.2 (#11367) ([415a9f2](https://github.com/bitnami/charts/commit/415a9f20fc93abc098e98b2c51f4ece3b4982d07)), closes [#11367](https://github.com/bitnami/charts/issues/11367)
 
 ## <small>8.0.1 (2022-07-16)</small>
 
-* [bitnami/discourse] Release 8.0.1 (#11206) ([547841d](https://github.com/bitnami/charts/commit/547841d)), closes [#11206](https://github.com/bitnami/charts/issues/11206)
+* [bitnami/discourse] Release 8.0.1 (#11206) ([547841d](https://github.com/bitnami/charts/commit/547841d95c06f894a9d3ac227cf8ea77e143e5b2)), closes [#11206](https://github.com/bitnami/charts/issues/11206)
 
 ## 8.0.0 (2022-07-13)
 
-* [bitnami/discourse] Update Redis subchart (#11171) ([377e784](https://github.com/bitnami/charts/commit/377e784)), closes [#11171](https://github.com/bitnami/charts/issues/11171)
+* [bitnami/discourse] Update Redis subchart (#11171) ([377e784](https://github.com/bitnami/charts/commit/377e784f73305e389c373e19cc88d0d24efaa1a4)), closes [#11171](https://github.com/bitnami/charts/issues/11171)
 
 ## <small>7.3.13 (2022-07-13)</small>
 
-* [bitnami/discourse] Release 7.3.13 (#11157) ([b29e16a](https://github.com/bitnami/charts/commit/b29e16a)), closes [#11157](https://github.com/bitnami/charts/issues/11157)
+* [bitnami/discourse] Release 7.3.13 (#11157) ([b29e16a](https://github.com/bitnami/charts/commit/b29e16aec1644b66f451d395530ca7b0e2c752c1)), closes [#11157](https://github.com/bitnami/charts/issues/11157)
 
 ## <small>7.3.12 (2022-07-09)</small>
 
-* [bitnami/discourse] Release 7.3.12 (#11103) ([c357425](https://github.com/bitnami/charts/commit/c357425)), closes [#11103](https://github.com/bitnami/charts/issues/11103)
+* [bitnami/discourse] Release 7.3.12 (#11103) ([c357425](https://github.com/bitnami/charts/commit/c357425a318d545a3826bb3c9a6f570f1cd2b026)), closes [#11103](https://github.com/bitnami/charts/issues/11103)
 
 ## <small>7.3.11 (2022-07-06)</small>
 
-* [bitnami/discourse] Release 7.3.11 (#11064) ([1c3b624](https://github.com/bitnami/charts/commit/1c3b624)), closes [#11064](https://github.com/bitnami/charts/issues/11064)
+* [bitnami/discourse] Release 7.3.11 (#11064) ([1c3b624](https://github.com/bitnami/charts/commit/1c3b624f23d1d5a480899a8ce93a5adacb1de3d8)), closes [#11064](https://github.com/bitnami/charts/issues/11064)
 
 ## <small>7.3.10 (2022-07-04)</small>
 
-* [bitnami/discourse] Release 7.3.10 (#11025) ([50c5993](https://github.com/bitnami/charts/commit/50c5993)), closes [#11025](https://github.com/bitnami/charts/issues/11025)
+* [bitnami/discourse] Release 7.3.10 (#11025) ([50c5993](https://github.com/bitnami/charts/commit/50c5993759a355e747bdf2a1593e71a2dd5de9a1)), closes [#11025](https://github.com/bitnami/charts/issues/11025)
 
 ## <small>7.3.9 (2022-07-01)</small>
 
-* [bitnami/discourse] Release 7.3.9 (#10991) ([f76f366](https://github.com/bitnami/charts/commit/f76f366)), closes [#10991](https://github.com/bitnami/charts/issues/10991)
+* [bitnami/discourse] Release 7.3.9 (#10991) ([f76f366](https://github.com/bitnami/charts/commit/f76f366992d8dde7d4a706ccf8be985084c4fc06)), closes [#10991](https://github.com/bitnami/charts/issues/10991)
 
 ## <small>7.3.8 (2022-06-30)</small>
 
-* [bitnami/discourse] Release 7.3.8 (#10967) ([9d9fb76](https://github.com/bitnami/charts/commit/9d9fb76)), closes [#10967](https://github.com/bitnami/charts/issues/10967)
+* [bitnami/discourse] Release 7.3.8 (#10967) ([9d9fb76](https://github.com/bitnami/charts/commit/9d9fb76fd1bbfa6c146f260673e9b9a53a75f9a2)), closes [#10967](https://github.com/bitnami/charts/issues/10967)
 
 ## <small>7.3.7 (2022-06-14)</small>
 
-* [bitnami/discourse] Release 7.3.7 updating components versions ([f0ae46f](https://github.com/bitnami/charts/commit/f0ae46f))
+* [bitnami/discourse] Release 7.3.7 updating components versions ([f0ae46f](https://github.com/bitnami/charts/commit/f0ae46f21b36700fbd2b651b5780d594f455c36c))
 
 ## <small>7.3.6 (2022-06-13)</small>
 
-* [bitnami/discourse] Release 7.3.6 updating components versions ([170bad8](https://github.com/bitnami/charts/commit/170bad8))
+* [bitnami/discourse] Release 7.3.6 updating components versions ([170bad8](https://github.com/bitnami/charts/commit/170bad83cd6aeb5532eaf121216469be3eca08e4))
 
 ## <small>7.3.5 (2022-06-11)</small>
 
-* [bitnami/discourse] Release 7.3.5 updating components versions ([426457a](https://github.com/bitnami/charts/commit/426457a))
+* [bitnami/discourse] Release 7.3.5 updating components versions ([426457a](https://github.com/bitnami/charts/commit/426457a9c467ba79dfaf897a31c69eb1a90927b8))
 
 ## <small>7.3.4 (2022-06-07)</small>
 
-* [bitnami/*] Replace Kubeapps URL in READMEs (and kubeapps Chart.yaml) and remove BKPR references (#1 ([c6a7914](https://github.com/bitnami/charts/commit/c6a7914)), closes [#10600](https://github.com/bitnami/charts/issues/10600)
-* Fix tolerations and topologySpreadConstraints default values (#10624) ([643f24b](https://github.com/bitnami/charts/commit/643f24b)), closes [#10624](https://github.com/bitnami/charts/issues/10624)
+* [bitnami/*] Replace Kubeapps URL in READMEs (and kubeapps Chart.yaml) and remove BKPR references (#1 ([c6a7914](https://github.com/bitnami/charts/commit/c6a7914361e5aea6016fb45bf4d621edfd111d32)), closes [#10600](https://github.com/bitnami/charts/issues/10600)
+* Fix tolerations and topologySpreadConstraints default values (#10624) ([643f24b](https://github.com/bitnami/charts/commit/643f24bb84e5ed9db9e5dc25d65b482ec5ac2a04)), closes [#10624](https://github.com/bitnami/charts/issues/10624)
 
 ## <small>7.3.3 (2022-06-06)</small>
 
-* [bitnami/discourse] Release 7.3.3 updating components versions ([87bd819](https://github.com/bitnami/charts/commit/87bd819))
+* [bitnami/discourse] Release 7.3.3 updating components versions ([87bd819](https://github.com/bitnami/charts/commit/87bd819dc98a88bd313925e01ab502da4c99e2db))
 
 ## <small>7.3.2 (2022-06-02)</small>
 
-* Update Redis trademark references ([2cada87](https://github.com/bitnami/charts/commit/2cada87))
+* Update Redis trademark references ([2cada87](https://github.com/bitnami/charts/commit/2cada87ed4967d5cb578b0409a0bb1edee79029a))
 
 ## <small>7.3.1 (2022-06-01)</small>
 
-* [bitnami/several] Replace maintainers email by url (#10523) ([ff3cf61](https://github.com/bitnami/charts/commit/ff3cf61)), closes [#10523](https://github.com/bitnami/charts/issues/10523)
+* [bitnami/several] Replace maintainers email by url (#10523) ([ff3cf61](https://github.com/bitnami/charts/commit/ff3cf617a1680509b0f3855d17c4ccff7b29a0ff)), closes [#10523](https://github.com/bitnami/charts/issues/10523)
 
 ## 7.3.0 (2022-05-26)
 
-* [bitnami/discourse] Add missing service parameter (#10405) ([9ae52bb](https://github.com/bitnami/charts/commit/9ae52bb)), closes [#10405](https://github.com/bitnami/charts/issues/10405)
+* [bitnami/discourse] Add missing service parameter (#10405) ([9ae52bb](https://github.com/bitnami/charts/commit/9ae52bbce3e03756608b49e766425b6485757a52)), closes [#10405](https://github.com/bitnami/charts/issues/10405)
 
 ## <small>7.2.4 (2022-05-25)</small>
 
-* [bitnami/discourse] Release 7.2.4 updating components versions ([2a53ef8](https://github.com/bitnami/charts/commit/2a53ef8))
+* [bitnami/discourse] Release 7.2.4 updating components versions ([2a53ef8](https://github.com/bitnami/charts/commit/2a53ef86b63944f308c2a835bd8c6362f7fd1143))
 
 ## <small>7.2.3 (2022-05-20)</small>
 
-* [bitnami/discourse] Release 7.2.3 updating components versions ([53afa62](https://github.com/bitnami/charts/commit/53afa62))
+* [bitnami/discourse] Release 7.2.3 updating components versions ([53afa62](https://github.com/bitnami/charts/commit/53afa62a1bbd19e38f35791ac54010cafd777123))
 
 ## <small>7.2.2 (2022-05-19)</small>
 
-* [bitnami/discourse] Release 7.2.2 updating components versions ([11a1f95](https://github.com/bitnami/charts/commit/11a1f95))
+* [bitnami/discourse] Release 7.2.2 updating components versions ([11a1f95](https://github.com/bitnami/charts/commit/11a1f9572b012151ba4c68ff37b60f34eca8f2b5))
 
 ## <small>7.2.1 (2022-05-18)</small>
 
-* [bitnami/discourse] Release 7.2.1 updating components versions ([062e36c](https://github.com/bitnami/charts/commit/062e36c))
+* [bitnami/discourse] Release 7.2.1 updating components versions ([062e36c](https://github.com/bitnami/charts/commit/062e36c563d6efbe8563963829599b12820f96f1))
 
 ## 7.2.0 (2022-05-16)
 
-* [bitnami/*] add ingress extraRules feature (#10253) ([0f6cbb9](https://github.com/bitnami/charts/commit/0f6cbb9)), closes [#10253](https://github.com/bitnami/charts/issues/10253)
+* [bitnami/*] add ingress extraRules feature (#10253) ([0f6cbb9](https://github.com/bitnami/charts/commit/0f6cbb9099b0e56685cc1d36ba50340f3d7278a1)), closes [#10253](https://github.com/bitnami/charts/issues/10253)
 
 ## 7.1.0 (2022-05-16)
 
-* [bitnami/*] Add missing 'persistence.annotations' (#10202) ([ad1d8a5](https://github.com/bitnami/charts/commit/ad1d8a5)), closes [#10202](https://github.com/bitnami/charts/issues/10202)
+* [bitnami/*] Add missing 'persistence.annotations' (#10202) ([ad1d8a5](https://github.com/bitnami/charts/commit/ad1d8a5fd977ecd82e82ec8a2530d0d2522a8ed0)), closes [#10202](https://github.com/bitnami/charts/issues/10202)
 
 ## <small>7.0.19 (2022-05-15)</small>
 
-* [bitnami/discourse] Release 7.0.19 updating components versions ([e83f457](https://github.com/bitnami/charts/commit/e83f457))
+* [bitnami/discourse] Release 7.0.19 updating components versions ([e83f457](https://github.com/bitnami/charts/commit/e83f4577fe4f7d09613f500e3ba1c31d1f7a9dfd))
 
 ## <small>7.0.18 (2022-05-13)</small>
 
-* [bitnami/*] Remove old 'ci' files (#10171) ([5df30c4](https://github.com/bitnami/charts/commit/5df30c4)), closes [#10171](https://github.com/bitnami/charts/issues/10171)
-* [bitnami/*] Unify k8s directives separators (#10185) ([2650214](https://github.com/bitnami/charts/commit/2650214)), closes [#10185](https://github.com/bitnami/charts/issues/10185)
+* [bitnami/*] Remove old 'ci' files (#10171) ([5df30c4](https://github.com/bitnami/charts/commit/5df30c44dbd1812da8786579ce4a94917d46a6ad)), closes [#10171](https://github.com/bitnami/charts/issues/10171)
+* [bitnami/*] Unify k8s directives separators (#10185) ([2650214](https://github.com/bitnami/charts/commit/26502141d146ca3bdfb3bf744fcdec8ca5cece44)), closes [#10185](https://github.com/bitnami/charts/issues/10185)
 
 ## <small>7.0.17 (2022-05-11)</small>
 
-* [bitnami/*] Fix typo in comments (relay -> rely) (#10151) ([9cfe4a4](https://github.com/bitnami/charts/commit/9cfe4a4)), closes [#10151](https://github.com/bitnami/charts/issues/10151)
+* [bitnami/*] Fix typo in comments (relay -> rely) (#10151) ([9cfe4a4](https://github.com/bitnami/charts/commit/9cfe4a48cc35851faea6be7ffb2a978d223befa0)), closes [#10151](https://github.com/bitnami/charts/issues/10151)
 
 ## <small>7.0.16 (2022-04-21)</small>
 
-* [bitnami/discourse] Release 7.0.16 updating components versions ([4338620](https://github.com/bitnami/charts/commit/4338620))
+* [bitnami/discourse] Release 7.0.16 updating components versions ([4338620](https://github.com/bitnami/charts/commit/43386206ba9ebcf1ef5527181675c597666d5963))
 
 ## <small>7.0.15 (2022-04-19)</small>
 
-* [bitnami/discourse] Release 7.0.15 updating components versions ([582d909](https://github.com/bitnami/charts/commit/582d909))
+* [bitnami/discourse] Release 7.0.15 updating components versions ([582d909](https://github.com/bitnami/charts/commit/582d909e2e34cdf5a06c18e70f1ec06478708374))
 
 ## <small>7.0.14 (2022-04-14)</small>
 
-* [bitnami/discourse] Release 7.0.14 updating components versions ([3c43a39](https://github.com/bitnami/charts/commit/3c43a39))
+* [bitnami/discourse] Release 7.0.14 updating components versions ([3c43a39](https://github.com/bitnami/charts/commit/3c43a39494cea9968c425ad8750d4bc36582a035))
 
 ## <small>7.0.13 (2022-04-07)</small>
 
-* [bitnami/discourse] Release 7.0.13 updating components versions ([0191079](https://github.com/bitnami/charts/commit/0191079))
+* [bitnami/discourse] Release 7.0.13 updating components versions ([0191079](https://github.com/bitnami/charts/commit/01910798c5e3ad137b8f76238831ead12336c7e2))
 
 ## <small>7.0.12 (2022-04-06)</small>
 
-* [bitnami/discourse] Release 7.0.12 updating components versions ([213aed1](https://github.com/bitnami/charts/commit/213aed1))
+* [bitnami/discourse] Release 7.0.12 updating components versions ([213aed1](https://github.com/bitnami/charts/commit/213aed1920a02afdad6a7f4beecbcd9949668afe))
 
 ## <small>7.0.11 (2022-04-03)</small>
 
-* [bitnami/discourse] Release 7.0.11 updating components versions ([26ffcc3](https://github.com/bitnami/charts/commit/26ffcc3))
+* [bitnami/discourse] Release 7.0.11 updating components versions ([26ffcc3](https://github.com/bitnami/charts/commit/26ffcc3b4f4cae9bb2fe27b73c41a39c0e3d7efc))
 
 ## <small>7.0.10 (2022-04-02)</small>
 
-* [bitnami/discourse] Release 7.0.10 updating components versions ([440ecb0](https://github.com/bitnami/charts/commit/440ecb0))
+* [bitnami/discourse] Release 7.0.10 updating components versions ([440ecb0](https://github.com/bitnami/charts/commit/440ecb0cb36aa291733179a01f0fdf594b3c16e6))
 
 ## <small>7.0.9 (2022-03-29)</small>
 
-* [bitnami/discourse] Release 7.0.9 updating components versions ([f180eec](https://github.com/bitnami/charts/commit/f180eec))
+* [bitnami/discourse] Release 7.0.9 updating components versions ([f180eec](https://github.com/bitnami/charts/commit/f180eec9c15a33daab47f540ad3b956d0543624a))
 
 ## <small>7.0.8 (2022-03-27)</small>
 
-* [bitnami/discourse] Release 7.0.8 updating components versions ([47c17b3](https://github.com/bitnami/charts/commit/47c17b3))
+* [bitnami/discourse] Release 7.0.8 updating components versions ([47c17b3](https://github.com/bitnami/charts/commit/47c17b343599645c72dad01dda25f90dd9d8c8eb))
 
 ## <small>7.0.7 (2022-03-26)</small>
 
-* [bitnami/discourse] Release 7.0.7 updating components versions ([1245be4](https://github.com/bitnami/charts/commit/1245be4))
+* [bitnami/discourse] Release 7.0.7 updating components versions ([1245be4](https://github.com/bitnami/charts/commit/1245be48af9db94ad9f5f776c576c1f162ecbb5f))
 
 ## <small>7.0.6 (2022-03-25)</small>
 
-* [bitnami/discourse] Release 7.0.6 updating components versions ([fa9ac0d](https://github.com/bitnami/charts/commit/fa9ac0d))
+* [bitnami/discourse] Release 7.0.6 updating components versions ([fa9ac0d](https://github.com/bitnami/charts/commit/fa9ac0df83be43c1fba3aab3fadd085415cfe15b))
 
 ## <small>7.0.5 (2022-03-23)</small>
 
-* [bitnami/discourse] Release 7.0.5 updating components versions ([0d14dc4](https://github.com/bitnami/charts/commit/0d14dc4))
+* [bitnami/discourse] Release 7.0.5 updating components versions ([0d14dc4](https://github.com/bitnami/charts/commit/0d14dc440d7f43b17c2b97071228d9b5ba8a0c30))
 
 ## <small>7.0.4 (2022-03-18)</small>
 
-* [bitnami/discourse] Release 7.0.4 updating components versions ([ff8cf2b](https://github.com/bitnami/charts/commit/ff8cf2b))
+* [bitnami/discourse] Release 7.0.4 updating components versions ([ff8cf2b](https://github.com/bitnami/charts/commit/ff8cf2b8c321c79f8b3f9e314eb11418f6cde6bd))
 
 ## <small>7.0.3 (2022-03-16)</small>
 
-* [bitnami/discourse] Release 7.0.3 updating components versions ([b8dbfed](https://github.com/bitnami/charts/commit/b8dbfed))
+* [bitnami/discourse] Release 7.0.3 updating components versions ([b8dbfed](https://github.com/bitnami/charts/commit/b8dbfedf483b95639a19b13c3eaedc9016ba7901))
 
 ## <small>7.0.2 (2022-03-10)</small>
 
-* [bitnami/discourse] Release 7.0.2 updating components versions ([6e64168](https://github.com/bitnami/charts/commit/6e64168))
+* [bitnami/discourse] Release 7.0.2 updating components versions ([6e64168](https://github.com/bitnami/charts/commit/6e6416842ff2301871f4eb3b707c77ad17a151ea))
 
 ## <small>7.0.1 (2022-03-04)</small>
 
-* [bitnami/several] Reorder subcharts (#9299) ([a041f6b](https://github.com/bitnami/charts/commit/a041f6b)), closes [#9299](https://github.com/bitnami/charts/issues/9299)
+* [bitnami/several] Reorder subcharts (#9299) ([a041f6b](https://github.com/bitnami/charts/commit/a041f6b0ff2dea82b3d030cb99454cede94dbc9a)), closes [#9299](https://github.com/bitnami/charts/issues/9299)
 
 ## 7.0.0 (2022-03-04)
 
-* [bitnami/discourse] MAJOR: Update to 2.8.x (#9293) ([784cf97](https://github.com/bitnami/charts/commit/784cf97)), closes [#9293](https://github.com/bitnami/charts/issues/9293)
+* [bitnami/discourse] MAJOR: Update to 2.8.x (#9293) ([784cf97](https://github.com/bitnami/charts/commit/784cf9769a7adda85f70e33d7d2b6fad683a2898)), closes [#9293](https://github.com/bitnami/charts/issues/9293)
 
 ## <small>6.0.3 (2022-02-27)</small>
 
-* [bitnami/discourse] Release 6.0.3 updating components versions ([5edcb48](https://github.com/bitnami/charts/commit/5edcb48))
+* [bitnami/discourse] Release 6.0.3 updating components versions ([5edcb48](https://github.com/bitnami/charts/commit/5edcb482b1e69d4aa16add87748a45619332cf88))
 
 ## <small>6.0.2 (2022-02-24)</small>
 
-* [bitnami/discourse]: fix: :bug: Fix incorrect indent in PVC (#9198) ([e5c4d3e](https://github.com/bitnami/charts/commit/e5c4d3e)), closes [#9198](https://github.com/bitnami/charts/issues/9198)
+* [bitnami/discourse]: fix: :bug: Fix incorrect indent in PVC (#9198) ([e5c4d3e](https://github.com/bitnami/charts/commit/e5c4d3e112166977631648573d7202a455f2e305)), closes [#9198](https://github.com/bitnami/charts/issues/9198)
 
 ## <small>6.0.1 (2022-02-24)</small>
 
-* [bitnami/discourse] Release 6.0.1 updating components versions ([4e51dc8](https://github.com/bitnami/charts/commit/4e51dc8))
+* [bitnami/discourse] Release 6.0.1 updating components versions ([4e51dc8](https://github.com/bitnami/charts/commit/4e51dc8a01e73bb1ef00312ba8d34ddca6d53b64))
 
 ## 6.0.0 (2022-02-22)
 
-* [bitnami/discourse] Chart standardization (#8991) ([82db1c7](https://github.com/bitnami/charts/commit/82db1c7)), closes [#8991](https://github.com/bitnami/charts/issues/8991)
+* [bitnami/discourse] Chart standardization (#8991) ([82db1c7](https://github.com/bitnami/charts/commit/82db1c79a8dad6b7a4b7b588be906655467b43f2)), closes [#8991](https://github.com/bitnami/charts/issues/8991)
 
 ## <small>5.2.6 (2022-02-13)</small>
 
-* [bitnami/discourse] Release 5.2.6 updating components versions ([c841ed2](https://github.com/bitnami/charts/commit/c841ed2))
+* [bitnami/discourse] Release 5.2.6 updating components versions ([c841ed2](https://github.com/bitnami/charts/commit/c841ed2c5abc908f9e3d5a6bc8b5c28bfcd4bcf5))
 
 ## <small>5.2.5 (2022-02-12)</small>
 
-* [bitnami/discourse] Release 5.2.5 updating components versions ([89fdcba](https://github.com/bitnami/charts/commit/89fdcba))
+* [bitnami/discourse] Release 5.2.5 updating components versions ([89fdcba](https://github.com/bitnami/charts/commit/89fdcba75afaaa828664461b942baff8b164afe6))
 
 ## <small>5.2.4 (2022-02-09)</small>
 
-* [bitnami/discourse] test: :white_check_mark: Add ct-values.yaml (#8947) ([8492f40](https://github.com/bitnami/charts/commit/8492f40)), closes [#8947](https://github.com/bitnami/charts/issues/8947)
-* Non utf8 chars (#8923) ([6ffd18f](https://github.com/bitnami/charts/commit/6ffd18f)), closes [#8923](https://github.com/bitnami/charts/issues/8923)
+* [bitnami/discourse] test: :white_check_mark: Add ct-values.yaml (#8947) ([8492f40](https://github.com/bitnami/charts/commit/8492f406a0d3c06838879bb2bf7a85bacfef2d2f)), closes [#8947](https://github.com/bitnami/charts/issues/8947)
+* Non utf8 chars (#8923) ([6ffd18f](https://github.com/bitnami/charts/commit/6ffd18fbbdf10e94ea1a90cf5b84ef610ac2a72d)), closes [#8923](https://github.com/bitnami/charts/issues/8923)
 
 ## <small>5.2.3 (2022-01-20)</small>
 
-* [bitnami/*] Readme automation (#8579) ([78d1938](https://github.com/bitnami/charts/commit/78d1938)), closes [#8579](https://github.com/bitnami/charts/issues/8579)
-* [bitnami/*] Update READMEs (#8716) ([b9a9533](https://github.com/bitnami/charts/commit/b9a9533)), closes [#8716](https://github.com/bitnami/charts/issues/8716)
-* [bitnami/several] Change prerequisites (#8725) ([8d740c5](https://github.com/bitnami/charts/commit/8d740c5)), closes [#8725](https://github.com/bitnami/charts/issues/8725)
+* [bitnami/*] Readme automation (#8579) ([78d1938](https://github.com/bitnami/charts/commit/78d193831c900d178198491ffd08fa2217a64ecd)), closes [#8579](https://github.com/bitnami/charts/issues/8579)
+* [bitnami/*] Update READMEs (#8716) ([b9a9533](https://github.com/bitnami/charts/commit/b9a953337590eb2979453385874a267bacf50936)), closes [#8716](https://github.com/bitnami/charts/issues/8716)
+* [bitnami/several] Change prerequisites (#8725) ([8d740c5](https://github.com/bitnami/charts/commit/8d740c566cfdb7e2d933c40128b4e919fce953a5)), closes [#8725](https://github.com/bitnami/charts/issues/8725)
 
 ## <small>5.2.2 (2022-01-13)</small>
 
-* [bitnami/discourse] Release 5.2.2 updating components versions ([67a0401](https://github.com/bitnami/charts/commit/67a0401))
+* [bitnami/discourse] Release 5.2.2 updating components versions ([67a0401](https://github.com/bitnami/charts/commit/67a0401c40e3d0eca4c72a8f00b40800e83e1433))
 
 ## <small>5.2.1 (2022-01-12)</small>
 
-* [bitnami/discourse] Release 5.2.1 updating components versions ([be69d93](https://github.com/bitnami/charts/commit/be69d93))
+* [bitnami/discourse] Release 5.2.1 updating components versions ([be69d93](https://github.com/bitnami/charts/commit/be69d93b344d361658f88416f982f1ca2ff2831a))
 
 ## 5.2.0 (2022-01-05)
 
-* [bitnami/several] Adapt templating format (#8562) ([8cad18a](https://github.com/bitnami/charts/commit/8cad18a)), closes [#8562](https://github.com/bitnami/charts/issues/8562)
-* [bitnami/several] Add license to the README ([05f7633](https://github.com/bitnami/charts/commit/05f7633))
-* [bitnami/several] Add license to the README ([32fb238](https://github.com/bitnami/charts/commit/32fb238))
-* [bitnami/several] Add license to the README ([b87c2f7](https://github.com/bitnami/charts/commit/b87c2f7))
+* [bitnami/several] Adapt templating format (#8562) ([8cad18a](https://github.com/bitnami/charts/commit/8cad18aed9966a6f0208e5ad6cee46cb217f47ab)), closes [#8562](https://github.com/bitnami/charts/issues/8562)
+* [bitnami/several] Add license to the README ([05f7633](https://github.com/bitnami/charts/commit/05f763372501d596e57db713dd53ff4ff3027cc4))
+* [bitnami/several] Add license to the README ([32fb238](https://github.com/bitnami/charts/commit/32fb238e60a0affc6debd3142eaa3c3d9089ec2a))
+* [bitnami/several] Add license to the README ([b87c2f7](https://github.com/bitnami/charts/commit/b87c2f7899d48a8b02c506765e6ae82937e9ba3f))
 
 ## <small>5.1.4 (2021-12-27)</small>
 
-* [bitnami/discourse] Release 5.1.4 updating components versions ([f0c0825](https://github.com/bitnami/charts/commit/f0c0825))
+* [bitnami/discourse] Release 5.1.4 updating components versions ([f0c0825](https://github.com/bitnami/charts/commit/f0c08255a0e4180da8df2a8b5235e9bcd68b0b2c))
 
 ## <small>5.1.3 (2021-12-22)</small>
 
-* [bitnami/discourse] Release 5.1.3 updating components versions ([cf6b61d](https://github.com/bitnami/charts/commit/cf6b61d))
-* [bitnami/several] Regenerate README tables ([a43cca7](https://github.com/bitnami/charts/commit/a43cca7))
+* [bitnami/discourse] Release 5.1.3 updating components versions ([cf6b61d](https://github.com/bitnami/charts/commit/cf6b61d3bae33b976a27ded533322433e9483a76))
+* [bitnami/several] Regenerate README tables ([a43cca7](https://github.com/bitnami/charts/commit/a43cca73cabae95609e943f6eb2cdeefc04e866b))
 
 ## <small>5.1.2 (2021-12-02)</small>
 
-* [bitnami/discourse] Release 5.1.2 updating components versions ([9e167d8](https://github.com/bitnami/charts/commit/9e167d8))
+* [bitnami/discourse] Release 5.1.2 updating components versions ([9e167d8](https://github.com/bitnami/charts/commit/9e167d88c4bf5a59e9245ef7ff5a028abbc89024))
 
 ## <small>5.1.1 (2021-11-29)</small>
 
-* [bitnami/several] Add 'community support' note to some Helm chart READMEs (#8148) ([ce6b838](https://github.com/bitnami/charts/commit/ce6b838)), closes [#8148](https://github.com/bitnami/charts/issues/8148)
-* [bitnami/several] Replace HTTP by HTTPS when possible (#8259) ([eafb5bd](https://github.com/bitnami/charts/commit/eafb5bd)), closes [#8259](https://github.com/bitnami/charts/issues/8259)
+* [bitnami/several] Add 'community support' note to some Helm chart READMEs (#8148) ([ce6b838](https://github.com/bitnami/charts/commit/ce6b83829ac261c04784d7818c9cfa844f403213)), closes [#8148](https://github.com/bitnami/charts/issues/8148)
+* [bitnami/several] Replace HTTP by HTTPS when possible (#8259) ([eafb5bd](https://github.com/bitnami/charts/commit/eafb5bd5a2cc3aaf04fc1e8ebedd73f420d76864)), closes [#8259](https://github.com/bitnami/charts/issues/8259)
 
 ## 5.1.0 (2021-11-17)
 
-* [bitnami/*] Add network policies - first batch (#8088) ([81ece48](https://github.com/bitnami/charts/commit/81ece48)), closes [#8088](https://github.com/bitnami/charts/issues/8088)
+* [bitnami/*] Add network policies - first batch (#8088) ([81ece48](https://github.com/bitnami/charts/commit/81ece48240d42de95b08e33b78c80078126d0139)), closes [#8088](https://github.com/bitnami/charts/issues/8088)
 
 ## <small>5.0.7 (2021-11-17)</small>
 
-* [bitnami/several] Add extraDeploy feature to the pending charts (#8164) ([d812a24](https://github.com/bitnami/charts/commit/d812a24)), closes [#8164](https://github.com/bitnami/charts/issues/8164)
-* [bitnami/several] Regenerate README tables ([1cde837](https://github.com/bitnami/charts/commit/1cde837))
+* [bitnami/several] Add extraDeploy feature to the pending charts (#8164) ([d812a24](https://github.com/bitnami/charts/commit/d812a243cb1bba69c67ac22cfce1f7999848ef74)), closes [#8164](https://github.com/bitnami/charts/issues/8164)
+* [bitnami/several] Regenerate README tables ([1cde837](https://github.com/bitnami/charts/commit/1cde8378b3ee2e825ac07bb0266a988b95b8dbce))
 
 ## <small>5.0.6 (2021-11-16)</small>
 
-* [bitnami/discourse] Release 5.0.6 updating components versions ([3d1e0da](https://github.com/bitnami/charts/commit/3d1e0da))
-* [bitnami/several] Regenerate README tables ([412cf6a](https://github.com/bitnami/charts/commit/412cf6a))
+* [bitnami/discourse] Release 5.0.6 updating components versions ([3d1e0da](https://github.com/bitnami/charts/commit/3d1e0da93e0ffa93e932762a4d5d629df031952e))
+* [bitnami/several] Regenerate README tables ([412cf6a](https://github.com/bitnami/charts/commit/412cf6a513cb0c03444a6e7811c6f27193239a10))
 
 ## <small>5.0.5 (2021-10-26)</small>
 
-* [bitnami/discourse] Release 5.0.5 updating components versions ([022bfc4](https://github.com/bitnami/charts/commit/022bfc4))
+* [bitnami/discourse] Release 5.0.5 updating components versions ([022bfc4](https://github.com/bitnami/charts/commit/022bfc4e4795e2785788b4aab87ff2193fbcea83))
 
 ## <small>5.0.4 (2021-10-22)</small>
 
-* [bitnami/several] Add chart info to NOTES.txt (#7889) ([a6751cd](https://github.com/bitnami/charts/commit/a6751cd)), closes [#7889](https://github.com/bitnami/charts/issues/7889)
-* [bitnami/several] Regenerate README tables ([6c31f25](https://github.com/bitnami/charts/commit/6c31f25))
+* [bitnami/several] Add chart info to NOTES.txt (#7889) ([a6751cd](https://github.com/bitnami/charts/commit/a6751cdd33c461fabbc459fbea6f219ec64ab6b2)), closes [#7889](https://github.com/bitnami/charts/issues/7889)
+* [bitnami/several] Regenerate README tables ([6c31f25](https://github.com/bitnami/charts/commit/6c31f256389531fd334aedb0b99c82ee11803621))
 
 ## <small>5.0.3 (2021-10-21)</small>
 
-* [bitnami/discourse] Add registered icon and trademark information to the Discourse's README (#7679) ([ce1a546](https://github.com/bitnami/charts/commit/ce1a546)), closes [#7679](https://github.com/bitnami/charts/issues/7679)
-* [bitnami/discourse] Release 5.0.3 updating components versions ([ad3729e](https://github.com/bitnami/charts/commit/ad3729e))
+* [bitnami/discourse] Add registered icon and trademark information to the Discourse's README (#7679) ([ce1a546](https://github.com/bitnami/charts/commit/ce1a54647bd672ee1904106d148dc054b9016dd6)), closes [#7679](https://github.com/bitnami/charts/issues/7679)
+* [bitnami/discourse] Release 5.0.3 updating components versions ([ad3729e](https://github.com/bitnami/charts/commit/ad3729ef43c999ab122baaf770b4cb0fbf4034a9))
 
 ## <small>5.0.2 (2021-10-01)</small>
 
-* [bitnami/*] Drop support for deprecated cert-manager annotation (#7582) ([a081792](https://github.com/bitnami/charts/commit/a081792)), closes [#7582](https://github.com/bitnami/charts/issues/7582)
-* [bitnami/several] Regenerate README tables ([5a24d1f](https://github.com/bitnami/charts/commit/5a24d1f))
+* [bitnami/*] Drop support for deprecated cert-manager annotation (#7582) ([a081792](https://github.com/bitnami/charts/commit/a08179293543f063e5de966a9976ca967161de7b)), closes [#7582](https://github.com/bitnami/charts/issues/7582)
+* [bitnami/several] Regenerate README tables ([5a24d1f](https://github.com/bitnami/charts/commit/5a24d1fc9508abfef7fc8a85d0ac64f5d2f7926a))
 
 ## <small>5.0.1 (2021-09-28)</small>
 
-* [bitnami/*] Generate READMEs with new generator version (#7614) ([e5ab2e6](https://github.com/bitnami/charts/commit/e5ab2e6)), closes [#7614](https://github.com/bitnami/charts/issues/7614)
-* [bitnami/discourse] Release 5.0.1 updating components versions ([23ab230](https://github.com/bitnami/charts/commit/23ab230))
+* [bitnami/*] Generate READMEs with new generator version (#7614) ([e5ab2e6](https://github.com/bitnami/charts/commit/e5ab2e6ecdd6bce800863f154cda524ff9f6c117)), closes [#7614](https://github.com/bitnami/charts/issues/7614)
+* [bitnami/discourse] Release 5.0.1 updating components versions ([23ab230](https://github.com/bitnami/charts/commit/23ab230f8451afae37f7ba6f4c8a2115db36f89a))
 
 ## 5.0.0 (2021-09-14)
 
-* [bitnami/ several charts] Redis dependency upgrade (#7481) ([bbed564](https://github.com/bitnami/charts/commit/bbed564)), closes [#7481](https://github.com/bitnami/charts/issues/7481)
-* [bitnami/several] Regenerate README tables ([9c82ba2](https://github.com/bitnami/charts/commit/9c82ba2))
+* [bitnami/ several charts] Redis dependency upgrade (#7481) ([bbed564](https://github.com/bitnami/charts/commit/bbed5645fc1e93bde1341f50ba47c614b53ba42a)), closes [#7481](https://github.com/bitnami/charts/issues/7481)
+* [bitnami/several] Regenerate README tables ([9c82ba2](https://github.com/bitnami/charts/commit/9c82ba295d70b1cac50ab4d8d494fdbefc1ec0ac))
 
 ## <small>4.2.14 (2021-09-02)</small>
 
-* [bitnami/discourse] Release 4.2.14 updating components versions ([0cd3d53](https://github.com/bitnami/charts/commit/0cd3d53))
+* [bitnami/discourse] Release 4.2.14 updating components versions ([0cd3d53](https://github.com/bitnami/charts/commit/0cd3d53751439b81b380f5b502f2f66b31ca4d8d))
 
 ## <small>4.2.13 (2021-08-27)</small>
 
-* [bitnami/discourse] add service.loadBalancerIP to the service (#7336) ([8db46e7](https://github.com/bitnami/charts/commit/8db46e7)), closes [#7336](https://github.com/bitnami/charts/issues/7336)
-* [bitnami/several] Regenerate README tables ([da2513b](https://github.com/bitnami/charts/commit/da2513b))
+* [bitnami/discourse] add service.loadBalancerIP to the service (#7336) ([8db46e7](https://github.com/bitnami/charts/commit/8db46e793b911d90b81bdb5dae21ce8312c9b8d3)), closes [#7336](https://github.com/bitnami/charts/issues/7336)
+* [bitnami/several] Regenerate README tables ([da2513b](https://github.com/bitnami/charts/commit/da2513bf0a33819f3b1151d387c631a9ffdb03e2))
 
 ## <small>4.2.12 (2021-08-25)</small>
 
-* [bitnami/discourse] Release 4.2.12 updating components versions ([b37de4b](https://github.com/bitnami/charts/commit/b37de4b))
-* [bitnami/several] Regenerate README tables ([6c107e8](https://github.com/bitnami/charts/commit/6c107e8))
+* [bitnami/discourse] Release 4.2.12 updating components versions ([b37de4b](https://github.com/bitnami/charts/commit/b37de4b1063349379f24da6c178a1c9ef390bd4e))
+* [bitnami/several] Regenerate README tables ([6c107e8](https://github.com/bitnami/charts/commit/6c107e835d6caf8db2e8b17dcd48c5971637e013))
 
 ## <small>4.2.11 (2021-08-04)</small>
 
-* [bitnami/discourse] Release 4.2.11 updating components versions ([e22225a](https://github.com/bitnami/charts/commit/e22225a))
+* [bitnami/discourse] Release 4.2.11 updating components versions ([e22225a](https://github.com/bitnami/charts/commit/e22225abb9c34ea504f14ba1bc4cbc792bc6468a))
 
 ## <small>4.2.10 (2021-07-27)</small>
 
-* [bitnami/several] Bump version and update READMEs (#7069) ([6340bff](https://github.com/bitnami/charts/commit/6340bff)), closes [#7069](https://github.com/bitnami/charts/issues/7069)
-* Replace <sup> strings with &trade; in the README files (#7066) ([d298b49](https://github.com/bitnami/charts/commit/d298b49)), closes [#7066](https://github.com/bitnami/charts/issues/7066)
+* [bitnami/several] Bump version and update READMEs (#7069) ([6340bff](https://github.com/bitnami/charts/commit/6340bff66f93c8c797bda3ca0842e4bf770059f1)), closes [#7069](https://github.com/bitnami/charts/issues/7069)
+* Replace <sup> strings with &trade; in the README files (#7066) ([d298b49](https://github.com/bitnami/charts/commit/d298b4996da33c9580c2594e6dc8ad665dd0ebab)), closes [#7066](https://github.com/bitnami/charts/issues/7066)
 
 ## <small>4.2.9 (2021-07-25)</small>
 
-* [bitnami/discourse] Release 4.2.9 updating components versions ([fa9c0c2](https://github.com/bitnami/charts/commit/fa9c0c2))
+* [bitnami/discourse] Release 4.2.9 updating components versions ([fa9c0c2](https://github.com/bitnami/charts/commit/fa9c0c27c3fb36f908eba915692c19d6916a6899))
 
 ## <small>4.2.8 (2021-07-22)</small>
 
-* [bitnami/several] Fix default values and regenerate README (#7023) ([c443ded](https://github.com/bitnami/charts/commit/c443ded)), closes [#7023](https://github.com/bitnami/charts/issues/7023)
+* [bitnami/several] Fix default values and regenerate README (#7023) ([c443ded](https://github.com/bitnami/charts/commit/c443ded691a1184a72af7b812759fad54b240ae9)), closes [#7023](https://github.com/bitnami/charts/issues/7023)
 
 ## <small>4.2.7 (2021-07-19)</small>
 
-* [bitnami/*] Adapt values.yaml of dataplatform-bp1, dataplatform-bp2 and Discourse charts (#6764) ([e27908f](https://github.com/bitnami/charts/commit/e27908f)), closes [#6764](https://github.com/bitnami/charts/issues/6764)
+* [bitnami/*] Adapt values.yaml of dataplatform-bp1, dataplatform-bp2 and Discourse charts (#6764) ([e27908f](https://github.com/bitnami/charts/commit/e27908fab52b2f5ab1faf087150a296af0adefe4)), closes [#6764](https://github.com/bitnami/charts/issues/6764)
 
 ## <small>4.2.6 (2021-07-19)</small>
 
-* [bitnami/discourse] fixed indentation of sidecars containers on discourse deployment which caused a  ([29428ff](https://github.com/bitnami/charts/commit/29428ff)), closes [#6984](https://github.com/bitnami/charts/issues/6984)
+* [bitnami/discourse] fixed indentation of sidecars containers on discourse deployment which caused a  ([29428ff](https://github.com/bitnami/charts/commit/29428ff29cd346c17747467bb461811cef312d74)), closes [#6984](https://github.com/bitnami/charts/issues/6984)
 
 ## <small>4.2.5 (2021-07-16)</small>
 
-* [bitnami/discourse] Release 4.2.5 updating components versions ([2dcbc2a](https://github.com/bitnami/charts/commit/2dcbc2a))
+* [bitnami/discourse] Release 4.2.5 updating components versions ([2dcbc2a](https://github.com/bitnami/charts/commit/2dcbc2aea0c09b0d0405a533919064d324e627e8))
 
 ## <small>4.2.4 (2021-07-15)</small>
 
-* [bitnami/discourse] Avoid to include ports in DISCOURSE_HOST (#6958) ([8fef231](https://github.com/bitnami/charts/commit/8fef231)), closes [#6958](https://github.com/bitnami/charts/issues/6958)
+* [bitnami/discourse] Avoid to include ports in DISCOURSE_HOST (#6958) ([8fef231](https://github.com/bitnami/charts/commit/8fef2315c181004d94c0b87e2c6677ce00b86441)), closes [#6958](https://github.com/bitnami/charts/issues/6958)
 
 ## <small>4.2.3 (2021-07-09)</small>
 
-* [bitnami/discourse] Release 4.2.3 updating components versions ([6077e9c](https://github.com/bitnami/charts/commit/6077e9c))
+* [bitnami/discourse] Release 4.2.3 updating components versions ([6077e9c](https://github.com/bitnami/charts/commit/6077e9ccbe533562fc0260c4a7232a0c2fb2a4f5))
 
 ## <small>4.2.2 (2021-07-05)</small>
 
-* [bitnami/*] Avoid creating PVC when unneeded (#6840) ([9ae4a7d](https://github.com/bitnami/charts/commit/9ae4a7d)), closes [#6840](https://github.com/bitnami/charts/issues/6840)
+* [bitnami/*] Avoid creating PVC when unneeded (#6840) ([9ae4a7d](https://github.com/bitnami/charts/commit/9ae4a7df69ccd9ab719c7c4ec27eb7d0970ced4a)), closes [#6840](https://github.com/bitnami/charts/issues/6840)
 
 ## <small>4.2.1 (2021-06-25)</small>
 
-* [bitnami/discourse] Release 4.2.1 updating components versions ([0ddbaf4](https://github.com/bitnami/charts/commit/0ddbaf4))
+* [bitnami/discourse] Release 4.2.1 updating components versions ([0ddbaf4](https://github.com/bitnami/charts/commit/0ddbaf44b0dfc71cb4cb9370f378e00b919b979c))
 
 ## 4.2.0 (2021-06-17)
 
-* [bitnami/discourse] Add SMTP variables (#6652) ([3cb886e](https://github.com/bitnami/charts/commit/3cb886e)), closes [#6652](https://github.com/bitnami/charts/issues/6652)
+* [bitnami/discourse] Add SMTP variables (#6652) ([3cb886e](https://github.com/bitnami/charts/commit/3cb886ef78990f7882d18eacad90bad99b6f1b90)), closes [#6652](https://github.com/bitnami/charts/issues/6652)
 
 ## <small>4.1.3 (2021-06-16)</small>
 
-* Fix health probes for discourse container in [bitnami/discourse] (#6676) ([13fdff2](https://github.com/bitnami/charts/commit/13fdff2)), closes [#6676](https://github.com/bitnami/charts/issues/6676)
+* Fix health probes for discourse container in [bitnami/discourse] (#6676) ([13fdff2](https://github.com/bitnami/charts/commit/13fdff248968d6673ad64619a588548ac0fd3464)), closes [#6676](https://github.com/bitnami/charts/issues/6676)
 
 ## <small>4.1.2 (2021-06-14)</small>
 
-* [bitnami/discourse] Make POSTGRESQL_CLIENT_* env vars optional for externalDatabase (#6650) ([770989b](https://github.com/bitnami/charts/commit/770989b)), closes [#6650](https://github.com/bitnami/charts/issues/6650)
+* [bitnami/discourse] Make POSTGRESQL_CLIENT_* env vars optional for externalDatabase (#6650) ([770989b](https://github.com/bitnami/charts/commit/770989beafa2df3b61d79e7780c702773b2c8ba0)), closes [#6650](https://github.com/bitnami/charts/issues/6650)
 
 ## <small>4.1.1 (2021-06-12)</small>
 
-* [bitnami/discourse] Release 4.1.1 updating components versions ([3d090ba](https://github.com/bitnami/charts/commit/3d090ba))
+* [bitnami/discourse] Release 4.1.1 updating components versions ([3d090ba](https://github.com/bitnami/charts/commit/3d090ba6dd517321febebab2fbbd8e29b65bf5f9))
 
 ## 4.1.0 (2021-06-11)
 
-* [bitnami/discourse] Add volume-permissions init container (#6632) ([bdee99e](https://github.com/bitnami/charts/commit/bdee99e)), closes [#6632](https://github.com/bitnami/charts/issues/6632)
+* [bitnami/discourse] Add volume-permissions init container (#6632) ([bdee99e](https://github.com/bitnami/charts/commit/bdee99e775c0857490adf801998ab052ed62938f)), closes [#6632](https://github.com/bitnami/charts/issues/6632)
 
 ## <small>4.0.3 (2021-06-11)</small>
 
-* Rename 'DISCOURSE_DATABASE_USERNAME' to 'DISCOURSE_DATABASE_USER' (#6622) ([28a6f1a](https://github.com/bitnami/charts/commit/28a6f1a)), closes [#6622](https://github.com/bitnami/charts/issues/6622)
+* Rename 'DISCOURSE_DATABASE_USERNAME' to 'DISCOURSE_DATABASE_USER' (#6622) ([28a6f1a](https://github.com/bitnami/charts/commit/28a6f1acf1c2b5f68015d5d0bc3bfe60fc34acf5)), closes [#6622](https://github.com/bitnami/charts/issues/6622)
 
 ## <small>4.0.2 (2021-06-09)</small>
 
-* [bitnami/discourse] Fix external DB support (#6615) ([e9b786f](https://github.com/bitnami/charts/commit/e9b786f)), closes [#6615](https://github.com/bitnami/charts/issues/6615)
+* [bitnami/discourse] Fix external DB support (#6615) ([e9b786f](https://github.com/bitnami/charts/commit/e9b786f98dfd8b51e2d89e36a7603e54d7442aa4)), closes [#6615](https://github.com/bitnami/charts/issues/6615)
 
 ## <small>4.0.1 (2021-06-07)</small>
 
-* [bitnami/discourse] Fix URLs for emojis and attachments (#6592) ([a51a77c](https://github.com/bitnami/charts/commit/a51a77c)), closes [#6592](https://github.com/bitnami/charts/issues/6592)
+* [bitnami/discourse] Fix URLs for emojis and attachments (#6592) ([a51a77c](https://github.com/bitnami/charts/commit/a51a77c505509cd0c2251e41803ec617208f4457)), closes [#6592](https://github.com/bitnami/charts/issues/6592)
 
 ## 4.0.0 (2021-06-03)
 
-* [bitnami/discourse] MAJOR: Discourse image refactor (#6516) ([cf300d9](https://github.com/bitnami/charts/commit/cf300d9)), closes [#6516](https://github.com/bitnami/charts/issues/6516)
+* [bitnami/discourse] MAJOR: Discourse image refactor (#6516) ([cf300d9](https://github.com/bitnami/charts/commit/cf300d9b736a66ccbb5326ea7a25f46fc3721a81)), closes [#6516](https://github.com/bitnami/charts/issues/6516)
 
 ## <small>3.0.7 (2021-05-28)</small>
 
-* [bitnami/discourse] Release 3.0.7 updating components versions ([2af8e4d](https://github.com/bitnami/charts/commit/2af8e4d))
+* [bitnami/discourse] Release 3.0.7 updating components versions ([2af8e4d](https://github.com/bitnami/charts/commit/2af8e4d8d7b2003def4a4f118abbe2c138f2d62e))
 
 ## <small>3.0.6 (2021-05-28)</small>
 
-* [bitnami/discourse] adding extraPorts gives invalid YAML error (#6467) ([9d1f2bb](https://github.com/bitnami/charts/commit/9d1f2bb)), closes [#6467](https://github.com/bitnami/charts/issues/6467)
+* [bitnami/discourse] adding extraPorts gives invalid YAML error (#6467) ([9d1f2bb](https://github.com/bitnami/charts/commit/9d1f2bba1d6cbdb662344630d2bca4220ad7b06c)), closes [#6467](https://github.com/bitnami/charts/issues/6467)
 
 ## <small>3.0.5 (2021-05-23)</small>
 
-* [bitnami/discourse] Release 3.0.5 updating components versions ([b092283](https://github.com/bitnami/charts/commit/b092283))
+* [bitnami/discourse] Release 3.0.5 updating components versions ([b092283](https://github.com/bitnami/charts/commit/b0922831445af7da18f9e77964549e7468611113))
 
 ## <small>3.0.4 (2021-05-11)</small>
 
-* [bitnami/discourse] Release 3.0.4 updating components versions ([c32c2b6](https://github.com/bitnami/charts/commit/c32c2b6))
+* [bitnami/discourse] Release 3.0.4 updating components versions ([c32c2b6](https://github.com/bitnami/charts/commit/c32c2b687c58fc9d1207e79a4d1a8cca949a6dcf))
 
 ## <small>3.0.3 (2021-05-05)</small>
 
-* Update NOTES.txt (#6292) ([ee5597c](https://github.com/bitnami/charts/commit/ee5597c)), closes [#6292](https://github.com/bitnami/charts/issues/6292)
+* Update NOTES.txt (#6292) ([ee5597c](https://github.com/bitnami/charts/commit/ee5597c86b1cd3587fb50feb1dbc7518195c8cab)), closes [#6292](https://github.com/bitnami/charts/issues/6292)
 
 ## <small>3.0.2 (2021-04-29)</small>
 
-* [bitnami/discourse] Release 3.0.2 updating components versions ([515326a](https://github.com/bitnami/charts/commit/515326a))
+* [bitnami/discourse] Release 3.0.2 updating components versions ([515326a](https://github.com/bitnami/charts/commit/515326ac03125dd380a225cefb7421692ac3dd0a))
 
 ## <small>3.0.1 (2021-04-28)</small>
 
-* [bitnami/discourse] Release 3.0.1 updating components versions ([292bfbe](https://github.com/bitnami/charts/commit/292bfbe))
+* [bitnami/discourse] Release 3.0.1 updating components versions ([292bfbe](https://github.com/bitnami/charts/commit/292bfbe70e354a9d4af94d95e196d25e3058457d))
 
 ## 3.0.0 (2021-04-28)
 
-* [bitnami/*] Update redis subchart to new major (#6079) ([c7e8ef4](https://github.com/bitnami/charts/commit/c7e8ef4)), closes [#6079](https://github.com/bitnami/charts/issues/6079)
+* [bitnami/*] Update redis subchart to new major (#6079) ([c7e8ef4](https://github.com/bitnami/charts/commit/c7e8ef4d5d09aa638910471c77ef488ebe4b26cd)), closes [#6079](https://github.com/bitnami/charts/issues/6079)
 
 ## <small>2.3.6 (2021-04-27)</small>
 
-* [bitnami/discourse] Release 2.3.6 updating components versions ([0f01411](https://github.com/bitnami/charts/commit/0f01411))
+* [bitnami/discourse] Release 2.3.6 updating components versions ([0f01411](https://github.com/bitnami/charts/commit/0f01411e3ef67061ae0e0860fa0b611ba5b4f42c))
 
 ## <small>2.3.5 (2021-04-16)</small>
 
-* [bitnami/discourse] Release 2.3.5 updating components versions ([4a972a6](https://github.com/bitnami/charts/commit/4a972a6))
+* [bitnami/discourse] Release 2.3.5 updating components versions ([4a972a6](https://github.com/bitnami/charts/commit/4a972a621206f88a96c96f261aa295dfd69ce2cf))
 
 ## <small>2.3.4 (2021-04-09)</small>
 
-* [bitnami/discourse] Release 2.3.4 updating components versions ([fa544bf](https://github.com/bitnami/charts/commit/fa544bf))
+* [bitnami/discourse] Release 2.3.4 updating components versions ([fa544bf](https://github.com/bitnami/charts/commit/fa544bf2665a725c32231ad1083da1621a9ff8a2))
 
 ## <small>2.3.3 (2021-04-03)</small>
 
-* [bitnami/discourse] Release 2.3.3 updating components versions ([0f2868b](https://github.com/bitnami/charts/commit/0f2868b))
+* [bitnami/discourse] Release 2.3.3 updating components versions ([0f2868b](https://github.com/bitnami/charts/commit/0f2868b824a869872a23749cd602a98c00533b4f))
 
 ## <small>2.3.2 (2021-03-04)</small>
 
-* [bitnami/discourse] Release 2.3.2 updating components versions ([5084d54](https://github.com/bitnami/charts/commit/5084d54))
+* [bitnami/discourse] Release 2.3.2 updating components versions ([5084d54](https://github.com/bitnami/charts/commit/5084d54d6b11c5baa3ff10769799ac54693a8e22))
 
 ## <small>2.3.1 (2021-02-18)</small>
 
-* [bitnami/discourse] Release 2.3.1 updating components versions ([71682ad](https://github.com/bitnami/charts/commit/71682ad))
+* [bitnami/discourse] Release 2.3.1 updating components versions ([71682ad](https://github.com/bitnami/charts/commit/71682ad13831767651f65687c46ff99321fc102a))
 
 ## 2.3.0 (2021-02-12)
 
-* [bitnami/*] Add notice regarding parameters immutability after chart installation (#4853) ([5f09573](https://github.com/bitnami/charts/commit/5f09573)), closes [#4853](https://github.com/bitnami/charts/issues/4853)
-* [bitnami/charts/discourse] Add selector option to pvc (#5466) ([295bff0](https://github.com/bitnami/charts/commit/295bff0)), closes [#5466](https://github.com/bitnami/charts/issues/5466)
+* [bitnami/*] Add notice regarding parameters immutability after chart installation (#4853) ([5f09573](https://github.com/bitnami/charts/commit/5f095734f92555dec7cd0e3ee961f315eac170ff)), closes [#4853](https://github.com/bitnami/charts/issues/4853)
+* [bitnami/charts/discourse] Add selector option to pvc (#5466) ([295bff0](https://github.com/bitnami/charts/commit/295bff062eb1fa544565622d1f3a69f51738a030)), closes [#5466](https://github.com/bitnami/charts/issues/5466)
 
 ## <small>2.2.1 (2021-01-27)</small>
 
-* [bitnami/discourse] Release 2.2.1 updating components versions ([c81e7f9](https://github.com/bitnami/charts/commit/c81e7f9))
+* [bitnami/discourse] Release 2.2.1 updating components versions ([c81e7f9](https://github.com/bitnami/charts/commit/c81e7f92312e9b1ff7e76f59575650d6becd1f27))
 
 ## 2.2.0 (2021-01-26)
 
-* [bitnami/discourse] Add hostAliases (#5220) ([5e183af](https://github.com/bitnami/charts/commit/5e183af)), closes [#5220](https://github.com/bitnami/charts/issues/5220)
+* [bitnami/discourse] Add hostAliases (#5220) ([5e183af](https://github.com/bitnami/charts/commit/5e183af82a8abff187e46e6ffd52aee3c6804637)), closes [#5220](https://github.com/bitnami/charts/issues/5220)
 
 ## <small>2.1.4 (2021-01-25)</small>
 
-* [bitnami/*] Unify icons in Chart.yaml and add missing fields (#5206) ([0462921](https://github.com/bitnami/charts/commit/0462921)), closes [#5206](https://github.com/bitnami/charts/issues/5206)
+* [bitnami/*] Unify icons in Chart.yaml and add missing fields (#5206) ([0462921](https://github.com/bitnami/charts/commit/0462921418ca8d54308b7466197a6d53ffae4628)), closes [#5206](https://github.com/bitnami/charts/issues/5206)
 
 ## <small>2.1.3 (2021-01-19)</small>
 
-* [bitnami/*] Change helm version in the prerequisites (#5090) ([c5e67a3](https://github.com/bitnami/charts/commit/c5e67a3)), closes [#5090](https://github.com/bitnami/charts/issues/5090)
-* [bitnami/discourse] Drop values-production.yaml support (#5101) ([a774d37](https://github.com/bitnami/charts/commit/a774d37)), closes [#5101](https://github.com/bitnami/charts/issues/5101)
+* [bitnami/*] Change helm version in the prerequisites (#5090) ([c5e67a3](https://github.com/bitnami/charts/commit/c5e67a388743cbee28439d2cabca27884b9daf97)), closes [#5090](https://github.com/bitnami/charts/issues/5090)
+* [bitnami/discourse] Drop values-production.yaml support (#5101) ([a774d37](https://github.com/bitnami/charts/commit/a774d374d5c2929f512db76dbbf6adcb8d81f044)), closes [#5101](https://github.com/bitnami/charts/issues/5101)
 
 ## <small>2.1.2 (2021-01-14)</small>
 
-* [bitnami/several] Add Redis trademark (#5023) ([dfa89b8](https://github.com/bitnami/charts/commit/dfa89b8)), closes [#5023](https://github.com/bitnami/charts/issues/5023)
+* [bitnami/several] Add Redis trademark (#5023) ([dfa89b8](https://github.com/bitnami/charts/commit/dfa89b865989da26a3c73f397fd3c402dd56ebe8)), closes [#5023](https://github.com/bitnami/charts/issues/5023)
 
 ## <small>2.1.1 (2021-01-01)</small>
 
-* [bitnami/discourse] Release 2.1.1 updating components versions ([cf068f4](https://github.com/bitnami/charts/commit/cf068f4))
+* [bitnami/discourse] Release 2.1.1 updating components versions ([cf068f4](https://github.com/bitnami/charts/commit/cf068f4adedbc682ed4c338b198bf1e600515194))
 
 ## 2.1.0 (2020-12-31)
 
-* [bitnami/*] fix typos (#4699) ([49adc63](https://github.com/bitnami/charts/commit/49adc63)), closes [#4699](https://github.com/bitnami/charts/issues/4699)
-* [bitnami/*] Update ingress rules (batch 1) (#4870) ([2f3e2be](https://github.com/bitnami/charts/commit/2f3e2be)), closes [#4870](https://github.com/bitnami/charts/issues/4870)
+* [bitnami/*] fix typos (#4699) ([49adc63](https://github.com/bitnami/charts/commit/49adc63b672da976c55af2e077aa5648a357b77f)), closes [#4699](https://github.com/bitnami/charts/issues/4699)
+* [bitnami/*] Update ingress rules (batch 1) (#4870) ([2f3e2be](https://github.com/bitnami/charts/commit/2f3e2beea845c8403fc33b5a75f57909bb63037a)), closes [#4870](https://github.com/bitnami/charts/issues/4870)
 
 ## <small>2.0.3 (2020-12-11)</small>
 
-* [bitnami/*] Update dependencies (#4694) ([2826c12](https://github.com/bitnami/charts/commit/2826c12)), closes [#4694](https://github.com/bitnami/charts/issues/4694)
+* [bitnami/*] Update dependencies (#4694) ([2826c12](https://github.com/bitnami/charts/commit/2826c125b42505f28431301e3c1bbe5366e47a01)), closes [#4694](https://github.com/bitnami/charts/issues/4694)
 
 ## <small>2.0.2 (2020-12-02)</small>
 
-* [bitnami/*] Add upgrade details to README (#4480) ([10bd8e1](https://github.com/bitnami/charts/commit/10bd8e1)), closes [#4480](https://github.com/bitnami/charts/issues/4480)
-* [bitnami/discourse] Release 2.0.2 updating components versions ([40ccc1f](https://github.com/bitnami/charts/commit/40ccc1f))
+* [bitnami/*] Add upgrade details to README (#4480) ([10bd8e1](https://github.com/bitnami/charts/commit/10bd8e1fbbe69461a5d90ba61562f72b526c9caf)), closes [#4480](https://github.com/bitnami/charts/issues/4480)
+* [bitnami/discourse] Release 2.0.2 updating components versions ([40ccc1f](https://github.com/bitnami/charts/commit/40ccc1fb5b4da2a48bae3ce77b92c13d2a601a33))
 
 ## <small>2.0.1 (2020-11-21)</small>
 
-* [bitnami/discourse] Release 2.0.1 updating components versions ([0beb388](https://github.com/bitnami/charts/commit/0beb388))
+* [bitnami/discourse] Release 2.0.1 updating components versions ([0beb388](https://github.com/bitnami/charts/commit/0beb388e23525da0df334999714f4bf02d7b83f0))
 
 ## 2.0.0 (2020-11-18)
 
-* [bitnami/discourse] Major version. Adapt Chart to apiVersion: v2 (#4315) ([02156de](https://github.com/bitnami/charts/commit/02156de)), closes [#4315](https://github.com/bitnami/charts/issues/4315)
+* [bitnami/discourse] Major version. Adapt Chart to apiVersion: v2 (#4315) ([02156de](https://github.com/bitnami/charts/commit/02156de9c858e0b356ba2a84da2336ec53af1d11)), closes [#4315](https://github.com/bitnami/charts/issues/4315)
 
 ## <small>1.0.2 (2020-11-12)</small>
 
-* [bitnami/discourse] Release 1.0.2 updating components versions ([ffb99d9](https://github.com/bitnami/charts/commit/ffb99d9))
+* [bitnami/discourse] Release 1.0.2 updating components versions ([ffb99d9](https://github.com/bitnami/charts/commit/ffb99d993f62f923600bf5b7915b5b02adf9d434))
 
 ## <small>1.0.1 (2020-10-30)</small>
 
-* [bitnami/*] Include link to Troubleshootin guide on README.md (#4136) ([c08a20e](https://github.com/bitnami/charts/commit/c08a20e)), closes [#4136](https://github.com/bitnami/charts/issues/4136)
-* [bitnami/discourse] Release 1.0.1 updating components versions ([cb42bc1](https://github.com/bitnami/charts/commit/cb42bc1))
+* [bitnami/*] Include link to Troubleshootin guide on README.md (#4136) ([c08a20e](https://github.com/bitnami/charts/commit/c08a20e3db004215383004ff023a73fcc2522e72)), closes [#4136](https://github.com/bitnami/charts/issues/4136)
+* [bitnami/discourse] Release 1.0.1 updating components versions ([cb42bc1](https://github.com/bitnami/charts/commit/cb42bc1af77af117312e7721fcb5570ba5a884f1))
 
 ## 1.0.0 (2020-10-27)
 
-* [bitnami/discourse] Bump subcharts and common helpers (#4087) ([842d972](https://github.com/bitnami/charts/commit/842d972)), closes [#4087](https://github.com/bitnami/charts/issues/4087)
+* [bitnami/discourse] Bump subcharts and common helpers (#4087) ([842d972](https://github.com/bitnami/charts/commit/842d9725effa6dd9d00abc4e547493d79139aff8)), closes [#4087](https://github.com/bitnami/charts/issues/4087)
 
 ## <small>0.5.1 (2020-10-15)</small>
 
-* [bitnami/discourse] Release 0.5.1 updating components versions ([acd8d1b](https://github.com/bitnami/charts/commit/acd8d1b))
+* [bitnami/discourse] Release 0.5.1 updating components versions ([acd8d1b](https://github.com/bitnami/charts/commit/acd8d1b8c93bc8bd14b7d7f3f2676a956248c895))
 
 ## 0.5.0 (2020-10-06)
 
-* [bitnami/discourse] Update strategy added (#3865) ([61c3f1a](https://github.com/bitnami/charts/commit/61c3f1a)), closes [#3865](https://github.com/bitnami/charts/issues/3865)
+* [bitnami/discourse] Update strategy added (#3865) ([61c3f1a](https://github.com/bitnami/charts/commit/61c3f1ac7130fec15362425cdad3edc99f1605f0)), closes [#3865](https://github.com/bitnami/charts/issues/3865)
 
 ## <small>0.4.2 (2020-10-05)</small>
 
-* [bitnami/discourse] Release 0.4.2 updating components versions ([43906a5](https://github.com/bitnami/charts/commit/43906a5))
+* [bitnami/discourse] Release 0.4.2 updating components versions ([43906a5](https://github.com/bitnami/charts/commit/43906a56f67707ed607151e81ac9c4714dabe556))
 
 ## <small>0.4.1 (2020-09-25)</small>
 
-* [bitnami/discourse] Release 0.4.1 updating components versions ([56c28ae](https://github.com/bitnami/charts/commit/56c28ae))
+* [bitnami/discourse] Release 0.4.1 updating components versions ([56c28ae](https://github.com/bitnami/charts/commit/56c28ae775a6fe4e270feaf3a320f8cf87ef8589))
 
 ## 0.4.0 (2020-09-24)
 
-* [bitnami/*] Affinity based on common presets (#3746) ([01884c7](https://github.com/bitnami/charts/commit/01884c7)), closes [#3746](https://github.com/bitnami/charts/issues/3746)
+* [bitnami/*] Affinity based on common presets (#3746) ([01884c7](https://github.com/bitnami/charts/commit/01884c767c48c38e6fa4c2984bd1acd5d6d81f9e)), closes [#3746](https://github.com/bitnami/charts/issues/3746)
 
 ## <small>0.3.6 (2020-09-21)</small>
 
-* [bitnami/discourse] Release 0.3.6 updating components versions ([ac1fd62](https://github.com/bitnami/charts/commit/ac1fd62))
-* [bitnami/metrics-server] Add source repo (#3577) ([1ed12f9](https://github.com/bitnami/charts/commit/1ed12f9)), closes [#3577](https://github.com/bitnami/charts/issues/3577)
-* [discourse] docs: there is no Redis user (#3207) ([03a0159](https://github.com/bitnami/charts/commit/03a0159)), closes [#3207](https://github.com/bitnami/charts/issues/3207)
+* [bitnami/discourse] Release 0.3.6 updating components versions ([ac1fd62](https://github.com/bitnami/charts/commit/ac1fd62f011a944af8556cbd40a8c6b71cb05699))
+* [bitnami/metrics-server] Add source repo (#3577) ([1ed12f9](https://github.com/bitnami/charts/commit/1ed12f96af75322b46afdb2b3d9907c11b13f765)), closes [#3577](https://github.com/bitnami/charts/issues/3577)
+* [discourse] docs: there is no Redis user (#3207) ([03a0159](https://github.com/bitnami/charts/commit/03a01593e97c0e534f778c17b597602a9e51b71c)), closes [#3207](https://github.com/bitnami/charts/issues/3207)
 
 ## <small>0.3.5 (2020-09-01)</small>
 
-* [bitnami/discourse] Release 0.3.5 updating components versions ([3fdcbee](https://github.com/bitnami/charts/commit/3fdcbee))
+* [bitnami/discourse] Release 0.3.5 updating components versions ([3fdcbee](https://github.com/bitnami/charts/commit/3fdcbee82dc0d33435deddf77855ca16809cebd0))
 
 ## <small>0.3.4 (2020-08-21)</small>
 
-* [bitnami/discourse] Changes to tls-secrets template to use global scope for the objects referenced i ([81e98b3](https://github.com/bitnami/charts/commit/81e98b3)), closes [#3477](https://github.com/bitnami/charts/issues/3477)
+* [bitnami/discourse] Changes to tls-secrets template to use global scope for the objects referenced i ([81e98b3](https://github.com/bitnami/charts/commit/81e98b36f6c4e8322a73d4220eb133f00f81ec1d)), closes [#3477](https://github.com/bitnami/charts/issues/3477)
 
 ## <small>0.3.3 (2020-08-11)</small>
 
-* [bitnami/discourse] #3199 - Fix DISCOURSE_SKIP_INSTALL (#3200) ([1299606](https://github.com/bitnami/charts/commit/1299606)), closes [#3200](https://github.com/bitnami/charts/issues/3200)
+* [bitnami/discourse] #3199 - Fix DISCOURSE_SKIP_INSTALL (#3200) ([1299606](https://github.com/bitnami/charts/commit/1299606345713d0d7fb1ade675496c4e9ae9aca0)), closes [#3200](https://github.com/bitnami/charts/issues/3200)
 
 ## <small>0.3.2 (2020-08-07)</small>
 
-* [bitnami/discourse] Release 0.3.2 updating components versions ([3e5b405](https://github.com/bitnami/charts/commit/3e5b405))
+* [bitnami/discourse] Release 0.3.2 updating components versions ([3e5b405](https://github.com/bitnami/charts/commit/3e5b40560e9ba46d14a0abf819f4aff1cc620369))
 
 ## <small>0.3.1 (2020-08-06)</small>
 
-* [bitnami/discourse] Release 0.3.1 updating components versions ([0bb0860](https://github.com/bitnami/charts/commit/0bb0860))
+* [bitnami/discourse] Release 0.3.1 updating components versions ([0bb0860](https://github.com/bitnami/charts/commit/0bb08605f4418213568aca2caadc2b18339b8e3c))
 
 ## 0.3.0 (2020-08-05)
 
-* [bitnami/discourse] Allow specifying different admin username for external dbs (#3325) ([f190af1](https://github.com/bitnami/charts/commit/f190af1)), closes [#3325](https://github.com/bitnami/charts/issues/3325)
+* [bitnami/discourse] Allow specifying different admin username for external dbs (#3325) ([f190af1](https://github.com/bitnami/charts/commit/f190af12e19d7c76b63c25d9a127843603fa1b70)), closes [#3325](https://github.com/bitnami/charts/issues/3325)
 
 ## 0.2.0 (2020-08-05)
 
-* [bitnami/*] Fix TL;DR typo in READMEs (#3280) ([3d7ab40](https://github.com/bitnami/charts/commit/3d7ab40)), closes [#3280](https://github.com/bitnami/charts/issues/3280)
-* [bitnami/discourse] Add existingSecrets sections to chart configuratoin (#3036) ([cea8bde](https://github.com/bitnami/charts/commit/cea8bde)), closes [#3036](https://github.com/bitnami/charts/issues/3036)
+* [bitnami/*] Fix TL;DR typo in READMEs (#3280) ([3d7ab40](https://github.com/bitnami/charts/commit/3d7ab406fecd64f1af25f53e7d27f03ec95b29a4)), closes [#3280](https://github.com/bitnami/charts/issues/3280)
+* [bitnami/discourse] Add existingSecrets sections to chart configuratoin (#3036) ([cea8bde](https://github.com/bitnami/charts/commit/cea8bdeb8ad3437b6038d6ca0b16b0a7a2e9c72f)), closes [#3036](https://github.com/bitnami/charts/issues/3036)
 
 ## <small>0.1.7 (2020-07-17)</small>
 
-* [bitnami/discourse] Release 0.1.7 updating components versions ([7d4104c](https://github.com/bitnami/charts/commit/7d4104c))
+* [bitnami/discourse] Release 0.1.7 updating components versions ([7d4104c](https://github.com/bitnami/charts/commit/7d4104c61407fcf4e19ca6e620d41f5283203f25))
 
 ## <small>0.1.6 (2020-07-16)</small>
 
-* [bitnami/discourse] fix(discourse): wrong indentation (#3137) ([0b265c7](https://github.com/bitnami/charts/commit/0b265c7)), closes [#3137](https://github.com/bitnami/charts/issues/3137)
+* [bitnami/discourse] fix(discourse): wrong indentation (#3137) ([0b265c7](https://github.com/bitnami/charts/commit/0b265c7ba54b3b80a67cd8a598e14add71795b3c)), closes [#3137](https://github.com/bitnami/charts/issues/3137)
 
 ## <small>0.1.5 (2020-07-16)</small>
 
-* fix external database passwords when empty (#3125) ([524d172](https://github.com/bitnami/charts/commit/524d172)), closes [#3125](https://github.com/bitnami/charts/issues/3125)
+* fix external database passwords when empty (#3125) ([524d172](https://github.com/bitnami/charts/commit/524d1723f00ccd020d031eba452d764ea7a11125)), closes [#3125](https://github.com/bitnami/charts/issues/3125)
 
 ## <small>0.1.4 (2020-07-16)</small>
 
-* [bitnami/all] Add categories (#3075) ([63bde06](https://github.com/bitnami/charts/commit/63bde06)), closes [#3075](https://github.com/bitnami/charts/issues/3075)
-* [bitnami/discourse] Release 0.1.4 updating components versions ([b0c0732](https://github.com/bitnami/charts/commit/b0c0732))
+* [bitnami/all] Add categories (#3075) ([63bde06](https://github.com/bitnami/charts/commit/63bde066b87a140fab52264d0522401ab3d63509)), closes [#3075](https://github.com/bitnami/charts/issues/3075)
+* [bitnami/discourse] Release 0.1.4 updating components versions ([b0c0732](https://github.com/bitnami/charts/commit/b0c0732b5ef07d31a84cb64d2770b34fee6ecc57))
 
 ## <small>0.1.3 (2020-07-01)</small>
 
-* [bitnami/discourse] Release 0.1.3 updating components versions ([debfa7e](https://github.com/bitnami/charts/commit/debfa7e))
+* [bitnami/discourse] Release 0.1.3 updating components versions ([debfa7e](https://github.com/bitnami/charts/commit/debfa7e99f0f1e531fffa1f88b4c523a91beda3d))
 
 ## <small>0.1.2 (2020-07-01)</small>
 
-* [bitnami/discourse] do not pass quoted string to printf template functions (#2971) ([ee397b0](https://github.com/bitnami/charts/commit/ee397b0)), closes [#2971](https://github.com/bitnami/charts/issues/2971)
+* [bitnami/discourse] do not pass quoted string to printf template functions (#2971) ([ee397b0](https://github.com/bitnami/charts/commit/ee397b06d9486db497079851da4031f852a196aa)), closes [#2971](https://github.com/bitnami/charts/issues/2971)
 
 ## <small>0.1.1 (2020-06-25)</small>
 
-* [bitnami/discourse] Release 0.1.1 updating components versions ([09de4b8](https://github.com/bitnami/charts/commit/09de4b8))
+* [bitnami/discourse] Release 0.1.1 updating components versions ([09de4b8](https://github.com/bitnami/charts/commit/09de4b82a2fc312d9c494b571315307a9688bd5b))
 
 ## 0.1.0 (2020-06-24)
 
-* [bitnami/discourse] discourse helm chart (#2072) ([5493b53](https://github.com/bitnami/charts/commit/5493b53)), closes [#2072](https://github.com/bitnami/charts/issues/2072)
+* [bitnami/discourse] discourse helm chart (#2072) ([5493b53](https://github.com/bitnami/charts/commit/5493b53a9f2b1362abd9fe9c949c9a4e082e556d)), closes [#2072](https://github.com/bitnami/charts/issues/2072)

--- a/bitnami/discourse/Chart.lock
+++ b/bitnami/discourse/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: redis
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 19.3.4
+  version: 19.5.0
 - name: postgresql
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 15.3.5
+  version: 15.4.0
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 2.19.3
-digest: sha256:37a8b391285258cf40665ac1efb414d33ee4973b49a8022b00c1cf7a4949ec08
-generated: "2024-05-21T13:34:19.955336077+02:00"
+digest: sha256:f453342bd1f29b2d0e059a873b74b0fdf83b29eb4309e67be59e86baa0b035d5
+generated: "2024-05-24T19:37:34.502942+02:00"

--- a/bitnami/discourse/Chart.yaml
+++ b/bitnami/discourse/Chart.yaml
@@ -41,4 +41,4 @@ maintainers:
 name: discourse
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/discourse
-version: 13.1.0
+version: 13.2.0

--- a/bitnami/discourse/README.md
+++ b/bitnami/discourse/README.md
@@ -259,56 +259,59 @@ See the [Parameters](#parameters) section to configure the PVC or to disable per
 
 ### Discourse Common parameters
 
-| Name                                     | Description                                                                                                              | Value                       |
-| ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ | --------------------------- |
-| `image.registry`                         | Discourse image registry                                                                                                 | `REGISTRY_NAME`             |
-| `image.repository`                       | Discourse image repository                                                                                               | `REPOSITORY_NAME/discourse` |
-| `image.digest`                           | Discourse image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag                | `""`                        |
-| `image.pullPolicy`                       | Discourse image pull policy                                                                                              | `IfNotPresent`              |
-| `image.pullSecrets`                      | Discourse image pull secrets                                                                                             | `[]`                        |
-| `image.debug`                            | Enable image debug mode                                                                                                  | `false`                     |
-| `auth.email`                             | Discourse admin user email                                                                                               | `user@example.com`          |
-| `auth.username`                          | Discourse admin user                                                                                                     | `user`                      |
-| `auth.password`                          | Discourse admin password. WARNING: Minimum length of 10 characters                                                       | `""`                        |
-| `auth.existingSecret`                    | Name of an existing secret to use for Discourse credentials                                                              | `""`                        |
-| `host`                                   | Hostname to create application URLs (include the port if =/= 80)                                                         | `""`                        |
-| `siteName`                               | Discourse site name                                                                                                      | `My Site!`                  |
-| `smtp.enabled`                           | Enable/disable SMTP                                                                                                      | `false`                     |
-| `smtp.host`                              | SMTP host name                                                                                                           | `""`                        |
-| `smtp.port`                              | SMTP port number                                                                                                         | `""`                        |
-| `smtp.user`                              | SMTP account user name                                                                                                   | `""`                        |
-| `smtp.password`                          | SMTP account password                                                                                                    | `""`                        |
-| `smtp.protocol`                          | SMTP protocol (Allowed values: tls, ssl)                                                                                 | `""`                        |
-| `smtp.auth`                              | SMTP authentication method                                                                                               | `""`                        |
-| `smtp.existingSecret`                    | Name of an existing Kubernetes secret. The secret must have the following key configured: `smtp-password`                | `""`                        |
-| `replicaCount`                           | Number of Discourse & Sidekiq replicas                                                                                   | `1`                         |
-| `podSecurityContext.enabled`             | Enabled Discourse pods' Security Context                                                                                 | `true`                      |
-| `podSecurityContext.fsGroupChangePolicy` | Set filesystem group change policy                                                                                       | `Always`                    |
-| `podSecurityContext.sysctls`             | Set kernel settings using the sysctl interface                                                                           | `[]`                        |
-| `podSecurityContext.supplementalGroups`  | Set filesystem extra groups                                                                                              | `[]`                        |
-| `podSecurityContext.fsGroup`             | Set Discourse pod's Security Context fsGroup                                                                             | `0`                         |
-| `automountServiceAccountToken`           | Mount Service Account token in pod                                                                                       | `false`                     |
-| `hostAliases`                            | Add deployment host aliases                                                                                              | `[]`                        |
-| `podAnnotations`                         | Additional pod annotations                                                                                               | `{}`                        |
-| `podLabels`                              | Additional pod labels                                                                                                    | `{}`                        |
-| `podAffinityPreset`                      | Pod affinity preset. Allowed values: soft, hard                                                                          | `""`                        |
-| `podAntiAffinityPreset`                  | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                 | `soft`                      |
-| `nodeAffinityPreset.type`                | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                | `""`                        |
-| `nodeAffinityPreset.key`                 | Node label key to match Ignored if `affinity` is set.                                                                    | `""`                        |
-| `nodeAffinityPreset.values`              | Node label values to match. Ignored if `affinity` is set.                                                                | `[]`                        |
-| `affinity`                               | Affinity for pod assignment                                                                                              | `{}`                        |
-| `nodeSelector`                           | Node labels for pod assignment.                                                                                          | `{}`                        |
-| `tolerations`                            | Tolerations for pod assignment.                                                                                          | `[]`                        |
-| `topologySpreadConstraints`              | Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template | `[]`                        |
-| `priorityClassName`                      | Priority Class Name                                                                                                      | `""`                        |
-| `schedulerName`                          | Use an alternate scheduler, e.g. "stork".                                                                                | `""`                        |
-| `terminationGracePeriodSeconds`          | Seconds Discourse pod needs to terminate gracefully                                                                      | `""`                        |
-| `updateStrategy.type`                    | Discourse deployment strategy type                                                                                       | `RollingUpdate`             |
-| `updateStrategy.rollingUpdate`           | Discourse deployment rolling update configuration parameters                                                             | `{}`                        |
-| `sidecars`                               | Add additional sidecar containers to the Discourse pods                                                                  | `[]`                        |
-| `initContainers`                         | Add additional init containers to the Discourse pods                                                                     | `[]`                        |
-| `extraVolumeMounts`                      | Optionally specify extra list of additional volumeMounts for the Discourse pods                                          | `[]`                        |
-| `extraVolumes`                           | Optionally specify extra list of additional volumes for the Discourse pods                                               | `[]`                        |
+| Name                                     | Description                                                                                                                                    | Value                       |
+| ---------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------- |
+| `image.registry`                         | Discourse image registry                                                                                                                       | `REGISTRY_NAME`             |
+| `image.repository`                       | Discourse image repository                                                                                                                     | `REPOSITORY_NAME/discourse` |
+| `image.digest`                           | Discourse image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag                                      | `""`                        |
+| `image.pullPolicy`                       | Discourse image pull policy                                                                                                                    | `IfNotPresent`              |
+| `image.pullSecrets`                      | Discourse image pull secrets                                                                                                                   | `[]`                        |
+| `image.debug`                            | Enable image debug mode                                                                                                                        | `false`                     |
+| `auth.email`                             | Discourse admin user email                                                                                                                     | `user@example.com`          |
+| `auth.username`                          | Discourse admin user                                                                                                                           | `user`                      |
+| `auth.password`                          | Discourse admin password. WARNING: Minimum length of 10 characters                                                                             | `""`                        |
+| `auth.existingSecret`                    | Name of an existing secret to use for Discourse credentials                                                                                    | `""`                        |
+| `host`                                   | Hostname to create application URLs (include the port if =/= 80)                                                                               | `""`                        |
+| `siteName`                               | Discourse site name                                                                                                                            | `My Site!`                  |
+| `smtp.enabled`                           | Enable/disable SMTP                                                                                                                            | `false`                     |
+| `smtp.host`                              | SMTP host name                                                                                                                                 | `""`                        |
+| `smtp.port`                              | SMTP port number                                                                                                                               | `""`                        |
+| `smtp.user`                              | SMTP account user name                                                                                                                         | `""`                        |
+| `smtp.password`                          | SMTP account password                                                                                                                          | `""`                        |
+| `smtp.protocol`                          | SMTP protocol (Allowed values: tls, ssl)                                                                                                       | `""`                        |
+| `smtp.auth`                              | SMTP authentication method                                                                                                                     | `""`                        |
+| `smtp.existingSecret`                    | Name of an existing Kubernetes secret. The secret must have the following key configured: `smtp-password`                                      | `""`                        |
+| `replicaCount`                           | Number of Discourse & Sidekiq replicas                                                                                                         | `1`                         |
+| `podSecurityContext.enabled`             | Enabled Discourse pods' Security Context                                                                                                       | `true`                      |
+| `podSecurityContext.fsGroupChangePolicy` | Set filesystem group change policy                                                                                                             | `Always`                    |
+| `podSecurityContext.sysctls`             | Set kernel settings using the sysctl interface                                                                                                 | `[]`                        |
+| `podSecurityContext.supplementalGroups`  | Set filesystem extra groups                                                                                                                    | `[]`                        |
+| `podSecurityContext.fsGroup`             | Set Discourse pod's Security Context fsGroup                                                                                                   | `0`                         |
+| `automountServiceAccountToken`           | Mount Service Account token in pod                                                                                                             | `false`                     |
+| `hostAliases`                            | Add deployment host aliases                                                                                                                    | `[]`                        |
+| `podAnnotations`                         | Additional pod annotations                                                                                                                     | `{}`                        |
+| `podLabels`                              | Additional pod labels                                                                                                                          | `{}`                        |
+| `podAffinityPreset`                      | Pod affinity preset. Allowed values: soft, hard                                                                                                | `""`                        |
+| `podAntiAffinityPreset`                  | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                                       | `soft`                      |
+| `nodeAffinityPreset.type`                | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                                      | `""`                        |
+| `nodeAffinityPreset.key`                 | Node label key to match Ignored if `affinity` is set.                                                                                          | `""`                        |
+| `nodeAffinityPreset.values`              | Node label values to match. Ignored if `affinity` is set.                                                                                      | `[]`                        |
+| `affinity`                               | Affinity for pod assignment                                                                                                                    | `{}`                        |
+| `nodeSelector`                           | Node labels for pod assignment.                                                                                                                | `{}`                        |
+| `tolerations`                            | Tolerations for pod assignment.                                                                                                                | `[]`                        |
+| `topologySpreadConstraints`              | Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template                       | `[]`                        |
+| `priorityClassName`                      | Priority Class Name                                                                                                                            | `""`                        |
+| `schedulerName`                          | Use an alternate scheduler, e.g. "stork".                                                                                                      | `""`                        |
+| `terminationGracePeriodSeconds`          | Seconds Discourse pod needs to terminate gracefully                                                                                            | `""`                        |
+| `updateStrategy.type`                    | Discourse deployment strategy type                                                                                                             | `RollingUpdate`             |
+| `updateStrategy.rollingUpdate`           | Discourse deployment rolling update configuration parameters                                                                                   | `{}`                        |
+| `sidecars`                               | Add additional sidecar containers to the Discourse pods                                                                                        | `[]`                        |
+| `initContainers`                         | Add additional init containers to the Discourse pods                                                                                           | `[]`                        |
+| `pdb.create`                             | Enable/disable a Pod Disruption Budget creation                                                                                                | `true`                      |
+| `pdb.minAvailable`                       | Minimum number/percentage of pods that should remain scheduled                                                                                 | `""`                        |
+| `pdb.maxUnavailable`                     | Maximum number/percentage of pods that may be made unavailable. Defaults to `1` if both `pdb.minAvailable` and `pdb.maxUnavailable` are empty. | `""`                        |
+| `extraVolumeMounts`                      | Optionally specify extra list of additional volumeMounts for the Discourse pods                                                                | `[]`                        |
+| `extraVolumes`                           | Optionally specify extra list of additional volumes for the Discourse pods                                                                     | `[]`                        |
 
 ### Discourse container parameters
 

--- a/bitnami/discourse/templates/pdb.yaml
+++ b/bitnami/discourse/templates/pdb.yaml
@@ -1,0 +1,26 @@
+{{- /*
+Copyright Broadcom, Inc. All Rights Reserved.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+{{- if and (include "discourse.host" .) (or .Values.postgresql.enabled .Values.externalDatabase.host) .Values.pdb.create }}
+apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "common.names.fullname" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.pdb.minAvailable }}
+  minAvailable: {{ .Values.pdb.minAvailable }}
+  {{- end  }}
+  {{- if or .Values.pdb.maxUnavailable (not .Values.pdb.minAvailable) }}
+  maxUnavailable: {{ .Values.pdb.maxUnavailable | default 1 }}
+  {{- end  }}
+  {{- $podLabels := include "common.tplvalues.merge" (dict "values" (list .Values.podLabels .Values.commonLabels) "context" .) }}
+  selector:
+    matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
+{{- end }}

--- a/bitnami/discourse/values.yaml
+++ b/bitnami/discourse/values.yaml
@@ -259,6 +259,16 @@ sidecars: []
 ##         containerPort: 1234
 ##
 initContainers: []
+## Pod Disruption Budget configuration
+## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb
+## @param pdb.create Enable/disable a Pod Disruption Budget creation
+## @param pdb.minAvailable Minimum number/percentage of pods that should remain scheduled
+## @param pdb.maxUnavailable Maximum number/percentage of pods that may be made unavailable. Defaults to `1` if both `pdb.minAvailable` and `pdb.maxUnavailable` are empty.
+##
+pdb:
+  create: true
+  minAvailable: ""
+  maxUnavailable: ""
 ## @param extraVolumeMounts Optionally specify extra list of additional volumeMounts for the Discourse pods
 ##
 extraVolumeMounts: []


### PR DESCRIPTION
### Description of the change

Enabled PodDisruptionBudget by default and little fixes in PDB configuration to keep it aligned with current templates.

### Benefits

PDB protects our applications from voluntary disruption initiated by cluster administrators.
Keep our charts up to date according to our templates.

### Possible drawbacks

None

### Adition information

* [Pod disruption budgets](https://kubernetes.io/docs/concepts/workloads/pods/disruptions/#pod-disruption-budgets)
* [Specifying a Disruption Budget for your Application](https://kubernetes.io/docs/tasks/run-application/configure-pdb/)

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
