### PR TITLE
[bitnami/redis-cluster] Template podAnnotation values

### DIFF
--- a/bitnami/redis-cluster/Chart.yaml
+++ b/bitnami/redis-cluster/Chart.yaml
@@ -14,22 +14,22 @@ annotations:
 apiVersion: v2
 appVersion: 7.2.5
 dependencies:
-- name: common
-  repository: oci://registry-1.docker.io/bitnamicharts
-  tags:
-  - bitnami-common
-  version: 2.x.x
+  - name: common
+    repository: oci://registry-1.docker.io/bitnamicharts
+    tags:
+      - bitnami-common
+    version: 2.x.x
 description: Redis(R) is an open source, scalable, distributed in-memory cache for applications. It can be used to store and serve data in the form of strings, hashes, lists, sets and sorted sets.
 home: https://bitnami.com
 icon: https://bitnami.com/assets/stacks/redis/img/redis-stack-220x234.png
 keywords:
-- redis
-- keyvalue
-- database
+  - redis
+  - keyvalue
+  - database
 maintainers:
-- name: Broadcom, Inc. All Rights Reserved.
-  url: https://github.com/bitnami/charts
+  - name: Broadcom, Inc. All Rights Reserved.
+    url: https://github.com/bitnami/charts
 name: redis-cluster
 sources:
-- https://github.com/bitnami/charts/tree/main/bitnami/redis-cluster
-version: 10.2.0
+  - https://github.com/bitnami/charts/tree/main/bitnami/redis-cluster
+version: 10.2.1

--- a/bitnami/redis-cluster/templates/redis-statefulset.yaml
+++ b/bitnami/redis-cluster/templates/redis-statefulset.yaml
@@ -36,10 +36,10 @@ spec:
         {{- end }}
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         {{- if .Values.redis.podAnnotations }}
-        {{- toYaml .Values.redis.podAnnotations | nindent 8 }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.redis.podAnnotations "context" $) | nindent 8 }}
         {{- end }}
         {{- if and .Values.metrics.enabled .Values.metrics.podAnnotations }}
-        {{- toYaml .Values.metrics.podAnnotations | nindent 8 }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.metrics.podAnnotations "context" $) | nindent 8 }}
         {{- end }}
     spec:
       hostNetwork: {{ .Values.redis.hostNetwork }}


### PR DESCRIPTION
### Description of the change

Add templating to sts' podAnnotations values.

### Benefits

values can contain helm template.

### Possible drawbacks

None that I know of.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
