### PR TITLE
[bitnami/matomo] Fix wrong initContainers[0].imagePullSecrets value

### DIFF
--- a/bitnami/matomo/CHANGELOG.md
+++ b/bitnami/matomo/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
+## 8.0.1 (2024-07-16)
+
+* [bitnami/matomo] Fix wrong initContainers[0].imagePullSecrets value ([#28115](https://github.com/bitnami/charts/pull/28115))
+
 ## 8.0.0 (2024-07-13)
 
-* [bitnami/matomo] chore!: :arrow_up: :boom: Update mariadb to 11.4 ([#27943](https://github.com/bitnami/charts/pull/27943))
+* [bitnami/matomo] chore!: :arrow_up: :boom: Update mariadb to 11.4 (#27943) ([ee74a7f](https://github.com/bitnami/charts/commit/ee74a7fc02d22cbbdcd1eaec39960ea7215e50c0)), closes [#27943](https://github.com/bitnami/charts/issues/27943)
 
 ## <small>7.3.8 (2024-07-12)</small>
 

--- a/bitnami/matomo/Chart.lock
+++ b/bitnami/matomo/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 19.0.0
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.20.4
-digest: sha256:b15a896cb6fe528b3a9dab85a74e69e045ff903c5afb62e9868488e93c039d4e
-generated: "2024-07-12T12:12:53.661054069+02:00"
+  version: 2.20.5
+digest: sha256:be8d03838bd3ebd1edb44f0dccefcc1741d45d8643c49e2437fc0d87898a135f
+generated: "2024-07-16T12:39:48.951961+02:00"

--- a/bitnami/matomo/Chart.yaml
+++ b/bitnami/matomo/Chart.yaml
@@ -39,4 +39,4 @@ maintainers:
 name: matomo
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/matomo
-version: 8.0.0
+version: 8.0.1

--- a/bitnami/matomo/templates/_helpers.tpl
+++ b/bitnami/matomo/templates/_helpers.tpl
@@ -172,10 +172,6 @@ Return the matomo pods needed initContainers
 - name: certificates
   image: {{ template "certificates.image" . }}
   imagePullPolicy: {{ default .Values.image.pullPolicy .Values.certificates.image.pullPolicy }}
-  imagePullSecrets:
-  {{- range (default .Values.image.pullSecrets .Values.certificates.image.pullSecrets) }}
-    - name: {{ . }}
-  {{- end }}
   securityContext:
     runAsUser: 0
   {{- if .Values.certificates.command }}

--- a/bitnami/matomo/templates/cronjob.yaml
+++ b/bitnami/matomo/templates/cronjob.yaml
@@ -45,7 +45,7 @@ spec:
           tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.cronjobs.archive.tolerations "context" $) | nindent 12 }}
           {{- end }}
           initContainers:
-            {{ include "matomo.initContainers" . | nindent 12 }}
+            {{- include "matomo.initContainers" . | nindent 12 }}
           {{- if .Values.cronjobs.archive.podSecurityContext.enabled }}
           securityContext: {{- omit .Values.cronjobs.archive.podSecurityContext "enabled" | toYaml | nindent 16 }}
           {{- end }}
@@ -217,7 +217,7 @@ spec:
           {{- end }}
           restartPolicy: OnFailure
           initContainers:
-            {{ include "matomo.initContainers" . | nindent 12 }}
+            {{- include "matomo.initContainers" . | nindent 12 }}
           {{- if .Values.cronjobs.taskScheduler.podSecurityContext.enabled }}
           securityContext: {{- omit .Values.cronjobs.taskScheduler.podSecurityContext "enabled" | toYaml | nindent 16 }}
           {{- end }}

--- a/bitnami/matomo/templates/deployment.yaml
+++ b/bitnami/matomo/templates/deployment.yaml
@@ -71,7 +71,7 @@ spec:
         {{- if .Values.initContainers }}
         {{- include "common.tplvalues.render" (dict "value" .Values.initContainers "context" $) | nindent 8 }}
         {{- end }}
-        {{ include "matomo.initContainers" . | nindent 8 }}
+        {{- include "matomo.initContainers" . | nindent 8 }}
       containers:
         - name: {{ include "common.names.fullname" . }}
           image: {{ template "matomo.image" . }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Remove wrong `initContainers[0].imagePullSecrets` references

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

N/A

### Applicable issues

- #27879

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
