### PR TITLE
[bitnami/apisix] Added multi-auth plugin to the plugins list

### DIFF
--- a/bitnami/apisix/CHANGELOG.md
+++ b/bitnami/apisix/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 3.3.10 (2024-08-20)
+## 3.3.11 (2024-09-03)
 
-* [bitnami/apisix] Release 3.3.10 ([#28942](https://github.com/bitnami/charts/pull/28942))
+* [bitnami/apisix] Added multi-auth plugin to the plugins list ([#29170](https://github.com/bitnami/charts/pull/29170))
+
+## <small>3.3.10 (2024-08-20)</small>
+
+* [bitnami/apisix] Release 3.3.10 (#28942) ([f7bd58e](https://github.com/bitnami/charts/commit/f7bd58e4b2842e0bf1bf2dcd0288beea98dd87a9)), closes [#28942](https://github.com/bitnami/charts/issues/28942)
 
 ## <small>3.3.9 (2024-07-25)</small>
 

--- a/bitnami/apisix/Chart.yaml
+++ b/bitnami/apisix/Chart.yaml
@@ -45,4 +45,4 @@ sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/apisix
 - https://github.com/bitnami/charts/tree/main/bitnami/apisix-dashboard
 - https://github.com/bitnami/charts/tree/main/bitnami/apisix-ingress-controller
-version: 3.3.10
+version: 3.3.11

--- a/bitnami/apisix/values.yaml
+++ b/bitnami/apisix/values.yaml
@@ -1822,6 +1822,8 @@ dashboard:
       - tencent-cloud-cls
       - ai
       - cas-auth
+      - multi-auth
+      
   ## @param dashboard.extraConfig extra configuration settings for APISIX Dashboard
   ##
   extraConfig: {}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->


### Description of the change
The `multi-auth` plugin that was added to APISIX in the 3.8.0 release is not available in the plugins list even though the APISIX version that is being used in 3.10.0 and I could see the plugin by shelling into the container.

https://apisix.apache.org/docs/apisix/next/plugins/multi-auth/

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
