### PR TITLE
[bitnami/seaweedfs] Fix tests

### DIFF
--- a/.vib/seaweedfs/ginkgo/seaweedfs_suite_test.go
+++ b/.vib/seaweedfs/ginkgo/seaweedfs_suite_test.go
@@ -68,22 +68,12 @@ func createPVC(ctx context.Context, c kubernetes.Interface, name, size string) e
 	return err
 }
 
-func createJob(ctx context.Context, c kubernetes.Interface, name, port, image, pvcName, kind string) error {
+func createJob(ctx context.Context, c kubernetes.Interface, name, port, image, pvcName, kind string, fsGroup, user *int64) error {
 	podSecurityContext := &v1.PodSecurityContext{
-		FSGroup:             &[]int64{1001}[0],
-		FSGroupChangePolicy: &[]v1.PodFSGroupChangePolicy{v1.FSGroupChangeAlways}[0],
+		FSGroup: fsGroup,
 	}
 	containerSecurityContext := &v1.SecurityContext{
-		Privileged:               &[]bool{false}[0],
-		AllowPrivilegeEscalation: &[]bool{false}[0],
-		RunAsUser:                &[]int64{1001}[0],
-		RunAsNonRoot:             &[]bool{true}[0],
-		Capabilities: &v1.Capabilities{
-			Drop: []v1.Capability{"ALL"},
-		},
-		SeccompProfile: &v1.SeccompProfile{
-			Type: "RuntimeDefault",
-		},
+		RunAsUser: user,
 	}
 
 	args := []string{"-ec"}


### PR DESCRIPTION
### Description of the change
Add `runAsUser` and `fsGroup` to the testing jobs based on the values from the main pod.

### Benefits
Testing jobs can run on Openshift.

### Checklist
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
