### PR TITLE
[bitnami/cilium] Compatible with read-only fs

### DIFF
--- a/bitnami/cilium/CHANGELOG.md
+++ b/bitnami/cilium/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 1.0.7 (2024-07-18)
+## 1.0.8 (2024-07-23)
 
-* [bitnami/cilium] Release 1.0.7 ([#28165](https://github.com/bitnami/charts/pull/28165))
+* [bitnami/cilium] Compatible with read-only fs ([#28223](https://github.com/bitnami/charts/pull/28223))
+
+## <small>1.0.7 (2024-07-18)</small>
+
+* [bitnami/cilium] Release 1.0.7 (#28165) ([3729e0f](https://github.com/bitnami/charts/commit/3729e0fb0046a54d82815219dd4d19996e61d707)), closes [#28165](https://github.com/bitnami/charts/issues/28165)
 
 ## <small>1.0.6 (2024-07-18)</small>
 

--- a/bitnami/cilium/Chart.yaml
+++ b/bitnami/cilium/Chart.yaml
@@ -52,4 +52,4 @@ sources:
 - https://github.com/bitnami/containers/tree/main/bitnami/hubble-relay
 - https://github.com/bitnami/containers/tree/main/bitnami/hubble-ui
 - https://github.com/bitnami/containers/tree/main/bitnami/hubble-ui-backend
-version: 1.0.7
+version: 1.0.8

--- a/bitnami/cilium/templates/agent/daemonset.yaml
+++ b/bitnami/cilium/templates/agent/daemonset.yaml
@@ -242,6 +242,9 @@ spec:
               mountPath: /tmp
               subPath: tmp-dir
             - name: empty-dir
+              mountPath: /var/log
+              subPath: var-log-dir
+            - name: empty-dir
               mountPath: /.config
               subPath: gops-config-dir
             - name: empty-dir


### PR DESCRIPTION
### Description of the change

Some system binaries (e.g. `update-alternatives`) use the `/var/log` directory to write some log files. We need to add write permissions to this directory then.

### Possible drawbacks

None

### Applicable issues

N/A

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
