### PR TITLE
[bitnami/minio] Fix provisioning in non-tty environment

### DIFF
--- a/bitnami/minio/CHANGELOG.md
+++ b/bitnami/minio/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 14.6.22 (2024-07-15)
+## 14.6.23 (2024-07-16)
 
-* [bitnami/minio] Release 14.6.22 ([#27991](https://github.com/bitnami/charts/pull/27991))
+* [bitnami/minio] Fix provisioning in non-tty environment ([#28118](https://github.com/bitnami/charts/pull/28118))
+
+## <small>14.6.22 (2024-07-15)</small>
+
+* [bitnami/minio] Release 14.6.22 (#27991) ([0771882](https://github.com/bitnami/charts/commit/07718826311f3a9ee5a10b8b507ee3a16bb21990)), closes [#27991](https://github.com/bitnami/charts/issues/27991)
 
 ## <small>14.6.21 (2024-07-13)</small>
 

--- a/bitnami/minio/Chart.yaml
+++ b/bitnami/minio/Chart.yaml
@@ -34,4 +34,4 @@ maintainers:
 name: minio
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/minio
-version: 14.6.22
+version: 14.6.23

--- a/bitnami/minio/templates/provisioning-job.yaml
+++ b/bitnami/minio/templates/provisioning-job.yaml
@@ -141,7 +141,7 @@ spec:
               mc admin config set {{ $minioAlias }} {{ $config.name }} {{ $options }};
               {{- end }}
 
-              mc admin service restart {{ $minioAlias }};
+              mc admin service restart {{ $minioAlias }} --wait --json;
 
               {{- range $policy := .Values.provisioning.policies }}
               mc admin policy create {{ $minioAlias }} {{ $policy.name }} /etc/ilm/policy-{{ $policy.name }}.json;


### PR DESCRIPTION
### Description of the change

This fixes an error in the provisioning job, where the `mc admin service restart` command requires a TTY-enabled console to work.

### Benefits

Provisioning job works again. :)

### Possible drawbacks

Not sure if these flags are backwards compatible with previous MinIO versions. Is this desired?

### Applicable issues

- fixes #27898

### Additional information

The `--json` flag seems to disable the required TTY feature. The `--wait` flag is for sanity. It looked like the provisioning already continues even when the restart is still in progress.

An alternative approach would've been adding `tty: true` to the container. However, this massively slowed down the provisioning script and caused my `helm upgrade` command to time out.

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
