### PR TITLE
[bitnami/grafana-tempo] Allow rendering resources values

### DIFF
--- a/bitnami/grafana-tempo/CHANGELOG.md
+++ b/bitnami/grafana-tempo/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 3.7.9 (2024-09-06)
+## 3.7.10 (2024-09-10)
 
-* [bitnami/grafana-tempo] Release 3.7.9 ([#29238](https://github.com/bitnami/charts/pull/29238))
+* [bitnami/grafana-tempo] Allow rendering resources values ([#29344](https://github.com/bitnami/charts/pull/29344))
+
+## <small>3.7.9 (2024-09-06)</small>
+
+* [bitnami/grafana-tempo] Release 3.7.9 (#29238) ([4685bca](https://github.com/bitnami/charts/commit/4685bca5832244969c233e10ea9a350fa7ededb3)), closes [#29238](https://github.com/bitnami/charts/issues/29238)
 
 ## <small>3.7.8 (2024-09-04)</small>
 

--- a/bitnami/grafana-tempo/CHANGELOG.md
+++ b/bitnami/grafana-tempo/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 3.7.10 (2024-09-10)
+## 3.7.10 (2024-09-11)
 
 * [bitnami/grafana-tempo] Allow rendering resources values ([#29344](https://github.com/bitnami/charts/pull/29344))
 

--- a/bitnami/grafana-tempo/Chart.yaml
+++ b/bitnami/grafana-tempo/Chart.yaml
@@ -39,4 +39,4 @@ maintainers:
 name: grafana-tempo
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/grafana-tempo
-version: 3.7.9
+version: 3.7.10

--- a/bitnami/grafana-tempo/templates/compactor/deployment.yaml
+++ b/bitnami/grafana-tempo/templates/compactor/deployment.yaml
@@ -113,7 +113,7 @@ spec:
             - containerPort: {{ .Values.tempo.containerPorts.gossipRing }}
               name: http-memberlist
           {{- if .Values.compactor.resources }}
-          resources: {{- toYaml .Values.compactor.resources | nindent 12 }}
+          resources: {{- include "common.tplvalues.render" (dict "value" .Values.compactor.resources "context" $) | nindent 12 }}
           {{- else if ne .Values.compactor.resourcesPreset "none" }}
           resources: {{- include "common.resources.preset" (dict "type" .Values.compactor.resourcesPreset) | nindent 12 }}
           {{- end }}

--- a/bitnami/grafana-tempo/templates/distributor/deployment.yaml
+++ b/bitnami/grafana-tempo/templates/distributor/deployment.yaml
@@ -152,7 +152,7 @@ spec:
               protocol: TCP
             {{- end }}
           {{- if .Values.distributor.resources }}
-          resources: {{- toYaml .Values.distributor.resources | nindent 12 }}
+          resources: {{- include "common.tplvalues.render" (dict "value" .Values.distributor.resources "context" $) | nindent 12 }}
           {{- else if ne .Values.distributor.resourcesPreset "none" }}
           resources: {{- include "common.resources.preset" (dict "type" .Values.distributor.resourcesPreset) | nindent 12 }}
           {{- end }}

--- a/bitnami/grafana-tempo/templates/ingester/statefulset.yaml
+++ b/bitnami/grafana-tempo/templates/ingester/statefulset.yaml
@@ -90,7 +90,7 @@ spec:
           securityContext: {{- .Values.volumePermissions.containerSecurityContext | toYaml | nindent 12 }}
           {{- end }}
           {{- if .Values.volumePermissions.resources }}
-          resources: {{- toYaml .Values.volumePermissions.resources | nindent 12 }}
+          resources: {{- include "common.tplvalues.render" (dict "value" .Values.volumePermissions.resources "context" $) | nindent 12 }}
           {{- else if ne .Values.volumePermissions.resourcesPreset "none" }}
           resources: {{- include "common.resources.preset" (dict "type" .Values.volumePermissions.resourcesPreset) | nindent 12 }}
           {{- end }}
@@ -143,7 +143,7 @@ spec:
             - containerPort: {{ .Values.tempo.containerPorts.grpc }}
               name: grpc
           {{- if .Values.ingester.resources }}
-          resources: {{- toYaml .Values.ingester.resources | nindent 12 }}
+          resources: {{- include "common.tplvalues.render" (dict "value" .Values.ingester.resources "context" $) | nindent 12 }}
           {{- else if ne .Values.ingester.resourcesPreset "none" }}
           resources: {{- include "common.resources.preset" (dict "type" .Values.ingester.resourcesPreset) | nindent 12 }}
           {{- end }}

--- a/bitnami/grafana-tempo/templates/metrics-generator/deployment.yaml
+++ b/bitnami/grafana-tempo/templates/metrics-generator/deployment.yaml
@@ -112,7 +112,7 @@ spec:
             - containerPort: {{ .Values.tempo.containerPorts.grpc }}
               name: grpc
           {{- if .Values.metricsGenerator.resources }}
-          resources: {{- toYaml .Values.metricsGenerator.resources | nindent 12 }}
+          resources: {{- include "common.tplvalues.render" (dict "value" .Values.metricsGenerator.resources "context" $) | nindent 12 }}
           {{- else if ne .Values.metricsGenerator.resourcesPreset "none" }}
           resources: {{- include "common.resources.preset" (dict "type" .Values.metricsGenerator.resourcesPreset) | nindent 12 }}
           {{- end }}

--- a/bitnami/grafana-tempo/templates/querier/deployment.yaml
+++ b/bitnami/grafana-tempo/templates/querier/deployment.yaml
@@ -112,7 +112,7 @@ spec:
             - containerPort: {{ .Values.tempo.containerPorts.grpc }}
               name: grpc
           {{- if .Values.querier.resources }}
-          resources: {{- toYaml .Values.querier.resources | nindent 12 }}
+          resources: {{- include "common.tplvalues.render" (dict "value" .Values.querier.resources "context" $) | nindent 12 }}
           {{- else if ne .Values.querier.resourcesPreset "none" }}
           resources: {{- include "common.resources.preset" (dict "type" .Values.querier.resourcesPreset) | nindent 12 }}
           {{- end }}

--- a/bitnami/grafana-tempo/templates/query-frontend/deployment.yaml
+++ b/bitnami/grafana-tempo/templates/query-frontend/deployment.yaml
@@ -111,7 +111,7 @@ spec:
             - containerPort: {{ .Values.tempo.containerPorts.grpc }}
               name: grpc
           {{- if .Values.queryFrontend.resources }}
-          resources: {{- toYaml .Values.queryFrontend.resources | nindent 12 }}
+          resources: {{- include "common.tplvalues.render" (dict "value" .Values.queryFrontend.resources "context" $) | nindent 12 }}
           {{- else if ne .Values.queryFrontend.resourcesPreset "none" }}
           resources: {{- include "common.resources.preset" (dict "type" .Values.queryFrontend.resourcesPreset) | nindent 12 }}
           {{- end }}

--- a/bitnami/grafana-tempo/templates/vulture/deployment.yaml
+++ b/bitnami/grafana-tempo/templates/vulture/deployment.yaml
@@ -110,7 +110,7 @@ spec:
             - containerPort: {{ .Values.vulture.containerPorts.http }}
               name: http
           {{- if .Values.vulture.resources }}
-          resources: {{- toYaml .Values.vulture.resources | nindent 12 }}
+          resources: {{- include "common.tplvalues.render" (dict "value" .Values.vulture.resources "context" $) | nindent 12 }}
           {{- else if ne .Values.vulture.resourcesPreset "none" }}
           resources: {{- include "common.resources.preset" (dict "type" .Values.vulture.resourcesPreset) | nindent 12 }}
           {{- end }}


### PR DESCRIPTION
### Description of the change

This mirrors the use of `common.tplvalues.render` on `resources` values, like is done in many other Bitnami charts,

### Benefits

Users can provide templated strings to render for `resources` values.

### Possible drawbacks

None noted

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
