### PR TITLE
[bitnami/clickhouse] fix: Add missing version, kind to volumeClaimTemplates

### DIFF
--- a/bitnami/clickhouse/CHANGELOG.md
+++ b/bitnami/clickhouse/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 6.2.22 (2024-09-06)
+## 6.2.23 (2024-09-09)
 
-* [bitnami/clickhouse] Release 6.2.22 ([#29285](https://github.com/bitnami/charts/pull/29285))
+* [bitnami/clickhouse] fix: Add missing version, kind to volumeClaimTemplates ([#29304](https://github.com/bitnami/charts/pull/29304))
+
+## <small>6.2.22 (2024-09-06)</small>
+
+* [bitnami/clickhouse] Release 6.2.22 (#29285) ([6a90f23](https://github.com/bitnami/charts/commit/6a90f23e7a5c5dd4db87e18589ace4f4359c66ba)), closes [#29285](https://github.com/bitnami/charts/issues/29285)
 
 ## <small>6.2.21 (2024-09-05)</small>
 

--- a/bitnami/clickhouse/Chart.yaml
+++ b/bitnami/clickhouse/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: clickhouse
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/clickhouse
-version: 6.2.22
+version: 6.2.23

--- a/bitnami/clickhouse/templates/statefulset.yaml
+++ b/bitnami/clickhouse/templates/statefulset.yaml
@@ -428,8 +428,10 @@ spec:
         {{- end }}
   {{- if or $.Values.extraVolumeClaimTemplates (and $.Values.persistence.enabled (not $.Values.persistence.existingClaim)) }}
   volumeClaimTemplates:
-    {{- if and $.Values.persistence.enabled (not $.Values.persistence.existingClaim) }}
-    - metadata:
+    {{- if and $.Values.persistence.enabled (not $.Values.persistence.existingClaim) }}    
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
         name: data
         {{- if or $.Values.persistence.annotations $.Values.commonAnnotations }}
         {{- $claimAnnotations := include "common.tplvalues.merge" ( dict "values" ( list $.Values.persistence.annotations $.Values.commonLabels ) "context" $ ) }}


### PR DESCRIPTION
### Description of the change

ArgoCD says that the VolumeClaimTemplate is missing the kind and apiVersion and tries to add it. Since this is never addressed in the actual app (ArgoCD is set to automatically "fix" itself), the issue repeats over and over.
![image](https://github.com/user-attachments/assets/9b23e59c-9b68-473f-9106-423c62e6c997)

### Benefits

ArgoCD will not try to constantly "fix" the application to be in sync. No need to workaround with strategicMergePatches

### Possible drawbacks

None found, fully compatible.

### Applicable issues

### Additional information

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
