### PR TITLE
[bitnami/keycloak] move hostname variables to config map to allow override

### DIFF
--- a/bitnami/keycloak/CHANGELOG.md
+++ b/bitnami/keycloak/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 22.1.1 (2024-08-12)
+## 22.1.1 (2024-08-13)
 
 * [bitnami/keycloak] move hostname variables to config map to allow override ([#28838](https://github.com/bitnami/charts/pull/28838))
 

--- a/bitnami/keycloak/CHANGELOG.md
+++ b/bitnami/keycloak/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
+## 22.1.1 (2024-08-12)
+
+* [bitnami/keycloak] move hostname variables to config map to allow override ([#28838](https://github.com/bitnami/charts/pull/28838))
+
 ## 22.1.0 (2024-08-06)
 
-* [bitnami/keycloak] use hostname v2 options ([#28611](https://github.com/bitnami/charts/pull/28611))
+* [bitnami/keycloak] use hostname v2 options (#28611) ([559b860](https://github.com/bitnami/charts/commit/559b8604bb021798592ee276e9553d80d0735bbf)), closes [#28611](https://github.com/bitnami/charts/issues/28611)
 
 ## <small>22.0.2 (2024-08-06)</small>
 

--- a/bitnami/keycloak/Chart.yaml
+++ b/bitnami/keycloak/Chart.yaml
@@ -33,4 +33,4 @@ maintainers:
 name: keycloak
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/keycloak
-version: 22.1.0
+version: 22.1.1

--- a/bitnami/keycloak/templates/configmap-env-vars.yaml
+++ b/bitnami/keycloak/templates/configmap-env-vars.yaml
@@ -21,6 +21,34 @@ data:
   {{- else }}
   KEYCLOAK_PROXY_HEADERS: {{ .Values.proxyHeaders | quote }}
   {{- end }}
+  {{- if and .Values.adminIngress.enabled .Values.adminIngress.hostname }}
+  KEYCLOAK_HOSTNAME_ADMIN: |-
+    {{ ternary "https://" "http://" ( or .Values.adminIngress.tls (eq .Values.proxy "edge") (not (empty .Values.proxyHeaders)) ) -}}
+    {{- include "common.tplvalues.render" (dict "value" .Values.adminIngress.hostname "context" $) -}}
+    {{- if eq .Values.adminIngress.controller "default" }}
+      {{- include "common.tplvalues.render" (dict "value" .Values.adminIngress.path "context" $) }}
+    {{- else if eq .Values.adminIngress.controller "gce" }}
+      {{- $path := .Values.adminIngress.path -}}
+      {{- if hasSuffix "*" $path -}}
+        {{- $path = trimSuffix "*" $path -}}
+      {{- end -}}
+      {{- include "common.tplvalues.render" (dict "value" $path "context" $) }}
+    {{- end }}
+  {{- end }}
+  {{- if and .Values.ingress.enabled .Values.ingress.hostname }}
+  KEYCLOAK_HOSTNAME: |-
+    {{ ternary "https://" "http://" ( or .Values.ingress.tls (eq .Values.proxy "edge") (not (empty .Values.proxyHeaders)) ) -}}
+    {{- include "common.tplvalues.render" (dict "value" .Values.ingress.hostname "context" $) -}}
+    {{- if eq .Values.ingress.controller "default" }}
+      {{- include "common.tplvalues.render" (dict "value" .Values.ingress.path "context" $) }}
+    {{- else if eq .Values.ingress.controller "gce" }}
+      {{- $path := .Values.ingress.path -}}
+      {{- if hasSuffix "*" $path -}}
+        {{- $path = trimSuffix "*" $path -}}
+      {{- end -}}
+      {{- include "common.tplvalues.render" (dict "value" $path "context" $) }}
+    {{- end }}
+  {{- end }}
   {{- if .Values.ingress.enabled }}
   KEYCLOAK_HOSTNAME_STRICT: {{ ternary "true" "false" .Values.ingress.hostnameStrict | quote }}
   {{- end }}

--- a/bitnami/keycloak/templates/statefulset.yaml
+++ b/bitnami/keycloak/templates/statefulset.yaml
@@ -217,36 +217,6 @@ spec:
             - name: KEYCLOAK_EXTRA_ARGS
               value: {{ .Values.extraStartupArgs | quote }}
             {{- end }}
-            {{- if and .Values.adminIngress.enabled .Values.adminIngress.hostname }}
-            - name: KEYCLOAK_HOSTNAME_ADMIN
-              value: |-
-                {{ ternary "https://" "http://" ( or .Values.adminIngress.tls (eq .Values.proxy "edge") (not (empty .Values.proxyHeaders)) ) -}}
-                {{- include "common.tplvalues.render" (dict "value" .Values.adminIngress.hostname "context" $) -}}
-                {{- if eq .Values.adminIngress.controller "default" }}
-                  {{- include "common.tplvalues.render" (dict "value" .Values.adminIngress.path "context" $) }}
-                {{- else if eq .Values.adminIngress.controller "gce" }}
-                  {{- $path := .Values.adminIngress.path -}}
-                  {{- if hasSuffix "*" $path -}}
-                    {{- $path = trimSuffix "*" $path -}}
-                  {{- end -}}
-                  {{- include "common.tplvalues.render" (dict "value" $path "context" $) }}
-                {{- end }}
-            {{- end }}
-            {{- if and .Values.ingress.enabled .Values.ingress.hostname }}
-            - name: KEYCLOAK_HOSTNAME
-              value: |-
-                {{ ternary "https://" "http://" ( or .Values.ingress.tls (eq .Values.proxy "edge") (not (empty .Values.proxyHeaders)) ) -}}
-                {{- include "common.tplvalues.render" (dict "value" .Values.ingress.hostname "context" $) -}}
-                {{- if eq .Values.ingress.controller "default" }}
-                  {{- include "common.tplvalues.render" (dict "value" .Values.ingress.path "context" $) }}
-                {{- else if eq .Values.ingress.controller "gce" }}
-                  {{- $path := .Values.ingress.path -}}
-                  {{- if hasSuffix "*" $path -}}
-                    {{- $path = trimSuffix "*" $path -}}
-                  {{- end -}}
-                  {{- include "common.tplvalues.render" (dict "value" $path "context" $) }}
-                {{- end }}
-            {{- end }}
             {{- if .Values.adminRealm }}
             - name: KC_SPI_ADMIN_REALM
               value: "{{ .Values.adminRealm }}"


### PR DESCRIPTION
### Description of the change

Moves the definition of hostname variables (`KEYCLOAK_HOSTNAME_ADMIN` and `KEYCLOAK_HOSTNAME`) to the config map instead of defining them directly on statefulset. This allows them to be manually overridden using `extraEnvVars` Helm value.

### Benefits

In certain scenarios, the generated path is not correct. For example, when using Regex path matching. This allows the override without creating additional Helm values.

### Possible drawbacks

With great power comes great responsibility. Users can provide invalid values in the override.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #28590

### Additional information

This is an alternative solution to #28523.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
