### PR TITLE
[bitnami/schema-registry] Update chart dependency (kafka)

### DIFF
--- a/bitnami/kafka/README.md
+++ b/bitnami/kafka/README.md
@@ -1066,6 +1066,10 @@ Find more information about how to deal with common errors related to Bitnami's 
 
 ## Upgrading
 
+### To 30.0.0
+
+This major release bumps the Kafka version to 3.8. Find notable changes in [kafka upgrade notes](https://kafka.apache.org/38/documentation.html#upgrade).
+
 ### To 29.0.0
 
 This major version of Kafka deprecates Kafka Exporter component.

--- a/bitnami/kafka/README.md
+++ b/bitnami/kafka/README.md
@@ -1066,10 +1066,6 @@ Find more information about how to deal with common errors related to Bitnami's 
 
 ## Upgrading
 
-### To 30.0.0
-
-This major release bumps the Kafka version to 3.8. Find notable changes in [kafka upgrade notes](https://kafka.apache.org/38/documentation.html#upgrade).
-
 ### To 29.0.0
 
 This major version of Kafka deprecates Kafka Exporter component.

--- a/bitnami/schema-registry/CHANGELOG.md
+++ b/bitnami/schema-registry/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
+## 21.0.0 (2024-08-05)
+
+* [bitnami/schema-registry] Update chart dependency (kafka) ([#28672](https://github.com/bitnami/charts/pull/28672))
+
 ## 20.0.0 (2024-08-02)
 
-* [bitnami/schema-registry] Release 20.0.0 ([#28641](https://github.com/bitnami/charts/pull/28641))
+* [bitnami/schema-registry] Release 20.0.0 (#28641) ([b6f2246](https://github.com/bitnami/charts/commit/b6f22465529a3990027ff4de3f72e589c394ed20)), closes [#28641](https://github.com/bitnami/charts/issues/28641)
 
 ## <small>19.2.5 (2024-07-25)</small>
 

--- a/bitnami/schema-registry/Chart.lock
+++ b/bitnami/schema-registry/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: kafka
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 29.3.14
+  version: 30.0.0
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 2.20.5
-digest: sha256:8829a53e0217c23dbdb975b62f39e2ae866d2ec1bb21814a3cf48b6407042db3
-generated: "2024-08-02T15:59:46.292363519Z"
+digest: sha256:c944a1927bfab6bd8186c343b8f42ffba172cdcec9191f35253dc22d1fca0d81
+generated: "2024-08-05T17:21:26.630459+02:00"

--- a/bitnami/schema-registry/Chart.yaml
+++ b/bitnami/schema-registry/Chart.yaml
@@ -13,7 +13,7 @@ dependencies:
 - condition: kafka.enabled
   name: kafka
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 29.x.x
+  version: 30.x.x
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
   tags:
@@ -34,4 +34,4 @@ maintainers:
 name: schema-registry
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/schema-registry
-version: 20.0.0
+version: 21.0.0

--- a/bitnami/schema-registry/README.md
+++ b/bitnami/schema-registry/README.md
@@ -429,6 +429,10 @@ Find more information about how to deal with common errors related to Bitnami's 
 
 ## Upgrading
 
+### To 21.0.0
+
+This major updates the Kafka subchart to its newest major, 30.0.0. For more information on this subchart's major, please refer to [Kafka upgrade notes](https://github.com/bitnami/charts/tree/main/bitnami/kafka#to-3000).
+
 ### To 19.0.0
 
 This major updates the Kafka subchart to its newest major, 29.0.0. For more information on this subchart's major, please refer to [Kafka upgrade notes](https://github.com/bitnami/charts/tree/main/bitnami/kafka#to-2900).


### PR DESCRIPTION
### Description of the change

This major updates the Kafka subchart to its newest major, 30.0.0

### Possible drawbacks

None

### Applicable issues

None

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
