### PR TITLE
[bitnami/wordpress] Add the possibility to set `smtpFromEmail` and `smtpFromName`

### DIFF
--- a/bitnami/wordpress/CHANGELOG.md
+++ b/bitnami/wordpress/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 23.0.15 (2024-08-05)
+## 23.1.0 (2024-08-06)
 
-* [bitnami/wordpress] Release 23.0.15 ([#28679](https://github.com/bitnami/charts/pull/28679))
+* [bitnami/wordpress] Add the possibility to set `smtpFromEmail` and `smtpFromName` ([#28648](https://github.com/bitnami/charts/pull/28648))
+
+## <small>23.0.15 (2024-08-05)</small>
+
+* [bitnami/wordpress] Release 23.0.15 (#28679) ([7ddd441](https://github.com/bitnami/charts/commit/7ddd4419c6bdab3b310e484c5f3dba66e0c176b6)), closes [#28679](https://github.com/bitnami/charts/issues/28679)
 
 ## <small>23.0.14 (2024-08-05)</small>
 

--- a/bitnami/wordpress/Chart.yaml
+++ b/bitnami/wordpress/Chart.yaml
@@ -44,4 +44,4 @@ maintainers:
 name: wordpress
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/wordpress
-version: 23.0.15
+version: 23.1.0

--- a/bitnami/wordpress/README.md
+++ b/bitnami/wordpress/README.md
@@ -303,6 +303,8 @@ As an alternative, use one of the preset configurations for pod affinity, pod an
 | `smtpUser`                             | SMTP username                                                                         | `""`               |
 | `smtpPassword`                         | SMTP user password                                                                    | `""`               |
 | `smtpProtocol`                         | SMTP protocol                                                                         | `""`               |
+| `smtpFromEmail`                        | SMTP from email (default is `smtpUser`)                                               | `""`               |
+| `smtpFromName`                         | SMTP from name  (default is `wordpressFirstName` and `wordpressLastName`)             | `""`               |
 | `smtpExistingSecret`                   | The name of an existing secret with SMTP credentials                                  | `""`               |
 | `allowEmptyPassword`                   | Allow the container to be started with blank passwords                                | `true`             |
 | `allowOverrideNone`                    | Configure Apache to prohibit overriding directives with htaccess files                | `false`            |

--- a/bitnami/wordpress/templates/deployment.yaml
+++ b/bitnami/wordpress/templates/deployment.yaml
@@ -265,6 +265,14 @@ spec:
             - name: SMTP_PROTOCOL
               value: {{ .Values.smtpProtocol | quote }}
             {{- end }}
+            {{- if .Values.smtpFromEmail }}
+            - name: WORDPRESS_SMTP_FROM_EMAIL
+              value: {{ .Values.smtpFromEmail | quote }}
+            {{- end }}
+            {{- if .Values.smtpFromName }}
+            - name: WORDPRESS_SMTP_FROM_NAME
+              value: {{ .Values.smtpFromName | quote }}
+            {{- end }}
             - name: APACHE_HTTP_PORT_NUMBER
               value: {{ .Values.containerPorts.http | quote }}
             - name: APACHE_HTTPS_PORT_NUMBER

--- a/bitnami/wordpress/values.yaml
+++ b/bitnami/wordpress/values.yaml
@@ -198,12 +198,16 @@ customPostInitScripts: {}
 ## @param smtpUser SMTP username
 ## @param smtpPassword SMTP user password
 ## @param smtpProtocol SMTP protocol
+## @param smtpFromEmail SMTP from email (default is `smtpUser`)
+## @param smtpFromName SMTP from name  (default is `wordpressFirstName` and `wordpressLastName`)
 ##
 smtpHost: ""
 smtpPort: ""
 smtpUser: ""
 smtpPassword: ""
 smtpProtocol: ""
+smtpFromEmail: ""
+smtpFromName: ""
 ## @param smtpExistingSecret The name of an existing secret with SMTP credentials
 ## NOTE: Must contain key `smtp-password`
 ## NOTE: When it's set, the `smtpPassword` parameter is ignored


### PR DESCRIPTION
### Description of the change

As discussed here https://github.com/bitnami/charts/issues/25174 and implemented in the container here https://github.com/bitnami/containers/pull/67399

This change makes it possible to adjust the sender email and the sender name in the smtp config.
It is backwards compatible because it uses the previous environment variables if none are specified.

### Applicable issues

- fixes #25174

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
