### PR TITLE
[bitnami/cilium] Rollout restart Cilium sub-components for better VIB reliability

### DIFF
--- a/.vib/cilium/runtime-parameters.yaml
+++ b/.vib/cilium/runtime-parameters.yaml
@@ -52,4 +52,67 @@ hubble:
       ports:
         http: 80
       type: LoadBalancer
+extraDeploy:
+- |
+  apiVersion: rbac.authorization.k8s.io/v1
+  kind: Role
+  metadata:
+    name: deployment-restart
+    namespace: "{{ include "common.names.namespace" . }}"
+  rules:
+    - apiGroups: ["apps"]
+      resources: ["deployments"]
+      verbs: ["get", "update", "patch"]
+    - apiGroups: ["apps"]
+      resources: ["daemonsets"]
+      verbs: ["get", "list", "watch"]
+    - apiGroups: [""]
+      resources: ["pods"]
+      verbs: ["get", "list"]
+  ---
+  apiVersion: rbac.authorization.k8s.io/v1
+  kind: RoleBinding
+  metadata:
+    name: deployment-restart
+    namespace: {{ include "common.names.namespace" . }}
+  subjects:
+  - kind: ServiceAccount
+    name: deployment-restarter
+    namespace: {{ include "common.names.namespace" . }}
+  roleRef:
+    kind: Role
+    name: deployment-restart
+  ---
+  apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    name: deployment-restarter
+    namespace: {{ include "common.names.namespace" . }}
+  ---
+  apiVersion: batch/v1
+  kind: Job
+  metadata:
+    name: deployment-restarter
+    namespace: {{ include "common.names.namespace" . }}
+  spec:
+    template:
+      spec:
+        automountServiceAccountToken: true
+        serviceAccountName: deployment-restarter
+        restartPolicy: OnFailure
+        containers:
+          - name: kubectl
+            image: docker.io/bitnami/kubectl:latest
+            command:
+              - /bin/bash
+            args:
+              - -ec
+              - |
+                set -o errexit
+                set -o nounset
+                set -o pipefail
 
+                kubectl rollout status --namespace {{ include "common.names.namespace" . }} daemonset {{ include "cilium.agent.fullname" . }}
+                echo "Cilium agents are ready"
+                kubectl rollout restart deployment --namespace {{ include "common.names.namespace" . }} {{ include "cilium.hubble.relay.fullname" . }}
+                kubectl rollout restart deployment --namespace {{ include "common.names.namespace" . }} {{ include "cilium.hubble.ui.fullname" . }}

--- a/bitnami/cilium/CHANGELOG.md
+++ b/bitnami/cilium/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 1.2.1 (2024-09-05)
+## 1.2.2 (2024-09-06)
 
-* [bitnami/cilium] Release 1.2.1 ([#29229](https://github.com/bitnami/charts/pull/29229))
+* [bitnami/cilium] Rollout restart Cilium sub-components for better VIB reliability ([#29268](https://github.com/bitnami/charts/pull/29268))
+
+## <small>1.2.1 (2024-09-05)</small>
+
+* [bitnami/cilium] Release 1.2.1 (#29229) ([3f63741](https://github.com/bitnami/charts/commit/3f637418fd624a1fe2810964a4c1449ab74b9498)), closes [#29229](https://github.com/bitnami/charts/issues/29229)
 
 ## 1.2.0 (2024-09-05)
 

--- a/bitnami/cilium/Chart.yaml
+++ b/bitnami/cilium/Chart.yaml
@@ -52,4 +52,4 @@ sources:
 - https://github.com/bitnami/containers/tree/main/bitnami/hubble-relay
 - https://github.com/bitnami/containers/tree/main/bitnami/hubble-ui
 - https://github.com/bitnami/containers/tree/main/bitnami/hubble-ui-backend
-version: 1.2.1
+version: 1.2.2

--- a/bitnami/cilium/templates/NOTES.txt
+++ b/bitnami/cilium/templates/NOTES.txt
@@ -24,6 +24,11 @@ In order to replicate the container startup scripts execute this command:
 
 {{- else }}
 
+IMPORTANT: Cilium can only take ownership of CNI on a node after starting. Therefore, pods starting before Cilium runs on a given node may get IPs from the pre-configured CNI.
+It is recommended to rollout restart pre-existing pods in your cluster. Read more about this topic in the upstream docs below:
+
+  https://docs.cilium.io/en/latest/installation/taints
+
 Watch the Cilium Agent daemonset status using the command:
 
     kubectl get daemonset -w --namespace {{ include "common.names.namespace" . }} -l app.kubernetes.io/name={{ include "common.names.name" . }},app.kubernetes.io/instance={{ .Release.Name }},app.kubernetes.io/component=agent


### PR DESCRIPTION
### Description of the change

This PR introduces a K8s job for VIB testing that rollout restarts Cilium sub-components deployments after Cilium agents are ready.

It also adds a note in NOTES.txt warning users about unmanaged pods.

### Benefits

Ensure Cilium sub-components aren't assigned IPs from the pre-configured CNI.

### Possible drawbacks

None

### Applicable issues

None

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
