### PR TITLE
[bitnami/postgresql-ha] Fix readiness probe when enabling TLS for PostgreSQL

### DIFF
--- a/bitnami/postgresql-ha/Chart.yaml
+++ b/bitnami/postgresql-ha/Chart.yaml
@@ -40,4 +40,4 @@ maintainers:
 name: postgresql-ha
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/postgresql-ha
-version: 14.2.7
+version: 14.2.8

--- a/bitnami/postgresql-ha/templates/_helpers.tpl
+++ b/bitnami/postgresql-ha/templates/_helpers.tpl
@@ -726,7 +726,7 @@ Get the readiness probe command
 {{- $block := index .context.Values .component }}
 {{- if eq .component "postgresql" -}}
 - |
-  exec pg_isready -U "postgres" {{- if $block.tls.enabled }} -d "sslcert={{ include "postgresql-ha.postgresql.tlsCert" . }} sslkey={{ include "postgresql-ha.postgresql.tlsCertKey" . }}"{{- end }} -h 127.0.0.1 -p {{ $block.containerPorts.postgresql }}
+  exec pg_isready -U "postgres" {{- if $block.tls.enabled }} -d "sslcert={{ include "postgresql-ha.postgresql.tlsCert" .context }} sslkey={{ include "postgresql-ha.postgresql.tlsCertKey" .context }}"{{- end }} -h 127.0.0.1 -p {{ $block.containerPorts.postgresql }}
 {{- if contains "bitnami/" $block.image.repository }}
   [ -f /opt/bitnami/postgresql/tmp/.initialized ] || [ -f /bitnami/postgresql/.initialized ]
 {{- end }}


### PR DESCRIPTION
### Description of the change

This PR fixes the readiness probe when enabling TLS for PostgreSQL

### Benefits

User can enable TLS for PostgreSQL without issues.

### Possible drawbacks

None

### Applicable issues

- fixes https://github.com/bitnami/charts/issues/26434

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
