### PR TITLE
[bitnami/cilium] test: :white_check_mark: Improve resiliency of goss test

### DIFF
--- a/.vib/cilium/goss/goss-wait.yaml
+++ b/.vib/cilium/goss/goss-wait.yaml
@@ -1,0 +1,10 @@
+# Copyright Broadcom, Inc. All Rights Reserved.
+# SPDX-License-Identifier: APACHE-2.0
+
+addr:
+  tcp://cilium-agent-metrics:{{ .Vars.agent.metrics.service.port }}:
+    reachable: true
+    timeout: 60000
+  tcp://cilium-hubble-peers-metrics:{{ .Vars.hubble.peers.metrics.service.port }}:
+    reachable: true
+    timeout: 60000

--- a/.vib/cilium/vib-verify.json
+++ b/.vib/cilium/vib-verify.json
@@ -38,6 +38,9 @@
             },
             "tests_file": "cilium/goss/goss.yaml",
             "vars_file": "cilium/runtime-parameters.yaml",
+            "wait": {
+              "file": "cilium/goss/goss-wait.yaml"
+            },
             "remote": {
               "pod": {
                 "workload": "ds-cilium-agent"

--- a/bitnami/cilium/CHANGELOG.md
+++ b/bitnami/cilium/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 1.0.18 (2024-08-28)
+## 1.0.19 (2024-08-29)
 
-* [bitnami/cilium] fix: :bug: Use namespace to avoid collisions in hubble UI RBAC objects ([#29086](https://github.com/bitnami/charts/pull/29086))
+* [bitnami/cilium] test: :white_check_mark: Improve resiliency of goss test ([#29104](https://github.com/bitnami/charts/pull/29104))
+
+## <small>1.0.18 (2024-08-28)</small>
+
+* [bitnami/cilium] fix: :bug: Use namespace to avoid collisions in hubble UI RBAC objects (#29086) ([bda56fa](https://github.com/bitnami/charts/commit/bda56faff0bf3bfbb142955fea632e902446ef33)), closes [#29086](https://github.com/bitnami/charts/issues/29086)
 
 ## <small>1.0.17 (2024-08-14)</small>
 

--- a/bitnami/cilium/Chart.yaml
+++ b/bitnami/cilium/Chart.yaml
@@ -52,4 +52,4 @@ sources:
 - https://github.com/bitnami/containers/tree/main/bitnami/hubble-relay
 - https://github.com/bitnami/containers/tree/main/bitnami/hubble-ui
 - https://github.com/bitnami/containers/tree/main/bitnami/hubble-ui-backend
-version: 1.0.18
+version: 1.0.19


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->

This PR improves the test resiliency of the bitnami/cilium chart by addressing DNS resolution issues encountered on some platforms. The change adds a wait mechanism in the goss tests to ensure that all necessary services are ready before proceeding with DNS resolution checks.

### Benefits

<!-- What benefits will be realized by the code change? -->

1. Increased reliability of the test suite, particularly on platforms where services may take longer to become fully operational.
2. Reduction in false negative test results caused by premature DNS resolution attempts.



### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/cilium] Improve test resiliency by adding wait for DNS resolution
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)