### PR TITLE
[bitnami/airflow] chore: Update Redis subchart

### DIFF
--- a/bitnami/airflow/CHANGELOG.md
+++ b/bitnami/airflow/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 18.3.17 (2024-08-06)
+## 19.0.0 (2024-08-12)
 
-* [bitnami/airflow] Release 18.3.17 ([#28702](https://github.com/bitnami/charts/pull/28702))
+* [bitnami/airflow] chore: Update Redis subchart ([#28836](https://github.com/bitnami/charts/pull/28836))
+
+## <small>18.3.17 (2024-08-06)</small>
+
+* [bitnami/airflow] Release 18.3.17 (#28702) ([3e6f5f9](https://github.com/bitnami/charts/commit/3e6f5f969a926151eb0d8925678ff2e69ba0d5f1)), closes [#28702](https://github.com/bitnami/charts/issues/28702)
 
 ## <small>18.3.16 (2024-08-01)</small>
 

--- a/bitnami/airflow/Chart.lock
+++ b/bitnami/airflow/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: redis
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 19.6.4
+  version: 20.0.1
 - name: postgresql
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 15.5.20
+  version: 15.5.21
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.21.0
-digest: sha256:bac16de0ba32317d8d85c3a6ff141c3fe3daa07d31bf38d7697646d4851e8d12
-generated: "2024-08-06T18:29:41.285996192Z"
+  version: 2.22.0
+digest: sha256:5b94c0676d870937be844475f7e00c9980df994d682bb11050e9fbd048d708fc
+generated: "2024-08-12T18:29:45.025998+02:00"

--- a/bitnami/airflow/Chart.yaml
+++ b/bitnami/airflow/Chart.yaml
@@ -23,7 +23,7 @@ dependencies:
 - condition: redis.enabled
   name: redis
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 19.x.x
+  version: 20.x.x
 - condition: postgresql.enabled
   name: postgresql
   repository: oci://registry-1.docker.io/bitnamicharts
@@ -47,4 +47,4 @@ maintainers:
 name: airflow
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/airflow
-version: 18.3.17
+version: 19.0.0

--- a/bitnami/airflow/README.md
+++ b/bitnami/airflow/README.md
@@ -761,6 +761,10 @@ Find more information about how to deal with common errors related to Bitnami's 
 
 ## Upgrading
 
+### To 19.0.0
+
+This major update the Redis&reg; subchart to its newest major, 20.0.0, which updates Redis&reg; from its version 7.2 to the latest 7.4.
+
 ### To 18.0.0
 
 This major bump changes the following security defaults:


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

This PR updates the Redis subchart to its latest major 20.0.1, which updates Redis to its latest version 7.4.

### Additional information

Related to #28810

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
