### PR TITLE
[bitnami/flux] Use nginx instead of dokuwiki for testing

### DIFF
--- a/.vib/flux/goss/goss.yaml
+++ b/.vib/flux/goss/goss.yaml
@@ -84,10 +84,10 @@ http:
       - /ImageUpdateAutomation.*{{ $imageUpdateAutomationName }}/
   # Ensure that the deployment done by the helm controller worked
   {{ if not ( has "air-gapped" .Vars.target_platform_properties ) }}
-  http://{{ $chartReleaseName }}/doku.php:
+  http://{{ $chartReleaseName }}/:
     status: 200
     body:
-      - /DokuWiki/
+      - /Welcome to nginx/
   # Ensure that the deployment done by the kustomize controller worked
   # This name is hardcoded in the git repository
   http://podinfo:9898:

--- a/.vib/flux/runtime-parameters.yaml
+++ b/.vib/flux/runtime-parameters.yaml
@@ -125,7 +125,7 @@ extraDeploy:
   - apiVersion: helm.toolkit.fluxcd.io/v2beta2
     kind: HelmRelease
     metadata:
-      name: vib-dokuwiki
+      name: vib-nginx
       namespace: '{{ include "common.names.namespace" . }}'
       annotations:
         "helm.sh/hook": post-install
@@ -133,7 +133,7 @@ extraDeploy:
       interval: 5m
       chart:
         spec:
-          chart: ./bitnami/dokuwiki
+          chart: ./bitnami/nginx
           sourceRef:
             kind: GitRepository
             name: vib-bitnami-charts
@@ -144,7 +144,7 @@ extraDeploy:
           compatibility:
             openshift:
               adaptSecurityContext: auto
-        fullnameOverride: vib-dokuwiki
+        fullnameOverride: vib-nginx
         persistence:
           enabled: false
   # This is for image-notification-controller. We will use the metrics to ensure that it is consumed

--- a/bitnami/flux/CHANGELOG.md
+++ b/bitnami/flux/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 2.3.12 (2024-07-25)
+## 2.3.13 (2024-08-05)
 
-* [bitnami/flux] Release 2.3.12 ([#28429](https://github.com/bitnami/charts/pull/28429))
+* [bitnami/flux] Use nginx instead of dokuwiki for testing ([#28671](https://github.com/bitnami/charts/pull/28671))
+
+## <small>2.3.12 (2024-07-25)</small>
+
+* [bitnami/flux] Release 2.3.12 (#28429) ([d37fda0](https://github.com/bitnami/charts/commit/d37fda0b2b83f0f961b3cbb2d8dc985cf5ce3de2)), closes [#28429](https://github.com/bitnami/charts/issues/28429)
 
 ## <small>2.3.11 (2024-07-24)</small>
 

--- a/bitnami/flux/Chart.yaml
+++ b/bitnami/flux/Chart.yaml
@@ -43,4 +43,4 @@ maintainers:
 name: flux
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/flux
-version: 2.3.12
+version: 2.3.13


### PR DESCRIPTION
### Description of the change

Change the testing deployment from dokuwiki (deprected) to NGINX

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
