### PR TITLE
[bitnami/wordpress] Fix php session mgmt

### DIFF
--- a/bitnami/wordpress/CHANGELOG.md
+++ b/bitnami/wordpress/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 23.1.5 (2024-08-21)
+## 23.1.6 (2024-08-22)
 
-* [bitnami/wordpress] Release 23.1.5 ([#28957](https://github.com/bitnami/charts/pull/28957))
+* [bitnami/wordpress] Fix php session mgmt ([#28974](https://github.com/bitnami/charts/pull/28974))
+
+## <small>23.1.5 (2024-08-21)</small>
+
+* [bitnami/wordpress] Release 23.1.5 (#28957) ([1f647f0](https://github.com/bitnami/charts/commit/1f647f06d1e2c4d1494f1ff5ca50964b10d48ec0)), closes [#28957](https://github.com/bitnami/charts/issues/28957)
 
 ## <small>23.1.4 (2024-08-15)</small>
 

--- a/bitnami/wordpress/CHANGELOG.md
+++ b/bitnami/wordpress/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 * [bitnami/wordpress] Fix php session mgmt ([#28974](https://github.com/bitnami/charts/pull/28974))
 
-## 23.1.7 (2024-08-22)
+## <small>23.1.7 (2024-08-22)</small>
 
-* [bitnami/wordpress] Release 23.1.7 ([#28979](https://github.com/bitnami/charts/pull/28979))
+* [bitnami/wordpress] Release 23.1.7 (#28979) ([899c4cc](https://github.com/bitnami/charts/commit/899c4cc32132ba25475c51444175f33e445bc53b)), closes [#28979](https://github.com/bitnami/charts/issues/28979)
 
 ## <small>23.1.6 (2024-08-22)</small>
 

--- a/bitnami/wordpress/Chart.yaml
+++ b/bitnami/wordpress/Chart.yaml
@@ -44,4 +44,4 @@ maintainers:
 name: wordpress
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/wordpress
-version: 23.1.5
+version: 23.1.6

--- a/bitnami/wordpress/templates/deployment.yaml
+++ b/bitnami/wordpress/templates/deployment.yaml
@@ -148,6 +148,11 @@ spec:
               info "Copying default PHP config"
               cp -r --preserve=mode /opt/bitnami/php/etc /emptydir/php-conf-dir
 
+              info "Copying php var directory"
+              if ! is_dir_empty /opt/bitnami/php/var; then
+                cp -r /opt/bitnami/php/var /emptydir/php-var-dir
+              fi
+
               info "Copy operation completed"
           volumeMounts:
             - name: empty-dir


### PR DESCRIPTION
### Description of the change

The php-var-dir needs to be pre-populated in the emptyDir volume to avoid issues in PHP session management.

Same fix as https://github.com/bitnami/charts/pull/25697 but for wordpress

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
