### PR TITLE
[bitnami/mysql] Include database in service binding secret when using root user

### DIFF
--- a/bitnami/mysql/CHANGELOG.md
+++ b/bitnami/mysql/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 11.1.15 (2024-08-06)
+## 11.1.15 (2024-08-07)
 
 * [bitnami/mysql] Include database in service binding secret when using root user ([#28693](https://github.com/bitnami/charts/pull/28693))
 

--- a/bitnami/mysql/CHANGELOG.md
+++ b/bitnami/mysql/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
-## 11.1.14 (2024-07-25)
+## 11.1.15 (2024-08-06)
 
-* [bitnami/mysql] Release 11.1.14 ([#28478](https://github.com/bitnami/charts/pull/28478))
+* [bitnami/mysql] Include database in service binding secret when using root user ([#28693](https://github.com/bitnami/charts/pull/28693))
+
+## <small>11.1.14 (2024-07-25)</small>
+
+* [bitnami/mysql] Release 11.1.14 (#28478) ([2405890](https://github.com/bitnami/charts/commit/24058909b3d44a845a90ab63898076348c0fe1a6)), closes [#28478](https://github.com/bitnami/charts/issues/28478)
+* [bnitnami/mysql] Update documentation to use bash instead of sh (#28252) ([672cab7](https://github.com/bitnami/charts/commit/672cab7251e9aa1a0081aadedd6d8322ce2235b6)), closes [#28252](https://github.com/bitnami/charts/issues/28252) [#28195](https://github.com/bitnami/charts/issues/28195)
 
 ## <small>11.1.13 (2024-07-24)</small>
 

--- a/bitnami/mysql/Chart.yaml
+++ b/bitnami/mysql/Chart.yaml
@@ -34,4 +34,4 @@ maintainers:
 name: mysql
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/mysql
-version: 11.1.14
+version: 11.1.15

--- a/bitnami/mysql/templates/secrets.yaml
+++ b/bitnami/mysql/templates/secrets.yaml
@@ -26,6 +26,7 @@ data:
   {{- end }}
 {{- end }}
 {{- if .Values.serviceBindings.enabled }}
+{{- $database := .Values.auth.database  }}
 ---
 apiVersion: v1
 kind: Secret
@@ -43,11 +44,13 @@ data:
   host: {{ print $host | b64enc | quote }}
   port: {{ print $port | b64enc | quote }}
   username: {{ print "root" | b64enc | quote }}
+  {{- if $database }}
+  database: {{ print $database | b64enc | quote }}
+  {{- end }}
   password: {{ print $rootPassword | b64enc | quote }}
-  uri: {{ printf "mysql://root:%s@%s:%s" $rootPassword $host $port | b64enc | quote }}
+  uri: {{ printf "mysql://root:%s@%s:%s/%s" $rootPassword $host $port $database | b64enc | quote }}
 
 {{- if .Values.auth.username }}
-{{- $database := .Values.auth.database  }}
 ---
 apiVersion: v1
 kind: Secret


### PR DESCRIPTION


### Description of the change

Adds database to service binding secret when root user is used.

### Benefits

Allows the service binding secret to contain the database without also needing to set a custom user.

### Possible drawbacks

None

### Applicable issues

Fixes #28627

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
