### PR TITLE
[bitnami/postgresql-ha] test: :white_check_mark: Improve ginkgo test reliability

### DIFF
--- a/.vib/postgresql-ha/ginkgo/postgresql_test.go
+++ b/.vib/postgresql-ha/ginkgo/postgresql_test.go
@@ -10,6 +10,7 @@ import (
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
@@ -38,6 +39,9 @@ var _ = Describe("Postgresql", Ordered, func() {
 			getAvailableReplicas := func(ss *appsv1.StatefulSet) int32 { return ss.Status.AvailableReplicas }
 			getSucceededJobs := func(j *batchv1.Job) int32 { return j.Status.Succeeded }
 			getOpts := metav1.GetOptions{}
+			restartKey := "kubectl.kubernetes.io/restartedAt"
+			restartAnnotation := map[string]string{restartKey: time.Now().Format(time.RFC3339)}
+			getRestartedAtAnnotation := func(pod *v1.Pod) string { return pod.Annotations[restartKey] }
 
 			By("checking all the replicas are available")
 			ss, err := c.AppsV1().StatefulSets(namespace).Get(ctx, stsName, getOpts)
@@ -72,17 +76,17 @@ var _ = Describe("Postgresql", Ordered, func() {
 				return c.BatchV1().Jobs(namespace).Get(ctx, createDBJobName, getOpts)
 			}, timeout, PollingInterval).Should(WithTransform(getSucceededJobs, Equal(int32(1))))
 
-			By("scaling down to 0 replicas")
-			ss, err = utils.StsScale(ctx, c, ss, 0)
+			By("running rollout restart")
+			// Annotate pods to force a rollout restart
+			ss, err = utils.StsAnnotateTemplate(ctx, c, ss, restartAnnotation)
 			Expect(err).NotTo(HaveOccurred())
 
-			Eventually(func() (*appsv1.StatefulSet, error) {
-				return c.AppsV1().StatefulSets(namespace).Get(ctx, stsName, getOpts)
-			}, timeout, PollingInterval).Should(WithTransform(getAvailableReplicas, BeZero()))
-
-			By("scaling up to the original replicas")
-			ss, err = utils.StsScale(ctx, c, ss, origReplicas)
-			Expect(err).NotTo(HaveOccurred())
+			// Wait for the new annotation in the existing pods
+			for i := int(origReplicas) - 1; i >= 0; i-- {
+				Eventually(func() (*v1.Pod, error) {
+					return c.CoreV1().Pods(namespace).Get(ctx, fmt.Sprintf("%s-%d", stsName, i), getOpts)
+				}, timeout, PollingInterval).Should(WithTransform(getRestartedAtAnnotation, Equal(restartAnnotation[restartKey])))
+			}
 
 			Eventually(func() (*appsv1.StatefulSet, error) {
 				return c.AppsV1().StatefulSets(namespace).Get(ctx, stsName, getOpts)

--- a/bitnami/postgresql-ha/CHANGELOG.md
+++ b/bitnami/postgresql-ha/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 14.2.19 (2024-08-30)
+## 14.2.20 (2024-09-03)
 
-* [bitnami/postgresql-ha] Release 14.2.19 ([#29123](https://github.com/bitnami/charts/pull/29123))
+* [bitnami/postgresql-ha] test: :white_check_mark: Improve ginkgo test reliability ([#29166](https://github.com/bitnami/charts/pull/29166))
+
+## <small>14.2.19 (2024-08-30)</small>
+
+* [bitnami/postgresql-ha] Release 14.2.19 (#29123) ([2f2875a](https://github.com/bitnami/charts/commit/2f2875a13ca7fdf326da080d5c733bd2c0b25f67)), closes [#29123](https://github.com/bitnami/charts/issues/29123)
 
 ## <small>14.2.18 (2024-08-24)</small>
 

--- a/bitnami/postgresql-ha/Chart.yaml
+++ b/bitnami/postgresql-ha/Chart.yaml
@@ -40,4 +40,4 @@ maintainers:
 name: postgresql-ha
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/postgresql-ha
-version: 14.2.19
+version: 14.2.20


### PR DESCRIPTION
### Description of the change

This PR modifies the ginkgo tests for the postgresql-ha chart to improve reliability. Specifically, it changes the "scale to 0 and back to n replicas" operation, which was used to ensure persistence, to a restart operation. This change addresses reliability issues encountered in some cloud environments where scaling to 0 caused problems with PVCs and occasionally led to race conditions.

### Benefits

- Improved test reliability across different cloud environments
- Reduced likelihood of PVC-related issues during testing
- Minimized occurrence of race conditions
- Maintained ability to verify persistence logic without compromising stability

### Possible drawbacks

- The restart operation may not cover all edge cases that the scale to 0 operation did, although it should be sufficient for verifying persistence in most scenarios

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/postgresql-ha] Improve ginkgo test reliability by replacing scale operation with restart
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)