### PR TITLE
[bitnami/argo-cd] Add missing verbs to ApplicationSet role

### DIFF
--- a/bitnami/argo-cd/CHANGELOG.md
+++ b/bitnami/argo-cd/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 7.0.1 (2024-08-16)
+## 7.0.2 (2024-08-16)
 
-* [bitnami/argo-cd] Release 7.0.1 ([#28911](https://github.com/bitnami/charts/pull/28911))
+* [bitnami/argo-cd] Add missing verbs to ApplicationSet role ([#28914](https://github.com/bitnami/charts/pull/28914))
+
+## <small>7.0.1 (2024-08-16)</small>
+
+* [bitnami/argo-cd] Release 7.0.1 (#28911) ([179665c](https://github.com/bitnami/charts/commit/179665c13f0dc2baaf3432655ed62ca1b81cbf4d)), closes [#28911](https://github.com/bitnami/charts/issues/28911)
 
 ## 7.0.0 (2024-08-13)
 

--- a/bitnami/argo-cd/CHANGELOG.md
+++ b/bitnami/argo-cd/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 7.0.2 (2024-08-16)
+## 7.0.2 (2024-08-17)
 
 * [bitnami/argo-cd] Add missing verbs to ApplicationSet role ([#28914](https://github.com/bitnami/charts/pull/28914))
 

--- a/bitnami/argo-cd/Chart.yaml
+++ b/bitnami/argo-cd/Chart.yaml
@@ -39,4 +39,4 @@ maintainers:
 name: argo-cd
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/argo-cd
-version: 7.0.1
+version: 7.0.2

--- a/bitnami/argo-cd/templates/applicationset/role.yaml
+++ b/bitnami/argo-cd/templates/applicationset/role.yaml
@@ -43,6 +43,8 @@ rules:
     - appprojects
     verbs:
     - get
+    - list
+    - watch
   - apiGroups:
     - ""
     resources:


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->
Add missing verbs (list, watch) to the ApplicationSet controller's role.

### Benefits

<!-- What benefits will be realized by the code change? -->
The new verbs are required since a recent update. Not granting them in the role results in errors in the ApplicationSet controller's logs, e.g.

(without `list`)

```
W0816 22:58:18.236433       1 reflector.go:539] pkg/mod/k8s.io/client-go@v0.29.6/tools/cache/reflector.go:229: failed to list *v1alpha1.AppProject: appprojects.argoproj.io is forbidden: User "system:serviceaccount:argocd:argocd-argo-cd-applicationset-controller" cannot list resource "appprojects" in API group "argoproj.io" in the namespace "argocd"
```

(without `watch`)

```
E0816 23:20:09.253511       1 reflector.go:147] pkg/mod/k8s.io/client-go@v0.29.6/tools/cache/reflector.go:229: Failed to watch *v1alpha1.AppProject: unknown (get appprojects.argoproj.io)
```

### Possible drawbacks

<!-- Describe any known limitations with your change -->
Overly broad privileges when overriding the controller's image to an older version. Not relevant imo

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
n/a

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
* upstream issue: https://github.com/argoproj/argo-cd/issues/18829
* upstream PR: https://github.com/argoproj/argo-cd/pull/18943

I've also tested these changes using chart version `7.0.0` and a quick `kubectl edit role -n argocd argocd-argo-cd-applicationset-controller`

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
