### PR TITLE
[bitnami/cassandra] Update readme to fix typo

### DIFF
--- a/bitnami/cassandra/README.md
+++ b/bitnami/cassandra/README.md
@@ -79,7 +79,7 @@ kubectl create secret generic my-exisiting-stores --from-file=./keystore --from-
 kubectl create secret generic my-stores-password --from-literal=keystore-password=KEYSTORE_PASSWORD --from-literal=truststore-password=TRUSTSTORE_PASSWORD
 ```
 
-Keystore and Truststore files can be dinamycally created from the certificates files. In this case a secret with the tls.crt, tls.key and ca.crt in pem format is required. The following example shows how the secret can be created and assumes that all certificate files are in the working directory:
+Keystore and Truststore files can be dynamically created from the certificates files. In this case a secret with the tls.crt, tls.key and ca.crt in pem format is required. The following example shows how the secret can be created and assumes that all certificate files are in the working directory:
 
 ```console
 kubectl create secret tls my-certs --cert ./tls.crt --key ./tls.key


### PR DESCRIPTION
### Description of the change

Fixed the typo and changed to "dynamically".

### Checklist

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
