### PR TITLE
[bitnami/rabbitmq-cluster-operator] Adding TopicPermission webhook missing configuration in Topology Operator

### DIFF
--- a/bitnami/rabbitmq-cluster-operator/CHANGELOG.md
+++ b/bitnami/rabbitmq-cluster-operator/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 4.3.8 (2024-06-18)
+## 4.3.9 (2024-06-19)
 
-* [bitnami/rabbitmq-cluster-operator] Release 4.3.8 ([#27408](https://github.com/bitnami/charts/pull/27408))
+* [bitnami/rabbitmq-cluster-operator] Adding TopicPermission webhook missing configuration in Topology Operator ([#27195](https://github.com/bitnami/charts/pull/27195))
+
+## <small>4.3.8 (2024-06-18)</small>
+
+* [bitnami/rabbitmq-cluster-operator] Release 4.3.8 (#27408) ([0ee7816](https://github.com/bitnami/charts/commit/0ee7816b52e298a0861c38ef4e86109f6067f7a8)), closes [#27408](https://github.com/bitnami/charts/issues/27408)
 
 ## <small>4.3.7 (2024-06-17)</small>
 

--- a/bitnami/rabbitmq-cluster-operator/Chart.yaml
+++ b/bitnami/rabbitmq-cluster-operator/Chart.yaml
@@ -37,4 +37,4 @@ maintainers:
 name: rabbitmq-cluster-operator
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/rabbitmq-cluster-operator
-version: 4.3.8
+version: 4.3.9

--- a/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/validating-webhook-configuration.yaml
+++ b/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/validating-webhook-configuration.yaml
@@ -196,6 +196,30 @@ webhooks:
       service:
         name: {{ template "rmqco.msgTopologyOperator.webhook.fullname" . }}
         namespace: {{ include "common.names.namespace" . | quote }}
+        path: /validate-rabbitmq-com-v1beta1-topicpermission
+        port: {{ .Values.msgTopologyOperator.service.ports.webhook }}
+    failurePolicy: Fail
+    name: vtopicpermission.kb.io
+    rules:
+      - apiGroups:
+          - rabbitmq.com
+        apiVersions:
+          - v1beta1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - topicpermissions
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      {{- if not .Values.useCertManager }}
+      caBundle: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "ca.crt" "defaultValue" (default $ca.Cert .Values.msgTopologyOperator.existingWebhookCertCABundle) "context" $) }}
+      {{- end }}
+      service:
+        name: {{ template "rmqco.msgTopologyOperator.webhook.fullname" . }}
+        namespace: {{ include "common.names.namespace" . | quote }}
         path: /validate-rabbitmq-com-v1beta1-policy
         port: {{ .Values.msgTopologyOperator.service.ports.webhook }}
     failurePolicy: Fail


### PR DESCRIPTION
### Description of the change

This closes https://github.com/bitnami/charts/issues/27143
Webhook configuration for the TopicPermission controller in "RabbitMQ-cluster-operator" Messaging Topology Operator is missing, this PR is adding it

### Benefits

TopicPermission controller will now work properly

### Possible drawbacks

None

### Applicable issues

- fixes https://github.com/bitnami/charts/issues/27143

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
