### PR TITLE
[bitnami/mlflow] feat: Fixup to allow database dialects to be configured (#25965)

### DIFF
--- a/bitnami/mlflow/CHANGELOG.md
+++ b/bitnami/mlflow/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 1.4.17 (2024-07-18)
+## 1.4.18 (2024-07-24)
 
-* [bitnami/mlflow] Global StorageClass as default value ([#28060](https://github.com/bitnami/charts/pull/28060))
+* [bitnami/mlflow] feat: Fixup to allow database dialects to be configured (#25965) ([#28316](https://github.com/bitnami/charts/pull/28316))
+
+## <small>1.4.17 (2024-07-19)</small>
+
+* [bitnami/mlflow] Global StorageClass as default value (#28060) ([ad82fbf](https://github.com/bitnami/charts/commit/ad82fbf05614fe2bbd5155164cee374aceb00bf5)), closes [#28060](https://github.com/bitnami/charts/issues/28060)
 
 ## <small>1.4.16 (2024-07-17)</small>
 

--- a/bitnami/mlflow/Chart.yaml
+++ b/bitnami/mlflow/Chart.yaml
@@ -44,4 +44,4 @@ sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/mlflow
   - https://github.com/bitnami/containers/tree/main/bitnami/mlflow
   - https://github.com/mlflow/mlflow
-version: 1.4.17
+version: 1.4.18     

--- a/bitnami/mlflow/templates/_helpers.tpl
+++ b/bitnami/mlflow/templates/_helpers.tpl
@@ -503,7 +503,7 @@ Retrieve key of the PostgreSQL secret
 Retrieve the URI of the database
 */}}
 {{- define "mlflow.v0.database.uri" -}}
-{{- printf "postgresql://%s:$(MLFLOW_DATABASE_PASSWORD)@%s:%v/%s" (include "mlflow.v0.database.user" .) (include "mlflow.v0.database.host" .) (include "mlflow.v0.database.port" .) (include "mlflow.v0.database.name" .) -}}
+{{- printf "%s://%s:$(MLFLOW_DATABASE_PASSWORD)@%s:%v/%s" (include "mlflow.v0.database.dialectDriver" .) (include "mlflow.v0.database.user" .) (include "mlflow.v0.database.host" .) (include "mlflow.v0.database.port" .) (include "mlflow.v0.database.name" .) -}}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
### Description of the change

This is a fixup for the auth database URI generation. The previous commit PR #25965
did not apply the dialect template / config to the uri of the auth database.

Fixes: #25965
Fixes: #25964
Signed-off-by: Christian Rohmann <christian.rohmann@inovex.de>


### Benefits



### Possible drawbacks



### Applicable issues



### Additional information



### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
