### PR TITLE
[bitnami/pinniped] fix: :bug: Add missing rbac resources

### DIFF
--- a/bitnami/pinniped/CHANGELOG.md
+++ b/bitnami/pinniped/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 2.2.13 (2024-08-07)
+## 2.2.14 (2024-08-09)
 
-* [bitnami/pinniped] Release 2.2.13 ([#28753](https://github.com/bitnami/charts/pull/28753))
+* [bitnami/pinniped] fix: :bug: Add missing rbac resources ([#28804](https://github.com/bitnami/charts/pull/28804))
+
+## <small>2.2.13 (2024-08-07)</small>
+
+* [bitnami/pinniped] Release 2.2.13 (#28753) ([5984af4](https://github.com/bitnami/charts/commit/5984af460eebd9a1763528e818d88c359f5298fb)), closes [#28753](https://github.com/bitnami/charts/issues/28753)
 
 ## <small>2.2.12 (2024-07-25)</small>
 

--- a/bitnami/pinniped/Chart.yaml
+++ b/bitnami/pinniped/Chart.yaml
@@ -27,4 +27,4 @@ maintainers:
 name: pinniped
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/pinniped
-version: 2.2.13
+version: 2.2.14

--- a/bitnami/pinniped/templates/supervisor/rbac.yaml
+++ b/bitnami/pinniped/templates/supervisor/rbac.yaml
@@ -240,6 +240,8 @@ rules:
     resources:
       - validatingwebhookconfigurations
       - mutatingwebhookconfigurations
+      - validatingadmissionpolicies
+      - validatingadmissionpolicybindings
     verbs:
       - get
       - list


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->
This PR syncs missing RBAC sections in the supervisor ClusterRole
### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
