### PR TITLE
[bitnami/redmine] chore!: :arrow_up: :boom: Update mariadb to 11.4

### DIFF
--- a/bitnami/redmine/CHANGELOG.md
+++ b/bitnami/redmine/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
-## 28.2.7 (2024-07-03)
+## 29.0.0 (2024-07-12)
 
-* [bitnami/redmine] Release 28.2.7 ([#27717](https://github.com/bitnami/charts/pull/27717))
+* [bitnami/redmine] chore!: :arrow_up: :boom: Update mariadb to 11.4 ([#27936](https://github.com/bitnami/charts/pull/27936))
+
+## <small>28.2.7 (2024-07-03)</small>
+
+* [bitnami/*] Update README changing TAC wording (#27530) ([52dfed6](https://github.com/bitnami/charts/commit/52dfed6bac44d791efabfaf06f15daddc4fefb0c)), closes [#27530](https://github.com/bitnami/charts/issues/27530)
+* [bitnami/redmine] Release 28.2.7 (#27717) ([34ba5f5](https://github.com/bitnami/charts/commit/34ba5f51aa4e678fc5511103d67987fd691dbf7b)), closes [#27717](https://github.com/bitnami/charts/issues/27717)
 
 ## <small>28.2.6 (2024-06-18)</small>
 

--- a/bitnami/redmine/Chart.lock
+++ b/bitnami/redmine/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: postgresql
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 15.5.12
+  version: 15.5.16
 - name: mariadb
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 18.2.6
+  version: 19.0.0
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.20.3
-digest: sha256:ab08aa748d6e77ec8b1967c6675539418d571923f35c80252df1da3c19a41034
-generated: "2024-07-03T07:21:56.504617398Z"
+  version: 2.20.4
+digest: sha256:1704baeddfef615ff77488782a03ee236560371161a5d45cce742af94c172b5c
+generated: "2024-07-12T11:57:05.47573549+02:00"

--- a/bitnami/redmine/Chart.yaml
+++ b/bitnami/redmine/Chart.yaml
@@ -19,7 +19,7 @@ dependencies:
 - condition: mariadb.enabled
   name: mariadb
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 18.x.x
+  version: 19.x.x
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
   tags:
@@ -43,4 +43,4 @@ maintainers:
 name: redmine
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/redmine
-version: 28.2.7
+version: 29.0.0

--- a/bitnami/redmine/README.md
+++ b/bitnami/redmine/README.md
@@ -572,6 +572,10 @@ Find more information about how to deal with common errors related to Bitnami's 
 
 ## Upgrading
 
+### To 29.0.0
+
+This major release bumps the MariaDB version to 11.4. Follow the [upstream instructions](https://mariadb.com/kb/en/upgrading-from-mariadb-11-3-to-mariadb-11-4/) for upgrading from MariaDB 11.3 to 11.4. No major issues are expected during the upgrade.
+
 ### To 28.0.0
 
 This major bump changes the following security defaults:


### PR DESCRIPTION
BREAKING CHANGE

Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

### Description of the change

This PR updates the MariaDB dependency from 11.3 to 11.4 (chart version 19.0.0). Users should follow the upstream instructions to update MariaDB. 

### Benefits

Latest version of MariaDB database

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

Potential database upgrade issues as it is a major bump.

<!-- Describe any known limitations with your change -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
