### PR TITLE
[bitnami/kubeapps] Use nginx for testing

### DIFF
--- a/.vib/kubeapps/cypress/cypress/e2e/kubeapps.cy.js
+++ b/.vib/kubeapps/cypress/cypress/e2e/kubeapps.cy.js
@@ -12,14 +12,12 @@ it('allows managing a helm chart release', () => {
   // Prefer UI interaction over direct navigation because the URL includes references to
   // the ns name, which is only known at runtime.
   cy.contains('Catalog').click();
-  cy.wait(5000);
   cy.fixture('releases').then((releases) => {
     const releaseName = `${releases.newRelease.name}-${random}`
 
     cy.contains('div.card', releases.newRelease.application).click();
     cy.contains(Cypress.env('registryName'));
     cy.contains('Deploy').click();
-    cy.wait(5000);
     cy.get('#releaseName').type(releaseName);
 
     // TKG clusters may enforce PodSecurity policies, so podSecurityContext and

--- a/.vib/kubeapps/cypress/cypress/fixtures/releases.json
+++ b/.vib/kubeapps/cypress/cypress/fixtures/releases.json
@@ -1,6 +1,6 @@
 {
   "newRelease": {
-    "application": "apache",
+    "application": "nginx",
     "name": "oatmeal"
   }
 }

--- a/.vib/kubeapps/runtime-parameters.yaml
+++ b/.vib/kubeapps/runtime-parameters.yaml
@@ -24,6 +24,8 @@ apprepository:
   initialRepos:
     - name: bitnami
       url: https://charts.bitnami.com/bitnami
+      filterRule:
+        jq: .name == "nginx"
   watchAllNamespaces: false
 authProxy:
   enabled: false


### PR DESCRIPTION
### Description of the change

Filter the charts synced by the apprepository job and use `nginx` for testing.

### Benefits

Reduce the load in the testing infrastructure and use `nginx` because it allows us to set `securityContext`s in the deploy.

### Possible drawbacks

None

### Applicable issues

Several PRs are blocked due to this failure.
* #26505
* #26573
* #26488
### Additional information

This is a [succeeded execution](https://github.com/bitnami/charts/actions/runs/9352171884/job/25739875791?pr=26605)

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [N/A] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [N/A] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
