### PR TITLE
[bitnami/redis] Use common password manager to handle password

### DIFF
--- a/bitnami/redis/CHANGELOG.md
+++ b/bitnami/redis/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 20.1.1 (2024-09-12)
+## 20.1.2 (2024-09-13)
 
-* [bitnami/redis] fix: move variable from annotation to label ([#29209](https://github.com/bitnami/charts/pull/29209))
+* [bitnami/redis] Use common password manager to handle password ([#29376](https://github.com/bitnami/charts/pull/29376))
+
+## <small>20.1.1 (2024-09-13)</small>
+
+* [bitnami/redis] fix: move variable from annotation to label (#29209) ([396fa01](https://github.com/bitnami/charts/commit/396fa01503a29a5c4695073ed9e6bde1923b187b)), closes [#29209](https://github.com/bitnami/charts/issues/29209)
 
 ## 20.1.0 (2024-09-09)
 

--- a/bitnami/redis/Chart.yaml
+++ b/bitnami/redis/Chart.yaml
@@ -36,4 +36,4 @@ maintainers:
 name: redis
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/redis
-version: 20.1.1
+version: 20.1.2

--- a/bitnami/redis/templates/_helpers.tpl
+++ b/bitnami/redis/templates/_helpers.tpl
@@ -222,34 +222,13 @@ Get the password key to be retrieved from Redis&reg; secret.
 {{- end -}}
 {{- end -}}
 
-
-{{/*
-Returns the available value for certain key in an existing secret (if it exists),
-otherwise it generates a random value.
-*/}}
-{{- define "getValueFromSecret" }}
-    {{- $len := (default 16 .Length) | int -}}
-    {{- $obj := (lookup "v1" "Secret" .Namespace .Name).data -}}
-    {{- if $obj }}
-        {{- index $obj .Key | b64dec -}}
-    {{- else -}}
-        {{- randAlphaNum $len -}}
-    {{- end -}}
-{{- end }}
-
 {{/*
 Return Redis&reg; password
 */}}
 {{- define "redis.password" -}}
-{{- if or .Values.auth.enabled .Values.global.redis.password }}
-    {{- if not (empty .Values.global.redis.password) }}
-        {{- .Values.global.redis.password -}}
-    {{- else if not (empty .Values.auth.password) -}}
-        {{- .Values.auth.password -}}
-    {{- else -}}
-        {{- include "getValueFromSecret" (dict "Namespace" (include "common.names.namespace" .) "Name" (include "redis.secretName" .) "Length" 10 "Key" (include "redis.secretPasswordKey" .))  -}}
-    {{- end -}}
-{{- end -}}
+{{- if or .Values.auth.enabled .Values.global.redis.password -}}
+    {{- include "common.secrets.passwords.manage" (dict "secret" (include "redis.secretName" .) "key" (include "redis.secretPasswordKey" .) "providedValues" (list "global.redis.password" "auth.password") "length" 10 "skipB64enc" true "skipQuote" true "context" $) -}}
+{{- end }}
 {{- end }}
 
 {{/* Check if there are rolling tags in the images */}}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Switch to the common helper `common.secrets.passwords.manage` for managing the password instead of the local undocumented helper.

### Benefits

* Streamline with the other charts
* Use a documented helper
* Benefit from the common helper features

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
The custom helper was introduced by https://github.com/bitnami/charts/pull/8486

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
