### PR TITLE
[bitnami/argo-cd] Typo in notifications service

### DIFF
--- a/bitnami/argo-cd/Chart.yaml
+++ b/bitnami/argo-cd/Chart.yaml
@@ -39,4 +39,4 @@ maintainers:
 name: argo-cd
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/argo-cd
-version: 6.4.5
+version: 6.4.6

--- a/bitnami/argo-cd/templates/notifications/metrics-svc.yaml
+++ b/bitnami/argo-cd/templates/notifications/metrics-svc.yaml
@@ -39,7 +39,7 @@ spec:
   ports:
     - name:  http-metrics
       targetPort: metrics
-      port: {{ coalesce .Values.notifications.metrics.service.port .Valeus.notifications.metrics.service.ports.metrics }}
+      port: {{ coalesce .Values.notifications.metrics.service.port .Values.notifications.metrics.service.ports.metrics }}
       protocol: TCP
       {{- if (and (or (eq .Values.notifications.metrics.service.type "NodePort") (eq .Values.notifications.metrics.service.type "LoadBalancer")) (not (empty (coalesce .Values.notifications.metrics.service.nodePort .Values.notifications.metrics.service.nodePorts.metrics)))) }}
       nodePort: {{ coalesce .Values.notifications.metrics.service.nodePort .Values.notifications.metrics.service.nodePorts.metrics }}


### PR DESCRIPTION
### Description of the change

A typo was introduced in the metrics service for notification. This is fixing it.

### Benefits
Now metrics will work
### Possible drawbacks
None
### Applicable issues

```
Error: template: argo-cd/templates/notifications/metrics-svc.yaml:42:74: executing "argo-cd/templates/notifications/metrics-svc.yaml" at <.Valeus.notifications.metrics.service.ports.metrics>: nil pointer evaluating interface {}.notifications Use --debug flag to render out invalid YAML
```
### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
