### PR TITLE
[bitnami/keycloak] Specify which keys must the secret have for jks in values.yaml comments

### DIFF
--- a/bitnami/keycloak/CHANGELOG.md
+++ b/bitnami/keycloak/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 22.2.1 (2024-08-26)
+## 22.2.2 (2024-09-09)
 
-* [bitnami/keycloak] fix: :bug: Add emptyDir at /bitnami to allow init scripts ([#29020](https://github.com/bitnami/charts/pull/29020))
+* [bitnami/keycloak] Specify which keys must the secret have for jks in values.yaml comments ([#29301](https://github.com/bitnami/charts/pull/29301))
+
+## <small>22.2.1 (2024-08-26)</small>
+
+* [bitnami/keycloak] fix: :bug: Add emptyDir at /bitnami to allow init scripts (#29020) ([3d04a65](https://github.com/bitnami/charts/commit/3d04a655e59ce25587d84b1a2a44844dfcf19de3)), closes [#29020](https://github.com/bitnami/charts/issues/29020)
 
 ## 22.2.0 (2024-08-26)
 

--- a/bitnami/keycloak/Chart.yaml
+++ b/bitnami/keycloak/Chart.yaml
@@ -33,4 +33,4 @@ maintainers:
 name: keycloak
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/keycloak
-version: 22.2.1
+version: 22.2.2

--- a/bitnami/keycloak/values.yaml
+++ b/bitnami/keycloak/values.yaml
@@ -166,7 +166,7 @@ tls:
   ##
   existingSecret: ""
   ## @param tls.usePem Use PEM certificates as input instead of PKS12/JKS stores
-  ## If "true", the Keycloak chart will look for the files keycloak.key and keycloak.crt inside the secret provided with 'existingSecret'.
+  ## If "true", the Keycloak chart will look for the files tls.key and tls.crt inside the secret provided with 'existingSecret'.
   ##
   usePem: false
   ## @param tls.truststoreFilename Truststore filename inside the existing secret
@@ -182,6 +182,7 @@ tls:
   ##
   truststorePassword: ""
   ## @param tls.passwordsSecret Secret containing the Keystore and Truststore passwords.
+  ## The secret must have "tls-keystore-password" and "tls-truststore-password" keys for the keystore and truststore respectively.
   ##
   passwordsSecret: ""
 ## SPI TLS settings
@@ -202,6 +203,7 @@ spi:
   ##
   truststoreFilename: "keycloak-spi.truststore.jks"
   ## @param spi.passwordsSecret Secret containing the SPI Truststore passwords.
+  ## The secret must have "spi-truststore-password" key.
   ##
   passwordsSecret: ""
   ## @param spi.hostnameVerificationPolicy Verify the hostname of the server's certificate. Allowed values: "ANY", "WILDCARD", "STRICT".


### PR DESCRIPTION
### Description of the change

Just make the comments clearer about what keys are required for the password of jks truststore and keystore.
Also, remove the contradicting comment about `usePem` stating that it will search for `keycloak.crt` and  `keycloak.key` while in reality it uses `tls.key` and `tls.crt`.


### Benefits

Document the right behaviour.

### Checklist

- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)