### PR TITLE
[bitnami/matomo] Increase readiness probes' initial delay for VIB tests

### DIFF
--- a/.vib/matomo/runtime-parameters.yaml
+++ b/.vib/matomo/runtime-parameters.yaml
@@ -7,7 +7,7 @@ service:
   ports:
     http: 80
 readinessProbe:
-  initialDelaySeconds: 90
+  initialDelaySeconds: 120
 cronjobs:
   archive:
     enabled: false

--- a/bitnami/matomo/Chart.lock
+++ b/bitnami/matomo/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 19.0.3
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.20.5
-digest: sha256:bdb3bb68e405ddb99a5ca3861b3600439252bd1fa7e47301807c0cb13be89fc2
-generated: "2024-07-25T08:56:54.795024752Z"
+  version: 2.22.0
+digest: sha256:b177642b18397ccf1120d5bea4a729de766977e0da59a8dfd67152d884afb578
+generated: "2024-08-13T09:55:30.679206+02:00"

--- a/bitnami/matomo/Chart.yaml
+++ b/bitnami/matomo/Chart.yaml
@@ -39,4 +39,4 @@ maintainers:
 name: matomo
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/matomo
-version: 8.0.6
+version: 8.0.7

--- a/bitnami/matomo/templates/_helpers.tpl
+++ b/bitnami/matomo/templates/_helpers.tpl
@@ -152,11 +152,12 @@ Return the matomo pods needed initContainers
   image: {{ include "matomo.volumePermissions.image" . }}
   imagePullPolicy: {{ .Values.volumePermissions.image.pullPolicy | quote }}
   command:
-    - sh
-    - -c
+    - /bin/bash
+  args:
+    - -ec
     - |
-      mkdir -p "/bitnami/matomo"
-      chown -R "{{ .Values.containerSecurityContext.runAsUser }}:{{ .Values.podSecurityContext.fsGroup }}" "/bitnami/matomo"
+      mkdir -p /bitnami/matomo
+      find /bitnami/matomo -mindepth 0 -maxdepth 1 -not -name ".snapshot" -not -name "lost+found" | xargs -r chown -R {{ .Values.containerSecurityContext.runAsUser }}:{{ .Values.podSecurityContext.fsGroup }}
   securityContext:
     runAsUser: 0
   {{- if .Values.volumePermissions.resources }}
@@ -216,6 +217,7 @@ Return the matomo pods needed initContainers
       readOnly: true
 {{- end }}
 {{- end }}
+
 {{/*
 Return if cronjob X is enabled. Takes into account the deprecated value 'cronjobs.enabled'.
 Use: include "matomo.cronjobs.enabled" (dict "context" $ "cronjob" "archive" )


### PR DESCRIPTION
### Description of the change

Some testing platforms we use in VIB use slow filesystems and, as a consequence, we need to give some extra time for the wizard to be completed during the 1st bootstrap.

### Benefits

Tests reliability.

### Possible drawbacks

None

### Applicable issues

None

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
