### PR TITLE
bitnami/Keycloak] Allow manual override fo KC_HOSTNAME_URL and KC_ADMIN_HOSTNAME_URL

### DIFF
--- a/bitnami/keycloak/CHANGELOG.md
+++ b/bitnami/keycloak/CHANGELOG.md
@@ -1,16 +1,12 @@
 # Changelog
 
+## 22.0.1 (2024-08-01)
+
+* bitnami/Keycloak] Allow manual override fo KC_HOSTNAME_URL and KC_ADMIN_HOSTNAME_URL ([#28523](https://github.com/bitnami/charts/pull/28523))
+
 ## 22.0.0 (2024-07-29)
 
-* [bitnami/keycloak] Release 22.0.0 ([#28563](https://github.com/bitnami/charts/pull/28563))
-
-## 21.8.0 (2024-07-26)
-
-* [bitnami/keycloak] Allow support for gce based ingress controllers (#28519) ([87b60d7](https://github.com/bitnami/charts/commit/87b60d7526474cc22fd8295732f6b1ed7b3771a6)), closes [#28519](https://github.com/bitnami/charts/issues/28519)
-
-## <small>21.7.6 (2024-07-26)</small>
-
-* [bitnami/keycloak] Fix invalid value of proxy headers when legacy proxy is used (#28530) ([372d263](https://github.com/bitnami/charts/commit/372d2638677330da509c8ff2783a2efd48484d45)), closes [#28530](https://github.com/bitnami/charts/issues/28530)
+* [bitnami/keycloak] Release 22.0.0 (#28563) ([81162c4](https://github.com/bitnami/charts/commit/81162c45a2a9759ac00ae26ad0bb5310af4597e4)), closes [#28563](https://github.com/bitnami/charts/issues/28563)
 
 ## 21.8.0 (2024-07-26)
 

--- a/bitnami/keycloak/CHANGELOG.md
+++ b/bitnami/keycloak/CHANGELOG.md
@@ -12,6 +12,14 @@
 
 * [bitnami/keycloak] Fix invalid value of proxy headers when legacy proxy is used (#28530) ([372d263](https://github.com/bitnami/charts/commit/372d2638677330da509c8ff2783a2efd48484d45)), closes [#28530](https://github.com/bitnami/charts/issues/28530)
 
+## 21.8.0 (2024-07-26)
+
+* [bitnami/keycloak] Allow support for gce based ingress controllers (#28519) ([87b60d7](https://github.com/bitnami/charts/commit/87b60d7526474cc22fd8295732f6b1ed7b3771a6)), closes [#28519](https://github.com/bitnami/charts/issues/28519)
+
+## <small>21.7.6 (2024-07-26)</small>
+
+* [bitnami/keycloak] Fix invalid value of proxy headers when legacy proxy is used (#28530) ([372d263](https://github.com/bitnami/charts/commit/372d2638677330da509c8ff2783a2efd48484d45)), closes [#28530](https://github.com/bitnami/charts/issues/28530)
+
 ## <small>21.7.5 (2024-07-25)</small>
 
 * [bitnami/keycloak] Release 21.7.5 (#28428) ([8c7be7d](https://github.com/bitnami/charts/commit/8c7be7d0937fb83efb89b26fdd44cd055c2c118e)), closes [#28428](https://github.com/bitnami/charts/issues/28428)

--- a/bitnami/keycloak/Chart.yaml
+++ b/bitnami/keycloak/Chart.yaml
@@ -33,4 +33,4 @@ maintainers:
 name: keycloak
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/keycloak
-version: 22.0.0
+version: 22.0.1

--- a/bitnami/keycloak/README.md
+++ b/bitnami/keycloak/README.md
@@ -469,6 +469,7 @@ As an alternative, you can use of the preset configurations for pod affinity, po
 | `ingress.controller`                    | The ingress controller type. Currently supports `default` and `gce`                                                              | `default`                |
 | `ingress.hostname`                      | Default host for the ingress record (evaluated as template)                                                                      | `keycloak.local`         |
 | `ingress.path`                          | Default path for the ingress record (evaluated as template)                                                                      | `""`                     |
+| `ingress.hostnameUrl`                   | Hostname url to pass to the keycloak service.                                                                                    | `""`                     |
 | `ingress.servicePort`                   | Backend service port to use                                                                                                      | `http`                   |
 | `ingress.annotations`                   | Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations. | `{}`                     |
 | `ingress.labels`                        | Additional labels for the Ingress resource.                                                                                      | `{}`                     |
@@ -486,6 +487,7 @@ As an alternative, you can use of the preset configurations for pod affinity, po
 | `adminIngress.controller`               | The ingress controller type. Currently supports `default` and `gce`                                                              | `default`                |
 | `adminIngress.hostname`                 | Default host for the admin ingress record (evaluated as template)                                                                | `keycloak.local`         |
 | `adminIngress.path`                     | Default path for the admin ingress record (evaluated as template)                                                                | `""`                     |
+| `adminIngress.hostnameUrl`              | Admin hostname url to pass to the keycloak service.                                                                              | `""`                     |
 | `adminIngress.servicePort`              | Backend service port to use                                                                                                      | `http`                   |
 | `adminIngress.annotations`              | Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations. | `{}`                     |
 | `adminIngress.labels`                   | Additional labels for the Ingress resource.                                                                                      | `{}`                     |

--- a/bitnami/keycloak/templates/statefulset.yaml
+++ b/bitnami/keycloak/templates/statefulset.yaml
@@ -218,31 +218,39 @@ spec:
             {{- if and .Values.adminIngress.enabled .Values.adminIngress.hostname }}
             - name: KC_HOSTNAME_ADMIN_URL
               value: |-
-                {{ ternary "https://" "http://" ( or .Values.adminIngress.tls (eq .Values.proxy "edge") (not (empty .Values.proxyHeaders)) ) -}}
-                {{- include "common.tplvalues.render" (dict "value" .Values.adminIngress.hostname "context" $) -}}
-                {{- if eq .Values.adminIngress.controller "default" }}
-                  {{- include "common.tplvalues.render" (dict "value" .Values.adminIngress.path "context" $) }}
-                {{- else if eq .Values.adminIngress.controller "gce" }}
-                  {{- $path := .Values.adminIngress.path -}}
-                  {{- if hasSuffix "*" $path -}}
-                    {{- $path = trimSuffix "*" $path -}}
-                  {{- end -}}
-                  {{- include "common.tplvalues.render" (dict "value" $path "context" $) }}
+                {{ if .Values.adminIngress.hostnameUrl }}
+                {{- .Values.adminIngress.path }}
+                {{- else }}
+                  {{- ternary "https://" "http://" ( or .Values.adminIngress.tls (eq .Values.proxy "edge") (not (empty .Values.proxyHeaders)) ) -}}
+                  {{- include "common.tplvalues.render" (dict "value" .Values.adminIngress.hostname "context" $) -}}
+                  {{- if eq .Values.adminIngress.controller "default" }}
+                    {{- include "common.tplvalues.render" (dict "value" .Values.adminIngress.path "context" $) }}
+                  {{- else if eq .Values.adminIngress.controller "gce" }}
+                    {{- $path := .Values.adminIngress.path -}}
+                    {{- if hasSuffix "*" $path -}}
+                      {{- $path = trimSuffix "*" $path -}}
+                    {{- end -}}
+                    {{- include "common.tplvalues.render" (dict "value" $path "context" $) }}
+                  {{- end }}
                 {{- end }}
             {{- end }}
             {{- if and .Values.ingress.enabled .Values.ingress.hostname }}
             - name: KC_HOSTNAME_URL
               value: |-
-                {{ ternary "https://" "http://" ( or .Values.ingress.tls (eq .Values.proxy "edge") (not (empty .Values.proxyHeaders)) ) -}}
-                {{- include "common.tplvalues.render" (dict "value" .Values.ingress.hostname "context" $) -}}
-                {{- if eq .Values.ingress.controller "default" }}
-                  {{- include "common.tplvalues.render" (dict "value" .Values.ingress.path "context" $) }}
-                {{- else if eq .Values.ingress.controller "gce" }}
-                  {{- $path := .Values.ingress.path -}}
-                  {{- if hasSuffix "*" $path -}}
-                    {{- $path = trimSuffix "*" $path -}}
-                  {{- end -}}
-                  {{- include "common.tplvalues.render" (dict "value" $path "context" $) }}
+                {{ if .Values.ingress.hostnameUrl -}}
+                {{- .Values.ingress.hostnameUrl }}
+                {{- else -}}
+                  {{- ternary "https://" "http://" ( or .Values.ingress.tls (eq .Values.proxy "edge") (not (empty .Values.proxyHeaders)) ) -}}
+                  {{- include "common.tplvalues.render" (dict "value" .Values.ingress.hostname "context" $) -}}
+                  {{- if eq .Values.ingress.controller "default" }}
+                    {{- include "common.tplvalues.render" (dict "value" .Values.ingress.path "context" $) }}
+                  {{- else if eq .Values.ingress.controller "gce" }}
+                    {{- $path := .Values.ingress.path -}}
+                    {{- if hasSuffix "*" $path -}}
+                      {{- $path = trimSuffix "*" $path -}}
+                    {{- end -}}
+                    {{- include "common.tplvalues.render" (dict "value" $path "context" $) }}
+                  {{- end }}
                 {{- end }}
             {{- end }}
             {{- if .Values.adminRealm }}

--- a/bitnami/keycloak/values.yaml
+++ b/bitnami/keycloak/values.yaml
@@ -630,6 +630,10 @@ ingress:
   hostname: keycloak.local
   ## @param ingress.path [string] Default path for the ingress record (evaluated as template)
   ##
+  hostnameUrl: ""
+  ## @param ingress.hostnameUrl [string] Hostname url to pass to the keycloak service.
+  ## Default this will be automatically constructed with ingress.hostname and ingress.path
+  ##
   path: "{{ .Values.httpRelativePath }}"
   ## @param ingress.servicePort Backend service port to use
   ## Default is http. Alternative is https.
@@ -741,6 +745,10 @@ adminIngress:
   ##
   hostname: keycloak.local
   ## @param adminIngress.path [string] Default path for the admin ingress record (evaluated as template)
+  ##
+  hostnameUrl: ""
+  ## @param adminIngress.hostnameUrl [string] Admin hostname url to pass to the keycloak service.
+  ## Default this will be automatically constructed with adminIngress.hostname and adminIngress.path
   ##
   path: "{{ .Values.httpRelativePath }}"
   ## @param adminIngress.servicePort Backend service port to use


### PR DESCRIPTION
### Description of the change

Allow users to provide their own value of the KC_HOSTNAME_URL and KC_ADMIN_HOSTNAME_URL parameters.

### Benefits

Currently a lot of assumptions are made when constructing these environment variables. This behaviour can be wanted in simple setups but it is impossible to foresee all possible scenarios. To accommodate this we can allow users to override this themselves but fallback on autogeneration if not provided.

### Possible drawbacks

The change is backwards compatible so no drawbacks are expected.

### Applicable issues

- fixes #28357 

### Additional information

Inspired out of discussions in issues: #28357 #28121 and #28161 

Closes: #28520 

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)