### PR TITLE
[bitnami/juypterhub] postgres image missing when postgres is disabled (fluxCD/argoCD)

### DIFF
--- a/bitnami/jupyterhub/CHANGELOG.md
+++ b/bitnami/jupyterhub/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 7.2.15 (2024-08-13)
+## 7.2.15 (2024-08-21)
 
 * [bitnami/juypterhub] postgres image missing when postgres is disabled (fluxCD/argoCD) ([#28841](https://github.com/bitnami/charts/pull/28841))
 

--- a/bitnami/jupyterhub/CHANGELOG.md
+++ b/bitnami/jupyterhub/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 7.2.15 (2024-08-12)
+## 7.2.15 (2024-08-13)
 
 * [bitnami/juypterhub] postgres image missing when postgres is disabled (fluxCD/argoCD) ([#28841](https://github.com/bitnami/charts/pull/28841))
 

--- a/bitnami/jupyterhub/CHANGELOG.md
+++ b/bitnami/jupyterhub/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 7.2.14 (2024-07-31)
+## 7.2.15 (2024-08-12)
 
-* [bitnami/jupyterhub] Release 7.2.14 ([#28600](https://github.com/bitnami/charts/pull/28600))
+* [bitnami/juypterhub] postgres image missing when postgres is disabled (fluxCD/argoCD) ([#28841](https://github.com/bitnami/charts/pull/28841))
+
+## <small>7.2.14 (2024-07-31)</small>
+
+* [bitnami/jupyterhub] Release 7.2.14 (#28600) ([b6af234](https://github.com/bitnami/charts/commit/b6af23429e898606e2ec2a2fd0bdfc2c26cb1bb7)), closes [#28600](https://github.com/bitnami/charts/issues/28600)
 
 ## <small>7.2.13 (2024-07-25)</small>
 

--- a/bitnami/jupyterhub/Chart.yaml
+++ b/bitnami/jupyterhub/Chart.yaml
@@ -37,4 +37,4 @@ maintainers:
 name: jupyterhub
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/jupyterhub
-version: 7.2.14
+version: 7.2.15

--- a/bitnami/jupyterhub/README.md
+++ b/bitnami/jupyterhub/README.md
@@ -801,7 +801,6 @@ There are cases where you may want to deploy extra objects, such a ConfigMap con
 | Name                                         | Description                                                             | Value                |
 | -------------------------------------------- | ----------------------------------------------------------------------- | -------------------- |
 | `postgresql.enabled`                         | Switch to enable or disable the PostgreSQL helm chart                   | `true`               |
-| `postgresql.image`                           | Postgres Image                                                          | `""`                 |
 | `postgresql.auth.username`                   | Name for a custom user to create                                        | `bn_jupyterhub`      |
 | `postgresql.auth.password`                   | Password for the custom user to create                                  | `""`                 |
 | `postgresql.auth.database`                   | Name for a custom database to create                                    | `bitnami_jupyterhub` |

--- a/bitnami/jupyterhub/README.md
+++ b/bitnami/jupyterhub/README.md
@@ -801,7 +801,7 @@ There are cases where you may want to deploy extra objects, such a ConfigMap con
 | Name                                         | Description                                                             | Value                |
 | -------------------------------------------- | ----------------------------------------------------------------------- | -------------------- |
 | `postgresql.enabled`                         | Switch to enable or disable the PostgreSQL helm chart                   | `true`               |
-| `postgresql.image`                           | Postgres Image                                                          | ``                   |
+| `postgresql.image`                           | Postgres Image                                                          | `""`                 |
 | `postgresql.auth.username`                   | Name for a custom user to create                                        | `bn_jupyterhub`      |
 | `postgresql.auth.password`                   | Password for the custom user to create                                  | `""`                 |
 | `postgresql.auth.database`                   | Name for a custom database to create                                    | `bitnami_jupyterhub` |

--- a/bitnami/jupyterhub/README.md
+++ b/bitnami/jupyterhub/README.md
@@ -801,6 +801,7 @@ There are cases where you may want to deploy extra objects, such a ConfigMap con
 | Name                                         | Description                                                             | Value                |
 | -------------------------------------------- | ----------------------------------------------------------------------- | -------------------- |
 | `postgresql.enabled`                         | Switch to enable or disable the PostgreSQL helm chart                   | `true`               |
+| `postgresql.image`                           | Postgres Image                                                          | ``                   |
 | `postgresql.auth.username`                   | Name for a custom user to create                                        | `bn_jupyterhub`      |
 | `postgresql.auth.password`                   | Password for the custom user to create                                  | `""`                 |
 | `postgresql.auth.database`                   | Name for a custom database to create                                    | `bitnami_jupyterhub` |

--- a/bitnami/jupyterhub/templates/hub/deployment.yaml
+++ b/bitnami/jupyterhub/templates/hub/deployment.yaml
@@ -80,7 +80,7 @@ spec:
         # it had the binary wait-for-port.
         # This init container is for avoiding CrashLoopback errors in the Hub container because the PostgreSQL container is not ready
         - name: wait-for-db
-          image: {{{ include "common.images.image" (dict "imageRoot" .Values.postgresql.image "global" .Values.global) }}
+          image: {{ include "common.images.image" (dict "imageRoot" .Values.postgresql.image "global" .Values.global) }}
           imagePullPolicy: {{ .Values.postgresql.image.pullPolicy  }}
           command:
             - /bin/bash

--- a/bitnami/jupyterhub/templates/hub/deployment.yaml
+++ b/bitnami/jupyterhub/templates/hub/deployment.yaml
@@ -74,16 +74,13 @@ spec:
       {{- if .Values.hub.terminationGracePeriodSeconds }}
       terminationGracePeriodSeconds: {{ .Values.hub.terminationGracePeriodSeconds }}
       {{- end }}
+      {{- if .Values.postgresql.enabled }} 
       initContainers:
         # NOTE: The value postgresql.image is not available unless postgresql.enabled is not set. We could change this to use os-shell if
         # it had the binary wait-for-port.
         # This init container is for avoiding CrashLoopback errors in the Hub container because the PostgreSQL container is not ready
         - name: wait-for-db
-          {{- if .Values.postgresql.image }}
-          image: {{ .Values.postgresql.image  }}
-          {{- else }}
           image: {{{ include "common.images.image" (dict "imageRoot" .Values.postgresql.image "global" .Values.global) }}
-          {{- end }}
           imagePullPolicy: {{ .Values.postgresql.image.pullPolicy  }}
           command:
             - /bin/bash
@@ -131,6 +128,7 @@ spec:
         {{- if .Values.hub.initContainers }}
         {{- include "common.tplvalues.render" (dict "value" .Values.hub.initContainers "context" $) | nindent 8 }}
         {{- end }}
+      {{- end }}
       containers:
         - name: hub
           image: {{ template "jupyterhub.hub.image" . }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change
When using fluxCD or argoCD `and` using an external postgres instances, the postgres image is lost in translation and causes the following error.
```
Helm install failed for release my_namespace/jupyterhub with chart jupyterhub@7.2.14: template: jupyterhub/templates/hub/deployment.yaml:82:20: executing "jupyterhub/templates/hub/deployment.yaml" at <include "common.images.image" (dict "imageRoot" .Values.postgresql.image "global" .Values.global)>: error calling include: template: jupyterhub/charts/common/templates/_images.tpl:12:39: executing "common.images.image" at <.imageRoot.registry>: can't evaluate field registry in type interface {}
``` 
This creates a catchall so that the deploy user/manifest can still lint the postgres image to the init container and deploy successfully. 

### Benefits

fluxCD and ArgoCD deployments are happy. For some odd reason this is not happening in non CD deployments. Believe it to be due to helm rendering validation baked into flux and argo.  

### Possible drawbacks
none to my knowledge, if `postgres.image` is not set, uses defaults from helm chart.

### Applicable issues
None 


### Additional information

Simply just allows the deployer to specify the postgres image for the init-container, currently fails and prevents deployments in CD tools. 

### Checklist
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
