### PR TITLE
[bitnami/keycloak] Allow support for gce based ingress controllers

### DIFF
--- a/bitnami/keycloak/CHANGELOG.md
+++ b/bitnami/keycloak/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 21.7.6 (2024-07-26)
+## 21.8.0 (2024-07-26)
 
-* [bitnami/keycloak] Fix invalid value of proxy headers when legacy proxy is used ([#28530](https://github.com/bitnami/charts/pull/28530))
+* [bitnami/keycloak] Allow support for gce based ingress controllers ([#28519](https://github.com/bitnami/charts/pull/28519))
+
+## <small>21.7.6 (2024-07-26)</small>
+
+* [bitnami/keycloak] Fix invalid value of proxy headers when legacy proxy is used (#28530) ([372d263](https://github.com/bitnami/charts/commit/372d2638677330da509c8ff2783a2efd48484d45)), closes [#28530](https://github.com/bitnami/charts/issues/28530)
 
 ## <small>21.7.5 (2024-07-25)</small>
 

--- a/bitnami/keycloak/CHANGELOG.md
+++ b/bitnami/keycloak/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 21.7.5 (2024-07-25)
+## 21.8.0 (2024-07-25)
 
-* [bitnami/keycloak] Release 21.7.5 ([#28428](https://github.com/bitnami/charts/pull/28428))
+* [bitnami/keycloak] Allow support for gce based ingress controllers ([#28519](https://github.com/bitnami/charts/pull/28519))
+
+## <small>21.7.5 (2024-07-25)</small>
+
+* [bitnami/keycloak] Release 21.7.5 (#28428) ([8c7be7d](https://github.com/bitnami/charts/commit/8c7be7d0937fb83efb89b26fdd44cd055c2c118e)), closes [#28428](https://github.com/bitnami/charts/issues/28428)
 
 ## <small>21.7.4 (2024-07-24)</small>
 

--- a/bitnami/keycloak/CHANGELOG.md
+++ b/bitnami/keycloak/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 21.8.0 (2024-07-25)
+## 21.8.0 (2024-07-26)
 
 * [bitnami/keycloak] Allow support for gce based ingress controllers ([#28519](https://github.com/bitnami/charts/pull/28519))
 

--- a/bitnami/keycloak/Chart.yaml
+++ b/bitnami/keycloak/Chart.yaml
@@ -33,4 +33,4 @@ maintainers:
 name: keycloak
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/keycloak
-version: 21.7.5
+version: 21.8.0

--- a/bitnami/keycloak/README.md
+++ b/bitnami/keycloak/README.md
@@ -466,7 +466,7 @@ As an alternative, you can use of the preset configurations for pod affinity, po
 | `ingress.ingressClassName`              | IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)                                                    | `""`                     |
 | `ingress.pathType`                      | Ingress path type                                                                                                                | `ImplementationSpecific` |
 | `ingress.apiVersion`                    | Force Ingress API version (automatically detected if not set)                                                                    | `""`                     |
-| `ingress.controller`                   | The ingress controller type. Currently supports `default` and `gce`                                                       | `default`                |
+| `ingress.controller`                    | The ingress controller type. Currently supports `default` and `gce`                                                       | `default`                |
 | `ingress.hostname`                      | Default host for the ingress record (evaluated as template)                                                                      | `keycloak.local`         |
 | `ingress.path`                          | Default path for the ingress record (evaluated as template)                                                                      | `""`                     |
 | `ingress.servicePort`                   | Backend service port to use                                                                                                      | `http`                   |

--- a/bitnami/keycloak/README.md
+++ b/bitnami/keycloak/README.md
@@ -466,7 +466,7 @@ As an alternative, you can use of the preset configurations for pod affinity, po
 | `ingress.ingressClassName`              | IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)                                                    | `""`                     |
 | `ingress.pathType`                      | Ingress path type                                                                                                                | `ImplementationSpecific` |
 | `ingress.apiVersion`                    | Force Ingress API version (automatically detected if not set)                                                                    | `""`                     |
-| `ingress.controller`      | The ingress controller type. Currently supports `default` and `gce`                                                       | `default`                |
+| `ingress.controller`                   | The ingress controller type. Currently supports `default` and `gce`                                                       | `default`                |
 | `ingress.hostname`                      | Default host for the ingress record (evaluated as template)                                                                      | `keycloak.local`         |
 | `ingress.path`                          | Default path for the ingress record (evaluated as template)                                                                      | `""`                     |
 | `ingress.servicePort`                   | Backend service port to use                                                                                                      | `http`                   |
@@ -483,7 +483,7 @@ As an alternative, you can use of the preset configurations for pod affinity, po
 | `adminIngress.ingressClassName`         | IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)                                                    | `""`                     |
 | `adminIngress.pathType`                 | Ingress path type                                                                                                                | `ImplementationSpecific` |
 | `adminIngress.apiVersion`               | Force Ingress API version (automatically detected if not set)                                                                    | `""`                     |
-| `adminIngress.controller`              | The ingress controller type. Currently supports `default` and `gce`                                                       | `default`                |
+| `adminIngress.controller`               | The ingress controller type. Currently supports `default` and `gce`                                                       | `default`                |
 | `adminIngress.hostname`                 | Default host for the admin ingress record (evaluated as template)                                                                | `keycloak.local`         |
 | `adminIngress.path`                     | Default path for the admin ingress record (evaluated as template)                                                                | `""`                     |
 | `adminIngress.servicePort`              | Backend service port to use                                                                                                      | `http`                   |

--- a/bitnami/keycloak/README.md
+++ b/bitnami/keycloak/README.md
@@ -466,7 +466,7 @@ As an alternative, you can use of the preset configurations for pod affinity, po
 | `ingress.ingressClassName`              | IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)                                                    | `""`                     |
 | `ingress.pathType`                      | Ingress path type                                                                                                                | `ImplementationSpecific` |
 | `ingress.apiVersion`                    | Force Ingress API version (automatically detected if not set)                                                                    | `""`                     |
-| `ingress.controller`          | The ingress controller type. Currently supports `default` and `gce`                                                       | `default`                |
+| `ingress.controller`      | The ingress controller type. Currently supports `default` and `gce`                                                       | `default`                |
 | `ingress.hostname`                      | Default host for the ingress record (evaluated as template)                                                                      | `keycloak.local`         |
 | `ingress.path`                          | Default path for the ingress record (evaluated as template)                                                                      | `""`                     |
 | `ingress.servicePort`                   | Backend service port to use                                                                                                      | `http`                   |
@@ -483,7 +483,7 @@ As an alternative, you can use of the preset configurations for pod affinity, po
 | `adminIngress.ingressClassName`         | IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)                                                    | `""`                     |
 | `adminIngress.pathType`                 | Ingress path type                                                                                                                | `ImplementationSpecific` |
 | `adminIngress.apiVersion`               | Force Ingress API version (automatically detected if not set)                                                                    | `""`                     |
-| `adminIngress.controller`          | The ingress controller type. Currently supports `default` and `gce`                                                       | `default`                |
+| `adminIngress.controller`              | The ingress controller type. Currently supports `default` and `gce`                                                       | `default`                |
 | `adminIngress.hostname`                 | Default host for the admin ingress record (evaluated as template)                                                                | `keycloak.local`         |
 | `adminIngress.path`                     | Default path for the admin ingress record (evaluated as template)                                                                | `""`                     |
 | `adminIngress.servicePort`              | Backend service port to use                                                                                                      | `http`                   |

--- a/bitnami/keycloak/README.md
+++ b/bitnami/keycloak/README.md
@@ -466,7 +466,7 @@ As an alternative, you can use of the preset configurations for pod affinity, po
 | `ingress.ingressClassName`              | IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)                                                    | `""`                     |
 | `ingress.pathType`                      | Ingress path type                                                                                                                | `ImplementationSpecific` |
 | `ingress.apiVersion`                    | Force Ingress API version (automatically detected if not set)                                                                    | `""`                     |
-| `ingress.controller`                    | The ingress controller type. Currently supports `default` and `gce`                                                       | `default`                |
+| `ingress.controller`                    | The ingress controller type. Currently supports `default` and `gce`                                                              | `default`                |
 | `ingress.hostname`                      | Default host for the ingress record (evaluated as template)                                                                      | `keycloak.local`         |
 | `ingress.path`                          | Default path for the ingress record (evaluated as template)                                                                      | `""`                     |
 | `ingress.servicePort`                   | Backend service port to use                                                                                                      | `http`                   |
@@ -483,7 +483,7 @@ As an alternative, you can use of the preset configurations for pod affinity, po
 | `adminIngress.ingressClassName`         | IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)                                                    | `""`                     |
 | `adminIngress.pathType`                 | Ingress path type                                                                                                                | `ImplementationSpecific` |
 | `adminIngress.apiVersion`               | Force Ingress API version (automatically detected if not set)                                                                    | `""`                     |
-| `adminIngress.controller`               | The ingress controller type. Currently supports `default` and `gce`                                                       | `default`                |
+| `adminIngress.controller`               | The ingress controller type. Currently supports `default` and `gce`                                                              | `default`                |
 | `adminIngress.hostname`                 | Default host for the admin ingress record (evaluated as template)                                                                | `keycloak.local`         |
 | `adminIngress.path`                     | Default path for the admin ingress record (evaluated as template)                                                                | `""`                     |
 | `adminIngress.servicePort`              | Backend service port to use                                                                                                      | `http`                   |

--- a/bitnami/keycloak/README.md
+++ b/bitnami/keycloak/README.md
@@ -466,6 +466,7 @@ As an alternative, you can use of the preset configurations for pod affinity, po
 | `ingress.ingressClassName`              | IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)                                                    | `""`                     |
 | `ingress.pathType`                      | Ingress path type                                                                                                                | `ImplementationSpecific` |
 | `ingress.apiVersion`                    | Force Ingress API version (automatically detected if not set)                                                                    | `""`                     |
+| `ingress.controller`          | The ingress controller type. Currently supports `default` and `gce`                                                       | `default`                |
 | `ingress.hostname`                      | Default host for the ingress record (evaluated as template)                                                                      | `keycloak.local`         |
 | `ingress.path`                          | Default path for the ingress record (evaluated as template)                                                                      | `""`                     |
 | `ingress.servicePort`                   | Backend service port to use                                                                                                      | `http`                   |
@@ -482,6 +483,7 @@ As an alternative, you can use of the preset configurations for pod affinity, po
 | `adminIngress.ingressClassName`         | IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)                                                    | `""`                     |
 | `adminIngress.pathType`                 | Ingress path type                                                                                                                | `ImplementationSpecific` |
 | `adminIngress.apiVersion`               | Force Ingress API version (automatically detected if not set)                                                                    | `""`                     |
+| `adminIngress.controller`          | The ingress controller type. Currently supports `default` and `gce`                                                       | `default`                |
 | `adminIngress.hostname`                 | Default host for the admin ingress record (evaluated as template)                                                                | `keycloak.local`         |
 | `adminIngress.path`                     | Default path for the admin ingress record (evaluated as template)                                                                | `""`                     |
 | `adminIngress.servicePort`              | Backend service port to use                                                                                                      | `http`                   |

--- a/bitnami/keycloak/templates/statefulset.yaml
+++ b/bitnami/keycloak/templates/statefulset.yaml
@@ -221,7 +221,7 @@ spec:
                 {{ ternary "https://" "http://" ( or .Values.adminIngress.tls (eq .Values.proxy "edge") (not (empty .Values.proxyHeaders)) ) -}}
                 {{- include "common.tplvalues.render" (dict "value" .Values.adminIngress.hostname "context" $) -}}
                 {{- if eq .Values.adminIngress.controller "default" }}
-                    {{- include "common.tplvalues.render" (dict "value" .Values.adminIngress.path "context" $) }}
+                  {{- include "common.tplvalues.render" (dict "value" .Values.adminIngress.path "context" $) }}
                 {{- else if eq .Values.adminIngress.controller "gce" }}
                   {{- $path := .Values.adminIngress.path -}}
                   {{- if hasSuffix "*" $path -}}
@@ -236,7 +236,7 @@ spec:
                 {{ ternary "https://" "http://" ( or .Values.ingress.tls (eq .Values.proxy "edge") (not (empty .Values.proxyHeaders)) ) -}}
                 {{- include "common.tplvalues.render" (dict "value" .Values.ingress.hostname "context" $) -}}
                 {{- if eq .Values.ingress.controller "default" }}
-                    {{- include "common.tplvalues.render" (dict "value" .Values.ingress.path "context" $) }}
+                  {{- include "common.tplvalues.render" (dict "value" .Values.ingress.path "context" $) }}
                 {{- else if eq .Values.ingress.controller "gce" }}
                   {{- $path := .Values.ingress.path -}}
                   {{- if hasSuffix "*" $path -}}

--- a/bitnami/keycloak/templates/statefulset.yaml
+++ b/bitnami/keycloak/templates/statefulset.yaml
@@ -215,39 +215,35 @@ spec:
             - name: KEYCLOAK_EXTRA_ARGS
               value: {{ .Values.extraStartupArgs | quote }}
             {{- end }}
-            {{- if and .Values.adminIngress.enabled .Values.adminIngress.hostname (eq .Values.adminIngress.controller "default") }}
+            {{- if and .Values.adminIngress.enabled .Values.adminIngress.hostname }}
             - name: KC_HOSTNAME_ADMIN_URL
               value: |-
                 {{ ternary "https://" "http://" ( or .Values.adminIngress.tls (eq .Values.proxy "edge") (not (empty .Values.proxyHeaders)) ) -}}
                 {{- include "common.tplvalues.render" (dict "value" .Values.adminIngress.hostname "context" $) -}}
-                {{- include "common.tplvalues.render" (dict "value" .Values.adminIngress.path "context" $) }}
-            {{- else if and .Values.adminIngress.enabled .Values.adminIngress.hostname (eq .Values.adminIngress.controller "gce") }}
-            - name: KC_HOSTNAME_ADMIN_URL
-              value: |-
-                {{ ternary "https://" "http://" ( or .Values.adminIngress.tls (eq .Values.proxy "edge") (not (empty .Values.proxyHeaders)) ) -}}
-                {{- include "common.tplvalues.render" (dict "value" .Values.adminIngress.hostname "context" $) -}}
-                {{- $path := .Values.adminIngress.path -}}
-                {{- if hasSuffix "*" $path -}}
-                  {{- $path = trimSuffix "*" $path -}}
-                {{- end -}}
-                {{- include "common.tplvalues.render" (dict "value" $path "context" $) }}
+                {{- if eq .Values.adminIngress.controller "default" }}
+                    {{- include "common.tplvalues.render" (dict "value" .Values.adminIngress.path "context" $) }}
+                {{- else if eq .Values.adminIngress.controller "gce" }}
+                  {{- $path := .Values.adminIngress.path -}}
+                  {{- if hasSuffix "*" $path -}}
+                    {{- $path = trimSuffix "*" $path -}}
+                  {{- end -}}
+                  {{- include "common.tplvalues.render" (dict "value" $path "context" $) }}
+                {{- end }}
             {{- end }}
-            {{- if and .Values.ingress.enabled .Values.ingress.hostname (eq .Values.ingress.controller "default") }}
+            {{- if and .Values.ingress.enabled .Values.ingress.hostname }}
             - name: KC_HOSTNAME_URL
               value: |-
                 {{ ternary "https://" "http://" ( or .Values.ingress.tls (eq .Values.proxy "edge") (not (empty .Values.proxyHeaders)) ) -}}
                 {{- include "common.tplvalues.render" (dict "value" .Values.ingress.hostname "context" $) -}}
-                {{- include "common.tplvalues.render" (dict "value" .Values.ingress.path "context" $) }}
-            {{- else if and .Values.ingress.enabled .Values.ingress.hostname (eq .Values.ingress.controller "gce") }}
-            - name: KC_HOSTNAME_URL
-              value: |-
-                {{ ternary "https://" "http://" ( or .Values.ingress.tls (eq .Values.proxy "edge") (not (empty .Values.proxyHeaders)) ) -}}
-                {{- include "common.tplvalues.render" (dict "value" .Values.ingress.hostname "context" $) -}}
-                {{- $path := .Values.ingress.path -}}
-                {{- if hasSuffix "*" $path -}}
-                  {{- $path = trimSuffix "*" $path -}}
-                {{- end -}}
-                {{- include "common.tplvalues.render" (dict "value" $path "context" $) }}
+                {{- if eq .Values.ingress.controller "default" }}
+                    {{- include "common.tplvalues.render" (dict "value" .Values.ingress.path "context" $) }}
+                {{- else if eq .Values.ingress.controller "gce" }}
+                  {{- $path := .Values.ingress.path -}}
+                  {{- if hasSuffix "*" $path -}}
+                    {{- $path = trimSuffix "*" $path -}}
+                  {{- end -}}
+                  {{- include "common.tplvalues.render" (dict "value" $path "context" $) }}
+                {{- end }}
             {{- end }}
             {{- if .Values.adminRealm }}
             - name: KC_SPI_ADMIN_REALM

--- a/bitnami/keycloak/templates/statefulset.yaml
+++ b/bitnami/keycloak/templates/statefulset.yaml
@@ -215,19 +215,39 @@ spec:
             - name: KEYCLOAK_EXTRA_ARGS
               value: {{ .Values.extraStartupArgs | quote }}
             {{- end }}
-            {{- if and .Values.adminIngress.enabled .Values.adminIngress.hostname }}
+            {{- if and .Values.adminIngress.enabled .Values.adminIngress.hostname (eq .Values.adminIngress.controller "default") }}
             - name: KC_HOSTNAME_ADMIN_URL
               value: |-
                 {{ ternary "https://" "http://" ( or .Values.adminIngress.tls (eq .Values.proxy "edge") (not (empty .Values.proxyHeaders)) ) -}}
                 {{- include "common.tplvalues.render" (dict "value" .Values.adminIngress.hostname "context" $) -}}
                 {{- include "common.tplvalues.render" (dict "value" .Values.adminIngress.path "context" $) }}
+            {{- else if and .Values.adminIngress.enabled .Values.adminIngress.hostname (eq .Values.adminIngress.controller "gce") }}
+            - name: KC_HOSTNAME_ADMIN_URL
+              value: |-
+                {{ ternary "https://" "http://" ( or .Values.adminIngress.tls (eq .Values.proxy "edge") (not (empty .Values.proxyHeaders)) ) -}}
+                {{- include "common.tplvalues.render" (dict "value" .Values.adminIngress.hostname "context" $) -}}
+                {{- $path := .Values.adminIngress.path -}}
+                {{- if hasSuffix "*" $path -}}
+                  {{- $path = trimSuffix "*" $path -}}
+                {{- end -}}
+                {{- include "common.tplvalues.render" (dict "value" $path "context" $) }}
             {{- end }}
-            {{- if and .Values.ingress.enabled .Values.ingress.hostname }}
+            {{- if and .Values.ingress.enabled .Values.ingress.hostname (eq .Values.ingress.controller "default") }}
             - name: KC_HOSTNAME_URL
               value: |-
                 {{ ternary "https://" "http://" ( or .Values.ingress.tls (eq .Values.proxy "edge") (not (empty .Values.proxyHeaders)) ) -}}
                 {{- include "common.tplvalues.render" (dict "value" .Values.ingress.hostname "context" $) -}}
                 {{- include "common.tplvalues.render" (dict "value" .Values.ingress.path "context" $) }}
+            {{- else if and .Values.ingress.enabled .Values.ingress.hostname (eq .Values.ingress.controller "gce") }}
+            - name: KC_HOSTNAME_URL
+              value: |-
+                {{ ternary "https://" "http://" ( or .Values.ingress.tls (eq .Values.proxy "edge") (not (empty .Values.proxyHeaders)) ) -}}
+                {{- include "common.tplvalues.render" (dict "value" .Values.ingress.hostname "context" $) -}}
+                {{- $path := .Values.ingress.path -}}
+                {{- if hasSuffix "*" $path -}}
+                  {{- $path = trimSuffix "*" $path -}}
+                {{- end -}}
+                {{- include "common.tplvalues.render" (dict "value" $path "context" $) }}
             {{- end }}
             {{- if .Values.adminRealm }}
             - name: KC_SPI_ADMIN_REALM

--- a/bitnami/keycloak/values.yaml
+++ b/bitnami/keycloak/values.yaml
@@ -620,6 +620,11 @@ ingress:
   ## @param ingress.apiVersion Force Ingress API version (automatically detected if not set)
   ##
   apiVersion: ""
+  ## @param ingress.controller The ingress controller type. Currently supports `default` and `gce`
+  ## leave as `default` for most ingress controllers.
+  ## set to `gce` if using the GCE ingress controller
+  ##
+  controller: default
   ## @param ingress.hostname Default host for the ingress record (evaluated as template)
   ##
   hostname: keycloak.local
@@ -727,6 +732,11 @@ adminIngress:
   ## @param adminIngress.apiVersion Force Ingress API version (automatically detected if not set)
   ##
   apiVersion: ""
+  ## @param adminIngress.controller The ingress controller type. Currently supports `default` and `gce`
+  ## leave as `default` for most ingress controllers.
+  ## set to `gce` if using the GCE ingress controller
+  ##
+  controller: default
   ## @param adminIngress.hostname Default host for the admin ingress record (evaluated as template)
   ##
   hostname: keycloak.local


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Adds new options ingress.controller and adminIngress.controller to support ingress controllers such as GCE and APISIX, which require * to be appended in the ingress.path, such that the * suffix is not added into KC_HOSTNAME_ADMIN_URL and KC_HOSTNAME_URL in case the controller type is set as gce (default is default)

The specification of ingress.controller is inspired from the bitnami/harbor helm chart

### Benefits

Allow users to deploy with Ingress controllers such as GCE and APISIX and not break Admin UI functionality

### Possible drawbacks

NA

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #28357

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
NA

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
