### PR TITLE
[bitnami/argo-cd] Define port for notifications probes

### DIFF
--- a/bitnami/argo-cd/CHANGELOG.md
+++ b/bitnami/argo-cd/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 6.3.3 (2024-05-24)
+## 6.3.4 (2024-05-28)
 
-* [bitnami/argo-cd] Release 6.3.3 ([#26415](https://github.com/bitnami/charts/pull/26415))
+* [bitnami/argo-cd] Define port for notifications probes ([#26485](https://github.com/bitnami/charts/pull/26485))
+
+## <small>6.3.3 (2024-05-24)</small>
+
+* [bitnami/argo-cd] Release 6.3.3 (#26415) ([e4f57d1](https://github.com/bitnami/charts/commit/e4f57d1a1a2c32bb471bb50d28f1241cbac421d3)), closes [#26415](https://github.com/bitnami/charts/issues/26415)
 
 ## <small>6.3.2 (2024-05-24)</small>
 

--- a/bitnami/argo-cd/Chart.yaml
+++ b/bitnami/argo-cd/Chart.yaml
@@ -39,4 +39,4 @@ maintainers:
 name: argo-cd
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/argo-cd
-version: 6.3.3
+version: 6.3.4

--- a/bitnami/argo-cd/templates/notifications/bots/slack/deployment.yaml
+++ b/bitnami/argo-cd/templates/notifications/bots/slack/deployment.yaml
@@ -96,7 +96,7 @@ spec:
           {{- else if .Values.notifications.bots.slack.livenessProbe.enabled }}
           livenessProbe:
             tcpSocket:
-              path: /metrics
+              port: metrics
             initialDelaySeconds: {{ .Values.notifications.bots.slack.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.notifications.bots.slack.livenessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.notifications.bots.slack.livenessProbe.timeoutSeconds }}

--- a/bitnami/argo-cd/templates/notifications/deployment.yaml
+++ b/bitnami/argo-cd/templates/notifications/deployment.yaml
@@ -99,7 +99,7 @@ spec:
           {{- else if .Values.notifications.livenessProbe.enabled }}
           livenessProbe:
             tcpSocket:
-              path: /metrics
+              port: metrics
             initialDelaySeconds: {{ .Values.notifications.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.notifications.livenessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.notifications.livenessProbe.timeoutSeconds }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Fix typo in tcpSocket probe where port was missing.

### Benefits

Deployment works with `--set notifications.enabled=true`.

### Possible drawbacks

N/A

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #26405

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- ~[ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)~
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
