### PR TITLE
[bitnami/cilium] Compatible with read-only fs - part ii

### DIFF
--- a/bitnami/cilium/CHANGELOG.md
+++ b/bitnami/cilium/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 1.0.8 (2024-07-23)
+## 1.0.9 (2024-07-24)
 
-* [bitnami/cilium] Compatible with read-only fs ([#28223](https://github.com/bitnami/charts/pull/28223))
+* [bitnami/cilium] Compatible with read-only fs - part ii ([#28329](https://github.com/bitnami/charts/pull/28329))
+
+## <small>1.0.8 (2024-07-23)</small>
+
+* [bitnami/cilium] Compatible with read-only fs (#28223) ([f1c461c](https://github.com/bitnami/charts/commit/f1c461c89dacc0ea3d545610c6212d8dde5ec392)), closes [#28223](https://github.com/bitnami/charts/issues/28223)
 
 ## <small>1.0.7 (2024-07-18)</small>
 

--- a/bitnami/cilium/Chart.yaml
+++ b/bitnami/cilium/Chart.yaml
@@ -52,4 +52,4 @@ sources:
 - https://github.com/bitnami/containers/tree/main/bitnami/hubble-relay
 - https://github.com/bitnami/containers/tree/main/bitnami/hubble-ui
 - https://github.com/bitnami/containers/tree/main/bitnami/hubble-ui-backend
-version: 1.0.8
+version: 1.0.9

--- a/bitnami/cilium/templates/agent/_init_containers.tpl
+++ b/bitnami/cilium/templates/agent/_init_containers.tpl
@@ -29,6 +29,16 @@ Returns an init-container that copies some dirs to an empty dir volume to make t
       # In order to not break the application functionality we need to make some
       # directories writable, so we need to copy it to an empty dir volume
       cp -r --preserve=mode /opt/bitnami/cilium/var/lib/bpf /emptydir/bpf-lib-dir
+      # We use the iptables-wrapper that dynamically adapts the iptables mode to use ("legacy" or "nft")
+      # This wrappers uses the "update-alternatives" command to switch between the iptables modes and
+      # therefore we need to ensure the directories used by this command are writable
+      # ref: https://www.man7.org/linux/man-pages/man1/update-alternatives.1.html#FILES
+      cp -r --preserve=mode /etc/alternatives /emptydir/alternatives-dir
+      if [ -d /var/lib/dpkg/alternatives ]; then
+          cp -r --preserve=mode /var/lib/dpkg/alternatives /emptydir/alternatives-admin-dir
+      elif [ -d /var/lib/alternatives ]; then
+          cp -r --preserve=mode /var/lib/alternatives /emptydir/alternatives-admin-dir
+      fi
       info "Copy operation completed"
   volumeMounts:
     - name: empty-dir

--- a/bitnami/cilium/templates/agent/daemonset.yaml
+++ b/bitnami/cilium/templates/agent/daemonset.yaml
@@ -242,6 +242,15 @@ spec:
               mountPath: /tmp
               subPath: tmp-dir
             - name: empty-dir
+              mountPath: /etc/alternatives
+              subPath: alternatives-dir
+            - name: empty-dir
+              mountPath: /var/lib/dpkg/alternatives
+              subPath: alternatives-admin-dir
+            - name: empty-dir
+              mountPath: /var/lib/alternatives
+              subPath: alternatives-admin-dir
+            - name: empty-dir
               mountPath: /var/log
               subPath: var-log-dir
             - name: empty-dir


### PR DESCRIPTION
### Description of the change

Follows up https://github.com/bitnami/charts/pull/28223 ensuring other directories that require write access are writable.

### Possible drawbacks

None

### Applicable issues

N/A

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
