### PR TITLE
[bitnami/discourse] Fix pgrep on livenessProbe typo

### DIFF
--- a/bitnami/discourse/CHANGELOG.md
+++ b/bitnami/discourse/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 13.2.9 (2024-07-05)
+## 13.2.9 (2024-07-08)
 
 * [bitnami/discourse] Fix pgrep on livenessProbe typo ([#27824](https://github.com/bitnami/charts/pull/27824))
 

--- a/bitnami/discourse/CHANGELOG.md
+++ b/bitnami/discourse/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 13.2.8 (2024-07-03)
+## 13.2.9 (2024-07-05)
 
-* [bitnami/discourse] Release 13.2.8 ([#27749](https://github.com/bitnami/charts/pull/27749))
+* [bitnami/discourse] Fix pgrep on livenessProbe typo ([#27824](https://github.com/bitnami/charts/pull/27824))
+
+## <small>13.2.8 (2024-07-03)</small>
+
+* [bitnami/discourse] Release 13.2.8 (#27749) ([bc83af9](https://github.com/bitnami/charts/commit/bc83af9654e2901e463ff39f7baff6e231cb6853)), closes [#27749](https://github.com/bitnami/charts/issues/27749)
 
 ## <small>13.2.7 (2024-07-03)</small>
 

--- a/bitnami/discourse/Chart.yaml
+++ b/bitnami/discourse/Chart.yaml
@@ -41,4 +41,4 @@ maintainers:
 name: discourse
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/discourse
-version: 13.2.8
+version: 13.2.9

--- a/bitnami/discourse/templates/deployment.yaml
+++ b/bitnami/discourse/templates/deployment.yaml
@@ -309,10 +309,7 @@ spec:
           {{- else if .Values.sidekiq.livenessProbe.enabled }}
           livenessProbe:
             exec:
-              command:
-                - pgreg
-                - -f
-                - sidekiq
+              command: ["/bin/sh", "-c", "pgrep -f ^sidekiq"]
             initialDelaySeconds: {{ .Values.sidekiq.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.sidekiq.livenessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.sidekiq.livenessProbe.timeoutSeconds }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->
Liveness probe for the sidekiq container has been spitting out errors by default due to the "pgreg" typo. I also made the livenessProbe command consistent with the rest of the probes while I'm at it.

### Benefits

<!-- What benefits will be realized by the code change? -->
There would be no need to use custom livenessProbe to avoid the errors.

### Possible drawbacks

<!-- Describe any known limitations with your change -->
None

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
Haven't posted an issue regarding this as it is a simple fix

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
