### PR TITLE
[bitnami/common] Increase ephemeral-storage default limits

### DIFF
--- a/bitnami/common/CHANGELOG.md
+++ b/bitnami/common/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 2.20.3 (2024-06-17)
+## 2.20.4 (2024-07-11)
 
-* [bitnami/common] chore: :wrench: Relax large and xlarge presets resource requests ([#27312](https://github.com/bitnami/charts/pull/27312))
+* [bitnami/common] Increase ephemeral-storage default limits ([#27902](https://github.com/bitnami/charts/pull/27902))
+
+## <small>2.20.3 (2024-06-17)</small>
+
+* [bitnami/common] chore: :wrench: Relax large and xlarge presets resource requests (#27312) ([6ca69f6](https://github.com/bitnami/charts/commit/6ca69f6769d0f65acc850fa0bcc08506de50cc41)), closes [#27312](https://github.com/bitnami/charts/issues/27312)
 
 ## <small>2.20.2 (2024-06-10)</small>
 

--- a/bitnami/common/Chart.yaml
+++ b/bitnami/common/Chart.yaml
@@ -6,7 +6,7 @@ annotations:
   licenses: Apache-2.0
 apiVersion: v2
 # Please make sure that version and appVersion are always the same.
-appVersion: 2.20.3
+appVersion: 2.20.4
 description: A Library Helm Chart for grouping common logic between bitnami charts. This chart is not deployable by itself.
 home: https://bitnami.com
 icon: https://bitnami.com/downloads/logos/bitnami-mark.png
@@ -23,4 +23,4 @@ name: common
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/common
 type: library
-version: 2.20.3
+version: 2.20.4

--- a/bitnami/common/templates/_resources.tpl
+++ b/bitnami/common/templates/_resources.tpl
@@ -15,31 +15,31 @@ These presets are for basic testing and not meant to be used in production
 {{- $presets := dict 
   "nano" (dict 
       "requests" (dict "cpu" "100m" "memory" "128Mi" "ephemeral-storage" "50Mi")
-      "limits" (dict "cpu" "150m" "memory" "192Mi" "ephemeral-storage" "1024Mi")
+      "limits" (dict "cpu" "150m" "memory" "192Mi" "ephemeral-storage" "2Gi")
    )
   "micro" (dict 
       "requests" (dict "cpu" "250m" "memory" "256Mi" "ephemeral-storage" "50Mi")
-      "limits" (dict "cpu" "375m" "memory" "384Mi" "ephemeral-storage" "1024Mi")
+      "limits" (dict "cpu" "375m" "memory" "384Mi" "ephemeral-storage" "2Gi")
    )
   "small" (dict 
       "requests" (dict "cpu" "500m" "memory" "512Mi" "ephemeral-storage" "50Mi")
-      "limits" (dict "cpu" "750m" "memory" "768Mi" "ephemeral-storage" "1024Mi")
+      "limits" (dict "cpu" "750m" "memory" "768Mi" "ephemeral-storage" "2Gi")
    )
   "medium" (dict 
       "requests" (dict "cpu" "500m" "memory" "1024Mi" "ephemeral-storage" "50Mi")
-      "limits" (dict "cpu" "750m" "memory" "1536Mi" "ephemeral-storage" "1024Mi")
+      "limits" (dict "cpu" "750m" "memory" "1536Mi" "ephemeral-storage" "2Gi")
    )
   "large" (dict 
       "requests" (dict "cpu" "1.0" "memory" "2048Mi" "ephemeral-storage" "50Mi")
-      "limits" (dict "cpu" "1.5" "memory" "3072Mi" "ephemeral-storage" "1024Mi")
+      "limits" (dict "cpu" "1.5" "memory" "3072Mi" "ephemeral-storage" "2Gi")
    )
   "xlarge" (dict 
       "requests" (dict "cpu" "1.0" "memory" "3072Mi" "ephemeral-storage" "50Mi")
-      "limits" (dict "cpu" "3.0" "memory" "6144Mi" "ephemeral-storage" "1024Mi")
+      "limits" (dict "cpu" "3.0" "memory" "6144Mi" "ephemeral-storage" "2Gi")
    )
   "2xlarge" (dict 
       "requests" (dict "cpu" "1.0" "memory" "3072Mi" "ephemeral-storage" "50Mi")
-      "limits" (dict "cpu" "6.0" "memory" "12288Mi" "ephemeral-storage" "1024Mi")
+      "limits" (dict "cpu" "6.0" "memory" "12288Mi" "ephemeral-storage" "2Gi")
    )
  }}
 {{- if hasKey $presets .type -}}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->
Sonarqube is failing due to the usage of the resources being higher than the limits 

```
  Warning  Evicted              9m38s  kubelet            Pod ephemeral local storage usage exceeds the total limit of containers 1Gi.
```

### Benefits

<!-- What benefits will be realized by the code change? -->

Increase limits in volume usage

### Possible drawbacks

<!-- Describe any known limitations with your change -->
None

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- would fix this other PR https://github.com/bitnami/charts/pull/27731 

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
