### PR TITLE
[bitnami/grafana-loki] bugfix: loki component not include `.Values.metrics.serviceMonitor.labels`

### DIFF
--- a/bitnami/grafana-loki/Chart.yaml
+++ b/bitnami/grafana-loki/Chart.yaml
@@ -55,4 +55,4 @@ maintainers:
 name: grafana-loki
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/grafana-loki
-version: 4.6.15
+version: 4.6.16

--- a/bitnami/grafana-loki/templates/compactor/servicemonitor.yaml
+++ b/bitnami/grafana-loki/templates/compactor/servicemonitor.yaml
@@ -9,7 +9,9 @@ kind: ServiceMonitor
 metadata:
   name: {{ template "grafana-loki.compactor.fullname" . }}
   namespace: {{ default .Release.Namespace .Values.metrics.serviceMonitor.namespace | quote }}
-  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- $versionLabel := dict "app.kubernetes.io/version" ( include "common.images.version" ( dict "imageRoot" .Values.promtail.image "chart" .Chart ) ) }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.metrics.serviceMonitor.labels .Values.commonLabels $versionLabel ) "context" . ) }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: grafana-loki
     app.kubernetes.io/component: compactor
    {{- if or .Values.commonAnnotations .Values.metrics.serviceMonitor.annotations }}

--- a/bitnami/grafana-loki/templates/distributor/servicemonitor.yaml
+++ b/bitnami/grafana-loki/templates/distributor/servicemonitor.yaml
@@ -9,7 +9,9 @@ kind: ServiceMonitor
 metadata:
   name: {{ template "grafana-loki.distributor.fullname" . }}
   namespace: {{ default .Release.Namespace .Values.metrics.serviceMonitor.namespace | quote }}
-  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- $versionLabel := dict "app.kubernetes.io/version" ( include "common.images.version" ( dict "imageRoot" .Values.promtail.image "chart" .Chart ) ) }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.metrics.serviceMonitor.labels .Values.commonLabels $versionLabel ) "context" . ) }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: grafana-loki
     app.kubernetes.io/component: distributor
    {{- if or .Values.commonAnnotations .Values.metrics.serviceMonitor.annotations }}

--- a/bitnami/grafana-loki/templates/index-gateway/servicemonitor.yaml
+++ b/bitnami/grafana-loki/templates/index-gateway/servicemonitor.yaml
@@ -9,7 +9,9 @@ kind: ServiceMonitor
 metadata:
   name: {{ template "grafana-loki.index-gateway.fullname" . }}
   namespace: {{ default .Release.Namespace .Values.metrics.serviceMonitor.namespace | quote }}
-  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- $versionLabel := dict "app.kubernetes.io/version" ( include "common.images.version" ( dict "imageRoot" .Values.promtail.image "chart" .Chart ) ) }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.metrics.serviceMonitor.labels .Values.commonLabels $versionLabel ) "context" . ) }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: grafana-loki
     app.kubernetes.io/component: index-gateway
    {{- if or .Values.commonAnnotations .Values.metrics.serviceMonitor.annotations }}

--- a/bitnami/grafana-loki/templates/ingester/servicemonitor.yaml
+++ b/bitnami/grafana-loki/templates/ingester/servicemonitor.yaml
@@ -9,7 +9,9 @@ kind: ServiceMonitor
 metadata:
   name: {{ template "grafana-loki.ingester.fullname" . }}
   namespace: {{ default .Release.Namespace .Values.metrics.serviceMonitor.namespace | quote }}
-  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- $versionLabel := dict "app.kubernetes.io/version" ( include "common.images.version" ( dict "imageRoot" .Values.promtail.image "chart" .Chart ) ) }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.metrics.serviceMonitor.labels .Values.commonLabels $versionLabel ) "context" . ) }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: grafana-loki
     app.kubernetes.io/component: ingester
    {{- if or .Values.commonAnnotations .Values.metrics.serviceMonitor.annotations }}

