### PR TITLE
[bitnami/thanos] fix thanos dual-stack receive monitoring

### DIFF
--- a/bitnami/thanos/CHANGELOG.md
+++ b/bitnami/thanos/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 15.7.7 (2024-06-17)
+## 15.7.8 (2024-06-17)
 
-* [bitnami/thanos] Release 15.7.7 ([#27294](https://github.com/bitnami/charts/pull/27294))
+* [bitnami/thanos] fix thanos dual-stack receive monitoring ([#27112](https://github.com/bitnami/charts/pull/27112))
+
+## <small>15.7.7 (2024-06-17)</small>
+
+* [bitnami/thanos] Release 15.7.7 (#27294) ([7e339f1](https://github.com/bitnami/charts/commit/7e339f15ac83263c386d63e2bf68cfd82fca7deb)), closes [#27294](https://github.com/bitnami/charts/issues/27294)
 
 ## <small>15.7.6 (2024-06-12)</small>
 

--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: thanos
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/thanos
-version: 15.7.7
+version: 15.7.8

--- a/bitnami/thanos/templates/receive/service-headless.yaml
+++ b/bitnami/thanos/templates/receive/service-headless.yaml
@@ -11,7 +11,9 @@ metadata:
   namespace: {{ include "common.names.namespace" . }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: receive
+    {{- if eq .Values.receive.mode "dual-mode" }}
     {{- include "thanos.servicemonitor.matchLabels" . | nindent 4 -}}
+    {{- end }}
   {{- if or .Values.receive.service.headless.annotations .Values.commonAnnotations }}
   {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.receive.service.headless.annotations .Values.commonAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}

--- a/bitnami/thanos/templates/receive/service.yaml
+++ b/bitnami/thanos/templates/receive/service.yaml
@@ -11,7 +11,11 @@ metadata:
   namespace: {{ include "common.names.namespace" . }}
   {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.receive.service.labels .Values.commonLabels ) "context" . ) }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
+    {{- if eq .Values.receive.mode "dual-mode" }}
+    app.kubernetes.io/component: receive-distributor
+    {{ else }}
     app.kubernetes.io/component: receive
+    {{ end }}
     {{- include "thanos.servicemonitor.matchLabels" . | nindent 4 -}}
   {{- if or .Values.receive.service.annotations .Values.commonAnnotations }}
   {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.receive.service.annotations .Values.commonAnnotations ) "context" . ) }}


### PR DESCRIPTION
### Description of the change

As of 15.7.5, both receive and receive-distributor pods are scrapped by the receive servicemonitor, and when mode is standalone receive pods are scrapped twice. 

To fix this : 
* when "receive.mode: dual-stack", change "app.kubernetes.io/component" label of the thanos-receive service (which is selecting receive-distributor pods in this mode) from receive to "receive-distributor" to make it scrapped by the "receive-distributor" servicemonitor correctly
* only add "prometheus-operator/monitor: true" label to thanos-receive-headless service to avoid having thanos-receive pods scrapped twice when "receive.mode: standalone"

### Benefits

Targets will be configurable by the correct serviceMonitor, and in standalone mode receive pods will not be scrapped twice.

### Possible drawbacks

Change labels of the receive service between standalone and dual-stack.

### Applicable issues

- fixes #27103. 

### Additional information

Nothing to add. 

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
