### PR TITLE
[bitnami/nginx] Release 18.1.12 - bugfix prometheusrules label collision

### DIFF
--- a/bitnami/nginx/CHANGELOG.md
+++ b/bitnami/nginx/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 18.1.11 (2024-08-23)
+## 18.1.12 (2024-09-06)
 
-* [bitnami/nginx] Release 18.1.11 ([#28993](https://github.com/bitnami/charts/pull/28993))
+* [bitnami/nginx] Release 18.1.12 - bugfix prometheusrules label collision ([#29276](https://github.com/bitnami/charts/pull/29276))
+
+## <small>18.1.11 (2024-08-23)</small>
+
+* [bitnami/nginx] Release 18.1.11 (#28993) ([34e0c37](https://github.com/bitnami/charts/commit/34e0c3727b2b67d946bda7b7250be6bc88dfc4e3)), closes [#28993](https://github.com/bitnami/charts/issues/28993)
 
 ## <small>18.1.10 (2024-08-21)</small>
 

--- a/bitnami/nginx/Chart.yaml
+++ b/bitnami/nginx/Chart.yaml
@@ -34,4 +34,4 @@ maintainers:
 name: nginx
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/nginx
-version: 18.1.11
+version: 18.1.12

--- a/bitnami/nginx/templates/prometheusrules.yaml
+++ b/bitnami/nginx/templates/prometheusrules.yaml
@@ -10,7 +10,6 @@ metadata:
   name: {{ include "common.names.fullname" . }}
   namespace: {{ default (include "common.names.namespace" .) .Values.metrics.prometheusRule.namespace | quote }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
-    app.kubernetes.io/component: nginx
     app.kubernetes.io/component: metrics
     {{- if .Values.metrics.prometheusRule.additionalLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.metrics.prometheusRule.additionalLabels "context" $ ) | nindent 4 }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->
This change removes a conflicting label from the prometheusrules template. Two labels with the key 'app.kubernetes.io/component' existed. This is not possible, and caused issues with FluxCD. This change removes the first label 'app.kubernetes.io/component=nginx' as it was overwritten with 'app.kubernetes.io/component=metrics' during manual installs anyways.


### Benefits

<!-- What benefits will be realized by the code change? -->
This chart can be deployed by FluxCD

### Possible drawbacks

<!-- Describe any known limitations with your change -->
None

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
