### PR TITLE
[bitnami/vault] Only mount data volume if persistence is enabled

### DIFF
--- a/bitnami/vault/CHANGELOG.md
+++ b/bitnami/vault/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 1.4.13 (2024-07-16)
+## 1.4.14 (2024-07-19)
 
-* [bitnami/vault] Global StorageClass as default value ([#28107](https://github.com/bitnami/charts/pull/28107))
+* [bitnami/vault] Only mount data volume if persistence is enabled ([#27986](https://github.com/bitnami/charts/pull/27986))
+
+## <small>1.4.13 (2024-07-18)</small>
+
+* [bitnami/vault] Global StorageClass as default value (#28107) ([3ad8853](https://github.com/bitnami/charts/commit/3ad885391c5c6e655078b6c65792616e3553ec44)), closes [#28107](https://github.com/bitnami/charts/issues/28107)
 
 ## <small>1.4.12 (2024-07-10)</small>
 

--- a/bitnami/vault/CHANGELOG.md
+++ b/bitnami/vault/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.4.14 (2024-07-19)
+## 1.4.14 (2024-07-22)
 
 * [bitnami/vault] Only mount data volume if persistence is enabled ([#27986](https://github.com/bitnami/charts/pull/27986))
 

--- a/bitnami/vault/Chart.yaml
+++ b/bitnami/vault/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: vault
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/vault
-version: 1.4.13
+version: 1.4.14

--- a/bitnami/vault/templates/server/statefulset.yaml
+++ b/bitnami/vault/templates/server/statefulset.yaml
@@ -91,8 +91,10 @@ spec:
           resources: {{- include "common.resources.preset" (dict "type" .Values.volumePermissions.resourcesPreset) | nindent 12 }}
           {{- end }}
           volumeMounts:
+            {{- if .Values.server.persistence.enabled }}
             - name: data
               mountPath: {{ .Values.server.persistence.mountPath }}
+            {{- end }}
         {{- end }}
         {{- if .Values.server.initContainers }}
           {{- include "common.tplvalues.render" (dict "value" .Values.server.initContainers "context" $) | nindent 8 }}
@@ -224,8 +226,10 @@ spec:
                   ]
           {{- end }}
           volumeMounts:
+            {{- if .Values.server.persistence.enabled }}
             - name: data
               mountPath: {{ .Values.server.persistence.mountPath }}
+            {{- end }}
             - name: config
               mountPath: /bitnami/vault/config
             - name: home


### PR DESCRIPTION
Current chart tries to mount data volume even if persistence is disabled.

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Adds a conditional to add a volumeMount for data. 

### Benefits

This is useful when we are running with `vault.server.command: ["vault", "server", "-dev"]` to install vault on dev mode only.

### Possible drawbacks

N/A

### Applicable issues

N/A
### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
N/A

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [ ] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [ ] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
