### PR TITLE
[bitnami/cassandra] Fix for cassandra.commitstorage.class helper

### DIFF
--- a/bitnami/cassandra/CHANGELOG.md
+++ b/bitnami/cassandra/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 11.3.6 (2024-07-16)
+## 11.3.7 (2024-07-16)
 
-* [bitnami/cassandra] Global StorageClass as default value ([#28002](https://github.com/bitnami/charts/pull/28002))
+* [bitnami/cassandra] Fix for cassandra.commitstorage.class helper ([#28119](https://github.com/bitnami/charts/pull/28119))
+
+## <small>11.3.6 (2024-07-16)</small>
+
+* [bitnami/cassandra] Global StorageClass as default value (#28002) ([691d719](https://github.com/bitnami/charts/commit/691d71984aa90d993cc8d869950bb2ef8ea46374)), closes [#28002](https://github.com/bitnami/charts/issues/28002)
 
 ## <small>11.3.5 (2024-07-12)</small>
 

--- a/bitnami/cassandra/Chart.yaml
+++ b/bitnami/cassandra/Chart.yaml
@@ -32,4 +32,4 @@ maintainers:
 name: cassandra
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/cassandra
-version: 11.3.6
+version: 11.3.7

--- a/bitnami/cassandra/templates/_helpers.tpl
+++ b/bitnami/cassandra/templates/_helpers.tpl
@@ -105,12 +105,7 @@ Return  the proper Commit Storage Class
 {{ include "cassandra.commitstorage.class" ( dict "persistence" .Values.path.to.the.persistence "global" $) }}
 */}}
 {{- define "cassandra.commitstorage.class" -}}
-{{- $storageClass := .persistence.commitStorageClass -}}
-{{- if .global -}}
-    {{- if .global.storageClass -}}
-        {{- $storageClass = .global.commitStorageClass -}}
-    {{- end -}}
-{{- end -}}
+{{- $storageClass := (.global).storageClass | default .persistence.commitStorageClass | default (.global).defaultStorageClass | default "" -}}
 
 {{- if $storageClass -}}
   {{- if (eq "-" $storageClass) -}}


### PR DESCRIPTION
### Description of the change

This PR follows up https://github.com/bitnami/charts/pull/28002 given there was a reference to `global.storageClass` that we didn't take into account.

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
