### PR TITLE
[bitnami/cilium] test: :white_check_mark: Add a wait before goss test

### DIFF
--- a/.vib/cilium/goss/goss-wait.yaml
+++ b/.vib/cilium/goss/goss-wait.yaml
@@ -1,10 +1,6 @@
-# Copyright Broadcom, Inc. All Rights Reserved.
-# SPDX-License-Identifier: APACHE-2.0
-
-addr:
-  tcp://cilium-agent-metrics:{{ .Vars.agent.metrics.service.port }}:
-    reachable: true
-    timeout: 60000
-  tcp://cilium-hubble-peers-metrics:{{ .Vars.hubble.peers.metrics.service.port }}:
-    reachable: true
-    timeout: 60000
+command:
+  # Cilium requires to be stable before checking endpoints
+  wait-to-be-available:
+    exec: "sleep 300"
+    exit-status: 0
+    timeout: 310000

--- a/bitnami/cilium/CHANGELOG.md
+++ b/bitnami/cilium/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 1.0.19 (2024-08-29)
+## 1.0.20 (2024-08-29)
 
-* [bitnami/cilium] test: :white_check_mark: Improve resiliency of goss test ([#29104](https://github.com/bitnami/charts/pull/29104))
+* [bitnami/cilium] test: :white_check_mark: Add a wait before goss test ([#29108](https://github.com/bitnami/charts/pull/29108))
+
+## <small>1.0.19 (2024-08-29)</small>
+
+* [bitnami/cilium] test: :white_check_mark: Improve resiliency of goss test (#29104) ([2bb5384](https://github.com/bitnami/charts/commit/2bb5384294ed233bf040d87e1004fd885ce4a8e6)), closes [#29104](https://github.com/bitnami/charts/issues/29104)
 
 ## <small>1.0.18 (2024-08-28)</small>
 

--- a/bitnami/cilium/Chart.yaml
+++ b/bitnami/cilium/Chart.yaml
@@ -52,4 +52,4 @@ sources:
 - https://github.com/bitnami/containers/tree/main/bitnami/hubble-relay
 - https://github.com/bitnami/containers/tree/main/bitnami/hubble-ui
 - https://github.com/bitnami/containers/tree/main/bitnami/hubble-ui-backend
-version: 1.0.19
+version: 1.0.20


### PR DESCRIPTION
### Description of the change

This change adds a waiting time to the goss test to address issues we've been experiencing with goss testing and some endpoints. The modification introduces a delay before checking the endpoints, allowing more time for services to fully initialize.


### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/&lt;name_of_the_chart&gt;] Add wait time to goss test
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)