### PR TITLE
[bitnami/argo-cd] Render PDBs and NetworkPolicies only if apps are enabled as well

### DIFF
--- a/bitnami/argo-cd/CHANGELOG.md
+++ b/bitnami/argo-cd/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 6.5.5 (2024-07-05)
+## 6.5.6 (2024-07-05)
 
-* [bitnami/argo-cd] Use correct port in NetworkPolicy of Repo Server ([#27615](https://github.com/bitnami/charts/pull/27615))
+* [bitnami/argo-cd] Render PDBs and NetworkPolicies only if apps are enabled as well ([#27614](https://github.com/bitnami/charts/pull/27614))
+
+## <small>6.5.5 (2024-07-05)</small>
+
+* [bitnami/argo-cd] Use correct port in NetworkPolicy of Repo Server (#27615) ([afe2d37](https://github.com/bitnami/charts/commit/afe2d3707912e9717615a38e5a54741800b443a1)), closes [#27615](https://github.com/bitnami/charts/issues/27615)
 
 ## <small>6.5.4 (2024-07-04)</small>
 

--- a/bitnami/argo-cd/Chart.yaml
+++ b/bitnami/argo-cd/Chart.yaml
@@ -39,4 +39,4 @@ maintainers:
 name: argo-cd
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/argo-cd
-version: 6.5.5
+version: 6.5.6

--- a/bitnami/argo-cd/templates/applicationset/networkpolicy.yaml
+++ b/bitnami/argo-cd/templates/applicationset/networkpolicy.yaml
@@ -3,7 +3,7 @@ Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- if .Values.applicationSet.networkPolicy.enabled }}
+{{- if and .Values.applicationSet.enabled .Values.applicationSet.networkPolicy.enabled }}
 kind: NetworkPolicy
 apiVersion: {{ include "common.capabilities.networkPolicy.apiVersion" . }}
 metadata:

--- a/bitnami/argo-cd/templates/applicationset/pdb.yaml
+++ b/bitnami/argo-cd/templates/applicationset/pdb.yaml
@@ -3,7 +3,7 @@ Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- if .Values.applicationSet.pdb.create }}
+{{- if and .Values.applicationSet.enabled .Values.applicationSet.pdb.create }}
 apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:

--- a/bitnami/argo-cd/templates/applicationset/role.yaml
+++ b/bitnami/argo-cd/templates/applicationset/role.yaml
@@ -3,7 +3,7 @@ Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- if and .Values.rbac.create .Values.applicationSet.enabled }}
+{{- if and .Values.applicationSet.enabled .Values.rbac.create }}
 kind: Role
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 metadata:

--- a/bitnami/argo-cd/templates/dex/pdb.yaml
+++ b/bitnami/argo-cd/templates/dex/pdb.yaml
@@ -3,7 +3,7 @@ Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- if .Values.dex.pdb.create }}
+{{- if and .Values.dex.enabled .Values.dex.pdb.create }}
 apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:

--- a/bitnami/argo-cd/templates/notifications/pdb.yaml
+++ b/bitnami/argo-cd/templates/notifications/pdb.yaml
@@ -3,7 +3,7 @@ Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- if .Values.notifications.pdb.create }}
+{{- if and .Values.notifications.enabled .Values.notifications.pdb.create }}
 apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:

--- a/bitnami/argo-cd/templates/repo-server/pdb.yaml
+++ b/bitnami/argo-cd/templates/repo-server/pdb.yaml
@@ -3,7 +3,7 @@ Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- if and .Values.repoServer.pdb.create }}
+{{- if .Values.repoServer.pdb.create }}
 apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:

--- a/bitnami/argo-cd/templates/server/pdb.yaml
+++ b/bitnami/argo-cd/templates/server/pdb.yaml
@@ -3,7 +3,7 @@ Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- if and .Values.server.pdb.create }}
+{{- if .Values.server.pdb.create }}
 apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:


### PR DESCRIPTION
### Description of the change

PodDisruptionBudgets and NetworkPolicies of the ArgoCD applications are only rendered when the corresponding application is enabled.

PDBs have been created as part of #26419.  NetworkPolicies as part of #23359.

### Benefits

No unnecessary resources in the cluster.

### Possible drawbacks

None

### Applicable issues

None

### Additional information

%

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
