### PR TITLE
[bitnami/phpmyadmin] Fix typo in deployment.yaml template

### DIFF
--- a/bitnami/phpmyadmin/CHANGELOG.md
+++ b/bitnami/phpmyadmin/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
+## 16.2.1 (2024-06-04)
+
+* [bitnami/phpmyadmin] Fix typo in deployment.yaml template ([#26616](https://github.com/bitnami/charts/pull/26616))
+
 ## 16.2.0 (2024-05-29)
 
-* [bitnami/phpmyadmin] Enable PodDisruptionBudgets ([#26528](https://github.com/bitnami/charts/pull/26528))
+* [bitnami/phpmyadmin] Enable PodDisruptionBudgets (#26528) ([9f90a31](https://github.com/bitnami/charts/commit/9f90a31561545ecacbc62f5c8fe9343b85fbc846)), closes [#26528](https://github.com/bitnami/charts/issues/26528)
 
 ## 16.1.0 (2024-05-21)
 

--- a/bitnami/phpmyadmin/Chart.yaml
+++ b/bitnami/phpmyadmin/Chart.yaml
@@ -36,4 +36,4 @@ maintainers:
 name: phpmyadmin
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/phpmyadmin
-version: 16.2.0
+version: 16.2.1

--- a/bitnami/phpmyadmin/templates/deployment.yaml
+++ b/bitnami/phpmyadmin/templates/deployment.yaml
@@ -224,7 +224,7 @@ spec:
               subPath: apache-logs-dir
             - name: empty-dir
               mountPath: /opt/bitnami/apache/var/run
-              subPath: apcahe-tmp-dir
+              subPath: apache-tmp-dir
             - name: empty-dir
               mountPath: /opt/bitnami/php/etc
               subPath: php-conf-dir


### PR DESCRIPTION
### Description of the change

Fix typo in deployment.yaml template file.

### Benefits

Fix typo.

### Possible drawbacks

None.

### Applicable issues

N/A

### Additional information

N/A

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
