### PR TITLE
[github-actions] Add Kubescape score action

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -305,16 +305,13 @@ jobs:
           fi
   chart-score:
     runs-on: ubuntu-latest
-    needs: [get-chart, update-pr]
+    needs: [get-chart]
     name: Get chart latest Kubescape score
+    permissions:
+      contents: read
     outputs:
       threshold: ${{ steps.set-output.outputs.threshold }}
-    if: |
-      needs.get-chart.outputs.result == 'ok' &&
-      needs.update-pr.outputs.result == 'skip' &&
-      (
-        contains(github.event.pull_request.labels.*.name, 'verify') || (github.event.action == 'labeled' && github.event.label.name == 'verify')
-      )
+    if: needs.get-chart.outputs.result == 'ok'
     steps:
       - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29
         name: Checkout 'main' branch

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -303,9 +303,63 @@ jobs:
           else
             echo "result=skip" >> $GITHUB_OUTPUT
           fi
-  vib-verify:
+  chart-score:
     runs-on: ubuntu-latest
     needs: [get-chart, update-pr]
+    name: Get chart latest Kubescape score
+    outputs:
+      threshold: ${{ steps.set-output.outputs.threshold }}
+    if: |
+      needs.get-chart.outputs.result == 'ok' &&
+      needs.update-pr.outputs.result == 'skip' &&
+      (
+        contains(github.event.pull_request.labels.*.name, 'verify') || (github.event.action == 'labeled' && github.event.label.name == 'verify')
+      )
+    steps:
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29
+        name: Checkout 'main' branch
+        with:
+          path: charts-main
+          repository: bitnami/charts
+          fetch-depth: 1
+      - name: Install helm
+        run: |
+          HELM_TARBALL="helm-v3.8.1-linux-amd64.tar.gz"
+          curl -SsLfO "https://get.helm.sh/${HELM_TARBALL}" && sudo tar xf "$HELM_TARBALL" --strip-components 1 -C /usr/local/bin
+      - name: Run helm-dep-build
+        env:
+          CHART: ${{ needs.get-chart.outputs.chart }}
+        run: |
+          if [ -d "charts-main/bitnami/${CHART}" ]; then
+            helm dep build charts-main/bitnami/${CHART}
+          fi
+      - id: get-chart-score
+        uses: addnab/docker-run-action@v3
+        name: Get main branch kubescape score
+        env:
+          CHART: ${{ needs.get-chart.outputs.chart }}
+        with:
+          image: bitnami/kubescape:3.0.3
+          options: -v  /home/runner/work/charts/charts/charts-main:/charts -v /tmp:/out -e CHART
+          run: |
+            if [ -d "/charts/bitnami/${CHART}" ]; then
+              kubescape scan framework MITRE,NSA,SOC2,cis-v1.23-t1.0.1 /charts/bitnami/${CHART} --format json -o /out/report.json
+              score=$(jq .summaryDetails.complianceScore /out/report.json)
+              # Truncate score to 2 decimals
+              printf "%s.%.2s" $(echo "$(jq .summaryDetails.complianceScore /out/report.json)" | tr '.' ' ') > /out/score
+            else
+              echo "Chart not found at /charts/bitnami/${CHART}. It will be assumed that the upstream chart does not exist."
+              echo "0.00" > /out/score
+            fi
+      - id: set-output
+        name: Set threshold score
+        run: |
+          score="$(cat /tmp/score)"
+          echo "Using threshold score: ${score}"
+          echo "threshold=${score}" >> $GITHUB_OUTPUT
+  vib-verify:
+    runs-on: ubuntu-latest
+    needs: [get-chart, update-pr, chart-score]
     permissions:
       contents: read
     # Given performance issues of the action feature on GH's side, we need to be very restrictive in the job's triggers:
@@ -367,6 +421,8 @@ jobs:
           VIB_ENV_TARGET_PLATFORM: ${{ secrets.VIB_ENV_TARGET_PLATFORM }}
           # Alternative Target-Platform to be used in case of incompatibilities
           VIB_ENV_ALTERNATIVE_TARGET_PLATFORM: ${{ secrets.VIB_ENV_ALTERNATIVE_TARGET_PLATFORM }}
+          # Set kubescape score threshold
+          VIB_ENV_KUBESCAPE_SCORE_THRESHOLD: ${{ needs.chart-score.outputs.threshold }}
   auto-pr-review:
     runs-on: ubuntu-latest
     needs: vib-verify

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -334,7 +334,7 @@ jobs:
             helm dep build charts-main/bitnami/${CHART}
           fi
       - id: get-chart-score
