### PR TITLE
[bitnami/grafana-operator] Global StorageClass as default value

### DIFF
--- a/bitnami/grafana-operator/Chart.lock
+++ b/bitnami/grafana-operator/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.20.3
-digest: sha256:569e1c9d81abdcad3891e065c0f23c83786527d2043f2bc68193c43d18886c19
-generated: "2024-06-18T11:39:01.625491156Z"
+  version: 2.20.4
+digest: sha256:73045308add144761f12bc13cbad9fddcdce25c6919140e0683d18622bf56ba0
+generated: "2024-07-16T10:01:30.152564+02:00"

--- a/bitnami/grafana-operator/Chart.yaml
+++ b/bitnami/grafana-operator/Chart.yaml
@@ -12,22 +12,22 @@ annotations:
 apiVersion: v2
 appVersion: 5.10.0
 dependencies:
-- name: common
-  repository: oci://registry-1.docker.io/bitnamicharts
-  tags:
-  - bitnami-common
-  version: 2.x.x
+  - name: common
+    repository: oci://registry-1.docker.io/bitnamicharts
+    tags:
+      - bitnami-common
+    version: 2.x.x
 description: Grafana Operator is a Kubernetes operator that enables the installation and management of Grafana instances, dashboards and plugins.
 home: https://bitnami.com
 icon: https://bitnami.com/assets/stacks/grafana/img/grafana-stack-220x234.png
 keywords:
-- grafana
-- operator
-- monitoring
+  - grafana
+  - operator
+  - monitoring
 maintainers:
-- name: Broadcom, Inc. All Rights Reserved.
-  url: https://github.com/bitnami/charts
+  - name: Broadcom, Inc. All Rights Reserved.
+    url: https://github.com/bitnami/charts
 name: grafana-operator
 sources:
-- https://github.com/bitnami/charts/tree/main/bitnami/grafana-operator
-version: 4.4.10
+  - https://github.com/bitnami/charts/tree/main/bitnami/grafana-operator
+version: 4.4.11

--- a/bitnami/grafana-operator/values.yaml
+++ b/bitnami/grafana-operator/values.yaml
@@ -753,6 +753,7 @@ grafana:
     ##   GKE, AWS & OpenStack)
     ##
     defaultStorageClass: ""
+  storageClass: ""
     ## @param grafana.persistence.existingVolume Define the existingVolume for the persistent storage provisioned outside this chart
     ## https://github.com/grafana-operator/grafana-operator/blob/master/deploy/examppersistentvolume/Grafana-existingVolume.yaml
     existingVolume: ""

--- a/bitnami/grafana-operator/values.yaml
+++ b/bitnami/grafana-operator/values.yaml
@@ -752,7 +752,7 @@ grafana:
     ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
     ##   GKE, AWS & OpenStack)
     ##
-    storageClass: ""
+    defaultStorageClass: ""
     ## @param grafana.persistence.existingVolume Define the existingVolume for the persistent storage provisioned outside this chart
     ## https://github.com/grafana-operator/grafana-operator/blob/master/deploy/examppersistentvolume/Grafana-existingVolume.yaml
     existingVolume: ""


### PR DESCRIPTION
### Description of the change

This PR deprecates _global.storageClass_ in favor of _global.defaultStorageClass_ given it's more convenient for this parameter to behave as a fallback instead of taking precedence over more specific values.

This PR shouldn't be merged until the changes in the common helpers at this [PR](https://github.com/bitnami/charts/pull/24863) are merged and published.

### Checklist

- [x] Chart version bumped in Chart.yaml according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
