### PR TITLE
[bitnami/redis-cluster] Template podAnnotation values

### DIFF
--- a/bitnami/redis-cluster/CHANGELOG.md
+++ b/bitnami/redis-cluster/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 10.2.0 (2024-05-23)
+## 10.2.1 (2024-05-31)
 
-* [bitnami/redis-cluster] Enable PodDisruptionBudgets ([#26375](https://github.com/bitnami/charts/pull/26375))
+* [bitnami/redis-cluster] Template podAnnotation values ([#26583](https://github.com/bitnami/charts/pull/26583))
+
+## 10.2.0 (2024-05-24)
+
+* [bitnami/redis-cluster] Enable PodDisruptionBudgets (#26375) ([50431fd](https://github.com/bitnami/charts/commit/50431fde7aaf7a1946de384cb15dff13961ccfe9)), closes [#26375](https://github.com/bitnami/charts/issues/26375)
 
 ## 10.1.0 (2024-05-21)
 

--- a/bitnami/redis-cluster/CHANGELOG.md
+++ b/bitnami/redis-cluster/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 10.2.1 (2024-05-31)
+## 10.2.1 (2024-06-02)
 
 * [bitnami/redis-cluster] Template podAnnotation values ([#26583](https://github.com/bitnami/charts/pull/26583))
 

--- a/bitnami/redis-cluster/Chart.yaml
+++ b/bitnami/redis-cluster/Chart.yaml
@@ -32,4 +32,4 @@ maintainers:
 name: redis-cluster
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/redis-cluster
-version: 10.2.0
+version: 10.2.1

--- a/bitnami/redis-cluster/templates/redis-statefulset.yaml
+++ b/bitnami/redis-cluster/templates/redis-statefulset.yaml
@@ -36,10 +36,10 @@ spec:
         {{- end }}
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         {{- if .Values.redis.podAnnotations }}
-        {{- toYaml .Values.redis.podAnnotations | nindent 8 }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.redis.podAnnotations "context" $) | nindent 8 }}
         {{- end }}
         {{- if and .Values.metrics.enabled .Values.metrics.podAnnotations }}
-        {{- toYaml .Values.metrics.podAnnotations | nindent 8 }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.metrics.podAnnotations "context" $) | nindent 8 }}
         {{- end }}
     spec:
       hostNetwork: {{ .Values.redis.hostNetwork }}


### PR DESCRIPTION
### Description of the change

Add templating to sts' podAnnotations values.

### Benefits

values can contain helm template.

### Possible drawbacks

None that I know of.

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
