### PR TITLE
[bitnami/mongodb] Remove UTF-8 chars

### DIFF
--- a/bitnami/mongodb/CHANGELOG.md
+++ b/bitnami/mongodb/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 15.6.1 (2024-05-28)
+## 15.6.2 (2024-06-03)
 
-* [bitnami/mongodb] Release 15.6.1 ([#26481](https://github.com/bitnami/charts/pull/26481))
+* [bitnami/mongodb] Remove UTF-8 chars ([#26607](https://github.com/bitnami/charts/pull/26607))
+
+## <small>15.6.1 (2024-05-28)</small>
+
+* [bitnami/mongodb] Release 15.6.1 (#26481) ([f4dbc07](https://github.com/bitnami/charts/commit/f4dbc07bf19489d2ce4156675c1cf7e291ad0385)), closes [#26481](https://github.com/bitnami/charts/issues/26481)
 
 ## 15.6.0 (2024-05-24)
 

--- a/bitnami/mongodb/Chart.yaml
+++ b/bitnami/mongodb/Chart.yaml
@@ -39,4 +39,4 @@ maintainers:
 name: mongodb
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/mongodb
-version: 15.6.1
+version: 15.6.2

--- a/bitnami/mongodb/values.yaml
+++ b/bitnami/mongodb/values.yaml
@@ -959,7 +959,7 @@ externalAccess:
     ##
     loadBalancerIPs: []
     ## @param externalAccess.service.publicNames Array of public names. The size should be equal to the number of replicas.
-    ## 
+    ##
     publicNames: []
     ## @param externalAccess.service.loadBalancerClass loadBalancerClass when service type is LoadBalancer
     # ref: https://kubernetes.io/docs/concepts/services-networking/service/#load-balancer-class


### PR DESCRIPTION
This PR removes Unicode characters from the values.yaml which isn't compatible with certain automation tools.

Before:
```console
$ perl -ne 'print "$. $_" if m/[\x80-\xFF]/' bitnami/mongodb/values.yaml
962     ##

$ encguess bitnami/mongodb/values.yaml
bitnami/mongodb/values.yaml	UTF-8

$ uchardet bitnami/mongodb/values.yaml
UTF-8
```

After:
```console
$ perl -ne 'print "$. $_" if m/[\x80-\xFF]/' bitnami/mongodb/values.yaml

$ encguess bitnami/mongodb/values.yaml
bitnami/mongodb/values.yaml	US-ASCII

$ uchardet bitnami/mongodb/values.yaml
ASCII
```

⚠️ It seems the check implemented at https://github.com/bitnami/charts/pull/25542 is not enough