### PR TITLE
[bitnami/keydb] ci: simplify goss tests

### DIFF
--- a/.vib/keydb/goss/goss.yaml
+++ b/.vib/keydb/goss/goss.yaml
@@ -3,7 +3,7 @@
 
 {{- $auth := printf "REDISCLI_AUTH='%s'" .Vars.auth.password }}
 {{- $tls := print "--tls --cacert /opt/bitnami/keydb/certs/ca.crt" }}
-{{- $master_endpoint := printf "-h keydb-master -p %d" .Vars.master.service.ports.keydb }}
+{{- $master_endpoint := printf "-h 127.0.0.1 -p %d" .Vars.master.containerPorts.keydb }}
 {{- $replicas_endpoint := printf "-h keydb-replica -p %d" .Vars.replica.service.ports.keydb }}
 {{- $replicas := .Vars.replica.replicaCount }}
 command:

--- a/bitnami/keydb/CHANGELOG.md
+++ b/bitnami/keydb/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 0.1.1 (2024-08-28)
+## 0.1.2 (2024-08-28)
 
-* [bitnami/keydb] Release 0.1.1 ([#29079](https://github.com/bitnami/charts/pull/29079))
+* [bitnami/keydb] ci: simplify goss tests ([#29088](https://github.com/bitnami/charts/pull/29088))
+
+## <small>0.1.1 (2024-08-28)</small>
+
+* [bitnami/keydb] Release 0.1.1 (#29079) ([5bbaa0f](https://github.com/bitnami/charts/commit/5bbaa0f47f562b11a55c273c8ec69c86204a0093)), closes [#29079](https://github.com/bitnami/charts/issues/29079)
 
 ## 0.1.0 (2024-08-28)
 

--- a/bitnami/keydb/Chart.yaml
+++ b/bitnami/keydb/Chart.yaml
@@ -34,4 +34,4 @@ name: keydb
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/keydb
 - https://github.com/bitnami/containers/tree/main/bitnami/keydb
-version: 0.1.1
+version: 0.1.2


### PR DESCRIPTION
### Description of the change

Goss tests are executed inside the `keydb-master-0` pod and, we're implicitly testing that `keydb-master` service works as expected (otherwise Replica pods won't be able to sync data from the master).

Therefore, we can simplify Goss tests and use `127.0.0.1` to run `keydb-cli` commands that target the master.

### Benefits

Simplify CI tests

### Possible drawbacks

None

### Applicable issues

None

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
