### PR TITLE
[CI/CD] Remove registry from container list

### DIFF
--- a/.github/workflows/cd-pipeline.yml
+++ b/.github/workflows/cd-pipeline.yml
@@ -224,13 +224,13 @@ jobs:
           # Get chart and app version
           chart_version="$(yq e '.version' "${chart}/Chart.yaml")"
           app_version="$(yq e '.appVersion' "${chart}/Chart.yaml")"
-          # Get image list
+          # Get image list (removing the registry)
           helm dep build ${chart}
-          image_list="$(yq '.annotations.images' "${chart}/Chart.yaml" | yq '[ .[] | .image ] | tojson')"
+          image_list="$(yq '.annotations.images' "${chart}/Chart.yaml" | yq '[ .[] | .image | sub("^[^/]+/", "")] ] | tojson')"
           for dependency in "${chart}/charts/"*.tgz; do
             chart_yaml_file="$(tar -tzf "$dependency" | grep -E "^[^/]+/Chart.yaml$")"
             if [[ -n "${chart_yaml_file}" ]]; then
-              dependency_image_list="$(tar -xzO -f "$dependency" "$chart_yaml_file" | yq '.annotations.images' | yq '[ .[] | .image ] | tojson')"
+              dependency_image_list="$(tar -xzO -f "$dependency" "$chart_yaml_file" | yq '.annotations.images' | yq '[ .[] | .image | sub("^[^/]+/", "") ] | tojson')"
               image_list="$(jq -c --null-input --argjson arr1 "$image_list" --argjson arr2 "$dependency_image_list" '$arr1 + $arr2 | unique')"
             fi
           done

--- a/.github/workflows/cd-pipeline.yml
+++ b/.github/workflows/cd-pipeline.yml
@@ -228,10 +228,12 @@ jobs:
           helm dep build ${chart}
           image_list="$(yq '.annotations.images' "${chart}/Chart.yaml" | yq '[ .[] | .image | sub("^[^/]+/", "")] ] | tojson')"
           for dependency in "${chart}/charts/"*.tgz; do
-            chart_yaml_file="$(tar -tzf "$dependency" | grep -E "^[^/]+/Chart.yaml$")"
-            if [[ -n "${chart_yaml_file}" ]]; then
-              dependency_image_list="$(tar -xzO -f "$dependency" "$chart_yaml_file" | yq '.annotations.images' | yq '[ .[] | .image | sub("^[^/]+/", "") ] | tojson')"
-              image_list="$(jq -c --null-input --argjson arr1 "$image_list" --argjson arr2 "$dependency_image_list" '$arr1 + $arr2 | unique')"
+            if [[ -f "$dependency" ]] && [[ -s "$dependency" ]]; then
+              chart_yaml_file="$(tar -tzf "$dependency" | grep -E "^[^/]+/Chart.yaml$")"
+              if [[ -n "${chart_yaml_file}" ]]; then
+                dependency_image_list="$(tar -xzO -f "$dependency" "$chart_yaml_file" | yq '.annotations.images' | yq '[ .[] | .image | sub("^[^/]+/", "") ] | tojson')"
+                image_list="$(jq -c --null-input --argjson arr1 "$image_list" --argjson arr2 "$dependency_image_list" '$arr1 + $arr2 | unique')"
+              fi
             fi
           done
           # Build JSON files

--- a/.github/workflows/cd-pipeline.yml
+++ b/.github/workflows/cd-pipeline.yml
@@ -229,11 +229,13 @@ jobs:
           image_list="$(yq '.annotations.images' "${chart}/Chart.yaml" | yq '[ .[] | .image | sub("^[^/]+/", "")] ] | tojson')"
           for dependency in "${chart}/charts/"*.tgz; do
             if [[ -s "$dependency" ]]; then
-              chart_yaml_file="$(tar -tzf "$dependency" | grep -E "^[^/]+/Chart.yaml$")"
-              if [[ -n "${chart_yaml_file}" ]]; then
-                dependency_image_list="$(tar -xzO -f "$dependency" "$chart_yaml_file" | yq '.annotations.images' | yq '[ .[] | .image | sub("^[^/]+/", "") ] | tojson')"
-                image_list="$(jq -c --null-input --argjson arr1 "$image_list" --argjson arr2 "$dependency_image_list" '$arr1 + $arr2 | unique')"
-              fi
+              # Analyse all 'Chart.yaml' files in dependencies
+              while read -r chart_yaml_file; do 
+                if [[ -n "${chart_yaml_file}" ]]; then
+                  dependency_image_list="$(tar -xzO -f "$dependency" "$chart_yaml_file" | yq '.annotations.images' | yq '[ .[] | .image | sub("^[^/]+/", "") ] | tojson')"
+                  image_list="$(jq -c --null-input --argjson arr1 "$image_list" --argjson arr2 "$dependency_image_list" '$arr1 + $arr2 | unique')"
+                fi
+              done < <(tar -tzf "$dependency" | grep -E "Chart.yaml$")
             fi
           done
           # Build JSON files

--- a/.github/workflows/cd-pipeline.yml
+++ b/.github/workflows/cd-pipeline.yml
@@ -228,7 +228,7 @@ jobs:
           helm dep build ${chart}
           image_list="$(yq '.annotations.images' "${chart}/Chart.yaml" | yq '[ .[] | .image | sub("^[^/]+/", "")] ] | tojson')"
           for dependency in "${chart}/charts/"*.tgz; do
-            if [[ -f "$dependency" ]] && [[ -s "$dependency" ]]; then
+            if [[ -s "$dependency" ]]; then
               chart_yaml_file="$(tar -tzf "$dependency" | grep -E "^[^/]+/Chart.yaml$")"
               if [[ -n "${chart_yaml_file}" ]]; then
                 dependency_image_list="$(tar -xzO -f "$dependency" "$chart_yaml_file" | yq '.annotations.images' | yq '[ .[] | .image | sub("^[^/]+/", "") ] | tojson')"


### PR DESCRIPTION
### Description of the change

Remove registry information (`doker.io`) from containers list.
Iterate recursively over all Chart.yaml file in dependencies.

### Benefits

Keep same format as previous files.
Ensure we don't miss any image in the container list.

### Possible drawbacks

None

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [NA] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [NA] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [NA] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
