### PR TITLE
[bitnami/grafana-loki] Allow rendering resources values

### DIFF
--- a/bitnami/grafana-loki/Chart.yaml
+++ b/bitnami/grafana-loki/Chart.yaml
@@ -55,4 +55,4 @@ maintainers:
 name: grafana-loki
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/grafana-loki
-version: 4.6.14
+version: 4.6.15

--- a/bitnami/grafana-loki/templates/compactor/deployment.yaml
+++ b/bitnami/grafana-loki/templates/compactor/deployment.yaml
@@ -119,7 +119,7 @@ spec:
             - containerPort: {{ .Values.loki.containerPorts.grpc }}
               name: grpc
           {{- if .Values.compactor.resources }}
-          resources: {{- toYaml .Values.compactor.resources | nindent 12 }}
+          resources: {{- include "common.tplvalues.render" (dict "value" .Values.compactor.resources "context" $) | nindent 12 }}
           {{- else if ne .Values.compactor.resourcesPreset "none" }}
           resources: {{- include "common.resources.preset" (dict "type" .Values.compactor.resourcesPreset) | nindent 12 }}
           {{- end }}

--- a/bitnami/grafana-loki/templates/distributor/deployment.yaml
+++ b/bitnami/grafana-loki/templates/distributor/deployment.yaml
@@ -119,7 +119,7 @@ spec:
             - containerPort: {{ .Values.loki.containerPorts.grpc }}
               name: grpc
           {{- if .Values.distributor.resources }}
-          resources: {{- toYaml .Values.distributor.resources | nindent 12 }}
+          resources: {{- include "common.tplvalues.render" (dict "value" .Values.distributor.resources "context" $) | nindent 12 }}
           {{- else if ne .Values.distributor.resourcesPreset "none" }}
           resources: {{- include "common.resources.preset" (dict "type" .Values.distributor.resourcesPreset) | nindent 12 }}
           {{- end }}

--- a/bitnami/grafana-loki/templates/gateway/deployment.yaml
+++ b/bitnami/grafana-loki/templates/gateway/deployment.yaml
@@ -147,7 +147,7 @@ spec:
           {{- end }}
           {{- end }}
           {{- if .Values.gateway.resources }}
-          resources: {{- toYaml .Values.gateway.resources | nindent 12 }}
+          resources: {{- include "common.tplvalues.render" (dict "value" .Values.gateway.resources "context" $) | nindent 12 }}
           {{- else if ne .Values.gateway.resourcesPreset "none" }}
           resources: {{- include "common.resources.preset" (dict "type" .Values.gateway.resourcesPreset) | nindent 12 }}
           {{- end }}

--- a/bitnami/grafana-loki/templates/index-gateway/statefulset.yaml
+++ b/bitnami/grafana-loki/templates/index-gateway/statefulset.yaml
@@ -120,7 +120,7 @@ spec:
             - containerPort: {{ .Values.loki.containerPorts.grpc }}
               name: grpc
           {{- if .Values.indexGateway.resources }}
-          resources: {{- toYaml .Values.indexGateway.resources | nindent 12 }}
+          resources: {{- include "common.tplvalues.render" (dict "value" .Values.indexGateway.resources "context" $) | nindent 12 }}
           {{- else if ne .Values.indexGateway.resourcesPreset "none" }}
           resources: {{- include "common.resources.preset" (dict "type" .Values.indexGateway.resourcesPreset) | nindent 12 }}
           {{- end }}

--- a/bitnami/grafana-loki/templates/ingester/statefulset.yaml
+++ b/bitnami/grafana-loki/templates/ingester/statefulset.yaml
@@ -94,7 +94,7 @@ spec:
           securityContext: {{- .Values.volumePermissions.containerSecurityContext | toYaml | nindent 12 }}
           {{- end }}
           {{- if .Values.volumePermissions.resources }}
-          resources: {{- toYaml .Values.volumePermissions.resources | nindent 12 }}
+          resources: {{- include "common.tplvalues.render" (dict "value" .Values.volumePermissions.resources "context" $) | nindent 12 }}
           {{- else if ne .Values.volumePermissions.resourcesPreset "none" }}
           resources: {{- include "common.resources.preset" (dict "type" .Values.volumePermissions.resourcesPreset) | nindent 12 }}
           {{- end }}
@@ -149,7 +149,7 @@ spec:
             - containerPort: {{ .Values.loki.containerPorts.grpc }}
               name: grpc
           {{- if .Values.ingester.resources }}
-          resources: {{- toYaml .Values.ingester.resources | nindent 12 }}
+          resources: {{- include "common.tplvalues.render" (dict "value" .Values.ingester.resources "context" $) | nindent 12 }}
           {{- else if ne .Values.ingester.resourcesPreset "none" }}
           resources: {{- include "common.resources.preset" (dict "type" .Values.ingester.resourcesPreset) | nindent 12 }}
           {{- end }}

--- a/bitnami/grafana-loki/templates/promtail/daemonset.yaml
+++ b/bitnami/grafana-loki/templates/promtail/daemonset.yaml
@@ -120,7 +120,7 @@ spec:
             - containerPort: {{ .Values.promtail.containerPorts.grpc }}
               name: grpc
           {{- if .Values.promtail.resources }}
-          resources: {{- toYaml .Values.promtail.resources | nindent 12 }}
+          resources: {{- include "common.tplvalues.render" (dict "value" .Values.promtail.resources "context" $) | nindent 12 }}
           {{- else if ne .Values.promtail.resourcesPreset "none" }}
           resources: {{- include "common.resources.preset" (dict "type" .Values.promtail.resourcesPreset) | nindent 12 }}
           {{- end }}

