### PR TITLE
[bitnami/apisix] Correct service port name in control plane ingress

### DIFF
--- a/bitnami/apisix/CHANGELOG.md
+++ b/bitnami/apisix/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 3.3.2 (2024-07-03)
+## 3.3.3 (2024-07-08)
 
-* [bitnami/apisix] Updated jsonschema to allow string values for fields passed to tpl ([#27441](https://github.com/bitnami/charts/pull/27441))
+* [bitnami/apisix] Correct service port name in control plane ingress ([#27839](https://github.com/bitnami/charts/pull/27839))
+
+## <small>3.3.2 (2024-07-08)</small>
+
+* [bitnami/apisix] Updated jsonschema to allow string values for fields passed to tpl (#27441) ([d3967c3](https://github.com/bitnami/charts/commit/d3967c3c5308e70f54028e67328552523d2358b4)), closes [#27441](https://github.com/bitnami/charts/issues/27441)
 
 ## <small>3.3.1 (2024-07-03)</small>
 

--- a/bitnami/apisix/Chart.yaml
+++ b/bitnami/apisix/Chart.yaml
@@ -45,4 +45,4 @@ sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/apisix
 - https://github.com/bitnami/charts/tree/main/bitnami/apisix-dashboard
 - https://github.com/bitnami/charts/tree/main/bitnami/apisix-ingress-controller
-version: 3.3.2
+version: 3.3.3

--- a/bitnami/apisix/templates/control-plane/ingress.yaml
+++ b/bitnami/apisix/templates/control-plane/ingress.yaml
@@ -21,7 +21,7 @@ spec:
   ingressClassName: {{ .Values.controlPlane.ingress.ingressClassName | quote }}
   {{- end }}
   rules:
-    {{- $servicePort := (printf "%s-%s" (ternary "https" "http" .Values.controlPlane.tls.enabled) "admin") }}
+    {{- $servicePort := (printf "%s-%s" (ternary "https" "http" .Values.controlPlane.tls.enabled) "admin-api") }}
     {{- if .Values.controlPlane.ingress.hostname }}
     - host: {{ .Values.controlPlane.ingress.hostname }}
       http:


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

This PR makes a correction in the control plane ingress template. 

Previously, the backend service port name set in the control plane ingress manifest, e.g. `http-admin`, did not match the service port name as set in the control plane service, e.g. `http-admin-api`, and as a result, access to the control plane through ingress always resulted in error 503. The affected port name in the ingress manifest has now been corrected.

### Benefits

The change will make connections to the control plane's Admin API through an ingress succeed.

### Possible drawbacks

None

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #27729

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
None

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
