### PR TITLE
bitnami/kafka Add extraListeners to kafka.listeners in _helpers.tpl

### DIFF
--- a/bitnami/kafka/CHANGELOG.md
+++ b/bitnami/kafka/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 29.3.13 (2024-07-25)
+## 29.3.14 (2024-08-01)
 
-* [bitnami/kafka] Release 29.3.13 ([#28426](https://github.com/bitnami/charts/pull/28426))
+* bitnami/kafka Add extraListeners to kafka.listeners in _helpers.tpl ([#28604](https://github.com/bitnami/charts/pull/28604))
+
+## <small>29.3.13 (2024-07-25)</small>
+
+* [bitnami/kafka] Release 29.3.13 (#28426) ([f922a04](https://github.com/bitnami/charts/commit/f922a041e5af921fa4b4a48f2ee549720f55a577)), closes [#28426](https://github.com/bitnami/charts/issues/28426)
 
 ## <small>29.3.12 (2024-07-24)</small>
 
@@ -91,9 +95,15 @@
 
 ## <small>29.0.3 (2024-05-24)</small>
 
-* [bitnami/kafka] Deprecate Kafka Exporter (#26395) ([bf9a653](https://github.com/bitnami/charts/commit/bf9a6535fabdd4c0ad3210920cdd6c4963c5511c)), closes [#26395](https://github.com/bitnami/charts/issues/26395)
 * [bitnami/kafka] Fix linter rules after deprecating Kafka Exporter (#26411) ([69856e9](https://github.com/bitnami/charts/commit/69856e985f1325b3e72cd126b6990647d35f1cbb)), closes [#26411](https://github.com/bitnami/charts/issues/26411)
+
+## <small>29.0.2 (2024-05-24)</small>
+
 * [bitnami/kafka] Release 28.3.1 (#26403) ([0428ec7](https://github.com/bitnami/charts/commit/0428ec724a1e6b139b12e8c3a6ab489a6459660c)), closes [#26403](https://github.com/bitnami/charts/issues/26403)
+
+## 29.0.0 (2024-05-24)
+
+* [bitnami/kafka] Deprecate Kafka Exporter (#26395) ([bf9a653](https://github.com/bitnami/charts/commit/bf9a6535fabdd4c0ad3210920cdd6c4963c5511c)), closes [#26395](https://github.com/bitnami/charts/issues/26395)
 
 ## 28.3.0 (2024-05-21)
 

--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -40,4 +40,4 @@ maintainers:
 name: kafka
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/kafka
-version: 29.3.13
+version: 29.3.14

--- a/bitnami/kafka/templates/_helpers.tpl
+++ b/bitnami/kafka/templates/_helpers.tpl
@@ -459,6 +459,9 @@ Returns the Kafka listeners settings based on the listeners.* object
   {{- $listeners = append $listeners .context.Values.listeners.controller -}}
   {{- end -}}
   {{- end -}}
+  {{- range $i := .context.Values.listeners.extraListeners -}}
+  {{- $listeners = append $listeners $i -}}
+  {{- end -}}
   {{- $res := list -}}
   {{- range $listener := $listeners -}}
   {{- $res = append $res (printf "%s://:%d" (upper $listener.name) (int $listener.containerPort)) -}}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change
Changed kafka chart _helpers.tpl
Added extraListeners to kafka.listeners the same way it is done in kafka.advertisedListeners

### Benefits
Allow to use extraListeners without manually overriding them.

### Possible drawbacks

None, as without it kafka doesn`t start.
Exception in thread "main" java.lang.IllegalArgumentException: requirement failed: advertised.listeners listener names must be equal to or a subset of the ones defined in listeners. Found CLIENT,INTERNAL,CLUSTER,EXTERNAL. The valid options based on the current configuration are CLIENT,INTERNAL,EXTERNAL,CONTROLLER

### Applicable issues
- fixes #21747
- fixes #21746

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
