### PR TITLE
[bitnami/seaweedfs] chore!: :arrow_up: :boom: Update mariadb to 11.4

### DIFF
--- a/bitnami/seaweedfs/CHANGELOG.md
+++ b/bitnami/seaweedfs/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 0.4.5 (2024-07-04)
+## 1.0.0 (2024-07-12)
 
-* [bitnami/seaweedfs] Release 0.4.5 ([#27793](https://github.com/bitnami/charts/pull/27793))
+* [bitnami/seaweedfs] chore!: :arrow_up: :boom: Update mariadb to 11.4 ([#27937](https://github.com/bitnami/charts/pull/27937))
+
+## <small>0.4.5 (2024-07-04)</small>
+
+* [bitnami/seaweedfs] Release 0.4.5 (#27793) ([f38eab0](https://github.com/bitnami/charts/commit/f38eab0be837bead6abc9e75085241ac0eeb4b23)), closes [#27793](https://github.com/bitnami/charts/issues/27793)
 
 ## <small>0.4.4 (2024-07-03)</small>
 

--- a/bitnami/seaweedfs/Chart.lock
+++ b/bitnami/seaweedfs/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: mariadb
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 18.2.6
+  version: 19.0.0
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.20.3
-digest: sha256:93457e654a90340dd23065b69cffe6919f772c64fd4321a3dac4aa6bc2a85b4e
-generated: "2024-07-03T05:32:37.393564541Z"
+  version: 2.20.4
+digest: sha256:68c2579ef8dc92314dc43819b193a3daa712501a78c366fb54cbd3fde4ab4404
+generated: "2024-07-12T11:58:56.820163338+02:00"

--- a/bitnami/seaweedfs/Chart.yaml
+++ b/bitnami/seaweedfs/Chart.yaml
@@ -17,7 +17,7 @@ dependencies:
   repository: oci://registry-1.docker.io/bitnamicharts
   tags:
   - seaweedfs-database
-  version: 18.x.x
+  version: 19.x.x
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
   tags:
@@ -40,4 +40,4 @@ name: seaweedfs
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/seawwedfs
 - https://github.com/bitnami/containers/tree/main/bitnami/seaweedfs
-version: 0.4.5
+version: 1.0.0

--- a/bitnami/seaweedfs/README.md
+++ b/bitnami/seaweedfs/README.md
@@ -1074,6 +1074,12 @@ helm install my-release -f values.yaml oci://REGISTRY_NAME/REPOSITORY_NAME/seawe
 > Note: You need to substitute the placeholders `REGISTRY_NAME` and `REPOSITORY_NAME` with a reference to your Helm chart registry and repository. For example, in the case of Bitnami, you need to use `REGISTRY_NAME=registry-1.docker.io` and `REPOSITORY_NAME=bitnamicharts`.
 > **Tip**: You can use the default [values.yaml](https://github.com/bitnami/charts/blob/main/template/seaweedfs/values.yaml)
 
+## Upgrading
+
+### To 1.0.0
+
+This major release bumps the MariaDB version to 11.4. Follow the [upstream instructions](https://mariadb.com/kb/en/upgrading-from-mariadb-11-3-to-mariadb-11-4/) for upgrading from MariaDB 11.3 to 11.4. No major issues are expected during the upgrade.
+
 ## Troubleshooting
 
 Find more information about how to deal with common errors related to Bitnami's Helm charts in [this troubleshooting guide](https://docs.bitnami.com/general/how-to/troubleshoot-helm-chart-issues).


### PR DESCRIPTION
BREAKING CHANGE

Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

### Description of the change

This PR updates the MariaDB dependency from 11.3 to 11.4 (chart version 19.0.0). Users should follow the upstream instructions to update MariaDB. 

### Benefits

Latest version of MariaDB database

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

Potential database upgrade issues as it is a major bump.

<!-- Describe any known limitations with your change -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
