### PR TITLE
[bitnami/grafana-loki]Disable Promtail secret creation if existing secret is provided

### DIFF
--- a/bitnami/grafana-loki/Chart.yaml
+++ b/bitnami/grafana-loki/Chart.yaml
@@ -55,4 +55,4 @@ maintainers:
 name: grafana-loki
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/grafana-loki
-version: 4.6.2
+version: 4.6.3

--- a/bitnami/grafana-loki/templates/promtail/secret.yaml
+++ b/bitnami/grafana-loki/templates/promtail/secret.yaml
@@ -3,7 +3,7 @@ Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- if .Values.promtail.enabled }}
+{{- if and .Values.promtail.enabled (not .Values.promtail.existingSecret) }}
 apiVersion: v1
 kind: Secret
 metadata:


### PR DESCRIPTION
fixes #27464 

### Description of the change

Disable Promtail secret creation if existing secret is provided

### Benefits

1. remove unused secret

### Possible drawbacks

None

### Applicable issues

- fixes #27464 

### Additional information

None

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
