### PR TITLE
[bitnami/juypterhub] fix extraVolume-volMount chart values.yaml

### DIFF
--- a/bitnami/jupyterhub/CHANGELOG.md
+++ b/bitnami/jupyterhub/CHANGELOG.md
@@ -1,12 +1,12 @@
 # Changelog
 
-## 7.2.18 (2024-08-27)
+## 7.2.18 (2024-08-28)
 
 * [bitnami/juypterhub] fix extraVolume-volMount chart values.yaml ([#29067](https://github.com/bitnami/charts/pull/29067))
 
-## 7.2.17 (2024-08-27)
+## <small>7.2.17 (2024-08-28)</small>
 
-* [bitnami/jupyterhub] Fix indents of singleuser extra volumes & mounts for #24458 ([#29032](https://github.com/bitnami/charts/pull/29032))
+* [bitnami/jupyterhub] Fix indents of singleuser extra volumes & mounts for #24458 (#29032) ([0592bba](https://github.com/bitnami/charts/commit/0592bbaa59bc68adbd322d4cc3101249d582fde9)), closes [#24458](https://github.com/bitnami/charts/issues/24458) [#29032](https://github.com/bitnami/charts/issues/29032)
 
 ## <small>7.2.16 (2024-08-24)</small>
 

--- a/bitnami/jupyterhub/CHANGELOG.md
+++ b/bitnami/jupyterhub/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 7.2.16 (2024-08-24)
+## 7.2.17 (2024-08-27)
 
-* [bitnami/jupyterhub] Release 7.2.16 ([#29014](https://github.com/bitnami/charts/pull/29014))
+* [bitnami/juypterhub] fix extraVolume-volMount chart values.yaml ([#29067](https://github.com/bitnami/charts/pull/29067))
+
+## <small>7.2.16 (2024-08-24)</small>
+
+* [bitnami/jupyterhub] Release 7.2.16 (#29014) ([eaa5262](https://github.com/bitnami/charts/commit/eaa526250ca6eafe1ed19f78c81a5544c46ba1c8)), closes [#29014](https://github.com/bitnami/charts/issues/29014)
 
 ## <small>7.2.15 (2024-08-23)</small>
 

--- a/bitnami/jupyterhub/Chart.yaml
+++ b/bitnami/jupyterhub/Chart.yaml
@@ -37,4 +37,4 @@ maintainers:
 name: jupyterhub
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/jupyterhub
-version: 7.2.17
+version: 7.2.18

--- a/bitnami/jupyterhub/Chart.yaml
+++ b/bitnami/jupyterhub/Chart.yaml
@@ -37,4 +37,4 @@ maintainers:
 name: jupyterhub
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/jupyterhub
-version: 7.2.16
+version: 7.2.17

--- a/bitnami/jupyterhub/values.yaml
+++ b/bitnami/jupyterhub/values.yaml
@@ -227,14 +227,14 @@ hub:
           - name: empty-dir
             emptyDir: {}
           {{- if .Values.singleuser.extraVolumes }}
-          {{- include "common.tplvalues.render" ( dict "value" .Values.singleuser.extraVolumes "context" $ ) | nindent 4 }}
+          {{- include "common.tplvalues.render" ( dict "value" .Values.singleuser.extraVolumes "context" $ ) | nindent 6 }}
           {{- end }}
         extraVolumeMounts:
           - name: empty-dir
             mountPath: /tmp
             subPath: tmp-dir
           {{- if .Values.singleuser.extraVolumeMounts }}
-          {{- include "common.tplvalues.render" ( dict "value" .Values.singleuser.extraVolumeMounts "context" $ ) | nindent 4 }}
+          {{- include "common.tplvalues.render" ( dict "value" .Values.singleuser.extraVolumeMounts "context" $ ) | nindent 6 }}
           {{- end }}
         capacity: {{ .Values.singleuser.persistence.size }}
         homeMountPath: {{ .Values.singleuser.notebookDir }}


### PR DESCRIPTION
When using extra volumemounts or extra volumes, once rendered out the secret for jupyterhub-hub, key: values.yaml has a syntax error causing the pod to error loop. 
error: 
```
    yaml.parser.ParserError: while parsing a block mapping
      in "/usr/local/etc/jupyterhub/secret/values.yaml", line 76, column 5
    expected <block end>, but found '-'
      in "/usr/local/etc/jupyterhub/secret/values.yaml", line 87, column 5
```
Current values.yaml output:
```yaml
extraVolumes:
      - name: empty-dir
        emptyDir: {}
    - name: mountname1
      persistentVolumeClaim:
        claimName: my-pvc
    - name: mountname2
      persistentVolumeClaim:
        claimName: my-pvc-etc.
    extraVolumeMounts:
      - name: empty-dir
        mountPath: /tmp
        subPath: tmp-dir
    - mountPath: /mountname1
      name: mountname1
    - mountPath: /mountname1
      name: mountname2
```

The output should be fixed with PR suggestions
values.yaml output:
```yaml
extraVolumes:
      - name: empty-dir
        emptyDir: {}
      - name: mountname1
        persistentVolumeClaim:
          claimName: my-pvc
      - name: mountname2
        persistentVolumeClaim:
          claimName: my-pvc-etc.
    extraVolumeMounts:
      - name: empty-dir
        mountPath: /tmp
        subPath: tmp-dir
      - mountPath: /mountname1
         name: mountname1
      - mountPath: /mountname1
        name: mountname2
```

### Description of the change

Indexation is off by 2 spaces on extraVolumes and extraVolumeMounts

### Benefits

App is not broken on start-up

### Applicable issues

- fixes juypterhub failed startup when using additional volume mounts. 

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
