### PR TITLE
[btinami/schema-registry] Fix typo in README: envVars -> extraEnvVars.

### DIFF
--- a/bitnami/schema-registry/README.md
+++ b/bitnami/schema-registry/README.md
@@ -122,7 +122,7 @@ kubectl create secret generic kafka-jks --from-file=kafka.truststore.jks=common.
 In case you want to add extra environment variables to Schema Registry, you can use `extraEnvs` parameter. For instance:
 
 ```yaml
-extraEnvs:
+extraEnvVars:
   - name: FOO
     value: BAR
 ```


### PR DESCRIPTION
### Description of the change

Fix typo in schema-registry README:  envVars -> extraEnvVars


### Checklist


- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
