### PR TITLE
[bitnami/common] improve renderSecurityContext

### DIFF
--- a/bitnami/common/CHANGELOG.md
+++ b/bitnami/common/CHANGELOG.md
@@ -1,8 +1,14 @@
 # Changelog
 
+## 2.20.1 (2024-06-07)
+
+* [bitnami/common] improve renderSecurityContext ([#27053](https://github.com/bitnami/charts/pull/27053))
+
 ## 2.20.0 (2024-06-05)
 
-* [bitnami/common] Capabilities to return latest apiVersion if kubeVersion is undefined ([#26758](https://github.com/bitnami/charts/pull/26758))
+* [bitnami/*] ci: :construction_worker: Add tag and changelog support (#25359) ([91c707c](https://github.com/bitnami/charts/commit/91c707c9e4e574725a09505d2d313fb93f1b4c0a)), closes [#25359](https://github.com/bitnami/charts/issues/25359)
+* [bitnami/common] Capabilities to return latest apiVersion if kubeVersion is undefined (#26758) ([6582c32](https://github.com/bitnami/charts/commit/6582c3237b772af9cb379f7eaceddb2d64b507f0)), closes [#26758](https://github.com/bitnami/charts/issues/26758)
+* [bitnami/common] docs: :memo: Add changelog ([23349c9](https://github.com/bitnami/charts/commit/23349c99b70313f3e19ebcf9d3e0c154836b2cc0))
 
 ## <small>2.19.3 (2024-05-20)</small>
 

--- a/bitnami/common/Chart.yaml
+++ b/bitnami/common/Chart.yaml
@@ -6,7 +6,7 @@ annotations:
   licenses: Apache-2.0
 apiVersion: v2
 # Please make sure that version and appVersion are always the same.
-appVersion: 2.20.0
+appVersion: 2.20.1
 description: A Library Helm Chart for grouping common logic between bitnami charts. This chart is not deployable by itself.
 home: https://bitnami.com
 icon: https://bitnami.com/downloads/logos/bitnami-mark.png
@@ -23,4 +23,4 @@ name: common
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/common
 type: library
-version: 2.20.0
+version: 2.20.1

--- a/bitnami/common/templates/_compatibility.tpl
+++ b/bitnami/common/templates/_compatibility.tpl
@@ -34,5 +34,9 @@ Usage:
     {{- end -}}
   {{- end -}}
 {{- end -}}
+{{/* Remove fields that are disregarded when running the container in privileged mode */}}
+{{- if $adaptedContext.privileged -}}
+  {{- $adaptedContext = omit $adaptedContext "capabilities" "readOnlyRootFilesystem" "runAsNonRoot" "seLinuxOptions" -}}
+{{- end -}}
 {{- omit $adaptedContext "enabled" | toYaml -}}
 {{- end -}}

--- a/bitnami/common/templates/_compatibility.tpl
+++ b/bitnami/common/templates/_compatibility.tpl
@@ -36,7 +36,7 @@ Usage:
 {{- end -}}
 {{/* Remove fields that are disregarded when running the container in privileged mode */}}
 {{- if $adaptedContext.privileged -}}
-  {{- $adaptedContext = omit $adaptedContext "capabilities" "runAsNonRoot" "seLinuxOptions" -}}
+  {{- $adaptedContext = omit $adaptedContext "capabilities" "seLinuxOptions" -}}
 {{- end -}}
 {{- omit $adaptedContext "enabled" | toYaml -}}
 {{- end -}}

--- a/bitnami/common/templates/_compatibility.tpl
+++ b/bitnami/common/templates/_compatibility.tpl
@@ -36,7 +36,7 @@ Usage:
 {{- end -}}
 {{/* Remove fields that are disregarded when running the container in privileged mode */}}
 {{- if $adaptedContext.privileged -}}
-  {{- $adaptedContext = omit $adaptedContext "capabilities" "readOnlyRootFilesystem" "runAsNonRoot" "seLinuxOptions" -}}
+  {{- $adaptedContext = omit $adaptedContext "capabilities" "runAsNonRoot" "seLinuxOptions" -}}
 {{- end -}}
 {{- omit $adaptedContext "enabled" | toYaml -}}
 {{- end -}}


### PR DESCRIPTION
### Description of the change

This PR improves `common.compatibility.renderSecurityContext` helper by ensuring that disregarded fields are omitted when running a container in privileged mode.

### Benefits

Simplify (when possible) rendered container security contexts.

### Possible drawbacks

None

### Applicable issues

None

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
