### PR TITLE
postgres exporter monitor all databases

### DIFF
--- a/bitnami/postgresql/CHANGELOG.md
+++ b/bitnami/postgresql/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
-## 15.5.11 (2024-06-26)
+## 15.5.12 (2024-06-28)
 
-* [bitnami/postgresql] Release 15.5.11 ([#27548](https://github.com/bitnami/charts/pull/27548))
+* postgres exporter monitor all databases ([#27586](https://github.com/bitnami/charts/pull/27586))
+
+## <small>15.5.11 (2024-06-26)</small>
+
+* [bitnami/*] Update README changing TAC wording (#27530) ([52dfed6](https://github.com/bitnami/charts/commit/52dfed6bac44d791efabfaf06f15daddc4fefb0c)), closes [#27530](https://github.com/bitnami/charts/issues/27530)
+* [bitnami/postgresql] Release 15.5.11 (#27548) ([0fe73e3](https://github.com/bitnami/charts/commit/0fe73e31c5dad97c86b9db11af28388d0324aea8)), closes [#27548](https://github.com/bitnami/charts/issues/27548)
 
 ## <small>15.5.10 (2024-06-25)</small>
 

--- a/bitnami/postgresql/CHANGELOG.md
+++ b/bitnami/postgresql/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 15.5.12 (2024-06-28)
+## 15.5.12 (2024-07-01)
 
 * postgres exporter monitor all databases ([#27586](https://github.com/bitnami/charts/pull/27586))
 

--- a/bitnami/postgresql/CHANGELOG.md
+++ b/bitnami/postgresql/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 15.5.12 (2024-07-01)
+## 15.5.12 (2024-07-02)
 
 * postgres exporter monitor all databases ([#27586](https://github.com/bitnami/charts/pull/27586))
 

--- a/bitnami/postgresql/Chart.yaml
+++ b/bitnami/postgresql/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: postgresql
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/postgresql
-version: 15.5.11
+version: 15.5.12

--- a/bitnami/postgresql/templates/primary/statefulset.yaml
+++ b/bitnami/postgresql/templates/primary/statefulset.yaml
@@ -532,7 +532,7 @@ spec:
             {{- end }}
           {{- end }}
           env:
-            {{- $database := required "In order to enable metrics you need to specify a database (.Values.auth.database or .Values.global.postgresql.auth.database)" (include "postgresql.v1.database" .) }}
+            {{- $database := include "postgresql.v1.database" . }}
             - name: DATA_SOURCE_URI
               value: {{ printf "127.0.0.1:%d/%s?sslmode=disable" (int (include "postgresql.v1.service.port" .)) $database }}
             {{- $pwdKey := ternary (include "postgresql.v1.adminPasswordKey" .) (include "postgresql.v1.userPasswordKey" .) (or (eq $customUser "postgres") (empty $customUser)) }}

--- a/bitnami/postgresql/templates/primary/statefulset.yaml
+++ b/bitnami/postgresql/templates/primary/statefulset.yaml
@@ -532,9 +532,8 @@ spec:
             {{- end }}
           {{- end }}
           env:
-            {{- $database := include "postgresql.v1.database" . }}
             - name: DATA_SOURCE_URI
-              value: {{ printf "127.0.0.1:%d/%s?sslmode=disable" (int (include "postgresql.v1.service.port" .)) $database }}
+              value: {{ printf "127.0.0.1:%d/?sslmode=disable" (int (include "postgresql.v1.service.port" .)) }}
             {{- $pwdKey := ternary (include "postgresql.v1.adminPasswordKey" .) (include "postgresql.v1.userPasswordKey" .) (or (eq $customUser "postgres") (empty $customUser)) }}
             {{- if .Values.auth.usePasswordFiles }}
             - name: DATA_SOURCE_PASS_FILE

--- a/bitnami/postgresql/templates/read/statefulset.yaml
+++ b/bitnami/postgresql/templates/read/statefulset.yaml
@@ -432,9 +432,8 @@ spec:
           args: [ "--extend.query-path", "/conf/custom-metrics.yaml" ]
           {{- end }}
           env:
-          {{- $database := required "In order to enable metrics you need to specify a database (.Values.auth.database or .Values.global.postgresql.auth.database)" (include "postgresql.v1.database" .) }}
             - name: DATA_SOURCE_URI
-              value: {{ printf "127.0.0.1:%d/%s?sslmode=disable" (int (include "postgresql.v1.service.port" .)) $database }}
+              value: {{ printf "127.0.0.1:%d/?sslmode=disable" (int (include "postgresql.v1.service.port" .)) }}
             {{- if .Values.auth.usePasswordFiles }}
             - name: DATA_SOURCE_PASS_FILE
               value: {{ printf "/opt/bitnami/postgresql/secrets/%s" (include "postgresql.v1.userPasswordKey" .) }}


### PR DESCRIPTION
Currently there is no option to monitor all databases with postgres exporter without mentioning the databases names and creating them in the init scripts. (.Values.auth.database). Postgres Exporter does let this feature work if you dont mention any databases in the URI and that is why i think the required statement is not correct so i removed it.
