### PR TITLE
[bitnami/nats] Fix single replica Jetstream

### DIFF
--- a/bitnami/nats/CHANGELOG.md
+++ b/bitnami/nats/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
+## 8.4.1 (2024-09-12)
+
+* [bitnami/nats] Fix single replica Jetstream ([#29379](https://github.com/bitnami/charts/pull/29379))
+
 ## 8.4.0 (2024-09-12)
 
-* [bitnami/nats] Add `PersistentVolumeRetentionPolicy` ([#29371](https://github.com/bitnami/charts/pull/29371))
+* [bitnami/nats] Add `PersistentVolumeRetentionPolicy` (#29371) ([15d5c40](https://github.com/bitnami/charts/commit/15d5c40828d572501ad98281c3afff73e36a2a71)), closes [#29371](https://github.com/bitnami/charts/issues/29371)
 
 ## <small>8.3.5 (2024-09-06)</small>
 

--- a/bitnami/nats/CHANGELOG.md
+++ b/bitnami/nats/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 8.4.1 (2024-09-12)
+## 8.4.1 (2024-09-13)
 
 * [bitnami/nats] Fix single replica Jetstream ([#29379](https://github.com/bitnami/charts/pull/29379))
 

--- a/bitnami/nats/Chart.yaml
+++ b/bitnami/nats/Chart.yaml
@@ -31,4 +31,4 @@ maintainers:
 name: nats
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/nats
-version: 8.4.0
+version: 8.4.1

--- a/bitnami/nats/values.yaml
+++ b/bitnami/nats/values.yaml
@@ -235,6 +235,7 @@ configuration: |-
   write_deadline: {{ .Values.writeDeadline | quote }}
   {{- end }}
 
+  {{- if or (gt (int .Values.replicaCount) 1) (not .Values.jetstream.enabled) }}
   # Clustering definition
   cluster {
     name: {{ .Values.cluster.name | quote }}
@@ -262,6 +263,7 @@ configuration: |-
     connect_retries: {{ .Values.cluster.connectRetries }}
     {{- end }}
   }
+  {{- end }}
 
   {{- if .Values.jetstream.enabled }}
   # JetStream configuration

--- a/bitnami/nats/values.yaml
+++ b/bitnami/nats/values.yaml
@@ -235,7 +235,7 @@ configuration: |-
   write_deadline: {{ .Values.writeDeadline | quote }}
   {{- end }}
 
-  {{- if or (gt (int .Values.replicaCount) 1) (not .Values.jetstream.enabled) }}
+  {{- if gt (int .Values.replicaCount) 1 }}
   # Clustering definition
   cluster {
     name: {{ .Values.cluster.name | quote }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change
* Only enable Clustering if `replicaCount > 1`
* Allows single replica Jetstream to work as expected

### Benefits
Allows you to run NATS with Jetstream enabled in a single replica

### Possible drawbacks

### Applicable issues

- fixes #29378

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
