### PR TITLE
[bitnami/keycloak] fix conditions for KC_HOSTNAME_URL

### DIFF
--- a/bitnami/keycloak/CHANGELOG.md
+++ b/bitnami/keycloak/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 21.6.0 (2024-07-08)
+## 21.6.1 (2024-07-10)
 
-* [bitnami/keycloak] Add support for minReadySeconds ([#27550](https://github.com/bitnami/charts/pull/27550))
+* [bitnami/keycloak] fix conditions for KC_HOSTNAME_URL ([#27867](https://github.com/bitnami/charts/pull/27867))
+
+## 21.6.0 (2024-07-09)
+
+* [bitnami/keycloak] Add support for minReadySeconds (#27550) ([bf357f9](https://github.com/bitnami/charts/commit/bf357f93bb2ad28d3a27826f4bae8a65a0bc3af5)), closes [#27550](https://github.com/bitnami/charts/issues/27550)
 
 ## 21.5.0 (2024-07-08)
 

--- a/bitnami/keycloak/Chart.yaml
+++ b/bitnami/keycloak/Chart.yaml
@@ -33,4 +33,4 @@ maintainers:
 name: keycloak
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/keycloak
-version: 21.6.0
+version: 21.6.1

--- a/bitnami/keycloak/templates/statefulset.yaml
+++ b/bitnami/keycloak/templates/statefulset.yaml
@@ -219,9 +219,9 @@ spec:
             - name: KC_HOSTNAME_ADMIN_URL
               value: "http{{ if or .Values.adminIngress.tls (eq .Values.proxy "edge") }}s{{ end }}://{{ include "common.tplvalues.render" (dict "value" .Values.adminIngress.hostname "context" $) }}"
             {{- end }}
-            {{- if and .Values.adminIngress.enabled (not .Values.ingress.enabled) }}
+            {{- if .Values.ingress.enabled }}
             - name: KC_HOSTNAME_URL
-              value: "http{{ if or .Values.adminIngress.tls (eq .Values.proxy "edge") }}s{{ end }}://{{ include "common.tplvalues.render" (dict "value" .Values.adminIngress.hostname "context" $) }}"
+              value: "http{{ if or .Values.ingress.tls (eq .Values.proxy "edge") }}s{{ end }}://{{ include "common.tplvalues.render" (dict "value" .Values.ingress.hostname "context" $) }}"
             {{- end }}
             {{- if .Values.adminRealm }}
             - name: KC_SPI_ADMIN_REALM


### PR DESCRIPTION
### Description of the change

#25386 added usage of `KC_HOSTNAME_ADMIN_URL` and `KC_HOSTNAME_URL`; however, the implementation has many issues. One such issue (dealing with `edge` proxy mode) was fixed earlier in #27436; another issue is documented in #25963. This PR is resolving yet another issue. Per [v1 docs](https://www.keycloak.org/server/hostname-deprecated), `KC_HOSTNAME_URL` and `KC_HOSTNAME_ADMIN_URL` are independent environment variables. Since the chart makes two separate ingresses (one public and one admin), these variables should be defined independently based on the ingress values. Without this, in the proxy edge mode, Keycloak is returning Kubernetes internal DNS when calling `.well-known/openid-configuration` from within the same cluster using internal services since `KC_HOSTNAME_URL` is not defined.


### Benefits

* Fixes the issue of returning the correct frontend URL
* This will help migrate to [v2 hostname](https://www.keycloak.org/server/hostname), see #26175

### Possible drawbacks

None, this is a bug fix

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
