### PR TITLE
[bitnami/janusgraph] Fix storage password secretName helper function

### DIFF
--- a/bitnami/janusgraph/CHANGELOG.md
+++ b/bitnami/janusgraph/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 0.3.7 (2024-06-06)
+## 0.3.8 (2024-06-10)
 
-* [bitnami/janusgraph] Release 0.3.7 ([#26963](https://github.com/bitnami/charts/pull/26963))
+* [bitnami/janusgraph] Fix storage password secretName helper function ([#27074](https://github.com/bitnami/charts/pull/27074))
+
+## <small>0.3.7 (2024-06-06)</small>
+
+* [bitnami/janusgraph] Release 0.3.7 (#26963) ([0ee8a5b](https://github.com/bitnami/charts/commit/0ee8a5bac4ea4b18d6828e7fcfa43259d31d48ca)), closes [#26963](https://github.com/bitnami/charts/issues/26963)
 
 ## <small>0.3.6 (2024-06-06)</small>
 

--- a/bitnami/janusgraph/Chart.yaml
+++ b/bitnami/janusgraph/Chart.yaml
@@ -38,4 +38,4 @@ sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/janusgraph
 - https://github.com/bitnami/containers/tree/main/bitnami/janusgraph
 - https://github.com/janusgraph/janusgraph
-version: 0.3.7
+version: 0.3.8

--- a/bitnami/janusgraph/templates/_helpers.tpl
+++ b/bitnami/janusgraph/templates/_helpers.tpl
@@ -254,7 +254,7 @@ Create the storage password secret name
 */}}
 {{- define "janusgraph.storage.password.secretName" -}}
 {{- if .Values.storageBackend.cassandra.enabled -}}
-{{- printf "%s-cassandra" (include "common.names.fullname" .) -}}
+{{- include "common.names.dependency.fullname" (dict "chartName" "cassandra" "chartValues" .Values.storageBackend.cassandra "context" $) -}}
 {{- else if .Values.storageBackend.external.existingSecret -}}
 {{- print (tpl .Values.storageBackend.external.existingSecret .) -}}
 {{- end -}}


### PR DESCRIPTION
### Description of the change

This PR fixes an issue resolving the storage password secretName when the release name is not "janusgraph".

### Applicable issues

- fixes #26354

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] n/a ~Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)~
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
