### PR TITLE
[bitnami/milvus] Update chart dependency (kafka)

### DIFF
--- a/bitnami/milvus/CHANGELOG.md
+++ b/bitnami/milvus/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 8.3.8 (2024-08-02)
+## 9.0.0 (2024-08-05)
 
-* [bitnami/milvus] Release 8.3.8 ([#28642](https://github.com/bitnami/charts/pull/28642))
+* [bitnami/milvus] Update chart dependency (kafka) ([#28674](https://github.com/bitnami/charts/pull/28674))
+
+## <small>8.3.8 (2024-08-02)</small>
+
+* [bitnami/milvus] Release 8.3.8 (#28642) ([c0e7077](https://github.com/bitnami/charts/commit/c0e7077b6d65a0442334ae1da0eacdaf3505e5f4)), closes [#28642](https://github.com/bitnami/charts/issues/28642)
 
 ## <small>8.3.7 (2024-07-25)</small>
 

--- a/bitnami/milvus/Chart.lock
+++ b/bitnami/milvus/Chart.lock
@@ -4,12 +4,12 @@ dependencies:
   version: 10.2.11
 - name: kafka
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 29.3.14
+  version: 30.0.0
 - name: minio
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 14.6.31
+  version: 14.6.32
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 2.20.5
-digest: sha256:4f7e943d561cb5913764f776b0a207845f9596e4cda4698d727dcd88b1bc5159
-generated: "2024-08-02T16:42:00.796870841Z"
+digest: sha256:06664ad8d94aa6ade2a4f80b67198df67ec3029bb25636b296f0650080586253
+generated: "2024-08-05T17:28:21.330516+02:00"

--- a/bitnami/milvus/Chart.yaml
+++ b/bitnami/milvus/Chart.yaml
@@ -23,7 +23,7 @@ dependencies:
 - condition: kafka.enabled
   name: kafka
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 29.x.x
+  version: 30.x.x
 - condition: minio.enabled
   name: minio
   repository: oci://registry-1.docker.io/bitnamicharts
@@ -48,4 +48,4 @@ maintainers:
 name: milvus
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/milvus
-version: 8.3.8
+version: 9.0.0

--- a/bitnami/milvus/README.md
+++ b/bitnami/milvus/README.md
@@ -242,7 +242,6 @@ wrj2wDbCDCFmfqnSJ+dKI3vFLlEz44sAV8jX/kd4Y6ZTQhlLbYc=
 | `global.imageRegistry`                                | Global Docker image registry                                                                                                                                                                                                                                                                                                                                        | `""`   |
 | `global.imagePullSecrets`                             | Global Docker registry secret names as an array                                                                                                                                                                                                                                                                                                                     | `[]`   |
 | `global.defaultStorageClass`                          | Global default StorageClass for Persistent Volume(s)                                                                                                                                                                                                                                                                                                                | `""`   |
-| `global.storageClass`                                 | DEPRECATED: use global.defaultStorageClass instead                                                                                                                                                                                                                                                                                                                  | `""`   |
 | `global.compatibility.openshift.adaptSecurityContext` | Adapt the securityContext sections of the deployment to make them compatible with Openshift restricted-v2 SCC: remove runAsUser, runAsGroup and fsGroup and let the platform use their allowed default IDs. Possible values: auto (apply if the detected running cluster is Openshift), force (perform the adaptation always), disabled (do not perform adaptation) | `auto` |
 
 ### Common parameters
@@ -1831,6 +1830,10 @@ helm install my-release -f values.yaml oci://REGISTRY_NAME/REPOSITORY_NAME/milvu
 Find more information about how to deal with common errors related to Bitnami's Helm charts in [this troubleshooting guide](https://docs.bitnami.com/general/how-to/troubleshoot-helm-chart-issues).
 
 ## Upgrading
+
+### To 9.0.0
+
+This major updates the Kafka subchart to its newest major, 30.0.0. For more information on this subchart's major, please refer to [Kafka upgrade notes](https://github.com/bitnami/charts/tree/main/bitnami/kafka#to-3000).
 
 ### To 8.0.0
 

--- a/bitnami/milvus/values.yaml
+++ b/bitnami/milvus/values.yaml
@@ -10,7 +10,6 @@
 ## @param global.imageRegistry Global Docker image registry
 ## @param global.imagePullSecrets Global Docker registry secret names as an array
 ## @param global.defaultStorageClass Global default StorageClass for Persistent Volume(s)
-## @param global.storageClass DEPRECATED: use global.defaultStorageClass instead
 ##
 global:
   imageRegistry: ""
@@ -20,7 +19,6 @@ global:
   ##
   imagePullSecrets: []
   defaultStorageClass: ""
-  storageClass: ""
   ## Compatibility adaptations for Kubernetes platforms
   ##
   compatibility:


### PR DESCRIPTION
### Description of the change

This major updates the Kafka subchart to its newest major, 30.0.0

### Possible drawbacks

None

### Applicable issues

None

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)