### PR TITLE
[bitnami/redis-cluster] fix: Use rollout restart in ginkgo tests

### DIFF
--- a/.vib/redis-cluster/ginkgo/redis_suite_test.go
+++ b/.vib/redis-cluster/ginkgo/redis_suite_test.go
@@ -38,6 +38,8 @@ func TestRedis(t *testing.T) {
 }
 
 func createJob(ctx context.Context, c kubernetes.Interface, name, port, image, stmt string) error {
+	// Default job TTL in seconds
+	ttl := int32(10)
 	securityContext := &v1.SecurityContext{
 		Privileged:               &[]bool{false}[0],
 		AllowPrivilegeEscalation: &[]bool{false}[0],
@@ -57,6 +59,7 @@ func createJob(ctx context.Context, c kubernetes.Interface, name, port, image, s
 			Kind: "Job",
 		},
 		Spec: batchv1.JobSpec{
+			TTLSecondsAfterFinished: &ttl,
 			Template: v1.PodTemplateSpec{
 				Spec: v1.PodSpec{
 					RestartPolicy: "Never",

--- a/bitnami/redis-cluster/CHANGELOG.md
+++ b/bitnami/redis-cluster/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
+## 11.0.1 (2024-08-09)
+
+* [bitnami/redis-cluster] fix: Use rollout restart in ginkgo tests ([#28814](https://github.com/bitnami/charts/pull/28814))
+
 ## 11.0.0 (2024-08-09)
 
-* [bitnami/redis-cluster] Release 11.0.0 ([#28806](https://github.com/bitnami/charts/pull/28806))
+* [bitnami/redis-cluster] Release 11.0.0 (#28806) ([6dcde75](https://github.com/bitnami/charts/commit/6dcde759edb811d3b59211b7d18fe1cd8010bb6f)), closes [#28806](https://github.com/bitnami/charts/issues/28806)
 
 ## 10.3.0 (2024-08-01)
 

--- a/bitnami/redis-cluster/Chart.yaml
+++ b/bitnami/redis-cluster/Chart.yaml
@@ -32,4 +32,4 @@ maintainers:
 name: redis-cluster
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/redis-cluster
-version: 11.0.0
+version: 11.0.1


### PR DESCRIPTION
### Description of the change

Perform rolling update instead of scaling down and up the STS. 

### Benefits

The test is a little bit faster and we get some seconds extra to avoid the volume clean up performed in some environments.

### Possible drawbacks

None

### Additional information

Similar changes:
* #28598
* #28813


### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
