### PR TITLE
[bitnami/chainloop] chore: Remove default command and args

### DIFF
--- a/bitnami/chainloop/CHANGELOG.md
+++ b/bitnami/chainloop/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 0.1.5 (2024-08-13)
+## 0.1.6 (2024-08-13)
 
-* [bitnami/chainloop] Release 0.1.5 ([#28862](https://github.com/bitnami/charts/pull/28862))
+* [bitnami/chainloop] chore: Remove default command and args ([#28866](https://github.com/bitnami/charts/pull/28866))
+
+## <small>0.1.5 (2024-08-13)</small>
+
+* [bitnami/chainloop] Release 0.1.5 (#28862) ([92d3cbf](https://github.com/bitnami/charts/commit/92d3cbf97424186129480cdb9b83aee74643643d)), closes [#28862](https://github.com/bitnami/charts/issues/28862)
 
 ## <small>0.1.4 (2024-08-12)</small>
 

--- a/bitnami/chainloop/Chart.yaml
+++ b/bitnami/chainloop/Chart.yaml
@@ -63,4 +63,4 @@ sources:
 - https://github.com/bitnami/containers/tree/main/bitnami/chainloop-control-plane-migrations
 - https://github.com/bitnami/containers/tree/main/bitnami/chainloop-artifact-cas
 - https://github.com/chainloop-dev/chainloop
-version: 0.1.5
+version: 0.1.6

--- a/bitnami/chainloop/templates/cas/deployment.yaml
+++ b/bitnami/chainloop/templates/cas/deployment.yaml
@@ -77,8 +77,6 @@ spec:
           {{- end }}
           image: {{ include "chainloop.cas.image" . }}
           imagePullPolicy: {{ .Values.cas.image.pullPolicy }}
-          command: [ "./artifact-cas" ]
-          args: [ "--conf", "/data/conf" ]
           ports:
             - name: http
               containerPort: {{ .Values.cas.containerPorts.http }}

--- a/bitnami/chainloop/templates/controlplane/deployment.yaml
+++ b/bitnami/chainloop/templates/controlplane/deployment.yaml
@@ -98,8 +98,6 @@ spec:
           {{- end }}
           image: {{ include "chainloop.controlplane.image" . }}
           imagePullPolicy: {{ .Values.controlplane.image.pullPolicy }}
-          command: [ "./control-plane" ]
-          args: [ "--conf", "/data/conf" ]
           ports:
             - name: http
               containerPort: {{ .Values.controlplane.containerPorts.http }}


### PR DESCRIPTION
### Description of the change

Remove command and args in the deployments to use the default values.

### Benefits

It will make easier the transition to non scratch containers.

### Possible drawbacks

None. These values were hardcoded

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
