### PR TITLE
[bitnami/common] chore: :wrench: Relax large and xlarge presets resource requests

### DIFF
--- a/bitnami/common/CHANGELOG.md
+++ b/bitnami/common/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 2.20.2 (2024-06-10)
+## 2.20.3 (2024-06-17)
 
-* [bitnami/common] remove trailing spaces from imagePullSecrets rendering ([#26882](https://github.com/bitnami/charts/pull/26882))
+* [bitnami/common] chore: :wrench: Relax large and xlarge presets resource requests ([#27312](https://github.com/bitnami/charts/pull/27312))
+
+## <small>2.20.2 (2024-06-10)</small>
+
+* [bitnami/common] remove trailing spaces from imagePullSecrets rendering (#26882) ([362d4ac](https://github.com/bitnami/charts/commit/362d4ac94dd69be1b607fc531ceac4d67d8d57ef)), closes [#26882](https://github.com/bitnami/charts/issues/26882)
 
 ## <small>2.20.1 (2024-06-10)</small>
 

--- a/bitnami/common/Chart.yaml
+++ b/bitnami/common/Chart.yaml
@@ -6,7 +6,7 @@ annotations:
   licenses: Apache-2.0
 apiVersion: v2
 # Please make sure that version and appVersion are always the same.
-appVersion: 2.20.1
+appVersion: 2.20.3
 description: A Library Helm Chart for grouping common logic between bitnami charts. This chart is not deployable by itself.
 home: https://bitnami.com
 icon: https://bitnami.com/downloads/logos/bitnami-mark.png
@@ -23,4 +23,4 @@ name: common
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/common
 type: library
-version: 2.20.2
+version: 2.20.3

--- a/bitnami/common/templates/_resources.tpl
+++ b/bitnami/common/templates/_resources.tpl
@@ -34,11 +34,11 @@ These presets are for basic testing and not meant to be used in production
       "limits" (dict "cpu" "1.5" "memory" "3072Mi" "ephemeral-storage" "1024Mi")
    )
   "xlarge" (dict 
-      "requests" (dict "cpu" "1.5" "memory" "4096Mi" "ephemeral-storage" "50Mi")
+      "requests" (dict "cpu" "1.0" "memory" "3012Mi" "ephemeral-storage" "50Mi")
       "limits" (dict "cpu" "3.0" "memory" "6144Mi" "ephemeral-storage" "1024Mi")
    )
   "2xlarge" (dict 
-      "requests" (dict "cpu" "1.5" "memory" "4096Mi" "ephemeral-storage" "50Mi")
+      "requests" (dict "cpu" "1.0" "memory" "3012Mi" "ephemeral-storage" "50Mi")
       "limits" (dict "cpu" "6.0" "memory" "12288Mi" "ephemeral-storage" "1024Mi")
    )
  }}

--- a/bitnami/common/templates/_resources.tpl
+++ b/bitnami/common/templates/_resources.tpl
@@ -34,11 +34,11 @@ These presets are for basic testing and not meant to be used in production
       "limits" (dict "cpu" "1.5" "memory" "3072Mi" "ephemeral-storage" "1024Mi")
    )
   "xlarge" (dict 
-      "requests" (dict "cpu" "1.0" "memory" "3012Mi" "ephemeral-storage" "50Mi")
+      "requests" (dict "cpu" "1.0" "memory" "3072Mi" "ephemeral-storage" "50Mi")
       "limits" (dict "cpu" "3.0" "memory" "6144Mi" "ephemeral-storage" "1024Mi")
    )
   "2xlarge" (dict 
-      "requests" (dict "cpu" "1.0" "memory" "3012Mi" "ephemeral-storage" "50Mi")
+      "requests" (dict "cpu" "1.0" "memory" "3072Mi" "ephemeral-storage" "50Mi")
       "limits" (dict "cpu" "6.0" "memory" "12288Mi" "ephemeral-storage" "1024Mi")
    )
  }}


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change
This PR relaxes the xlarge and 2xlarge resources requests to acommodate the testing of big Java applications like Dremio.

NOTE: resourcesPreset is not meant for production so the change should not be considered breaking.

<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits
Better testing of some solutions.

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

n/a
<!-- Describe any known limitations with your change -->

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [ ] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [ ] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
