### PR TITLE
[bitnami/fluentd] make initContainer fail if extra gems fail to install

### DIFF
--- a/bitnami/fluentd/Chart.yaml
+++ b/bitnami/fluentd/Chart.yaml
@@ -30,4 +30,4 @@ maintainers:
 name: fluentd
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/fluentd
-version: 6.5.3
+version: 6.5.4

--- a/bitnami/fluentd/templates/aggregator-statefulset.yaml
+++ b/bitnami/fluentd/templates/aggregator-statefulset.yaml
@@ -81,6 +81,7 @@ spec:
             - -c
           args:
             - |-
+              set -e
               cd /tmp
 
               # install extra gems

--- a/bitnami/fluentd/templates/forwarder-daemonset.yaml
+++ b/bitnami/fluentd/templates/forwarder-daemonset.yaml
@@ -74,6 +74,7 @@ spec:
             - -c
           args:
             - |-
+              set -e
               cd /tmp
 
               # install extra gems


### PR DESCRIPTION
Under certain circumstances (like rubygems.org being temporarily unreachable, for instance) fluentd's initContainer fails to install extra gems:
```
ERROR:  Could not find a valid gem 'fluent-plugin-vmware-log-intelligence' (>= 0), here is why:
          Unable to download data from https://rubygems.org/ - SocketError: Failed to open TCP connection to rubygems.org:443 (getaddrinfo: Temporary failure in name resolution) (https://rubygems.org/specs.4.8.gz)
```

Currently the initContainer wrongly returns exit code 0, making the main container crash repeatedly with the following error:
```
2024-06-12 07:53:34 +0000 [error]: config error file="/opt/bitnami/fluentd/conf/fluentd.conf" error_class=Fluent::NotFoundPluginError error="Unknown output plugin 'vmware_log_intelligence'. Run 'gem search -rd fluent-plugin' to find plugins"
```
Thus requiring manual deletion of the unrecoverable pod.

The initContainer should fail if the installation of any of the extra gems fails, so K8s retry policy also retries the initContainer.

### Description of the change

Use the `set -e` flag:
> Exit immediately if a pipeline (see Pipelines), which may consist of a single simple command (see Simple Commands), a list (see Lists of Commands), or a compound command (see Compound Commands) returns a non-zero status.

[Additional info](https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html)

### Benefits

The initContainer shouldn't wrongfully return exit code 0, so K8s can restart the whole pod, not only the main container.

### Possible drawbacks

initContainer wrongfully failing.

### Applicable issues

### Additional information

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
