### PR TITLE
[bitnami/metallb] Global StorageClass as default value

### DIFF
--- a/bitnami/metallb/CHANGELOG.md
+++ b/bitnami/metallb/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 6.3.7 (2024-07-04)
+## 6.3.8 (2024-07-16)
 
-* [bitnami/metallb] Release 6.3.7 ([#27796](https://github.com/bitnami/charts/pull/27796))
+* [bitnami/metallb] Global StorageClass as default value ([#28056](https://github.com/bitnami/charts/pull/28056))
+
+## <small>6.3.7 (2024-07-04)</small>
+
+* [bitnami/metallb] Release 6.3.7 (#27796) ([bfd90e5](https://github.com/bitnami/charts/commit/bfd90e589210411ecf58128c2c92dc178ff3299b)), closes [#27796](https://github.com/bitnami/charts/issues/27796)
 
 ## <small>6.3.6 (2024-07-03)</small>
 

--- a/bitnami/metallb/Chart.lock
+++ b/bitnami/metallb/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.20.4
-digest: sha256:73045308add144761f12bc13cbad9fddcdce25c6919140e0683d18622bf56ba0
-generated: "2024-07-16T10:03:34.558958+02:00"
+  version: 2.20.5
+digest: sha256:5b98791747a148b9d4956b81bb8635f49a0ae831869d700d52e514b8fd1a2445
+generated: "2024-07-16T12:12:33.253292+02:00"

--- a/bitnami/metallb/Chart.lock
+++ b/bitnami/metallb/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.20.3
-digest: sha256:569e1c9d81abdcad3891e065c0f23c83786527d2043f2bc68193c43d18886c19
-generated: "2024-06-18T11:51:05.681419265Z"
+  version: 2.20.4
+digest: sha256:73045308add144761f12bc13cbad9fddcdce25c6919140e0683d18622bf56ba0
+generated: "2024-07-16T10:03:34.558958+02:00"

--- a/bitnami/metallb/Chart.yaml
+++ b/bitnami/metallb/Chart.yaml
@@ -12,27 +12,27 @@ annotations:
 apiVersion: v2
 appVersion: 0.14.5
 dependencies:
-- name: common
-  repository: oci://registry-1.docker.io/bitnamicharts
-  tags:
-  - bitnami-common
-  version: 2.x.x
+  - name: common
+    repository: oci://registry-1.docker.io/bitnamicharts
+    tags:
+      - bitnami-common
+    version: 2.x.x
 description: MetalLB is a load-balancer implementation for bare metal Kubernetes clusters, using standard routing protocols.
 home: https://bitnami.com
 icon: https://bitnami.com/assets/stacks/metallb-speaker/img/metallb-speaker-stack-220x234.png
 keywords:
-- load-balancer
-- balancer
-- lb
-- bgp
-- arp
-- vrrp
-- vip
+  - load-balancer
+  - balancer
+  - lb
+  - bgp
+  - arp
+  - vrrp
+  - vip
 kubeVersion: '>= 1.19.0-0'
 maintainers:
-- name: Broadcom, Inc. All Rights Reserved.
-  url: https://github.com/bitnami/charts
+  - name: Broadcom, Inc. All Rights Reserved.
+    url: https://github.com/bitnami/charts
 name: metallb
 sources:
-- https://github.com/bitnami/charts/tree/main/bitnami/metallb
-version: 6.3.7
+  - https://github.com/bitnami/charts/tree/main/bitnami/metallb
+version: 6.3.8


### PR DESCRIPTION
### Description of the change

This PR deprecates _global.storageClass_ in favor of _global.defaultStorageClass_ given it's more convenient for this parameter to behave as a fallback instead of taking precedence over more specific values.

This PR shouldn't be merged until the changes in the common helpers at this [PR](https://github.com/bitnami/charts/pull/24863) are merged and published.

### Checklist

- [x] Chart version bumped in Chart.yaml according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
