### PR TITLE
[bitnami/milvus] fix: :bug: Set cache directory fully writable in attu

### DIFF
--- a/bitnami/milvus/CHANGELOG.md
+++ b/bitnami/milvus/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 8.3.6 (2024-07-25)
+## 8.3.7 (2024-07-25)
 
-* [bitnami/milvus] Release 8.3.6 ([#28439](https://github.com/bitnami/charts/pull/28439))
+* [bitnami/milvus] fix: :bug: Set cache directory fully writable in attu ([#28521](https://github.com/bitnami/charts/pull/28521))
+
+## <small>8.3.6 (2024-07-25)</small>
+
+* [bitnami/milvus] Release 8.3.6 (#28439) ([33e113a](https://github.com/bitnami/charts/commit/33e113a21a95f4c6c6075a1bb83b485d885f0e52)), closes [#28439](https://github.com/bitnami/charts/issues/28439)
 
 ## <small>8.3.5 (2024-07-24)</small>
 

--- a/bitnami/milvus/Chart.yaml
+++ b/bitnami/milvus/Chart.yaml
@@ -48,4 +48,4 @@ maintainers:
 name: milvus
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/milvus
-version: 8.3.6
+version: 8.3.7

--- a/bitnami/milvus/templates/attu/deployment.yaml
+++ b/bitnami/milvus/templates/attu/deployment.yaml
@@ -161,7 +161,7 @@ spec:
               mountPath: /.yarn
               subPath: yarn-dir
             - name: empty-dir
-              mountPath: /.cache/yarn
+              mountPath: /.cache
               subPath: yarn-cache-dir
           {{- if .Values.attu.extraVolumeMounts }}
           {{- include "common.tplvalues.render" (dict "value" .Values.attu.extraVolumeMounts "context" $) | nindent 12 }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change
This PR adds a fix for future attu versions, which need to fully write in the .cache folder.
<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [ ] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [ ] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
