### PR TITLE
[github-action] Fix kubescape score step for common chart

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -329,11 +329,13 @@ jobs:
         run: |
           if [ -d "charts-main/bitnami/${CHART}" ]; then
             helm dep build charts-main/bitnami/${CHART}
-            cd charts-main/bitnami/${CHART}/charts
-            for filename in *.tgz; do
-              tar -xf "$filename"
-              rm -f "$filename"
-            done
+            if [ -d "charts-main/bitnami/${CHART}/charts" ]; then
+              cd charts-main/bitnami/${CHART}/charts
+              for filename in *.tgz; do
+                tar -xf "$filename"
+                rm -f "$filename"
+              done
+            fi
           fi
       - id: get-chart-score
         uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185


### PR DESCRIPTION
### Description of the change

Fixes an issue with the 'chart-score' step in the CI pipeline that affects the common chart.

It omits the untar step when there are no sub-charts.