### PR TITLE
[bitnami/logstash] fix #29129 missing protocol in networkPolicy

### DIFF
--- a/bitnami/logstash/CHANGELOG.md
+++ b/bitnami/logstash/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 6.3.3 (2024-09-06)
+## 6.3.4 (2024-09-06)
 
-* [bitnami/logstash] Release 6.3.3 ([#29250](https://github.com/bitnami/charts/pull/29250))
+* [bitnami/logstash] fix #29129 missing protocol in networkPolicy ([#29277](https://github.com/bitnami/charts/pull/29277))
+
+## <small>6.3.3 (2024-09-06)</small>
+
+* [bitnami/logstash] Release 6.3.3 (#29250) ([8a7a49b](https://github.com/bitnami/charts/commit/8a7a49b1f3070436c4bb0cf7074c827b16116852)), closes [#29250](https://github.com/bitnami/charts/issues/29250)
 
 ## <small>6.3.2 (2024-08-08)</small>
 

--- a/bitnami/logstash/Chart.yaml
+++ b/bitnami/logstash/Chart.yaml
@@ -30,4 +30,4 @@ maintainers:
 name: logstash
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/logstash
-version: 6.3.3
+version: 6.3.4

--- a/bitnami/logstash/templates/networkpolicy.yaml
+++ b/bitnami/logstash/templates/networkpolicy.yaml
@@ -39,9 +39,11 @@ spec:
     - ports:
         {{- range .Values.containerPorts }}
         - port: {{ .containerPort }}
+          protocol: {{ default "TCP" .protocol }}
         {{- end }}
         {{- range .Values.service.ports }}
         - port: {{ .port }}
+          protocol: {{ default "TCP" .protocol }}
         {{- end }}
       to:
         - podSelector:
@@ -54,9 +56,11 @@ spec:
     - ports:
         {{- range .Values.containerPorts }}
         - port: {{ .containerPort }}
+          protocol: {{ default "TCP" .protocol }}
         {{- end }}
         {{- range .Values.extraContainerPorts }}
         - port: {{ . }}
+          protocol: {{ default "TCP" .protocol }}
         {{- end }}
         {{- if .Values.enableMonitoringAPI }}
         - port: {{ .Values.monitoringAPIPort }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Fixes the missing protocol in computed NetworkPolicy for logstash.

### Benefits

We can now open ports on UDP protocol.

### Possible drawbacks

I don't see any.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #29129 

### Additional information

None

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm) **Not needed**
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
