### PR TITLE
[bitnami/argo-cd] Fix duplicate `selector:` in applicationset deployment

### DIFF
--- a/bitnami/argo-cd/CHANGELOG.md
+++ b/bitnami/argo-cd/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 7.0.10 (2024-09-05)
+## 7.0.11 (2024-09-12)
 
-* [bitnami/argo-cd] Release 7.0.10 ([#29224](https://github.com/bitnami/charts/pull/29224))
+* [bitnami/argo-cd] Fix duplicate `selector:` in applicationset deployment ([#29386](https://github.com/bitnami/charts/pull/29386))
+
+## <small>7.0.10 (2024-09-05)</small>
+
+* [bitnami/argo-cd] Release 7.0.10 (#29224) ([92a32cb](https://github.com/bitnami/charts/commit/92a32cbbf02f492afaa562a98303cd7921348827)), closes [#29224](https://github.com/bitnami/charts/issues/29224)
 
 ## <small>7.0.9 (2024-09-04)</small>
 

--- a/bitnami/argo-cd/CHANGELOG.md
+++ b/bitnami/argo-cd/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 7.0.11 (2024-09-12)
+## 7.0.11 (2024-09-13)
 
 * [bitnami/argo-cd] Fix duplicate `selector:` in applicationset deployment ([#29386](https://github.com/bitnami/charts/pull/29386))
 

--- a/bitnami/argo-cd/Chart.yaml
+++ b/bitnami/argo-cd/Chart.yaml
@@ -39,4 +39,4 @@ maintainers:
 name: argo-cd
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/argo-cd
-version: 7.0.10
+version: 7.0.11

--- a/bitnami/argo-cd/templates/applicationset/deployment.yaml
+++ b/bitnami/argo-cd/templates/applicationset/deployment.yaml
@@ -19,7 +19,6 @@ spec:
   {{- if .Values.applicationSet.updateStrategy }}
   strategy: {{- toYaml .Values.applicationSet.updateStrategy | nindent 4 }}
   {{- end }}
-  selector:
   {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.applicationSet.podLabels .Values.commonLabels ) "context" . ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

No functional change. Remove (illegal) duplicate yaml key

### Benefits

Tools such as kustomize (relying on kyaml) will no longer crash like this:
```
❯ kubectl kustomize --enable-helm .
error: map[string]interface {}(nil): yaml: unmarshal errors:
  line 19: mapping key "selector" already defined at line 18
```

### Possible drawbacks

I'm not too familiar with helm's syntax, I _hope_ this is correct (`$podLabels` just gets assigned, doesn't matter where)
possible drawback: I missed something obvious and this is wrong

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
n/a - didn't bother creating an issue for such a trivial fix

### Additional information

This is a regression from https://github.com/bitnami/charts/pull/18458, [here](https://github.com/bitnami/charts/pull/18458/files#diff-4a98e2a629963611f398c32ddeb6de161be4e4444ba9c2da413510c93acf8ff5)
I assume this was just a mass-edit copy pasting mishap

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] **N/A** ~~Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)~~
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
