### PR TITLE
[bitnami/common] Remove kubescape from VIB pipeline

### DIFF
--- a/.vib/common/vib-verify.json
+++ b/.vib/common/vib-verify.json
@@ -13,12 +13,6 @@
         },
         {
           "action_id": "helm-lint"
-        },
-        {
-          "action_id": "kubescape",
-          "params": {
-            "threshold": {VIB_ENV_KUBESCAPE_SCORE_THRESHOLD}
-          }
         }
       ]
     }


### PR DESCRIPTION
### Description of the change

Removes the kubescape step from VIB pipeline file.

The `common` chart does not have a verify phase in its VIB pipeline, the kubescape action was added to the `package` phase by accident.
