### PR TITLE
[bitnami/common] Add option to remove empty seLinuxOptions from securityContext in non OpenShift environment

### DIFF
--- a/bitnami/common/CHANGELOG.md
+++ b/bitnami/common/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2.23.0 (2024-08-23)
+## 2.23.0 (2024-09-13)
 
 * [bitnami/common] Add option to remove empty seLinuxOptions from securityContext in non OpenShift environment ([#28945](https://github.com/bitnami/charts/pull/28945))
 

--- a/bitnami/common/CHANGELOG.md
+++ b/bitnami/common/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 2.22.0 (2024-08-07)
+## 2.23.0 (2024-08-23)
 
-* [bitnami/common] Fallback to chart appVersion in common.images.image ([#28764](https://github.com/bitnami/charts/pull/28764))
+* [bitnami/common] Add option to remove empty seLinuxOptions from securityContext in non OpenShift environment ([#28945](https://github.com/bitnami/charts/pull/28945))
+
+## 2.22.0 (2024-08-08)
+
+* [bitnami/common] Fallback to chart appVersion in common.images.image (#28764) ([b4aa0a6](https://github.com/bitnami/charts/commit/b4aa0a685a21c50ca10e41e3eb2023bbd4282cf7)), closes [#28764](https://github.com/bitnami/charts/issues/28764)
 
 ## 2.21.0 (2024-08-05)
 

--- a/bitnami/common/Chart.yaml
+++ b/bitnami/common/Chart.yaml
@@ -6,7 +6,7 @@ annotations:
   licenses: Apache-2.0
 apiVersion: v2
 # Please make sure that version and appVersion are always the same.
-appVersion: 2.22.0
+appVersion: 2.23.0
 description: A Library Helm Chart for grouping common logic between bitnami charts. This chart is not deployable by itself.
 home: https://bitnami.com
 icon: https://bitnami.com/downloads/logos/bitnami-mark.png
@@ -23,4 +23,4 @@ name: common
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/common
 type: library
-version: 2.22.0
+version: 2.23.0

--- a/bitnami/common/templates/_compatibility.tpl
+++ b/bitnami/common/templates/_compatibility.tpl
@@ -34,6 +34,7 @@ Usage:
     {{- end -}}
   {{- end -}}
 {{- end -}}
+{{/* Remove empty seLinuxOptions object if global.compatibility.omitEmptySeLinuxOptions is set to true */}}
 {{- if and (((.context.Values.global).compatibility).omitEmptySeLinuxOptions) (not .secContext.seLinuxOptions) -}}
   {{- $adaptedContext = omit $adaptedContext "seLinuxOptions" -}}
 {{- end -}}

--- a/bitnami/common/templates/_compatibility.tpl
+++ b/bitnami/common/templates/_compatibility.tpl
@@ -34,6 +34,9 @@ Usage:
     {{- end -}}
   {{- end -}}
 {{- end -}}
+{{- if and (((.context.Values.global).compatibility).omitEmptySeLinuxOptions) (not .secContext.seLinuxOptions) -}}
+  {{- $adaptedContext = omit $adaptedContext "seLinuxOptions" -}}
+{{- end -}}
 {{/* Remove fields that are disregarded when running the container in privileged mode */}}
 {{- if $adaptedContext.privileged -}}
   {{- $adaptedContext = omit $adaptedContext "capabilities" "seLinuxOptions" -}}

--- a/template/CHART_NAME/values.yaml
+++ b/template/CHART_NAME/values.yaml
@@ -28,6 +28,9 @@ global:
       ## @param global.compatibility.openshift.adaptSecurityContext Adapt the securityContext sections of the deployment to make them compatible with Openshift restricted-v2 SCC: remove runAsUser, runAsGroup and fsGroup and let the platform use their allowed default IDs. Possible values: auto (apply if the detected running cluster is Openshift), force (perform the adaptation always), disabled (do not perform adaptation)
       ##
       adaptSecurityContext: auto
+    ## @param global.compatibility.omitEmptySeLinuxOptions If set to true, removes the seLinuxOptions from the securityContexts when it is set to an empty object
+    ##
+    omitEmptySeLinuxOptions: false
 
 ## @section Common parameters
 ##


### PR DESCRIPTION
### Description of the change

Adding new `global.compatibility.omitEmptySeLinuxOption` option to conditionally remove empty/falsy `seLinuxOptions`property.

### Applicable issues

- fixes #28934

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
