### PR TITLE
[bitnami/metallb] Remove duplicate keys

### DIFF
--- a/bitnami/metallb/CHANGELOG.md
+++ b/bitnami/metallb/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 6.3.8 (2024-07-16)
+## 6.3.9 (2024-07-23)
 
-* [bitnami/metallb] Global StorageClass as default value ([#28056](https://github.com/bitnami/charts/pull/28056))
+* [bitnami/metallb] Remove duplicate keys ([#28203](https://github.com/bitnami/charts/pull/28203))
+
+## <small>6.3.8 (2024-07-16)</small>
+
+* [bitnami/metallb] Global StorageClass as default value (#28056) ([d0ab955](https://github.com/bitnami/charts/commit/d0ab95565e69472a14c13408893b8207fe5ec578)), closes [#28056](https://github.com/bitnami/charts/issues/28056)
 
 ## <small>6.3.7 (2024-07-04)</small>
 

--- a/bitnami/metallb/CHANGELOG.md
+++ b/bitnami/metallb/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 6.3.9 (2024-07-23)
+## 6.3.9 (2024-07-24)
 
 * [bitnami/metallb] Remove duplicate keys ([#28203](https://github.com/bitnami/charts/pull/28203))
 

--- a/bitnami/metallb/Chart.yaml
+++ b/bitnami/metallb/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: metallb
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/metallb
-version: 6.3.8
+version: 6.3.9

--- a/bitnami/metallb/templates/speaker/daemonset.yaml
+++ b/bitnami/metallb/templates/speaker/daemonset.yaml
@@ -223,9 +223,6 @@ spec:
           {{- if .Values.speaker.frr.containerSecurityContext.enabled }}
           securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.speaker.frr.containerSecurityContext "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.speaker.frr.image.pullPolicy }}
-          imagePullPolicy: {{ .Values.speaker.frr.image.pullPolicy }}
-          {{- end }}
           volumeMounts:
             - name: frr-sockets
               mountPath: /var/run/frr
@@ -246,11 +243,6 @@ spec:
                 attempts=$(( $attempts + 1 ))
               done
               tail -f /etc/frr/frr.log
-          {{- if .Values.speaker.frr.resources }}
-          resources: {{- toYaml .Values.speaker.frr.resources | nindent 12 }}
-          {{- else if ne .Values.speaker.frr.resourcesPreset "none" }}
-          resources: {{- include "common.resources.preset" (dict "type" .Values.speaker.frr.resourcesPreset) | nindent 12 }}
-          {{- end }}
           {{- if .Values.speaker.frr.resources }}
           resources: {{- toYaml .Values.speaker.frr.resources | nindent 12 }}
           {{- else if ne .Values.speaker.frr.resourcesPreset "none" }}
@@ -282,9 +274,6 @@ spec:
           securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.speaker.frr.containerSecurityContext "context" $) | nindent 12 }}
           {{- end }}
           command: ["/etc/frr_metrics/frr-metrics"]
-          {{- if .Values.speaker.frr.containerSecurityContext.enabled }}
-          securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.speaker.frr.containerSecurityContext "context" $) | nindent 12 }}
-          {{- end }}
           args:
             - --metrics-port={{ .Values.speaker.frr.containerPorts.metrics }}
           ports:


### PR DESCRIPTION
### Description of the change

Remove duplicated keys that cause applying with flux to fail when frr is enabled

### Benefits

Fixes usage by tools that reject duplicate keys (such as flux):

```
2024-07-20T22:40:36.520Z error HelmRelease/metallb.metallb-system - Reconciler error error while running post render on files: map[string]interface {}(nil): yaml: unmarshal errors:
  line 183: mapping key "imagePullPolicy" already defined at line 173
  line 213: mapping key "resources" already defined at line 204
  line 264: mapping key "securityContext" already defined at line 254
```


### Possible drawbacks

None. The same values were defined a few lines above the removed ones.

### Applicable issues

### Additional information


### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
