### PR TITLE
[github-actions] kubescape score: untar subcharts for score match

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -329,6 +329,11 @@ jobs:
         run: |
           if [ -d "charts-main/bitnami/${CHART}" ]; then
             helm dep build charts-main/bitnami/${CHART}
+            cd charts-main/bitnami/${CHART}/charts
+            for filename in *.tgz; do
+              tar -xf "$filename"
+              rm -f "$filename"
+            done
           fi
       - id: get-chart-score
         uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185


### PR DESCRIPTION
### Description of the change

Fixes an issue with the kubescape score check in the CI pipeline.

The issue is that both VIB and the 'get-score' step generate different scores using the 'same' sources.

The main difference is that VIB uses `helm pull oci://...`, while the `get-score` step uses the `main branch + helm dep update`.

This results in VIB having subcharts uncompressed, while `get-score` step has compressed subcharts `.tgz` files.

This causes both reports to differ, resulting in slightly different scores in those charts that have subcharts.

### Additional information

Tested at https://github.com/migruiz4/charts/pull/21

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
