### PR TITLE
[bitnami/supabase] Do not render any resources for disabled components

### DIFF
--- a/bitnami/supabase/CHANGELOG.md
+++ b/bitnami/supabase/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
-## 5.2.8 (2024-07-03)
+## 5.2.9 (2024-07-04)
 
-* [bitnami/supabase] Release 5.2.8 ([#27728](https://github.com/bitnami/charts/pull/27728))
+* [bitnami/supabase] Do not render any resources for disabled components ([#27580](https://github.com/bitnami/charts/pull/27580))
+
+## <small>5.2.8 (2024-07-04)</small>
+
+* [bitnami/*] Update README changing TAC wording (#27530) ([52dfed6](https://github.com/bitnami/charts/commit/52dfed6bac44d791efabfaf06f15daddc4fefb0c)), closes [#27530](https://github.com/bitnami/charts/issues/27530)
+* [bitnami/supabase] Release 5.2.8 (#27728) ([33e773b](https://github.com/bitnami/charts/commit/33e773b50bc227d85afee414fba8728833a8b529)), closes [#27728](https://github.com/bitnami/charts/issues/27728)
 
 ## <small>5.2.7 (2024-06-18)</small>
 

--- a/bitnami/supabase/Chart.yaml
+++ b/bitnami/supabase/Chart.yaml
@@ -53,4 +53,4 @@ maintainers:
 name: supabase
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/supabase
-version: 5.2.8
+version: 5.2.9

--- a/bitnami/supabase/templates/auth/networkpolicy.yaml
+++ b/bitnami/supabase/templates/auth/networkpolicy.yaml
@@ -3,7 +3,7 @@ Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- if .Values.auth.networkPolicy.enabled }}
+{{- if and .Values.auth.enabled .Values.auth.networkPolicy.enabled }}
 kind: NetworkPolicy
 apiVersion: {{ include "common.capabilities.networkPolicy.apiVersion" . }}
 metadata:
@@ -43,7 +43,7 @@ spec:
         - podSelector:
             matchLabels:
               app.kubernetes.io/name: postgresql
-              app.kubernetes.io/instance: {{ .Release.Name }}              
+              app.kubernetes.io/instance: {{ .Release.Name }}
       {{- end }}
     {{- if .Values.kong.enabled }}
     # Allow connection to public endpoint (Kong)
@@ -53,7 +53,7 @@ spec:
         - podSelector:
             matchLabels:
               app.kubernetes.io/name: kong
-              app.kubernetes.io/instance: {{ .Release.Name }}              
+              app.kubernetes.io/instance: {{ .Release.Name }}
     {{- end }}
     {{- if .Values.auth.networkPolicy.extraEgress }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.auth.networkPolicy.extraEgress "context" $ ) | nindent 4 }}

--- a/bitnami/supabase/templates/auth/service.yaml
+++ b/bitnami/supabase/templates/auth/service.yaml
@@ -3,6 +3,7 @@ Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
+{{- if .Values.auth.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -54,3 +55,4 @@ spec:
   {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.auth.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: auth
+{{- end }}

--- a/bitnami/supabase/templates/meta/networkpolicy.yaml
+++ b/bitnami/supabase/templates/meta/networkpolicy.yaml
@@ -3,7 +3,7 @@ Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- if .Values.meta.networkPolicy.enabled }}
+{{- if and .Values.meta.enabled .Values.meta.networkPolicy.enabled }}
 kind: NetworkPolicy
 apiVersion: {{ include "common.capabilities.networkPolicy.apiVersion" . }}
 metadata:
@@ -43,7 +43,7 @@ spec:
         - podSelector:
             matchLabels:
               app.kubernetes.io/name: postgresql
-              app.kubernetes.io/instance: {{ .Release.Name }}              
+              app.kubernetes.io/instance: {{ .Release.Name }}
       {{- end }}
     {{- if .Values.meta.networkPolicy.extraEgress }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.meta.networkPolicy.extraEgress "context" $ ) | nindent 4 }}

--- a/bitnami/supabase/templates/meta/service.yaml
+++ b/bitnami/supabase/templates/meta/service.yaml
@@ -3,6 +3,7 @@ Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
+{{- if .Values.meta.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -54,3 +55,4 @@ spec:
   {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.meta.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: meta
+{{- end }}

--- a/bitnami/supabase/templates/realtime/networkpolicy.yaml
+++ b/bitnami/supabase/templates/realtime/networkpolicy.yaml
@@ -3,7 +3,7 @@ Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- if .Values.realtime.networkPolicy.enabled }}
+{{- if and .Values.realtime.enabled .Values.realtime.networkPolicy.enabled }}
 kind: NetworkPolicy
 apiVersion: {{ include "common.capabilities.networkPolicy.apiVersion" . }}
 metadata:
@@ -43,8 +43,8 @@ spec:
         - podSelector:
             matchLabels:
               app.kubernetes.io/name: postgresql
-              app.kubernetes.io/instance: {{ .Release.Name }}              
-      {{- end }}  
+              app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- end }}
     {{- if .Values.realtime.networkPolicy.extraEgress }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.realtime.networkPolicy.extraEgress "context" $ ) | nindent 4 }}
     {{- end }}

--- a/bitnami/supabase/templates/realtime/secret.yaml
+++ b/bitnami/supabase/templates/realtime/secret.yaml
@@ -3,7 +3,7 @@ Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- if (not .Values.realtime.existingSecret) }}
+{{- if and .Values.realtime.enabled (not .Values.realtime.existingSecret) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/bitnami/supabase/templates/realtime/service.yaml
+++ b/bitnami/supabase/templates/realtime/service.yaml
@@ -3,6 +3,7 @@ Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
+{{- if .Values.realtime.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -54,3 +55,4 @@ spec:
   {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.realtime.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: realtime
+ {{- end }}

--- a/bitnami/supabase/templates/rest/networkpolicy.yaml
+++ b/bitnami/supabase/templates/rest/networkpolicy.yaml
@@ -3,7 +3,7 @@ Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- if .Values.rest.networkPolicy.enabled }}
+{{- if and .Values.rest.enabled .Values.rest.networkPolicy.enabled }}
 kind: NetworkPolicy
 apiVersion: {{ include "common.capabilities.networkPolicy.apiVersion" . }}
 metadata:
@@ -43,8 +43,8 @@ spec:
         - podSelector:
             matchLabels:
               app.kubernetes.io/name: postgresql
-              app.kubernetes.io/instance: {{ .Release.Name }}              
-      {{- end }}  
+              app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- end }}
     {{- if .Values.rest.networkPolicy.extraEgress }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.rest.networkPolicy.extraEgress "context" $ ) | nindent 4 }}
     {{- end }}

--- a/bitnami/supabase/templates/rest/service.yaml
+++ b/bitnami/supabase/templates/rest/service.yaml
@@ -3,6 +3,7 @@ Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
+{{- if .Values.rest.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -54,3 +55,4 @@ spec:
   {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.rest.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: rest
+{{- end }}

--- a/bitnami/supabase/templates/storage/networkpolicy.yaml
+++ b/bitnami/supabase/templates/storage/networkpolicy.yaml
@@ -3,7 +3,7 @@ Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- if .Values.storage.networkPolicy.enabled }}
+{{- if and .Values.storage.enabled .Values.storage.networkPolicy.enabled }}
 kind: NetworkPolicy
 apiVersion: {{ include "common.capabilities.networkPolicy.apiVersion" . }}
 metadata:
@@ -43,8 +43,8 @@ spec:
         - podSelector:
             matchLabels:
               app.kubernetes.io/name: postgresql
-              app.kubernetes.io/instance: {{ .Release.Name }}              
-      {{- end }}  
+              app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- end }}
     {{- if .Values.rest.enabled }}
     # Allow connection to Supabase Rest
     - ports:

--- a/bitnami/supabase/templates/storage/pvc.yaml
+++ b/bitnami/supabase/templates/storage/pvc.yaml
@@ -3,7 +3,7 @@ Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- if and .Values.storage.persistence.enabled (not .Values.storage.persistence.existingClaim) -}}
+{{- if and .Values.storage.enabled .Values.storage.persistence.enabled (not .Values.storage.persistence.existingClaim) -}}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:

--- a/bitnami/supabase/templates/storage/service.yaml
+++ b/bitnami/supabase/templates/storage/service.yaml
@@ -3,6 +3,7 @@ Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
+{{- if .Values.storage.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -54,3 +55,4 @@ spec:
   {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.storage.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: storage
+{{- end }}

--- a/bitnami/supabase/templates/studio/ingress.yaml
+++ b/bitnami/supabase/templates/studio/ingress.yaml
@@ -3,7 +3,7 @@ Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- if .Values.studio.ingress.enabled }}
+{{- if and .Values.studio.enabled .Values.studio.ingress.enabled }}
 apiVersion: {{ include "common.capabilities.ingress.apiVersion" . }}
 kind: Ingress
 metadata:

--- a/bitnami/supabase/templates/studio/networkpolicy.yaml
+++ b/bitnami/supabase/templates/studio/networkpolicy.yaml
@@ -3,7 +3,7 @@ Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- if .Values.studio.networkPolicy.enabled }}
+{{- if and .Values.studio.enabled .Values.studio.networkPolicy.enabled }}
 kind: NetworkPolicy
 apiVersion: {{ include "common.capabilities.networkPolicy.apiVersion" . }}
 metadata:
@@ -43,8 +43,8 @@ spec:
         - podSelector:
             matchLabels:
               app.kubernetes.io/name: postgresql
-              app.kubernetes.io/instance: {{ .Release.Name }}              
-      {{- end }}  
+              app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- end }}
     {{- if .Values.kong.enabled }}
     # Allow connection to public endpoint (Kong)
     - ports:
@@ -53,7 +53,7 @@ spec:
         - podSelector:
             matchLabels:
               app.kubernetes.io/name: kong
-              app.kubernetes.io/instance: {{ .Release.Name }}              
+              app.kubernetes.io/instance: {{ .Release.Name }}
     {{- end }}
     {{- if .Values.studio.networkPolicy.extraEgress }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.studio.networkPolicy.extraEgress "context" $ ) | nindent 4 }}

--- a/bitnami/supabase/templates/studio/service.yaml
+++ b/bitnami/supabase/templates/studio/service.yaml
@@ -3,6 +3,7 @@ Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
+{{- if .Values.studio.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -51,3 +52,4 @@ spec:
   {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.studio.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: studio
+{{- end }}

--- a/bitnami/supabase/templates/studio/tls-secret.yaml
+++ b/bitnami/supabase/templates/studio/tls-secret.yaml
@@ -3,7 +3,7 @@ Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- if .Values.studio.ingress.enabled }}
+{{- if and .Values.studio.enabled .Values.studio.ingress.enabled }}
 {{- if .Values.studio.ingress.secrets }}
 {{- range .Values.studio.ingress.secrets }}
 apiVersion: v1


### PR DESCRIPTION
Skip rendering resources like network policies, services, secrets or even pvc for components 
(auth, meta, realtime, rest, storage, studio) which are disabled.

Resolves: #27540

### Description of the change

Add condition for a supabase component (auth, meta, realtime, rest, storage, studio) to be enabled, prior to rendering ayn resource for it.

### Benefits

No dangling and unused resources in Kubernetes.

### Possible drawbacks

I believe there are none 

### Applicable issues
- fixes #27540

### Additional information

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
