### PR TITLE
[bitnami/supabase] chore: :arrow_up: Update supabase-storage to 1.6.8

### DIFF
--- a/bitnami/supabase/CHANGELOG.md
+++ b/bitnami/supabase/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 5.2.9 (2024-07-04)
+## 5.3.0 (2024-07-09)
 
-* [bitnami/supabase] Do not render any resources for disabled components ([#27580](https://github.com/bitnami/charts/pull/27580))
+* [bitnami/supabase] chore: :arrow_up: Update supabase-storage to 1.6.8 ([#27857](https://github.com/bitnami/charts/pull/27857))
+
+## <small>5.2.9 (2024-07-04)</small>
+
+* [bitnami/supabase] Do not render any resources for disabled components (#27580) ([5d703ba](https://github.com/bitnami/charts/commit/5d703bad49025ab95654a09ecacef304de7492bd)), closes [#27580](https://github.com/bitnami/charts/issues/27580) [#27540](https://github.com/bitnami/charts/issues/27540)
 
 ## <small>5.2.8 (2024-07-04)</small>
 

--- a/bitnami/supabase/Chart.lock
+++ b/bitnami/supabase/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: postgresql
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 15.5.12
+  version: 15.5.15
 - name: kong
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 12.2.5
+  version: 12.2.6
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 2.20.3
-digest: sha256:64eab32ee8ff82d2b3b1d04314b6d8c0e26e364cce709537f549f50b0cc2a468
-generated: "2024-07-03T07:23:14.531737968Z"
+digest: sha256:d37bee776fe4ee23a06e78a429679255d26974df6658be1d85ee298b4af390de
+generated: "2024-07-09T15:19:22.017189139+02:00"

--- a/bitnami/supabase/Chart.yaml
+++ b/bitnami/supabase/Chart.yaml
@@ -22,7 +22,7 @@ annotations:
     - name: supabase-realtime
       image: docker.io/bitnami/supabase-realtime:2.29.15-debian-12-r0
     - name: supabase-storage
-      image: docker.io/bitnami/supabase-storage:1.6.4-debian-12-r1
+      image: docker.io/bitnami/supabase-storage:1.6.8-debian-12-r0
     - name: supabase-studio
       image: docker.io/bitnami/supabase-studio:1.24.5-debian-12-r1
 apiVersion: v2
@@ -53,4 +53,4 @@ maintainers:
 name: supabase
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/supabase
-version: 5.2.9
+version: 5.3.0

--- a/bitnami/supabase/templates/storage/deployment.yaml
+++ b/bitnami/supabase/templates/storage/deployment.yaml
@@ -133,7 +133,7 @@ spec:
               #!/bin/bash
 
               cd /opt/bitnami/supabase-storage
-              node dist/server.js
+              node dist/start/server.js
           {{- end }}
           env:
             - name: DB_USER

--- a/bitnami/supabase/values.yaml
+++ b/bitnami/supabase/values.yaml
@@ -2109,7 +2109,7 @@ storage:
   image:
     registry: docker.io
     repository: bitnami/supabase-storage
-    tag: 1.6.4-debian-12-r1
+    tag: 1.6.8-debian-12-r0
     digest: ""
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

This PR bumps the version of supabase-storage to 1.6.8, together with the kong and postgresql subcharts. 

<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
