### PR TITLE
[bitnami/mongodb-sharded] Fix mongos livenessProbe

### DIFF
--- a/bitnami/mongodb-sharded/CHANGELOG.md
+++ b/bitnami/mongodb-sharded/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 8.2.2 (2024-05-28)
+## 8.2.3 (2024-05-30)
 
-* [bitnami/mongodb-sharded] Release 8.2.2 ([#26480](https://github.com/bitnami/charts/pull/26480))
+* [bitnami/mongodb-sharded] Fix mongos livenessProbe ([#26566](https://github.com/bitnami/charts/pull/26566))
+
+## <small>8.2.2 (2024-05-28)</small>
+
+* [bitnami/mongodb-sharded] Release 8.2.2 (#26480) ([673962c](https://github.com/bitnami/charts/commit/673962cb934f1899372497ae3964a5c6913b42df)), closes [#26480](https://github.com/bitnami/charts/issues/26480)
 
 ## <small>8.2.1 (2024-05-22)</small>
 

--- a/bitnami/mongodb-sharded/Chart.yaml
+++ b/bitnami/mongodb-sharded/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: mongodb-sharded
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/mongodb-sharded
-version: 8.2.2
+version: 8.2.3

--- a/bitnami/mongodb-sharded/templates/mongos/mongos-dep-sts.yaml
+++ b/bitnami/mongodb-sharded/templates/mongos/mongos-dep-sts.yaml
@@ -207,8 +207,8 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.mongos.livenessProbe "enabled") "context" $) | nindent 12 }}
             exec:
               command:
-                - pegrep
-                - mongod
+                - pgrep
+                - mongos
           {{- end }}
           {{- if .Values.mongos.customReadinessProbe }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.mongos.customReadinessProbe "context" $) | nindent 12 }}
@@ -216,8 +216,8 @@ spec:
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.mongos.readinessProbe "enabled") "context" $) | nindent 12 }}
             exec:
               command:
-                - /bin/sh 
-                - -c 
+                - /bin/sh
+                - -c
                 - mongosh --port $MONGODB_PORT_NUMBER --eval "db.adminCommand('ping')"
           {{- end }}
           {{- if .Values.mongos.customStartupProbe }}
@@ -225,7 +225,7 @@ spec:
           {{- else if .Values.mongos.startupProbe.enabled }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.mongos.startupProbe "enabled") "context" $) | nindent 12 }}
             tcpSocket:
-              port: mongodb 
+              port: mongodb
           {{- end }}
           {{- end }}
           {{- if .Values.mongos.lifecycleHooks }}


### PR DESCRIPTION
### Description of the change

Fixes the mongos deployment/statefulset liveness probe

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #26360

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
