### PR TITLE
[bitnami/fluentd] fix: :bug: Only check replaced images when set

### DIFF
--- a/bitnami/fluentd/CHANGELOG.md
+++ b/bitnami/fluentd/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
+## 6.5.1 (2024-05-28)
+
+* [bitnami/fluentd] fix: :bug: Only check replaced images when set ([#26506](https://github.com/bitnami/charts/pull/26506))
+
 ## 6.5.0 (2024-05-28)
 
-* [bitnami/fluentd] add extra gems extensions volume on forwarders ([#26489](https://github.com/bitnami/charts/pull/26489))
+* [bitnami/fluentd] add extra gems extensions volume on forwarders (#26489) ([64c2708](https://github.com/bitnami/charts/commit/64c27084c6f03dc505a30ad77852a38c46ddf1f5)), closes [#26489](https://github.com/bitnami/charts/issues/26489)
 
 ## 6.4.0 (2024-05-27)
 

--- a/bitnami/fluentd/Chart.yaml
+++ b/bitnami/fluentd/Chart.yaml
@@ -30,4 +30,4 @@ maintainers:
 name: fluentd
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/fluentd
-version: 6.5.0
+version: 6.5.1

--- a/bitnami/fluentd/templates/NOTES.txt
+++ b/bitnami/fluentd/templates/NOTES.txt
@@ -54,4 +54,11 @@ In order to replicate the container startup scripts execute this command:
 {{- include "fluentd.validateValues" . }}
 {{- include "fluentd.checkRollingTags" . -}}
 {{- include "common.warnings.resources" (dict "sections" (list "aggregator" "forwarder") "context" $) }}
-{{- include "common.warnings.modifiedImages" (dict "images" (list .Values.image .Values.forwarder.image .Values.aggregator.image) "context" $) }}
+{{- $imagesToCheck := (list .Values.image) }}
+{{- if .Values.forwarder.image.repository }}
+{{- $imagesToCheck = append $imagesToCheck .Values.forwarder.image }}
+{{- end }}
+{{- if .Values.aggregator.image.repository }}
+{{- $imagesToCheck = append $imagesToCheck .Values.aggregator.image }}
+{{- end }}
+{{- include "common.warnings.modifiedImages" (dict "images" $imagesToCheck "context" $) }}


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

This chart has the option to define different images for aggregator and forwarder via aggregator.image and forwarder.image. As these sections are optional, it was causing a false positive in the `common.warnings.modifiedImages` helper. This PR checks if these optional images are configured before passing them as parameters to the helper

<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
