### PR TITLE
[bitnami/nats] Add `PersistentVolumeRetentionPolicy`

### DIFF
--- a/bitnami/nats/CHANGELOG.md
+++ b/bitnami/nats/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 8.3.5 (2024-09-06)
+## 8.4.0 (2024-09-12)
 
-* [bitnami/nats] Release 8.3.5 ([#29253](https://github.com/bitnami/charts/pull/29253))
+* [bitnami/nats] Add `PersistentVolumeRetentionPolicy` ([#29371](https://github.com/bitnami/charts/pull/29371))
+
+## <small>8.3.5 (2024-09-06)</small>
+
+* [bitnami/nats] Release 8.3.5 (#29253) ([a1687c9](https://github.com/bitnami/charts/commit/a1687c981454b4ec06fbc05993a6c498e5b29bcd)), closes [#29253](https://github.com/bitnami/charts/issues/29253)
 
 ## <small>8.3.4 (2024-08-30)</small>
 

--- a/bitnami/nats/Chart.yaml
+++ b/bitnami/nats/Chart.yaml
@@ -31,4 +31,4 @@ maintainers:
 name: nats
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/nats
-version: 8.3.5
+version: 8.4.0

--- a/bitnami/nats/README.md
+++ b/bitnami/nats/README.md
@@ -345,7 +345,7 @@ As an alternative, you can use of the preset configurations for pod affinity, po
 | `persistence.size`                                 | PVC Storage Request for NATS data volume                                       | `8Gi`               |
 | `persistence.annotations`                          | Annotations for the PVC                                                        | `{}`                |
 | `persistence.selector`                             | Selector to match an existing Persistent Volume for NATS's data PVC            | `{}`                |
-| `persistentVolumeClaimRetentionPolicy.enabled`     | Enable Persistent volume retention policy for postgresql Statefulset           | `false`             |
+| `persistentVolumeClaimRetentionPolicy.enabled`     | Enable Persistent volume retention policy for NATS statefulset                 | `false`             |
 | `persistentVolumeClaimRetentionPolicy.whenScaled`  | Volume retention behavior when the replica count of the StatefulSet is reduced | `Retain`            |
 | `persistentVolumeClaimRetentionPolicy.whenDeleted` | Volume retention behavior that applies when the StatefulSet is deleted         | `Retain`            |
 

--- a/bitnami/nats/README.md
+++ b/bitnami/nats/README.md
@@ -337,14 +337,17 @@ As an alternative, you can use of the preset configurations for pod affinity, po
 
 ### Persistence parameters
 
-| Name                       | Description                                                         | Value               |
-| -------------------------- | ------------------------------------------------------------------- | ------------------- |
-| `persistence.enabled`      | Enable NATS data persistence using PVC(s)                           | `false`             |
-| `persistence.storageClass` | PVC Storage Class for NATS data volume                              | `""`                |
-| `persistence.accessModes`  | PVC Access modes                                                    | `["ReadWriteOnce"]` |
-| `persistence.size`         | PVC Storage Request for NATS data volume                            | `8Gi`               |
-| `persistence.annotations`  | Annotations for the PVC                                             | `{}`                |
-| `persistence.selector`     | Selector to match an existing Persistent Volume for NATS's data PVC | `{}`                |
+| Name                                               | Description                                                                    | Value               |
+| -------------------------------------------------- | ------------------------------------------------------------------------------ | ------------------- |
+| `persistence.enabled`                              | Enable NATS data persistence using PVC(s)                                      | `false`             |
+| `persistence.storageClass`                         | PVC Storage Class for NATS data volume                                         | `""`                |
+| `persistence.accessModes`                          | PVC Access modes                                                               | `["ReadWriteOnce"]` |
+| `persistence.size`                                 | PVC Storage Request for NATS data volume                                       | `8Gi`               |
+| `persistence.annotations`                          | Annotations for the PVC                                                        | `{}`                |
+| `persistence.selector`                             | Selector to match an existing Persistent Volume for NATS's data PVC            | `{}`                |
+| `persistentVolumeClaimRetentionPolicy.enabled`     | Enable Persistent volume retention policy for postgresql Statefulset           | `false`             |
+| `persistentVolumeClaimRetentionPolicy.whenScaled`  | Volume retention behavior when the replica count of the StatefulSet is reduced | `Retain`            |
+| `persistentVolumeClaimRetentionPolicy.whenDeleted` | Volume retention behavior that applies when the StatefulSet is deleted         | `Retain`            |
 
 ### Other parameters
 

--- a/bitnami/nats/templates/statefulset.yaml
+++ b/bitnami/nats/templates/statefulset.yaml
@@ -224,6 +224,11 @@ spec:
         {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumes "context" $) | nindent 8 }}
         {{- end }}
   {{- if .Values.persistence.enabled }}
+  {{- if .Values.persistentVolumeClaimRetentionPolicy.enabled }}
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: {{ .Values.persistentVolumeClaimRetentionPolicy.whenDeleted }}
+    whenScaled: {{ .Values.persistentVolumeClaimRetentionPolicy.whenScaled }}
+  {{- end }}
   volumeClaimTemplates:
     - metadata:
         name: data

--- a/bitnami/nats/values.yaml
+++ b/bitnami/nats/values.yaml
@@ -940,6 +940,19 @@ persistence:
   ##     app: my-app
   ##
   selector: {}
+## Persistent Volume Claim Retention Policy
+## ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#persistentvolumeclaim-retention
+##
+persistentVolumeClaimRetentionPolicy:
+  ## @param persistentVolumeClaimRetentionPolicy.enabled Enable Persistent volume retention policy for postgresql Statefulset
+  ##
+  enabled: false
+  ## @param persistentVolumeClaimRetentionPolicy.whenScaled Volume retention behavior when the replica count of the StatefulSet is reduced
+  ##
+  whenScaled: Retain
+  ## @param persistentVolumeClaimRetentionPolicy.whenDeleted Volume retention behavior that applies when the StatefulSet is deleted
+  ##
+  whenDeleted: Retain
 ## @section Other parameters
 
 ## NATS Pod Disruption Budget configuration

--- a/bitnami/nats/values.yaml
+++ b/bitnami/nats/values.yaml
@@ -944,7 +944,7 @@ persistence:
 ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#persistentvolumeclaim-retention
 ##
 persistentVolumeClaimRetentionPolicy:
-  ## @param persistentVolumeClaimRetentionPolicy.enabled Enable Persistent volume retention policy for postgresql Statefulset
+  ## @param persistentVolumeClaimRetentionPolicy.enabled Enable Persistent volume retention policy for NATS statefulset
   ##
   enabled: false
   ## @param persistentVolumeClaimRetentionPolicy.whenScaled Volume retention behavior when the replica count of the StatefulSet is reduced


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change
<!-- Describe the scope of your change - i.e. what the change does. -->
Added the `PersistentVolumeRetentionPolicy` to the NATS Statefulset so that PVCs can be configured to automatically be cleaned up when scaling or deleting the NATS Statefulset.
Disabled and set to Retain by default.

### Benefits
<!-- What benefits will be realized by the code change? -->
PVCs can be configured to automatically be deleted (retained by default) when scaling or deleting the statefulset.

### Possible drawbacks
<!-- Describe any known limitations with your change -->
None, disabled by default as in other charts (`bitnami/redis`, `bitnami/postgresql`, for example)

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
None

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
