### PR TITLE
[bitnami/kubeapps] Fix permissions for apprepositories issue 5323 tanzu

### DIFF
--- a/bitnami/kubeapps/CHANGELOG.md
+++ b/bitnami/kubeapps/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 15.2.1 (2024-06-05)
+## 15.2.2 (2024-06-05)
 
-* [bitnami/kubeapps] Bump chart version ([#26784](https://github.com/bitnami/charts/pull/26784))
+* [bitnami/kubeapps] Fix permissions for apprepositories issue 5323 tanzu ([#26814](https://github.com/bitnami/charts/pull/26814))
+
+## <small>15.2.1 (2024-06-05)</small>
+
+* [bitnami/kubeapps] Bump chart version (#26784) ([30ed241](https://github.com/bitnami/charts/commit/30ed241740bd6dab47af5ec3ebfbae0fc2aa4970)), closes [#26784](https://github.com/bitnami/charts/issues/26784)
 
 ## 15.2.0 (2024-06-04)
 

--- a/bitnami/kubeapps/Chart.yaml
+++ b/bitnami/kubeapps/Chart.yaml
@@ -52,4 +52,4 @@ maintainers:
 name: kubeapps
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/kubeapps
-version: 15.2.1
+version: 15.2.2

--- a/bitnami/kubeapps/templates/apprepository/rbac.yaml
+++ b/bitnami/kubeapps/templates/apprepository/rbac.yaml
@@ -151,6 +151,7 @@ rules:
       - secrets
     verbs:
       - create
+      - get
 ---
 # The Kubeapps app repository controller can read and watch its own
 # AppRepository resources cluster-wide. The read and write cluster-roles can
@@ -175,6 +176,12 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - kubeapps.com
+    resources:
+      - secrets
+    verbs:
+      - get
 ---
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRoleBinding


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

 [bitnami/kubeapps] RBAC
Fix RBAC  permissions for apprepositories issue 5323 tanzu 
Replaces PR #26488

### Benefits

Fix error:
```
Missing permissions internal: Unable to fetch app repo "datahub-repo" from namespace "kubeapps": unable to read secret "apprepo-datahub-repo-secrets": secrets "apprepo-datahub-repo-secrets" is forbidden: User "xxxxxxx" cannot get resource "secrets" in API group "" in the namespace "kubeapps".
```
### Possible drawbacks

N/A

### Applicable issues

- Fixes https://github.com/bitnami/charts/issues/26478
- Related to https://github.com/vmware-tanzu/kubeapps/issues/5323

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
