### PR TITLE
[bitnami/apache] Enable PodDisruptionBudgets

### DIFF
--- a/bitnami/apache/CHANGELOG.md
+++ b/bitnami/apache/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 11.1.2 (2024-06-04)
+## 11.2.0 (2024-06-04)
 
-* [bitnami/apache] Bump chart version ([#26620](https://github.com/bitnami/charts/pull/26620))
+* [bitnami/apache] Enable PodDisruptionBudgets ([#26685](https://github.com/bitnami/charts/pull/26685))
+
+## <small>11.1.2 (2024-06-04)</small>
+
+* [bitnami/apache] Bump chart version (#26620) ([9bae7f7](https://github.com/bitnami/charts/commit/9bae7f7b76c811851721f4bb3de1df8da6151502)), closes [#26620](https://github.com/bitnami/charts/issues/26620)
 
 ## <small>11.1.1 (2024-05-29)</small>
 

--- a/bitnami/apache/Chart.yaml
+++ b/bitnami/apache/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: apache
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/apache
-version: 11.1.2
+version: 11.2.0

--- a/bitnami/apache/README.md
+++ b/bitnami/apache/README.md
@@ -213,8 +213,8 @@ As an alternative, you can use  the preset configurations for pod affinity, pod 
 
 | Name                       | Description                                                    | Value   |
 | -------------------------- | -------------------------------------------------------------- | ------- |
-| `pdb.create`               | Enable a Pod Disruption Budget creation                        | `false` |
-| `pdb.minAvailable`         | Minimum number/percentage of pods that should remain scheduled | `1`     |
+| `pdb.create`               | Enable a Pod Disruption Budget creation                        | `true`  |
+| `pdb.minAvailable`         | Minimum number/percentage of pods that should remain scheduled | `""`    |
 | `pdb.maxUnavailable`       | Maximum number/percentage of pods that may be made unavailable | `""`    |
 | `autoscaling.enabled`      | Enable Horizontal POD autoscaling for Apache                   | `false` |
 | `autoscaling.minReplicas`  | Minimum number of Apache replicas                              | `1`     |

--- a/bitnami/apache/templates/pdb.yaml
+++ b/bitnami/apache/templates/pdb.yaml
@@ -17,8 +17,8 @@ spec:
   {{- if .Values.pdb.minAvailable }}
   minAvailable: {{ .Values.pdb.minAvailable }}
   {{- end }}
-  {{- if .Values.pdb.maxUnavailable }}
-  maxUnavailable: {{ .Values.pdb.maxUnavailable }}
+  {{- if or .Values.pdb.maxUnavailable ( not .Values.pdb.minAvailable ) }}
+  maxUnavailable: {{ .Values.pdb.maxUnavailable | default 1 }}
   {{- end }}
   {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.podLabels .Values.commonLabels ) "context" . ) }}
   selector:

--- a/bitnami/apache/values.yaml
+++ b/bitnami/apache/values.yaml
@@ -425,8 +425,8 @@ updateStrategy:
 ## @param pdb.maxUnavailable Maximum number/percentage of pods that may be made unavailable
 ##
 pdb:
-  create: false
-  minAvailable: 1
+  create: true
+  minAvailable: ""
   maxUnavailable: ""
 ## Apache Autoscaling parameters
 ## ref: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/


### PR DESCRIPTION
### Description of the change

Enabled PodDisruptionBudget by default and little fixes in PDB configuration to keep it aligned with current templates.

### Benefits

PDB protects our applications from voluntary disruption initiated by cluster administrators.
Keep our charts up to date according to our templates.

### Possible drawbacks

None

### Adition information

* [Pod disruption budgets](https://kubernetes.io/docs/concepts/workloads/pods/disruptions/#pod-disruption-budgets)
* [Specifying a Disruption Budget for your Application](https://kubernetes.io/docs/tasks/run-application/configure-pdb/)

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
