### PR TITLE
[bitnami/argo-cd] test: :white_check_mark: Improve resilience of cypress test

### DIFF
--- a/.vib/argo-cd/cypress/cypress/e2e/argo_cd.cy.js
+++ b/.vib/argo-cd/cypress/cypress/e2e/argo_cd.cy.js
@@ -55,7 +55,7 @@ it('allows deploying a healthy app for a new project', () => {
     cy.get('[qe-id="applications-list-button-create"]').click();
 
     cy.get('.applications-list').within(() => {
-      cy.contains(`${applications.newApplication.name}-${random}`, {timeout: 60000}).click();
+      cy.contains(`${applications.newApplication.name}-${random}`, {timeout: 60000}).click({force: true});
     });
   });
   // Ensure that UI shows the basic K8s objects

--- a/bitnami/argo-cd/CHANGELOG.md
+++ b/bitnami/argo-cd/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 7.0.2 (2024-08-17)
+## 7.0.3 (2024-08-20)
 
-* [bitnami/argo-cd] Add missing verbs to ApplicationSet role ([#28914](https://github.com/bitnami/charts/pull/28914))
+* [bitnami/argo-cd] test: :white_check_mark: Improve resilience of cypress test ([#28936](https://github.com/bitnami/charts/pull/28936))
+
+## <small>7.0.2 (2024-08-19)</small>
+
+* [bitnami/argo-cd] Add missing verbs to ApplicationSet role (#28914) ([69e8d7b](https://github.com/bitnami/charts/commit/69e8d7bfa54ff1892f0405d31d29aa988bd79440)), closes [#28914](https://github.com/bitnami/charts/issues/28914)
 
 ## <small>7.0.1 (2024-08-16)</small>
 

--- a/bitnami/argo-cd/Chart.yaml
+++ b/bitnami/argo-cd/Chart.yaml
@@ -39,4 +39,4 @@ maintainers:
 name: argo-cd
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/argo-cd
-version: 7.0.2
+version: 7.0.3


### PR DESCRIPTION
### Description of the change

Added a test change to the Argo CD Cypress tests to address an issue where the UI was not loading fast enough on some platforms, leading to an error when attempting to click on an element.

### Benefits

This change improves the reliability of the Cypress tests.

### Additional information

The error encountered was: 
```
'FAILURES: [Timed out retrying after 30050ms: `cy.click()` failed because this element: `<span class="applications-list__title" aria-expanded="false">all-new...</span>` is being covered by another element: `<div class="white-box">...</div>` Fix this problem, or use {force: true} to disable error checking. <https://on.cypress.io/element-cannot-be-interacted-with>
```

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](<http://semver.org/>). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](<https://github.com/bitnami/readme-generator-for-helm>)
- [x] Title of the pull request follows this pattern [bitnami/argo-cd] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](<https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work>)
