### PR TITLE
[bitnami/nginx] Support for Non-Bitnami Nginx Images in nginx Helm Chart

### DIFF
--- a/bitnami/nginx/CHANGELOG.md
+++ b/bitnami/nginx/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 18.1.7 (2024-07-25)
+## 18.1.8 (2024-08-07)
 
-* [bitnami/nginx] Release 18.1.7 ([#28450](https://github.com/bitnami/charts/pull/28450))
+* Support for Non-Bitnami Nginx Images in nginx Helm Chart ([#28741](https://github.com/bitnami/charts/pull/28741))
+
+## <small>18.1.7 (2024-07-25)</small>
+
+* [bitnami/nginx] Release 18.1.7 (#28450) ([2ffa35e](https://github.com/bitnami/charts/commit/2ffa35ed405b77ab312413b1d7370e4f39c0281d)), closes [#28450](https://github.com/bitnami/charts/issues/28450)
 
 ## <small>18.1.6 (2024-07-24)</small>
 

--- a/bitnami/nginx/CHANGELOG.md
+++ b/bitnami/nginx/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 18.1.8 (2024-08-08)
+## 18.1.8 (2024-08-09)
 
 * [bitnami/nginx] Support for Non-Bitnami Nginx Images in nginx Helm Chart ([#28741](https://github.com/bitnami/charts/pull/28741))
 

--- a/bitnami/nginx/CHANGELOG.md
+++ b/bitnami/nginx/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-## 18.1.8 (2024-08-07)
+## 18.1.8 (2024-08-08)
 
-* Support for Non-Bitnami Nginx Images in nginx Helm Chart ([#28741](https://github.com/bitnami/charts/pull/28741))
+* [bitnami/nginx] Support for Non-Bitnami Nginx Images in nginx Helm Chart ([#28741](https://github.com/bitnami/charts/pull/28741))
 
 ## <small>18.1.7 (2024-07-25)</small>
 

--- a/bitnami/nginx/Chart.yaml
+++ b/bitnami/nginx/Chart.yaml
@@ -34,4 +34,4 @@ maintainers:
 name: nginx
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/nginx
-version: 18.1.7
+version: 18.1.8

--- a/bitnami/nginx/templates/deployment.yaml
+++ b/bitnami/nginx/templates/deployment.yaml
@@ -81,6 +81,7 @@ spec:
       {{- if .Values.terminationGracePeriodSeconds }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       {{- end }}
+      {{- if .Values.containerSecurityContext.readOnlyRootFilesystem }}
       initContainers:
         - name: preserve-logs-symlinks
           image: {{ include "nginx.image" . }}
@@ -107,6 +108,7 @@ spec:
           volumeMounts:
             - name: empty-dir
               mountPath: /emptydir
+      {{- end }}        
       {{- if or .Values.cloneStaticSiteFromGit.enabled .Values.initContainers }}
         {{- if .Values.cloneStaticSiteFromGit.enabled }}
         - name: git-clone-repository


### PR DESCRIPTION
### Description of the change

This modification allows the Bitnami nginx Helm chart to support non-Bitnami nginx images by conditionally executing an initContainer based on the readOnlyRootFilesystem setting. The initContainer is necessary for handling logs via Bitnami-specific scripts, which non-Bitnami images lack. By adding a conditional check, users can deploy with alternative nginx images without encountering errors related to missing Bitnami-specific scripts.

### Benefits

Allows users to use any nginx image, not just those provided by Bitnami.

### Possible drawbacks

None

### Applicable issues

None

### Additional information

This change does not affect the primary operation of nginx within the Helm chart but instead broadens the potential user base by accommodating more image options. It is particularly useful for users who may be operating in environments where Bitnami images are not ideal or preferred.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
