### PR TITLE
[bitnami/harbor] fix: exporter.existingEnvVarsSecret should be core.existingEnvVarsSecret

### DIFF
--- a/bitnami/harbor/CHANGELOG.md
+++ b/bitnami/harbor/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 21.4.6 (2024-06-18)
+## 21.4.7 (2024-06-19)
 
-* [bitnami/harbor] Release 21.4.6 ([#27355](https://github.com/bitnami/charts/pull/27355))
+* [bitnami/harbor] fix: exporter.existingEnvVarsSecret should be core.existingEnvVarsSecret ([#27451](https://github.com/bitnami/charts/pull/27451))
+
+## <small>21.4.6 (2024-06-18)</small>
+
+* [bitnami/harbor] Release 21.4.6 (#27355) ([9867f13](https://github.com/bitnami/charts/commit/9867f138b7a9597f772510d0996818776fb5c079)), closes [#27355](https://github.com/bitnami/charts/issues/27355)
 
 ## <small>21.4.5 (2024-06-17)</small>
 

--- a/bitnami/harbor/Chart.yaml
+++ b/bitnami/harbor/Chart.yaml
@@ -55,4 +55,4 @@ maintainers:
 name: harbor
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/harbor
-version: 21.4.6
+version: 21.4.7

--- a/bitnami/harbor/templates/exporter/exporter-dpl.yaml
+++ b/bitnami/harbor/templates/exporter/exporter-dpl.yaml
@@ -99,8 +99,8 @@ spec:
             - name: HARBOR_DATABASE_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  {{- if .Values.exporter.existingEnvVarsSecret }}
-                  name: {{ .Values.exporter.existingEnvVarsSecret }}
+                  {{- if .Values.core.existingEnvVarsSecret }}
+                  name: {{ .Values.core.existingEnvVarsSecret }}
                   {{- else }}
                   name: {{ printf "%s-envvars" (include "harbor.core" .) }}
                   {{- end }}
@@ -108,8 +108,8 @@ spec:
             - name: HARBOR_ADMIN_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  {{- if .Values.exporter.existingEnvVarsSecret }}
-                  name: {{ .Values.exporter.existingEnvVarsSecret }}
+                  {{- if .Values.core.existingEnvVarsSecret }}
+                  name: {{ .Values.core.existingEnvVarsSecret }}
                   {{- else }}
                   name: {{ printf "%s-envvars" (include "harbor.core" .) }}
                   {{- end }}


### PR DESCRIPTION
### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

If someone sets core.existingEnvVarsSecret and deploys inside a clean environment, they will not get a failed deployment with
```
  Normal   Scheduled  35s               default-scheduler  Successfully assigned harbor/harbor-exporter-688889b977-6vr8c to chorus-dev-5c89bd55fb-kvsxr
  Normal   Pulled     4s (x4 over 34s)  kubelet            Container image "docker.io/bitnami/harbor-exporter:2.11.0-debian-12-r0" already present on machine
  Warning  Failed     4s (x4 over 34s)  kubelet            Error: secret "harbor-core-envvars" not found
```

### Possible drawbacks

If this was intended, then it might be that my merge request should instead document this in the README.md but exporter.existingEnvVarsSecret would be the only parameter below exporter

### Applicable issues

Surprisingly, I did not find an open issue about this.

### Additional information

Credits to @greut for spotting this.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
