### PR TITLE
[github-ci] Kubescape action improvements

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -333,6 +333,13 @@ jobs:
       - id: get-chart-score
         uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185
         name: Get main branch kubescape score
+        # Skip step when user is bitnami-bot or 'skip-score' label is used
+        if: |
+          !(
+            github.event.pull_request.user.login == 'bitnami-bot' ||
+            contains(github.event.pull_request.labels.*.name, 'skip-score') ||
+            (github.event.action == 'labeled' && github.event.label.name == 'skip-score')
+          )
         env:
           CHART: ${{ needs.get-chart.outputs.chart }}
         with:
@@ -341,17 +348,20 @@ jobs:
           run: |
             if [ -d "/charts/bitnami/${CHART}" ]; then
               kubescape scan framework MITRE,NSA,SOC2,cis-v1.23-t1.0.1 /charts/bitnami/${CHART} --format json -o /out/report.json
-              score=$(jq .summaryDetails.complianceScore /out/report.json)
               # Truncate score to 2 decimals
-              printf "%s.%.2s" $(echo "$(jq .summaryDetails.complianceScore /out/report.json)" | tr '.' ' ') > /out/score
+              printf "%s.%.2s" $(echo "$(jq .summaryDetails.complianceScore /out/report.json)" | tr '.' ' ') | sed 's/\.$//' > /out/score
             else
               echo "Chart not found at /charts/bitnami/${CHART}. It will be assumed that the upstream chart does not exist."
-              echo "0.00" > /out/score
             fi
       - id: set-output
         name: Set threshold score
         run: |
-          score="$(cat /tmp/score)"
+          if [[ -f "/tmp/score" ]]; then
+            score="$(cat /tmp/score)"
+          else
+            echo "Skipping Kubescape score check."
+            score="0"
+          fi
           echo "Using threshold score: ${score}"
           echo "threshold=${score}" >> $GITHUB_OUTPUT
   vib-verify:


### PR DESCRIPTION
### Description of the change

Improves the kubescape action in the CI pipeline by implementing these changes:

- Fixes an issue when the Kubescape report returns an integer, for example `100%`.
- Allows manually bypassing the score check. Useful when a new feature slightly decreases the score and it can not be avoided.
- Skip score check for automated PRs, to avoid issues with score changes caused by subchart updates.
