### PR TITLE
[bitnami/matomo] Remove dokuwiki reference

### DIFF
--- a/bitnami/matomo/CHANGELOG.md
+++ b/bitnami/matomo/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 8.0.5 (2024-07-25)
+## 8.0.6 (2024-08-05)
 
-* [bitnami/matomo] Release 8.0.5 ([#28484](https://github.com/bitnami/charts/pull/28484))
+* [bitnami/matomo] Remove dokuwiki reference ([#28661](https://github.com/bitnami/charts/pull/28661))
+
+## <small>8.0.5 (2024-07-25)</small>
+
+* [bitnami/matomo] Release 8.0.5 (#28484) ([d08a865](https://github.com/bitnami/charts/commit/d08a86525aa160ba1c9595123d2f4913ecb33540)), closes [#28484](https://github.com/bitnami/charts/issues/28484)
 
 ## <small>8.0.4 (2024-07-24)</small>
 

--- a/bitnami/matomo/Chart.yaml
+++ b/bitnami/matomo/Chart.yaml
@@ -39,4 +39,4 @@ maintainers:
 name: matomo
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/matomo
-version: 8.0.5
+version: 8.0.6

--- a/bitnami/matomo/values.yaml
+++ b/bitnami/matomo/values.yaml
@@ -117,7 +117,7 @@ matomoWebsiteHost: https://example.org
 ##
 matomoSkipInstall: false
 ## @param customPostInitScripts Custom post-init.d user scripts
-## ref: https://github.com/bitnami/containers/tree/main/bitnami/dokuwiki
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/matomo
 ## NOTE: supported formats are `.sh` or `.php`
 ## NOTE: scripts are exclusively executed during the 1st boot of the container
 ## e.g:


### PR DESCRIPTION
### Description of the change

Remove wrong dokuwiki reference.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
