### PR TITLE
[bitnami/jupyterhub] Fix indents of singleuser extra volumes & mounts for #24458

### DIFF
--- a/bitnami/jupyterhub/CHANGELOG.md
+++ b/bitnami/jupyterhub/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 7.2.16 (2024-08-24)
+## 7.2.17 (2024-08-26)
 
-* [bitnami/jupyterhub] Release 7.2.16 ([#29014](https://github.com/bitnami/charts/pull/29014))
+* [bitnami/jupyterhub] Fix indents of singleuser extra volumes & mounts for #24458 ([#29032](https://github.com/bitnami/charts/pull/29032))
+
+## <small>7.2.16 (2024-08-24)</small>
+
+* [bitnami/jupyterhub] Release 7.2.16 (#29014) ([eaa5262](https://github.com/bitnami/charts/commit/eaa526250ca6eafe1ed19f78c81a5544c46ba1c8)), closes [#29014](https://github.com/bitnami/charts/issues/29014)
 
 ## <small>7.2.15 (2024-08-23)</small>
 

--- a/bitnami/jupyterhub/CHANGELOG.md
+++ b/bitnami/jupyterhub/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 7.2.17 (2024-08-26)
+## 7.2.17 (2024-08-27)
 
 * [bitnami/jupyterhub] Fix indents of singleuser extra volumes & mounts for #24458 ([#29032](https://github.com/bitnami/charts/pull/29032))
 

--- a/bitnami/jupyterhub/Chart.yaml
+++ b/bitnami/jupyterhub/Chart.yaml
@@ -37,4 +37,4 @@ maintainers:
 name: jupyterhub
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/jupyterhub
-version: 7.2.16
+version: 7.2.17

--- a/bitnami/jupyterhub/values.yaml
+++ b/bitnami/jupyterhub/values.yaml
@@ -227,14 +227,14 @@ hub:
           - name: empty-dir
             emptyDir: {}
           {{- if .Values.singleuser.extraVolumes }}
-          {{- include "common.tplvalues.render" ( dict "value" .Values.singleuser.extraVolumes "context" $ ) | nindent 4 }}
+          {{- include "common.tplvalues.render" ( dict "value" .Values.singleuser.extraVolumes "context" $ ) | nindent 6 }}
           {{- end }}
         extraVolumeMounts:
           - name: empty-dir
             mountPath: /tmp
             subPath: tmp-dir
           {{- if .Values.singleuser.extraVolumeMounts }}
-          {{- include "common.tplvalues.render" ( dict "value" .Values.singleuser.extraVolumeMounts "context" $ ) | nindent 4 }}
+          {{- include "common.tplvalues.render" ( dict "value" .Values.singleuser.extraVolumeMounts "context" $ ) | nindent 6 }}
           {{- end }}
         capacity: {{ .Values.singleuser.persistence.size }}
         homeMountPath: {{ .Values.singleuser.notebookDir }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Fix idents for extra volumes and extra volume mounts in the values of Jupyterhub.

### Benefits

The Singleuser deployment with configured extra volumes will be successful.

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #24458

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
