### PR TITLE
[bitnami/mariadb-galera] allow template in existingSecret and extraVolumes

### DIFF
--- a/bitnami/mariadb-galera/CHANGELOG.md
+++ b/bitnami/mariadb-galera/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
+## 14.0.1 (2024-07-12)
+
+* [bitnami/mariadb-galera] allow template in existingSecret and extraVolumes ([#27915](https://github.com/bitnami/charts/pull/27915))
+
 ## 14.0.0 (2024-07-11)
 
-* [bitnami/mariadb-galera] Release 14.0.0 ([#27908](https://github.com/bitnami/charts/pull/27908))
+* [bitnami/mariadb-galera] Release 14.0.0 (#27908) ([faedc05](https://github.com/bitnami/charts/commit/faedc0596e9734afaed3f1715a12906538505b12)), closes [#27908](https://github.com/bitnami/charts/issues/27908)
 
 ## <small>13.2.7 (2024-07-03)</small>
 

--- a/bitnami/mariadb-galera/Chart.yaml
+++ b/bitnami/mariadb-galera/Chart.yaml
@@ -10,7 +10,7 @@ annotations:
     - name: mysqld-exporter
       image: docker.io/bitnami/mysqld-exporter:0.15.1-debian-12-r27
 apiVersion: v2
-appVersion: 11.4.2
+appVersion: 11.4.3
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts

--- a/bitnami/mariadb-galera/Chart.yaml
+++ b/bitnami/mariadb-galera/Chart.yaml
@@ -10,7 +10,7 @@ annotations:
     - name: mysqld-exporter
       image: docker.io/bitnami/mysqld-exporter:0.15.1-debian-12-r27
 apiVersion: v2
-appVersion: 11.4.3
+appVersion: 11.4.2
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts

--- a/bitnami/mariadb-galera/Chart.yaml
+++ b/bitnami/mariadb-galera/Chart.yaml
@@ -33,4 +33,4 @@ maintainers:
 name: mariadb-galera
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/mariadb-galera
-version: 14.0.0
+version: 14.0.1

--- a/bitnami/mariadb-galera/templates/_helpers.tpl
+++ b/bitnami/mariadb-galera/templates/_helpers.tpl
@@ -31,7 +31,7 @@ Return the secret with MariaDB credentials
 */}}
 {{- define "mariadb-galera.secretName" -}}
     {{- if .Values.existingSecret -}}
-        {{- printf "%s" .Values.existingSecret -}}
+        {{- printf "%s" (tpl .Values.existingSecret $) -}}
     {{- else -}}
         {{- printf "%s" (include "common.names.fullname" .) -}}
     {{- end -}}

--- a/bitnami/mariadb-galera/templates/statefulset.yaml
+++ b/bitnami/mariadb-galera/templates/statefulset.yaml
@@ -499,7 +499,7 @@ spec:
         - name: empty-dir
           emptyDir: {}
         {{- if .Values.extraVolumes }}
-        {{- toYaml .Values.extraVolumes | nindent 8 }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumes "context" $) | nindent 8 }}
         {{- end }}
 {{- if and .Values.persistence.enabled .Values.persistence.existingClaim }}
         - name: data


### PR DESCRIPTION
### Description of the change

Allows template in value of keys `existingSecret` and `extraVolumes` which usually contains references to configMaps and that usually has release name as part of the name.

### Benefits

By prefixing configMaps with release name dynamically, we will avoid conflicts when multiple releases are installed in same cluster.

### Possible drawbacks

None.

### Applicable issues

- fixes #27914

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [ ] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
