### PR TITLE
[bitnami/rabbitmq-cluster-operator]: Fix operatorpolicies permissions…

### DIFF
--- a/bitnami/rabbitmq-cluster-operator/CHANGELOG.md
+++ b/bitnami/rabbitmq-cluster-operator/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 4.3.9 (2024-06-19)
+## 4.3.10 (2024-06-21)
 
-* [bitnami/rabbitmq-cluster-operator] Adding TopicPermission webhook missing configuration in Topology Operator ([#27195](https://github.com/bitnami/charts/pull/27195))
+* [bitnami/rabbitmq-cluster-operator]: Fix operatorpolicies permissions… ([#27484](https://github.com/bitnami/charts/pull/27484))
+
+## <small>4.3.9 (2024-06-19)</small>
+
+* [bitnami/rabbitmq-cluster-operator] Adding TopicPermission webhook missing configuration in Topology ([9bfffb5](https://github.com/bitnami/charts/commit/9bfffb5b65c9294a4ca06e585275c81230be25c9)), closes [#27195](https://github.com/bitnami/charts/issues/27195)
 
 ## <small>4.3.8 (2024-06-18)</small>
 

--- a/bitnami/rabbitmq-cluster-operator/Chart.yaml
+++ b/bitnami/rabbitmq-cluster-operator/Chart.yaml
@@ -37,4 +37,4 @@ maintainers:
 name: rabbitmq-cluster-operator
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/rabbitmq-cluster-operator
-version: 4.3.9
+version: 4.3.10

--- a/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/clusterrole.yaml
+++ b/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/clusterrole.yaml
@@ -330,5 +330,7 @@ rules:
     - operatorpolicies/status
     verbs:
     - get
+    - patch
+    - update
   {{- end }}
 {{- end }}


### PR DESCRIPTION
### Description of the change

In the RabbitMQ Messaging topology operator, the operatorpolicies/status permissions in the clusterrole should be get/patch and update similarly to the policies controller.

### Benefits

the status information of the controller will now be updated and patched correctly.

### Applicable issues

- fixes https://github.com/bitnami/charts/issues/27146

### Additional information


### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
