### PR TITLE
[bitnami/tensorflow-resnet] Global StorageClass as default value

### DIFF
--- a/bitnami/tensorflow-resnet/CHANGELOG.md
+++ b/bitnami/tensorflow-resnet/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
-## 4.2.6 (2024-07-03)
+## 4.2.7 (2024-07-16)
 
-* [bitnami/tensorflow-resnet] Release 4.2.6 ([#27714](https://github.com/bitnami/charts/pull/27714))
+* [bitnami/tensorflow-resnet] Global StorageClass as default value ([#28102](https://github.com/bitnami/charts/pull/28102))
+
+## <small>4.2.6 (2024-07-03)</small>
+
+* [bitnami/*] Update README changing TAC wording (#27530) ([52dfed6](https://github.com/bitnami/charts/commit/52dfed6bac44d791efabfaf06f15daddc4fefb0c)), closes [#27530](https://github.com/bitnami/charts/issues/27530)
+* [bitnami/tensorflow-resnet] Release 4.2.6 (#27714) ([1d97768](https://github.com/bitnami/charts/commit/1d97768803359a386f0d0e1f1a3edf6702ae1645)), closes [#27714](https://github.com/bitnami/charts/issues/27714)
 
 ## <small>4.2.5 (2024-06-18)</small>
 

--- a/bitnami/tensorflow-resnet/Chart.lock
+++ b/bitnami/tensorflow-resnet/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.20.4
-digest: sha256:73045308add144761f12bc13cbad9fddcdce25c6919140e0683d18622bf56ba0
-generated: "2024-07-16T10:06:28.761384+02:00"
+  version: 2.20.5
+digest: sha256:5b98791747a148b9d4956b81bb8635f49a0ae831869d700d52e514b8fd1a2445
+generated: "2024-07-16T12:19:42.095361+02:00"

--- a/bitnami/tensorflow-resnet/Chart.lock
+++ b/bitnami/tensorflow-resnet/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.20.3
-digest: sha256:569e1c9d81abdcad3891e065c0f23c83786527d2043f2bc68193c43d18886c19
-generated: "2024-06-18T12:55:33.989795795Z"
+  version: 2.20.4
+digest: sha256:73045308add144761f12bc13cbad9fddcdce25c6919140e0683d18622bf56ba0
+generated: "2024-07-16T10:06:28.761384+02:00"

--- a/bitnami/tensorflow-resnet/Chart.yaml
+++ b/bitnami/tensorflow-resnet/Chart.yaml
@@ -12,25 +12,25 @@ annotations:
 apiVersion: v2
 appVersion: 2.16.1
 dependencies:
-- name: common
-  repository: oci://registry-1.docker.io/bitnamicharts
-  tags:
-  - bitnami-common
-  version: 2.x.x
+  - name: common
+    repository: oci://registry-1.docker.io/bitnamicharts
+    tags:
+      - bitnami-common
+    version: 2.x.x
 description: TensorFlow ResNet is a client utility for use with TensorFlow Serving and ResNet models.
 home: https://bitnami.com
 icon: https://bitnami.com/assets/stacks/tensorflow-inception/img/tensorflow-inception-stack-220x234.png
 keywords:
-- tensorflow
-- serving
-- resnet
-- machine
-- learning
-- library
+  - tensorflow
+  - serving
+  - resnet
+  - machine
+  - learning
+  - library
 maintainers:
-- name: Broadcom, Inc. All Rights Reserved.
-  url: https://github.com/bitnami/charts
+  - name: Broadcom, Inc. All Rights Reserved.
+    url: https://github.com/bitnami/charts
 name: tensorflow-resnet
 sources:
-- https://github.com/bitnami/charts/tree/main/bitnami/tensorflow-resnet
-version: 4.2.6
+  - https://github.com/bitnami/charts/tree/main/bitnami/tensorflow-resnet
+version: 4.2.7


### PR DESCRIPTION
### Description of the change

This PR deprecates _global.storageClass_ in favor of _global.defaultStorageClass_ given it's more convenient for this parameter to behave as a fallback instead of taking precedence over more specific values.

This PR shouldn't be merged until the changes in the common helpers at this [PR](https://github.com/bitnami/charts/pull/24863) are merged and published.

### Checklist

- [x] Chart version bumped in Chart.yaml according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
