### PR TITLE
[bitnami/keycloak] Added nodeSelector and toleration for postgres

### DIFF
--- a/bitnami/keycloak/CHANGELOG.md
+++ b/bitnami/keycloak/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 21.6.0 (2024-07-08)
+## 21.6.1 (2024-07-09)
 
-* [bitnami/keycloak] Add support for minReadySeconds ([#27550](https://github.com/bitnami/charts/pull/27550))
+* [bitnami/keycloak] Added nodeSelector and toleration for postgres ([#27856](https://github.com/bitnami/charts/pull/27856))
+
+## 21.6.0 (2024-07-09)
+
+* [bitnami/keycloak] Add support for minReadySeconds (#27550) ([bf357f9](https://github.com/bitnami/charts/commit/bf357f93bb2ad28d3a27826f4bae8a65a0bc3af5)), closes [#27550](https://github.com/bitnami/charts/issues/27550)
 
 ## 21.5.0 (2024-07-08)
 

--- a/bitnami/keycloak/Chart.yaml
+++ b/bitnami/keycloak/Chart.yaml
@@ -33,4 +33,4 @@ maintainers:
 name: keycloak
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/keycloak
-version: 21.6.0
+version: 21.6.1

--- a/bitnami/keycloak/README.md
+++ b/bitnami/keycloak/README.md
@@ -618,6 +618,10 @@ As an alternative, you can use of the preset configurations for pod affinity, po
 | `postgresql.auth.database`                   | Name for a custom database to create                                                                              | `bitnami_keycloak` |
 | `postgresql.auth.existingSecret`             | Name of existing secret to use for PostgreSQL credentials                                                         | `""`               |
 | `postgresql.architecture`                    | PostgreSQL architecture (`standalone` or `replication`)                                                           | `standalone`       |
+| `postgresql.primary.nodeSelector`            | Node selector for postgres pod assignment                                                                         | `{}`               |
+| `postgresql.primary.tolerations`             | Tolerations for postgres pod assignment                                                                           | `[]`               |
+| `postgresql.readReplicas.nodeSelector`       | Node selector for postgres read only pod assignment                                                               | `{}`               |
+| `postgresql.readReplicas.tolerations`        | Tolerations for postgres read only assignment                                                                     | `[]`               |
 | `externalDatabase.host`                      | Database host                                                                                                     | `""`               |
 | `externalDatabase.port`                      | Database port number                                                                                              | `5432`             |
 | `externalDatabase.user`                      | Non-root username for Keycloak                                                                                    | `bn_keycloak`      |

--- a/bitnami/keycloak/values.yaml
+++ b/bitnami/keycloak/values.yaml
@@ -1281,6 +1281,10 @@ keycloakConfigCli:
 ## @param postgresql.auth.database Name for a custom database to create
 ## @param postgresql.auth.existingSecret Name of existing secret to use for PostgreSQL credentials
 ## @param postgresql.architecture PostgreSQL architecture (`standalone` or `replication`)
+## @param postgresql.primary.nodeSelector Node selector for postgres pod assignment
+## @param postgresql.primary.tolerations Tolerations for postgres pod assignment
+## @param postgresql.readReplicas.nodeSelector Node selector for postgres read only pod assignment
+## @param postgresql.readReplicas.tolerations Tolerations for postgres read only assignment
 ##
 postgresql:
   enabled: true
@@ -1291,6 +1295,12 @@ postgresql:
     database: bitnami_keycloak
     existingSecret: ""
   architecture: standalone
+  primary:
+    nodeSelector: {}
+    tolerations: []
+  readReplicas:
+    nodeSelector: {}
+    tolerations: []
 ## External PostgreSQL configuration
 ## All of these values are only used when postgresql.enabled is set to false
 ## @param externalDatabase.host Database host


### PR DESCRIPTION
### Description of the change

Made it possible to parse nodeSelector and tolerations to postgres, if not using an external database.

### Benefits

if using different nodes for storage or stateful apps, this makes it possible to deploy postgres and its data to those nodes

### Possible drawbacks

n/a

### Applicable issues

n/a

### Additional information

The reason this is made, is because in our usecase, we have longhorn deployed on certain nodes, which handles data and stateful applications and operators.
Without parsing nodeSelector and toleration towards postgres, we're forced to setup and use an external database.

Of course, we could just deploy a postgresql chart. But that creates more dependencies, that's not packed together

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
