### PR TITLE
[bitnami/redis] fix: Use rollout restart in ginkgo tests

### DIFF
--- a/.vib/redis/ginkgo/redis_suite_test.go
+++ b/.vib/redis/ginkgo/redis_suite_test.go
@@ -38,6 +38,8 @@ func TestRedis(t *testing.T) {
 }
 
 func createJob(ctx context.Context, c kubernetes.Interface, name, port, image, stmt string) error {
+	// Default job TTL in seconds
+	ttl := int32(10)
 	securityContext := &v1.SecurityContext{
 		Privileged:               &[]bool{false}[0],
 		AllowPrivilegeEscalation: &[]bool{false}[0],
@@ -57,6 +59,7 @@ func createJob(ctx context.Context, c kubernetes.Interface, name, port, image, s
 			Kind: "Job",
 		},
 		Spec: batchv1.JobSpec{
+			TTLSecondsAfterFinished: &ttl,
 			Template: v1.PodTemplateSpec{
 				Spec: v1.PodSpec{
 					RestartPolicy: "Never",

--- a/.vib/redis/ginkgo/redis_test.go
+++ b/.vib/redis/ginkgo/redis_test.go
@@ -10,6 +10,7 @@ import (
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
@@ -36,6 +37,9 @@ var _ = Describe("Redis", Ordered, func() {
 			getAvailableReplicas := func(ss *appsv1.StatefulSet) int32 { return ss.Status.AvailableReplicas }
 			getSucceededJobs := func(j *batchv1.Job) int32 { return j.Status.Succeeded }
 			getOpts := metav1.GetOptions{}
+			restartKey := "kubectl.kubernetes.io/restartedAt"
+			restartAnnotation := map[string]string{restartKey: time.Now().Format(time.RFC3339)}
+			getRestartedAtAnnotation := func(pod *v1.Pod) string { return pod.Annotations[restartKey] }
 
 			By("checking all the replicas are available")
 			ss, err := c.AppsV1().StatefulSets(namespace).Get(ctx, stsName, getOpts)
@@ -71,17 +75,16 @@ var _ = Describe("Redis", Ordered, func() {
 				return c.BatchV1().Jobs(namespace).Get(ctx, createKEYJobName, getOpts)
 			}, timeout, PollingInterval).Should(WithTransform(getSucceededJobs, Equal(int32(1))))
 
-			By("scaling down to 0 replicas")
-			ss, err = utils.StsScale(ctx, c, ss, 0)
-			Expect(err).NotTo(HaveOccurred())
+			By("running rollout restart")
+			// Annotate pods to force a rollout restart
+			ss, err = utils.StsAnnotateTemplate(ctx, c, ss, restartAnnotation)
 
-			Eventually(func() (*appsv1.StatefulSet, error) {
-				return c.AppsV1().StatefulSets(namespace).Get(ctx, stsName, getOpts)
-			}, timeout, PollingInterval).Should(WithTransform(getAvailableReplicas, BeZero()))
-
-			By("scaling up to the original replicas")
-			ss, err = utils.StsScale(ctx, c, ss, origReplicas)
-			Expect(err).NotTo(HaveOccurred())
+			// Wait for the new annotation in the existing pods
+			for i := int(origReplicas) - 1; i >= 0; i-- {
+				Eventually(func() (*v1.Pod, error) {
+					return c.CoreV1().Pods(namespace).Get(ctx, fmt.Sprintf("%s-%d", stsName, i), getOpts)
+				}, timeout, PollingInterval).Should(WithTransform(getRestartedAtAnnotation, Equal(restartAnnotation[restartKey])))
+			}
 
 			Eventually(func() (*appsv1.StatefulSet, error) {
 				return c.AppsV1().StatefulSets(namespace).Get(ctx, stsName, getOpts)

--- a/bitnami/redis/CHANGELOG.md
+++ b/bitnami/redis/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
+## 20.0.1 (2024-08-09)
+
+* [bitnami/redis] fix: Use rollout restart in ginkgo tests ([#28813](https://github.com/bitnami/charts/pull/28813))
+
 ## 20.0.0 (2024-08-09)
 
-* [bitnami/redis] Release 20.0.0 ([#28810](https://github.com/bitnami/charts/pull/28810))
+* [bitnami/redis] Release 20.0.0 (#28810) ([9e08d34](https://github.com/bitnami/charts/commit/9e08d34b938aebbe3ed955f4224b8e525313821d)), closes [#28810](https://github.com/bitnami/charts/issues/28810)
 
 ## <small>19.6.4 (2024-07-25)</small>
 

--- a/bitnami/redis/Chart.yaml
+++ b/bitnami/redis/Chart.yaml
@@ -36,4 +36,4 @@ maintainers:
 name: redis
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/redis
-version: 20.0.0
+version: 20.0.1


### PR DESCRIPTION
### Description of the change

Perform rolling update instead of scaling down and up the STS. 

### Benefits

The test is a little bit faster and we get some seconds extra to avoid the volume clean up performed in some environments.

### Possible drawbacks

None

### Additional information

Similar changes:
*  #28598
* https://github.com/bitnami/charts/pull/28814

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
