### PR TITLE
[bitnami/mlflow] Fix tests definition and remove legacy code from PDBs

### DIFF
--- a/.vib/mlflow/goss/goss.yaml
+++ b/.vib/mlflow/goss/goss.yaml
@@ -30,12 +30,12 @@ http:
     status: 401
     timeout: 10000
   # Authenticated
-  http://mlflow-tracking:{{ .Vars.tracking.service.ports.http }}:
+  http://mlflow-tracking:{{ .Vars.tracking.service.ports.http }}/:
     status: 200
     username: {{ .Vars.tracking.auth.username }}
     password: {{ .Vars.tracking.auth.password  }}
     timeout: 10000
-  http://127.0.0.1:{{ .Vars.tracking.containerPorts.http }}:
+  http://127.0.0.1:{{ .Vars.tracking.containerPorts.http }}/:
     status: 200
     username: {{ .Vars.tracking.auth.username }}
     password: {{ .Vars.tracking.auth.password  }}

--- a/bitnami/mlflow/CHANGELOG.md
+++ b/bitnami/mlflow/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 1.4.1 (2024-06-05)
+## 1.4.2 (2024-06-06)
 
-* [bitnami/mlflow] Bump chart version ([#26848](https://github.com/bitnami/charts/pull/26848))
+* [bitnami/mlflow] Fix tests definition and remove legacy code from PDBs ([#26895](https://github.com/bitnami/charts/pull/26895))
+
+## <small>1.4.1 (2024-06-05)</small>
+
+* [bitnami/mlflow] Bump chart version (#26848) ([c01d8ed](https://github.com/bitnami/charts/commit/c01d8edce57340a0f0b2a386ad2480162f7249f4)), closes [#26848](https://github.com/bitnami/charts/issues/26848)
 
 ## 1.4.0 (2024-06-05)
 

--- a/bitnami/mlflow/Chart.yaml
+++ b/bitnami/mlflow/Chart.yaml
@@ -44,4 +44,4 @@ sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/mlflow
   - https://github.com/bitnami/containers/tree/main/bitnami/mlflow
   - https://github.com/mlflow/mlflow
-version: 1.4.1
+version: 1.4.2

--- a/bitnami/mlflow/templates/tracking/pdb.yaml
+++ b/bitnami/mlflow/templates/tracking/pdb.yaml
@@ -3,8 +3,7 @@ Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- $replicaCount := int .Values.tracking.replicaCount }}
-{{- if and .Values.tracking.enabled .Values.tracking.pdb.create (or (gt $replicaCount 1) .Values.tracking.autoscaling.hpa.enabled) }}
+{{- if and .Values.tracking.enabled .Values.tracking.pdb.create }}
 apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:


### PR DESCRIPTION
### Description of the change

Fix tests definition, adding a final dash to avoid entries with the same name.
Clean legacy code from the PDB.

### Benefits

mlflow can pass the tests again.

### Possible drawbacks

None

### Applicable issues


### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