-        uses: addnab/docker-run-action@v3
+        uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185
         name: Get main branch kubescape score
         env:
           CHART: ${{ needs.get-chart.outputs.chart }}

--- a/.vib/airflow/vib-verify.json
+++ b/.vib/airflow/vib-verify.json
@@ -57,6 +57,12 @@
               "password": "ComplicatedPassword123!4"
             }
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/apache/vib-verify.json
+++ b/.vib/apache/vib-verify.json
@@ -54,6 +54,12 @@
             "endpoint": "lb-apache-http",
             "app_protocol": "HTTP"
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/apisix/vib-verify.json
+++ b/.vib/apisix/vib-verify.json
@@ -58,6 +58,12 @@
               "password": "ComplicatedPassword123!4"
             }
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/appsmith/vib-verify.json
+++ b/.vib/appsmith/vib-verify.json
@@ -58,6 +58,12 @@
               "password": "bitnami!1234"
             }
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/argo-cd/vib-verify.json
+++ b/.vib/argo-cd/vib-verify.json
@@ -58,6 +58,12 @@
               "password": "ComplicatedPassword123!4"
             }
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/argo-workflows/vib-verify.json
+++ b/.vib/argo-workflows/vib-verify.json
@@ -39,6 +39,12 @@
             "endpoint": "lb-argo-workflows-server-http",
             "app_protocol": "HTTP"
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/aspnet-core/vib-verify.json
+++ b/.vib/aspnet-core/vib-verify.json
@@ -54,6 +54,12 @@
             "endpoint": "lb-aspnet-core-http",
             "app_protocol": "HTTP"
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/cassandra/vib-verify.json
+++ b/.vib/cassandra/vib-verify.json
@@ -59,6 +59,12 @@
               "password": "ComplicatedPassword123!4"
             }
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/cert-manager/vib-verify.json
+++ b/.vib/cert-manager/vib-verify.json
@@ -56,6 +56,12 @@
               }
             }
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/cilium/vib-verify.json
+++ b/.vib/cilium/vib-verify.json
@@ -57,6 +57,12 @@
               "releaseName": "cilium"
             }
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/clickhouse/vib-verify.json
+++ b/.vib/clickhouse/vib-verify.json
@@ -70,6 +70,12 @@
               "password": "bitnami1234"
             }
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/common/vib-verify.json
+++ b/.vib/common/vib-verify.json
@@ -13,6 +13,12 @@
         },
         {
           "action_id": "helm-lint"
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/concourse/vib-verify.json
+++ b/.vib/concourse/vib-verify.json
@@ -69,6 +69,12 @@
             "endpoint": "lb-concourse-web-http",
             "app_protocol": "HTTP"
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/consul/vib-verify.json
+++ b/.vib/consul/vib-verify.json
@@ -71,6 +71,12 @@
               "name": "consul"
             }
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/contour/vib-verify.json
+++ b/.vib/contour/vib-verify.json
@@ -57,6 +57,12 @@
               "ingress-name": "contour-vib-test"
             }
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/deepspeed/vib-verify.json
+++ b/.vib/deepspeed/vib-verify.json
@@ -44,6 +44,12 @@
               }
             }
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/discourse/vib-verify.json
+++ b/.vib/discourse/vib-verify.json
@@ -58,6 +58,12 @@
               "password": "ComplicatedPassword123!4"
             }
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/dokuwiki/vib-verify.json
+++ b/.vib/dokuwiki/vib-verify.json
@@ -58,6 +58,12 @@
               }
             }
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/dremio/vib-verify.json
+++ b/.vib/dremio/vib-verify.json
@@ -54,6 +54,12 @@
             "endpoint": "lb-dremio-http-web",
             "app_protocol": "HTTP"
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/drupal/vib-verify.json
+++ b/.vib/drupal/vib-verify.json
@@ -58,6 +58,12 @@
               "password": "ComplicatedPassword123!4"
             }
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/ejbca/vib-verify.json
+++ b/.vib/ejbca/vib-verify.json
@@ -57,6 +57,12 @@
             "endpoint": "lb-ejbca-https",
             "app_protocol": "HTTPS"
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/elasticsearch/vib-verify.json
+++ b/.vib/elasticsearch/vib-verify.json
@@ -67,6 +67,12 @@
               "name": "elasticsearch"
             }
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/etcd/vib-verify.json
+++ b/.vib/etcd/vib-verify.json
@@ -58,6 +58,12 @@
               "password": "ComplicatedPassword123!4"
             }
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/external-dns/vib-verify.json
+++ b/.vib/external-dns/vib-verify.json
@@ -54,6 +54,12 @@
             "endpoint": "lb-external-dns-http",
             "app_protocol": "HTTP"
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/flink/vib-verify.json
+++ b/.vib/flink/vib-verify.json
@@ -54,6 +54,12 @@
             "endpoint": "lb-flink-jobmanager-http",
             "app_protocol": "HTTP"
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/fluent-bit/vib-verify.json
+++ b/.vib/fluent-bit/vib-verify.json
@@ -51,6 +51,12 @@
               }
             }
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/fluentd/vib-verify.json
+++ b/.vib/fluentd/vib-verify.json
@@ -47,6 +47,12 @@
               }
             }
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/flux/vib-verify.json
+++ b/.vib/flux/vib-verify.json
@@ -47,6 +47,12 @@
               "file": "flux/goss/goss-wait.yaml"
             }
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/ghost/vib-verify.json
+++ b/.vib/ghost/vib-verify.json
@@ -59,6 +59,12 @@
               "password": "Complicated123!4"
             }
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/gitea/vib-verify.json
+++ b/.vib/gitea/vib-verify.json
@@ -58,6 +58,12 @@
               "password": "bitnami!1234"
             }
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/grafana-loki/vib-verify.json
+++ b/.vib/grafana-loki/vib-verify.json
@@ -69,6 +69,12 @@
             "endpoint": "lb-grafana-loki-gateway-http",
             "app_protocol": "HTTP"
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/grafana-mimir/vib-verify.json
+++ b/.vib/grafana-mimir/vib-verify.json
@@ -54,6 +54,12 @@
             "endpoint": "lb-grafana-mimir-gateway-http",
             "app_protocol": "HTTP"
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/grafana-operator/vib-verify.json
+++ b/.vib/grafana-operator/vib-verify.json
@@ -58,6 +58,12 @@
               "password": "ComplicatedPassword123!4"
             }
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/grafana-tempo/vib-verify.json
+++ b/.vib/grafana-tempo/vib-verify.json
@@ -62,6 +62,12 @@
               "gossipRingPort": "7946"
             }
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/grafana/vib-verify.json
+++ b/.vib/grafana/vib-verify.json
@@ -58,6 +58,12 @@
               "password": "ComplicatedPassword123!4"
             }
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/haproxy/vib-verify.json
+++ b/.vib/haproxy/vib-verify.json
@@ -54,6 +54,12 @@
             "endpoint": "lb-haproxy-http",
             "app_protocol": "HTTP"
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/harbor/vib-verify.json
+++ b/.vib/harbor/vib-verify.json
@@ -58,6 +58,12 @@
               "password": "ComplicatedPassword123!4"
             }
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/influxdb/vib-verify.json
+++ b/.vib/influxdb/vib-verify.json
@@ -76,6 +76,12 @@
               "bucket": "testBucket"
             }
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/jaeger/vib-verify.json
+++ b/.vib/jaeger/vib-verify.json
@@ -55,6 +55,12 @@
             "endpoint": "lb-jaeger-query-api",
             "app_protocol": "HTTP"
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/janusgraph/vib-verify.json
+++ b/.vib/janusgraph/vib-verify.json
@@ -44,6 +44,12 @@
               }
             }
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/jenkins/vib-verify.json
+++ b/.vib/jenkins/vib-verify.json
@@ -58,6 +58,12 @@
               "password": "ComplicatedPassword123!4"
             }
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/joomla/vib-verify.json
+++ b/.vib/joomla/vib-verify.json
@@ -58,6 +58,12 @@
               "password": "ComplicatedPassword123!4"
             }
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/jupyterhub/vib-verify.json
+++ b/.vib/jupyterhub/vib-verify.json
@@ -58,6 +58,12 @@
               "password": "ComplicatedPassword123!4"
             }
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/kafka/vib-verify.json
+++ b/.vib/kafka/vib-verify.json
@@ -57,6 +57,12 @@
               "name": "kafka"
             }
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/keycloak/vib-verify.json
+++ b/.vib/keycloak/vib-verify.json
@@ -58,6 +58,12 @@
               "password": "ComplicatedPassword123!4"
             }
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/kiam/vib-verify.json
+++ b/.vib/kiam/vib-verify.json
@@ -13,6 +13,12 @@
         },
         {
           "action_id": "helm-lint"
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/kibana/vib-verify.json
+++ b/.vib/kibana/vib-verify.json
@@ -54,6 +54,12 @@
             "endpoint": "lb-kibana-http",
             "app_protocol": "HTTP"
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/kong/vib-verify.json
+++ b/.vib/kong/vib-verify.json
@@ -60,6 +60,12 @@
               "adminHttpPort": "443"
             }
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/kube-prometheus/vib-verify.json
+++ b/.vib/kube-prometheus/vib-verify.json
@@ -54,6 +54,12 @@
               }
             }
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/kube-state-metrics/vib-verify.json
+++ b/.vib/kube-state-metrics/vib-verify.json
@@ -51,6 +51,12 @@
               }
             }
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/kubeapps/vib-verify.json
+++ b/.vib/kubeapps/vib-verify.json
@@ -57,6 +57,12 @@
             },
             "app_protocol": "HTTP"
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/kuberay/vib-verify.json
+++ b/.vib/kuberay/vib-verify.json
@@ -54,6 +54,12 @@
             "endpoint": "lb-kuberay-cluster-head-vib-svc-http",
             "app_protocol": "HTTP"
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/kubernetes-event-exporter/vib-verify.json
+++ b/.vib/kubernetes-event-exporter/vib-verify.json
@@ -56,6 +56,12 @@
               "namespace": "{{namespace}}"
             }
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/logstash/vib-verify.json
+++ b/.vib/logstash/vib-verify.json
@@ -54,6 +54,12 @@
             "endpoint": "lb-logstash-monitoring",
             "app_protocol": "HTTP"
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/magento/vib-verify.json
+++ b/.vib/magento/vib-verify.json
@@ -57,6 +57,12 @@
               "password": "ComplicatedPassword123!4"
             }
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/mariadb-galera/vib-verify.json
+++ b/.vib/mariadb-galera/vib-verify.json
@@ -59,6 +59,12 @@
               "password": "ComplicatedPassword123!4"
             }
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/mariadb/vib-verify.json
+++ b/.vib/mariadb/vib-verify.json
@@ -59,6 +59,12 @@
               "password": "R0ot)Password"
             }
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/mastodon/vib-verify.json
+++ b/.vib/mastodon/vib-verify.json
@@ -58,6 +58,12 @@
               "password": "bitnami!1234"
             }
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/matomo/vib-verify.json
+++ b/.vib/matomo/vib-verify.json
@@ -57,6 +57,12 @@
               "password": "ComplicatedPassword123!4"
             }
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/mediawiki/vib-verify.json
+++ b/.vib/mediawiki/vib-verify.json
@@ -58,6 +58,12 @@
               "password": "ComplicatedPassword123!4"
             }
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/memcached/vib-verify.json
+++ b/.vib/memcached/vib-verify.json
@@ -51,6 +51,12 @@
               }
             }
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/metallb/vib-verify.json
+++ b/.vib/metallb/vib-verify.json
@@ -56,6 +56,12 @@
               }
             }
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/metrics-server/vib-verify.json
+++ b/.vib/metrics-server/vib-verify.json
@@ -51,6 +51,12 @@
               }
             }
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/milvus/vib-verify.json
+++ b/.vib/milvus/vib-verify.json
@@ -58,6 +58,12 @@
               "password": "ComplicatedPassword123!4"
             }
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/minio/vib-verify.json
+++ b/.vib/minio/vib-verify.json
@@ -73,6 +73,12 @@
               "password": "ComplicatedPassword123!4"
             }
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/mlflow/vib-verify.json
+++ b/.vib/mlflow/vib-verify.json
@@ -61,6 +61,12 @@
               "password": "ComplicatedPassword123!4"
             }
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/mongodb-sharded/vib-verify.json
+++ b/.vib/mongodb-sharded/vib-verify.json
@@ -60,6 +60,12 @@
               "password": "Password123!4"
             }
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/mongodb/vib-verify.json
+++ b/.vib/mongodb/vib-verify.json
@@ -59,6 +59,12 @@
               "password": "ComplicatedPassword123!4"
             }
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/moodle/vib-verify.json
+++ b/.vib/moodle/vib-verify.json
@@ -58,6 +58,12 @@
               "password": "ComplicatedPassword123!4"
             }
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/multus-cni/vib-verify.json
+++ b/.vib/multus-cni/vib-verify.json
@@ -44,6 +44,12 @@
               }
             }
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/mysql/vib-verify.json
+++ b/.vib/mysql/vib-verify.json
@@ -59,6 +59,12 @@
               "password": "R0ot)Password"
             }
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/nats/vib-verify.json
+++ b/.vib/nats/vib-verify.json
@@ -69,6 +69,12 @@
               "password": "ComplicatedPassword123!4"
             }
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/nessie/vib-verify.json
+++ b/.vib/nessie/vib-verify.json
@@ -67,6 +67,12 @@
               "name": "nessie"
             }
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/nginx-ingress-controller/vib-verify.json
+++ b/.vib/nginx-ingress-controller/vib-verify.json
@@ -58,6 +58,12 @@
               "service-port": "80"
             }
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/nginx/vib-verify.json
+++ b/.vib/nginx/vib-verify.json
@@ -54,6 +54,12 @@
             "endpoint": "lb-nginx-http",
             "app_protocol": "HTTP"
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/node-exporter/vib-verify.json
+++ b/.vib/node-exporter/vib-verify.json
@@ -54,6 +54,12 @@
             "endpoint": "lb-node-exporter-metrics",
             "app_protocol": "HTTP"
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/oauth2-proxy/vib-verify.json
+++ b/.vib/oauth2-proxy/vib-verify.json
@@ -59,6 +59,12 @@
               "dexPort": "5556"
             }
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/odoo/vib-verify.json
+++ b/.vib/odoo/vib-verify.json
@@ -58,6 +58,12 @@
               }
             }
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/opencart/vib-verify.json
+++ b/.vib/opencart/vib-verify.json
@@ -58,6 +58,12 @@
               "password": "Password123!4"
             }
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/opensearch/vib-verify.json
+++ b/.vib/opensearch/vib-verify.json
@@ -67,6 +67,12 @@
               "name": "opensearch"
             }
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/parse/vib-verify.json
+++ b/.vib/parse/vib-verify.json
@@ -73,6 +73,12 @@
               "masterKey": "M4ster#K3y"
             }
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/phpbb/vib-verify.json
+++ b/.vib/phpbb/vib-verify.json
@@ -57,6 +57,12 @@
               "password": "ComplicatedPassword123!4"
             }
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/phpmyadmin/vib-verify.json
+++ b/.vib/phpmyadmin/vib-verify.json
@@ -58,6 +58,12 @@
               "password": "rootPassword"
             }
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/pinniped/vib-verify.json
+++ b/.vib/pinniped/vib-verify.json
@@ -43,6 +43,12 @@
               "auth-password": "vibUser123"
             }
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/postgresql-ha/vib-verify.json
+++ b/.vib/postgresql-ha/vib-verify.json
@@ -74,6 +74,12 @@
               "password": "psqlPassword123!4"
             }
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/postgresql/vib-verify.json
+++ b/.vib/postgresql/vib-verify.json
@@ -59,6 +59,12 @@
               "password": "ComplicatedPassword123!4"
             }
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/prestashop/vib-verify.json
+++ b/.vib/prestashop/vib-verify.json
@@ -59,6 +59,12 @@
               "password": "ComplicatedPassword123!4"
             }
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/prometheus/vib-verify.json
+++ b/.vib/prometheus/vib-verify.json
@@ -54,6 +54,12 @@
               }
             }
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/pytorch/vib-verify.json
+++ b/.vib/pytorch/vib-verify.json
@@ -44,6 +44,12 @@
               }
             }
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/rabbitmq-cluster-operator/vib-verify.json
+++ b/.vib/rabbitmq-cluster-operator/vib-verify.json
@@ -58,6 +58,12 @@
               "password": "ComplicatedPassword123!4"
             }
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/rabbitmq/vib-verify.json
+++ b/.vib/rabbitmq/vib-verify.json
@@ -73,6 +73,12 @@
               "password": "ComplicatedPassword123!4"
             }
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/redis-cluster/vib-verify.json
+++ b/.vib/redis-cluster/vib-verify.json
@@ -58,6 +58,12 @@
               "password": "ComplicatedPassword123!4"
             }
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/redis/vib-verify.json
+++ b/.vib/redis/vib-verify.json
@@ -58,6 +58,12 @@
               "password": "ComplicatedPassword123!4"
             }
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/redmine/vib-verify.json
+++ b/.vib/redmine/vib-verify.json
@@ -58,6 +58,12 @@
               "password": "ComplicatedPassword123!4"
             }
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/schema-registry/vib-verify.json
+++ b/.vib/schema-registry/vib-verify.json
@@ -54,6 +54,12 @@
             "endpoint": "lb-schema-registry-http",
             "app_protocol": "HTTP"
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/scylladb/vib-verify.json
+++ b/.vib/scylladb/vib-verify.json
@@ -59,6 +59,12 @@
               "password": "ComplicatedPassword123!4"
             }
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/sealed-secrets/vib-verify.json
+++ b/.vib/sealed-secrets/vib-verify.json
@@ -51,6 +51,12 @@
               "namespace": "{{namespace}}"
             }
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/seaweedfs/vib-verify.json
+++ b/.vib/seaweedfs/vib-verify.json
@@ -62,6 +62,12 @@
               "releaseName": "seaweedfs"
             }
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/solr/vib-verify.json
+++ b/.vib/solr/vib-verify.json
@@ -69,6 +69,12 @@
               "password": "ComplicatedPassword123!4"
             }
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/sonarqube/vib-verify.json
+++ b/.vib/sonarqube/vib-verify.json
@@ -58,6 +58,12 @@
               }
             }
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/spark/vib-verify.json
+++ b/.vib/spark/vib-verify.json
@@ -57,6 +57,12 @@
               "expectedWorkers": "2"
             }
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/spring-cloud-dataflow/vib-verify.json
+++ b/.vib/spring-cloud-dataflow/vib-verify.json
@@ -54,6 +54,12 @@
             "endpoint": "lb-spring-cloud-dataflow-server-http",
             "app_protocol": "HTTP"
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/supabase/vib-verify.json
+++ b/.vib/supabase/vib-verify.json
@@ -57,6 +57,12 @@
               "serviceKey": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.ewogICAgInJvbGUiOiAic2VydmljZV9yb2xlIiwKICAgICJpc3MiOiAic3VwYWJhc2UiLAogICAgImlhdCI6IDE2NzU0MDA0MDAsCiAgICAiZXhwIjogMTgzMzE2NjgwMAp9.qNsmXzz4tG7eqJPh1Y58DbtIlJBauwpqx39UF-MwM8k"
             }
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/tensorflow-resnet/vib-verify.json
+++ b/.vib/tensorflow-resnet/vib-verify.json
@@ -54,6 +54,12 @@
             "endpoint": "lb-tensorflow-resnet-tf-serving-api",
             "app_protocol": "HTTP"
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/thanos/vib-verify.json
+++ b/.vib/thanos/vib-verify.json
@@ -43,6 +43,12 @@
               "receivePort": "10904"
             }
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/tomcat/vib-verify.json
+++ b/.vib/tomcat/vib-verify.json
@@ -58,6 +58,12 @@
               "password": "ComplicatedPassword123!4"
             }
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/valkey/vib-verify.json
+++ b/.vib/valkey/vib-verify.json
@@ -58,6 +58,12 @@
               "password": "ComplicatedPassword123!4"
             }
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/vault/vib-verify.json
+++ b/.vib/vault/vib-verify.json
@@ -58,6 +58,12 @@
               "password": "ComplicatedPassword123!4"
             }
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/whereabouts/vib-verify.json
+++ b/.vib/whereabouts/vib-verify.json
@@ -44,6 +44,12 @@
               }
             }
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/wildfly/vib-verify.json
+++ b/.vib/wildfly/vib-verify.json
@@ -54,6 +54,12 @@
             "endpoint": "lb-wildfly-http",
             "app_protocol": "HTTP"
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/wordpress/vib-verify.json
+++ b/.vib/wordpress/vib-verify.json
@@ -76,6 +76,12 @@
               "wordpress.password": "ComplicatedPassword123!4"
             }
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }

--- a/.vib/zookeeper/vib-verify.json
+++ b/.vib/zookeeper/vib-verify.json
@@ -44,6 +44,12 @@
               }
             }
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }


### PR DESCRIPTION
### Description of the change

This additional CI action checks that contributions do not reduce the Kubescape score.

Tested at https://github.com/migruiz4/charts/pull/19

### Additional information

* The action obtains the score of the affected chart from the `main` branch using the bitnami/kubescape image.
* The score obtained is truncated to two decimal digits precision.
* Then, the score is set as `threshold` for the VIB kubescape action, which will return not passed if the obtained score is lower than the threshold score.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
