### PR TITLE
CI: Verify values.yaml are ASCII

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -201,6 +201,12 @@ jobs:
               echo "error=Please ensure there are no unprintable characters in the bitnami/${CHART}/values.yaml file"
               exit "$exit_code"
             fi
+            # Ensuring ASCII characters in values.yaml
+            encguess bitnami/${CHART}/values.yaml | grep ASCII || exit_code=$?
+            if [[ $exit_code -ne 0 ]]; then
+              echo "error=Please ensure all characters in the bitnami/${CHART}/values.yaml file are ASCII. Check with perl -ne 'print "$. $_" if m/[\x80-\xFF]/' bitnami/${CHART}//values.yaml"
+              exit "$exit_code"
+            fi
             echo "Updating README.md for bitnami/${CHART}"
             readme-generator --values "bitnami/${CHART}/values.yaml" --readme "bitnami/${CHART}/README.md" --schema "/tmp/schema.json"
             # Commit all changes, if any


### PR DESCRIPTION
This PR aims to verify that values.yaml are encoded as ASCII to avoid issues like the ones solved at https://github.com/bitnami/charts/pull/26607 and https://github.com/bitnami/charts/pull/26608