### PR TITLE
[bitnami/mongodb] Fix autoDiscovery initContainer template

### DIFF
--- a/bitnami/mongodb/CHANGELOG.md
+++ b/bitnami/mongodb/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
-## 15.6.12 (2024-07-01)
+## 15.6.13 (2024-07-13)
 
-* [bitnami/mongodb] Release 15.6.12 ([#27590](https://github.com/bitnami/charts/pull/27590))
+* [bitnami/mongodb] Fix autoDiscovery initContainer template ([#27953](https://github.com/bitnami/charts/pull/27953))
+
+## <small>15.6.12 (2024-07-01)</small>
+
+* [bitnami/*] Update README changing TAC wording (#27530) ([52dfed6](https://github.com/bitnami/charts/commit/52dfed6bac44d791efabfaf06f15daddc4fefb0c)), closes [#27530](https://github.com/bitnami/charts/issues/27530)
+* [bitnami/mongodb] Release 15.6.12 (#27590) ([97d0ec8](https://github.com/bitnami/charts/commit/97d0ec8a20365d93a4121dd7df98352eac8e69a7)), closes [#27590](https://github.com/bitnami/charts/issues/27590)
 
 ## <small>15.6.11 (2024-06-25)</small>
 

--- a/bitnami/mongodb/Chart.yaml
+++ b/bitnami/mongodb/Chart.yaml
@@ -39,4 +39,4 @@ maintainers:
 name: mongodb
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/mongodb
-version: 15.6.12
+version: 15.6.13

--- a/bitnami/mongodb/templates/_helpers.tpl
+++ b/bitnami/mongodb/templates/_helpers.tpl
@@ -303,7 +303,6 @@ Init container definition to get external IP addresses.
   image: {{ include "mongodb.externalAccess.autoDiscovery.image" . }}
   imagePullPolicy: {{ .Values.externalAccess.autoDiscovery.image.pullPolicy | quote }}
   # We need the service account token for contacting the k8s API
-  automountServiceAccountToken: true
   command:
     - /scripts/auto-discovery.sh
   env:


### PR DESCRIPTION
Signed-off-by: Oliver Ni <oliverni@berkeley.edu>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

`automountServiceAccountToken` is a field on Pod spec, not the container spec

Currently, this breaks the template

<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #26596

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
