### PR TITLE
[bitnami/sonarqube] Enable PodDisruptionBudgets

### DIFF
--- a/bitnami/sonarqube/CHANGELOG.md
+++ b/bitnami/sonarqube/CHANGELOG.md
@@ -1,557 +1,562 @@
 # Changelog
 
+## 5.2.0 (2024-05-29)
+
+* [bitnami/sonarqube] Enable PodDisruptionBudgets ([#26535](https://github.com/bitnami/charts/pull/26535))
+
 ## 5.1.0 (2024-05-21)
 
-* [bitnami/sonarqube] feat: :sparkles: :lock: Add warning when original images are replaced ([#26278](https://github.com/bitnami/charts/pulls/26278))
+* [bitnami/*] ci: :construction_worker: Add tag and changelog support (#25359) ([91c707c](https://github.com/bitnami/charts/commit/91c707c9e4e574725a09505d2d313fb93f1b4c0a)), closes [#25359](https://github.com/bitnami/charts/issues/25359)
+* [bitnami/sonarqube] feat: :sparkles: :lock: Add warning when original images are replaced (#26278) ([8926823](https://github.com/bitnami/charts/commit/89268238e58433a83a49f1500868fb6f58a5b8f8)), closes [#26278](https://github.com/bitnami/charts/issues/26278)
 
 ## <small>5.0.4 (2024-05-20)</small>
 
-* [bitnami/*] Change non-root and rolling-tags doc URLs (#25628) ([b067c94](https://github.com/bitnami/charts/commit/b067c94)), closes [#25628](https://github.com/bitnami/charts/issues/25628)
-* [bitnami/*] Set new header/owner (#25558) ([8d1dc11](https://github.com/bitnami/charts/commit/8d1dc11)), closes [#25558](https://github.com/bitnami/charts/issues/25558)
-* [bitnami/sonarqube] Use different liveness/readiness probes (#25989) ([65237cb](https://github.com/bitnami/charts/commit/65237cb)), closes [#25989](https://github.com/bitnami/charts/issues/25989)
+* [bitnami/*] Change non-root and rolling-tags doc URLs (#25628) ([b067c94](https://github.com/bitnami/charts/commit/b067c94f6bcde427863c197fd355f0b5ba12ff5b)), closes [#25628](https://github.com/bitnami/charts/issues/25628)
+* [bitnami/*] Set new header/owner (#25558) ([8d1dc11](https://github.com/bitnami/charts/commit/8d1dc11f5fb30db6fba50c43d7af59d2f79deed3)), closes [#25558](https://github.com/bitnami/charts/issues/25558)
+* [bitnami/sonarqube] Use different liveness/readiness probes (#25989) ([65237cb](https://github.com/bitnami/charts/commit/65237cb80a64804f49830ccd599fbf56aedbfe43)), closes [#25989](https://github.com/bitnami/charts/issues/25989)
 
 ## <small>5.0.3 (2024-05-06)</small>
 
-* [bitnami/multiple charts] Fix typo: "NetworkPolice" vs "NetworkPolicy" (#25348) ([6970c1b](https://github.com/bitnami/charts/commit/6970c1b)), closes [#25348](https://github.com/bitnami/charts/issues/25348)
-* [bitnami/sonarqube] Remove unicode characters (#25549) ([f49bd28](https://github.com/bitnami/charts/commit/f49bd28)), closes [#25549](https://github.com/bitnami/charts/issues/25549)
-* Replace VMware by Broadcom copyright text (#25306) ([a5e4bd0](https://github.com/bitnami/charts/commit/a5e4bd0)), closes [#25306](https://github.com/bitnami/charts/issues/25306)
+* [bitnami/multiple charts] Fix typo: "NetworkPolice" vs "NetworkPolicy" (#25348) ([6970c1b](https://github.com/bitnami/charts/commit/6970c1ba245873506e73d459c6eac1e4919b778f)), closes [#25348](https://github.com/bitnami/charts/issues/25348)
+* [bitnami/sonarqube] Remove unicode characters (#25549) ([f49bd28](https://github.com/bitnami/charts/commit/f49bd288903715e6d15bc897294d808ca043a913)), closes [#25549](https://github.com/bitnami/charts/issues/25549)
+* Replace VMware by Broadcom copyright text (#25306) ([a5e4bd0](https://github.com/bitnami/charts/commit/a5e4bd0e35e419203793976a78d9d0a13de92c76)), closes [#25306](https://github.com/bitnami/charts/issues/25306)
 
 ## <small>5.0.2 (2024-04-06)</small>
 
-* [bitnami/sonarqube] Release 5.0.2 updating components versions (#25021) ([f85434d](https://github.com/bitnami/charts/commit/f85434d)), closes [#25021](https://github.com/bitnami/charts/issues/25021)
+* [bitnami/sonarqube] Release 5.0.2 updating components versions (#25021) ([f85434d](https://github.com/bitnami/charts/commit/f85434d1506b88c02219ac8a68328efc3059e988)), closes [#25021](https://github.com/bitnami/charts/issues/25021)
 
 ## <small>5.0.1 (2024-04-03)</small>
 
-* [bitnami/sonarqube] fix base dir preparation (#24851) ([7fea8ce](https://github.com/bitnami/charts/commit/7fea8ce)), closes [#24851](https://github.com/bitnami/charts/issues/24851)
-* Update resourcesPreset comments (#24467) ([92e3e8a](https://github.com/bitnami/charts/commit/92e3e8a)), closes [#24467](https://github.com/bitnami/charts/issues/24467)
+* [bitnami/sonarqube] fix base dir preparation (#24851) ([7fea8ce](https://github.com/bitnami/charts/commit/7fea8ce5f7127f1d55e239abadf5389e168c019b)), closes [#24851](https://github.com/bitnami/charts/issues/24851)
+* Update resourcesPreset comments (#24467) ([92e3e8a](https://github.com/bitnami/charts/commit/92e3e8a507326d2a20a8f10ab3e7746a2ec5c554)), closes [#24467](https://github.com/bitnami/charts/issues/24467)
 
 ## 5.0.0 (2024-04-02)
 
-* [bitnami/*] Reorder Chart sections (#24455) ([0cf4048](https://github.com/bitnami/charts/commit/0cf4048)), closes [#24455](https://github.com/bitnami/charts/issues/24455)
-* [bitnami/sonarqube] feat!: :lock: :boom: Improve security defaults (#24688) ([6647970](https://github.com/bitnami/charts/commit/6647970)), closes [#24688](https://github.com/bitnami/charts/issues/24688)
+* [bitnami/*] Reorder Chart sections (#24455) ([0cf4048](https://github.com/bitnami/charts/commit/0cf4048e8743f70a9753d460655bd030cbff6824)), closes [#24455](https://github.com/bitnami/charts/issues/24455)
+* [bitnami/sonarqube] feat!: :lock: :boom: Improve security defaults (#24688) ([6647970](https://github.com/bitnami/charts/commit/66479703518cabe0ffbb2baae25510e2dfc8dff7)), closes [#24688](https://github.com/bitnami/charts/issues/24688)
 
 ## 4.7.0 (2024-03-06)
 
-* [bitnami/sonarqube] feat: :sparkles: :lock: Add automatic adaptation for Openshift restricted-v2 SCC ([b17836d](https://github.com/bitnami/charts/commit/b17836d)), closes [#24155](https://github.com/bitnami/charts/issues/24155)
+* [bitnami/sonarqube] feat: :sparkles: :lock: Add automatic adaptation for Openshift restricted-v2 SCC ([b17836d](https://github.com/bitnami/charts/commit/b17836d19109454d1a48ce0e379b4588bff39aaa)), closes [#24155](https://github.com/bitnami/charts/issues/24155)
 
 ## <small>4.6.2 (2024-02-26)</small>
 
-* [bitnami/sonarqube] Release 4.6.2 updating components versions (#23925) ([e9b1560](https://github.com/bitnami/charts/commit/e9b1560)), closes [#23925](https://github.com/bitnami/charts/issues/23925)
+* [bitnami/sonarqube] Release 4.6.2 updating components versions (#23925) ([e9b1560](https://github.com/bitnami/charts/commit/e9b1560ae9c7d9be4c5b5769f9c8be789d55c804)), closes [#23925](https://github.com/bitnami/charts/issues/23925)
 
 ## <small>4.6.1 (2024-02-22)</small>
 
-* [bitnami/sonarqube] feat: :sparkles: :lock: Add resource preset support (#23522) ([5ba71f3](https://github.com/bitnami/charts/commit/5ba71f3)), closes [#23522](https://github.com/bitnami/charts/issues/23522)
-* [bitnami/sonarqube] Release 4.6.1 updating components versions (#23853) ([c57b1bc](https://github.com/bitnami/charts/commit/c57b1bc)), closes [#23853](https://github.com/bitnami/charts/issues/23853)
+* [bitnami/sonarqube] feat: :sparkles: :lock: Add resource preset support (#23522) ([5ba71f3](https://github.com/bitnami/charts/commit/5ba71f3236d29f094de72be9ce22e20a71832eb6)), closes [#23522](https://github.com/bitnami/charts/issues/23522)
+* [bitnami/sonarqube] Release 4.6.1 updating components versions (#23853) ([c57b1bc](https://github.com/bitnami/charts/commit/c57b1bc3d2a32a0997f4e85c554aaa88311e0058)), closes [#23853](https://github.com/bitnami/charts/issues/23853)
 
 ## 4.6.0 (2024-02-20)
 
-* [bitnami/*] Bump all versions (#23602) ([b70ee2a](https://github.com/bitnami/charts/commit/b70ee2a)), closes [#23602](https://github.com/bitnami/charts/issues/23602)
+* [bitnami/*] Bump all versions (#23602) ([b70ee2a](https://github.com/bitnami/charts/commit/b70ee2a30e4dc256bf0ac52928fb2fa7a70f049b)), closes [#23602](https://github.com/bitnami/charts/issues/23602)
 
 ## <small>4.5.1 (2024-02-09)</small>
 
-* [bitnami/sonarqube] Release 4.4.3 (#23168) ([6c80427](https://github.com/bitnami/charts/commit/6c80427)), closes [#23168](https://github.com/bitnami/charts/issues/23168)
+* [bitnami/sonarqube] Release 4.4.3 (#23168) ([6c80427](https://github.com/bitnami/charts/commit/6c80427f7b5813ef189f9ff491ef6a481b22299a)), closes [#23168](https://github.com/bitnami/charts/issues/23168)
 
 ## 4.5.0 (2024-02-07)
 
-* [bitnami/sonarqube] fix: :bug: Add allowExternalEgress to avoid breaking istio (#22976) ([ad80673](https://github.com/bitnami/charts/commit/ad80673)), closes [#22976](https://github.com/bitnami/charts/issues/22976)
+* [bitnami/sonarqube] fix: :bug: Add allowExternalEgress to avoid breaking istio (#22976) ([ad80673](https://github.com/bitnami/charts/commit/ad806739e96143045a3bde27b5b099f64900b4d7)), closes [#22976](https://github.com/bitnami/charts/issues/22976)
 
 ## <small>4.4.2 (2024-02-02)</small>
 
-* [bitnami/sonarqube] Release 4.4.2 updating components versions (#23047) ([ca1db69](https://github.com/bitnami/charts/commit/ca1db69)), closes [#23047](https://github.com/bitnami/charts/issues/23047)
+* [bitnami/sonarqube] Release 4.4.2 updating components versions (#23047) ([ca1db69](https://github.com/bitnami/charts/commit/ca1db69c577476bfe60e18e1d2694c63615c15eb)), closes [#23047](https://github.com/bitnami/charts/issues/23047)
 
 ## <small>4.4.1 (2024-02-01)</small>
 
-* [bitnami/sonarqube] Fix updateStrategy.type option comment in default values (#22753) ([ae17119](https://github.com/bitnami/charts/commit/ae17119)), closes [#22753](https://github.com/bitnami/charts/issues/22753)
+* [bitnami/sonarqube] Fix updateStrategy.type option comment in default values (#22753) ([ae17119](https://github.com/bitnami/charts/commit/ae17119ccef0f913075dbef1a0f4a821a69f8d10)), closes [#22753](https://github.com/bitnami/charts/issues/22753)
 
 ## 4.4.0 (2024-01-26)
 
-* [bitnami/sonarqube] feat: :lock: Enable networkPolicy (#22722) ([cfc94a7](https://github.com/bitnami/charts/commit/cfc94a7)), closes [#22722](https://github.com/bitnami/charts/issues/22722)
+* [bitnami/sonarqube] feat: :lock: Enable networkPolicy (#22722) ([cfc94a7](https://github.com/bitnami/charts/commit/cfc94a7d63c5b1b57c0900130806ace401bb9c06)), closes [#22722](https://github.com/bitnami/charts/issues/22722)
 
 ## <small>4.3.1 (2024-01-25)</small>
 
-* [bitnami/*] Move documentation sections from docs.bitnami.com back to the README (#22203) ([7564f36](https://github.com/bitnami/charts/commit/7564f36)), closes [#22203](https://github.com/bitnami/charts/issues/22203)
-* [bitnami/sonarqube] fix: :bug: Set seLinuxOptions to null for Openshift compatibility (#22659) ([b130cb9](https://github.com/bitnami/charts/commit/b130cb9)), closes [#22659](https://github.com/bitnami/charts/issues/22659)
+* [bitnami/*] Move documentation sections from docs.bitnami.com back to the README (#22203) ([7564f36](https://github.com/bitnami/charts/commit/7564f36ca1e95ff30ee686652b7ab8690561a707)), closes [#22203](https://github.com/bitnami/charts/issues/22203)
+* [bitnami/sonarqube] fix: :bug: Set seLinuxOptions to null for Openshift compatibility (#22659) ([b130cb9](https://github.com/bitnami/charts/commit/b130cb921e9f6c5dbf9755e8ada2ba49fb995e85)), closes [#22659](https://github.com/bitnami/charts/issues/22659)
 
 ## 4.3.0 (2024-01-22)
 
-* [bitnami/sonarqube] fix: :lock: Move service-account token auto-mount to pod declaration (#22461) ([666a768](https://github.com/bitnami/charts/commit/666a768)), closes [#22461](https://github.com/bitnami/charts/issues/22461)
+* [bitnami/sonarqube] fix: :lock: Move service-account token auto-mount to pod declaration (#22461) ([666a768](https://github.com/bitnami/charts/commit/666a768e7a8f7bfbee1f266679cbf5812f1ce1e9)), closes [#22461](https://github.com/bitnami/charts/issues/22461)
 
 ## <small>4.2.1 (2024-01-18)</small>
 
-* [bitnami/sonarqube] Release 4.2.1 updating components versions (#22338) ([1d09ccd](https://github.com/bitnami/charts/commit/1d09ccd)), closes [#22338](https://github.com/bitnami/charts/issues/22338)
+* [bitnami/sonarqube] Release 4.2.1 updating components versions (#22338) ([1d09ccd](https://github.com/bitnami/charts/commit/1d09ccd2f6b12f8a41eef6f79441ac8bf1a6a173)), closes [#22338](https://github.com/bitnami/charts/issues/22338)
 
 ## 4.2.0 (2024-01-16)
 
-* [bitnami/sonarqube] fix: :lock: Improve podSecurityContext and containerSecurityContext with essenti ([11229ad](https://github.com/bitnami/charts/commit/11229ad)), closes [#22190](https://github.com/bitnami/charts/issues/22190)
+* [bitnami/sonarqube] fix: :lock: Improve podSecurityContext and containerSecurityContext with essenti ([11229ad](https://github.com/bitnami/charts/commit/11229ad320a7147e230fa15a4dc1e7660ce7bf2f)), closes [#22190](https://github.com/bitnami/charts/issues/22190)
 
 ## <small>4.1.7 (2024-01-15)</small>
 
-* [bitnami/*] Fix docs.bitnami.com broken links (#21901) ([f35506d](https://github.com/bitnami/charts/commit/f35506d)), closes [#21901](https://github.com/bitnami/charts/issues/21901)
-* [bitnami/*] Fix ref links (in comments) (#21822) ([e4fa296](https://github.com/bitnami/charts/commit/e4fa296)), closes [#21822](https://github.com/bitnami/charts/issues/21822)
-* [bitnami/*] Update copyright: Year and company (#21815) ([6c4bf75](https://github.com/bitnami/charts/commit/6c4bf75)), closes [#21815](https://github.com/bitnami/charts/issues/21815)
-* [bitnami/sonarqube] fix: :lock: Do not automount the service account token unless necessary (#22062) ([6b98ee5](https://github.com/bitnami/charts/commit/6b98ee5)), closes [#22062](https://github.com/bitnami/charts/issues/22062)
+* [bitnami/*] Fix docs.bitnami.com broken links (#21901) ([f35506d](https://github.com/bitnami/charts/commit/f35506d2dadee4f097986e7792df1f53ab215b5d)), closes [#21901](https://github.com/bitnami/charts/issues/21901)
+* [bitnami/*] Fix ref links (in comments) (#21822) ([e4fa296](https://github.com/bitnami/charts/commit/e4fa296106b225cf8c82445727c675c7c725e380)), closes [#21822](https://github.com/bitnami/charts/issues/21822)
+* [bitnami/*] Update copyright: Year and company (#21815) ([6c4bf75](https://github.com/bitnami/charts/commit/6c4bf75dec58fc7c9aee9f089777b1a858c17d5b)), closes [#21815](https://github.com/bitnami/charts/issues/21815)
+* [bitnami/sonarqube] fix: :lock: Do not automount the service account token unless necessary (#22062) ([6b98ee5](https://github.com/bitnami/charts/commit/6b98ee5f9f44e6461934c2fe38c5eeecfc573de8)), closes [#22062](https://github.com/bitnami/charts/issues/22062)
 
 ## <small>4.1.6 (2023-12-12)</small>
 
-* [bitnami/sonarqube] Release 4.1.6 updating components versions (#21532) ([0f70bab](https://github.com/bitnami/charts/commit/0f70bab)), closes [#21532](https://github.com/bitnami/charts/issues/21532)
+* [bitnami/sonarqube] Release 4.1.6 updating components versions (#21532) ([0f70bab](https://github.com/bitnami/charts/commit/0f70bab253218cd909a15d07790fd7d3315d3a87)), closes [#21532](https://github.com/bitnami/charts/issues/21532)
 
 ## <small>4.1.5 (2023-12-12)</small>
 
-* [bitnami/sonarqube] Release 4.1.4 (#21249) ([09e8c7d](https://github.com/bitnami/charts/commit/09e8c7d)), closes [#21249](https://github.com/bitnami/charts/issues/21249)
-* [bitnami/sonarqube] Release 4.1.5 updating components versions (#21508) ([f2b561a](https://github.com/bitnami/charts/commit/f2b561a)), closes [#21508](https://github.com/bitnami/charts/issues/21508)
+* [bitnami/sonarqube] Release 4.1.4 (#21249) ([09e8c7d](https://github.com/bitnami/charts/commit/09e8c7dfc171eba6442fe6654e8d66479ed5cafa)), closes [#21249](https://github.com/bitnami/charts/issues/21249)
+* [bitnami/sonarqube] Release 4.1.5 updating components versions (#21508) ([f2b561a](https://github.com/bitnami/charts/commit/f2b561ac8f5dbe77c05a377185f7fd20fde3343e)), closes [#21508](https://github.com/bitnami/charts/issues/21508)
 
 ## <small>4.1.4 (2023-12-05)</small>
 
-* [bitnami/sonarqube] Replace deprecated pull secret partial (#21396) ([b155b41](https://github.com/bitnami/charts/commit/b155b41)), closes [#21396](https://github.com/bitnami/charts/issues/21396)
+* [bitnami/sonarqube] Replace deprecated pull secret partial (#21396) ([b155b41](https://github.com/bitnami/charts/commit/b155b41a642600ff55b01db044b23ed2bf8ad3fd)), closes [#21396](https://github.com/bitnami/charts/issues/21396)
 
 ## <small>4.1.3 (2023-11-21)</small>
 
-* [bitnami/*] Rename solutions to "Bitnami package for ..." (#21038) ([b82f979](https://github.com/bitnami/charts/commit/b82f979)), closes [#21038](https://github.com/bitnami/charts/issues/21038)
-* [bitnami/sonarqube] Release 4.1.3 updating components versions (#21176) ([aad7517](https://github.com/bitnami/charts/commit/aad7517)), closes [#21176](https://github.com/bitnami/charts/issues/21176)
+* [bitnami/*] Rename solutions to "Bitnami package for ..." (#21038) ([b82f979](https://github.com/bitnami/charts/commit/b82f979e4fb63423fe6e2192c946d09d79c944fc)), closes [#21038](https://github.com/bitnami/charts/issues/21038)
+* [bitnami/sonarqube] Release 4.1.3 updating components versions (#21176) ([aad7517](https://github.com/bitnami/charts/commit/aad7517015a4e42b64bd20d6051a387188458445)), closes [#21176](https://github.com/bitnami/charts/issues/21176)
 
 ## <small>4.1.2 (2023-11-17)</small>
 
-* [bitnami/*] Remove relative links to non-README sections, add verification for that and update TL;DR ([1103633](https://github.com/bitnami/charts/commit/1103633)), closes [#20967](https://github.com/bitnami/charts/issues/20967)
-* [bitnami/sonarqube] Release 4.1.2 updating components versions (#21031) ([da86979](https://github.com/bitnami/charts/commit/da86979)), closes [#21031](https://github.com/bitnami/charts/issues/21031)
+* [bitnami/*] Remove relative links to non-README sections, add verification for that and update TL;DR ([1103633](https://github.com/bitnami/charts/commit/11036334d82df0490aa4abdb591543cab6cf7d7f)), closes [#20967](https://github.com/bitnami/charts/issues/20967)
+* [bitnami/sonarqube] Release 4.1.2 updating components versions (#21031) ([da86979](https://github.com/bitnami/charts/commit/da86979d43150721b4e5b8fb46b6306723561ac2)), closes [#21031](https://github.com/bitnami/charts/issues/21031)
 
 ## <small>4.1.1 (2023-11-08)</small>
 
-* [bitnami/sonarqube] Release 4.1.1 updating components versions (#20710) ([45d8546](https://github.com/bitnami/charts/commit/45d8546)), closes [#20710](https://github.com/bitnami/charts/issues/20710)
+* [bitnami/sonarqube] Release 4.1.1 updating components versions (#20710) ([45d8546](https://github.com/bitnami/charts/commit/45d8546ded574010a7910b55cd10daf7ce90c1e9)), closes [#20710](https://github.com/bitnami/charts/issues/20710)
 
 ## 4.1.0 (2023-10-31)
 
-* [bitnami/*] Rename VMware Application Catalog (#20361) ([3acc734](https://github.com/bitnami/charts/commit/3acc734)), closes [#20361](https://github.com/bitnami/charts/issues/20361)
-* [bitnami/*] Skip image's tag in the README files of the Bitnami Charts (#19841) ([bb9a01b](https://github.com/bitnami/charts/commit/bb9a01b)), closes [#19841](https://github.com/bitnami/charts/issues/19841)
-* [bitnami/*] Standardize documentation (#19835) ([af5f753](https://github.com/bitnami/charts/commit/af5f753)), closes [#19835](https://github.com/bitnami/charts/issues/19835)
-* [bitnami/sonarqube] feat: :sparkles: Add support for PSA restricted policy (#20536) ([bfa7748](https://github.com/bitnami/charts/commit/bfa7748)), closes [#20536](https://github.com/bitnami/charts/issues/20536)
+* [bitnami/*] Rename VMware Application Catalog (#20361) ([3acc734](https://github.com/bitnami/charts/commit/3acc73472beb6fb56c4d99f929061001205bc57e)), closes [#20361](https://github.com/bitnami/charts/issues/20361)
+* [bitnami/*] Skip image's tag in the README files of the Bitnami Charts (#19841) ([bb9a01b](https://github.com/bitnami/charts/commit/bb9a01b65911c87e48318db922cc05eb42785e42)), closes [#19841](https://github.com/bitnami/charts/issues/19841)
+* [bitnami/*] Standardize documentation (#19835) ([af5f753](https://github.com/bitnami/charts/commit/af5f7530c1bc8c5ded53a6c4f7b8f384ac1804f2)), closes [#19835](https://github.com/bitnami/charts/issues/19835)
+* [bitnami/sonarqube] feat: :sparkles: Add support for PSA restricted policy (#20536) ([bfa7748](https://github.com/bitnami/charts/commit/bfa7748f7a38ef219f0c7c40cc3cb7db4f2e7492)), closes [#20536](https://github.com/bitnami/charts/issues/20536)
 
 ## <small>4.0.2 (2023-10-12)</small>
 
-* [bitnami/sonarqube] Release 4.0.2 (#20188) ([ea22167](https://github.com/bitnami/charts/commit/ea22167)), closes [#20188](https://github.com/bitnami/charts/issues/20188)
+* [bitnami/sonarqube] Release 4.0.2 (#20188) ([ea22167](https://github.com/bitnami/charts/commit/ea2216769e858b007fe12b33da45dbc510f13371)), closes [#20188](https://github.com/bitnami/charts/issues/20188)
 
 ## <small>4.0.1 (2023-10-09)</small>
 
-* [bitnami/*] Update Helm charts prerequisites (#19745) ([eb755dd](https://github.com/bitnami/charts/commit/eb755dd)), closes [#19745](https://github.com/bitnami/charts/issues/19745)
-* [bitnami/sonarqube] Release 4.0.1 (#19940) ([3547c39](https://github.com/bitnami/charts/commit/3547c39)), closes [#19940](https://github.com/bitnami/charts/issues/19940)
+* [bitnami/*] Update Helm charts prerequisites (#19745) ([eb755dd](https://github.com/bitnami/charts/commit/eb755dd36a4dd3cf6635be8e0598f9a7f4c4a554)), closes [#19745](https://github.com/bitnami/charts/issues/19745)
+* [bitnami/sonarqube] Release 4.0.1 (#19940) ([3547c39](https://github.com/bitnami/charts/commit/3547c397195b76df8d1d3f2f1a07dca48b28f77f)), closes [#19940](https://github.com/bitnami/charts/issues/19940)
 
 ## 4.0.0 (2023-09-29)
 
-* [bitnami/sonarqube] Update dependencies (#19622) ([53fb9e7](https://github.com/bitnami/charts/commit/53fb9e7)), closes [#19622](https://github.com/bitnami/charts/issues/19622)
+* [bitnami/sonarqube] Update dependencies (#19622) ([53fb9e7](https://github.com/bitnami/charts/commit/53fb9e705f4ca36382a13510d2a1dfd1d450a137)), closes [#19622](https://github.com/bitnami/charts/issues/19622)
 
 ## <small>3.3.4 (2023-09-26)</small>
 
-* [bitnami/sonarqube] Release 3.3.4 updating components versions (#19540) ([6d72b6b](https://github.com/bitnami/charts/commit/6d72b6b)), closes [#19540](https://github.com/bitnami/charts/issues/19540)
+* [bitnami/sonarqube] Release 3.3.4 updating components versions (#19540) ([6d72b6b](https://github.com/bitnami/charts/commit/6d72b6b07d3997904b38f2bf6633cf6c9187d5e7)), closes [#19540](https://github.com/bitnami/charts/issues/19540)
 
 ## <small>3.3.3 (2023-09-25)</small>
 
-* [bitnami/sonarqube] Release 3.3.3 (#19513) ([eea9a37](https://github.com/bitnami/charts/commit/eea9a37)), closes [#19513](https://github.com/bitnami/charts/issues/19513)
-* Autogenerate schema files (#19194) ([a2c2090](https://github.com/bitnami/charts/commit/a2c2090)), closes [#19194](https://github.com/bitnami/charts/issues/19194)
-* Revert "Autogenerate schema files (#19194)" (#19335) ([73d80be](https://github.com/bitnami/charts/commit/73d80be)), closes [#19194](https://github.com/bitnami/charts/issues/19194) [#19335](https://github.com/bitnami/charts/issues/19335)
+* [bitnami/sonarqube] Release 3.3.3 (#19513) ([eea9a37](https://github.com/bitnami/charts/commit/eea9a3750aff93dbc5256df193cccca4f2d38d39)), closes [#19513](https://github.com/bitnami/charts/issues/19513)
+* Autogenerate schema files (#19194) ([a2c2090](https://github.com/bitnami/charts/commit/a2c2090b5ac97f47b745c8028c6452bf99739772)), closes [#19194](https://github.com/bitnami/charts/issues/19194)
+* Revert "Autogenerate schema files (#19194)" (#19335) ([73d80be](https://github.com/bitnami/charts/commit/73d80be525c88fb4b8a54451a55acd506e337062)), closes [#19194](https://github.com/bitnami/charts/issues/19194) [#19335](https://github.com/bitnami/charts/issues/19335)
 
 ## <small>3.3.2 (2023-09-07)</small>
 
-* [bitnami/sonarqube: Use merge helper]: (#19107) ([51b97cd](https://github.com/bitnami/charts/commit/51b97cd)), closes [#19107](https://github.com/bitnami/charts/issues/19107)
+* [bitnami/sonarqube: Use merge helper]: (#19107) ([51b97cd](https://github.com/bitnami/charts/commit/51b97cd5724b01f923166ec22023e9c2e7293b31)), closes [#19107](https://github.com/bitnami/charts/issues/19107)
 
 ## <small>3.3.1 (2023-09-04)</small>
 
-* [bitnami/sonarqube] Release 3.3.1 (#19004) ([8b28fc4](https://github.com/bitnami/charts/commit/8b28fc4)), closes [#19004](https://github.com/bitnami/charts/issues/19004)
+* [bitnami/sonarqube] Release 3.3.1 (#19004) ([8b28fc4](https://github.com/bitnami/charts/commit/8b28fc43be32365ec2ceb1596d55a7843ed144c4)), closes [#19004](https://github.com/bitnami/charts/issues/19004)
 
 ## 3.3.0 (2023-08-29)
 
-* [bitnami/sonarqube] Support for customizing standard labels (#18748) ([e4683d1](https://github.com/bitnami/charts/commit/e4683d1)), closes [#18748](https://github.com/bitnami/charts/issues/18748)
+* [bitnami/sonarqube] Support for customizing standard labels (#18748) ([e4683d1](https://github.com/bitnami/charts/commit/e4683d16932b829f6055a75e00fbe127fc114d2c)), closes [#18748](https://github.com/bitnami/charts/issues/18748)
 
 ## <small>3.2.10 (2023-08-21)</small>
 
-* [bitnami/sonarqube] Release 3.2.10 (#18719) ([72a7514](https://github.com/bitnami/charts/commit/72a7514)), closes [#18719](https://github.com/bitnami/charts/issues/18719)
+* [bitnami/sonarqube] Release 3.2.10 (#18719) ([72a7514](https://github.com/bitnami/charts/commit/72a7514dd337cd44e9d6e1659795dd66460060b5)), closes [#18719](https://github.com/bitnami/charts/issues/18719)
 
 ## <small>3.2.9 (2023-08-17)</small>
 
-* [bitnami/sonarqube] Release 3.2.9 (#18592) ([fbcedd7](https://github.com/bitnami/charts/commit/fbcedd7)), closes [#18592](https://github.com/bitnami/charts/issues/18592)
+* [bitnami/sonarqube] Release 3.2.9 (#18592) ([fbcedd7](https://github.com/bitnami/charts/commit/fbcedd7308e69008eac1e087bab0613ce93accb2)), closes [#18592](https://github.com/bitnami/charts/issues/18592)
 
 ## <small>3.2.8 (2023-07-27)</small>
 
-* [bitnami/sonarqube] Release 3.2.8 (#17972) ([af32e6c](https://github.com/bitnami/charts/commit/af32e6c)), closes [#17972](https://github.com/bitnami/charts/issues/17972)
+* [bitnami/sonarqube] Release 3.2.8 (#17972) ([af32e6c](https://github.com/bitnami/charts/commit/af32e6c7cafee5b01c69058fa3854acc6d96fff8)), closes [#17972](https://github.com/bitnami/charts/issues/17972)
 
 ## <small>3.2.7 (2023-07-13)</small>
 
-* [bitnami/sonarqube] Release 3.2.7 (#17669) ([10180c6](https://github.com/bitnami/charts/commit/10180c6)), closes [#17669](https://github.com/bitnami/charts/issues/17669)
+* [bitnami/sonarqube] Release 3.2.7 (#17669) ([10180c6](https://github.com/bitnami/charts/commit/10180c62d59cf00bcf945662f4a5954277d9344e)), closes [#17669](https://github.com/bitnami/charts/issues/17669)
 
 ## <small>3.2.6 (2023-07-12)</small>
 
-* Add copyright header (#17300) ([da68be8](https://github.com/bitnami/charts/commit/da68be8)), closes [#17300](https://github.com/bitnami/charts/issues/17300)
-* Include service.annotations in template (#17567) ([cabefed](https://github.com/bitnami/charts/commit/cabefed)), closes [#17567](https://github.com/bitnami/charts/issues/17567)
-* Use os-shell in tempate and Jaeger runtime params (#17557) ([91a49eb](https://github.com/bitnami/charts/commit/91a49eb)), closes [#17557](https://github.com/bitnami/charts/issues/17557)
+* Add copyright header (#17300) ([da68be8](https://github.com/bitnami/charts/commit/da68be8e951225133c7dfb572d5101ca3d61c5ae)), closes [#17300](https://github.com/bitnami/charts/issues/17300)
+* Include service.annotations in template (#17567) ([cabefed](https://github.com/bitnami/charts/commit/cabefed2bc748e067f5b40814447008985bc62f1)), closes [#17567](https://github.com/bitnami/charts/issues/17567)
+* Use os-shell in tempate and Jaeger runtime params (#17557) ([91a49eb](https://github.com/bitnami/charts/commit/91a49eb1e3c81c7b7c6c28d1bc5d6d6ae698c1e2)), closes [#17557](https://github.com/bitnami/charts/issues/17557)
 
 ## <small>3.2.5 (2023-06-23)</small>
 
-* [bitnami/sonarqube] Release 3.2.5 (#17335) ([8520b5c](https://github.com/bitnami/charts/commit/8520b5c)), closes [#17335](https://github.com/bitnami/charts/issues/17335)
-* Update charts readme (#17217) ([31b3c0a](https://github.com/bitnami/charts/commit/31b3c0a)), closes [#17217](https://github.com/bitnami/charts/issues/17217)
+* [bitnami/sonarqube] Release 3.2.5 (#17335) ([8520b5c](https://github.com/bitnami/charts/commit/8520b5c5f98668a0bb19016577c84535a40b2f56)), closes [#17335](https://github.com/bitnami/charts/issues/17335)
+* Update charts readme (#17217) ([31b3c0a](https://github.com/bitnami/charts/commit/31b3c0afd968ff4429107e34101f7509e6a0e913)), closes [#17217](https://github.com/bitnami/charts/issues/17217)
 
 ## <small>3.2.4 (2023-06-20)</small>
 
-* [bitnami/sonarqube] Release 3.2.4 (#17233) ([0ad6743](https://github.com/bitnami/charts/commit/0ad6743)), closes [#17233](https://github.com/bitnami/charts/issues/17233)
+* [bitnami/sonarqube] Release 3.2.4 (#17233) ([0ad6743](https://github.com/bitnami/charts/commit/0ad6743f84bf0b7d3f71544f91dd3ccb4d8fa057)), closes [#17233](https://github.com/bitnami/charts/issues/17233)
 
 ## <small>3.2.3 (2023-06-13)</small>
 
-* [bitnami/*] Change copyright section in READMEs (#17006) ([ef986a1](https://github.com/bitnami/charts/commit/ef986a1)), closes [#17006](https://github.com/bitnami/charts/issues/17006)
-* [bitnami/several] Change copyright section in READMEs (#16989) ([5b6a5cf](https://github.com/bitnami/charts/commit/5b6a5cf)), closes [#16989](https://github.com/bitnami/charts/issues/16989)
-* enable custom ingress labels (#16918) ([0dd66f2](https://github.com/bitnami/charts/commit/0dd66f2)), closes [#16918](https://github.com/bitnami/charts/issues/16918)
+* [bitnami/*] Change copyright section in READMEs (#17006) ([ef986a1](https://github.com/bitnami/charts/commit/ef986a1605241102b3dcafe9fd8089e6fc1201ad)), closes [#17006](https://github.com/bitnami/charts/issues/17006)
+* [bitnami/several] Change copyright section in READMEs (#16989) ([5b6a5cf](https://github.com/bitnami/charts/commit/5b6a5cfb7625a751848a2e5cd796bd7278f406ca)), closes [#16989](https://github.com/bitnami/charts/issues/16989)
+* enable custom ingress labels (#16918) ([0dd66f2](https://github.com/bitnami/charts/commit/0dd66f2516ee136e9e7d53e0d122bbdbdfbbbbb8)), closes [#16918](https://github.com/bitnami/charts/issues/16918)
 
 ## <small>3.2.2 (2023-05-21)</small>
 
-* [bitnami/sonarqube] Release 3.2.2 (#16816) ([976a6e1](https://github.com/bitnami/charts/commit/976a6e1)), closes [#16816](https://github.com/bitnami/charts/issues/16816)
+* [bitnami/sonarqube] Release 3.2.2 (#16816) ([976a6e1](https://github.com/bitnami/charts/commit/976a6e1dacee7f750af06d448fbf70c19edaa99e)), closes [#16816](https://github.com/bitnami/charts/issues/16816)
 
 ## <small>3.2.1 (2023-05-15)</small>
 
-* [bitnami/sonarqube] Enable initContainers section in deployment.yaml for caCerts (#16620) ([4a44507](https://github.com/bitnami/charts/commit/4a44507)), closes [#16620](https://github.com/bitnami/charts/issues/16620)
-* Add wording for enterprise page (#16560) ([8f22774](https://github.com/bitnami/charts/commit/8f22774)), closes [#16560](https://github.com/bitnami/charts/issues/16560)
+* [bitnami/sonarqube] Enable initContainers section in deployment.yaml for caCerts (#16620) ([4a44507](https://github.com/bitnami/charts/commit/4a44507cd390c034954f072f7474e49d9d0bda96)), closes [#16620](https://github.com/bitnami/charts/issues/16620)
+* Add wording for enterprise page (#16560) ([8f22774](https://github.com/bitnami/charts/commit/8f2277440b976d52785ba9149762ad8620a73d1f)), closes [#16560](https://github.com/bitnami/charts/issues/16560)
 
 ## 3.2.0 (2023-05-09)
 
-* [bitnami/several] Adapt Chart.yaml to set desired OCI annotations (#16546) ([fc9b18f](https://github.com/bitnami/charts/commit/fc9b18f)), closes [#16546](https://github.com/bitnami/charts/issues/16546)
+* [bitnami/several] Adapt Chart.yaml to set desired OCI annotations (#16546) ([fc9b18f](https://github.com/bitnami/charts/commit/fc9b18f2e98805d4df629acbcde696f44f973344)), closes [#16546](https://github.com/bitnami/charts/issues/16546)
 
 ## <small>3.1.1 (2023-05-09)</small>
 
-* [bitnami/sonarqube] Release 3.1.1 (#16499) ([fb4e4be](https://github.com/bitnami/charts/commit/fb4e4be)), closes [#16499](https://github.com/bitnami/charts/issues/16499)
+* [bitnami/sonarqube] Release 3.1.1 (#16499) ([fb4e4be](https://github.com/bitnami/charts/commit/fb4e4bedde1ca5c80709294d32cb43a3cae95c54)), closes [#16499](https://github.com/bitnami/charts/issues/16499)
 
 ## 3.1.0 (2023-04-20)
 
-* [bitnami/*] Make Helm charts 100% OCI (#15998) ([8841510](https://github.com/bitnami/charts/commit/8841510)), closes [#15998](https://github.com/bitnami/charts/issues/15998)
+* [bitnami/*] Make Helm charts 100% OCI (#15998) ([8841510](https://github.com/bitnami/charts/commit/884151035efcbf2e1b3206e7def85511073fb57d)), closes [#15998](https://github.com/bitnami/charts/issues/15998)
 
 ## 3.0.0 (2023-04-18)
 
-* [bitnami/sonarqube] Fixed incorrect mapping for jvmOpts and jvmCeOpts (#15806) ([521f710](https://github.com/bitnami/charts/commit/521f710)), closes [#15806](https://github.com/bitnami/charts/issues/15806)
-* [bitnami/sonarqube] Release 3.0.0 (#16113) ([53dcf89](https://github.com/bitnami/charts/commit/53dcf89)), closes [#16113](https://github.com/bitnami/charts/issues/16113)
+* [bitnami/sonarqube] Fixed incorrect mapping for jvmOpts and jvmCeOpts (#15806) ([521f710](https://github.com/bitnami/charts/commit/521f7101bf1f23eca2675599c517688ad5af86b0)), closes [#15806](https://github.com/bitnami/charts/issues/15806)
+* [bitnami/sonarqube] Release 3.0.0 (#16113) ([53dcf89](https://github.com/bitnami/charts/commit/53dcf89b35db5a1ae8413c75b8991d646cccfc5e)), closes [#16113](https://github.com/bitnami/charts/issues/16113)
 
 ## <small>2.1.6 (2023-04-03)</small>
 
-* [bitnami/sonarqube] Release 2.1.6 (#15915) ([ceb370c](https://github.com/bitnami/charts/commit/ceb370c)), closes [#15915](https://github.com/bitnami/charts/issues/15915)
+* [bitnami/sonarqube] Release 2.1.6 (#15915) ([ceb370c](https://github.com/bitnami/charts/commit/ceb370ce8c53b20a2b39de429117823a3c869d8c)), closes [#15915](https://github.com/bitnami/charts/issues/15915)
 
 ## <small>2.1.5 (2023-03-29)</small>
 
-* [bitnami/sonarqube] Render initContainers when only plugins.install is set (#15774) ([21bde08](https://github.com/bitnami/charts/commit/21bde08)), closes [#15774](https://github.com/bitnami/charts/issues/15774)
+* [bitnami/sonarqube] Render initContainers when only plugins.install is set (#15774) ([21bde08](https://github.com/bitnami/charts/commit/21bde0872ae027759948558fc8228b9d88b2d89b)), closes [#15774](https://github.com/bitnami/charts/issues/15774)
 
 ## <small>2.1.4 (2023-03-19)</small>
 
-* [bitnami/charts] Apply linter to README files (#15357) ([0e29e60](https://github.com/bitnami/charts/commit/0e29e60)), closes [#15357](https://github.com/bitnami/charts/issues/15357)
-* [bitnami/sonarqube] Release 2.1.4 (#15620) ([454e38a](https://github.com/bitnami/charts/commit/454e38a)), closes [#15620](https://github.com/bitnami/charts/issues/15620)
+* [bitnami/charts] Apply linter to README files (#15357) ([0e29e60](https://github.com/bitnami/charts/commit/0e29e600d3adc8b1b46e506eccb3decfab3b4e63)), closes [#15357](https://github.com/bitnami/charts/issues/15357)
+* [bitnami/sonarqube] Release 2.1.4 (#15620) ([454e38a](https://github.com/bitnami/charts/commit/454e38a24ebbdbc378e67b93ad17c97b105e62e4)), closes [#15620](https://github.com/bitnami/charts/issues/15620)
 
 ## <small>2.1.3 (2023-03-01)</small>
 
-* [bitnami/sonarqube] Release 2.1.3 (#15232) ([868dbea](https://github.com/bitnami/charts/commit/868dbea)), closes [#15232](https://github.com/bitnami/charts/issues/15232)
+* [bitnami/sonarqube] Release 2.1.3 (#15232) ([868dbea](https://github.com/bitnami/charts/commit/868dbeaca6909e13d905400b950a97b0c2d125d5)), closes [#15232](https://github.com/bitnami/charts/issues/15232)
 
 ## <small>2.1.2 (2023-02-22)</small>
 
-* [bitnami/sonarqube] Release 2.1.2 (#15110) ([a6eca23](https://github.com/bitnami/charts/commit/a6eca23)), closes [#15110](https://github.com/bitnami/charts/issues/15110)
+* [bitnami/sonarqube] Release 2.1.2 (#15110) ([a6eca23](https://github.com/bitnami/charts/commit/a6eca236827d587cac8b406581741b2a36c31ff0)), closes [#15110](https://github.com/bitnami/charts/issues/15110)
 
 ## <small>2.1.1 (2023-02-17)</small>
 
-* [bitnami/*] Fix markdown linter issues (#14874) ([a51e0e8](https://github.com/bitnami/charts/commit/a51e0e8)), closes [#14874](https://github.com/bitnami/charts/issues/14874)
-* [bitnami/*] Fix markdown linter issues 2 (#14890) ([aa96572](https://github.com/bitnami/charts/commit/aa96572)), closes [#14890](https://github.com/bitnami/charts/issues/14890)
-* [bitnami/*] Remove unexpected extra spaces (#14873) ([c97c714](https://github.com/bitnami/charts/commit/c97c714)), closes [#14873](https://github.com/bitnami/charts/issues/14873)
-* [bitnami/sonarqube] Release 2.1.1 (#15028) ([ada274f](https://github.com/bitnami/charts/commit/ada274f)), closes [#15028](https://github.com/bitnami/charts/issues/15028)
+* [bitnami/*] Fix markdown linter issues (#14874) ([a51e0e8](https://github.com/bitnami/charts/commit/a51e0e8d35495b907f3e70dd2f8e7c3bcbf4166a)), closes [#14874](https://github.com/bitnami/charts/issues/14874)
+* [bitnami/*] Fix markdown linter issues 2 (#14890) ([aa96572](https://github.com/bitnami/charts/commit/aa9657237ee8df4a46db0d7fdf8a23230dd6902a)), closes [#14890](https://github.com/bitnami/charts/issues/14890)
+* [bitnami/*] Remove unexpected extra spaces (#14873) ([c97c714](https://github.com/bitnami/charts/commit/c97c714887380d47eae7bfeff316bf01595ecd1d)), closes [#14873](https://github.com/bitnami/charts/issues/14873)
+* [bitnami/sonarqube] Release 2.1.1 (#15028) ([ada274f](https://github.com/bitnami/charts/commit/ada274fe209311ba2aeda7c96296bda6e62b02ba)), closes [#15028](https://github.com/bitnami/charts/issues/15028)
 
 ## 2.1.0 (2023-02-10)
 
-* [bitnami/sonarqube] Close gap with upstream SonarQube Helm chart (#14252) ([01153ca](https://github.com/bitnami/charts/commit/01153ca)), closes [#14252](https://github.com/bitnami/charts/issues/14252)
+* [bitnami/sonarqube] Close gap with upstream SonarQube Helm chart (#14252) ([01153ca](https://github.com/bitnami/charts/commit/01153ca36cf487e73dddb5f31e429ff891381149)), closes [#14252](https://github.com/bitnami/charts/issues/14252)
 
 ## <small>2.0.10 (2023-02-08)</small>
 
-* [bitnami/sonarqube] Release 2.0.10 (#14781) ([fae0a47](https://github.com/bitnami/charts/commit/fae0a47)), closes [#14781](https://github.com/bitnami/charts/issues/14781)
+* [bitnami/sonarqube] Release 2.0.10 (#14781) ([fae0a47](https://github.com/bitnami/charts/commit/fae0a476917909bf25e67fe781b371a46aac511b)), closes [#14781](https://github.com/bitnami/charts/issues/14781)
 
 ## <small>2.0.9 (2023-02-01)</small>
 
-* [bitnami/sonarqube] fix memory opts for jmx-exporter (#14482) ([c72c16f](https://github.com/bitnami/charts/commit/c72c16f)), closes [#14482](https://github.com/bitnami/charts/issues/14482)
+* [bitnami/sonarqube] fix memory opts for jmx-exporter (#14482) ([c72c16f](https://github.com/bitnami/charts/commit/c72c16f0a38bccd24faf2758734cdb7b0ff77a66)), closes [#14482](https://github.com/bitnami/charts/issues/14482)
 
 ## <small>2.0.8 (2023-01-31)</small>
 
-* [bitnami/*] Change copyright date (#14682) ([add4ec7](https://github.com/bitnami/charts/commit/add4ec7)), closes [#14682](https://github.com/bitnami/charts/issues/14682)
-* [bitnami/*] Unify READMEs (#14472) ([2064fb8](https://github.com/bitnami/charts/commit/2064fb8)), closes [#14472](https://github.com/bitnami/charts/issues/14472)
-* [bitnami/sonarqube] Don't regenerate self-signed certs on upgrade (#14661) ([6e0bc14](https://github.com/bitnami/charts/commit/6e0bc14)), closes [#14661](https://github.com/bitnami/charts/issues/14661)
-* [bitnami/sonarqube] Modify README (#14376) ([4e4b727](https://github.com/bitnami/charts/commit/4e4b727)), closes [#14376](https://github.com/bitnami/charts/issues/14376)
+* [bitnami/*] Change copyright date (#14682) ([add4ec7](https://github.com/bitnami/charts/commit/add4ec701108ac36ed4de2dffbdf407a0d091067)), closes [#14682](https://github.com/bitnami/charts/issues/14682)
+* [bitnami/*] Unify READMEs (#14472) ([2064fb8](https://github.com/bitnami/charts/commit/2064fb8dcc78a845cdede8211af8c3cc52551161)), closes [#14472](https://github.com/bitnami/charts/issues/14472)
+* [bitnami/sonarqube] Don't regenerate self-signed certs on upgrade (#14661) ([6e0bc14](https://github.com/bitnami/charts/commit/6e0bc1452cfccdc9e72bc19609413037c1208a7a)), closes [#14661](https://github.com/bitnami/charts/issues/14661)
+* [bitnami/sonarqube] Modify README (#14376) ([4e4b727](https://github.com/bitnami/charts/commit/4e4b727da2d2c3f1c964734f1a005459839e64a4)), closes [#14376](https://github.com/bitnami/charts/issues/14376)
 
 ## <small>2.0.7 (2023-01-18)</small>
 
-* [bitnami/*] Add license annotation and remove obsolete engine parameter (#14293) ([da2a794](https://github.com/bitnami/charts/commit/da2a794)), closes [#14293](https://github.com/bitnami/charts/issues/14293)
-* [bitnami/*] Change licenses annotation format (#14377) ([0ab7608](https://github.com/bitnami/charts/commit/0ab7608)), closes [#14377](https://github.com/bitnami/charts/issues/14377)
-* [bitnami/sonarqube] Release 2.0.7 (#14437) ([ddeddee](https://github.com/bitnami/charts/commit/ddeddee)), closes [#14437](https://github.com/bitnami/charts/issues/14437)
+* [bitnami/*] Add license annotation and remove obsolete engine parameter (#14293) ([da2a794](https://github.com/bitnami/charts/commit/da2a7943bae95b6e9b5b4ed972c15e990b69fdb0)), closes [#14293](https://github.com/bitnami/charts/issues/14293)
+* [bitnami/*] Change licenses annotation format (#14377) ([0ab7608](https://github.com/bitnami/charts/commit/0ab760862c660fcc78cffadf8e1d8cdd70881473)), closes [#14377](https://github.com/bitnami/charts/issues/14377)
+* [bitnami/sonarqube] Release 2.0.7 (#14437) ([ddeddee](https://github.com/bitnami/charts/commit/ddeddeebb757cc00c7d6319348cc8d7aacbf2ec8)), closes [#14437](https://github.com/bitnami/charts/issues/14437)
 
 ## <small>2.0.6 (2023-01-10)</small>
 
-* [bitnami/sonarqube] Fix postgresql.persistence.enabled value (#14239) ([fa7f956](https://github.com/bitnami/charts/commit/fa7f956)), closes [#14239](https://github.com/bitnami/charts/issues/14239)
+* [bitnami/sonarqube] Fix postgresql.persistence.enabled value (#14239) ([fa7f956](https://github.com/bitnami/charts/commit/fa7f95692ac9fe3f52b89ef9f960a108dbd1a2ca)), closes [#14239](https://github.com/bitnami/charts/issues/14239)
 
 ## <small>2.0.5 (2022-12-20)</small>
 
-* [bitnami/sonarqube] Fix sonarqube to scale to more than one running pod (#14032) ([086290e](https://github.com/bitnami/charts/commit/086290e)), closes [#14032](https://github.com/bitnami/charts/issues/14032)
-* [bitnami/sonarqube] Undo postgresql persistence enabled value (#14050) ([91fca11](https://github.com/bitnami/charts/commit/91fca11)), closes [#14050](https://github.com/bitnami/charts/issues/14050)
+* [bitnami/sonarqube] Fix sonarqube to scale to more than one running pod (#14032) ([086290e](https://github.com/bitnami/charts/commit/086290ed34ad1baff201b6ff896c705946402e53)), closes [#14032](https://github.com/bitnami/charts/issues/14032)
+* [bitnami/sonarqube] Undo postgresql persistence enabled value (#14050) ([91fca11](https://github.com/bitnami/charts/commit/91fca1180126322b3d9ddc748ebe48de53f139fe)), closes [#14050](https://github.com/bitnami/charts/issues/14050)
 
 ## <small>2.0.4 (2022-12-19)</small>
 
-* [bitnami/sonarqube] Release 2.0.4 (#14036) ([b32e7c0](https://github.com/bitnami/charts/commit/b32e7c0)), closes [#14036](https://github.com/bitnami/charts/issues/14036)
+* [bitnami/sonarqube] Release 2.0.4 (#14036) ([b32e7c0](https://github.com/bitnami/charts/commit/b32e7c07f0dcc798651b65768b8454bb78d6b92e)), closes [#14036](https://github.com/bitnami/charts/issues/14036)
 
 ## <small>2.0.3 (2022-11-30)</small>
 
-* [bitnami/sonarqube] Add trademark information to SonarQube (#13754) ([2dbd72b](https://github.com/bitnami/charts/commit/2dbd72b)), closes [#13754](https://github.com/bitnami/charts/issues/13754)
+* [bitnami/sonarqube] Add trademark information to SonarQube (#13754) ([2dbd72b](https://github.com/bitnami/charts/commit/2dbd72b713b8653195eb58bc28ebc0649df3b909)), closes [#13754](https://github.com/bitnami/charts/issues/13754)
 
 ## <small>2.0.2 (2022-11-29)</small>
 
-* [bitnami/sonarqube] Release 2.0.2 (#13747) ([d73efb3](https://github.com/bitnami/charts/commit/d73efb3)), closes [#13747](https://github.com/bitnami/charts/issues/13747)
+* [bitnami/sonarqube] Release 2.0.2 (#13747) ([d73efb3](https://github.com/bitnami/charts/commit/d73efb3a46260d15de22bccbd31a4d0524623b2e)), closes [#13747](https://github.com/bitnami/charts/issues/13747)
 
 ## <small>2.0.1 (2022-10-31)</small>
 
-* [bitnami/sonarqube] Release 2.0.1 (#13268) ([d56afc3](https://github.com/bitnami/charts/commit/d56afc3)), closes [#13268](https://github.com/bitnami/charts/issues/13268)
+* [bitnami/sonarqube] Release 2.0.1 (#13268) ([d56afc3](https://github.com/bitnami/charts/commit/d56afc3aa744d1daed60e815759a7ad9e09b5527)), closes [#13268](https://github.com/bitnami/charts/issues/13268)
 
 ## 2.0.0 (2022-10-28)
 
-* [bitnami/sonarqube] Update dependencies (#13218) ([ef78a7f](https://github.com/bitnami/charts/commit/ef78a7f)), closes [#13218](https://github.com/bitnami/charts/issues/13218)
+* [bitnami/sonarqube] Update dependencies (#13218) ([ef78a7f](https://github.com/bitnami/charts/commit/ef78a7f7b927bc9b342e44c46b37282aafa6bb0d)), closes [#13218](https://github.com/bitnami/charts/issues/13218)
 
 ## <small>1.6.4 (2022-10-20)</small>
 
-* [bitnami/*] Use new default branch name in links (#12943) ([a529e02](https://github.com/bitnami/charts/commit/a529e02)), closes [#12943](https://github.com/bitnami/charts/issues/12943)
-* [bitnami/sonarqube] Release 1.6.4 (#13043) ([5a212ca](https://github.com/bitnami/charts/commit/5a212ca)), closes [#13043](https://github.com/bitnami/charts/issues/13043)
+* [bitnami/*] Use new default branch name in links (#12943) ([a529e02](https://github.com/bitnami/charts/commit/a529e02597d49d944eba1eb0f190713293247176)), closes [#12943](https://github.com/bitnami/charts/issues/12943)
+* [bitnami/sonarqube] Release 1.6.4 (#13043) ([5a212ca](https://github.com/bitnami/charts/commit/5a212ca4a7ff9a7aa401985eeed353d212b9d493)), closes [#13043](https://github.com/bitnami/charts/issues/13043)
 
 ## <small>1.6.3 (2022-10-14)</small>
 
-* [bitnami/sonarqube] Release 1.6.3 (#12961) ([0a2862c](https://github.com/bitnami/charts/commit/0a2862c)), closes [#12961](https://github.com/bitnami/charts/issues/12961)
-* Generic README instructions related to the repo (#12792) ([3cf6b10](https://github.com/bitnami/charts/commit/3cf6b10)), closes [#12792](https://github.com/bitnami/charts/issues/12792)
+* [bitnami/sonarqube] Release 1.6.3 (#12961) ([0a2862c](https://github.com/bitnami/charts/commit/0a2862c868ee72dadbf781b8def5b92d36fcb8c1)), closes [#12961](https://github.com/bitnami/charts/issues/12961)
+* Generic README instructions related to the repo (#12792) ([3cf6b10](https://github.com/bitnami/charts/commit/3cf6b10e10e60df4b3e191d6b99aa99a9f597755)), closes [#12792](https://github.com/bitnami/charts/issues/12792)
 
 ## <small>1.6.2 (2022-10-04)</small>
 
-* [bitnami/sonarqube] Use custom probes if given (#12558) ([7c80d13](https://github.com/bitnami/charts/commit/7c80d13)), closes [#12558](https://github.com/bitnami/charts/issues/12558) [#12354](https://github.com/bitnami/charts/issues/12354)
+* [bitnami/sonarqube] Use custom probes if given (#12558) ([7c80d13](https://github.com/bitnami/charts/commit/7c80d1395f1d1b27abeed4d524bc164a7f4899ec)), closes [#12558](https://github.com/bitnami/charts/issues/12558) [#12354](https://github.com/bitnami/charts/issues/12354)
 
 ## <small>1.6.1 (2022-09-14)</small>
 
-* [bitnami/sonarqube] Release 1.6.1 updating components versions ([4ec59c5](https://github.com/bitnami/charts/commit/4ec59c5))
+* [bitnami/sonarqube] Release 1.6.1 updating components versions ([4ec59c5](https://github.com/bitnami/charts/commit/4ec59c5a9287f984f23ad39594bb504d1e27008d))
 
 ## 1.6.0 (2022-09-05)
 
-* [bitnami/sonarqube] Add LDAP support (#11635) ([d21344c](https://github.com/bitnami/charts/commit/d21344c)), closes [#11635](https://github.com/bitnami/charts/issues/11635)
+* [bitnami/sonarqube] Add LDAP support (#11635) ([d21344c](https://github.com/bitnami/charts/commit/d21344cccf817ce906cadb73560419183783e692)), closes [#11635](https://github.com/bitnami/charts/issues/11635)
 
 ## <small>1.5.4 (2022-08-31)</small>
 
-* [bitnami/sonarqube] Release 1.5.4 updating components versions ([560a07b](https://github.com/bitnami/charts/commit/560a07b))
+* [bitnami/sonarqube] Release 1.5.4 updating components versions ([560a07b](https://github.com/bitnami/charts/commit/560a07bcd897906399725a506075712ab89d64fc))
 
 ## <small>1.5.3 (2022-08-30)</small>
 
-* [bitnami/sonarqube] Release 1.5.3 updating components versions ([9903c3c](https://github.com/bitnami/charts/commit/9903c3c))
+* [bitnami/sonarqube] Release 1.5.3 updating components versions ([9903c3c](https://github.com/bitnami/charts/commit/9903c3c5a653e7f9c7d0808938800964805bc11b))
 
 ## <small>1.5.2 (2022-08-23)</small>
 
-* [bitnami/sonarqube] Update Chart.lock (#12110) ([cde6a84](https://github.com/bitnami/charts/commit/cde6a84)), closes [#12110](https://github.com/bitnami/charts/issues/12110)
+* [bitnami/sonarqube] Update Chart.lock (#12110) ([cde6a84](https://github.com/bitnami/charts/commit/cde6a8424cf8679288046f1a7442202cd2de4aa8)), closes [#12110](https://github.com/bitnami/charts/issues/12110)
 
 ## <small>1.5.1 (2022-08-22)</small>
 
-* [bitnami/sonarqube] Update Chart.lock (#11981) ([fee2303](https://github.com/bitnami/charts/commit/fee2303)), closes [#11981](https://github.com/bitnami/charts/issues/11981)
+* [bitnami/sonarqube] Update Chart.lock (#11981) ([fee2303](https://github.com/bitnami/charts/commit/fee23035764ccf6f34a796583313ad4d0cd0cb56)), closes [#11981](https://github.com/bitnami/charts/issues/11981)
 
 ## 1.5.0 (2022-08-22)
 
-* [bitnami/sonarqube] Add support for image digest apart from tag (#11960) ([d891ee8](https://github.com/bitnami/charts/commit/d891ee8)), closes [#11960](https://github.com/bitnami/charts/issues/11960)
+* [bitnami/sonarqube] Add support for image digest apart from tag (#11960) ([d891ee8](https://github.com/bitnami/charts/commit/d891ee8506fe0bc7a528ba1ecf77a5c608dc366b)), closes [#11960](https://github.com/bitnami/charts/issues/11960)
 
 ## <small>1.4.9 (2022-08-04)</small>
 
-* [bitnami/sonarqube] Release 1.4.9 updating components versions ([2bef372](https://github.com/bitnami/charts/commit/2bef372))
+* [bitnami/sonarqube] Release 1.4.9 updating components versions ([2bef372](https://github.com/bitnami/charts/commit/2bef37233b42be20389f075823da2ae5b18b9d33))
 
 ## <small>1.4.8 (2022-08-04)</small>
 
-* [bitnami/*] Update URLs to point to the new bitnami/containers monorepo (#11352) ([d665af0](https://github.com/bitnami/charts/commit/d665af0)), closes [#11352](https://github.com/bitnami/charts/issues/11352)
-* [bitnami/sonarqube] Sonarqube pipeline fails using sysctl on a non-root container (#11566) ([0d5264a](https://github.com/bitnami/charts/commit/0d5264a)), closes [#11566](https://github.com/bitnami/charts/issues/11566)
+* [bitnami/*] Update URLs to point to the new bitnami/containers monorepo (#11352) ([d665af0](https://github.com/bitnami/charts/commit/d665af0c708846192d8d5fb2f5f9ea65dd464ab0)), closes [#11352](https://github.com/bitnami/charts/issues/11352)
+* [bitnami/sonarqube] Sonarqube pipeline fails using sysctl on a non-root container (#11566) ([0d5264a](https://github.com/bitnami/charts/commit/0d5264a64984906021aac71015a8e1bb4d9085f7)), closes [#11566](https://github.com/bitnami/charts/issues/11566)
 
 ## <small>1.4.7 (2022-06-30)</small>
 
-* [bitnami/sonarqube] Release 1.4.7 updating components versions ([a8899f8](https://github.com/bitnami/charts/commit/a8899f8))
+* [bitnami/sonarqube] Release 1.4.7 updating components versions ([a8899f8](https://github.com/bitnami/charts/commit/a8899f838c11e597acc329d4dd67cbcaf28cab46))
 
 ## <small>1.4.6 (2022-06-15)</small>
 
-* [bitnami/sonarqube] Release 1.4.6 updating components versions ([4bf067c](https://github.com/bitnami/charts/commit/4bf067c))
+* [bitnami/sonarqube] Release 1.4.6 updating components versions ([4bf067c](https://github.com/bitnami/charts/commit/4bf067c995aac4aa497a26ef4dabcead1c6ba632))
 
 ## <small>1.4.5 (2022-06-14)</small>
 
-* [bitnami/sonarqube] fix: :bug: Use proper type for sidecars and init containers (#10758) ([c7dfa01](https://github.com/bitnami/charts/commit/c7dfa01)), closes [#10758](https://github.com/bitnami/charts/issues/10758)
+* [bitnami/sonarqube] fix: :bug: Use proper type for sidecars and init containers (#10758) ([c7dfa01](https://github.com/bitnami/charts/commit/c7dfa010c88b56884f7ca07024060fc6d66e696d)), closes [#10758](https://github.com/bitnami/charts/issues/10758)
 
 ## <small>1.4.4 (2022-06-10)</small>
 
-* [bitnami/*] Replace Kubeapps URL in READMEs (and kubeapps Chart.yaml) and remove BKPR references (#1 ([c6a7914](https://github.com/bitnami/charts/commit/c6a7914)), closes [#10600](https://github.com/bitnami/charts/issues/10600)
-* [bitnami/sonarqube] Release 1.4.4 updating components versions ([14c73cb](https://github.com/bitnami/charts/commit/14c73cb))
+* [bitnami/*] Replace Kubeapps URL in READMEs (and kubeapps Chart.yaml) and remove BKPR references (#1 ([c6a7914](https://github.com/bitnami/charts/commit/c6a7914361e5aea6016fb45bf4d621edfd111d32)), closes [#10600](https://github.com/bitnami/charts/issues/10600)
+* [bitnami/sonarqube] Release 1.4.4 updating components versions ([14c73cb](https://github.com/bitnami/charts/commit/14c73cb20ef57385ce8c84ffa64a3466bb88cc77))
 
 ## <small>1.4.3 (2022-06-06)</small>
 
-* [bitnami/sonarqube] Release 1.4.3 updating components versions ([045b34d](https://github.com/bitnami/charts/commit/045b34d))
+* [bitnami/sonarqube] Release 1.4.3 updating components versions ([045b34d](https://github.com/bitnami/charts/commit/045b34db4dcb4ffc67d3c341910d24d0e4f0499b))
 
 ## <small>1.4.2 (2022-06-01)</small>
 
-* [bitnami/several] Replace maintainers email by url (#10523) ([ff3cf61](https://github.com/bitnami/charts/commit/ff3cf61)), closes [#10523](https://github.com/bitnami/charts/issues/10523)
+* [bitnami/several] Replace maintainers email by url (#10523) ([ff3cf61](https://github.com/bitnami/charts/commit/ff3cf617a1680509b0f3855d17c4ccff7b29a0ff)), closes [#10523](https://github.com/bitnami/charts/issues/10523)
 
 ## <small>1.4.1 (2022-05-30)</small>
 
-* [bitnami/several] Replace base64 --decode with base64 -d (#10495) ([099286a](https://github.com/bitnami/charts/commit/099286a)), closes [#10495](https://github.com/bitnami/charts/issues/10495)
+* [bitnami/several] Replace base64 --decode with base64 -d (#10495) ([099286a](https://github.com/bitnami/charts/commit/099286ae7a87784cf809df0b64ab24f7ff0144c8)), closes [#10495](https://github.com/bitnami/charts/issues/10495)
 
 ## 1.4.0 (2022-05-26)
 
-* [bitnami/sonarqube] Add missing service parameter (#10430) ([fda9912](https://github.com/bitnami/charts/commit/fda9912)), closes [#10430](https://github.com/bitnami/charts/issues/10430)
+* [bitnami/sonarqube] Add missing service parameter (#10430) ([fda9912](https://github.com/bitnami/charts/commit/fda9912db720b34604079bd438aebe5ccf60d870)), closes [#10430](https://github.com/bitnami/charts/issues/10430)
 
 ## <small>1.3.1 (2022-05-25)</small>
 
-* [bitnami/sonarqube] Release 1.3.1 updating components versions ([5713830](https://github.com/bitnami/charts/commit/5713830))
+* [bitnami/sonarqube] Release 1.3.1 updating components versions ([5713830](https://github.com/bitnami/charts/commit/5713830ec5d60368f0fbf5ebe11c2ff853fbb094))
 
 ## 1.3.0 (2022-05-23)
 
-* [bitnami/sonarqube] Add missing serviceAccount.* parameters (#10337) ([6394981](https://github.com/bitnami/charts/commit/6394981)), closes [#10337](https://github.com/bitnami/charts/issues/10337)
+* [bitnami/sonarqube] Add missing serviceAccount.* parameters (#10337) ([6394981](https://github.com/bitnami/charts/commit/63949815325971e32a0a9e157fe0dcd9cae34271)), closes [#10337](https://github.com/bitnami/charts/issues/10337)
 
 ## <small>1.2.4 (2022-05-22)</small>
 
-* [bitnami/sonarqube] Release 1.2.4 updating components versions ([616d268](https://github.com/bitnami/charts/commit/616d268))
+* [bitnami/sonarqube] Release 1.2.4 updating components versions ([616d268](https://github.com/bitnami/charts/commit/616d26880db562539de31ab21b413421484afa20))
 
 ## <small>1.2.3 (2022-05-21)</small>
 
-* [bitnami/sonarqube] Release 1.2.3 updating components versions ([4c1c0c3](https://github.com/bitnami/charts/commit/4c1c0c3))
+* [bitnami/sonarqube] Release 1.2.3 updating components versions ([4c1c0c3](https://github.com/bitnami/charts/commit/4c1c0c3359fbf41f8ebaf03258c12da09a21ef08))
 
 ## <small>1.2.2 (2022-05-19)</small>
 
-* [bitnami/sonarqube] Release 1.2.2 updating components versions ([79a2596](https://github.com/bitnami/charts/commit/79a2596))
+* [bitnami/sonarqube] Release 1.2.2 updating components versions ([79a2596](https://github.com/bitnami/charts/commit/79a259667f9d580d8225a41734c93152d23b1278))
 
 ## <small>1.2.1 (2022-05-18)</small>
 
-* [bitnami/sonarqube] Release 1.2.1 updating components versions ([7e71544](https://github.com/bitnami/charts/commit/7e71544))
+* [bitnami/sonarqube] Release 1.2.1 updating components versions ([7e71544](https://github.com/bitnami/charts/commit/7e7154476d9be47cf54025664714d5c92ecf93c2))
 
 ## 1.2.0 (2022-05-16)
 
-* [bitnami/*] add ingress extraRules feature (#10253) ([0f6cbb9](https://github.com/bitnami/charts/commit/0f6cbb9)), closes [#10253](https://github.com/bitnami/charts/issues/10253)
+* [bitnami/*] add ingress extraRules feature (#10253) ([0f6cbb9](https://github.com/bitnami/charts/commit/0f6cbb9099b0e56685cc1d36ba50340f3d7278a1)), closes [#10253](https://github.com/bitnami/charts/issues/10253)
 
 ## 1.1.0 (2022-05-16)
 
-* [bitnami/*] Add missing 'persistence.annotations' (#10202) ([ad1d8a5](https://github.com/bitnami/charts/commit/ad1d8a5)), closes [#10202](https://github.com/bitnami/charts/issues/10202)
-* [bitnami/*] Remove old 'ci' files (#10171) ([5df30c4](https://github.com/bitnami/charts/commit/5df30c4)), closes [#10171](https://github.com/bitnami/charts/issues/10171)
+* [bitnami/*] Add missing 'persistence.annotations' (#10202) ([ad1d8a5](https://github.com/bitnami/charts/commit/ad1d8a5fd977ecd82e82ec8a2530d0d2522a8ed0)), closes [#10202](https://github.com/bitnami/charts/issues/10202)
+* [bitnami/*] Remove old 'ci' files (#10171) ([5df30c4](https://github.com/bitnami/charts/commit/5df30c44dbd1812da8786579ce4a94917d46a6ad)), closes [#10171](https://github.com/bitnami/charts/issues/10171)
 
 ## <small>1.0.14 (2022-05-11)</small>
 
-* [bitnami/*] Fix typo in comments (relay -> rely) (#10151) ([9cfe4a4](https://github.com/bitnami/charts/commit/9cfe4a4)), closes [#10151](https://github.com/bitnami/charts/issues/10151)
+* [bitnami/*] Fix typo in comments (relay -> rely) (#10151) ([9cfe4a4](https://github.com/bitnami/charts/commit/9cfe4a48cc35851faea6be7ffb2a978d223befa0)), closes [#10151](https://github.com/bitnami/charts/issues/10151)
 
 ## <small>1.0.13 (2022-04-29)</small>
 
-* [bitnami/sonarqube] chart install instructions had a misspelling in the chart (#9974) ([b8dc970](https://github.com/bitnami/charts/commit/b8dc970)), closes [#9974](https://github.com/bitnami/charts/issues/9974)
-* [bitnami/sonarqube] Release 1.0.13 updating components versions ([ed3c028](https://github.com/bitnami/charts/commit/ed3c028))
-* [bitnami/sonarqube] wrong secret name called in deployment (#9878) ([1ca096c](https://github.com/bitnami/charts/commit/1ca096c)), closes [#9878](https://github.com/bitnami/charts/issues/9878)
+* [bitnami/sonarqube] chart install instructions had a misspelling in the chart (#9974) ([b8dc970](https://github.com/bitnami/charts/commit/b8dc970317f828e041da81191e9c21c290b925f4)), closes [#9974](https://github.com/bitnami/charts/issues/9974)
+* [bitnami/sonarqube] Release 1.0.13 updating components versions ([ed3c028](https://github.com/bitnami/charts/commit/ed3c0287acd5e1bbd0c9431f9881fe3ac5ad0529))
+* [bitnami/sonarqube] wrong secret name called in deployment (#9878) ([1ca096c](https://github.com/bitnami/charts/commit/1ca096c76d5f9df359dee468f58a77251157f1c0)), closes [#9878](https://github.com/bitnami/charts/issues/9878)
 
 ## <small>1.0.12 (2022-04-22)</small>
 
-* [bitnami/sonarqube] Release 1.0.12 updating components versions ([6751ed0](https://github.com/bitnami/charts/commit/6751ed0))
+* [bitnami/sonarqube] Release 1.0.12 updating components versions ([6751ed0](https://github.com/bitnami/charts/commit/6751ed06a4bcbc61f4463b78e4d7bc257748f7f4))
 
 ## <small>1.0.11 (2022-04-20)</small>
 
-* [bitnami/sonarqube] Release 1.0.11 updating components versions ([ddfbf4f](https://github.com/bitnami/charts/commit/ddfbf4f))
+* [bitnami/sonarqube] Release 1.0.11 updating components versions ([ddfbf4f](https://github.com/bitnami/charts/commit/ddfbf4f60485a96691846eec8d178c6e4a8976d8))
 
 ## <small>1.0.10 (2022-04-19)</small>
 
-* [bitnami/sonarqube] Release 1.0.10 updating components versions ([dd77f60](https://github.com/bitnami/charts/commit/dd77f60))
+* [bitnami/sonarqube] Release 1.0.10 updating components versions ([dd77f60](https://github.com/bitnami/charts/commit/dd77f604f46e45b21cbc7f35cd78b75b166e1bab))
 
 ## <small>1.0.9 (2022-04-06)</small>
 
-* [bitnami/sonarqube] Release 1.0.9 updating components versions ([2d37efd](https://github.com/bitnami/charts/commit/2d37efd))
+* [bitnami/sonarqube] Release 1.0.9 updating components versions ([2d37efd](https://github.com/bitnami/charts/commit/2d37efd01e1fd6dc1225fb591cab025af0b28830))
 
 ## <small>1.0.8 (2022-04-03)</small>
 
-* [bitnami/sonarqube] Release 1.0.8 updating components versions ([1e55429](https://github.com/bitnami/charts/commit/1e55429))
+* [bitnami/sonarqube] Release 1.0.8 updating components versions ([1e55429](https://github.com/bitnami/charts/commit/1e55429a70c6429f69414d65856a4432b32461b1))
 
 ## <small>1.0.7 (2022-04-02)</small>
 
-* [bitnami/sonarqube] Release 1.0.7 updating components versions ([91ae7fb](https://github.com/bitnami/charts/commit/91ae7fb))
+* [bitnami/sonarqube] Release 1.0.7 updating components versions ([91ae7fb](https://github.com/bitnami/charts/commit/91ae7fb1438c0a66e8411f6dbe8cd88cd1a5457a))
 
 ## <small>1.0.6 (2022-03-29)</small>
 
-* [bitnami/sonarqube] Release 1.0.6 updating components versions ([78ae4af](https://github.com/bitnami/charts/commit/78ae4af))
+* [bitnami/sonarqube] Release 1.0.6 updating components versions ([78ae4af](https://github.com/bitnami/charts/commit/78ae4af8084848e91414f4adc5dbe21c62c54e8f))
 
 ## <small>1.0.5 (2022-03-28)</small>
 
-* [bitnami/sonarqube] Release 1.0.5 updating components versions ([3fbedf1](https://github.com/bitnami/charts/commit/3fbedf1))
+* [bitnami/sonarqube] Release 1.0.5 updating components versions ([3fbedf1](https://github.com/bitnami/charts/commit/3fbedf19f28b4ac16bb688a1b7785428950aab2e))
 
 ## <small>1.0.4 (2022-03-27)</small>
 
-* [bitnami/sonarqube] Release 1.0.4 updating components versions ([ad32233](https://github.com/bitnami/charts/commit/ad32233))
+* [bitnami/sonarqube] Release 1.0.4 updating components versions ([ad32233](https://github.com/bitnami/charts/commit/ad32233a277c8f8d840cd27dbddbd3e48d4dac26))
 
 ## <small>1.0.3 (2022-03-22)</small>
 
-* [bitnami/sonarqube] Release 1.0.3 updating components versions ([a1da980](https://github.com/bitnami/charts/commit/a1da980))
+* [bitnami/sonarqube] Release 1.0.3 updating components versions ([a1da980](https://github.com/bitnami/charts/commit/a1da9802d488caaee8b9b305b5206792ca6c2e32))
 
 ## <small>1.0.2 (2022-03-16)</small>
 
-* [bitnami/sonarqube] Release 1.0.2 updating components versions ([e607d5d](https://github.com/bitnami/charts/commit/e607d5d))
+* [bitnami/sonarqube] Release 1.0.2 updating components versions ([e607d5d](https://github.com/bitnami/charts/commit/e607d5d7b9c79e59e10d9c5eda000970971296e2))
 
 ## <small>1.0.1 (2022-03-07)</small>
 
-* [bitnami/*] Take 'global.postgresql' values into account (#9314) ([dd428a0](https://github.com/bitnami/charts/commit/dd428a0)), closes [#9314](https://github.com/bitnami/charts/issues/9314)
+* [bitnami/*] Take 'global.postgresql' values into account (#9314) ([dd428a0](https://github.com/bitnami/charts/commit/dd428a06614551c92500afa84ce9750c4d8b90c9)), closes [#9314](https://github.com/bitnami/charts/issues/9314)
 
 ## 1.0.0 (2022-03-02)
 
-* [bitnami/sonarqube]: feat!: :arrow_up: Bump PostgreSQL subchart (#9266) ([cb2fb43](https://github.com/bitnami/charts/commit/cb2fb43)), closes [#9266](https://github.com/bitnami/charts/issues/9266)
+* [bitnami/sonarqube]: feat!: :arrow_up: Bump PostgreSQL subchart (#9266) ([cb2fb43](https://github.com/bitnami/charts/commit/cb2fb4370ffaa940681a8e13493d5e45ae7fe295)), closes [#9266](https://github.com/bitnami/charts/issues/9266)
 
 ## <small>0.2.8 (2022-02-27)</small>
 
-* [bitnami/sonarqube] Release 0.2.8 updating components versions ([92581c4](https://github.com/bitnami/charts/commit/92581c4))
+* [bitnami/sonarqube] Release 0.2.8 updating components versions ([92581c4](https://github.com/bitnami/charts/commit/92581c4fe8b52a0a6916a76b71d83ca7ab91131d))
 
 ## <small>0.2.7 (2022-02-21)</small>
 
-* [bitnami/sonarqube] Add flag '-r' to xargs in volumePermissions init-container (#9139) ([ce31834](https://github.com/bitnami/charts/commit/ce31834)), closes [#9139](https://github.com/bitnami/charts/issues/9139)
+* [bitnami/sonarqube] Add flag '-r' to xargs in volumePermissions init-container (#9139) ([ce31834](https://github.com/bitnami/charts/commit/ce31834f5bdcb2df8e866a6a325a2291b042f1fe)), closes [#9139](https://github.com/bitnami/charts/issues/9139)
 
 ## <small>0.2.6 (2022-02-02)</small>
 
-* [bitnami/*] Make use of new "common.ingress.certManagerRequest" helper (#8862) ([12e4c37](https://github.com/bitnami/charts/commit/12e4c37)), closes [#8862](https://github.com/bitnami/charts/issues/8862)
+* [bitnami/*] Make use of new "common.ingress.certManagerRequest" helper (#8862) ([12e4c37](https://github.com/bitnami/charts/commit/12e4c3733eaeaa9a5579fdf917fa098a0f2aae23)), closes [#8862](https://github.com/bitnami/charts/issues/8862)
 
 ## <small>0.2.5 (2022-01-31)</small>
 
-* [bitnami/sonarqube] Release 0.2.5 updating components versions ([9fb725c](https://github.com/bitnami/charts/commit/9fb725c))
+* [bitnami/sonarqube] Release 0.2.5 updating components versions ([9fb725c](https://github.com/bitnami/charts/commit/9fb725ce244079fc8a3cfa1c215d2550b9eef268))
 
 ## <small>0.2.4 (2022-01-20)</small>
 
-* [bitnami/*] Readme automation (#8579) ([78d1938](https://github.com/bitnami/charts/commit/78d1938)), closes [#8579](https://github.com/bitnami/charts/issues/8579)
-* [bitnami/*] Update READMEs (#8716) ([b9a9533](https://github.com/bitnami/charts/commit/b9a9533)), closes [#8716](https://github.com/bitnami/charts/issues/8716)
-* [bitnami/several] Change prerequisites (#8725) ([8d740c5](https://github.com/bitnami/charts/commit/8d740c5)), closes [#8725](https://github.com/bitnami/charts/issues/8725)
+* [bitnami/*] Readme automation (#8579) ([78d1938](https://github.com/bitnami/charts/commit/78d193831c900d178198491ffd08fa2217a64ecd)), closes [#8579](https://github.com/bitnami/charts/issues/8579)
+* [bitnami/*] Update READMEs (#8716) ([b9a9533](https://github.com/bitnami/charts/commit/b9a953337590eb2979453385874a267bacf50936)), closes [#8716](https://github.com/bitnami/charts/issues/8716)
+* [bitnami/several] Change prerequisites (#8725) ([8d740c5](https://github.com/bitnami/charts/commit/8d740c566cfdb7e2d933c40128b4e919fce953a5)), closes [#8725](https://github.com/bitnami/charts/issues/8725)
 
 ## <small>0.2.3 (2022-01-13)</small>
 
-* [bitnami/sonarqube] Release 0.2.3 updating components versions ([dde0d00](https://github.com/bitnami/charts/commit/dde0d00))
+* [bitnami/sonarqube] Release 0.2.3 updating components versions ([dde0d00](https://github.com/bitnami/charts/commit/dde0d00299bd5df1782d56dddea8fcf2d5266e2a))
 
 ## <small>0.2.2 (2022-01-11)</small>
 
-* [bitnami/sonarqube] Release 0.2.2 updating components versions ([91adfae](https://github.com/bitnami/charts/commit/91adfae))
+* [bitnami/sonarqube] Release 0.2.2 updating components versions ([91adfae](https://github.com/bitnami/charts/commit/91adfaecbe4404661ddfd6966a55559b1ac1bda6))
 
 ## <small>0.2.1 (2022-01-07)</small>
 
-* [bitnami/sonarqube] Removed extra quotes from externalDatabase variables (#8585) ([3306dd6](https://github.com/bitnami/charts/commit/3306dd6)), closes [#8585](https://github.com/bitnami/charts/issues/8585)
+* [bitnami/sonarqube] Removed extra quotes from externalDatabase variables (#8585) ([3306dd6](https://github.com/bitnami/charts/commit/3306dd642b166169b3c320a733f4224dc5368515)), closes [#8585](https://github.com/bitnami/charts/issues/8585)
 
 ## 0.2.0 (2022-01-05)
 
-* [bitnami/several] Adapt templating format (#8562) ([8cad18a](https://github.com/bitnami/charts/commit/8cad18a)), closes [#8562](https://github.com/bitnami/charts/issues/8562)
-* [bitnami/several] Add license to the README ([05f7633](https://github.com/bitnami/charts/commit/05f7633))
-* [bitnami/several] Add license to the README ([32fb238](https://github.com/bitnami/charts/commit/32fb238))
-* [bitnami/several] Add license to the README ([b87c2f7](https://github.com/bitnami/charts/commit/b87c2f7))
+* [bitnami/several] Adapt templating format (#8562) ([8cad18a](https://github.com/bitnami/charts/commit/8cad18aed9966a6f0208e5ad6cee46cb217f47ab)), closes [#8562](https://github.com/bitnami/charts/issues/8562)
+* [bitnami/several] Add license to the README ([05f7633](https://github.com/bitnami/charts/commit/05f763372501d596e57db713dd53ff4ff3027cc4))
+* [bitnami/several] Add license to the README ([32fb238](https://github.com/bitnami/charts/commit/32fb238e60a0affc6debd3142eaa3c3d9089ec2a))
+* [bitnami/several] Add license to the README ([b87c2f7](https://github.com/bitnami/charts/commit/b87c2f7899d48a8b02c506765e6ae82937e9ba3f))
 
 ## <small>0.1.6 (2021-12-21)</small>
 
-* [bitnami/sonarqube] Release 0.1.6 updating components versions ([42da287](https://github.com/bitnami/charts/commit/42da287))
+* [bitnami/sonarqube] Release 0.1.6 updating components versions ([42da287](https://github.com/bitnami/charts/commit/42da2878d408133e5dfac826acff14c4629fd108))
 
 ## <small>0.1.5 (2021-12-17)</small>
 
-* [bitnami/sonarqube] Release 0.1.5 updating components versions ([81f58d3](https://github.com/bitnami/charts/commit/81f58d3))
+* [bitnami/sonarqube] Release 0.1.5 updating components versions ([81f58d3](https://github.com/bitnami/charts/commit/81f58d30ed931915d60bd09d5fad33bdf1fe3a33))
 
 ## <small>0.1.4 (2021-12-17)</small>
 
-* [bitnami/sonarqube] Release 0.1.4 updating components versions ([83b8d94](https://github.com/bitnami/charts/commit/83b8d94))
+* [bitnami/sonarqube] Release 0.1.4 updating components versions ([83b8d94](https://github.com/bitnami/charts/commit/83b8d945a56b4f59eb9a60368bae9a1d647f968f))
 
 ## <small>0.1.3 (2021-12-16)</small>
 
-* [bitnami/several] Regenerate README tables ([8150149](https://github.com/bitnami/charts/commit/8150149))
-* [bitnami/sonarqube] Release 0.1.3 updating components versions ([1ca5ae2](https://github.com/bitnami/charts/commit/1ca5ae2))
+* [bitnami/several] Regenerate README tables ([8150149](https://github.com/bitnami/charts/commit/8150149f0bb746e86ff0029fc375d43775bdf15a))
+* [bitnami/sonarqube] Release 0.1.3 updating components versions ([1ca5ae2](https://github.com/bitnami/charts/commit/1ca5ae29743b1c0d8af1c8f8288ebca46aa8e8ca))
 
 ## <small>0.1.2 (2021-11-29)</small>
 
-* [bitnami/sonarqube] Release 0.1.2 updating components versions ([ae9d658](https://github.com/bitnami/charts/commit/ae9d658))
+* [bitnami/sonarqube] Release 0.1.2 updating components versions ([ae9d658](https://github.com/bitnami/charts/commit/ae9d6583ca92ce9ddb851a409f553956bce87b86))
 
 ## <small>0.1.1 (2021-11-29)</small>
 
-* [bitnami/several] Fix deadlinks in README.md (#8215) ([99e90d2](https://github.com/bitnami/charts/commit/99e90d2)), closes [#8215](https://github.com/bitnami/charts/issues/8215)
-* [bitnami/several] Replace HTTP by HTTPS when possible (#8259) ([eafb5bd](https://github.com/bitnami/charts/commit/eafb5bd)), closes [#8259](https://github.com/bitnami/charts/issues/8259)
-* [bitnami/sonarqube] Regenerate README tables ([615e036](https://github.com/bitnami/charts/commit/615e036))
+* [bitnami/several] Fix deadlinks in README.md (#8215) ([99e90d2](https://github.com/bitnami/charts/commit/99e90d244b3244e059a42f72dcbecd3cda2b66bb)), closes [#8215](https://github.com/bitnami/charts/issues/8215)
+* [bitnami/several] Replace HTTP by HTTPS when possible (#8259) ([eafb5bd](https://github.com/bitnami/charts/commit/eafb5bd5a2cc3aaf04fc1e8ebedd73f420d76864)), closes [#8259](https://github.com/bitnami/charts/issues/8259)
+* [bitnami/sonarqube] Regenerate README tables ([615e036](https://github.com/bitnami/charts/commit/615e0363212f9f6753d6812fc6251473379cada8))
 
 ## 0.1.0 (2021-11-02)
 
-* Add new chart: Sonarqube (#7819) ([df0d773](https://github.com/bitnami/charts/commit/df0d773)), closes [#7819](https://github.com/bitnami/charts/issues/7819)
+* Add new chart: Sonarqube (#7819) ([df0d773](https://github.com/bitnami/charts/commit/df0d773655c99fd59c8b9012cb14b77d0e74c7f2)), closes [#7819](https://github.com/bitnami/charts/issues/7819)

--- a/bitnami/sonarqube/Chart.yaml
+++ b/bitnami/sonarqube/Chart.yaml
@@ -37,4 +37,4 @@ maintainers:
 name: sonarqube
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/sonarqube
-version: 5.1.0
+version: 5.2.0

--- a/bitnami/sonarqube/README.md
+++ b/bitnami/sonarqube/README.md
@@ -372,6 +372,9 @@ As an alternative, this chart supports using an initContainer to change the owne
 | `extraVolumeMounts`                                 | Optionally specify extra list of additional volumeMounts for the SonarQube&trade; container(s)                                                                                                                    | `[]`             |
 | `sidecars`                                          | Add additional sidecar containers to the SonarQube&trade; pod(s)                                                                                                                                                  | `[]`             |
 | `initContainers`                                    | Add additional init containers to the SonarQube&trade; pod(s)                                                                                                                                                     | `[]`             |
+| `pdb.create`                                        | Enable/disable a Pod Disruption Budget creation                                                                                                                                                                   | `true`           |
+| `pdb.minAvailable`                                  | Minimum number/percentage of pods that should remain scheduled                                                                                                                                                    | `""`             |
+| `pdb.maxUnavailable`                                | Maximum number/percentage of pods that may be made unavailable. Defaults to `1` if both `pdb.minAvailable` and `pdb.maxUnavailable` are empty.                                                                    | `""`             |
 
 ### Traffic Exposure Parameters
 

--- a/bitnami/sonarqube/templates/pdb.yaml
+++ b/bitnami/sonarqube/templates/pdb.yaml
@@ -1,0 +1,26 @@
+{{- /*
+Copyright Broadcom, Inc. All Rights Reserved.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+{{- if .Values.pdb.create }}
+apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "common.names.fullname" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.pdb.minAvailable }}
+  minAvailable: {{ .Values.pdb.minAvailable }}
+  {{- end  }}
+  {{- if or .Values.pdb.maxUnavailable ( not .Values.pdb.minAvailable ) }}
+  maxUnavailable: {{ .Values.pdb.maxUnavailable | default 1 }}
+  {{- end  }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.podLabels .Values.commonLabels ) "context" . ) }}
+  selector:
+    matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
+{{- end }}

--- a/bitnami/sonarqube/values.yaml
+++ b/bitnami/sonarqube/values.yaml
@@ -460,6 +460,16 @@ sidecars: []
 ##    command: ['sh', '-c', 'echo "hello world"']
 ##
 initContainers: []
+## Pod Disruption Budget configuration
+## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb
+## @param pdb.create Enable/disable a Pod Disruption Budget creation
+## @param pdb.minAvailable Minimum number/percentage of pods that should remain scheduled
+## @param pdb.maxUnavailable Maximum number/percentage of pods that may be made unavailable. Defaults to `1` if both `pdb.minAvailable` and `pdb.maxUnavailable` are empty.
+##
+pdb:
+  create: true
+  minAvailable: ""
+  maxUnavailable: ""
 ## @section Traffic Exposure Parameters
 ##
 


### PR DESCRIPTION
### Description of the change

Enabled PodDisruptionBudget by default and little fixes in PDB configuration to keep it aligned with current templates.

### Benefits

PDB protects our applications from voluntary disruption initiated by cluster administrators.
Keep our charts up to date according to our templates.

### Possible drawbacks

None

### Adition information

* [Pod disruption budgets](https://kubernetes.io/docs/concepts/workloads/pods/disruptions/#pod-disruption-budgets)
* [Specifying a Disruption Budget for your Application](https://kubernetes.io/docs/tasks/run-application/configure-pdb/)

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
