### PR TITLE
[bitnami/seaweedfs] Fix mounting the S3 auth config.json from secret

### DIFF
--- a/bitnami/seaweedfs/CHANGELOG.md
+++ b/bitnami/seaweedfs/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.0.7 (2024-07-30)
+## 1.0.7 (2024-07-31)
 
 * [bitnami/seaweedfs] Fix mounting the S3 auth config.json from secret ([#28583](https://github.com/bitnami/charts/pull/28583))
 

--- a/bitnami/seaweedfs/CHANGELOG.md
+++ b/bitnami/seaweedfs/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 1.0.6 (2024-07-30)
+## 1.0.7 (2024-07-30)
 
-* [bitnami/seaweedfs] Fix tests ([#28572](https://github.com/bitnami/charts/pull/28572))
+* [bitnami/seaweedfs] Fix mounting the S3 auth config.json from secret ([#28583](https://github.com/bitnami/charts/pull/28583))
+
+## <small>1.0.6 (2024-07-30)</small>
+
+* [bitnami/seaweedfs] Fix tests (#28572) ([ef36337](https://github.com/bitnami/charts/commit/ef36337c5ffeedf577bb6fcadabbb3a92cf5d8e6)), closes [#28572](https://github.com/bitnami/charts/issues/28572)
 
 ## <small>1.0.5 (2024-07-25)</small>
 

--- a/bitnami/seaweedfs/Chart.yaml
+++ b/bitnami/seaweedfs/Chart.yaml
@@ -40,4 +40,4 @@ name: seaweedfs
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/seawwedfs
 - https://github.com/bitnami/containers/tree/main/bitnami/seaweedfs
-version: 1.0.6
+version: 1.0.7

--- a/bitnami/seaweedfs/templates/s3/deployment.yaml
+++ b/bitnami/seaweedfs/templates/s3/deployment.yaml
@@ -190,12 +190,14 @@ spec:
               mountPath: /tmp
               subPath: tmp-dir
             {{- if .Values.s3.auth.enabled }}
-            - mountPath: /auth
-              readOnly: true
             {{- if .Values.s3.auth.existingSecret }}
+            - mountPath: {{ printf "/auth/%s" (default "config.json" .Values.s3.auth.existingSecretConfigKey) }}
+              readOnly: true
               name: auth
               subPath: {{ default "config.json" .Values.s3.auth.existingSecretConfigKey }}
             {{- else }}
+            - mountPath: /auth
+              readOnly: true
               name: empty-dir
               subPath: auth-dir
             {{- end }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Seaweedfs S3 API allows enabling credential based access through [JSON file](https://github.com/seaweedfs/seaweedfs/wiki/Amazon-S3-API#static-configuration), which can be mounted as file from the secret named `.Values.s3.auth.existingSecret`. The Chart is using `subPath` to only select the key with the JSON configuration value from the Secret, the name of the key can be provided by passing `.Values.s3.auth.existingSecretConfigKey`. value.

```yaml
- mountPath: /auth
  readOnly: true
{{- if .Values.s3.auth.existingSecret }}
  name: auth
  subPath: {{ default "config.json" .Values.s3.auth.existingSecretConfigKey }}
{{- else }}
  name: empty-dir
  subPath: auth-dir
{{- end }}
```

The problem is that the Secret file gets mounted at `/auth` path, and because of the `subPath` it mounts the JSON config to a file `auth` in the `/` directory. This then causes errors when trying to [read the config file](https://github.com/seaweedfs/seaweedfs/blob/master/weed/s3api/auth_credentials.go#L147C34-L147C42), as the expected path is `/auth/<existing secret config key>`.

### Benefits

The RBAC JSON file will be mounted successfully - the users won't have to disable the auth to then manually add the volume and volumeMount with proper configuration, as well as modifying the S3 API command arguments to point to the correct file location.

### Possible drawbacks

<!-- Describe any known limitations with your change -->

No drawback

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
None

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

The reason that the default configuration (no existing secret / secret config key provided) is working as expected is due to the `authConfigInitContainer`, which writes simple configuration to `/auth/config.json`. But in this case, the `subPath` mounts the entire directory to `/auth`, which includes the `config.json` file. This is not the case when trying to mount a single file with `subPath` without providing the exact path, such as `/auth/config.json` in the mount path.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
