### PR TITLE
[bitnami/solr] Change permissions of the Solr data directory

### DIFF
--- a/bitnami/solr/CHANGELOG.md
+++ b/bitnami/solr/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 9.3.7 (2024-07-16)
+## 9.3.8 (2024-07-22)
 
-* [bitnami/solr] Global StorageClass as default value ([#28096](https://github.com/bitnami/charts/pull/28096))
+* [bitnami/solr] Change permissions of the Solr data directory ([#28189](https://github.com/bitnami/charts/pull/28189))
+
+## <small>9.3.7 (2024-07-18)</small>
+
+* [bitnami/solr] Global StorageClass as default value (#28096) ([6897cfa](https://github.com/bitnami/charts/commit/6897cfa75b4e26fc94e211c4984f6d9e713212ec)), closes [#28096](https://github.com/bitnami/charts/issues/28096)
 
 ## <small>9.3.6 (2024-07-03)</small>
 

--- a/bitnami/solr/Chart.yaml
+++ b/bitnami/solr/Chart.yaml
@@ -34,4 +34,4 @@ maintainers:
 name: solr
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/solr
-version: 9.3.7
+version: 9.3.8

--- a/bitnami/solr/templates/statefulset.yaml
+++ b/bitnami/solr/templates/statefulset.yaml
@@ -114,6 +114,7 @@ spec:
             - -ec
             - |
               mkdir -p /bitnami/solr
+              chown -R {{ .Values.containerSecurityContext.runAsUser }}:{{ .Values.podSecurityContext.fsGroup }} /bitnami/solr
               find /bitnami/solr -mindepth 1 -maxdepth 1 -not -name ".snapshot" -not -name "lost+found" | xargs -r chown -R {{ .Values.containerSecurityContext.runAsUser }}:{{ .Values.podSecurityContext.fsGroup }}
           {{- if .Values.volumePermissions.containerSecurityContext.enabled }}
           securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.volumePermissions.containerSecurityContext "context" $) | nindent 12 }}


### PR DESCRIPTION
* When using a volume permission change container, change permissions of the Solr data directory, as well as its content.
* Bump patch version. Now 9.3.8

### Description of the change

Make the initialization container change the owner of the data directory itself. Otherwise, Solr will not be able to create files in it and will get stuck in a crash loop. The same chown is being done on the zookeeper data directory, but it seems it is forgotten on Solr.

### Benefits

With this change, the permission system works. Otherwise, the chart fails to deploy on restricted settings. For example, if you use Talos and host path volumes, the existing init container fails.

### Possible drawbacks

None.

### Applicable issues

None

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
