### PR TITLE
[bitnami/jupyterhub] Fix for jupyterhub.storage.class helper

### DIFF
--- a/bitnami/jupyterhub/CHANGELOG.md
+++ b/bitnami/jupyterhub/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 7.2.9 (2024-07-16)
+## 7.2.10 (2024-07-16)
 
-* [bitnami/jupyterhub] Global StorageClass as default value ([#28037](https://github.com/bitnami/charts/pull/28037))
+* [bitnami/jupyterhub] Fix for jupyterhub.storage.class helper ([#28120](https://github.com/bitnami/charts/pull/28120))
+
+## <small>7.2.9 (2024-07-16)</small>
+
+* [bitnami/jupyterhub] Global StorageClass as default value (#28037) ([ca95359](https://github.com/bitnami/charts/commit/ca95359cf47bd71df8e091049bce8d5c55ab990d)), closes [#28037](https://github.com/bitnami/charts/issues/28037)
 
 ## <small>7.2.8 (2024-07-03)</small>
 

--- a/bitnami/jupyterhub/Chart.yaml
+++ b/bitnami/jupyterhub/Chart.yaml
@@ -37,4 +37,4 @@ maintainers:
 name: jupyterhub
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/jupyterhub
-version: 7.2.9
+version: 7.2.10

--- a/bitnami/jupyterhub/templates/_helpers.tpl
+++ b/bitnami/jupyterhub/templates/_helpers.tpl
@@ -222,14 +222,7 @@ Return  the proper Storage Class (adapted to the Jupyterhub configuration format
 {{ include "jupyterhub.storage.class" ( dict "persistence" .Values.path.to.the.persistence "global" $) }}
 */}}
 {{- define "jupyterhub.storage.class" -}}
-
-{{- $storageClass := .persistence.storageClass -}}
-{{- if .global -}}
-    {{- if .global.storageClass -}}
-        {{- $storageClass = .global.storageClass -}}
-    {{- end -}}
-{{- end -}}
-
+{{- $storageClass := (.global).storageClass | default .persistence.storageClass | default (.global).defaultStorageClass | default "" -}}
 {{- if $storageClass -}}
   {{- if (eq "-" $storageClass) -}}
       {{- printf "storageClass: \"\"" -}}


### PR DESCRIPTION
### Description of the change

This PR follows up https://github.com/bitnami/charts/pull/28037 given there was a reference to `global.storageClass` that we didn't take into account.

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
