### PR TITLE
[bitnami/keycloak] Fix invalid value of proxy headers when legacy proxy is used

### DIFF
--- a/bitnami/keycloak/CHANGELOG.md
+++ b/bitnami/keycloak/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 21.7.5 (2024-07-25)
+## 21.7.6 (2024-07-26)
 
-* [bitnami/keycloak] Release 21.7.5 ([#28428](https://github.com/bitnami/charts/pull/28428))
+* [bitnami/keycloak] Fix invalid value of proxy headers when legacy proxy is used ([#28530](https://github.com/bitnami/charts/pull/28530))
+
+## <small>21.7.5 (2024-07-25)</small>
+
+* [bitnami/keycloak] Release 21.7.5 (#28428) ([8c7be7d](https://github.com/bitnami/charts/commit/8c7be7d0937fb83efb89b26fdd44cd055c2c118e)), closes [#28428](https://github.com/bitnami/charts/issues/28428)
 
 ## <small>21.7.4 (2024-07-24)</small>
 

--- a/bitnami/keycloak/Chart.yaml
+++ b/bitnami/keycloak/Chart.yaml
@@ -33,4 +33,4 @@ maintainers:
 name: keycloak
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/keycloak
-version: 21.7.5
+version: 21.7.6

--- a/bitnami/keycloak/templates/configmap-env-vars.yaml
+++ b/bitnami/keycloak/templates/configmap-env-vars.yaml
@@ -17,7 +17,7 @@ data:
   KEYCLOAK_ADMIN: {{ .Values.auth.adminUser | quote }}
   KEYCLOAK_HTTP_PORT: {{ .Values.containerPorts.http | quote }}
   {{- if and .Values.proxy (empty .Values.proxyHeaders) }}
-  KEYCLOAK_PROXY_HEADERS: {{ ternary "" "forwarded|xforwarded" (eq .Values.proxy "passthrough") }}
+  KEYCLOAK_PROXY_HEADERS: {{ ternary "" "xforwarded" (eq .Values.proxy "passthrough") }}
   {{- else }}
   KEYCLOAK_PROXY_HEADERS: {{ .Values.proxyHeaders | quote }}
   {{- end }}


### PR DESCRIPTION
(Hopefully) Fixes issues mentioned in https://github.com/bitnami/charts/pull/27890

Even though `forwarded|xforwarded` is mentioned in the docs (https://www.keycloak.org/docs/latest/upgrading/index.html#deprecated-proxy-option) it is not valid and does not pass variable validation inside the container.

This PR changes it so proxy headers will now default to `xforwarded` when legacy `proxy` value is used.

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
