### PR TITLE
[bitnami/keycloak] Use database user secret key from PostgreSQL chart

### DIFF
--- a/bitnami/keycloak/CHANGELOG.md
+++ b/bitnami/keycloak/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 22.2.0 (2024-08-23)
+## 22.2.0 (2024-08-25)
 
 * [bitnami/keycloak] Use database user secret key from PostgreSQL chart ([#29008](https://github.com/bitnami/charts/pull/29008))
 

--- a/bitnami/keycloak/CHANGELOG.md
+++ b/bitnami/keycloak/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 22.1.3 (2024-08-22)
+## 22.2.0 (2024-08-23)
 
-* [bitnami/keycloak] Release 22.1.3 ([#28984](https://github.com/bitnami/charts/pull/28984))
+* [bitnami/keycloak] Use database user secret key from PostgreSQL chart ([#29008](https://github.com/bitnami/charts/pull/29008))
+
+## <small>22.1.3 (2024-08-22)</small>
+
+* [bitnami/keycloak] Release 22.1.3 (#28984) ([bb21c84](https://github.com/bitnami/charts/commit/bb21c84c422bdef42fad01db0252798d33e3499d)), closes [#28984](https://github.com/bitnami/charts/issues/28984)
 
 ## <small>22.1.2 (2024-08-19)</small>
 

--- a/bitnami/keycloak/Chart.yaml
+++ b/bitnami/keycloak/Chart.yaml
@@ -33,4 +33,4 @@ maintainers:
 name: keycloak
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/keycloak
-version: 22.1.3
+version: 22.2.0

--- a/bitnami/keycloak/README.md
+++ b/bitnami/keycloak/README.md
@@ -622,6 +622,7 @@ As an alternative, you can use of the preset configurations for pod affinity, po
 | `postgresql.auth.password`                   | Password for the custom user to create                                                                            | `""`               |
 | `postgresql.auth.database`                   | Name for a custom database to create                                                                              | `bitnami_keycloak` |
 | `postgresql.auth.existingSecret`             | Name of existing secret to use for PostgreSQL credentials                                                         | `""`               |
+| `postgresql.auth.secretKeys.userPasswordKey` | Name of key in existing secret to use for PostgreSQL credentials. Only used when `auth.existingSecret` is set.    | `password`         |
 | `postgresql.architecture`                    | PostgreSQL architecture (`standalone` or `replication`)                                                           | `standalone`       |
 | `externalDatabase.host`                      | Database host                                                                                                     | `""`               |
 | `externalDatabase.port`                      | Database port number                                                                                              | `5432`             |

--- a/bitnami/keycloak/templates/_helpers.tpl
+++ b/bitnami/keycloak/templates/_helpers.tpl
@@ -177,7 +177,7 @@ Add environment variables to configure database values
 */}}
 {{- define "keycloak.databaseSecretPasswordKey" -}}
 {{- if .Values.postgresql.enabled -}}
-    {{- print "password" -}}
+    {{- printf "%s" (.Values.postgresql.auth.secretKeys.userPasswordKey | default "password") -}}
 {{- else -}}
     {{- if .Values.externalDatabase.existingSecret -}}
         {{- if .Values.externalDatabase.existingSecretPasswordKey -}}

--- a/bitnami/keycloak/values.yaml
+++ b/bitnami/keycloak/values.yaml
@@ -1301,6 +1301,7 @@ keycloakConfigCli:
 ## @param postgresql.auth.password Password for the custom user to create
 ## @param postgresql.auth.database Name for a custom database to create
 ## @param postgresql.auth.existingSecret Name of existing secret to use for PostgreSQL credentials
+## @param postgresql.auth.secretKeys.userPasswordKey Name of key in existing secret to use for PostgreSQL credentials. Only used when `auth.existingSecret` is set.
 ## @param postgresql.architecture PostgreSQL architecture (`standalone` or `replication`)
 ##
 postgresql:
@@ -1311,6 +1312,8 @@ postgresql:
     password: ""
     database: bitnami_keycloak
     existingSecret: ""
+    secretKeys:
+      userPasswordKey: password
   architecture: standalone
 ## External PostgreSQL configuration
 ## All of these values are only used when postgresql.enabled is set to false


### PR DESCRIPTION
### Description of the change

Currently, a different database user secret key cannot be used in Keycloak, even if it can be changed in the PostgreSQL sub-chart.

The following does not affect Keycloak because the key is hard-coded in Keycloak:
```yaml
keycloak:
  postgresql:
    auth:
      secretKeys:
        userPasswordKey: "password-user"
```

Hence, the database user's secret key should be set to the one used in PostgreSQL (and fallback to `password`).

### Benefits

Allow to customize the database user secret key which is important if the user uses an existing secret.

### Possible drawbacks

No behavior change.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Additional information

None.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
