### PR TITLE
[bitanami/valkey-cluster] fix name generation loop in the external access template

### DIFF
--- a/bitnami/valkey-cluster/CHANGELOG.md
+++ b/bitnami/valkey-cluster/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.1.4 (2024-07-18)
+## 0.1.4 (2024-07-19)
 
 * [bitanami/valkey-cluster] fix name generation loop in the external access template ([#28163](https://github.com/bitnami/charts/pull/28163))
 

--- a/bitnami/valkey-cluster/CHANGELOG.md
+++ b/bitnami/valkey-cluster/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 0.1.3 (2024-07-16)
+## 0.1.4 (2024-07-18)
 
-* [bitnami/valkey-cluster] Global StorageClass as default value ([#28106](https://github.com/bitnami/charts/pull/28106))
+* [bitanami/valkey-cluster] fix name generation loop in the external access template ([#28163](https://github.com/bitnami/charts/pull/28163))
+
+## <small>0.1.3 (2024-07-18)</small>
+
+* [bitnami/valkey-cluster] Global StorageClass as default value (#28106) ([47318eb](https://github.com/bitnami/charts/commit/47318eb3fad504d94ad0e4450dcb7cb36380e0c1)), closes [#28106](https://github.com/bitnami/charts/issues/28106)
 
 ## <small>0.1.2 (2024-07-11)</small>
 

--- a/bitnami/valkey-cluster/Chart.yaml
+++ b/bitnami/valkey-cluster/Chart.yaml
@@ -33,4 +33,4 @@ name: valkey-cluster
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/valkey-cluster
   - https://github.com/bitnami/containers/tree/main/bitnami/vakey-cluster
-version: 0.1.3
+version: 0.1.4

--- a/bitnami/valkey-cluster/templates/svc-cluster-external-access.yaml
+++ b/bitnami/valkey-cluster/templates/svc-cluster-external-access.yaml
@@ -14,7 +14,7 @@ SPDX-License-Identifier: APACHE-2.0
 apiVersion: v1
 kind: Service
 metadata:
-  name: name: {{ printf "%s-%s-svc" ((include "common.names.fullname" . ) | replace "+" "_" | trunc 63 | trimSuffix "-") $i }}
+  name: {{ template "common.names.fullname" $ }}-{{ $i }}-svc
   namespace: {{ $.Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" $root.Values.commonLabels "context" $ ) | nindent 4 }}
     pod: {{ $targetPod }}


### PR DESCRIPTION


### Description of the change

Changes the loop which generates pod names to not throw errors when templating with `externalAccess` enabled. Matches the method used in the Redis-Cluster chart here: https://github.com/bitnami/charts/blob/51eeb01d38beed95f3cbb0f2e538cb5fe09bb42c/bitnami/redis-cluster/templates/svc-cluster-external-access.yaml#L17C8-L17C62

### Benefits

Unblocks enabling external-access

### Applicable issues

- Resolves: https://github.com/bitnami/charts/issues/28162

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
