### PR TITLE
[bitnami/cassandra] feat: :sparkles: Allow setting initdb scripts in values

### DIFF
--- a/bitnami/cassandra/CHANGELOG.md
+++ b/bitnami/cassandra/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 11.3.14 (2024-08-28)
+## 11.4.0 (2024-09-03)
 
-* [bitnami/cassandra] Release 11.3.14 ([#29077](https://github.com/bitnami/charts/pull/29077))
+* [bitnami/cassandra] feat: :sparkles: Allow setting initdb scripts in values ([#29172](https://github.com/bitnami/charts/pull/29172))
+
+## <small>11.3.14 (2024-08-28)</small>
+
+* [bitnami/cassandra] Release 11.3.14 (#29077) ([70e610c](https://github.com/bitnami/charts/commit/70e610c83801ad78a7d6370ee830df0ff97c129e)), closes [#29077](https://github.com/bitnami/charts/issues/29077)
 
 ## <small>11.3.13 (2024-08-21)</small>
 

--- a/bitnami/cassandra/Chart.yaml
+++ b/bitnami/cassandra/Chart.yaml
@@ -32,4 +32,4 @@ maintainers:
 name: cassandra
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/cassandra
-version: 11.3.14
+version: 11.4.0

--- a/bitnami/cassandra/README.md
+++ b/bitnami/cassandra/README.md
@@ -177,6 +177,7 @@ As the image run as non-root by default, it is necessary to adjust the ownership
 | `dbUser.forcePassword`        | Force the user to provide a non                                                                                        | `false`                     |
 | `dbUser.password`             | Password for `dbUser.user`. Randomly generated if empty                                                                | `""`                        |
 | `dbUser.existingSecret`       | Use an existing secret object for `dbUser.user` password (will ignore `dbUser.password`)                               | `""`                        |
+| `initDB`                      | Object with cql scripts. Useful for creating a keyspace and pre-populating data                                        | `{}`                        |
 | `initDBConfigMap`             | ConfigMap with cql scripts. Useful for creating a keyspace and pre-populating data                                     | `""`                        |
 | `initDBSecret`                | Secret with cql script (with sensitive data). Useful for creating a keyspace and pre-populating data                   | `""`                        |
 | `existingConfiguration`       | ConfigMap with custom cassandra configuration files. This overrides any other Cassandra configuration set in the chart | `""`                        |

--- a/bitnami/cassandra/templates/initdb-configmap.yaml
+++ b/bitnami/cassandra/templates/initdb-configmap.yaml
@@ -1,0 +1,19 @@
+{{- /*
+Copyright Broadcom, Inc. All Rights Reserved.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+{{- if and .Values.initDB (not .Values.initDBConfigMap) }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ printf "%s-init-scripts" (include "common.names.fullname" .) }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+    app.kubernetes.io/part-of: cassandra
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+data:
+{{- include "common.tplvalues.render" (dict "value" .Values.initDB "context" .) | nindent 2 }}
+{{ end }}

--- a/bitnami/cassandra/templates/statefulset.yaml
+++ b/bitnami/cassandra/templates/statefulset.yaml
@@ -462,7 +462,7 @@ spec:
             - name: certs-shared
               mountPath: /opt/bitnami/cassandra/certs
             {{- end }}
-            {{- if .Values.initDBConfigMap }}
+            {{- if or .Values.initDBConfigMap .Values.initDB }}
             - name: init-db-cm
               mountPath: /docker-entrypoint-initdb.d/configmap
             {{- end }}
@@ -566,10 +566,10 @@ spec:
         {{- end }}
         - name: empty-dir
           emptyDir: {}
-        {{- if .Values.initDBConfigMap }}
+        {{- if or .Values.initDB .Values.initDBConfigMap }}
         - name: init-db-cm
           configMap:
-            name: {{ tpl .Values.initDBConfigMap $ }}
+            name: {{ ternary (tpl .Values.initDBConfigMap $) (printf "%s-init-scripts" (include "common.names.fullname" .)) .Values.initDBConfigMap }}
         {{- end }}
         {{- if .Values.initDBSecret }}
         - name: init-db-secret

--- a/bitnami/cassandra/templates/statefulset.yaml
+++ b/bitnami/cassandra/templates/statefulset.yaml
@@ -569,7 +569,7 @@ spec:
         {{- if or .Values.initDB .Values.initDBConfigMap }}
         - name: init-db-cm
           configMap:
-            name: {{ ternary (tpl .Values.initDBConfigMap $) (printf "%s-init-scripts" (include "common.names.fullname" .)) .Values.initDBConfigMap }}
+            name: {{ ternary (printf "%s-init-scripts" (include "common.names.fullname" .)) (tpl .Values.initDBConfigMap $) (empty .Values.initDBConfigMap) }}
         {{- end }}
         {{- if .Values.initDBSecret }}
         - name: init-db-secret

--- a/bitnami/cassandra/values.yaml
+++ b/bitnami/cassandra/values.yaml
@@ -130,6 +130,9 @@ dbUser:
   ##     cassandra-password: myCassandraPasswordKey
   ##
   existingSecret: ""
+## @param initDB Object with cql scripts. Useful for creating a keyspace and pre-populating data
+##
+initDB: {}
 ## @param initDBConfigMap ConfigMap with cql scripts. Useful for creating a keyspace and pre-populating data
 ##
 initDBConfigMap: ""


### PR DESCRIPTION
### Description of the change

This pull request introduces a new feature to the bitnami/cassandra chart, allowing users to set init scripts directly in the `values.yaml` file. Previously, init scripts could only be set using configmaps or secrets. This change aligns with the functionality available in other charts, such as bitnami/mariadb and bitnami/mariadb-galera.

### Benefits

Users will have a more straightforward method for setting init scripts, improving ease of use and consistency across Bitnami charts.

### Possible drawbacks

n/a


### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/cassandra] Allow setting init scripts in values.yaml
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
