### PR TITLE
[bitnami/chainloop] feat: Change container name of CAS deployment

### DIFF
--- a/.vib/chainloop/ginkgo/chainloop_test.go
+++ b/.vib/chainloop/ginkgo/chainloop_test.go
@@ -90,7 +90,7 @@ var _ = Describe("Chainloop", Ordered, func() {
 			}
 
 			By("checking main container image is running")
-			_, err = utils.DplGetContainerImage(dpl, "cas")
+			_, err = utils.DplGetContainerImage(dpl, "cas-proxy")
 			Expect(err).NotTo(HaveOccurred())
 		})
 

--- a/bitnami/chainloop/Chart.yaml
+++ b/bitnami/chainloop/Chart.yaml
@@ -14,7 +14,7 @@ annotations:
     - name: dex
       image: docker.io/bitnami/dex:2.41.1-debian-12-r0
 apiVersion: v2
-appVersion: 0.95.4
+appVersion: 0.95.5
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts

--- a/bitnami/chainloop/templates/cas/deployment.yaml
+++ b/bitnami/chainloop/templates/cas/deployment.yaml
@@ -71,7 +71,7 @@ spec:
           {{- include "common.tplvalues.render" (dict "value" .Values.cas.initContainers "context" $) | nindent 8 }}
         {{- end }}
       containers:
-        - name: cas
+        - name: cas-proxy
           {{- if .Values.cas.containerSecurityContext.enabled }}
           securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.cas.containerSecurityContext "context" $) | nindent 12 }}
           {{- end }}


### PR DESCRIPTION
### Description of the change

Small change that changes the name of the main container under the CAS deployment from `cas` to `cas-proxy`. Tests have been updated accordingly.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
