### PR TITLE
[bitnami/nginx-ingress-controller] Global StorageClass as default value

### DIFF
--- a/bitnami/nginx-ingress-controller/CHANGELOG.md
+++ b/bitnami/nginx-ingress-controller/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 11.3.13 (2024-07-15)
+## 11.3.14 (2024-07-16)
 
-* [bitnami/nginx-ingress-controller] Release 11.3.13 ([#27971](https://github.com/bitnami/charts/pull/27971))
+* [bitnami/nginx-ingress-controller] Global StorageClass as default value ([#28071](https://github.com/bitnami/charts/pull/28071))
+
+## <small>11.3.13 (2024-07-15)</small>
+
+* [bitnami/nginx-ingress-controller] Release 11.3.13 (#27971) ([1f18a07](https://github.com/bitnami/charts/commit/1f18a07c2c8e31a3aa2bcf331e9b0561046d6371)), closes [#27971](https://github.com/bitnami/charts/issues/27971)
 
 ## <small>11.3.12 (2024-07-08)</small>
 

--- a/bitnami/nginx-ingress-controller/Chart.lock
+++ b/bitnami/nginx-ingress-controller/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.20.4
-digest: sha256:73045308add144761f12bc13cbad9fddcdce25c6919140e0683d18622bf56ba0
-generated: "2024-07-15T10:33:47.638134617Z"
+  version: 2.20.5
+digest: sha256:5b98791747a148b9d4956b81bb8635f49a0ae831869d700d52e514b8fd1a2445
+generated: "2024-07-16T12:14:52.844167+02:00"

--- a/bitnami/nginx-ingress-controller/Chart.yaml
+++ b/bitnami/nginx-ingress-controller/Chart.yaml
@@ -12,26 +12,26 @@ annotations:
 apiVersion: v2
 appVersion: 1.11.0
 dependencies:
-- name: common
-  repository: oci://registry-1.docker.io/bitnamicharts
-  tags:
-  - bitnami-common
-  version: 2.x.x
+  - name: common
+    repository: oci://registry-1.docker.io/bitnamicharts
+    tags:
+      - bitnami-common
+    version: 2.x.x
 description: NGINX Ingress Controller is an Ingress controller that manages external access to HTTP services in a Kubernetes cluster using NGINX.
 home: https://bitnami.com
 icon: https://bitnami.com/assets/stacks/nginx-ingress-controller/img/nginx-ingress-controller-stack-220x234.png
 keywords:
-- ingress
-- nginx
-- http
-- web
-- www
-- reverse proxy
+  - ingress
+  - nginx
+  - http
+  - web
+  - www
+  - reverse proxy
 kubeVersion: '>= 1.20.0-0'
 maintainers:
-- name: Broadcom, Inc. All Rights Reserved.
-  url: https://github.com/bitnami/charts
+  - name: Broadcom, Inc. All Rights Reserved.
+    url: https://github.com/bitnami/charts
 name: nginx-ingress-controller
 sources:
-- https://github.com/bitnami/charts/tree/main/bitnami/nginx-ingress-controller
-version: 11.3.13
+  - https://github.com/bitnami/charts/tree/main/bitnami/nginx-ingress-controller
+version: 11.3.14


### PR DESCRIPTION
### Description of the change

This PR deprecates _global.storageClass_ in favor of _global.defaultStorageClass_ given it's more convenient for this parameter to behave as a fallback instead of taking precedence over more specific values.

This PR shouldn't be merged until the changes in the common helpers at this [PR](https://github.com/bitnami/charts/pull/24863) are merged and published.

### Checklist

- [x] Chart version bumped in Chart.yaml according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
