### PR TITLE
[bitnami/keycloak] Preserve data on writable dirs

### DIFF
--- a/bitnami/keycloak/CHANGELOG.md
+++ b/bitnami/keycloak/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 21.7.6 (2024-07-29)
+## 22.0.1 (2024-08-01)
 
 * [bitnami/keycloak] Preserve data on writable dirs ([#28550](https://github.com/bitnami/charts/pull/28550))
+
+## 22.0.0 (2024-07-29)
+
+* [bitnami/keycloak] Release 22.0.0 (#28563) ([81162c4](https://github.com/bitnami/charts/commit/81162c45a2a9759ac00ae26ad0bb5310af4597e4)), closes [#28563](https://github.com/bitnami/charts/issues/28563)
 
 ## 21.8.0 (2024-07-26)
 

--- a/bitnami/keycloak/CHANGELOG.md
+++ b/bitnami/keycloak/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-## 22.0.0 (2024-07-29)
+## 21.7.6 (2024-07-29)
 
-* [bitnami/keycloak] Release 22.0.0 ([#28563](https://github.com/bitnami/charts/pull/28563))
+* [bitnami/keycloak] Preserve data on writable dirs ([#28550](https://github.com/bitnami/charts/pull/28550))
 
 ## 21.8.0 (2024-07-26)
 

--- a/bitnami/keycloak/Chart.yaml
+++ b/bitnami/keycloak/Chart.yaml
@@ -33,4 +33,4 @@ maintainers:
 name: keycloak
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/keycloak
-version: 22.0.0
+version: 22.0.1

--- a/bitnami/keycloak/templates/statefulset.yaml
+++ b/bitnami/keycloak/templates/statefulset.yaml
@@ -92,7 +92,7 @@ spec:
       {{- if or .Values.enableDefaultInitContainers .Values.initContainers }}
       initContainers:
         {{- if .Values.enableDefaultInitContainers }}
-        - name: init-quarkus-directory
+        - name: prepare-write-dirs
           image: {{ template "keycloak.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
@@ -100,8 +100,14 @@ spec:
           args:
             - -ec
             - |
-              #!/bin/bash
-              cp -r /opt/bitnami/keycloak/lib/quarkus/* /quarkus
+              . /opt/bitnami/scripts/liblog.sh
+
+              info "Copying writable dirs to empty dir"
+              # In order to not break the application functionality we need to make some
+              # directories writable, so we need to copy it to an empty dir volume
+              cp -r --preserve=mode /opt/bitnami/keycloak/lib/quarkus/* /emptydir/app-quarkus-dir
+              cp -r --preserve=mode /opt/bitnami/keycloak/data /emptydir/app-data-dir
+              info "Copy operation completed"
           {{- if .Values.containerSecurityContext.enabled }}
           securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.containerSecurityContext "context" $) | nindent 12 }}
           {{- end }}
@@ -111,12 +117,8 @@ spec:
           resources: {{- include "common.resources.preset" (dict "type" .Values.resourcesPreset) | nindent 12 }}
           {{- end }}
           volumeMounts:
-            - name: empty-dir
-              mountPath: /tmp
-              subPath: tmp-dir
-            - name: empty-dir
-              mountPath: /quarkus
-              subPath: app-quarkus-dir
+           - name: empty-dir
+             mountPath: /emptydir
         {{- end }}
         {{- if .Values.initContainers }}
         {{- include "common.tplvalues.render" (dict "value" .Values.initContainers "context" $) | nindent 8 }}

--- a/bitnami/keycloak/templates/statefulset.yaml
+++ b/bitnami/keycloak/templates/statefulset.yaml
@@ -105,7 +105,7 @@ spec:
               info "Copying writable dirs to empty dir"
               # In order to not break the application functionality we need to make some
               # directories writable, so we need to copy it to an empty dir volume
-              cp -r --preserve=mode /opt/bitnami/keycloak/lib/quarkus/* /emptydir/app-quarkus-dir
+              cp -r --preserve=mode /opt/bitnami/keycloak/lib/quarkus /emptydir/app-quarkus-dir
               cp -r --preserve=mode /opt/bitnami/keycloak/data /emptydir/app-data-dir
               info "Copy operation completed"
           {{- if .Values.containerSecurityContext.enabled }}


### PR DESCRIPTION
### Description of the change

This PR improves the ini-container we use to preserve original container data on writable dirs. As pointed out by @ @JBKoerber at https://github.com/bitnami/charts/pull/24939, the current chart was overwriting data available in the Keycloak data directory.

### Possible drawbacks

None

### Applicable issues

None

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
