### PR TITLE
[bitnami/mongodb-sharded]Ginkgo tests: Use rollout instead of scale down

### DIFF
--- a/.vib/mongodb-sharded/ginkgo/mongodb_suite_test.go
+++ b/.vib/mongodb-sharded/ginkgo/mongodb_suite_test.go
@@ -36,12 +36,14 @@ func init() {
 	timeout = time.Duration(timeoutSeconds) * time.Second
 }
 
-func TestMariaDB(t *testing.T) {
+func TestMongoDBSharded(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "MongoDB Sharded Persistence Test Suite")
 }
 
 func createJob(ctx context.Context, c kubernetes.Interface, name, port, image, stmt string) error {
+	// Default job TTL in seconds
+	ttl := int32(10)
 	securityContext := &v1.SecurityContext{
 		Privileged:               &[]bool{false}[0],
 		AllowPrivilegeEscalation: &[]bool{false}[0],
@@ -61,6 +63,7 @@ func createJob(ctx context.Context, c kubernetes.Interface, name, port, image, s
 			Kind: "Job",
 		},
 		Spec: batchv1.JobSpec{
+			TTLSecondsAfterFinished: &ttl,
 			Template: v1.PodTemplateSpec{
 				Spec: v1.PodSpec{
 					RestartPolicy: "Never",

--- a/bitnami/mongodb-sharded/CHANGELOG.md
+++ b/bitnami/mongodb-sharded/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 8.3.4 (2024-07-25)
+## 8.3.5 (2024-08-20)
 
-* [bitnami/mongodb-sharded] Release 8.3.4 ([#28476](https://github.com/bitnami/charts/pull/28476))
+* [bitnami/mongodb-sharded]Ginkgo tests: Use rollout instead of scale down ([#28937](https://github.com/bitnami/charts/pull/28937))
+
+## <small>8.3.4 (2024-07-25)</small>
+
+* [bitnami/mongodb-sharded] Release 8.3.4 (#28476) ([a0f15d4](https://github.com/bitnami/charts/commit/a0f15d4092aab507d6a2e98f457bda516f5caf80)), closes [#28476](https://github.com/bitnami/charts/issues/28476)
 
 ## <small>8.3.3 (2024-07-24)</small>
 

--- a/bitnami/mongodb-sharded/Chart.yaml
+++ b/bitnami/mongodb-sharded/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: mongodb-sharded
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/mongodb-sharded
-version: 8.3.4
+version: 8.3.5


### PR DESCRIPTION
### Description of the change

Updates the ginkgo tests to use rollout restart instead of replica scale up/down
