### PR TITLE
[bitnami/apache] Uses `common.compatibility.renderSecurityContext` template to render `containerSecurityContext` values in container specs

### DIFF
--- a/bitnami/apache/CHANGELOG.md
+++ b/bitnami/apache/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 11.2.7 (2024-07-03)
+## 11.2.8 (2024-07-03)
 
-* [bitnami/apache] Release 11.2.7 ([#27740](https://github.com/bitnami/charts/pull/27740))
+* [bitnami/apache] Uses common.compatibility.renderSecurityContext template to render containerSecurityContext values in container specs ([#27748](https://github.com/bitnami/charts/pull/27748))
+
+## <small>11.2.7 (2024-07-03)</small>
+
+* [bitnami/apache] Release 11.2.7 (#27740) ([06bc29e](https://github.com/bitnami/charts/commit/06bc29e845408e9b9825660981af83bde4f488b6)), closes [#27740](https://github.com/bitnami/charts/issues/27740)
 
 ## <small>11.2.6 (2024-07-01)</small>
 

--- a/bitnami/apache/CHANGELOG.md
+++ b/bitnami/apache/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-## 11.2.8 (2024-07-03)
+## 11.2.8 (2024-07-04)
 
-* [bitnami/apache] Uses common.compatibility.renderSecurityContext template to render containerSecurityContext values in container specs ([#27748](https://github.com/bitnami/charts/pull/27748))
+* [bitnami/apache] Uses `common.compatibility.renderSecurityContext` template to render `containerSecurityContext` values in container specs ([#27748](https://github.com/bitnami/charts/pull/27748))
 
 ## <small>11.2.7 (2024-07-03)</small>
 

--- a/bitnami/apache/Chart.yaml
+++ b/bitnami/apache/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: apache
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/apache
-version: 11.2.7
+version: 11.2.8

--- a/bitnami/apache/templates/deployment.yaml
+++ b/bitnami/apache/templates/deployment.yaml
@@ -71,7 +71,7 @@ spec:
           image: {{ include "apache.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
           {{- if .Values.containerSecurityContext.enabled }}
-          securityContext: {{- omit .Values.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+          securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.containerSecurityContext "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.resources }}
           resources: {{- toYaml .Values.resources | nindent 12 }}
@@ -146,7 +146,7 @@ spec:
           resources: {{- include "common.resources.preset" (dict "type" .Values.cloneHtdocsFromGit.resourcesPreset) | nindent 12 }}
           {{- end }}
           {{- if .Values.containerSecurityContext.enabled }}
-          securityContext: {{- omit .Values.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+          securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.containerSecurityContext "context" $) | nindent 12 }}
           {{- end }}
           volumeMounts:
             - name: htdocs
@@ -298,7 +298,7 @@ spec:
           resources: {{- include "common.resources.preset" (dict "type" .Values.metrics.resourcesPreset) | nindent 12 }}
           {{- end }}
           {{- if .Values.containerSecurityContext.enabled }}
-          securityContext: {{- omit .Values.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+          securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.containerSecurityContext "context" $) | nindent 12 }}
           {{- end }}
           volumeMounts:
             - name: empty-dir


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Use common.compatibility.renderSecurityContext template to render containerSecurityContext values in container specs.

### Benefits

Consistency with other Bitnami charts, and presumably the intended behavior.

### Possible drawbacks

It may be possible that a user relies on the current (incorrect) default behavior in a OpenShift environment - which would be to set `securityContext.runAsUser: 1001` and `securityContext.runAsGroup: 0` in the container specs (excepting the main `apache` container).  In this case, the default setting `global.compatibility.openshift.adaptSecurityContext: auto` would likely remove the securityContext config for container specs.  If in fact the user wants the pre-commit behavior, they can set global.compatibility.openshift.adaptSecurityContext to `disabled`. 

### Applicable issues

- fixes #27633 

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
