### PR TITLE
[bitnami/schema-registry] Render imagePullSecrets

### DIFF
--- a/bitnami/schema-registry/CHANGELOG.md
+++ b/bitnami/schema-registry/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 19.1.3 (2024-06-06)
+## 19.1.4 (2024-06-12)
 
-* [bitnami/schema-registry] Release 19.1.3 ([#27015](https://github.com/bitnami/charts/pull/27015))
+* [bitnami/schema-registry] Render imagePullSecrets ([#27129](https://github.com/bitnami/charts/pull/27129))
+
+## <small>19.1.3 (2024-06-06)</small>
+
+* [bitnami/schema-registry] Release 19.1.3 (#27015) ([9624f24](https://github.com/bitnami/charts/commit/9624f24d3cc8eaf0704ac828729ec486ab0779ac)), closes [#27015](https://github.com/bitnami/charts/issues/27015)
 
 ## <small>19.1.2 (2024-06-05)</small>
 

--- a/bitnami/schema-registry/Chart.lock
+++ b/bitnami/schema-registry/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: kafka
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 29.2.2
+  version: 29.3.0
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.20.0
-digest: sha256:e14535df810e72b0fd2bc617842ff209350d4786e717fee6d78af28ae149ec40
-generated: "2024-06-06T15:15:04.089373706Z"
+  version: 2.20.2
+digest: sha256:2cff3c036caa09981cfa4f6d23735bce4b5ceb2734d87481c928ede580addb9f
+generated: "2024-06-12T17:16:15.82786+02:00"

--- a/bitnami/schema-registry/Chart.yaml
+++ b/bitnami/schema-registry/Chart.yaml
@@ -34,4 +34,4 @@ maintainers:
 name: schema-registry
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/schema-registry
-version: 19.1.3
+version: 19.1.4

--- a/bitnami/schema-registry/templates/_helpers.tpl
+++ b/bitnami/schema-registry/templates/_helpers.tpl
@@ -35,7 +35,7 @@ Return the proper Schema Registry image name
 Return the proper Docker Image Registry Secret Names
 */}}
 {{- define "schema-registry.imagePullSecrets" -}}
-{{ include "common.images.pullSecrets" (dict "images" (list .Values.image) "global" .Values.global) }}
+{{ include "common.images.renderPullSecrets" (dict "images" (list .Values.image) "context" $) }}
 {{- end -}}
 
 {{/*

--- a/bitnami/schema-registry/templates/statefulset.yaml
+++ b/bitnami/schema-registry/templates/statefulset.yaml
@@ -46,7 +46,7 @@ spec:
       {{- end }}
       labels: {{- include "common.labels.standard" ( dict "customLabels" $podLabels "context" $ ) | nindent 8 }}
     spec:
-      {{- include "schema-registry.imagePullSecrets" . | indent 6 }}
+      {{- include "schema-registry.imagePullSecrets" . | nindent 6 }}
       serviceAccountName: {{ include "schema-registry.serviceAccountName" . }}
       automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
       {{- if .Values.hostAliases }}


### PR DESCRIPTION
### Description of the change

Use `nindent` instead of `indent` after rendering imagePullSecrets.

### Benefits

Avoid issues with latest `common` chart release.

### Possible drawbacks

None

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- Related to #26882

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [NA] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
