### PR TITLE
[bitnami/jaeger] Upgrade Cassandra to 12.x.x (appVersion 5.0.0)

### DIFF
--- a/bitnami/jaeger/Chart.lock
+++ b/bitnami/jaeger/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 2.22.0
 - name: cassandra
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 11.4.2
-digest: sha256:fda5a11e6c5e18ac08585b8a3e9b73dd8a93f1368f207a965896aff9ee94331e
-generated: "2024-09-06T01:01:19.678533587Z"
+  version: 12.0.0
+digest: sha256:d67467d123347c14ead76bf1fb465e53371e2dee0cd0e8b30fefa8384a6b2003
+generated: "2024-09-10T15:10:32.559191+02:00"

--- a/bitnami/jaeger/Chart.yaml
+++ b/bitnami/jaeger/Chart.yaml
@@ -6,7 +6,7 @@ annotations:
   licenses: Apache-2.0
   images: |
     - name: cassandra
-      image: docker.io/bitnami/cassandra:4.0.13-debian-12-r12
+      image: docker.io/bitnami/cassandra:5.0.0-debian-12-r4
     - name: jaeger
       image: docker.io/bitnami/jaeger:1.60.0-debian-12-r4
 apiVersion: v2
@@ -20,7 +20,7 @@ dependencies:
 - condition: cassandra.enabled
   name: cassandra
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 11.x.x
+  version: 12.x.x
 description: Jaeger is a distributed tracing system. It is used for monitoring and troubleshooting microservices-based distributed systems.
 home: https://bitnami.com
 icon: https://bitnami.com/assets/stacks/jaeger/img/jaeger-stack-220x234.png
@@ -34,4 +34,4 @@ maintainers:
 name: jaeger
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/jaeger
-version: 2.5.12
+version: 3.0.0

--- a/bitnami/jaeger/README.md
+++ b/bitnami/jaeger/README.md
@@ -588,6 +588,10 @@ Find more information about how to deal with common errors related to Bitnami's 
 
 ## Upgrading
 
+### To 3.0.0
+
+This major updates the Cassandra subchart to its newest major, 12.0.0. [Here](https://github.com/bitnami/charts/pull/29305) you can find more information about the changes introduced in that version.
+
 ### To 2.0.0
 
 This major bump changes the following security defaults:

--- a/bitnami/jaeger/values.yaml
+++ b/bitnami/jaeger/values.yaml
@@ -4,13 +4,12 @@
 ## @section Global parameters
 ## Global Docker image parameters
 ## Please, note that this will override the image parameters, including dependencies, configured to use the global value
-## Current available global Docker image parameters: imageRegistry, imagePullSecrets and storageClass
+## Current available global Docker image parameters: imageRegistry, imagePullSecrets, defaultStorageClass and compatibility.
 ##
 
 ## @param global.imageRegistry Global Docker image registry
 ## @param global.imagePullSecrets Global Docker registry secret names as an array
 ## @param global.defaultStorageClass Global default StorageClass for Persistent Volume(s)
-## @param global.storageClass DEPRECATED: use global.defaultStorageClass instead
 ##
 global:
   imageRegistry: ""
@@ -20,7 +19,6 @@ global:
   ##
   imagePullSecrets: []
   defaultStorageClass: ""
-  storageClass: ""
   ## Compatibility adaptations for Kubernetes platforms
   ##
   compatibility:


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

 Upgrade Cassandra to 12.x.x (appVersion 5.0.0)

It also removes deprecated `global.storageClass` parameter.

### Benefits

- Use latest stable version of Cassandra.

### Possible drawbacks

- N/A

### Additional information

https://cassandra.apache.org/doc/latest/cassandra/new/index.html

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
