### PR TITLE
[bitnami/kafka] fix: Mount kafka_jaas.conf in controller statefulset for kraft migration

### DIFF
--- a/bitnami/kafka/CHANGELOG.md
+++ b/bitnami/kafka/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
-## 29.3.5 (2024-07-01)
+## 29.3.6 (2024-07-02)
 
-* [bitnami/kafka] Release 29.3.5 ([#27613](https://github.com/bitnami/charts/pull/27613))
+* [bitnami/kafka] fix: Mount kafka_jaas.conf in controller statefulset for kraft migration ([#27610](https://github.com/bitnami/charts/pull/27610))
+
+## <small>29.3.5 (2024-07-01)</small>
+
+* [bitnami/*] Update README changing TAC wording (#27530) ([52dfed6](https://github.com/bitnami/charts/commit/52dfed6bac44d791efabfaf06f15daddc4fefb0c)), closes [#27530](https://github.com/bitnami/charts/issues/27530)
+* [bitnami/kafka] Release 29.3.5 (#27613) ([1ef0ca8](https://github.com/bitnami/charts/commit/1ef0ca867542f99b4e37ac3182727357a0fd17cf)), closes [#27613](https://github.com/bitnami/charts/issues/27613)
 
 ## <small>29.3.4 (2024-06-18)</small>
 

--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -40,4 +40,4 @@ maintainers:
 name: kafka
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/kafka
-version: 29.3.5
+version: 29.3.6

--- a/bitnami/kafka/templates/controller-eligible/statefulset.yaml
+++ b/bitnami/kafka/templates/controller-eligible/statefulset.yaml
@@ -310,6 +310,11 @@ spec:
             - name: kafka-config
               mountPath: /opt/bitnami/kafka/config/server.properties
               subPath: server.properties
+            {{- if .Values.sasl.zookeeper.user }}
+            - name: kafka-config
+              mountPath: /opt/bitnami/kafka/config/kafka_jaas.conf
+              subPath: kafka_jaas.conf
+            {{- end }}
             - name: tmp
               mountPath: /tmp
             {{- if or .Values.log4j .Values.existingLog4jConfigMap }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

During testing migration to kraft mode I recognized that the controller needs also a VolumeMount to the kafka_jaas.conf file to be able to properly connect to Zookeeper.

### Benefits

You can now migrate an external sasl authenticated zookeeper.

### Possible drawbacks

None

### Applicable issues

- fixes #27581

### Additional information

None

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
