### PR TITLE
[bitnami/apache] fix CrashLoopBackOff when using cloneHtdocsFromGit

### DIFF
--- a/bitnami/apache/CHANGELOG.md
+++ b/bitnami/apache/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 11.2.13 (2024-07-25)
+## 11.2.14 (2024-08-14)
 
-* [bitnami/apache] Release 11.2.13 ([#28398](https://github.com/bitnami/charts/pull/28398))
+* [bitnami/apache] fix CrashLoopBackOff when using cloneHtdocsFromGit ([#28868](https://github.com/bitnami/charts/pull/28868))
+
+## <small>11.2.13 (2024-07-25)</small>
+
+* [bitnami/apache] Release 11.2.13 (#28398) ([08be0e2](https://github.com/bitnami/charts/commit/08be0e271998c1046f66d815ac5c411b46e3af29)), closes [#28398](https://github.com/bitnami/charts/issues/28398)
 
 ## <small>11.2.12 (2024-07-24)</small>
 

--- a/bitnami/apache/CHANGELOG.md
+++ b/bitnami/apache/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 11.2.14 (2024-08-14)
+## 11.2.14 (2024-08-15)
 
 * [bitnami/apache] fix CrashLoopBackOff when using cloneHtdocsFromGit ([#28868](https://github.com/bitnami/charts/pull/28868))
 

--- a/bitnami/apache/Chart.yaml
+++ b/bitnami/apache/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: apache
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/apache
-version: 11.2.13
+version: 11.2.14

--- a/bitnami/apache/templates/deployment.yaml
+++ b/bitnami/apache/templates/deployment.yaml
@@ -112,12 +112,18 @@ spec:
           {{- else if ne .Values.cloneHtdocsFromGit.resourcesPreset "none" }}
           resources: {{- include "common.resources.preset" (dict "type" .Values.cloneHtdocsFromGit.resourcesPreset) | nindent 12 }}
           {{- end }}
+          {{- if .Values.containerSecurityContext.enabled }}
+          securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.containerSecurityContext "context" $) | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: htdocs
               mountPath: /app
             - name: empty-dir
               mountPath: /tmp
               subPath: tmp-dir
+            - name: empty-dir
+              mountPath: /etc/ssh
+              subPath: etc-ssh-dir
           {{- if .Values.cloneHtdocsFromGit.extraVolumeMounts }}
             {{- include "common.tplvalues.render" (dict "value" .Values.cloneHtdocsFromGit.extraVolumeMounts "context" $) | nindent 12 }}
           {{- end }}
@@ -154,6 +160,9 @@ spec:
             - name: empty-dir
               mountPath: /tmp
               subPath: tmp-dir
+            - name: empty-dir
+              mountPath: /etc/ssh
+              subPath: etc-ssh-dir
           {{- if .Values.cloneHtdocsFromGit.extraVolumeMounts }}
             {{- include "common.tplvalues.render" (dict "value" .Values.cloneHtdocsFromGit.extraVolumeMounts "context" $) | nindent 12 }}
           {{- end }}


### PR DESCRIPTION

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

* `bitnami/git` container crashes running the `entrypoint.sh` when it attempts to create a ssh key on the readonly file system.  Issue introduced with the changes to add a security context in https://github.com/bitnami/charts/commit/6b0889197e33f20b93f84fee9e6917634f358efc.
* Added a `/etc/ssh` volume mount to `git-clone-repository` and `git-repo-syncer` so it doesn't fail writing SSH keys to the readonly file system.
* Added a `securityContext` to `git-clone-repository`. Previously the repo is cloned as root, then the syncer fails unable to overwrite files created by root.

### Benefits

No CrashLoopBackOff when using cloneHtdocsFromGit

### Possible drawbacks

None

### Applicable issues

- fixes #28845

### Additional information

Tested with:
```
helm install my-apache . \
  --set-string cloneHtdocsFromGit.repository=https://github.com/russau/static-site.git \
  --set-string cloneHtdocsFromGit.enabled=true \
  --set-string cloneHtdocsFromGit.branch=main
```

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
