### PR TITLE
bitnami/keycloak Diversity: Allow Keycloak admin realm to be changed/configurable

### DIFF
--- a/bitnami/keycloak/CHANGELOG.md
+++ b/bitnami/keycloak/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
-## 21.4.5 (2024-07-03)
+## 21.4.6 (2024-07-05)
 
-* [bitnami/keycloak] Release 21.4.5 ([#27693](https://github.com/bitnami/charts/pull/27693))
+* bitnami/keycloak Diversity: Allow Keycloak admin realm to be changed/configurable ([#27821](https://github.com/bitnami/charts/pull/27821))
+
+## <small>21.4.5 (2024-07-03)</small>
+
+* [bitnami/*] Update README changing TAC wording (#27530) ([52dfed6](https://github.com/bitnami/charts/commit/52dfed6bac44d791efabfaf06f15daddc4fefb0c)), closes [#27530](https://github.com/bitnami/charts/issues/27530)
+* [bitnami/keycloak] Release 21.4.5 (#27693) ([ed5f4a4](https://github.com/bitnami/charts/commit/ed5f4a4a46bb408fea752de831eebe8ca9c6e9af)), closes [#27693](https://github.com/bitnami/charts/issues/27693)
 
 ## <small>21.4.4 (2024-06-20)</small>
 

--- a/bitnami/keycloak/CHANGELOG.md
+++ b/bitnami/keycloak/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 21.4.6 (2024-07-05)
+## 21.4.6 (2024-07-08)
 
 * bitnami/keycloak Diversity: Allow Keycloak admin realm to be changed/configurable ([#27821](https://github.com/bitnami/charts/pull/27821))
 

--- a/bitnami/keycloak/Chart.yaml
+++ b/bitnami/keycloak/Chart.yaml
@@ -33,4 +33,4 @@ maintainers:
 name: keycloak
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/keycloak
-version: 21.4.5
+version: 21.4.6

--- a/bitnami/keycloak/README.md
+++ b/bitnami/keycloak/README.md
@@ -349,6 +349,7 @@ As an alternative, you can use of the preset configurations for pod affinity, po
 | `spi.truststoreFilename`         | Truststore filename inside the existing secret                                                                               | `keycloak-spi.truststore.jks` |
 | `spi.passwordsSecret`            | Secret containing the SPI Truststore passwords.                                                                              | `""`                          |
 | `spi.hostnameVerificationPolicy` | Verify the hostname of the server's certificate. Allowed values: "ANY", "WILDCARD", "STRICT".                                | `""`                          |
+| `adminRealm`                     | Keycloak admin realm                                                                                                         | `master`                      |
 | `production`                     | Run Keycloak in production mode. TLS configuration is required except when using proxy=edge.                                 | `false`                       |
 | `proxy`                          | reverse Proxy mode edge, reencrypt, passthrough or none                                                                      | `passthrough`                 |
 | `httpRelativePath`               | Set the path relative to '/' for serving resources. Useful if you are migrating from older version which were using '/auth/' | `/`                           |

--- a/bitnami/keycloak/README.md
+++ b/bitnami/keycloak/README.md
@@ -349,7 +349,7 @@ As an alternative, you can use of the preset configurations for pod affinity, po
 | `spi.truststoreFilename`         | Truststore filename inside the existing secret                                                                               | `keycloak-spi.truststore.jks` |
 | `spi.passwordsSecret`            | Secret containing the SPI Truststore passwords.                                                                              | `""`                          |
 | `spi.hostnameVerificationPolicy` | Verify the hostname of the server's certificate. Allowed values: "ANY", "WILDCARD", "STRICT".                                | `""`                          |
-| `adminRealm`                     | Keycloak admin realm                                                                                                         | `master`                      |
+| `adminRealm`                     | Name of the admin realm                                                                                                      | `master`                      |
 | `production`                     | Run Keycloak in production mode. TLS configuration is required except when using proxy=edge.                                 | `false`                       |
 | `proxy`                          | reverse Proxy mode edge, reencrypt, passthrough or none                                                                      | `passthrough`                 |
 | `httpRelativePath`               | Set the path relative to '/' for serving resources. Useful if you are migrating from older version which were using '/auth/' | `/`                           |

--- a/bitnami/keycloak/templates/NOTES.txt
+++ b/bitnami/keycloak/templates/NOTES.txt
@@ -19,7 +19,7 @@ To access Keycloak from outside the cluster execute the following commands:
    echo "$CLUSTER_IP  {{ (tpl .Values.ingress.hostname .) }}" | sudo tee -a /etc/hosts
 
 {{- if .Values.adminIngress.enabled }}
-The admin area of Keycloak has been configured to point to a different domain ({{ .Values.adminIngress.hostname }}). Please remember to update the `frontendUrl` property of the `master` (or any other) realm for it to work properly (see README for an example) :
+The admin area of Keycloak has been configured to point to a different domain ({{ .Values.adminIngress.hostname }}). Please remember to update the `frontendUrl` property of the `{{ .Values.adminRealm | default "master" }}` (or any other) realm for it to work properly (see README for an example) :
 
    echo "Keycloak admin URL: http{{ if .Values.adminIngress.tls }}s{{ end }}://{{ (tpl .Values.adminIngress.hostname .) }}/"
    echo "$CLUSTER_IP  {{ (tpl .Values.adminIngress.hostname .) }}" | sudo tee -a /etc/hosts

--- a/bitnami/keycloak/templates/statefulset.yaml
+++ b/bitnami/keycloak/templates/statefulset.yaml
@@ -220,6 +220,10 @@ spec:
             - name: KC_HOSTNAME_URL
               value: "http{{ if or .Values.adminIngress.tls (eq .Values.proxy "edge") }}s{{ end }}://{{ include "common.tplvalues.render" (dict "value" .Values.adminIngress.hostname "context" $) }}"
             {{- end }}
+            {{- if .Values.adminRealm }}
+            - name: KC_SPI_ADMIN_REALM
+              value: "{{ .Values.adminRealm }}"
+            {{- end }}
             {{- if .Values.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}
@@ -275,7 +279,7 @@ spec:
           {{- else if .Values.readinessProbe.enabled }}
           readinessProbe: {{- omit .Values.readinessProbe "enabled" | toYaml | nindent 12 }}
             httpGet:
-              path: {{ .Values.httpRelativePath }}realms/master
+              path: {{ .Values.httpRelativePath }}realms/{{ .Values.adminRealm | default "master" }}
               port: http
           {{- end }}
           {{- end }}

--- a/bitnami/keycloak/values.yaml
+++ b/bitnami/keycloak/values.yaml
@@ -200,6 +200,9 @@ spi:
   ## @param spi.hostnameVerificationPolicy Verify the hostname of the server's certificate. Allowed values: "ANY", "WILDCARD", "STRICT".
   ##
   hostnameVerificationPolicy: ""
+## @param adminRealm Name of the admin realm
+##
+adminRealm: "master"
 ## @param production Run Keycloak in production mode. TLS configuration is required except when using proxy=edge.
 ##
 production: false
@@ -998,7 +1001,7 @@ metrics:
     ##
     endpoints:
       - path: '{{ include "keycloak.httpPath" . }}metrics'
-      - path: '{{ include "keycloak.httpPath" . }}realms/master/metrics'
+      - path: '{{ include "keycloak.httpPath" . }}realms/{{ .Values.adminRealm }}/metrics'
     ## @param metrics.serviceMonitor.path Metrics service HTTP path. Deprecated: Use @param metrics.serviceMonitor.endpoints instead
     ##
     path: ""


### PR DESCRIPTION
### Description of the change

The admin realm of Keycloak is fixed in this chart to 'master'. In an interest to allow users of this chart to not use this term, if the chart allowed for changing the admin realm name as a built-in, this would make supporting this easier.

This PR was based on values overrides that are possible with the existing Keycloak chart.

### Benefits

Enables the admin realm to be able to be named differently.  This allows for the use of a name other than 'master'.

This also has security improvements (allowing for use of a non-standard name).

### Possible drawbacks

Not currently able to verify the serviceMonitor portion.

### Applicable issues

- expected to address #27816

### Additional information

N/A

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm) - Note that I did not use the generator
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
