### PR TITLE
[bitnami/memcached] Align PodDisruptionBudgets with templates

### DIFF
--- a/bitnami/memcached/CHANGELOG.md
+++ b/bitnami/memcached/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 7.4.3 (2024-06-04)
+## 7.4.4 (2024-06-04)
 
-* [bitnami/memcached] Bump chart version ([#26646](https://github.com/bitnami/charts/pull/26646))
+* [bitnami/memcached] Enable PodDisruptionBudgets ([#26703](https://github.com/bitnami/charts/pull/26703))
+
+## <small>7.4.3 (2024-06-04)</small>
+
+* [bitnami/memcached] Bump chart version (#26646) ([466704c](https://github.com/bitnami/charts/commit/466704cfdc681cb9cce81225e7e59c1e0bb7a0d0)), closes [#26646](https://github.com/bitnami/charts/issues/26646)
 
 ## <small>7.4.2 (2024-05-31)</small>
 

--- a/bitnami/memcached/Chart.yaml
+++ b/bitnami/memcached/Chart.yaml
@@ -31,4 +31,4 @@ maintainers:
 name: memcached
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/memcached
-version: 7.4.3
+version: 7.4.4

--- a/bitnami/memcached/README.md
+++ b/bitnami/memcached/README.md
@@ -234,7 +234,7 @@ If you encounter errors when working with persistent volumes, refer to our [trou
 | `autoscaling.targetMemory`                          | memcached statefulset autoscaling target CPU memory                                                                                                                                                               | `50`             |
 | `pdb.create`                                        | Deploy a pdb object for the Memcached pod                                                                                                                                                                         | `true`           |
 | `pdb.minAvailable`                                  | Minimum available Memcached replicas                                                                                                                                                                              | `""`             |
-| `pdb.maxUnavailable`                                | Maximum unavailable Memcached replicas                                                                                                                                                                            | `1`              |
+| `pdb.maxUnavailable`                                | Maximum unavailable Memcached replicas                                                                                                                                                                            | `""`             |
 
 ### Traffic Exposure parameters
 

--- a/bitnami/memcached/templates/pdb.yaml
+++ b/bitnami/memcached/templates/pdb.yaml
@@ -17,8 +17,8 @@ spec:
   {{- if .Values.pdb.minAvailable }}
   minAvailable: {{ .Values.pdb.minAvailable }}
   {{- end }}
-  {{- if .Values.pdb.maxUnavailable }}
-  maxUnavailable: {{ .Values.pdb.maxUnavailable }}
+  {{- if or .Values.pdb.maxUnavailable ( not .Values.pdb.minAvailable ) }}
+  maxUnavailable: {{ .Values.pdb.maxUnavailable | default 1 }}
   {{- end }}
   {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.podLabels .Values.commonLabels ) "context" . ) }}
   selector:

--- a/bitnami/memcached/values.yaml
+++ b/bitnami/memcached/values.yaml
@@ -420,7 +420,7 @@ autoscaling:
 pdb:
   create: true
   minAvailable: ""
-  maxUnavailable: 1
+  maxUnavailable: ""
 ## @section Traffic Exposure parameters
 service:
   ## @param service.type Kubernetes Service type


### PR DESCRIPTION
### Description of the change

Little fixes in PDB configuration to keep it aligned with current templates.


### Benefits

Keep our charts up to date according to our templates.

### Possible drawbacks

None

### Adition information

* [Pod disruption budgets](https://kubernetes.io/docs/concepts/workloads/pods/disruptions/#pod-disruption-budgets)
* [Specifying a Disruption Budget for your Application](https://kubernetes.io/docs/tasks/run-application/configure-pdb/)

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
