### PR TITLE
[bitnami/oauth2-proxy] Add field externalRedis.databaseIndex

### DIFF
--- a/bitnami/oauth2-proxy/CHANGELOG.md
+++ b/bitnami/oauth2-proxy/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 5.2.0 (2024-05-23)
+## 5.3.0 (2024-05-26)
 
-* [bitnami/oauth2-proxy] Enable PodDisruptionBudgets ([#26161](https://github.com/bitnami/charts/pull/26161))
+* [bitnami/oauth2-proxy] Add field externalRedis.databaseIndex ([#26439](https://github.com/bitnami/charts/pull/26439))
+
+## 5.2.0 (2024-05-24)
+
+* [bitnami/oauth2-proxy] Enable PodDisruptionBudgets (#26161) ([cec7b38](https://github.com/bitnami/charts/commit/cec7b38a2124bf708cf55852cd705fdc800091dc)), closes [#26161](https://github.com/bitnami/charts/issues/26161)
 
 ## <small>5.1.1 (2024-05-21)</small>
 

--- a/bitnami/oauth2-proxy/CHANGELOG.md
+++ b/bitnami/oauth2-proxy/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 5.3.0 (2024-05-26)
+## 5.3.0 (2024-05-27)
 
 * [bitnami/oauth2-proxy] Add field externalRedis.databaseIndex ([#26439](https://github.com/bitnami/charts/pull/26439))
 

--- a/bitnami/oauth2-proxy/Chart.yaml
+++ b/bitnami/oauth2-proxy/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: oauth2-proxy
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/oauth2-proxy
-version: 5.2.0
+version: 5.3.0

--- a/bitnami/oauth2-proxy/README.md
+++ b/bitnami/oauth2-proxy/README.md
@@ -320,6 +320,7 @@ The [Bitnami OAuth2 Proxy](https://github.com/bitnami/containers/tree/main/bitna
 | `externalRedis.host`                      | External Redis&reg; server host                            | `""`   |
 | `externalRedis.password`                  | External Redis&reg; user password                          | `""`   |
 | `externalRedis.port`                      | External Redis&reg; server port                            | `6379` |
+| `externalRedis.databaseIndex`             | External Redis&reg; database index                         | `0`    |
 | `externalRedis.existingSecret`            | The name of an existing secret with Redis&reg; credentials | `""`   |
 | `externalRedis.existingSecretPasswordKey` | Key inside the existing secret with Redis&reg; credentials | `""`   |
 

--- a/bitnami/oauth2-proxy/templates/_helpers.tpl
+++ b/bitnami/oauth2-proxy/templates/_helpers.tpl
@@ -83,7 +83,8 @@ Create the name of the service account to use
 {{- end -}}
 {{- else if .Values.externalRedis.host -}}
 {{- $port := printf "%v" .Values.externalRedis.port -}}
-{{- printf "redis://%s:%s" .Values.externalRedis.host $port -}}
+{{- $databaseIndex := printf "%v" .Values.externalRedis.databaseIndex -}}
+{{- printf "redis://%s:%s/%s" .Values.externalRedis.host $port $databaseIndex -}}
 {{- end -}}
 {{- end -}}
 

--- a/bitnami/oauth2-proxy/values.yaml
+++ b/bitnami/oauth2-proxy/values.yaml
@@ -724,6 +724,9 @@ externalRedis:
   ## @param externalRedis.port External Redis&reg; server port
   ##
   port: 6379
+  ## @param externalRedis.databaseIndex External Redis&reg; database index
+  ##
+  databaseIndex: 0
   ## @param externalRedis.existingSecret The name of an existing secret with Redis&reg; credentials
   ## NOTE: Must contain key `redis-password`
   ## NOTE: When it's set, the `externalRedis.password` parameter is ignored


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->

This patch adds the field "externalRedis.databaseIndex" to the `oauth2-proxy` chart. This field controls the index of the Redis database when using an existing instance, and defaults to `0` (the current implicit behavior).

### Benefits

<!-- What benefits will be realized by the code change? -->

This allows this chart to be used with an existing Redis instance used by other services without risk of key collision or similar undesired behavior, including deploying multiple instances of this chart against a single Redis instance.

### Possible drawbacks

<!-- Describe any known limitations with your change -->

None known

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes https://github.com/bitnami/charts/issues/25529

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
