### PR TITLE
[bitnami/milvus] Do not expose externalKafka.tls.keyPassword

### DIFF
--- a/bitnami/milvus/CHANGELOG.md
+++ b/bitnami/milvus/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 8.2.3 (2024-06-13)
 
-* [bitnami/milvus] Do not expose externalKafka.tls.keyPassword ([#27145](https://api.github.com/repos/bitnami/charts/pulls/27145))
+* [bitnami/milvus] Do not expose externalKafka.tls.keyPassword ([#27145](https://github.com/bitnami/charts/pull/27145))
 
 ## <small>8.2.2 (2024-06-12)</small>
 

--- a/bitnami/milvus/CHANGELOG.md
+++ b/bitnami/milvus/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 8.2.3 (2024-06-13)
 
-* [bitnami/milvus] Do not expose externalKafka.tls.keyPassword ([#27145](https://github.com/bitnami/charts/pull/27145))
+* [bitnami/milvus] Do not expose `externalKafka.tls.keyPassword` ([#27145](https://github.com/bitnami/charts/pull/27145))
 
 ## <small>8.2.2 (2024-06-12)</small>
 

--- a/bitnami/milvus/CHANGELOG.md
+++ b/bitnami/milvus/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 8.2.3 (2024-06-13)
 
-* [bitnami/milvus] Do not expose externalKafka.tls.keyPassword ([#27145](https://github.com/bitnami/charts/pull/27145))
+* [bitnami/milvus] Do not expose externalKafka.tls.keyPassword ([#27145](https://api.github.com/repos/bitnami/charts/pulls/27145))
 
 ## <small>8.2.2 (2024-06-12)</small>
 

--- a/bitnami/milvus/CHANGELOG.md
+++ b/bitnami/milvus/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 8.2.2 (2024-06-12)
+## 8.2.3 (2024-06-13)
 
-* [bitnami/milvus] Release 8.2.2 ([#27115](https://github.com/bitnami/charts/pull/27115))
+* [bitnami/milvus] Do not expose externalKafka.tls.keyPassword ([#27145](https://github.com/bitnami/charts/pull/27145))
+
+## <small>8.2.2 (2024-06-12)</small>
+
+* [bitnami/milvus] Release 8.2.2 (#27115) ([6e4fd91](https://github.com/bitnami/charts/commit/6e4fd9138237cb84c50b77427aa37c7a69ca4975)), closes [#27115](https://github.com/bitnami/charts/issues/27115)
 
 ## <small>8.2.1 (2024-06-12)</small>
 

--- a/bitnami/milvus/CHANGELOG.md
+++ b/bitnami/milvus/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 8.2.5 (2024-06-17)
+
+* [bitnami/milvus] Do not expose externalKafka.tls.keyPassword ([#27145](https://github.com/bitnami/charts/pull/27145))
+
+## <small>8.2.4 (2024-06-14)</small>
+
+* [bitnami/milvus] Release 8.2.4 (#27171) ([5e6ddd4](https://github.com/bitnami/charts/commit/5e6ddd4911796bdc5e6456e8019c1600fe254deb)), closes [#27171](https://github.com/bitnami/charts/issues/27171)
+
+## <small>8.2.3 (2024-06-14)</small>
+
+* [bitnami/milvus] Fix milvus externalS3 config, address minor typos (#27140) ([e6c70d5](https://github.com/bitnami/charts/commit/e6c70d517ebb0c9e53957abd27b839d909b62d6f)), closes [#27140](https://github.com/bitnami/charts/issues/27140)
+
 ## <small>8.2.2 (2024-06-12)</small>
 
 * [bitnami/milvus] Release 8.2.2 (#27115) ([6e4fd91](https://github.com/bitnami/charts/commit/6e4fd9138237cb84c50b77427aa37c7a69ca4975)), closes [#27115](https://github.com/bitnami/charts/issues/27115)

--- a/bitnami/milvus/Chart.yaml
+++ b/bitnami/milvus/Chart.yaml
@@ -48,4 +48,4 @@ maintainers:
 name: milvus
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/milvus
-version: 8.2.2
+version: 8.2.3

--- a/bitnami/milvus/templates/externalkafka-tls-password-secret.yaml
+++ b/bitnami/milvus/templates/externalkafka-tls-password-secret.yaml
@@ -1,0 +1,20 @@
+{{- /*
+Copyright Broadcom, Inc. All Rights Reserved.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+{{- if and .Values.externalKafka.tls.enabled .Values.externalKafka.tls.keyPassword .Values.externalKafka.tls.existingSecret }}
+{{- $secretName := printf "%s-external-kafka-tls-passwords" (include "common.names.fullname" .) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $secretName }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+type: Opaque
+data:
+  key-password: {{ include "common.secrets.passwords.manage" (dict "secret" $secretName "key" "key-password" "providedValues" (list "externalKafka.tls.keyPassword") "context" $) }}
+{{- end }}


### PR DESCRIPTION
### Description of the change

Fixes the Milvus chart to not expose the externalKafka.tls.keyPassword in the init-container.

### Applicable issues

- Relates #26118

### Additional information
Pod root-coordinator no longer exposes the password in its init-container command:
```
     ...
      # Kafka TLS settings
      yq e -i '.kafka.ssl.enabled = true' /bitnami/milvus/rendered-conf/pre-render-config_01.yaml
      yq e -i '.kafka.ssl.tlsCert = "/opt/bitnami/milvus/configs/cert/kafka/client/tls.crt"' /bitnami/milvus/rendered-conf/pre-render-config_01.yaml
      yq e -i '.kafka.ssl.tlsKey = "/opt/bitnami/milvus/configs/cert/kafka/client/tls.key"' /bitnami/milvus/rendered-conf/pre-render-config_01.yaml
      yq e -i '.kafka.ssl.tlsCaCert = "/opt/bitnami/milvus/configs/cert/kafka/client/ca.crt"' /bitnami/milvus/rendered-conf/pre-render-config_01.yaml
      yq e -i '.kafka.ssl.tlsKeyPassword = "{{ MILVUS_KAFKA_TLS_KEY_PASSWORD }}"' /bitnami/milvus/rendered-conf/pre-render-config_01.yaml
```

Content of milvus.yaml:
```
# Kafka configuration
kafka:
  brokerList:
    - localhost:9092
  securityProtocol: PLAINTEXT
  ssl:
    enabled: true
    tlsCert: /opt/bitnami/milvus/configs/cert/kafka/client/tls.crt
    tlsKey: /opt/bitnami/milvus/configs/cert/kafka/client/tls.key
    tlsCaCert: /opt/bitnami/milvus/configs/cert/kafka/client/ca.crt
    tlsKeyPassword: 'my-pass'
```

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