--- a/bitnami/grafana-loki/templates/querier/statefulset.yaml
+++ b/bitnami/grafana-loki/templates/querier/statefulset.yaml
@@ -96,7 +96,7 @@ spec:
           securityContext: {{- .Values.volumePermissions.containerSecurityContext | toYaml | nindent 12 }}
           {{- end }}
           {{- if .Values.volumePermissions.resources }}
-          resources: {{- toYaml .Values.volumePermissions.resources | nindent 12 }}
+          resources: {{- include "common.tplvalues.render" (dict "value" .Values.volumePermissions.resources "context" $) | nindent 12 }}
           {{- else if ne .Values.volumePermissions.resourcesPreset "none" }}
           resources: {{- include "common.resources.preset" (dict "type" .Values.volumePermissions.resourcesPreset) | nindent 12 }}
           {{- end }}
@@ -154,7 +154,7 @@ spec:
             - containerPort: {{ .Values.loki.containerPorts.grpc }}
               name: grpc
           {{- if .Values.querier.resources }}
-          resources: {{- toYaml .Values.querier.resources | nindent 12 }}
+          resources: {{- include "common.tplvalues.render" (dict "value" .Values.querier.resources "context" $) | nindent 12 }}
           {{- else if ne .Values.querier.resourcesPreset "none" }}
           resources: {{- include "common.resources.preset" (dict "type" .Values.querier.resourcesPreset) | nindent 12 }}
           {{- end }}

--- a/bitnami/grafana-loki/templates/query-frontend/deployment.yaml
+++ b/bitnami/grafana-loki/templates/query-frontend/deployment.yaml
@@ -118,7 +118,7 @@ spec:
             - containerPort: {{ .Values.loki.containerPorts.grpc }}
               name: grpc
           {{- if .Values.queryFrontend.resources }}
-          resources: {{- toYaml .Values.queryFrontend.resources | nindent 12 }}
+          resources: {{- include "common.tplvalues.render" (dict "value" .Values.queryFrontend.resources "context" $) | nindent 12 }}
           {{- else if ne .Values.queryFrontend.resourcesPreset "none" }}
           resources: {{- include "common.resources.preset" (dict "type" .Values.queryFrontend.resourcesPreset) | nindent 12 }}
           {{- end }}

--- a/bitnami/grafana-loki/templates/query-scheduler/deployment.yaml
+++ b/bitnami/grafana-loki/templates/query-scheduler/deployment.yaml
@@ -119,7 +119,7 @@ spec:
             - containerPort: {{ .Values.loki.containerPorts.grpc }}
               name: grpc
           {{- if .Values.queryScheduler.resources }}
-          resources: {{- toYaml .Values.queryScheduler.resources | nindent 12 }}
+          resources: {{- include "common.tplvalues.render" (dict "value" .Values.queryScheduler.resources "context" $) | nindent 12 }}
           {{- else if ne .Values.queryScheduler.resourcesPreset "none" }}
           resources: {{- include "common.resources.preset" (dict "type" .Values.queryScheduler.resourcesPreset) | nindent 12 }}
           {{- end }}

--- a/bitnami/grafana-loki/templates/ruler/statefulset.yaml
+++ b/bitnami/grafana-loki/templates/ruler/statefulset.yaml
@@ -97,7 +97,7 @@ spec:
           securityContext: {{- .Values.volumePermissions.containerSecurityContext | toYaml | nindent 12 }}
           {{- end }}
           {{- if .Values.volumePermissions.resources }}
-          resources: {{- toYaml .Values.volumePermissions.resources | nindent 12 }}
+          resources: {{- include "common.tplvalues.render" (dict "value" .Values.volumePermissions.resources "context" $) | nindent 12 }}
           {{- else if ne .Values.volumePermissions.resourcesPreset "none" }}
           resources: {{- include "common.resources.preset" (dict "type" .Values.volumePermissions.resourcesPreset) | nindent 12 }}
           {{- end }}
@@ -152,7 +152,7 @@ spec:
             - containerPort: {{ .Values.loki.containerPorts.grpc }}
               name: grpc
           {{- if .Values.ruler.resources }}
-          resources: {{- toYaml .Values.ruler.resources | nindent 12 }}
+          resources: {{- include "common.tplvalues.render" (dict "value" .Values.ruler.resources "context" $) | nindent 12 }}
           {{- else if ne .Values.ruler.resourcesPreset "none" }}
           resources: {{- include "common.resources.preset" (dict "type" .Values.ruler.resourcesPreset) | nindent 12 }}
           {{- end }}

--- a/bitnami/grafana-loki/templates/table-manager/deployment.yaml
+++ b/bitnami/grafana-loki/templates/table-manager/deployment.yaml
@@ -116,7 +116,7 @@ spec:
             - containerPort: {{ .Values.loki.containerPorts.grpc }}
               name: grpc
           {{- if .Values.tableManager.resources }}
-          resources: {{- toYaml .Values.tableManager.resources | nindent 12 }}
+          resources: {{- include "common.tplvalues.render" (dict "value" .Values.tableManager.resources "context" $) | nindent 12 }}
           {{- else if ne .Values.tableManager.resourcesPreset "none" }}
           resources: {{- include "common.resources.preset" (dict "type" .Values.tableManager.resourcesPreset) | nindent 12 }}
           {{- end }}


### PR DESCRIPTION
### Description of the change

This mirrors the use of `common.tplvalues.render` on `resources` values, like is done in other Bitnami charts,

### Benefits

Users can provide templated strings to render for `resources` values.

### Possible drawbacks

None noted

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
