### PR TITLE
[bitnami/common] Allow handling of new secrets after initial installation

### DIFF
--- a/bitnami/common/CHANGELOG.md
+++ b/bitnami/common/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2.21.0 (2024-07-30)
+## 2.21.0 (2024-07-31)
 
 * [bitnami/common] Allow handling of new secrets after initial installation ([#28581](https://github.com/bitnami/charts/pull/28581))
 

--- a/bitnami/common/CHANGELOG.md
+++ b/bitnami/common/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 2.20.5 (2024-07-16)
+## 2.21.0 (2024-07-30)
 
-* [bitnami/common] [bitnami/wordpress] Use global.storageClass for fallback, not override ([#24863](https://github.com/bitnami/charts/pull/24863))
+* [bitnami/common] Allow handling of new secrets after initial installation ([#28581](https://github.com/bitnami/charts/pull/28581))
+
+## <small>2.20.5 (2024-07-16)</small>
+
+* [bitnami/common] [bitnami/wordpress] Use global.storageClass for fallback, not override (#24863) ([2b78e13](https://github.com/bitnami/charts/commit/2b78e137ac278cdf9d54523e8d37833a4ff0cd5b)), closes [#24863](https://github.com/bitnami/charts/issues/24863)
 
 ## <small>2.20.4 (2024-07-11)</small>
 

--- a/bitnami/common/Chart.yaml
+++ b/bitnami/common/Chart.yaml
@@ -6,7 +6,7 @@ annotations:
   licenses: Apache-2.0
 apiVersion: v2
 # Please make sure that version and appVersion are always the same.
-appVersion: 2.20.5
+appVersion: 2.21.0
 description: A Library Helm Chart for grouping common logic between bitnami charts. This chart is not deployable by itself.
 home: https://bitnami.com
 icon: https://bitnami.com/downloads/logos/bitnami-mark.png
@@ -23,4 +23,4 @@ name: common
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/common
 type: library
-version: 2.20.5
+version: 2.21.0


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

This changes the handling of non-existing secrets that should be generated so they will be generated if `failOnNew` is `true`.

### Benefits

This allows the user to add new secrets to a managed secret without having to specify it and letting this chart generate it.

### Possible drawbacks

Not that I can think of.

### Applicable issues

Non that I created, but we sometimes do https://github.com/teutonet/teutonet-helm-charts/blob/main/charts/base-cluster/templates/monitoring/kube-prometheus-stack/oauth-proxy-secret.yaml?plain=1#L14C204-L14C356 to work around this problem.

### Additional information

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
