### PR TITLE
[bitnami/keycloak] Allow `extraEnvVarsCM` and `extraEnvVarsSecret` to be lists

### DIFF
--- a/bitnami/keycloak/CHANGELOG.md
+++ b/bitnami/keycloak/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 21.4.4 (2024-06-18)
+## 21.4.5 (2024-06-24)
 
-* [bitnami/keycloak] fix Keycloak HTTP schema for edge proxy mode ([#27436](https://github.com/bitnami/charts/pull/27436))
+* [bitnami/keycloak] Allow `extraEnvVarsCM` and `extraEnvVarsSecret` to be lists ([#27513](https://github.com/bitnami/charts/pull/27513))
+
+## <small>21.4.4 (2024-06-20)</small>
+
+* [bitnami/keycloak] fix Keycloak HTTP schema for edge proxy mode (#27436) ([f04548a](https://github.com/bitnami/charts/commit/f04548a1dbae55d5dbad34cea87e6972f97c9bb7)), closes [#27436](https://github.com/bitnami/charts/issues/27436)
 
 ## <small>21.4.3 (2024-06-18)</small>
 

--- a/bitnami/keycloak/Chart.yaml
+++ b/bitnami/keycloak/Chart.yaml
@@ -33,4 +33,4 @@ maintainers:
 name: keycloak
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/keycloak
-version: 21.4.4
+version: 21.4.5

--- a/bitnami/keycloak/README.md
+++ b/bitnami/keycloak/README.md
@@ -361,8 +361,8 @@ As an alternative, you can use of the preset configurations for pod affinity, po
 | `command`                        | Override default container command (useful when using custom images)                                                         | `[]`                          |
 | `args`                           | Override default container args (useful when using custom images)                                                            | `[]`                          |
 | `extraEnvVars`                   | Extra environment variables to be set on Keycloak container                                                                  | `[]`                          |
-| `extraEnvVarsCM`                 | Name of existing ConfigMap containing extra env vars                                                                         | `""`                          |
-| `extraEnvVarsSecret`             | Name of existing Secret containing extra env vars                                                                            | `""`                          |
+| `extraEnvVarsCM`                 | Name of existing ConfigMaps containing extra env vars                                                                        | `[]`                          |
+| `extraEnvVarsSecret`             | Name of existing Secrets containing extra env vars                                                                           | `[]`                          |
 
 ### Keycloak statefulset parameters
 

--- a/bitnami/keycloak/templates/statefulset.yaml
+++ b/bitnami/keycloak/templates/statefulset.yaml
@@ -227,12 +227,26 @@ spec:
             - configMapRef:
                 name: {{ printf "%s-env-vars" (include "common.names.fullname" .) }}
             {{- if .Values.extraEnvVarsCM }}
+            {{- if kindIs "slice" .Values.extraEnvVarsCM }}
+            {{- range $configMap := .Values.extraEnvVarsCM }}
+            - configMapRef:
+                name: {{ include "common.tplvalues.render" (dict "value" $configMap "context" $) }}
+            {{- end }}
+            {{- else }}
             - configMapRef:
                 name: {{ include "common.tplvalues.render" (dict "value" .Values.extraEnvVarsCM "context" $) }}
             {{- end }}
+            {{- end }}
             {{- if .Values.extraEnvVarsSecret }}
+            {{- if kindIs "slice" .Values.extraEnvVarsSecret }}
+            {{- range $secret := .Values.extraEnvVarsSecret }}
+            - secretRef:
+                name: {{ include "common.tplvalues.render" (dict "value" $secret "context" $) }}
+            {{- end }}
+            {{- else }}
             - secretRef:
                 name: {{ include "common.tplvalues.render" (dict "value" .Values.extraEnvVarsSecret "context" $) }}
+            {{- end }}
             {{- end }}
           {{- if .Values.resources }}
           resources: {{- toYaml .Values.resources | nindent 12 }}

--- a/bitnami/keycloak/values.yaml
+++ b/bitnami/keycloak/values.yaml
@@ -262,12 +262,12 @@ args: []
 ##     value: "bar"
 ##
 extraEnvVars: []
-## @param extraEnvVarsCM Name of existing ConfigMap containing extra env vars
+## @param extraEnvVarsCM Name of existing ConfigMaps containing extra env vars
 ##
-extraEnvVarsCM: ""
-## @param extraEnvVarsSecret Name of existing Secret containing extra env vars
+extraEnvVarsCM: []
+## @param extraEnvVarsSecret Name of existing Secrets containing extra env vars
 ##
-extraEnvVarsSecret: ""
+extraEnvVarsSecret: []
 ## @section Keycloak statefulset parameters
 
 ## @param replicaCount Number of Keycloak replicas to deploy


### PR DESCRIPTION
### Description of the change

This PR allows `extraEnvVarsCM` and `extraEnvVarsSecret` to be lists, i.e. "slices". Motivation is described in #27156.
Also make list the default data type, while still accepting a single value like before.

### Benefits

`ConfigMap`s and `Secret`s can be used from different sources, e.g. different teams.

### Applicable issues

Fixes: #27156

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
