### PR TITLE
[bitnami/nginx] Global StorageClass as default value

### DIFF
--- a/bitnami/nginx/CHANGELOG.md
+++ b/bitnami/nginx/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 18.1.4 (2024-07-03)
+## 18.1.5 (2024-07-16)
 
-* [bitnami/nginx] Release 18.1.4 ([#27743](https://github.com/bitnami/charts/pull/27743))
+* [bitnami/nginx] Global StorageClass as default value ([#28070](https://github.com/bitnami/charts/pull/28070))
+
+## <small>18.1.4 (2024-07-03)</small>
+
+* [bitnami/nginx] Release 18.1.4 (#27743) ([a9c9841](https://github.com/bitnami/charts/commit/a9c9841d4f409ebcefb740fb323dd2268bc4930b)), closes [#27743](https://github.com/bitnami/charts/issues/27743)
 
 ## <small>18.1.3 (2024-07-03)</small>
 

--- a/bitnami/nginx/Chart.lock
+++ b/bitnami/nginx/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.20.4
-digest: sha256:73045308add144761f12bc13cbad9fddcdce25c6919140e0683d18622bf56ba0
-generated: "2024-07-16T10:04:25.894411+02:00"
+  version: 2.20.5
+digest: sha256:5b98791747a148b9d4956b81bb8635f49a0ae831869d700d52e514b8fd1a2445
+generated: "2024-07-16T12:14:43.774296+02:00"

--- a/bitnami/nginx/Chart.lock
+++ b/bitnami/nginx/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.20.3
-digest: sha256:569e1c9d81abdcad3891e065c0f23c83786527d2043f2bc68193c43d18886c19
-generated: "2024-06-18T11:56:45.220987834Z"
+  version: 2.20.4
+digest: sha256:73045308add144761f12bc13cbad9fddcdce25c6919140e0683d18622bf56ba0
+generated: "2024-07-16T10:04:25.894411+02:00"

--- a/bitnami/nginx/Chart.yaml
+++ b/bitnami/nginx/Chart.yaml
@@ -14,24 +14,24 @@ annotations:
 apiVersion: v2
 appVersion: 1.27.0
 dependencies:
-- name: common
-  repository: oci://registry-1.docker.io/bitnamicharts
-  tags:
-  - bitnami-common
-  version: 2.x.x
+  - name: common
+    repository: oci://registry-1.docker.io/bitnamicharts
+    tags:
+      - bitnami-common
+    version: 2.x.x
 description: NGINX Open Source is a web server that can be also used as a reverse proxy, load balancer, and HTTP cache. Recommended for high-demanding sites due to its ability to provide faster content.
 home: https://bitnami.com
 icon: https://bitnami.com/assets/stacks/nginx/img/nginx-stack-220x234.png
 keywords:
-- nginx
-- http
-- web
-- www
-- reverse proxy
+  - nginx
+  - http
+  - web
+  - www
+  - reverse proxy
 maintainers:
-- name: Broadcom, Inc. All Rights Reserved.
-  url: https://github.com/bitnami/charts
+  - name: Broadcom, Inc. All Rights Reserved.
+    url: https://github.com/bitnami/charts
 name: nginx
 sources:
-- https://github.com/bitnami/charts/tree/main/bitnami/nginx
-version: 18.1.4
+  - https://github.com/bitnami/charts/tree/main/bitnami/nginx
+version: 18.1.5


### PR DESCRIPTION
### Description of the change

This PR deprecates _global.storageClass_ in favor of _global.defaultStorageClass_ given it's more convenient for this parameter to behave as a fallback instead of taking precedence over more specific values.

This PR shouldn't be merged until the changes in the common helpers at this [PR](https://github.com/bitnami/charts/pull/24863) are merged and published.

### Checklist

- [x] Chart version bumped in Chart.yaml according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
