### PR TITLE
[bitnami/kibana] Increase wait for DOM content in Cypress test

### DIFF
--- a/.vib/kibana/cypress/cypress/e2e/kibana.cy.js
+++ b/.vib/kibana/cypress/cypress/e2e/kibana.cy.js
@@ -13,7 +13,7 @@ before(() => {
 
 it('allows uploading data', () => {
   // Wait for DOM content to load
-  cy.wait(2000);
+  cy.wait(10000);
   cy.get('body').then(($body) => {
     // Close welcome tutorial pop-up if present
     if ($body.find('[data-test-subj="skipWelcomeScreen"]').is(':visible')) {

--- a/bitnami/kibana/CHANGELOG.md
+++ b/bitnami/kibana/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 11.2.18 (2024-08-16)
+## 11.2.19 (2024-08-19)
 
-* [bitnami/kibana] Release 11.2.18 ([#28898](https://github.com/bitnami/charts/pull/28898))
+* [bitnami/kibana] Increase wait for DOM content in Cypress test ([#28924](https://github.com/bitnami/charts/pull/28924))
+
+## <small>11.2.18 (2024-08-16)</small>
+
+* [bitnami/kibana] Release 11.2.18 (#28898) ([9b955d2](https://github.com/bitnami/charts/commit/9b955d22fac1a09e2848a43d2d1dfe17b7d11808)), closes [#28898](https://github.com/bitnami/charts/issues/28898)
 
 ## <small>11.2.17 (2024-08-14)</small>
 

--- a/bitnami/kibana/Chart.yaml
+++ b/bitnami/kibana/Chart.yaml
@@ -32,4 +32,4 @@ maintainers:
 name: kibana
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/kibana
-version: 11.2.18
+version: 11.2.19


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change
Increase wait for DOM content in Cypress test/

### Benefits
Reduce failures for different scenarios that require more time to load.

### Possible drawbacks
N/A

### Additional information
Test fails on AKS with Photon OS 5.0 distro.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
