### PR TITLE
[bitnami/apache] Uses common.compatibility.renderSecurityContext template to render containerSecurityContext values in container specs

### DIFF
--- a/bitnami/airflow/CHANGELOG.md
+++ b/bitnami/airflow/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
-## 18.3.6 (2024-07-03)
+## 18.3.7 (2024-07-03)
 
-* [bitnami/airflow] Release 18.3.6 ([#27682](https://github.com/bitnami/charts/pull/27682))
+* [bitnami/airflow] Release 18.3.7 ([#27742](https://github.com/bitnami/charts/pull/27742))
+
+## <small>18.3.6 (2024-07-03)</small>
+
+* [bitnami/*] Update README changing TAC wording (#27530) ([52dfed6](https://github.com/bitnami/charts/commit/52dfed6bac44d791efabfaf06f15daddc4fefb0c)), closes [#27530](https://github.com/bitnami/charts/issues/27530)
+* [bitnami/airflow] Release 18.3.6 (#27682) ([792722b](https://github.com/bitnami/charts/commit/792722b9717ae2e4f35b420207761b7aac67e2ac)), closes [#27682](https://github.com/bitnami/charts/issues/27682)
 
 ## <small>18.3.5 (2024-06-25)</small>
 

--- a/bitnami/airflow/Chart.lock
+++ b/bitnami/airflow/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: redis
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 19.6.0
+  version: 19.6.1
 - name: postgresql
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 15.5.12
+  version: 15.5.13
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 2.20.3
-digest: sha256:7c6b6ec4671ff13ca7b25885727680bd21e3a45807e552e524b631b2e7407464
-generated: "2024-07-03T07:06:31.748976938Z"
+digest: sha256:c9f0f727c4b1fb8536f86931e07e44be48b699cd85570a713e384065da1f5d22
+generated: "2024-07-03T17:40:58.681596248Z"

--- a/bitnami/airflow/Chart.yaml
+++ b/bitnami/airflow/Chart.yaml
@@ -14,7 +14,7 @@ annotations:
     - name: airflow-worker
       image: docker.io/bitnami/airflow-worker:2.9.2-debian-12-r1
     - name: git
-      image: docker.io/bitnami/git:2.45.2-debian-12-r2
+      image: docker.io/bitnami/git:2.45.2-debian-12-r3
     - name: os-shell
       image: docker.io/bitnami/os-shell:12-debian-12-r24
 apiVersion: v2
@@ -47,4 +47,4 @@ maintainers:
 name: airflow
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/airflow
-version: 18.3.6
+version: 18.3.7

--- a/bitnami/airflow/values.yaml
+++ b/bitnami/airflow/values.yaml
@@ -1234,7 +1234,7 @@ git:
   image:
     registry: docker.io
     repository: bitnami/git
-    tag: 2.45.2-debian-12-r2
+    tag: 2.45.2-debian-12-r3
     digest: ""
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'

--- a/bitnami/apache/CHANGELOG.md
+++ b/bitnami/apache/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 11.2.7 (2024-07-03)
 
-* [bitnami/apache] Uses common.compatibility.renderSecurityContext template to render containerSecurityContext values in container specs ([#27736](https://github.com/bitnami/charts/pull/27736))
+* [bitnami/apache] Release 11.2.7 ([#27740](https://github.com/bitnami/charts/pull/27740))
 
 ## <small>11.2.6 (2024-07-01)</small>
 

--- a/bitnami/apache/CHANGELOG.md
+++ b/bitnami/apache/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
-## 11.2.6 (2024-07-01)
+## 11.2.7 (2024-07-03)
 
-* [bitnami/apache] Release 11.2.6 ([#27618](https://github.com/bitnami/charts/pull/27618))
+* [bitnami/apache] Uses common.compatibility.renderSecurityContext template to render containerSecurityContext values in container specs ([#27736](https://github.com/bitnami/charts/pull/27736))
+
+## <small>11.2.6 (2024-07-01)</small>
+
+* [bitnami/*] Update README changing TAC wording (#27530) ([52dfed6](https://github.com/bitnami/charts/commit/52dfed6bac44d791efabfaf06f15daddc4fefb0c)), closes [#27530](https://github.com/bitnami/charts/issues/27530)
+* [bitnami/apache] Release 11.2.6 (#27618) ([c9763df](https://github.com/bitnami/charts/commit/c9763df0112bdec4859a74280bde03160267a949)), closes [#27618](https://github.com/bitnami/charts/issues/27618)
 
 ## <small>11.2.5 (2024-06-18)</small>
 

--- a/bitnami/apache/Chart.yaml
+++ b/bitnami/apache/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: apache
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/apache
-version: 11.2.7
+version: 11.2.8

--- a/bitnami/apache/Chart.yaml
+++ b/bitnami/apache/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: apache
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/apache
-version: 11.2.6
+version: 11.2.7

--- a/bitnami/apache/Chart.yaml
+++ b/bitnami/apache/Chart.yaml
@@ -6,13 +6,13 @@ annotations:
   licenses: Apache-2.0
   images: |
     - name: apache
-      image: docker.io/bitnami/apache:2.4.60-debian-12-r0
+      image: docker.io/bitnami/apache:2.4.61-debian-12-r0
     - name: apache-exporter
-      image: docker.io/bitnami/apache-exporter:1.0.8-debian-12-r1
+      image: docker.io/bitnami/apache-exporter:1.0.8-debian-12-r2
     - name: git
-      image: docker.io/bitnami/git:2.45.2-debian-12-r1
+      image: docker.io/bitnami/git:2.45.2-debian-12-r3
 apiVersion: v2
-appVersion: 2.4.60
+appVersion: 2.4.61
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts

--- a/bitnami/apache/templates/deployment.yaml
+++ b/bitnami/apache/templates/deployment.yaml
@@ -71,7 +71,7 @@ spec:
           image: {{ include "apache.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
           {{- if .Values.containerSecurityContext.enabled }}
-          securityContext: {{- omit .Values.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+          securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.containerSecurityContext "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.resources }}
           resources: {{- toYaml .Values.resources | nindent 12 }}
@@ -146,7 +146,7 @@ spec:
           resources: {{- include "common.resources.preset" (dict "type" .Values.cloneHtdocsFromGit.resourcesPreset) | nindent 12 }}
           {{- end }}
           {{- if .Values.containerSecurityContext.enabled }}
-          securityContext: {{- omit .Values.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+          securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.containerSecurityContext "context" $) | nindent 12 }}
           {{- end }}
           volumeMounts:
             - name: htdocs
@@ -298,7 +298,7 @@ spec:
           resources: {{- include "common.resources.preset" (dict "type" .Values.metrics.resourcesPreset) | nindent 12 }}
           {{- end }}
           {{- if .Values.containerSecurityContext.enabled }}
-          securityContext: {{- omit .Values.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+          securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.containerSecurityContext "context" $) | nindent 12 }}
           {{- end }}
           volumeMounts:
             - name: empty-dir

--- a/bitnami/apache/values.yaml
+++ b/bitnami/apache/values.yaml
@@ -62,7 +62,7 @@ extraDeploy: []
 image:
   registry: docker.io
   repository: bitnami/apache
-  tag: 2.4.60-debian-12-r0
+  tag: 2.4.61-debian-12-r0
   digest: ""
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
@@ -92,7 +92,7 @@ image:
 git:
   registry: docker.io
   repository: bitnami/git
-  tag: 2.45.2-debian-12-r1
+  tag: 2.45.2-debian-12-r3
   digest: ""
   pullPolicy: IfNotPresent
   ## Optionally specify an array of imagePullSecrets.
@@ -683,7 +683,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/apache-exporter
-    tag: 1.0.8-debian-12-r1
+    tag: 1.0.8-debian-12-r2
     digest: ""
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.

--- a/bitnami/aspnet-core/CHANGELOG.md
+++ b/bitnami/aspnet-core/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
-## 6.2.4 (2024-07-03)
+## 6.2.5 (2024-07-03)
 
-* [bitnami/aspnet-core] Release 6.2.4 ([#27689](https://github.com/bitnami/charts/pull/27689))
+* [bitnami/aspnet-core] Release 6.2.5 ([#27744](https://github.com/bitnami/charts/pull/27744))
+
+## <small>6.2.4 (2024-07-03)</small>
+
+* [bitnami/*] Update README changing TAC wording (#27530) ([52dfed6](https://github.com/bitnami/charts/commit/52dfed6bac44d791efabfaf06f15daddc4fefb0c)), closes [#27530](https://github.com/bitnami/charts/issues/27530)
+* [bitnami/aspnet-core] Release 6.2.4 (#27689) ([6b7a9d0](https://github.com/bitnami/charts/commit/6b7a9d04956cfff086cc62faafa195781a1779cf)), closes [#27689](https://github.com/bitnami/charts/issues/27689)
 
 ## <small>6.2.3 (2024-06-18)</small>
 

--- a/bitnami/aspnet-core/Chart.yaml
+++ b/bitnami/aspnet-core/Chart.yaml
@@ -10,7 +10,7 @@ annotations:
     - name: dotnet-sdk
       image: docker.io/bitnami/dotnet-sdk:8.0.302-debian-12-r1
     - name: git
-      image: docker.io/bitnami/git:2.45.2-debian-12-r2
+      image: docker.io/bitnami/git:2.45.2-debian-12-r3
 apiVersion: v2
 appVersion: 8.0.6
 dependencies:
@@ -31,4 +31,4 @@ maintainers:
 name: aspnet-core
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/aspnet-core
-version: 6.2.4
+version: 6.2.5

--- a/bitnami/aspnet-core/values.yaml
+++ b/bitnami/aspnet-core/values.yaml
@@ -408,7 +408,7 @@ appFromExternalRepo:
     image:
       registry: docker.io
       repository: bitnami/git
-      tag: 2.45.2-debian-12-r2
+      tag: 2.45.2-debian-12-r3
       digest: ""
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'

--- a/bitnami/deepspeed/CHANGELOG.md
+++ b/bitnami/deepspeed/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 2.2.7 (2024-06-28)
+## 2.2.8 (2024-07-03)
 
-* [bitnami/deepspeed] Release 2.2.7 ([#27577](https://github.com/bitnami/charts/pull/27577))
+* [bitnami/deepspeed] Release 2.2.8 ([#27745](https://github.com/bitnami/charts/pull/27745))
+
+## <small>2.2.7 (2024-06-28)</small>
+
+* [bitnami/deepspeed] Release 2.2.7 (#27577) ([d403bd4](https://github.com/bitnami/charts/commit/d403bd4c5e7c2c762eead48d052a2f39fa42fe6c)), closes [#27577](https://github.com/bitnami/charts/issues/27577)
 
 ## <small>2.2.6 (2024-06-27)</small>
 

--- a/bitnami/deepspeed/Chart.yaml
+++ b/bitnami/deepspeed/Chart.yaml
@@ -6,11 +6,11 @@ annotations:
   licenses: Apache-2.0
   images: |
     - name: deepspeed
-      image: docker.io/bitnami/deepspeed:0.14.4-debian-12-r2
+      image: docker.io/bitnami/deepspeed:0.14.4-debian-12-r4
     - name: git
-      image: docker.io/bitnami/git:2.45.2-debian-12-r0
+      image: docker.io/bitnami/git:2.45.2-debian-12-r3
     - name: os-shell
-      image: docker.io/bitnami/os-shell:12-debian-12-r22
+      image: docker.io/bitnami/os-shell:12-debian-12-r24
 apiVersion: v2
 appVersion: 0.14.4
 dependencies:
@@ -35,4 +35,4 @@ name: deepspeed
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/deepspeed
 - https://github.com/bitnami/charts/tree/main/bitnami/pytorch
-version: 2.2.7
+version: 2.2.8

--- a/bitnami/deepspeed/values.yaml
+++ b/bitnami/deepspeed/values.yaml
@@ -80,7 +80,7 @@ diagnosticMode:
 image:
   registry: docker.io
   repository: bitnami/deepspeed
-  tag: 0.14.4-debian-12-r2
+  tag: 0.14.4-debian-12-r4
   digest: ""
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
@@ -1035,7 +1035,7 @@ worker:
 gitImage:
   registry: docker.io
   repository: bitnami/git
-  tag: 2.45.2-debian-12-r0
+  tag: 2.45.2-debian-12-r3
   digest: ""
   pullPolicy: IfNotPresent
   ## Optionally specify an array of imagePullSecrets.
@@ -1062,7 +1062,7 @@ volumePermissions:
   image:
     registry: docker.io
     repository: bitnami/os-shell
-    tag: 12-debian-12-r22
+    tag: 12-debian-12-r24
     digest: ""
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.

--- a/bitnami/mariadb-galera/CHANGELOG.md
+++ b/bitnami/mariadb-galera/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
-## 13.2.6 (2024-07-02)
+## 13.2.7 (2024-07-03)
 
-* [bitnami/mariadb-galera] Release 13.2.6 ([#27636](https://github.com/bitnami/charts/pull/27636))
+* [bitnami/mariadb-galera] Release 13.2.7 ([#27746](https://github.com/bitnami/charts/pull/27746))
+
+## <small>13.2.6 (2024-07-02)</small>
+
+* [bitnami/*] Update README changing TAC wording (#27530) ([52dfed6](https://github.com/bitnami/charts/commit/52dfed6bac44d791efabfaf06f15daddc4fefb0c)), closes [#27530](https://github.com/bitnami/charts/issues/27530)
+* [bitnami/mariadb-galera] Release 13.2.6 (#27636) ([e0d84d3](https://github.com/bitnami/charts/commit/e0d84d3c17b2049e432899630c947015a62ffe70)), closes [#27636](https://github.com/bitnami/charts/issues/27636)
 
 ## <small>13.2.5 (2024-06-18)</small>
 

--- a/bitnami/mariadb-galera/Chart.yaml
+++ b/bitnami/mariadb-galera/Chart.yaml
@@ -6,9 +6,9 @@ annotations:
   licenses: Apache-2.0
   images: |
     - name: mariadb-galera
-      image: docker.io/bitnami/mariadb-galera:11.3.2-debian-12-r7
+      image: docker.io/bitnami/mariadb-galera:11.3.2-debian-12-r9
     - name: mysqld-exporter
-      image: docker.io/bitnami/mysqld-exporter:0.15.1-debian-12-r25
+      image: docker.io/bitnami/mysqld-exporter:0.15.1-debian-12-r26
 apiVersion: v2
 appVersion: 11.3.2
 dependencies:
@@ -33,4 +33,4 @@ maintainers:
 name: mariadb-galera
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/mariadb-galera
-version: 13.2.6
+version: 13.2.7

--- a/bitnami/mariadb-galera/values.yaml
+++ b/bitnami/mariadb-galera/values.yaml
@@ -86,7 +86,7 @@ diagnosticMode:
 image:
   registry: docker.io
   repository: bitnami/mariadb-galera
-  tag: 11.3.2-debian-12-r7
+  tag: 11.3.2-debian-12-r9
   digest: ""
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
@@ -885,7 +885,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/mysqld-exporter
-    tag: 0.15.1-debian-12-r25
+    tag: 0.15.1-debian-12-r26
     digest: ""
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets (secrets must be manually created in the namespace)

--- a/bitnami/nginx/CHANGELOG.md
+++ b/bitnami/nginx/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
-## 18.1.3 (2024-07-03)
+## 18.1.4 (2024-07-03)
 
-* [bitnami/nginx] Release 18.1.3 ([#27704](https://github.com/bitnami/charts/pull/27704))
+* [bitnami/nginx] Release 18.1.4 ([#27743](https://github.com/bitnami/charts/pull/27743))
+
+## <small>18.1.3 (2024-07-03)</small>
+
+* [bitnami/*] Update README changing TAC wording (#27530) ([52dfed6](https://github.com/bitnami/charts/commit/52dfed6bac44d791efabfaf06f15daddc4fefb0c)), closes [#27530](https://github.com/bitnami/charts/issues/27530)
+* [bitnami/nginx] Release 18.1.3 (#27704) ([682210e](https://github.com/bitnami/charts/commit/682210e3c1b84e0aeeab9e9e14b6d50076aa8303)), closes [#27704](https://github.com/bitnami/charts/issues/27704)
 
 ## <small>18.1.2 (2024-06-18)</small>
 

--- a/bitnami/nginx/Chart.yaml
+++ b/bitnami/nginx/Chart.yaml
@@ -6,7 +6,7 @@ annotations:
   licenses: Apache-2.0
   images: |
     - name: git
-      image: docker.io/bitnami/git:2.45.2-debian-12-r2
+      image: docker.io/bitnami/git:2.45.2-debian-12-r3
     - name: nginx
       image: docker.io/bitnami/nginx:1.27.0-debian-12-r3
     - name: nginx-exporter
@@ -34,4 +34,4 @@ maintainers:
 name: nginx
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/nginx
-version: 18.1.3
+version: 18.1.4

--- a/bitnami/nginx/values.yaml
+++ b/bitnami/nginx/values.yaml
@@ -508,7 +508,7 @@ cloneStaticSiteFromGit:
   image:
     registry: docker.io
     repository: bitnami/git
-    tag: 2.45.2-debian-12-r2
+    tag: 2.45.2-debian-12-r3
     digest: ""
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'

--- a/bitnami/pytorch/CHANGELOG.md
+++ b/bitnami/pytorch/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
-## 4.2.8 (2024-07-03)
+## 4.2.9 (2024-07-03)
 
-* [bitnami/pytorch] Release 4.2.8 ([#27708](https://github.com/bitnami/charts/pull/27708))
+* [bitnami/pytorch] Release 4.2.9 ([#27741](https://github.com/bitnami/charts/pull/27741))
+
+## <small>4.2.8 (2024-07-03)</small>
+
+* [bitnami/*] Update README changing TAC wording (#27530) ([52dfed6](https://github.com/bitnami/charts/commit/52dfed6bac44d791efabfaf06f15daddc4fefb0c)), closes [#27530](https://github.com/bitnami/charts/issues/27530)
+* [bitnami/pytorch] Release 4.2.8 (#27708) ([f5fafe0](https://github.com/bitnami/charts/commit/f5fafe0482dc2dac6c5af083a159963cf2b937f7)), closes [#27708](https://github.com/bitnami/charts/issues/27708)
 
 ## <small>4.2.7 (2024-06-18)</small>
 

--- a/bitnami/pytorch/Chart.yaml
+++ b/bitnami/pytorch/Chart.yaml
@@ -6,7 +6,7 @@ annotations:
   licenses: Apache-2.0
   images: |
     - name: git
-      image: docker.io/bitnami/git:2.45.2-debian-12-r2
+      image: docker.io/bitnami/git:2.45.2-debian-12-r3
     - name: os-shell
       image: docker.io/bitnami/os-shell:12-debian-12-r24
     - name: pytorch
@@ -33,4 +33,4 @@ maintainers:
 name: pytorch
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/pytorch
-version: 4.2.8
+version: 4.2.9

--- a/bitnami/pytorch/values.yaml
+++ b/bitnami/pytorch/values.yaml
@@ -558,7 +558,7 @@ networkPolicy:
 git:
   registry: docker.io
   repository: bitnami/git
-  tag: 2.45.2-debian-12-r2
+  tag: 2.45.2-debian-12-r3
   digest: ""
   pullPolicy: IfNotPresent
   ## Optionally specify an array of imagePullSecrets.

--- a/bitnami/rabbitmq/CHANGELOG.md
+++ b/bitnami/rabbitmq/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
-## 14.4.5 (2024-07-03)
+## 14.4.6 (2024-07-03)
 
-* [bitnami/rabbitmq] Release 14.4.5 ([#27713](https://github.com/bitnami/charts/pull/27713))
+* [bitnami/rabbitmq] Release 14.4.6 ([#27739](https://github.com/bitnami/charts/pull/27739))
+
+## <small>14.4.5 (2024-07-03)</small>
+
+* [bitnami/*] Update README changing TAC wording (#27530) ([52dfed6](https://github.com/bitnami/charts/commit/52dfed6bac44d791efabfaf06f15daddc4fefb0c)), closes [#27530](https://github.com/bitnami/charts/issues/27530)
+* [bitnami/rabbitmq] Release 14.4.5 (#27713) ([c54e941](https://github.com/bitnami/charts/commit/c54e941e790295203771c7574c907c72a00aef80)), closes [#27713](https://github.com/bitnami/charts/issues/27713)
 
 ## <small>14.4.4 (2024-06-18)</small>
 

--- a/bitnami/rabbitmq/Chart.yaml
+++ b/bitnami/rabbitmq/Chart.yaml
@@ -8,9 +8,9 @@ annotations:
     - name: os-shell
       image: docker.io/bitnami/os-shell:12-debian-12-r24
     - name: rabbitmq
-      image: docker.io/bitnami/rabbitmq:3.13.3-debian-12-r1
+      image: docker.io/bitnami/rabbitmq:3.13.4-debian-12-r0
 apiVersion: v2
-appVersion: 3.13.3
+appVersion: 3.13.4
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
@@ -30,4 +30,4 @@ maintainers:
 name: rabbitmq
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/rabbitmq
-version: 14.4.5
+version: 14.4.6

--- a/bitnami/rabbitmq/values.yaml
+++ b/bitnami/rabbitmq/values.yaml
@@ -42,7 +42,7 @@ global:
 image:
   registry: docker.io
   repository: bitnami/rabbitmq
-  tag: 3.13.3-debian-12-r1
+  tag: 3.13.4-debian-12-r0
   digest: ""
   ## set to true if you would like to see extra information on logs
   ## It turns BASH and/or NAMI debugging in the image


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Use common.compatibility.renderSecurityContext template to render containerSecurityContext values in container specs.

### Benefits

Consistency with other Bitnami charts, and presumably the intended behavior.

### Possible drawbacks

It may be possible that a user relies on the current (incorrect) default behavior in a OpenShift environment - which would be to set `securityContext.runAsUser: 1001` and `securityContext.runAsGroup: 0` in the container specs (excepting the main `apache` container).  In this case, the default setting `global.compatibility.openshift.adaptSecurityContext: auto` would likely remove the securityContext config for container specs.  If in fact the user wants the pre-commit behavior, they can set global.compatibility.openshift.adaptSecurityContext to `disabled`. 

### Applicable issues

- fixes #27633 

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
