### PR TITLE
[bitnami/kibana] Updating readinessProbe when server.basePath is configured in extraConfiguration

### DIFF
--- a/bitnami/kibana/CHANGELOG.md
+++ b/bitnami/kibana/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 11.2.16 (2024-07-29)
+## 11.2.17 (2024-08-05)
 
-* add publicBaseUrl param ([#28543](https://github.com/bitnami/charts/pull/28543))
+* [bitnami/kibana] Updating readinessProbe when server.basePath is configured in extraConfiguration ([#28664](https://github.com/bitnami/charts/pull/28664))
+
+## <small>11.2.16 (2024-07-30)</small>
+
+* [bitnami/kibana] add publicBaseUrl param (#28543) ([edad571](https://github.com/bitnami/charts/commit/edad571366b89d72d52b30bbdc850535c87f96d6)), closes [#28543](https://github.com/bitnami/charts/issues/28543)
 
 ## <small>11.2.15 (2024-07-25)</small>
 

--- a/bitnami/kibana/Chart.yaml
+++ b/bitnami/kibana/Chart.yaml
@@ -32,4 +32,4 @@ maintainers:
 name: kibana
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/kibana
-version: 11.2.16
+version: 11.2.17

--- a/bitnami/kibana/templates/deployment.yaml
+++ b/bitnami/kibana/templates/deployment.yaml
@@ -237,7 +237,13 @@ spec:
           {{- else if .Values.readinessProbe.enabled }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.readinessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
-              path: {{ printf "%s/status" (default "" .Values.configuration.server.basePath) }}
+              path: {{ if .Values.configuration.server.basePath }}
+                {{- printf "%s/status" .Values.configuration.server.basePath }}
+              {{- else if and .Values.extraConfiguration.server .Values.extraConfiguration.server.basePath }}
+                {{- printf "%s/status" .Values.extraConfiguration.server.basePath }}
+              {{- else }}
+                {{- printf "/status"}}
+              {{- end }}
               port: http
               scheme: {{ ternary "HTTPS" "HTTP" .Values.tls.enabled }}
           {{- end }}

--- a/bitnami/kibana/templates/deployment.yaml
+++ b/bitnami/kibana/templates/deployment.yaml
@@ -237,13 +237,7 @@ spec:
           {{- else if .Values.readinessProbe.enabled }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.readinessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
-              path: {{ if .Values.configuration.server.basePath }}
-                {{- printf "%s/status" .Values.configuration.server.basePath }}
-              {{- else if and .Values.extraConfiguration.server .Values.extraConfiguration.server.basePath }}
-                {{- printf "%s/status" .Values.extraConfiguration.server.basePath }}
-              {{- else }}
-                {{- printf "/status"}}
-              {{- end }}
+              path: {{ printf "%s/status" (default "" .Values.configuration.server.basePath) }}
               port: http
               scheme: {{ ternary "HTTPS" "HTTP" .Values.tls.enabled }}
           {{- end }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

readinessProbe gets updated when .Values.extraConfiguration.server.basePath is configured.

### Benefits

Pods don't fail the readiness check when extraConfiguration.server.basePath is configured

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
