### PR TITLE
[bitnami/rabbitmq] Replace extraPorts with extraPortsHeadless in headless service

### DIFF
--- a/bitnami/rabbitmq/CHANGELOG.md
+++ b/bitnami/rabbitmq/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 14.4.6 (2024-07-03)
+## 14.5.0 (2024-07-09)
 
-* [bitnami/rabbitmq] Release 14.4.6 ([#27739](https://github.com/bitnami/charts/pull/27739))
+* [bitnami/rabbitmq] Replace extraPorts with extraPortsHeadless in headless service ([#27853](https://github.com/bitnami/charts/pull/27853))
+
+## <small>14.4.6 (2024-07-03)</small>
+
+* [bitnami/rabbitmq] Release 14.4.6 (#27739) ([891935d](https://github.com/bitnami/charts/commit/891935dae482369fc75a9be9cdf13e9a148fdb3f)), closes [#27739](https://github.com/bitnami/charts/issues/27739)
 
 ## <small>14.4.5 (2024-07-03)</small>
 

--- a/bitnami/rabbitmq/Chart.yaml
+++ b/bitnami/rabbitmq/Chart.yaml
@@ -30,4 +30,4 @@ maintainers:
 name: rabbitmq
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/rabbitmq
-version: 14.4.6
+version: 14.5.0

--- a/bitnami/rabbitmq/README.md
+++ b/bitnami/rabbitmq/README.md
@@ -580,6 +580,7 @@ You can enable this `initContainer` by setting `volumePermissions.enabled` to `t
 | `service.nodePorts.epmd`                | Node port for EPMD Discovery                                                                                                     | `""`                     |
 | `service.nodePorts.metrics`             | Node port for RabbitMQ Prometheues metrics                                                                                       | `""`                     |
 | `service.extraPorts`                    | Extra ports to expose in the service                                                                                             | `[]`                     |
+| `service.extraPortsHeadless`            | Extra ports to expose in the headless service                                                                                    | `[]`                     |
 | `service.loadBalancerSourceRanges`      | Address(es) that are allowed when service is `LoadBalancer`                                                                      | `[]`                     |
 | `service.allocateLoadBalancerNodePorts` | Whether to allocate node ports when service type is LoadBalancer                                                                 | `true`                   |
 | `service.externalIPs`                   | Set the ExternalIPs                                                                                                              | `[]`                     |

--- a/bitnami/rabbitmq/templates/svc-headless.yaml
+++ b/bitnami/rabbitmq/templates/svc-headless.yaml
@@ -37,8 +37,8 @@ spec:
       port: {{ .Values.service.ports.manager  }}
       targetPort: stats
     {{- end }}
-    {{- if .Values.service.extraPorts }}
-    {{- include "common.tplvalues.render" (dict "value" .Values.service.extraPorts "context" $) | nindent 4 }}
+    {{- if .Values.service.extraPortsHeadless }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.service.extraPortsHeadless "context" $) | nindent 4 }}
     {{- end }}
   {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}

--- a/bitnami/rabbitmq/values.yaml
+++ b/bitnami/rabbitmq/values.yaml
@@ -1065,6 +1065,14 @@ service:
   ##   targetPort: 1234
   ##
   extraPorts: []
+  ## @param service.extraPortsHeadless Extra ports to expose in the headless service
+  ## E.g.:
+  ## extraPortsHeadless:
+  ## - name: new_svc_name
+  ##   port: 1234
+  ##   targetPort: 1234
+  ##
+  extraPortsHeadless: []
   ## @param service.loadBalancerSourceRanges Address(es) that are allowed when service is `LoadBalancer`
   ## https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
   ## e.g:


### PR DESCRIPTION
### Description of the change

Fixes an issue with RabbitMQ headless service.

Due to the changes introduced at https://github.com/bitnami/charts/pull/26136, there could be issues when nodePort service is used and `service.extraPorts` includes `nodePort` settings, which are not valid in ClusterIP services.

Because of this, the headless extraPorts need to be provided in a separated value, which I created as `extraPortsHeadless`.

### Benefits

Allows using NodePort services with `extraPorts`.

### Possible drawbacks

Headless ports won't be automatically mapped to service ports.
This is not necessarily bad, since it provides granular control on which ports want to be exposed in the headless and which in the service.

### Applicable issues

- fixes #27460

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
