### PR TITLE
[bitnami/external-dns] Fixed oci workload identity secret creation

### DIFF
--- a/bitnami/external-dns/CHANGELOG.md
+++ b/bitnami/external-dns/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 8.3.7 (2024-09-05)
+## 8.3.8 (2024-09-12)
 
-* [bitnami/external-dns] Release 8.3.7 ([#29231](https://github.com/bitnami/charts/pull/29231))
+* [bitnami/external-dns] Fixed oci workload identity secret creation ([#29374](https://github.com/bitnami/charts/pull/29374))
+
+## <small>8.3.7 (2024-09-05)</small>
+
+* [bitnami/external-dns] Release 8.3.7 (#29231) ([e6c6578](https://github.com/bitnami/charts/commit/e6c65782c9e73b79537c59c33e945d72dcf29b26)), closes [#29231](https://github.com/bitnami/charts/issues/29231)
 
 ## <small>8.3.6 (2024-09-05)</small>
 

--- a/bitnami/external-dns/Chart.yaml
+++ b/bitnami/external-dns/Chart.yaml
@@ -28,4 +28,4 @@ maintainers:
 name: external-dns
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/external-dns
-version: 8.3.7
+version: 8.3.8

--- a/bitnami/external-dns/templates/_helpers.tpl
+++ b/bitnami/external-dns/templates/_helpers.tpl
@@ -112,7 +112,7 @@ Return true if a secret object should be created
     {{- true -}}
 {{- else if and (eq .Values.provider "linode") .Values.linode.apiToken (not .Values.linode.secretName) -}}
     {{- true -}}
-{{- else if and (eq .Values.provider "oci") .Values.oci.privateKeyFingerprint (not .Values.oci.secretName) -}}
+{{- else if and (eq .Values.provider "oci") (or .Values.oci.privateKeyFingerprint .Values.oci.useWorkloadIdentity) (not .Values.oci.secretName) -}}
     {{- true -}}
 {{- else if and (eq .Values.provider "rfc2136") (or .Values.rfc2136.tsigSecret (and .Values.rfc2136.kerberosUsername .Values.rfc2136.kerberosPassword)) (not .Values.rfc2136.secretName) -}}
     {{- true -}}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->

This resolves an issue when using workload identity with the external-dns oci provider. When `oci.useWorkloadIdentity` is true, the secret is needed to configure the oci provider as such, but secret generation depends on the field `oci.privateKeyFingerprint` being set even though it's not used.

I've updated the conditions to use either `oci.useWorkloadIdentity` or `oci.privateKeyFingerprint` to determine if the secret should be generated or not.

### Benefits

<!-- What benefits will be realized by the code change? -->

- Fixes an issue where `oci.privateKeyFingerprint` must be specified even when it's not needed.

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
None

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