--- a/bitnami/grafana-loki/templates/querier/servicemonitor.yaml
+++ b/bitnami/grafana-loki/templates/querier/servicemonitor.yaml
@@ -9,7 +9,9 @@ kind: ServiceMonitor
 metadata:
   name: {{ template "grafana-loki.querier.fullname" . }}
   namespace: {{ default .Release.Namespace .Values.metrics.serviceMonitor.namespace | quote }}
-  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- $versionLabel := dict "app.kubernetes.io/version" ( include "common.images.version" ( dict "imageRoot" .Values.promtail.image "chart" .Chart ) ) }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.metrics.serviceMonitor.labels .Values.commonLabels $versionLabel ) "context" . ) }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: grafana-loki
     app.kubernetes.io/component: querier
    {{- if or .Values.commonAnnotations .Values.metrics.serviceMonitor.annotations }}

--- a/bitnami/grafana-loki/templates/query-frontend/servicemonitor.yaml
+++ b/bitnami/grafana-loki/templates/query-frontend/servicemonitor.yaml
@@ -9,7 +9,9 @@ kind: ServiceMonitor
 metadata:
   name: {{ template "grafana-loki.query-frontend.fullname" . }}
   namespace: {{ default .Release.Namespace .Values.metrics.serviceMonitor.namespace | quote }}
-  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- $versionLabel := dict "app.kubernetes.io/version" ( include "common.images.version" ( dict "imageRoot" .Values.promtail.image "chart" .Chart ) ) }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.metrics.serviceMonitor.labels .Values.commonLabels $versionLabel ) "context" . ) }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: grafana-loki
     app.kubernetes.io/component: query-frontend
    {{- if or .Values.commonAnnotations .Values.metrics.serviceMonitor.annotations }}

--- a/bitnami/grafana-loki/templates/ruler/servicemonitor.yaml
+++ b/bitnami/grafana-loki/templates/ruler/servicemonitor.yaml
@@ -9,7 +9,9 @@ kind: ServiceMonitor
 metadata:
   name: {{ template "grafana-loki.ruler.fullname" . }}
   namespace: {{ default .Release.Namespace .Values.metrics.serviceMonitor.namespace | quote }}
-  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- $versionLabel := dict "app.kubernetes.io/version" ( include "common.images.version" ( dict "imageRoot" .Values.promtail.image "chart" .Chart ) ) }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.metrics.serviceMonitor.labels .Values.commonLabels $versionLabel ) "context" . ) }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: grafana-loki
     app.kubernetes.io/component: ruler
    {{- if or .Values.commonAnnotations .Values.metrics.serviceMonitor.annotations }}

--- a/bitnami/grafana-loki/templates/table-manager/servicemonitor.yaml
+++ b/bitnami/grafana-loki/templates/table-manager/servicemonitor.yaml
@@ -9,7 +9,9 @@ kind: ServiceMonitor
 metadata:
   name: {{ template "grafana-loki.table-manager.fullname" . }}
   namespace: {{ default .Release.Namespace .Values.metrics.serviceMonitor.namespace | quote }}
-  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- $versionLabel := dict "app.kubernetes.io/version" ( include "common.images.version" ( dict "imageRoot" .Values.promtail.image "chart" .Chart ) ) }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.metrics.serviceMonitor.labels .Values.commonLabels $versionLabel ) "context" . ) }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/part-of: grafana-loki
     app.kubernetes.io/component: table-manager
    {{- if or .Values.commonAnnotations .Values.metrics.serviceMonitor.annotations }}


### PR DESCRIPTION
loki component not include `.Values.metrics.serviceMonitor.labels`

component:
* compactor
* distributor
* index-gateway
* ingester
* querier
* query-frontend
* ruler
* table-manager

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change
<!-- Describe the scope of your change - i.e. what the change does. -->
component:
* compactor
* distributor
* index-gateway
* ingester
* querier
* query-frontend
* ruler
* table-manager

add  `.Values.metrics.serviceMonitor.labels` in each component `servicemonitor.yaml` label section.

### Benefits

<!-- What benefits will be realized by the code change? -->
bugfix.

### Possible drawbacks

<!-- Describe any known limitations with your change -->
don't have this.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
