### PR TITLE
[bitnami/mongodb-sharded] Changed to use namespaceOverride value when defining primaryhost in configsvr

### DIFF
--- a/bitnami/mongodb-sharded/CHANGELOG.md
+++ b/bitnami/mongodb-sharded/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 8.3.6 (2024-08-26)
+## 8.3.7 (2024-09-01)
 
-* [bitnami/mongodb-sharded] Release 8.3.6 ([#29028](https://github.com/bitnami/charts/pull/29028))
+* [bitnami/mongodb-sharded] Changed to use namespaceOverride value when defining primaryhost in configsvr ([#29145](https://github.com/bitnami/charts/pull/29145))
+
+## <small>8.3.6 (2024-08-26)</small>
+
+* [bitnami/mongodb-sharded] Release 8.3.6 (#29028) ([bc3ab9f](https://github.com/bitnami/charts/commit/bc3ab9fbfc042c1c4a17fe069b284bf0616c42dc)), closes [#29028](https://github.com/bitnami/charts/issues/29028)
 
 ## <small>8.3.5 (2024-08-20)</small>
 

--- a/bitnami/mongodb-sharded/Chart.yaml
+++ b/bitnami/mongodb-sharded/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: mongodb-sharded
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/mongodb-sharded
-version: 8.3.6
+version: 8.3.7

--- a/bitnami/mongodb-sharded/templates/_helpers.tpl
+++ b/bitnami/mongodb-sharded/templates/_helpers.tpl
@@ -33,7 +33,7 @@ Usage:
   {{- if .Values.configsvr.external.host -}}
   {{- .Values.configsvr.external.host }}
   {{- else -}}
-  {{- printf "%s-configsvr-0.%s-headless.%s.svc.%s" (include "common.names.fullname" . ) (include "common.names.fullname" .) .Release.Namespace .Values.clusterDomain -}}
+  {{- printf "%s-configsvr-0.%s-headless.%s.svc.%s" (include "common.names.fullname" . ) (include "common.names.fullname" .) (include "common.names.namespace" .) .Values.clusterDomain -}}
   {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

The namespace part of primaryhost in configsvr is modified to use `common.names.namespace`.

### Benefits

When installing helm, we can set a consistent namespace by simply setting the override namespace without passing a separate namespace argument. Therefore, mongodb-sharded charts become easier to use as subcharts.

### Possible drawbacks

N/A

### Applicable issues

- fixes #29142

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [ ] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [ ] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
