### PR TITLE
[bitnami/cilium] fix: :bug: Use namespace to avoid collisions in hubble UI RBAC objects

### DIFF
--- a/bitnami/cilium/CHANGELOG.md
+++ b/bitnami/cilium/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 1.0.17 (2024-08-14)
+## 1.0.18 (2024-08-28)
 
-* [bitnami/cilium] Release 1.0.17 ([#28873](https://github.com/bitnami/charts/pull/28873))
+* [bitnami/cilium] fix: :bug: Use namespace to avoid collisions in hubble UI RBAC objects ([#29086](https://github.com/bitnami/charts/pull/29086))
+
+## <small>1.0.17 (2024-08-14)</small>
+
+* [bitnami/cilium] Release 1.0.17 (#28873) ([4c97202](https://github.com/bitnami/charts/commit/4c972028d79f46ec57eecab72c24c0b8c4f8b99b)), closes [#28873](https://github.com/bitnami/charts/issues/28873)
 
 ## <small>1.0.16 (2024-08-07)</small>
 

--- a/bitnami/cilium/Chart.yaml
+++ b/bitnami/cilium/Chart.yaml
@@ -52,4 +52,4 @@ sources:
 - https://github.com/bitnami/containers/tree/main/bitnami/hubble-relay
 - https://github.com/bitnami/containers/tree/main/bitnami/hubble-ui
 - https://github.com/bitnami/containers/tree/main/bitnami/hubble-ui-backend
-version: 1.0.17
+version: 1.0.18

--- a/bitnami/cilium/templates/_helpers.tpl
+++ b/bitnami/cilium/templates/_helpers.tpl
@@ -53,6 +53,13 @@ Return the proper Cilium Operator fullname (with namespace)
 {{- end -}}
 
 {{/*
+Return the proper Hubble UI fullname
+*/}}
+{{- define "cilium.hubble.ui.fullname.namespace" -}}
+{{- printf "%s-hubble-ui" (include "common.names.fullname.namespace" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
 Return the proper Cilium key-value store fullname
 */}}
 {{- define "cilium.kvstore.fullname" -}}

--- a/bitnami/cilium/templates/hubble-ui/rbac.yaml
+++ b/bitnami/cilium/templates/hubble-ui/rbac.yaml
@@ -9,7 +9,7 @@ SPDX-License-Identifier: APACHE-2.0
 kind: ClusterRole
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 metadata:
-  name: {{ template "cilium.hubble.ui.fullname" . }}
+  name: {{ template "cilium.hubble.ui.fullname.namespace" . }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: cilium
     app.kubernetes.io/component: hubble-ui
@@ -61,7 +61,7 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 metadata:
-  name: {{ template "cilium.hubble.ui.fullname" . }}
+  name: {{ template "cilium.hubble.ui.fullname.namespace" . }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: cilium
     app.kubernetes.io/component: hubble-ui
@@ -71,7 +71,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ template "cilium.hubble.ui.fullname" . }}
+  name: {{ template "cilium.hubble.ui.fullname.namespace" . }}
 subjects:
   - kind: ServiceAccount
     name: {{ template "cilium.hubble.ui.serviceAccountName" . }}


### PR DESCRIPTION
### Description of the change

This change updates the Hubble UI ClusterRole objects in the bitnami/cilium chart to use the fullname.namespace helper. This fix prevents collisions when deploying the chart multiple times in different namespaces.

### Benefits

- Allows multiple deployments of the cilium chart in different namespaces without ClusterRole conflicts

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/cilium] Fix Hubble UI ClusterRole naming to use fullname.namespace helper
- [ ] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)