### PR TITLE
[bitnami/mastodon] Improve init-job stability

### DIFF
--- a/bitnami/mastodon/Chart.yaml
+++ b/bitnami/mastodon/Chart.yaml
@@ -49,4 +49,4 @@ maintainers:
 name: mastodon
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/mastodon
-version: 6.2.9
+version: 6.2.10

--- a/bitnami/mastodon/templates/init-job/init-job-configmap.yaml
+++ b/bitnami/mastodon/templates/init-job/init-job-configmap.yaml
@@ -51,8 +51,23 @@ data:
     mastodon_ensure_admin_user_exists
     {{- end }}
   {{- end }}
-
   {{- if .Values.initJob.precompileAssets }}
+  {{- if .Values.enableS3 }}
+  wait-for-s3.sh: |-
+    #!/bin/bash
+
+    set -o errexit
+    set -o nounset
+    set -o pipefail
+
+    # Load libraries
+    . /opt/bitnami/scripts/libmastodon.sh
+
+    # Load Mastodon environment variables
+    . /opt/bitnami/scripts/mastodon-env.sh
+
+    mastodon_wait_for_s3_connection "$MASTODON_S3_HOSTNAME" "$MASTODON_S3_PORT_NUMBER"
+  {{- end }}
   precompile-assets.sh: |-
     #!/bin/bash
 

--- a/bitnami/mastodon/templates/init-job/init-job.yaml
+++ b/bitnami/mastodon/templates/init-job/init-job.yaml
@@ -61,6 +61,47 @@ spec:
             - name: empty-dir
               mountPath: /public
               subPath: app-public-dir
+        {{- if and .Values.initJob.precompileAssets .Values.enableS3 }}
+        - name: wait-for-s3
+          image: {{ template "mastodon.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - /bin/bash
+            - -ec
+          args:
+            - /scripts/wait-for-s3.sh
+          {{- if .Values.initJob.containerSecurityContext.enabled }}
+          securityContext: {{- omit .Values.initJob.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+          {{- end }}
+          {{- if .Values.initJob.resources }}
+          resources: {{- toYaml .Values.initJob.resources | nindent 12 }}
+          {{- else if ne .Values.initJob.resourcesPreset "none" }}
+          resources: {{- include "common.resources.preset" (dict "type" .Values.initJob.resourcesPreset) | nindent 12 }}
+          {{- end }}
+          env:
+            - name: BITNAMI_DEBUG
+              value: {{ ternary "true" "false" (or .Values.image.debug .Values.diagnosticMode.enabled) | quote }}
+            - name: MASTODON_S3_HOSTNAME
+              value: {{ include "mastodon.s3.host" . | quote }}
+            - name: MASTODON_S3_PORT_NUMBER
+              value: {{ include "mastodon.s3.port" . | quote }}
+            - name: MASTODON_AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "mastodon.s3.secretName" . }}
+                  key: {{ include "mastodon.s3.accessKeyIDKey" . | quote }}
+            - name: MASTODON_AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "mastodon.s3.secretName" . }}
+                  key: {{ include "mastodon.s3.secretAccessKeyKey" . | quote }}
+          volumeMounts:
+            - name: empty-dir
+              mountPath: /tmp
+              subPath: tmp-dir
+            - name: scripts
+              mountPath: /scripts
+        {{- end }}
       containers:
         # We separate the job in multiple containers to be able to run them in parallel. We put everything on the same job
         # as it follows the Job Pattern best practices


### PR DESCRIPTION
### Description of the change

The container `mastodon-assets-precompile` usually enters in `CrashLoopBackOff ` state since given it's executed before the S3 system is ready to accept connections.

Introducing an init-container that waits for the S3 backend should improve the stability.

### Benefits

Tests reliability.

### Possible drawbacks

None

### Applicable issues

None

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
