### PR TITLE
[bitnami/mysql]: Remove duplicated ports in the network policies

### DIFF
--- a/bitnami/mysql/CHANGELOG.md
+++ b/bitnami/mysql/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 11.1.10 (2024-07-16)
+## 11.1.11 (2024-07-18)
 
-* [bitnami/mysql] Global StorageClass as default value ([#28066](https://github.com/bitnami/charts/pull/28066))
+* [bitnami/mysql]: Remove duplicated ports in the network policies ([#28136](https://github.com/bitnami/charts/pull/28136))
+
+## <small>11.1.10 (2024-07-18)</small>
+
+* [bitnami/mysql] Global StorageClass as default value (#28066) ([e92ae97](https://github.com/bitnami/charts/commit/e92ae976e916f66ce59736df3468f2e97d56b036)), closes [#28066](https://github.com/bitnami/charts/issues/28066)
 
 ## <small>11.1.9 (2024-07-09)</small>
 

--- a/bitnami/mysql/CHANGELOG.md
+++ b/bitnami/mysql/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 11.1.11 (2024-07-18)
+## 11.1.11 (2024-07-19)
 
 * [bitnami/mysql]: Remove duplicated ports in the network policies ([#28136](https://github.com/bitnami/charts/pull/28136))
 

--- a/bitnami/mysql/Chart.yaml
+++ b/bitnami/mysql/Chart.yaml
@@ -34,4 +34,4 @@ maintainers:
 name: mysql
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/mysql
-version: 11.1.10
+version: 11.1.11

--- a/bitnami/mysql/templates/networkpolicy.yaml
+++ b/bitnami/mysql/templates/networkpolicy.yaml
@@ -31,15 +31,17 @@ spec:
         - port: 53
           protocol: TCP
     # Allow connection to other cluster pods
+    {{- $containerEgressPorts := list .Values.primary.containerPorts.mysql .Values.secondary.containerPorts.mysql }}
+    {{- if .Values.primary.enableMySQLX }}
+    {{- $containerEgressPorts = append $containerEgressPorts .Values.primary.containerPorts.mysqlx }}
+    {{- end }}
+    {{- if .Values.secondary.enableMySQLX }}
+    {{- $containerEgressPorts = append $containerEgressPorts .Values.secondary.containerPorts.mysqlx }}
+    {{- end }}
     - ports:
-        - port: {{ .Values.primary.containerPorts.mysql }}
-        - port: {{ .Values.secondary.containerPorts.mysql }}
-      {{- if .Values.primary.enableMySQLX }}
-        - port: {{ .Values.primary.containerPorts.mysqlx }}
-      {{- end }}
-      {{- if .Values.secondary.enableMySQLX }}
-        - port: {{ .Values.secondary.containerPorts.mysql }}
-      {{- end }}
+        {{- range $value := (compact $containerEgressPorts | uniq ) }}
+        - port: {{ $value }}
+        {{- end }}
       to:
         - podSelector:
             matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 14 }}
@@ -48,38 +50,41 @@ spec:
     {{- end }}
   {{- end }}
   ingress:
+    # Allow connection from other cluster pods
+    {{- $containerIngressPorts := list .Values.primary.containerPorts.mysql .Values.secondary.containerPorts.mysql }}
+    {{- if .Values.primary.enableMySQLX }}
+    {{- $containerIngressPorts = append $containerIngressPorts .Values.primary.containerPorts.mysqlx }}
+    {{- end }}
+    {{- if .Values.secondary.enableMySQLX }}
+    {{- $containerIngressPorts = append $containerIngressPorts .Values.secondary.containerPorts.mysqlx }}
+    {{- end }}
+    {{- if .Values.metrics.enabled }}
+    {{- $containerIngressPorts = append $containerIngressPorts .Values.metrics.containerPorts.http }}
+    {{- end }}
+    {{- if .Values.primary.extraPorts }}
+    {{- range $value := .Values.primary.extraPorts }}
+    {{- $containerIngressPorts = append $containerIngressPorts $value.containerPort }}
+    {{- end }}
+    {{- end }}
+    {{- if .Values.primary.service.extraPorts }}
+    {{- range $value := .Values.primary.service.extraPorts }}
+    {{- $containerIngressPorts = append $containerIngressPorts $value.port }}
+    {{- end }}
+    {{- end }}
+    {{- if .Values.secondary.extraPorts }}
+    {{- range $value := .Values.secondary.extraPorts }}
+    {{- $containerIngressPorts = append $containerIngressPorts $value.containerPort }}
+    {{- end }}
+    {{- end }}
+    {{- if .Values.secondary.service.extraPorts }}
+    {{- range $value := .Values.secondary.service.extraPorts }}
+    {{- $containerIngressPorts = append $containerIngressPorts $value.port }}
+    {{- end }}
+    {{- end }}
     - ports:
-        - port: {{ .Values.primary.containerPorts.mysql }}
-        - port: {{ .Values.secondary.containerPorts.mysql }}
-      {{- if .Values.primary.enableMySQLX }}
-        - port: {{ .Values.primary.containerPorts.mysqlx }}
-      {{- end }}
-      {{- if .Values.secondary.enableMySQLX }}
-        - port: {{ .Values.secondary.containerPorts.mysql }}
-      {{- end }}
-      {{- if .Values.metrics.enabled }}
-        - port: {{ .Values.metrics.containerPorts.http }}
-      {{- end }}
-      {{- if .Values.primary.extraPorts }}
-        {{- range $value := .Values.primary.extraPorts }}
-        - port: {{ $value.containerPort }}
+        {{- range $value := (compact $containerIngressPorts | uniq ) }}
+        - port: {{ $value }}
         {{- end }}
-      {{- end }}
-      {{- if .Values.primary.service.extraPorts }}
-        {{- range $value := .Values.primary.service.extraPorts }}
-        - port: {{ $value.port }}
-        {{- end }}
-      {{- end }}
-      {{- if .Values.secondary.extraPorts }}
-        {{- range $value := .Values.secondary.extraPorts }}
-        - port: {{ $value.containerPort }}
-        {{- end }}
-      {{- end }}
-      {{- if .Values.secondary.service.extraPorts }}
-        {{- range $value := .Values.secondary.service.extraPorts }}
-        - port: {{ $value.port }}
-        {{- end }}
-      {{- end }}
       {{- if not .Values.networkPolicy.allowExternal }}
       from:
         - podSelector:


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

The main goal of this change is to simplify the template and remove duplications that may happen in the NetworkPolicy even when you are in standalone mode.

![Screenshot 2024-07-17 at 14 52 38](https://github.com/user-attachments/assets/64a3b803-0b0e-4630-bfa7-0ee2dafd33d2)
resource.

### Benefits

The main benefit is to fix two bugs:
* Remove duplicated ports in the ingress and egress NetworkPolicy
* The secondary instance has a bug using the `mysql` port instead of `mysqlx` port.

### Possible drawbacks

N/A

### Applicable issues

N/A

### Additional information

It's possible to compare the current and new version in the [Helm Playground](https://helm-playground.com/#t=KYcwTsDOkFwFAAIkIMQIIIBtMHsDuCAJgHaQISQ6YCuALgJY7GLIC0CADjmLbC8m07daMBAFYAzPwHIOYHLRwBjKqICqAEQAK0gey49Rk3TLkLlqhABUAwjoFob1MBGK0EANWBhIjZnqEePhlBAxEEAG8IhAA6DwBDGigYuXoAW3iwAE8YlTd4%2BmJvLWFIGLSsyABHTAQAXzqTJH1hUSjYhKSyyGA8wkycvNoCorASoPLKmvrGkKj2egAzDsTqZNSM7JjgYniAI0xgAFksgGUARQAZAA0ZpoQWw0jouNX1sHSB3KZhwuLSybVTAADzucwi7B2hDBMnmCCWKy6MR6fS%2BO32hxOFxuMJCj3C7VeSJRTH6WyGI3%2BEwqQNxyDhULpaAAcsACAA3by%2BJjSOEAEgpfzAAFFwFBIONeAgYABeBCYeiQdxEtZlDZfQWjSVlGnTFXJEnEMmDH6UsYA3W1Bq8iHw5b6tUfTY5dEHY5nK63a0Cfma7yiigS0oIOXxDgcRkC01CgPi7WI1UpJ0a6Nai1TEF0hlGrO2hEO5G9Ulo3ZurGe3PsKP5GNi6Dx0PhyN%2BkV1oNBBMGotGlM1tPUjOg73022M4dIOH5zqJ9VbHpgdn0JTAbbA2hgeLx8fPKst2P14NyvJKeLuau-Ub79tSgAU7LeZALs5y88Xy5SpQAlJWEGPZqFSngEIJ1tDdiBAYAED5e8kmlOUbxUNIOHiJQzz3Nt4wAHwQahiHoKoEG-bcAjCNpomgt46R9Ucc2tQo2yA5BHGcVx3C8Hw-GkfFgmA-EyM7R1PnJVMqV4QFpmIgCnkJacu1RYS%2B1EnUMyonc7QEpMhJdUtMQ9HFJOaQICReWTBOdb5FPNAcgSHf9qMhWi7JHBZ7VMwt5O0jF3WxL0nJI1png0w1jQsi8lPEq0-LUv8TEnVyH3KYB1yXMpXUOaEDIeIz%2BILNIko%2BJQyhbbUYgAC1oWgOFU7MMqiuKNOfVd103YNMrhMCIKgmC1jghrky2YA1w3LcosM0jAoopJQrNSVVJAhzatimjFvBFy%2Bq0wsFyXFdBuakb7na%2BJwMgyaetldbzNfbamuG1rRqy8b2lOlcwjm6LHKWhbqrzeLiW7ELdtujs2tAo7Oue3qC2CtEhpa4H7r4ibupXYrhDemrvq%2ByT6qh-6viu99AbhqUQfYDqTuRyG3OhudvDfHbYf24CHoCp7kY-Hh0eWzHfw%2BhwEFZAh2O5fxnKglsAElwMDeNzoVJULt7MKrLEy0grxhTlZKtXtxxtzGrS7yK1121zzNKWMMPBAwwjHMzaFC2ZeDJ9%2BpNSztcHH8Yvs9TcY87YdKN-SnN9ESwEduMrZt5sw4jg8Oz94tNZm9MbK9vmxanBK8uSwqA68laxft0Y4%2BvMhG1t6Fi%2B8Uv41y-KUumoUSvKyr08L%2Bbff112buJsgTbJsGKco86XY2ommaLyXpcjjsK5jyza%2BDZ6m-7dwB95jv3q3vWEsagmGb2u6bUH46upHuUx8uunron4%2Bfer8OZ-jqV57t6fLY7FfXo372xb-zuWc-r%2BzvvDE%2B5Ah7n1gqPamGsXSM3vlPWOz8y4hmtk2d%2ByDP5ShXqjTmv8M6dwAWpIBiYaYvhvoTBBYCfbkygWdS%2BsD-YH17pPTuj8l5z3QZXcWWCnZf3Zj-EO3MCFb24oxVaECz4Q3OghHASEUJoT4bPKU2FcL4UIm9RGbNKKk03m9e4XEjJ8E%2Bl3bODc86Gy3v5aSJlzG5yKmHFuFUqrYxEXVH6isBrUJJvdQ60jKYwL3j3UBvj7jaPIuzPB68-HuNMcQwBv0Zw9xYaE-usTT7g0CYw4JG1Uk%2BPSeE7KSM3gcxiQdOJkiEkkKSXJJO8Cj40OAv4rJF91YgIKVo4pOiprRK5ljDxAzTGkLqT2WmW0qGNLCczFpw9oE5OAfUza9NWGILxN0yJpShEVKGVUj68R%2BKPyvCNIAA&v=LQhQAcCcEsFsENIE8BcoAE6CmA7eAjAGywFkkBlARQBkANFdAF0gFcsN0BjAex0fmg4skAArdIjAM5pMmWEkkBHQgwDMqgAwA2DnIXKAHms1aNHLAebwxE6bvTAuvfoOE3GDAKwafHScIA3aE4sGVkLK3c7WQd0cHEPdABODRT7eNswmPklFXR1bXs9XKN8kzNQfx4cABNEVHM8IlIKGnp0ADN4Qn8OapchUQTo2RzlY0Ls-UJSgtNzS0hrYazY-oFB9y8fM0x-SCCQ1YilqNXHDMSUtJjLkanciZ0Y4sMnitgsZmCR3AJiGoMZhsPrODZuFb2AAWjEY4CeQA).

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
