### PR TITLE
[github-actions] CD pipeline: Use OCI url in index.yaml

### DIFF
--- a/.github/workflows/cd-pipeline.yml
+++ b/.github/workflows/cd-pipeline.yml
@@ -144,7 +144,7 @@ jobs:
             # Rebuild index
             helm repo index --url oci://registry-1.docker.io/bitnamicharts --merge bitnami/index.yaml ../download
             # Replace .tgz in URL with OCI tag
-            sed -i "s|oci://registry-1.docker.io/bitnamicharts/$app-$chart_version.tgz|oci://registry-1.docker.io/bitnamicharts/$app:$chart_version|" index.yaml
+            sed -i "s|oci://registry-1.docker.io/bitnamicharts/$app-$chart_version.tgz|oci://registry-1.docker.io/bitnamicharts/$app:$chart_version|" ../download/index.yaml
 
             # Compare size of files
             if [[ $(stat -c%s bitnami/index.yaml) -gt $(stat -c%s ../download/index.yaml) ]]; then

--- a/.github/workflows/cd-pipeline.yml
+++ b/.github/workflows/cd-pipeline.yml
@@ -142,7 +142,7 @@ jobs:
             git reset --hard $(git commit-tree origin/index^{tree} -m "Update index.yaml")
 
             # Rebuild index
-            helm repo index --url oci://registry-1.docker.io/bitnamicharts/ --merge bitnami/index.yaml ../download
+            helm repo index --url oci://registry-1.docker.io/bitnamicharts --merge bitnami/index.yaml ../download
             # Replace .tgz in URL with OCI tag
             sed -i "s|oci://registry-1.docker.io/bitnamicharts/$app-$chart_version.tgz|oci://registry-1.docker.io/bitnamicharts/$app:$chart_version|" index.yaml
 

--- a/.github/workflows/cd-pipeline.yml
+++ b/.github/workflows/cd-pipeline.yml
@@ -142,7 +142,10 @@ jobs:
             git reset --hard $(git commit-tree origin/index^{tree} -m "Update index.yaml")
 
             # Rebuild index
-            helm repo index --url https://charts.bitnami.com/bitnami --merge bitnami/index.yaml ../download
+            helm repo index --url oci://registry-1.docker.io/bitnamicharts/ --merge bitnami/index.yaml ../download
+            # Replace .tgz in URL with OCI tag
+            sed -i "s|oci://registry-1.docker.io/bitnamicharts/$app-$chart_version.tgz|oci://registry-1.docker.io/bitnamicharts/$app:$chart_version|" index.yaml
+
             # Compare size of files
             if [[ $(stat -c%s bitnami/index.yaml) -gt $(stat -c%s ../download/index.yaml) ]]; then
               echo "New index.yaml file is shorter than the current one"
@@ -230,7 +233,7 @@ jobs:
           for dependency in "${chart}/charts/"*.tgz; do
             if [[ -s "$dependency" ]]; then
               # Analyse all 'Chart.yaml' files in dependencies
-              while read -r chart_yaml_file; do 
+              while read -r chart_yaml_file; do
                 if [[ -n "${chart_yaml_file}" ]]; then
                   dependency_image_list="$(tar -xzO -f "$dependency" "$chart_yaml_file" | yq '.annotations.images' | yq '[ .[] | .image | sub("^[^/]+/", "") ] | tojson')"
                   image_list="$(jq -c --null-input --argjson arr1 "$image_list" --argjson arr2 "$dependency_image_list" '$arr1 + $arr2 | unique')"
@@ -249,7 +252,7 @@ jobs:
             "version": $app_version,
             "bundled_os_version": $bundled_os_version,
             "properties": {
-                "chart_url": "https://charts.bitnami.com/bitnami/\($app)-\($chart_version).tgz",
+                "chart_url": "oci://registry-1.docker.io/bitnamicharts/\($app):\($chart_version)",
                 "containers": $image_list,
                 "github_repository": "bitnami/charts/tree/main/bitnami/\($app)",
             }


### PR DESCRIPTION
### Description of the change

This PR updates the CD pipeline to use the OCI URL in the index.yaml for new charts.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
