### PR TITLE
[bitnami/harbor] Remove duplicated security context

### DIFF
--- a/bitnami/harbor/CHANGELOG.md
+++ b/bitnami/harbor/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 22.0.3 (2024-07-13)
+## 22.0.3 (2024-07-15)
 
 * [bitnami/harbor] Remove duplicated security context ([#27955](https://github.com/bitnami/charts/pull/27955))
 

--- a/bitnami/harbor/CHANGELOG.md
+++ b/bitnami/harbor/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 22.0.2 (2024-07-12)
+## 22.0.3 (2024-07-13)
 
-* [bitnami/harbor] initContainer for certificate vol ([#27753](https://github.com/bitnami/charts/pull/27753))
+* [bitnami/harbor] Remove duplicated security context ([#27955](https://github.com/bitnami/charts/pull/27955))
+
+## <small>22.0.2 (2024-07-12)</small>
+
+* [bitnami/harbor] initContainer for certificate vol (#27753) ([e924679](https://github.com/bitnami/charts/commit/e924679c363b1c2b2df6e602a691a6d9624c9391)), closes [#27753](https://github.com/bitnami/charts/issues/27753)
 
 ## <small>22.0.1 (2024-07-11)</small>
 

--- a/bitnami/harbor/Chart.yaml
+++ b/bitnami/harbor/Chart.yaml
@@ -55,4 +55,4 @@ maintainers:
 name: harbor
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/harbor
-version: 22.0.2
+version: 22.0.3

--- a/bitnami/harbor/templates/portal/portal-dpl.yaml
+++ b/bitnami/harbor/templates/portal/portal-dpl.yaml
@@ -75,9 +75,6 @@ spec:
         - name: certificate-volume
           image: {{ include "harbor.portal.image" . }}
           imagePullPolicy: {{ .Values.portal.image.pullPolicy | quote }}
-          {{- if .Values.portal.containerSecurityContext.enabled }}
-          securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.portal.containerSecurityContext "context" $) | nindent 12 }}
-          {{- end }}
           command:
             - /bin/bash
           args:


### PR DESCRIPTION
### Description of the change

Remove duplicated security context in templates/portal/portal-dpl.yaml since this causes deployments of harbor-22.0.2 using fluxcd v2.3.0 to fail with:

```
harbor  22.0.1          False           False   Helm upgrade failed for release harbor/harbor with chart harbor@22.0.2: error while running post render on files: map[string]interface {}(nil): yaml: unmarshal errors:
                                                  line 78: mapping key "securityContext" already defined at line 60        

```

### Benefits

Harbor can be deployed using fluxcd v2.3.0.

### Possible drawbacks

None.

### Applicable issues

N/A

### Additional information

I have tested this patch in fluxcd with successful result:

```
NAME    REVISION        SUSPENDED       READY   MESSAGE                                                                        
harbor  22.0.3          False           True    Helm upgrade succeeded for release harbor/harbor.v102 with chart harbor@22.0.3

```

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
