### PR TITLE
[bitnami/seaweedfs] Fix tests

### DIFF
--- a/.vib/seaweedfs/ginkgo/seaweedfs_suite_test.go
+++ b/.vib/seaweedfs/ginkgo/seaweedfs_suite_test.go
@@ -70,10 +70,20 @@ func createPVC(ctx context.Context, c kubernetes.Interface, name, size string) e
 
 func createJob(ctx context.Context, c kubernetes.Interface, name, port, image, pvcName, kind string, fsGroup, user *int64) error {
 	podSecurityContext := &v1.PodSecurityContext{
-		FSGroup: fsGroup,
+		FSGroup:             fsGroup,
+		FSGroupChangePolicy: &[]v1.PodFSGroupChangePolicy{v1.FSGroupChangeAlways}[0],
 	}
 	containerSecurityContext := &v1.SecurityContext{
-		RunAsUser: user,
+		RunAsUser:                user,
+		Privileged:               &[]bool{false}[0],
+		AllowPrivilegeEscalation: &[]bool{false}[0],
+		RunAsNonRoot:             &[]bool{true}[0],
+		Capabilities: &v1.Capabilities{
+			Drop: []v1.Capability{"ALL"},
+		},
+		SeccompProfile: &v1.SeccompProfile{
+			Type: "RuntimeDefault",
+		},
 	}
 
 	args := []string{"-ec"}

--- a/bitnami/seaweedfs/CHANGELOG.md
+++ b/bitnami/seaweedfs/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 1.0.5 (2024-07-25)
+## 1.0.6 (2024-07-30)
 
-* [bitnami/seaweedfs] Release 1.0.5 ([#28483](https://github.com/bitnami/charts/pull/28483))
+* [bitnami/seaweedfs] Fix tests ([#28572](https://github.com/bitnami/charts/pull/28572))
+
+## <small>1.0.5 (2024-07-25)</small>
+
+* [bitnami/seaweedfs] Release 1.0.5 (#28483) ([f8b7481](https://github.com/bitnami/charts/commit/f8b7481b1c4b5cb35adf6c82e78f132592fe3335)), closes [#28483](https://github.com/bitnami/charts/issues/28483)
 
 ## <small>1.0.4 (2024-07-24)</small>
 

--- a/bitnami/seaweedfs/Chart.yaml
+++ b/bitnami/seaweedfs/Chart.yaml
@@ -40,4 +40,4 @@ name: seaweedfs
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/seawwedfs
 - https://github.com/bitnami/containers/tree/main/bitnami/seaweedfs
-version: 1.0.5
+version: 1.0.6


### PR DESCRIPTION
### Description of the change
Add a restricted security context to the upload/download testing jobs to be able to run on TKG.

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
