### PR TITLE
[bitnami/mariadb] Fix deprecation warnings in checks

### DIFF
--- a/bitnami/mariadb/CHANGELOG.md
+++ b/bitnami/mariadb/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 19.0.4 (2024-08-14)
+## 19.0.5 (2024-08-26)
 
-* [bitnami/mariadb] Release 19.0.4 ([#28874](https://github.com/bitnami/charts/pull/28874))
+* [bitnami/mariadb] Fix deprecation warnings in checks ([#29021](https://github.com/bitnami/charts/pull/29021))
+
+## <small>19.0.4 (2024-08-14)</small>
+
+* [bitnami/mariadb] Release 19.0.4 (#28874) ([0f767f1](https://github.com/bitnami/charts/commit/0f767f1e215d103c10fa8e1661f023f807382036)), closes [#28874](https://github.com/bitnami/charts/issues/28874)
 
 ## <small>19.0.3 (2024-07-25)</small>
 

--- a/bitnami/mariadb/Chart.yaml
+++ b/bitnami/mariadb/Chart.yaml
@@ -34,4 +34,4 @@ maintainers:
 name: mariadb
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/mariadb
-version: 19.0.4
+version: 19.0.5

--- a/bitnami/mariadb/templates/primary/statefulset.yaml
+++ b/bitnami/mariadb/templates/primary/statefulset.yaml
@@ -240,7 +240,7 @@ spec:
                   if [[ -f "${MARIADB_ROOT_PASSWORD_FILE:-}" ]]; then
                       password_aux=$(cat "$MARIADB_ROOT_PASSWORD_FILE")
                   fi
-                  mysqladmin ping -uroot -p"${password_aux}"
+                  mariadb-admin ping -uroot -p"${password_aux}"
           {{- end }}
           {{- if .Values.primary.customLivenessProbe }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.primary.customLivenessProbe "context" $) | nindent 12 }}
@@ -255,7 +255,7 @@ spec:
                   if [[ -f "${MARIADB_ROOT_PASSWORD_FILE:-}" ]]; then
                       password_aux=$(cat "$MARIADB_ROOT_PASSWORD_FILE")
                   fi
-                  mysqladmin status -uroot -p"${password_aux}"
+                  mariadb-admin status -uroot -p"${password_aux}"
           {{- end }}
           {{- if .Values.primary.customReadinessProbe }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.primary.customReadinessProbe "context" $) | nindent 12 }}
@@ -270,7 +270,7 @@ spec:
                   if [[ -f "${MARIADB_ROOT_PASSWORD_FILE:-}" ]]; then
                       password_aux=$(cat "$MARIADB_ROOT_PASSWORD_FILE")
                   fi
-                  mysqladmin ping -uroot -p"${password_aux}"
+                  mariadb-admin ping -uroot -p"${password_aux}"
           {{- end }}
           {{- end }}
           {{- if .Values.primary.resources }}

--- a/bitnami/mariadb/templates/secondary/statefulset.yaml
+++ b/bitnami/mariadb/templates/secondary/statefulset.yaml
@@ -227,7 +227,7 @@ spec:
                   if [[ -f "${MARIADB_MASTER_ROOT_PASSWORD_FILE:-}" ]]; then
                       password_aux=$(cat "$MARIADB_MASTER_ROOT_PASSWORD_FILE")
                   fi
-                  mysqladmin ping -uroot -p"${password_aux}"
+                  mariadb-admin ping -uroot -p"${password_aux}"
           {{- end }}
           {{- if .Values.secondary.customLivenessProbe }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.secondary.customLivenessProbe "context" $) | nindent 12 }}
@@ -242,7 +242,7 @@ spec:
                   if [[ -f "${MARIADB_MASTER_ROOT_PASSWORD_FILE:-}" ]]; then
                       password_aux=$(cat "$MARIADB_MASTER_ROOT_PASSWORD_FILE")
                   fi
-                  mysqladmin status -uroot -p"${password_aux}"
+                  mariadb-admin status -uroot -p"${password_aux}"
           {{- end }}
           {{- if .Values.secondary.customReadinessProbe }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.secondary.customReadinessProbe "context" $) | nindent 12 }}
@@ -257,7 +257,7 @@ spec:
                   if [[ -f "${MARIADB_MASTER_ROOT_PASSWORD_FILE:-}" ]]; then
                       password_aux=$(cat "$MARIADB_MASTER_ROOT_PASSWORD_FILE")
                   fi
-                  mysqladmin ping -uroot -p"${password_aux}"
+                  mariadb-admin ping -uroot -p"${password_aux}"
           {{- end }}
           {{- end }}
           {{- if .Values.secondary.resources }}


### PR DESCRIPTION
### Description of the change

This fixes deprecation warnings in startup/liveness/readiness probes.

### Benefits

The `mysqladmin` command emits a deprecation warning, this is the first line of output, and this is the line that gets included in k8s events when a probe fails.  This obscures the actual error.

Before:
```
0s    Warning    Unhealthy    pod/mariadb-0    Readiness probe failed: mysqladmin: Deprecated program name. It will be removed in a future release, use '/opt/bitnami/mariadb/bin/mariadb-admin' instead...
```

After:
```
0s    Warning    Unhealthy    pod/mariadb-0    Readiness probe failed: mariadb-admin: connect to server at 'localhost' failed...
```

### Possible drawbacks

If people override the container image/version tag with something much older, it may not work.

### Applicable issues

Fixes #29016

### Other notes

Besides this, there's another deprecation message in the container logs:
```
mariadb 09:46:33.08 INFO  ==> ** Starting MariaDB **
/opt/bitnami/mariadb/sbin/mysqld: Deprecated program name. It will be removed in a future release, use '/opt/bitnami/mariadb/sbin/mariadbd' instead
```

This PR doesn't address that one.  I think it may be an entry/init script thing.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
