### PR TITLE
[bitnami/logstash] fix: :bug: Add missing ports in networkpolicy

### DIFF
--- a/bitnami/logstash/CHANGELOG.md
+++ b/bitnami/logstash/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
+## 6.3.1 (2024-08-05)
+
+* [bitnami/logstash] fix: :bug: Add missing ports in networkpolicy ([#28670](https://github.com/bitnami/charts/pull/28670))
+
 ## 6.3.0 (2024-08-01)
 
-* [bitnami/logstash] Add extra inputs and ports to pod and svc ([#27763](https://github.com/bitnami/charts/pull/27763))
+* [bitnami/logstash] Add extra inputs and ports to pod and svc (#27763) ([e4cc138](https://github.com/bitnami/charts/commit/e4cc1380c87dd6aa7ba3bdc568c0228cace42603)), closes [#27763](https://github.com/bitnami/charts/issues/27763)
 
 ## <small>6.2.14 (2024-07-25)</small>
 

--- a/bitnami/logstash/Chart.yaml
+++ b/bitnami/logstash/Chart.yaml
@@ -30,4 +30,4 @@ maintainers:
 name: logstash
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/logstash
-version: 6.3.0
+version: 6.3.1

--- a/bitnami/logstash/templates/networkpolicy.yaml
+++ b/bitnami/logstash/templates/networkpolicy.yaml
@@ -55,6 +55,12 @@ spec:
         {{- range .Values.containerPorts }}
         - port: {{ .containerPort }}
         {{- end }}
+        {{- range .Values.extraContainerPorts }}
+        - port: {{ . }}
+        {{- end }}
+        {{- if .Values.enableMonitoringAPI }}
+        - port: {{ .Values.monitoringAPIPort }}
+        {{- end }}
       {{- if not .Values.networkPolicy.allowExternal }}
       from:
         - podSelector:


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

This PR fixes a regression introduced in https://github.com/bitnami/charts/pull/27763. There were missing ports in the network policy definition. 
<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [ ] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [ ] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
