### PR TITLE
[bitnami/keycloak] fix Keycloak HTTP schema for edge proxy mode

### DIFF
--- a/bitnami/keycloak/CHANGELOG.md
+++ b/bitnami/keycloak/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 21.4.3 (2024-06-18)
+## 21.4.4 (2024-06-18)
 
-* [bitnami/keycloak] Release 21.4.3 ([#27361](https://github.com/bitnami/charts/pull/27361))
+* [bitnami/keycloak] fix Keycloak HTTP schema for edge proxy mode ([#27436](https://github.com/bitnami/charts/pull/27436))
+
+## <small>21.4.3 (2024-06-18)</small>
+
+* [bitnami/keycloak] Release 21.4.3 (#27361) ([31f011c](https://github.com/bitnami/charts/commit/31f011cb89e56bd33db8e51a9e42f7cc533dcc14)), closes [#27361](https://github.com/bitnami/charts/issues/27361)
 
 ## <small>21.4.2 (2024-06-17)</small>
 

--- a/bitnami/keycloak/Chart.yaml
+++ b/bitnami/keycloak/Chart.yaml
@@ -33,4 +33,4 @@ maintainers:
 name: keycloak
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/keycloak
-version: 21.4.3
+version: 21.4.4

--- a/bitnami/keycloak/templates/statefulset.yaml
+++ b/bitnami/keycloak/templates/statefulset.yaml
@@ -214,11 +214,11 @@ spec:
             {{- end }}
             {{- if .Values.adminIngress.enabled }}
             - name: KC_HOSTNAME_ADMIN_URL
-              value: "http{{ if .Values.adminIngress.tls }}s{{ end }}://{{ include "common.tplvalues.render" (dict "value" .Values.adminIngress.hostname "context" $) }}"
+              value: "http{{ if or .Values.adminIngress.tls (eq .Values.proxy "edge") }}s{{ end }}://{{ include "common.tplvalues.render" (dict "value" .Values.adminIngress.hostname "context" $) }}"
             {{- end }}
             {{- if and .Values.adminIngress.enabled (not .Values.ingress.enabled) }}
             - name: KC_HOSTNAME_URL
-              value: "http{{ if .Values.adminIngress.tls }}s{{ end }}://{{ include "common.tplvalues.render" (dict "value" .Values.adminIngress.hostname "context" $) }}"
+              value: "http{{ if or .Values.adminIngress.tls (eq .Values.proxy "edge") }}s{{ end }}://{{ include "common.tplvalues.render" (dict "value" .Values.adminIngress.hostname "context" $) }}"
             {{- end }}
             {{- if .Values.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.extraEnvVars "context" $) | nindent 12 }}


### PR DESCRIPTION
### Description of the change

Uses HTTPS for admin host url when using proxy=edge.

<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

Fixes the issue to make admin console accessible, otherwise we get `redirect_uri` incorrect error.

### Possible drawbacks

N/A

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #27315

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
