### PR TITLE
[bitnami/cassandra] test: :white_check_mark: Improve ginkgo testing reliability

### DIFF
--- a/.vib/cassandra/ginkgo/cassandra_test.go
+++ b/.vib/cassandra/ginkgo/cassandra_test.go
@@ -81,7 +81,7 @@ var _ = Describe("Cassandra", Ordered, func() {
 			_, err = utils.StsRolloutRestart(ctx, c, ss)
 			Expect(err).NotTo(HaveOccurred())
 
-			for i := 0; i < int(origReplicas); i++ {
+			for i := int(origReplicas) - 1; i >= 0; i-- {
 				Eventually(func() (*v1.Pod, error) {
 					return c.CoreV1().Pods(namespace).Get(ctx, fmt.Sprintf("%s-%d", stsName, i), getOpts)
 				}, timeout, PollingInterval).Should(WithTransform(getRestartedAtAnnotation, Not(BeEmpty())))

--- a/bitnami/cassandra/CHANGELOG.md
+++ b/bitnami/cassandra/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-## 11.4.0 (2024-09-03)
+## 11.4.1 (2024-09-03)
 
-* [bitnami/cassandra] feat: :sparkles: Allow setting initdb scripts in values ([#29172](https://github.com/bitnami/charts/pull/29172))
+* [bitnami/cassandra] test: :white_check_mark: Improve ginkgo testing reliability ([#29177](https://github.com/bitnami/charts/pull/29177))
 
 ## <small>11.3.14 (2024-08-28)</small>
 

--- a/bitnami/cassandra/Chart.yaml
+++ b/bitnami/cassandra/Chart.yaml
@@ -32,4 +32,4 @@ maintainers:
 name: cassandra
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/cassandra
-version: 11.4.0
+version: 11.4.1


### PR DESCRIPTION
### Description of the change

This pull request improves the resiliency of the tests in the bitnami/cassandra chart. The restart sequence for instances will now proceed from instance N-1 to 0, allowing for checks to be performed in the reverse order, ensuring a more robust verification process.

