### PR TITLE
[bitnami/kubernetes-event-exporter] Global StorageClass as default value

### DIFF
--- a/bitnami/kubernetes-event-exporter/CHANGELOG.md
+++ b/bitnami/kubernetes-event-exporter/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 3.2.7 (2024-07-04)
+## 3.2.8 (2024-07-16)
 
-* [bitnami/kubernetes-event-exporter] Release 3.2.7 ([#27802](https://github.com/bitnami/charts/pull/27802))
+* [bitnami/kubernetes-event-exporter] Global StorageClass as default value ([#28047](https://github.com/bitnami/charts/pull/28047))
+
+## <small>3.2.7 (2024-07-04)</small>
+
+* [bitnami/kubernetes-event-exporter] Release 3.2.7 (#27802) ([c7dd23a](https://github.com/bitnami/charts/commit/c7dd23a40f206ff3d6de389164b6b9341138cf78)), closes [#27802](https://github.com/bitnami/charts/issues/27802)
 
 ## <small>3.2.6 (2024-07-03)</small>
 

--- a/bitnami/kubernetes-event-exporter/Chart.lock
+++ b/bitnami/kubernetes-event-exporter/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.20.3
-digest: sha256:569e1c9d81abdcad3891e065c0f23c83786527d2043f2bc68193c43d18886c19
-generated: "2024-06-18T11:46:22.534924075Z"
+  version: 2.20.4
+digest: sha256:73045308add144761f12bc13cbad9fddcdce25c6919140e0683d18622bf56ba0
+generated: "2024-07-16T10:02:52.342844+02:00"

--- a/bitnami/kubernetes-event-exporter/Chart.lock
+++ b/bitnami/kubernetes-event-exporter/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.20.4
-digest: sha256:73045308add144761f12bc13cbad9fddcdce25c6919140e0683d18622bf56ba0
-generated: "2024-07-16T10:02:52.342844+02:00"
+  version: 2.20.5
+digest: sha256:5b98791747a148b9d4956b81bb8635f49a0ae831869d700d52e514b8fd1a2445
+generated: "2024-07-16T12:11:00.51331+02:00"

--- a/bitnami/kubernetes-event-exporter/Chart.yaml
+++ b/bitnami/kubernetes-event-exporter/Chart.yaml
@@ -10,25 +10,25 @@ annotations:
 apiVersion: v2
 appVersion: 1.7.0
 dependencies:
-- name: common
-  repository: oci://registry-1.docker.io/bitnamicharts
-  tags:
-  - bitnami-common
-  version: 2.x.x
+  - name: common
+    repository: oci://registry-1.docker.io/bitnamicharts
+    tags:
+      - bitnami-common
+    version: 2.x.x
 description: Kubernetes Event Exporter makes it easy to export Kubernetes events to other tools, thereby enabling better event observability, custom alerts and aggregation.
 home: https://bitnami.com
 icon: https://bitnami.com/assets/stacks/kubernetes-event-exporter/img/kubernetes-event-exporter-stack-220x234.png
 keywords:
-- alerting
-- event exporting
-- events
-- kubernetes events
-- monitoring
-- observability
+  - alerting
+  - event exporting
+  - events
+  - kubernetes events
+  - monitoring
+  - observability
 maintainers:
-- name: Broadcom, Inc. All Rights Reserved.
-  url: https://github.com/bitnami/charts
+  - name: Broadcom, Inc. All Rights Reserved.
+    url: https://github.com/bitnami/charts
 name: kubernetes-event-exporter
 sources:
-- https://github.com/bitnami/charts/tree/main/bitnami/kubernetes-event-exporter
-version: 3.2.7
+  - https://github.com/bitnami/charts/tree/main/bitnami/kubernetes-event-exporter
+version: 3.2.8


### PR DESCRIPTION
### Description of the change

This PR deprecates _global.storageClass_ in favor of _global.defaultStorageClass_ given it's more convenient for this parameter to behave as a fallback instead of taking precedence over more specific values.

This PR shouldn't be merged until the changes in the common helpers at this [PR](https://github.com/bitnami/charts/pull/24863) are merged and published.

### Checklist

- [x] Chart version bumped in Chart.yaml according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
