### PR TITLE
[bitnami/keycloak] use hostname v2 options

### DIFF
--- a/bitnami/keycloak/CHANGELOG.md
+++ b/bitnami/keycloak/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 22.0.2 (2024-08-06)
+## 22.1.0 (2024-08-06)
 
-* [bitnami/keycloak] Release 22.0.2 ([#28692](https://github.com/bitnami/charts/pull/28692))
+* [bitnami/keycloak] use hostname v2 options ([#28611](https://github.com/bitnami/charts/pull/28611))
+
+## <small>22.0.2 (2024-08-06)</small>
+
+* [bitnami/keycloak] Release 22.0.2 (#28692) ([af28509](https://github.com/bitnami/charts/commit/af285099f496589b4d3ad8379c00ae96628baab5)), closes [#28692](https://github.com/bitnami/charts/issues/28692)
 
 ## <small>22.0.1 (2024-08-06)</small>
 

--- a/bitnami/keycloak/Chart.yaml
+++ b/bitnami/keycloak/Chart.yaml
@@ -33,4 +33,4 @@ maintainers:
 name: keycloak
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/keycloak
-version: 22.0.2
+version: 22.1.0

--- a/bitnami/keycloak/README.md
+++ b/bitnami/keycloak/README.md
@@ -468,6 +468,7 @@ As an alternative, you can use of the preset configurations for pod affinity, po
 | `ingress.apiVersion`                    | Force Ingress API version (automatically detected if not set)                                                                    | `""`                     |
 | `ingress.controller`                    | The ingress controller type. Currently supports `default` and `gce`                                                              | `default`                |
 | `ingress.hostname`                      | Default host for the ingress record (evaluated as template)                                                                      | `keycloak.local`         |
+| `ingress.hostnameStrict`                | Disables dynamically resolving the hostname from request headers                                                                 | `false`                  |
 | `ingress.path`                          | Default path for the ingress record (evaluated as template)                                                                      | `""`                     |
 | `ingress.servicePort`                   | Backend service port to use                                                                                                      | `http`                   |
 | `ingress.annotations`                   | Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations. | `{}`                     |

--- a/bitnami/keycloak/README.md
+++ b/bitnami/keycloak/README.md
@@ -468,7 +468,7 @@ As an alternative, you can use of the preset configurations for pod affinity, po
 | `ingress.apiVersion`                    | Force Ingress API version (automatically detected if not set)                                                                    | `""`                     |
 | `ingress.controller`                    | The ingress controller type. Currently supports `default` and `gce`                                                              | `default`                |
 | `ingress.hostname`                      | Default host for the ingress record (evaluated as template)                                                                      | `keycloak.local`         |
-| `ingress.hostnameStrict`                | Disables dynamically resolving the hostname from request headers                                                                 | `false`                  |
+| `ingress.hostnameStrict`                | Disables dynamically resolving the hostname from request headers.                                                                | `false`                  |
 | `ingress.path`                          | Default path for the ingress record (evaluated as template)                                                                      | `""`                     |
 | `ingress.servicePort`                   | Backend service port to use                                                                                                      | `http`                   |
 | `ingress.annotations`                   | Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations. | `{}`                     |

--- a/bitnami/keycloak/templates/configmap-env-vars.yaml
+++ b/bitnami/keycloak/templates/configmap-env-vars.yaml
@@ -21,6 +21,9 @@ data:
   {{- else }}
   KEYCLOAK_PROXY_HEADERS: {{ .Values.proxyHeaders | quote }}
   {{- end }}
+  {{- if .Values.ingress.enabled }}
+  KEYCLOAK_HOSTNAME_STRICT: {{ ternary "true" "false" .Values.ingress.hostnameStrict | quote }}
+  {{- end }}
   KEYCLOAK_ENABLE_STATISTICS: {{ ternary "true" "false" .Values.metrics.enabled | quote }}
   {{- if not .Values.externalDatabase.existingSecretHostKey }}
   KEYCLOAK_DATABASE_HOST: {{ include "keycloak.databaseHost" . | quote }}
@@ -34,7 +37,7 @@ data:
   {{- if not .Values.externalDatabase.existingSecretUserKey }}
   KEYCLOAK_DATABASE_USER: {{ include "keycloak.databaseUser" . | quote }}
   {{- end }}
-  KEYCLOAK_PRODUCTION:  {{ ternary "true" "false" .Values.production | quote }}
+  KEYCLOAK_PRODUCTION: {{ ternary "true" "false" .Values.production | quote }}
   KEYCLOAK_ENABLE_HTTPS: {{ ternary "true" "false" .Values.tls.enabled | quote }}
   {{- if .Values.customCaExistingSecret }}
   KC_TRUSTSTORE_PATHS: "/opt/bitnami/keycloak/custom-ca"
@@ -59,10 +62,10 @@ data:
   {{- if .Values.cache.enabled }}
   KEYCLOAK_CACHE_TYPE: "ispn"
   {{- if .Values.cache.stackName }}
-  KEYCLOAK_CACHE_STACK: {{ .Values.cache.stackName | quote }} 
+  KEYCLOAK_CACHE_STACK: {{ .Values.cache.stackName | quote }}
   {{- end }}
   {{- if .Values.cache.stackFile }}
-  KEYCLOAK_CACHE_CONFIG_FILE: {{ .Values.cache.stackFile | quote }} 
+  KEYCLOAK_CACHE_CONFIG_FILE: {{ .Values.cache.stackFile | quote }}
   {{- end }}
   JAVA_OPTS_APPEND: {{ printf "-Djgroups.dns.query=%s-headless.%s.svc.%s" (include "common.names.fullname" .) (include "common.names.namespace" .) .Values.clusterDomain | quote }}
   {{- else }}

--- a/bitnami/keycloak/templates/statefulset.yaml
+++ b/bitnami/keycloak/templates/statefulset.yaml
@@ -218,7 +218,7 @@ spec:
               value: {{ .Values.extraStartupArgs | quote }}
             {{- end }}
             {{- if and .Values.adminIngress.enabled .Values.adminIngress.hostname }}
-            - name: KC_HOSTNAME_ADMIN_URL
+            - name: KEYCLOAK_HOSTNAME_ADMIN
               value: |-
                 {{ ternary "https://" "http://" ( or .Values.adminIngress.tls (eq .Values.proxy "edge") (not (empty .Values.proxyHeaders)) ) -}}
                 {{- include "common.tplvalues.render" (dict "value" .Values.adminIngress.hostname "context" $) -}}
@@ -233,7 +233,7 @@ spec:
                 {{- end }}
             {{- end }}
             {{- if and .Values.ingress.enabled .Values.ingress.hostname }}
-            - name: KC_HOSTNAME_URL
+            - name: KEYCLOAK_HOSTNAME
               value: |-
                 {{ ternary "https://" "http://" ( or .Values.ingress.tls (eq .Values.proxy "edge") (not (empty .Values.proxyHeaders)) ) -}}
                 {{- include "common.tplvalues.render" (dict "value" .Values.ingress.hostname "context" $) -}}

--- a/bitnami/keycloak/values.yaml
+++ b/bitnami/keycloak/values.yaml
@@ -628,6 +628,11 @@ ingress:
   ## @param ingress.hostname Default host for the ingress record (evaluated as template)
   ##
   hostname: keycloak.local
+  ## @param ingress.hostnameStrict Disables dynamically resolving the hostname from request headers.
+  ## Should always be set to true in production, unless your reverse proxy overwrites the Host header.
+  ## If enabled, the hostname option needs to be specified.
+  ##
+  hostnameStrict: false
   ## @param ingress.path [string] Default path for the ingress record (evaluated as template)
   ##
   path: "{{ .Values.httpRelativePath }}"


### PR DESCRIPTION
### Description of the change

Use [Hostname v2](https://www.keycloak.org/docs/latest/upgrading/index.html#new-hostname-options) options as v1 options are not used by default.

### Benefits

Use updated configurations in alignment with upstream Keycloak project.

### Possible drawbacks

Enabling hostname-strict when hostname is more secure, but may cause issues for some users.

### Applicable issues

- fixes #28586

### Additional information

This has be merged after the image is updated, see https://github.com/bitnami/containers/pull/70466.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
