### PR TITLE
[bitnami/clickhouse] Improve Ginkgo test

### DIFF
--- a/.vib/clickhouse/ginkgo/clickhouse_suite_test.go
+++ b/.vib/clickhouse/ginkgo/clickhouse_suite_test.go
@@ -32,7 +32,7 @@ func init() {
 	flag.StringVar(&username, "username", "", "database user")
 	flag.StringVar(&password, "password", "", "database password for username")
 	flag.IntVar(&shards, "shards", 2, "number of shards")
-	flag.IntVar(&timeoutSeconds, "timeout", 180, "timeout in seconds")
+	flag.IntVar(&timeoutSeconds, "timeout", 300, "timeout in seconds")
 	timeout = time.Duration(timeoutSeconds) * time.Second
 }
 

--- a/.vib/clickhouse/ginkgo/clickhouse_test.go
+++ b/.vib/clickhouse/ginkgo/clickhouse_test.go
@@ -10,6 +10,7 @@ import (
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
@@ -35,6 +36,7 @@ var _ = Describe("ClickHouse", Ordered, func() {
 
 			getAvailableReplicas := func(ss *appsv1.StatefulSet) int32 { return ss.Status.AvailableReplicas }
 			getSucceededJobs := func(j *batchv1.Job) int32 { return j.Status.Succeeded }
+			getRestartedAtAnnotation := func(pod *v1.Pod) string { return pod.Annotations["kubectl.kubernetes.io/restartedAt"] }
 			getOpts := metav1.GetOptions{}
 
 			image := ""
@@ -74,21 +76,24 @@ var _ = Describe("ClickHouse", Ordered, func() {
 				return c.BatchV1().Jobs(namespace).Get(ctx, createDBJobName, getOpts)
 			}, timeout, PollingInterval).Should(WithTransform(getSucceededJobs, Equal(int32(1))))
 
+			By("deleting the job once it has succeeded")
+			err = c.BatchV1().Jobs(namespace).Delete(ctx, createDBJobName, metav1.DeleteOptions{})
+
 			for i := 0; i < shards; i++ {
-				By(fmt.Sprintf("Scaling shard %d down to 0 replicas", i))
 				shardName := fmt.Sprintf("%s-shard%d", releaseName, i)
 				ss, err := c.AppsV1().StatefulSets(namespace).Get(ctx, shardName, getOpts)
 				shardOrigReplicas := *ss.Spec.Replicas
-				ss, err = utils.StsScale(ctx, c, ss, 0)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(ss.Status.Replicas).NotTo(BeZero())
-				Eventually(func() (*appsv1.StatefulSet, error) {
-					return c.AppsV1().StatefulSets(namespace).Get(ctx, shardName, getOpts)
-				}, timeout, PollingInterval).Should(WithTransform(getAvailableReplicas, BeZero()))
 
-				By(fmt.Sprintf("Scaling shard %d to the original replicas", i))
-				ss, err = utils.StsScale(ctx, c, ss, shardOrigReplicas)
+				Expect(ss.Status.Replicas).NotTo(BeZero())
+				By("rollout restart the statefulset")
+				_, err = utils.StsRolloutRestart(ctx, c, ss)
 				Expect(err).NotTo(HaveOccurred())
+
+				for i := 0; i < int(shardOrigReplicas); i++ {
+					Eventually(func() (*v1.Pod, error) {
+						return c.CoreV1().Pods(namespace).Get(ctx, fmt.Sprintf("%s-%d", shardName, i), getOpts)
+					}, timeout, PollingInterval).Should(WithTransform(getRestartedAtAnnotation, Not(BeEmpty())))
+				}
 
 				Eventually(func() (*appsv1.StatefulSet, error) {
 					return c.AppsV1().StatefulSets(namespace).Get(ctx, shardName, getOpts)
@@ -104,6 +109,9 @@ var _ = Describe("ClickHouse", Ordered, func() {
 			Eventually(func() (*batchv1.Job, error) {
 				return c.BatchV1().Jobs(namespace).Get(ctx, deleteDBJobName, getOpts)
 			}, timeout, PollingInterval).Should(WithTransform(getSucceededJobs, Equal(int32(1))))
+			By("deleting the job once it has succeeded")
+			err = c.BatchV1().Jobs(namespace).Delete(ctx, deleteDBJobName, metav1.DeleteOptions{})
+			Expect(err).NotTo(HaveOccurred())
 		})
 	})
 

--- a/bitnami/clickhouse/CHANGELOG.md
+++ b/bitnami/clickhouse/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 6.2.20 (2024-09-03)
+## 6.2.21 (2024-09-05)
 
-* [bitnami/clickhouse] Release 6.2.20 ([#29176](https://github.com/bitnami/charts/pull/29176))
+* [bitnami/clickhouse] Improve Ginkgo test ([#29213](https://github.com/bitnami/charts/pull/29213))
+
+## <small>6.2.20 (2024-09-03)</small>
+
+* [bitnami/clickhouse] Release 6.2.20 (#29176) ([cfdd018](https://github.com/bitnami/charts/commit/cfdd018c876f167b586f488d4ad0430460e172a7)), closes [#29176](https://github.com/bitnami/charts/issues/29176)
 
 ## <small>6.2.19 (2024-08-22)</small>
 

--- a/bitnami/clickhouse/Chart.yaml
+++ b/bitnami/clickhouse/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: clickhouse
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/clickhouse
-version: 6.2.20
+version: 6.2.21


### PR DESCRIPTION
### Description of the change

This PR improves Ginkgo tests reliability for Clickhouse chart by replacing scaling down to 0 and up to the original number of replicas by running a "rollout restart" on the statefulset pods.

The former mechanism is problematic due to an existing mechanism on provisioning service that delete PVC(s) which status is available every 30 seconds (grace period).


### Possible drawbacks

N/A

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
