### PR TITLE
[bitnami/solr] Use common password manager to handle password

### DIFF
--- a/bitnami/solr/Chart.yaml
+++ b/bitnami/solr/Chart.yaml
@@ -34,4 +34,4 @@ maintainers:
 name: solr
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/solr
-version: 9.4.3
+version: 9.4.4

--- a/bitnami/solr/templates/_helpers.tpl
+++ b/bitnami/solr/templates/_helpers.tpl
@@ -81,31 +81,6 @@ Return true if a Solr authentication credentials secret object should be created
 {{- end -}}
 
 {{/*
-Returns the available value for certain key in an existing secret (if it exists),
-otherwise it generates a random value.
-*/}}
-{{- define "getValueFromSecret" }}
-    {{- $len := (default 16 .Length) | int -}}
-    {{- $obj := (lookup "v1" "Secret" .Namespace .Name).data -}}
-    {{- if $obj }}
-        {{- index $obj .Key | b64dec -}}
-    {{- else -}}
-        {{- randAlphaNum $len -}}
-    {{- end -}}
-{{- end }}
-
-{{/*
-Return Solr admin password
-*/}}
-{{- define "solr.password" -}}
-{{- if not (empty .Values.auth.adminPassword) -}}
-    {{- .Values.auth.adminPassword -}}
-{{- else -}}
-    {{- include "getValueFromSecret" (dict "Namespace" (include "common.names.namespace" .) "Name" (include "common.names.fullname" .) "Length" 10 "Key" "solr-password")  -}}
-{{- end -}}
-{{- end -}}
-
-{{/*
 Return proper Zookeeper hosts
 */}}
 {{- define "solr.zookeeper.hosts" -}}

--- a/bitnami/solr/templates/secrets.yaml
+++ b/bitnami/solr/templates/secrets.yaml
@@ -16,7 +16,7 @@ metadata:
   namespace: {{ include "common.names.namespace" . | quote }}
 type: Opaque
 data:
-  solr-password: {{ include "solr.password" . | b64enc | quote }}
+  solr-password: {{ include "common.secrets.passwords.manage" (dict "secret" (include "common.names.fullname" .) "key" "solr-password" "providedValues" (list "auth.adminPassword") "context" $) }}
 {{- end }}
 {{- if (include "solr.createTlsPasswordsSecret" .) }}
 ---


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Switch to the common helper `common.secrets.passwords.manage` for managing the password instead of the local undocumented helper.

### Benefits

* Streamline with the other charts
* Use a documented helper
* Benefit from the common helper features

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
