### PR TITLE
[bitnami/dokuwiki] Fix typo in deployment.yaml template

### DIFF
--- a/bitnami/dokuwiki/CHANGELOG.md
+++ b/bitnami/dokuwiki/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 16.2.1 (2024-06-04)
+## 16.2.2 (2024-06-04)
 
-* [bitnami/dokuwiki] Bump chart version ([#26627](https://github.com/bitnami/charts/pull/26627))
+* [bitnami/dokuwiki] Fix typo in deployment.yaml template ([#26678](https://github.com/bitnami/charts/pull/26678))
+
+## <small>16.2.1 (2024-06-04)</small>
+
+* [bitnami/dokuwiki] Bump chart version (#26627) ([64ab63c](https://github.com/bitnami/charts/commit/64ab63cc2305887ba762cee47f84bda22494db4c)), closes [#26627](https://github.com/bitnami/charts/issues/26627)
 
 ## 16.2.0 (2024-05-27)
 

--- a/bitnami/dokuwiki/Chart.yaml
+++ b/bitnami/dokuwiki/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: dokuwiki
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/dokuwiki
-version: 16.2.1
+version: 16.2.2

--- a/bitnami/dokuwiki/templates/deployment.yaml
+++ b/bitnami/dokuwiki/templates/deployment.yaml
@@ -293,7 +293,7 @@ spec:
               subPath: apache-logs-dir
             - name: empty-dir
               mountPath: /opt/bitnami/apache/var/run
-              subPath: apcahe-tmp-dir
+              subPath: apache-tmp-dir
             - name: empty-dir
               mountPath: /opt/bitnami/php/etc
               subPath: php-conf-dir


### PR DESCRIPTION
### Description of the change

Fix typo in deployment.yaml template.

### Benefits

Fix typo.

### Possible drawbacks

None.

### Applicable issues

N/A

### Additional information

N/A

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
