### PR TITLE
[bitnami/valkey-cluster] Fix env-vars for metrics container

### DIFF
--- a/bitnami/valkey-cluster/CHANGELOG.md
+++ b/bitnami/valkey-cluster/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 0.1.8 (2024-07-31)
+## 0.1.9 (2024-08-14)
 
-* [bitnami/valkey-cluster] Release 0.1.8 ([#28609](https://github.com/bitnami/charts/pull/28609))
+* [bitnami/valkey-cluster] Fix env-vars for metrics container ([#28885](https://github.com/bitnami/charts/pull/28885))
+
+## <small>0.1.8 (2024-07-31)</small>
+
+* [bitnami/valkey-cluster] Release 0.1.8 (#28609) ([449f0fc](https://github.com/bitnami/charts/commit/449f0fcc372bd0a5e0eff5fb36acf34956143fd9)), closes [#28609](https://github.com/bitnami/charts/issues/28609)
 
 ## <small>0.1.7 (2024-07-29)</small>
 

--- a/bitnami/valkey-cluster/Chart.yaml
+++ b/bitnami/valkey-cluster/Chart.yaml
@@ -33,4 +33,4 @@ name: valkey-cluster
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/valkey-cluster
 - https://github.com/bitnami/containers/tree/main/bitnami/vakey-cluster
-version: 0.1.8
+version: 0.1.9

--- a/bitnami/valkey-cluster/templates/valkey-statefulset.yaml
+++ b/bitnami/valkey-cluster/templates/valkey-statefulset.yaml
@@ -320,37 +320,37 @@ spec:
             - -c
             - |
               {{- if .Values.usePasswordFile }}
-              export VALKEY_PASSWORD="$(< "${VALKEY_PASSWORD_FILE}")"
+              export REDIS_PASSWORD="$(< "${REDIS_PASSWORD_FILE}")"
               {{- end }}
-              valkey_exporter{{- range $key, $value := .Values.metrics.extraArgs }} --{{ $key }}={{ $value }}{{- end }}
+              redis_exporter{{- range $key, $value := .Values.metrics.extraArgs }} --{{ $key }}={{ $value }}{{- end }}
           {{- end }}
           env:
             - name: BITNAMI_DEBUG
               value: {{ ternary "true" "false" (or .Values.image.debug .Values.diagnosticMode.enabled) | quote }}
-            - name: VALKEY_ALIAS
+            - name: REDIS_ALIAS
               value: {{ template "common.names.fullname" . }}
-            - name: VALKEY_ADDR
+            - name: REDIS_ADDR
               value: {{ printf "%s://127.0.0.1:%g" (ternary "valkeys" "valkey" .Values.tls.enabled) .Values.valkey.containerPorts.valkey | quote }}
             {{- if and .Values.usePassword (not .Values.usePasswordFile) }}
-            - name: VALKEY_PASSWORD
+            - name: REDIS_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ template "valkey-cluster.secretName" . }}
                   key: {{ template "valkey-cluster.secretPasswordKey" . }}
             {{- end }}
             {{- if .Values.usePasswordFile }}
-            - name: VALKEY_PASSWORD_FILE
+            - name: REDIS_PASSWORD_FILE
               value: "/opt/bitnami/valkey/secrets/valkey-password"
             {{- end }}
             {{- if .Values.tls.enabled }}
-            - name: VALKEY_EXPORTER_TLS_CLIENT_KEY_FILE
+            - name: REDIS_EXPORTER_TLS_CLIENT_KEY_FILE
               value: {{ template "valkey-cluster.tlsCertKey" . }}
-            - name: VALKEY_EXPORTER_TLS_CLIENT_CERT_FILE
+            - name: REDIS_EXPORTER_TLS_CLIENT_CERT_FILE
               value: {{ template "valkey-cluster.tlsCert" . }}
-            - name: VALKEY_EXPORTER_TLS_CA_CERT_FILE
+            - name: REDIS_EXPORTER_TLS_CA_CERT_FILE
               value: {{ template "valkey-cluster.tlsCACert" . }}
             {{- end }}
-            - name: VALKEY_EXPORTER_WEB_LISTEN_ADDRESS
+            - name: REDIS_EXPORTER_WEB_LISTEN_ADDRESS
               value: {{ printf ":%v" .Values.metrics.containerPorts.http }}
             {{- if .Values.metrics.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.metrics.extraEnvVars "context" $) | nindent 12 }}


### PR DESCRIPTION
### Description of the change

`redis_exporter` does not adapt the env-vars to the `VALKEY_` format.

https://github.com/oliver006/redis_exporter?tab=readme-ov-file#command-line-flags

### Applicable issues

- fixes #28564

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] n/a ~Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)~
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
