### PR TITLE
[bitnami/harbor] Dont set redis DB if Sentinel is enabled

### DIFF
--- a/bitnami/harbor/CHANGELOG.md
+++ b/bitnami/harbor/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 22.0.3 (2024-07-15)
+## 22.0.4 (2024-07-15)
 
-* [bitnami/harbor] Remove duplicated security context ([#27955](https://github.com/bitnami/charts/pull/27955))
+* [bitnami/harbor] Dont set redis DB if Sentinel is enabled ([#27977](https://github.com/bitnami/charts/pull/27977))
+
+## <small>22.0.3 (2024-07-15)</small>
+
+* [bitnami/harbor] Remove duplicated security context (#27955) ([ddef5d9](https://github.com/bitnami/charts/commit/ddef5d9ebe14c95ba2c4637dac462f4db8603915)), closes [#27955](https://github.com/bitnami/charts/issues/27955)
 
 ## <small>22.0.2 (2024-07-12)</small>
 

--- a/bitnami/harbor/CHANGELOG.md
+++ b/bitnami/harbor/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 22.0.4 (2024-07-15)
+## 22.0.4 (2024-07-16)
 
 * [bitnami/harbor] Dont set redis DB if Sentinel is enabled ([#27977](https://github.com/bitnami/charts/pull/27977))
 

--- a/bitnami/harbor/Chart.yaml
+++ b/bitnami/harbor/Chart.yaml
@@ -55,4 +55,4 @@ maintainers:
 name: harbor
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/harbor
-version: 22.0.3
+version: 22.0.4

--- a/bitnami/harbor/templates/registry/registry-cm.yaml
+++ b/bitnami/harbor/templates/registry/registry-cm.yaml
@@ -167,7 +167,9 @@ data:
       {{- if ne "" (include "harbor.redis.sentinel.masterSet" .) }}
       sentinelMasterSet: "{{ template "harbor.redis.sentinel.masterSet" . }}"
       {{- end }}
+      {{- if and (eq .Values.externalRedis.sentinel.enabled false) (eq .Values.redis.sentinel.enabled false) -}}
       db: {{ template "harbor.redis.registryDatabaseIndex" . }}
+      {{- end }}
     http:
       relativeurls: {{ .Values.registry.relativeurls }}
       addr: :{{ ternary .Values.registry.server.containerPorts.https .Values.registry.server.containerPorts.http .Values.internalTLS.enabled }}

--- a/bitnami/harbor/templates/registry/registry-cm.yaml
+++ b/bitnami/harbor/templates/registry/registry-cm.yaml
@@ -167,7 +167,7 @@ data:
       {{- if ne "" (include "harbor.redis.sentinel.masterSet" .) }}
       sentinelMasterSet: "{{ template "harbor.redis.sentinel.masterSet" . }}"
       {{- end }}
-      {{- if and (eq .Values.externalRedis.sentinel.enabled false) (eq .Values.redis.sentinel.enabled false) -}}
+      {{- if and (eq .Values.externalRedis.sentinel.enabled false) (eq .Values.redis.sentinel.enabled false) }}
       db: {{ template "harbor.redis.registryDatabaseIndex" . }}
       {{- end }}
     http:


### PR DESCRIPTION
### Description of the change

This removes the DB setting from the registry config if you are running with redis sentinel
### Benefits
 The current config does not allow setting an DB with sentinel enabled, as this happens
`[harbor-registry-7f6579568-slz9t] time="2024-07-15T13:41:40.380848854Z" level=error msg="redis: error connecting: ERR unknown command 'SELECT', with args beginning with: '2' " go.version=go1.22.5 instance.id=779d36f5-ca6e-431a-bbc1-e0e4f481b7d3 redis.connect.duration=2.407059ms service=registry version=v2.8.3`

Removing the DBkey fixes redis caching for the registry
### Possible drawbacks

none
### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Additional information


### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
