### PR TITLE
[bitnami/kafka] Allow for domain name override

### DIFF
--- a/bitnami/kafka/CHANGELOG.md
+++ b/bitnami/kafka/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 30.1.0 (2024-09-09)
+## 30.1.0 (2024-09-10)
 
 * [bitnami/kafka] Allow for domain name override ([#29316](https://github.com/bitnami/charts/pull/29316))
 

--- a/bitnami/kafka/CHANGELOG.md
+++ b/bitnami/kafka/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 30.0.5 (2024-08-20)
+## 30.1.0 (2024-09-09)
 
-* bitnami/kafka Fix pem auth with custom encrypted private key ([#28618](https://github.com/bitnami/charts/pull/28618))
+* [bitnami/kafka] Allow for domain name override ([#29316](https://github.com/bitnami/charts/pull/29316))
+
+## <small>30.0.5 (2024-08-23)</small>
+
+* bitnami/kafka Fix pem auth with custom encrypted private key (#28618) ([96b751e](https://github.com/bitnami/charts/commit/96b751e3eb0a6acba28e0fcbca907bb2de88fdf5)), closes [#28618](https://github.com/bitnami/charts/issues/28618)
 
 ## <small>30.0.4 (2024-08-14)</small>
 

--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -40,4 +40,4 @@ maintainers:
 name: kafka
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/kafka
-version: 30.0.5
+version: 30.1.0

--- a/bitnami/kafka/README.md
+++ b/bitnami/kafka/README.md
@@ -64,6 +64,8 @@ This chart allows you to automatically configure Kafka with 3 listeners:
 - A second one for communications with clients within the K8s cluster.
 - (optional) a third listener for communications with clients outside the K8s cluster. Check [this section](#accessing-kafka-brokers-from-outside-the-cluster) for more information.
 
+When using an external domain, setting `listeners.overrideDomain` to `true` enforces the Kafka cluster to set all listeners in `advertisedListeners` to `podName.clusterDomain:port`.
+
 For more complex configurations, set the `listeners`, `advertisedListeners` and `listenerSecurityProtocolMap` parameters as needed.
 
 ### Enable security for Kafka and Zookeeper
@@ -456,6 +458,7 @@ You can enable this initContainer by setting `volumePermissions.enabled` to `tru
 | `heapOpts`                            | Kafka Java Heap size                                                                                                                                                                                       | `-Xmx1024m -Xms1024m`   |
 | `brokerRackAssignment`                | Set Broker Assignment for multi tenant environment Allowed values: `aws-az`                                                                                                                                | `""`                    |
 | `interBrokerProtocolVersion`          | Override the setting 'inter.broker.protocol.version' during the ZK migration.                                                                                                                              | `""`                    |
+| `listeners.overrideDomain`            | Replace the advertised listeners addresses with the pod name and cluster domain                                                                                                                            | `false`                 |
 | `listeners.client.name`               | Name for the Kafka client listener                                                                                                                                                                         | `CLIENT`                |
 | `listeners.client.containerPort`      | Port for the Kafka client listener                                                                                                                                                                         | `9092`                  |
 | `listeners.client.protocol`           | Security protocol for the Kafka client listener. Allowed values are 'PLAINTEXT', 'SASL_PLAINTEXT', 'SASL_SSL' and 'SSL'                                                                                    | `SASL_PLAINTEXT`        |

--- a/bitnami/kafka/templates/scripts-configmap.yaml
+++ b/bitnami/kafka/templates/scripts-configmap.yaml
@@ -365,7 +365,11 @@ data:
         {{- end }}
     fi
     {{- if not .Values.listeners.advertisedListeners }}
+    {{- if .Values.listeners.overrideDomain }}
+    replace_placeholder "advertised-address-placeholder" "${MY_POD_NAME}.{{ $clusterDomain }}"
+    {{- else }}
     replace_placeholder "advertised-address-placeholder" "${MY_POD_NAME}.{{ $fullname }}-${POD_ROLE}-headless.{{ $releaseNamespace }}.svc.{{ $clusterDomain }}"
+    {{- end }}
     if [[ "${EXTERNAL_ACCESS_ENABLED:-false}" =~ ^(yes|true)$ ]]; then
       configure_external_access
     fi
@@ -390,4 +394,3 @@ data:
       append_file_to_kafka_conf /secret-config/server-secret.properties $KAFKA_CONFIG_FILE
     fi
     {{- include "common.tplvalues.render" ( dict "value" .Values.extraInit "context" $ ) | nindent 4 }}
-

--- a/bitnami/kafka/values.yaml
+++ b/bitnami/kafka/values.yaml
@@ -160,6 +160,8 @@ interBrokerProtocolVersion: ""
 ## Kafka listeners configuration
 ##
 listeners:
+  ## @param listeners.overrideDomain Replace the advertised listeners addresses with the pod name and cluster domain
+  overrideDomain: false
   ## @param listeners.client.name Name for the Kafka client listener
   ## @param listeners.client.containerPort Port for the Kafka client listener
   ## @param listeners.client.protocol Security protocol for the Kafka client listener. Allowed values are 'PLAINTEXT', 'SASL_PLAINTEXT', 'SASL_SSL' and 'SSL'


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

This PR allows the server.properties to integrate external domains into the advertised listeners. When `listeners.overrideDomain` is set to `true`, the listeners will appear in the format `<listener_name>://<pod_name>.<cluster_domain>:<port>` on all listeners.

### Benefits

This configuration is to be used when an external JKS, matching a specific domain other than `cluster.local` is used, and ensures all SSL connections (interbroker, controller, client and external) are validated through that certificate.

### Possible drawbacks

None identified

### Applicable issues

None identified

### Additional information

N/A

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
