### PR TITLE
[bitnami/rabbitmq-cluster-operator]: Adding permissions on controller…

### DIFF
--- a/bitnami/rabbitmq-cluster-operator/CHANGELOG.md
+++ b/bitnami/rabbitmq-cluster-operator/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 4.3.12 (2024-07-04)
+## 4.3.13 (2024-07-08)
 
-* [bitnami/rabbitmq-cluster-operator] Release 4.3.12 ([#27779](https://github.com/bitnami/charts/pull/27779))
+* [bitnami/rabbitmq-cluster-operator]: Adding permissions on controller… ([#27834](https://github.com/bitnami/charts/pull/27834))
+
+## <small>4.3.12 (2024-07-04)</small>
+
+* [bitnami/rabbitmq-cluster-operator] Release 4.3.12 (#27779) ([2cd3bdf](https://github.com/bitnami/charts/commit/2cd3bdf391d4fed0be35e7593f11e8ce75b99ed1)), closes [#27779](https://github.com/bitnami/charts/issues/27779)
 
 ## <small>4.3.11 (2024-07-03)</small>
 

--- a/bitnami/rabbitmq-cluster-operator/Chart.yaml
+++ b/bitnami/rabbitmq-cluster-operator/Chart.yaml
@@ -37,4 +37,4 @@ maintainers:
 name: rabbitmq-cluster-operator
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/rabbitmq-cluster-operator
-version: 4.3.12
+version: 4.3.13

--- a/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/clusterrole.yaml
+++ b/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/clusterrole.yaml
@@ -81,6 +81,12 @@ rules:
   - apiGroups:
       - rabbitmq.com
     resources:
+      - bindings/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - rabbitmq.com
+    resources:
       - exchanges
     verbs:
       - create
@@ -97,6 +103,12 @@ rules:
     verbs:
       - get
       - patch
+      - update
+  - apiGroups:
+      - rabbitmq.com
+    resources:
+      - exchanges/finalizers
+    verbs:
       - update
   - apiGroups:
       - rabbitmq.com
@@ -121,6 +133,12 @@ rules:
   - apiGroups:
       - rabbitmq.com
     resources:
+      - federations/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - rabbitmq.com
+    resources:
       - permissions
     verbs:
       - create
@@ -137,6 +155,12 @@ rules:
     verbs:
       - get
       - patch
+      - update
+  - apiGroups:
+      - rabbitmq.com
+    resources:
+      - permissions/finalizers
+    verbs:
       - update
   - apiGroups:
       - rabbitmq.com
@@ -161,6 +185,12 @@ rules:
   - apiGroups:
       - rabbitmq.com
     resources:
+      - policies/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - rabbitmq.com
+    resources:
       - queues
     verbs:
       - create
@@ -177,6 +207,12 @@ rules:
     verbs:
       - get
       - patch
+      - update
+  - apiGroups:
+      - rabbitmq.com
+    resources:
+      - queues/finalizers
+    verbs:
       - update
   - apiGroups:
       - rabbitmq.com
@@ -215,6 +251,12 @@ rules:
   - apiGroups:
       - rabbitmq.com
     resources:
+      - schemareplications/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - rabbitmq.com
+    resources:
       - shovels
     verbs:
       - create
@@ -231,6 +273,12 @@ rules:
     verbs:
       - get
       - patch
+      - update
+  - apiGroups:
+      - rabbitmq.com
+    resources:
+      - shovels/finalizers
+    verbs:
       - update
   - apiGroups:
       - rabbitmq.com
@@ -255,6 +303,12 @@ rules:
   - apiGroups:
       - rabbitmq.com
     resources:
+      - superstreams/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - rabbitmq.com
+    resources:
       - users
     verbs:
       - create
@@ -271,6 +325,12 @@ rules:
     verbs:
       - get
       - patch
+      - update
+  - apiGroups:
+      - rabbitmq.com
+    resources:
+      - users/finalizers
+    verbs:
       - update
   - apiGroups:
       - rabbitmq.com
@@ -295,6 +355,12 @@ rules:
   - apiGroups:
       - rabbitmq.com
     resources:
+      - vhosts/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - rabbitmq.com
+    resources:
       - topicpermissions
     verbs:
       - create
@@ -311,6 +377,12 @@ rules:
     verbs:
       - get
       - patch
+      - update
+  - apiGroups:
+      - rabbitmq.com
+    resources:
+      - topicpermissions/finalizers
+    verbs:
       - update
   - apiGroups:
     - rabbitmq.com
@@ -332,5 +404,11 @@ rules:
     - get
     - patch
     - update
+  - apiGroups:
+      - rabbitmq.com
+    resources:
+      - operatorpolicies/finalizers
+    verbs:
+      - update
   {{- end }}
 {{- end }}


### PR DESCRIPTION
### Description of the change

On RabbitMQ-cluster-operator / Messaging topology operator we need to specify finalizers permissions on controllers to allow compatibility with Openshift.
See https://github.com/rabbitmq/messaging-topology-operator/pull/390

### Benefits
Compatibility with Openshfit 

### Possible drawbacks

None

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

None

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->


<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
