### PR TITLE
[bitnami/zookeeper] Reenable VIB kubescape action

### DIFF
--- a/.vib/zookeeper/vib-verify.json
+++ b/.vib/zookeeper/vib-verify.json
@@ -44,6 +44,12 @@
               }
             }
           }
+        },
+        {
+          "action_id": "kubescape",
+          "params": {
+            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
+          }
         }
       ]
     }


### PR DESCRIPTION
### Description of the change

POC to reenable the kubescape VIB action using the bitnami/zookeeper chart.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
