### PR TITLE
[bitnami/valkey-cluster] test: :white_check_mark: Improve ginkgo tests reliability

### DIFF
--- a/.vib/valkey-cluster/ginkgo/valkey_test.go
+++ b/.vib/valkey-cluster/ginkgo/valkey_test.go
@@ -78,6 +78,7 @@ var _ = Describe("Valkey Cluster", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			for i := 0; i < int(origReplicas); i++ {
+				By(fmt.Sprintf("Restart statefulset %s-%d", statName, i))
 				Eventually(func() (*v1.Pod, error) {
 					return c.CoreV1().Pods(namespace).Get(ctx, fmt.Sprintf("%s-%d", stsName, i), getOpts)
 				}, timeout, PollingInterval).Should(WithTransform(getRestartedAtAnnotation, Not(BeEmpty())))

--- a/.vib/valkey-cluster/ginkgo/valkey_test.go
+++ b/.vib/valkey-cluster/ginkgo/valkey_test.go
@@ -8,6 +8,7 @@ import (
 	utils "github.com/bitnami/charts/.vib/common-tests/ginkgo-utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/.vib/valkey-cluster/ginkgo/valkey_test.go
+++ b/.vib/valkey-cluster/ginkgo/valkey_test.go
@@ -78,7 +78,7 @@ var _ = Describe("Valkey Cluster", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			for i := 0; i < int(origReplicas); i++ {
-				By(fmt.Sprintf("Restart statefulset %s-%d", statName, i))
+				By(fmt.Sprintf("Restart statefulset %s-%d", stsName, i))
 				Eventually(func() (*v1.Pod, error) {
 					return c.CoreV1().Pods(namespace).Get(ctx, fmt.Sprintf("%s-%d", stsName, i), getOpts)
 				}, timeout, PollingInterval).Should(WithTransform(getRestartedAtAnnotation, Not(BeEmpty())))

--- a/.vib/valkey-cluster/ginkgo/valkey_test.go
+++ b/.vib/valkey-cluster/ginkgo/valkey_test.go
@@ -77,7 +77,7 @@ var _ = Describe("Valkey Cluster", Ordered, func() {
 			_, err = utils.StsRolloutRestart(ctx, c, ss)
 			Expect(err).NotTo(HaveOccurred())
 
-			for i := int(origReplicas) - 1; i >= int(origReplicas); i-- {
+			for i := int(origReplicas) - 1; i >= 0; i-- {
 				By(fmt.Sprintf("Restart statefulset %s-%d", stsName, i))
 				Eventually(func() (*v1.Pod, error) {
 					return c.CoreV1().Pods(namespace).Get(ctx, fmt.Sprintf("%s-%d", stsName, i), getOpts)

--- a/.vib/valkey-cluster/ginkgo/valkey_test.go
+++ b/.vib/valkey-cluster/ginkgo/valkey_test.go
@@ -77,7 +77,7 @@ var _ = Describe("Valkey Cluster", Ordered, func() {
 			_, err = utils.StsRolloutRestart(ctx, c, ss)
 			Expect(err).NotTo(HaveOccurred())
 
-			for i := 0; i < int(origReplicas); i++ {
+			for i := int(origReplicas) - 1; i >= int(origReplicas); i-- {
 				By(fmt.Sprintf("Restart statefulset %s-%d", stsName, i))
 				Eventually(func() (*v1.Pod, error) {
 					return c.CoreV1().Pods(namespace).Get(ctx, fmt.Sprintf("%s-%d", stsName, i), getOpts)

--- a/bitnami/valkey-cluster/CHANGELOG.md
+++ b/bitnami/valkey-cluster/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 0.1.9 (2024-08-14)
+## 0.1.10 (2024-08-28)
 
-* [bitnami/valkey-cluster] Fix env-vars for metrics container ([#28885](https://github.com/bitnami/charts/pull/28885))
+* [bitnami/valkey-cluster] test: :white_check_mark: Improve ginkgo tests reliability ([#29080](https://github.com/bitnami/charts/pull/29080))
+
+## <small>0.1.9 (2024-08-19)</small>
+
+* [bitnami/valkey-cluster] Fix env-vars for metrics container (#28885) ([1df2599](https://github.com/bitnami/charts/commit/1df2599056ee021039b91c7e6af3f37f086ebc27)), closes [#28885](https://github.com/bitnami/charts/issues/28885)
 
 ## <small>0.1.8 (2024-07-31)</small>
 

--- a/bitnami/valkey-cluster/Chart.yaml
+++ b/bitnami/valkey-cluster/Chart.yaml
@@ -33,4 +33,4 @@ name: valkey-cluster
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/valkey-cluster
 - https://github.com/bitnami/containers/tree/main/bitnami/vakey-cluster
-version: 0.1.9
+version: 0.1.10


### PR DESCRIPTION
### Description of the change

This PR modifies the ginkgo tests for the valkey-cluster chart to improve reliability. Specifically, it changes the "scale to 0 and back to n replicas" operation, which was used to ensure persistence, to a restart operation. This change addresses reliability issues encountered in some cloud environments where scaling to 0 caused problems with PVCs and occasionally led to race conditions.

### Benefits

- Improved test reliability across different cloud environments
- Reduced likelihood of PVC-related issues during testing
- Minimized occurrence of race conditions
- Maintained ability to verify persistence logic without compromising stability

### Possible drawbacks

- The restart operation may not cover all edge cases that the scale to 0 operation did, although it should be sufficient for verifying persistence in most scenarios

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/valkey-cluster] Improve ginkgo test reliability by replacing scale operation with restart
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)