### PR TITLE
[bitnami/keycloak] fix: :bug: Add emptyDir at /bitnami to allow init scripts

### DIFF
--- a/bitnami/keycloak/CHANGELOG.md
+++ b/bitnami/keycloak/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 22.2.0 (2024-08-25)
+## 22.2.1 (2024-08-26)
 
-* [bitnami/keycloak] Use database user secret key from PostgreSQL chart ([#29008](https://github.com/bitnami/charts/pull/29008))
+* [bitnami/keycloak] fix: :bug: Add emptyDir at /bitnami to allow init scripts ([#29020](https://github.com/bitnami/charts/pull/29020))
+
+## 22.2.0 (2024-08-26)
+
+* [bitnami/keycloak] Use database user secret key from PostgreSQL chart (#29008) ([bf7ea4a](https://github.com/bitnami/charts/commit/bf7ea4a17dbe47ea0171dfae8415c4d035e7c8ad)), closes [#29008](https://github.com/bitnami/charts/issues/29008)
 
 ## <small>22.1.3 (2024-08-22)</small>
 

--- a/bitnami/keycloak/Chart.yaml
+++ b/bitnami/keycloak/Chart.yaml
@@ -33,4 +33,4 @@ maintainers:
 name: keycloak
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/keycloak
-version: 22.2.0
+version: 22.2.1

--- a/bitnami/keycloak/templates/statefulset.yaml
+++ b/bitnami/keycloak/templates/statefulset.yaml
@@ -285,6 +285,9 @@ spec:
               mountPath: /tmp
               subPath: tmp-dir
             - name: empty-dir
+              mountPath: /bitnami
+              subPath: app-volume-dir
+            - name: empty-dir
               mountPath: /opt/bitnami/keycloak/conf
               subPath: app-conf-dir
             - name: empty-dir


### PR DESCRIPTION
### Description of the change

This change adds an emptyDir volume mount to the `/bitnami` folder in the Keycloak deployment. This is necessary for the init scripts to work properly.

### Benefits

- Ensures that the init scripts have the necessary permissions and storage to function correctly.
- Improves the overall stability and reliability of the Keycloak deployment.

### Possible drawbacks

- Slight increase in resource usage due to the additional volume mount.

### Applicable issues

- fixes #15930

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/keycloak] Add emptyDir volume for init scripts
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)