### PR TITLE
[bitnami/common] Fallback to chart appVersion in common.images.image

### DIFF
--- a/bitnami/common/CHANGELOG.md
+++ b/bitnami/common/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 2.21.0 (2024-07-31)
+## 2.22.0 (2024-08-07)
 
-* [bitnami/common] Allow handling of new secrets after initial installation ([#28581](https://github.com/bitnami/charts/pull/28581))
+* [bitnami/common] Fallback to chart appVersion in common.images.image ([#28764](https://github.com/bitnami/charts/pull/28764))
+
+## 2.21.0 (2024-08-05)
+
+* [bitnami/common] Allow handling of new secrets after initial installation (#28581) ([07062ee](https://github.com/bitnami/charts/commit/07062ee01382e24b8204b27083ff3e8102110c2f)), closes [#28581](https://github.com/bitnami/charts/issues/28581)
 
 ## <small>2.20.5 (2024-07-16)</small>
 

--- a/bitnami/common/Chart.yaml
+++ b/bitnami/common/Chart.yaml
@@ -6,7 +6,7 @@ annotations:
   licenses: Apache-2.0
 apiVersion: v2
 # Please make sure that version and appVersion are always the same.
-appVersion: 2.21.0
+appVersion: 2.22.0
 description: A Library Helm Chart for grouping common logic between bitnami charts. This chart is not deployable by itself.
 home: https://bitnami.com
 icon: https://bitnami.com/downloads/logos/bitnami-mark.png
@@ -23,4 +23,4 @@ name: common
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/common
 type: library
-version: 2.21.0
+version: 2.22.0

--- a/bitnami/common/templates/_images.tpl
+++ b/bitnami/common/templates/_images.tpl
@@ -5,8 +5,9 @@ SPDX-License-Identifier: APACHE-2.0
 
 {{/* vim: set filetype=mustache: */}}
 {{/*
-Return the proper image name
-{{ include "common.images.image" ( dict "imageRoot" .Values.path.to.the.image "global" .Values.global ) }}
+Return the proper image name.
+If image tag and digest are not defined, termination fallbacks to chart appVersion.
+{{ include "common.images.image" ( dict "imageRoot" .Values.path.to.the.image "global" .Values.global "chart" .Chart ) }}
 */}}
 {{- define "common.images.image" -}}
 {{- $registryName := default .imageRoot.registry ((.global).imageRegistry) -}}
@@ -14,6 +15,11 @@ Return the proper image name
 {{- $separator := ":" -}}
 {{- $termination := .imageRoot.tag | toString -}}
 
+{{- if not .imageRoot.tag }}
+  {{- if .chart }}
+    {{- $termination = .chart.AppVersion | toString -}}
+  {{- end -}}
+{{- end -}}
 {{- if .imageRoot.digest }}
     {{- $separator = "@" -}}
     {{- $termination = .imageRoot.digest | toString -}}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Implemented changes requested in #23536 by updating the `common.images.image` helper to set the image tag to `chart.AppVersion` if no tag is set.

It also replicates the behavior of `common.images.version` introduced in #19223, which returns the chart appVersion by default.

### Benefits

Allows chart maintainers to define a single source of truth for image versions in a chart.
Align behavior for `common.images.version` and `common.images.image` helpers.

### Possible drawbacks

Update the helper definition with a new `chart` argument. The impact should be limited or zero as the parameter is not mandatory to make this change backward compatible.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #23536 (Closed as stale)

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
N/A

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
