### PR TITLE
[bitnami/prometheus] Add chart source URL to sources list

### DIFF
--- a/bitnami/prometheus/CHANGELOG.md
+++ b/bitnami/prometheus/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 1.3.0 (2024-05-23)
+## 1.3.1 (2024-05-28)
 
-* [bitnami/prometheus] Enable PodDisruptionBudgets ([#26215](https://github.com/bitnami/charts/pull/26215))
+* [bitnami/prometheus] Add chart source URL to sources list ([#26487](https://github.com/bitnami/charts/pull/26487))
+
+## 1.3.0 (2024-05-24)
+
+* [bitnami/prometheus] Enable PodDisruptionBudgets (#26215) ([bca3d85](https://github.com/bitnami/charts/commit/bca3d855e95823d10028ff27a3cd6f65b4204dff)), closes [#26215](https://github.com/bitnami/charts/issues/26215)
 
 ## 1.2.0 (2024-05-22)
 

--- a/bitnami/prometheus/Chart.yaml
+++ b/bitnami/prometheus/Chart.yaml
@@ -32,7 +32,8 @@ maintainers:
   url: https://github.com/bitnami/charts
 name: prometheus
 sources:
+- https://github.com/bitnami/charts/tree/main/bitnami/prometheus
 - https://github.com/bitnami/containers/tree/main/bitnami/prometheus
 - https://github.com/prometheus/prometheus
 - https://github.com/prometheus-community/helm-charts
-version: 1.3.0
+version: 1.3.1


### PR DESCRIPTION
### Description of the change

Adds the chart repository to the sources list of the prometheus chart.

### Benefits

Allows tools (e.g. Renovate) to discover the new Changelogs (which are awesome BTW).

### Possible drawbacks

None noted

### Applicable issues

- fixes #

### Additional information
It does not look like many/any other charts have other URLs in their sources list.  Would you like the other 3 removed from this chart?

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
