### PR TITLE
 [bitnami/thanos] Fix sharded storegateway cache configs (again)

### DIFF
--- a/bitnami/thanos/CHANGELOG.md
+++ b/bitnami/thanos/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 15.7.5 (2024-06-11)
+## 15.7.6 (2024-06-11)
 
-* [bitnami/thanos] only deploy networkPolicy when component is enabled ([#27070](https://github.com/bitnami/charts/pull/27070))
+*  [bitnami/thanos] Fix sharded storegateway cache configs (again) ([#27101](https://github.com/bitnami/charts/pull/27101))
+
+## <small>15.7.5 (2024-06-11)</small>
+
+* [bitnami/thanos] only deploy networkPolicy when component is enabled (#27070) ([1bd3b34](https://github.com/bitnami/charts/commit/1bd3b342399ed142ef26f060f63d058e393435c2)), closes [#27070](https://github.com/bitnami/charts/issues/27070)
 
 ## <small>15.7.4 (2024-06-11)</small>
 

--- a/bitnami/thanos/CHANGELOG.md
+++ b/bitnami/thanos/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 15.7.6 (2024-06-11)
+## 15.7.6 (2024-06-12)
 
 *  [bitnami/thanos] Fix sharded storegateway cache configs (again) ([#27101](https://github.com/bitnami/charts/pull/27101))
 

--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: thanos
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/thanos
-version: 15.7.5
+version: 15.7.6

--- a/bitnami/thanos/templates/storegateway/statefulset-sharded.yaml
+++ b/bitnami/thanos/templates/storegateway/statefulset-sharded.yaml
@@ -152,7 +152,7 @@ spec:
             {{- if $.Values.bucketCacheConfig }}
             - --store.caching-bucket.config-file=/conf/cache/bucket-cache.yml
             {{- end }}
-            {{- if or (include "thanos.storegateway.createConfigmap" .) .Values.storegateway.existingConfigmap }}
+            {{- if or (include "thanos.storegateway.createConfigmap" $) $.Values.storegateway.existingConfigmap }}
             - --index-cache.config-file=/conf/cache/config.yml
             {{- end }}
             {{- if $.Values.storegateway.grpc.server.tls.enabled }}
@@ -281,7 +281,7 @@ spec:
             {{- end }}
             - name: data
               mountPath: /data
-            {{- if or (include "thanos.storegateway.createConfigmap" .) .Values.storegateway.existingConfigmap }}
+            {{- if or (include "thanos.storegateway.createConfigmap" $) $.Values.storegateway.existingConfigmap }}
             - name: cache-config
               mountPath: /conf/cache
             {{- end }}
@@ -312,7 +312,7 @@ spec:
         {{- if $.Values.storegateway.extraVolumes }}
         {{- include "common.tplvalues.render" (dict "value" $.Values.storegateway.extraVolumes "context" $) | nindent 8 }}
         {{- end }}
-        {{- if or (include "thanos.storegateway.createConfigmap" .) .Values.storegateway.existingConfigmap }}
+        {{- if or (include "thanos.storegateway.createConfigmap" $) $.Values.storegateway.existingConfigmap }}
         - name: cache-config
           configMap:
             name: {{ include "thanos.storegateway.configmapName" $ }}


### PR DESCRIPTION
### Description of the change

Make the sharded storegateway cache config mount condition use the root ($), not local dot (.) context. This bug was introduced in #26490 (but did not get caught by linting).

### Benefits

Rendering the chart with a sharded storegateway no longer fails.

### Possible drawbacks

N/A

### Applicable issues

Follow-up to #26490

### Additional information

N/A

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
