### PR TITLE
[bitnami/nats] Improve Ginkgo tests

### DIFF
--- a/.vib/nats/ginkgo/nats_test.go
+++ b/.vib/nats/ginkgo/nats_test.go
@@ -10,6 +10,7 @@ import (
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
@@ -32,8 +33,8 @@ var _ = Describe("NATS", Ordered, func() {
 
 	When("a bucket is created and is scaled down to 0 replicas and back up", func() {
 		It("should have access to the created database", func() {
-
 			getAvailableReplicas := func(ss *appsv1.StatefulSet) int32 { return ss.Status.AvailableReplicas }
+			getRestartedAtAnnotation := func(pod *v1.Pod) string { return pod.Annotations["kubectl.kubernetes.io/restartedAt"] }
 			getSucceededJobs := func(j *batchv1.Job) int32 { return j.Status.Succeeded }
 			getOpts := metav1.GetOptions{}
 
@@ -68,6 +69,10 @@ var _ = Describe("NATS", Ordered, func() {
 				return c.BatchV1().Jobs(namespace).Get(ctx, createDBJobName, getOpts)
 			}, timeout, PollingInterval).Should(WithTransform(getSucceededJobs, Equal(int32(1))))
 
+			By("deleting the job once it has succeeded")
+			err = c.BatchV1().Jobs(namespace).Delete(ctx, createDBJobName, metav1.DeleteOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
 			By("puting a value into a key")
 			putJobName := fmt.Sprintf("%s-putbc-%s",
 				stsName, jobSuffix)
@@ -78,26 +83,28 @@ var _ = Describe("NATS", Ordered, func() {
 				return c.BatchV1().Jobs(namespace).Get(ctx, putJobName, getOpts)
 			}, timeout, PollingInterval).Should(WithTransform(getSucceededJobs, Equal(int32(1))))
 
+			By("deleting the job once it has succeeded")
+			err = c.BatchV1().Jobs(namespace).Delete(ctx, putJobName, metav1.DeleteOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
 			// Give the application some time to sync the data
-			time.Sleep(10*time.Second)
+			time.Sleep(10 * time.Second)
 
-			By("scaling down to 0 replicas")
-			ss, err = utils.StsScale(ctx, c, ss, 0)
+			By("rollout restart the statefulset")
+			_, err = utils.StsRolloutRestart(ctx, c, ss)
 			Expect(err).NotTo(HaveOccurred())
 
-			Eventually(func() (*appsv1.StatefulSet, error) {
-				return c.AppsV1().StatefulSets(namespace).Get(ctx, stsName, getOpts)
-			}, timeout, PollingInterval).Should(WithTransform(getAvailableReplicas, BeZero()))
-
-			By("scaling up to the original replicas")
-			ss, err = utils.StsScale(ctx, c, ss, origReplicas)
-			Expect(err).NotTo(HaveOccurred())
+			for i := 0; i < int(origReplicas); i++ {
+				Eventually(func() (*v1.Pod, error) {
+					return c.CoreV1().Pods(namespace).Get(ctx, fmt.Sprintf("%s-%d", stsName, i), getOpts)
+				}, timeout, PollingInterval).Should(WithTransform(getRestartedAtAnnotation, Not(BeEmpty())))
+			}
 
 			Eventually(func() (*appsv1.StatefulSet, error) {
 				return c.AppsV1().StatefulSets(namespace).Get(ctx, stsName, getOpts)
 			}, timeout, PollingInterval).Should(WithTransform(getAvailableReplicas, Equal(origReplicas)))
 
-			By("getting a value for a key")
+			By("creating a job to get a value for a key")
 			getJobName := fmt.Sprintf("%s-getbc-%s",
 				stsName, jobSuffix)
 			err = createJob(ctx, c, getJobName, port, "get", bucketName, "testKey")
@@ -106,6 +113,10 @@ var _ = Describe("NATS", Ordered, func() {
 			Eventually(func() (*batchv1.Job, error) {
 				return c.BatchV1().Jobs(namespace).Get(ctx, getJobName, getOpts)
 			}, timeout, PollingInterval).Should(WithTransform(getSucceededJobs, Equal(int32(1))))
+
+			By("deleting the job once it has succeeded")
+			err = c.BatchV1().Jobs(namespace).Delete(ctx, getJobName, metav1.DeleteOptions{})
+			Expect(err).NotTo(HaveOccurred())
 
 			By("creating a job to get the test bucket")
 			deleteDBJobName := fmt.Sprintf("%s-delbc-%s",
@@ -116,6 +127,10 @@ var _ = Describe("NATS", Ordered, func() {
 			Eventually(func() (*batchv1.Job, error) {
 				return c.BatchV1().Jobs(namespace).Get(ctx, deleteDBJobName, getOpts)
 			}, timeout, PollingInterval).Should(WithTransform(getSucceededJobs, Equal(int32(1))))
+
+			By("deleting the job once it has succeeded")
+			err = c.BatchV1().Jobs(namespace).Delete(ctx, deleteDBJobName, metav1.DeleteOptions{})
+			Expect(err).NotTo(HaveOccurred())
 		})
 	})
 

--- a/.vib/nats/ginkgo/nats_test.go
+++ b/.vib/nats/ginkgo/nats_test.go
@@ -94,7 +94,7 @@ var _ = Describe("NATS", Ordered, func() {
 			_, err = utils.StsRolloutRestart(ctx, c, ss)
 			Expect(err).NotTo(HaveOccurred())
 
-			for i := 0; i < int(origReplicas); i++ {
+			for i := int(origReplicas) - 1; i >= 0; i-- {
 				Eventually(func() (*v1.Pod, error) {
 					return c.CoreV1().Pods(namespace).Get(ctx, fmt.Sprintf("%s-%d", stsName, i), getOpts)
 				}, timeout, PollingInterval).Should(WithTransform(getRestartedAtAnnotation, Not(BeEmpty())))

--- a/bitnami/nats/CHANGELOG.md
+++ b/bitnami/nats/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 8.4.1 (2024-09-13)
+## 8.4.2 (2024-09-17)
 
-* [bitnami/nats] Fix single replica Jetstream ([#29379](https://github.com/bitnami/charts/pull/29379))
+* [bitnami/nats] Improve Ginkgo tests ([#29462](https://github.com/bitnami/charts/pull/29462))
+
+## <small>8.4.1 (2024-09-16)</small>
+
+* [bitnami/nats] Fix single replica Jetstream (#29379) ([4959500](https://github.com/bitnami/charts/commit/4959500b4987deb760d38e06d181022bacc3308d)), closes [#29379](https://github.com/bitnami/charts/issues/29379)
 
 ## 8.4.0 (2024-09-12)
 

--- a/bitnami/nats/Chart.yaml
+++ b/bitnami/nats/Chart.yaml
@@ -31,4 +31,4 @@ maintainers:
 name: nats
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/nats
-version: 8.4.1
+version: 8.4.2


### PR DESCRIPTION
### Description of the change

This PR improves Ginkgo tests reliability for NATS chart by replacing scaling down to 0 and up to the original number of replicas by running a "rollout restart" on the statefulset pods.

The former mechanism is problematic due to an existing mechanism on provisioning service that delete PVC(s) which status is available every 30 seconds (grace period).

### Possible drawbacks

N/A

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)