### PR TITLE
[bitnami/cilium] Fix TLS cert for Hubble Relay

### DIFF
--- a/bitnami/cilium/CHANGELOG.md
+++ b/bitnami/cilium/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 1.0.4 (2024-07-15)
+## 1.0.5 (2024-07-17)
 
-* [bitnami/cilium] Fix Cilium Envoy configuration ([#27587](https://github.com/bitnami/charts/pull/27587))
+* [bitnami/cilium] Fix TLS cert for Hubble Relay ([#28139](https://github.com/bitnami/charts/pull/28139))
+
+## <small>1.0.4 (2024-07-15)</small>
+
+* [bitnami/cilium] Fix Cilium Envoy configuration (#27587) ([bc4297c](https://github.com/bitnami/charts/commit/bc4297c826dcf1a0020f1373bdfe9d801b40bd0b)), closes [#27587](https://github.com/bitnami/charts/issues/27587)
 
 ## <small>1.0.3 (2024-07-11)</small>
 

--- a/bitnami/cilium/Chart.yaml
+++ b/bitnami/cilium/Chart.yaml
@@ -52,4 +52,4 @@ sources:
 - https://github.com/bitnami/containers/tree/main/bitnami/hubble-relay
 - https://github.com/bitnami/containers/tree/main/bitnami/hubble-ui
 - https://github.com/bitnami/containers/tree/main/bitnami/hubble-ui-backend
-version: 1.0.4
+version: 1.0.5

--- a/bitnami/cilium/templates/hubble-ui/deployment.yaml
+++ b/bitnami/cilium/templates/hubble-ui/deployment.yaml
@@ -137,7 +137,7 @@ spec:
               value: {{ ternary "true" "false" .Values.hubble.tls.enabled | quote }}
             {{- if .Values.hubble.tls.enabled }}
             - name: TLS_RELAY_SERVER_NAME
-              value: {{ include "cilium.hubble.relay.fullname" . | quote }}
+              value: ui.hubble-relay.cilium.io
             - name: TLS_RELAY_CA_CERT_FILES
               value: /certs/client/ca.crt
             - name: TLS_RELAY_CLIENT_CERT_FILE

--- a/bitnami/cilium/templates/tls-secret.yaml
+++ b/bitnami/cilium/templates/tls-secret.yaml
@@ -51,7 +51,7 @@ data:
   tls.crt: {{ include "common.secrets.lookup" (dict "secret" $relaySecretName "key" "tls.crt" "defaultValue" $relayCert.Cert "context" $) }}
   tls.key: {{ include "common.secrets.lookup" (dict "secret" $relaySecretName "key" "tls.key" "defaultValue" $relayCert.Key "context" $) }}
 ---
-{{- $relayClientCert := genSignedCert $relayCN nil nil 365 $ca }}
+{{- $relayClientCert := genSignedCert $relayCN nil (list $relayCN) 365 $ca }}
 {{- $relayClientSecretName := include "cilium.hubble.tls.relayClient.secretName" . }}
 apiVersion: v1
 kind: Secret


### PR DESCRIPTION
### Description of the change

This PR fixes the TLS cert use on Hubble Relay pods for the client to connect with Hubble server via TLS.

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
