### PR TITLE
[bitnami/mediawiki] Fix typo in deployment.yaml template

### DIFF
--- a/bitnami/mediawiki/CHANGELOG.md
+++ b/bitnami/mediawiki/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 20.2.0 (2024-05-28)
+## 20.2.1 (2024-06-04)
 
-* [bitnami/mediawiki] Enable PodDisruptionBudgets ([#26510](https://github.com/bitnami/charts/pull/26510))
+* [bitnami/mediawiki] Fix typo in deployment.yaml template ([#26615](https://github.com/bitnami/charts/pull/26615))
+
+## 20.2.0 (2024-06-03)
+
+* [bitnami/mediawiki] Enable PodDisruptionBudgets (#26510) ([610f625](https://github.com/bitnami/charts/commit/610f62562ba92ba853b037ad9e8e04de7c947790)), closes [#26510](https://github.com/bitnami/charts/issues/26510)
 
 ## 20.1.0 (2024-05-21)
 

--- a/bitnami/mediawiki/Chart.yaml
+++ b/bitnami/mediawiki/Chart.yaml
@@ -39,4 +39,4 @@ maintainers:
 name: mediawiki
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/mediawiki
-version: 20.2.0
+version: 20.2.1

--- a/bitnami/mediawiki/templates/deployment.yaml
+++ b/bitnami/mediawiki/templates/deployment.yaml
@@ -229,7 +229,7 @@ spec:
               subPath: apache-logs-dir
             - name: empty-dir
               mountPath: /opt/bitnami/apache/var/run
-              subPath: apcahe-tmp-dir
+              subPath: apache-tmp-dir
             - name: empty-dir
               mountPath: /opt/bitnami/php/etc
               subPath: php-conf-dir


### PR DESCRIPTION
### Description of the change

Fix typo in deployment.yaml template file.

### Benefits

Fix typo.

### Possible drawbacks

None.

### Applicable issues

N/A

### Additional information

N/A

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
