### PR TITLE
[bitnami/template] Update PDB defintion in our scaffolding template

### DIFF
--- a/template/CHART_NAME/templates/pdb.yaml
+++ b/template/CHART_NAME/templates/pdb.yaml
@@ -3,7 +3,7 @@ Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- if and .Values.%%MAIN_OBJECT_BLOCK%%.pdb.create }}
+{{- if .Values.%%MAIN_OBJECT_BLOCK%%.pdb.create }}
 apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
@@ -18,10 +18,10 @@ spec:
   {{- if .Values.%%MAIN_OBJECT_BLOCK%%.pdb.minAvailable }}
   minAvailable: {{ .Values.%%MAIN_OBJECT_BLOCK%%.pdb.minAvailable }}
   {{- end  }}
-  {{- if .Values.%%MAIN_OBJECT_BLOCK%%.pdb.maxUnavailable }}
-  maxUnavailable: {{ .Values.%%MAIN_OBJECT_BLOCK%%.pdb.maxUnavailable }}
+  {{- if or .Values.%%MAIN_OBJECT_BLOCK%%.pdb.maxUnavailable ( not .Values.%%MAIN_OBJECT_BLOCK%%.pdb.minAvailable ) }}
+  maxUnavailable: {{ .Values.%%MAIN_OBJECT_BLOCK%%.pdb.maxUnavailable | default 1 }}
   {{- end  }}
-  {{- $podLabels := include "common.tplvalues.merge" (dict "values" (list .Values.%%MAIN_OBJECT_BLOCK%%.podLabels .Values.commonLabels) "context" .) }}
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.%%MAIN_OBJECT_BLOCK%%.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
       app.kubernetes.io/component: %%COMPONENT_NAME%%

--- a/template/CHART_NAME/values.yaml
+++ b/template/CHART_NAME/values.yaml
@@ -379,11 +379,11 @@ diagnosticMode:
   ## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb
   ## @param %%MAIN_OBJECT_BLOCK%%.pdb.create Enable/disable a Pod Disruption Budget creation
   ## @param %%MAIN_OBJECT_BLOCK%%.pdb.minAvailable Minimum number/percentage of pods that should remain scheduled
-  ## @param %%MAIN_OBJECT_BLOCK%%.pdb.maxUnavailable Maximum number/percentage of pods that may be made unavailable
+  ## @param %%MAIN_OBJECT_BLOCK%%.pdb.maxUnavailable Maximum number/percentage of pods that may be made unavailable. Defaults to `1` if both `%%MAIN_OBJECT_BLOCK%%.pdb.minAvailable` and `%%MAIN_OBJECT_BLOCK%%.pdb.maxUnavailable` are empty.
   ##
   pdb:
-    create: false
-    minAvailable: 1
+    create: true
+    minAvailable: ""
     maxUnavailable: ""
   ## Autoscaling configuration
   ## ref: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/


### PR DESCRIPTION
## Description of the change

Enabled PodDisruptionBudget by default and little fixes in PDB configuration to allow users set PDB values in an easier way.

### Benefits

PDB protects our applications from voluntary disruption initiated by cluster administrators.
Users can set any of the PDB values without unsetting the other.

### Possible drawbacks

None

### Adition information

* [Pod disruption budgets](https://kubernetes.io/docs/concepts/workloads/pods/disruptions/#pod-disruption-budgets)
* [Specifying a Disruption Budget for your Application](https://kubernetes.io/docs/tasks/run-application/configure-pdb/)

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [N/A] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
