### PR TITLE
[bitnami/apisix] wait container: support self-generated certificates at etcd

### DIFF
--- a/bitnami/apisix/CHANGELOG.md
+++ b/bitnami/apisix/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 3.3.4 (2024-07-15)
+## 3.3.4 (2024-07-16)
 
 * [bitnami/apisix] wait container: support self-generated certificates at etcd ([#27947](https://github.com/bitnami/charts/pull/27947))
 

--- a/bitnami/apisix/CHANGELOG.md
+++ b/bitnami/apisix/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 3.3.4 (2024-07-12)
+## 3.3.4 (2024-07-15)
 
 * [bitnami/apisix] wait container: support self-generated certificates at etcd ([#27947](https://github.com/bitnami/charts/pull/27947))
 

--- a/bitnami/apisix/CHANGELOG.md
+++ b/bitnami/apisix/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 3.3.3 (2024-07-08)
+## 3.3.4 (2024-07-12)
 
-* [bitnami/apisix] Correct service port name in control plane ingress ([#27839](https://github.com/bitnami/charts/pull/27839))
+* [bitnami/apisix] wait container: support self-generated certificates at etcd ([#27947](https://github.com/bitnami/charts/pull/27947))
+
+## <small>3.3.3 (2024-07-10)</small>
+
+* [bitnami/apisix] Correct service port name in control plane ingress (#27839) ([769db5e](https://github.com/bitnami/charts/commit/769db5e671e228bf2c74cc7c1b7d7b9079ff1e2a)), closes [#27839](https://github.com/bitnami/charts/issues/27839)
 
 ## <small>3.3.2 (2024-07-08)</small>
 

--- a/bitnami/apisix/Chart.yaml
+++ b/bitnami/apisix/Chart.yaml
@@ -45,4 +45,4 @@ sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/apisix
 - https://github.com/bitnami/charts/tree/main/bitnami/apisix-dashboard
 - https://github.com/bitnami/charts/tree/main/bitnami/apisix-ingress-controller
-version: 3.3.3
+version: 3.3.4

--- a/bitnami/apisix/templates/_helpers.tpl
+++ b/bitnami/apisix/templates/_helpers.tpl
@@ -447,7 +447,7 @@ Init container definition for waiting for the database to be ready
       check_etcd() {
           local curl_options=()
           {{- if and .Values.etcd.auth.client.secureTransport .Values.etcd.auth.client.useAutoTLS }}
-          curl_options=("--insecure")
+          curl_options=("--insecure" ${curl_options[*]})
           {{- end }}
 
           local -r etcd_host="${1:-?missing etcd}"

--- a/bitnami/apisix/templates/_helpers.tpl
+++ b/bitnami/apisix/templates/_helpers.tpl
@@ -446,7 +446,7 @@ Init container definition for waiting for the database to be ready
 
       check_etcd() {
           local -r etcd_host="${1:-?missing etcd}"
-          if curl --max-time 5 "${etcd_host}/version" | grep etcdcluster; then
+          if curl -k --max-time 5 "${etcd_host}/version" | grep etcdcluster; then
              return 0
           else
              return 1

--- a/bitnami/apisix/templates/_helpers.tpl
+++ b/bitnami/apisix/templates/_helpers.tpl
@@ -445,8 +445,13 @@ Init container definition for waiting for the database to be ready
       )
 
       check_etcd() {
+          local curl_options=()
+          {{- if and .Values.etcd.auth.client.secureTransport .Values.etcd.auth.client.useAutoTLS }}
+          curl_options=("--insecure")
+          {{- end }}
+
           local -r etcd_host="${1:-?missing etcd}"
-          if curl -k --max-time 5 "${etcd_host}/version" | grep etcdcluster; then
+          if curl "${curl_options[@]}" --max-time 5 "${etcd_host}/version" | grep etcdcluster; then
              return 0
           else
              return 1


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

The wait container in the control plane pod now supports untrusted certificates when checking availability of etcd using custom/auto-generated TLS certificates by skipping certificate verification.

### Possible drawbacks

Since certificates are not being verified, i.e. they are being just accepted regardless of their issuers, authenticity and integrity of the connection might be impacted. The insecure option is being used only if `etcd.auth.client.useAutoTLS` has been set, though.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #27924

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
