### PR TITLE
[bitnami/solr] test: :white_check_mark: Improve reliability of ginkgo tests

### DIFF
--- a/.vib/solr/ginkgo/solr_suite_test.go
+++ b/.vib/solr/ginkgo/solr_suite_test.go
@@ -31,7 +31,7 @@ func init() {
 	flag.StringVar(&namespace, "namespace", "", "namespace where the application is running")
 	flag.StringVar(&username, "username", "", "database user")
 	flag.StringVar(&password, "password", "", "database password for username")
-	flag.IntVar(&timeoutSeconds, "timeout", 120, "timeout in seconds")
+	flag.IntVar(&timeoutSeconds, "timeout", 200, "timeout in seconds")
 	timeout = time.Duration(timeoutSeconds) * time.Second
 }
 

--- a/.vib/solr/ginkgo/solr_test.go
+++ b/.vib/solr/ginkgo/solr_test.go
@@ -10,6 +10,7 @@ import (
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
@@ -35,6 +36,7 @@ var _ = Describe("Solr", Ordered, func() {
 
 			getAvailableReplicas := func(ss *appsv1.StatefulSet) int32 { return ss.Status.AvailableReplicas }
 			getSucceededJobs := func(j *batchv1.Job) int32 { return j.Status.Succeeded }
+			getRestartedAtAnnotation := func(pod *v1.Pod) string { return pod.Annotations["kubectl.kubernetes.io/restartedAt"] }
 			getOpts := metav1.GetOptions{}
 
 			By("checking all the replicas are available")
@@ -71,17 +73,15 @@ var _ = Describe("Solr", Ordered, func() {
 				return c.BatchV1().Jobs(namespace).Get(ctx, createColJobName, getOpts)
 			}, timeout, PollingInterval).Should(WithTransform(getSucceededJobs, Equal(int32(1))))
 
-			By("scaling down to 0 replicas")
-			ss, err = utils.StsScale(ctx, c, ss, 0)
+			By("rollout restart the statefulset")
+			_, err = utils.StsRolloutRestart(ctx, c, ss)
 			Expect(err).NotTo(HaveOccurred())
 
-			Eventually(func() (*appsv1.StatefulSet, error) {
-				return c.AppsV1().StatefulSets(namespace).Get(ctx, stsName, getOpts)
-			}, timeout, PollingInterval).Should(WithTransform(getAvailableReplicas, BeZero()))
-
-			By("scaling up to the original replicas")
-			ss, err = utils.StsScale(ctx, c, ss, origReplicas)
-			Expect(err).NotTo(HaveOccurred())
+			for i := int(origReplicas) - 1; i >= 0; i-- {
+				Eventually(func() (*v1.Pod, error) {
+					return c.CoreV1().Pods(namespace).Get(ctx, fmt.Sprintf("%s-%d", stsName, i), getOpts)
+				}, timeout, PollingInterval).Should(WithTransform(getRestartedAtAnnotation, Not(BeEmpty())))
+			}
 
 			Eventually(func() (*appsv1.StatefulSet, error) {
 				return c.AppsV1().StatefulSets(namespace).Get(ctx, stsName, getOpts)

--- a/bitnami/solr/CHANGELOG.md
+++ b/bitnami/solr/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 9.4.4 (2024-09-16)
+## 9.4.5 (2024-09-17)
 
-* [bitnami/solr] Use common password manager to handle password ([#29430](https://github.com/bitnami/charts/pull/29430))
+* [bitnami/solr] test: :white_check_mark: Improve reliability of ginkgo tests ([#29463](https://github.com/bitnami/charts/pull/29463))
+
+## <small>9.4.4 (2024-09-16)</small>
+
+* [bitnami/solr] Use common password manager to handle password (#29430) ([3ecd8bd](https://github.com/bitnami/charts/commit/3ecd8bd03ceb15b03d06744989dc6aafab51c34d)), closes [#29430](https://github.com/bitnami/charts/issues/29430)
 
 ## <small>9.4.3 (2024-09-11)</small>
 

--- a/bitnami/solr/Chart.yaml
+++ b/bitnami/solr/Chart.yaml
@@ -34,4 +34,4 @@ maintainers:
 name: solr
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/solr
-version: 9.4.4
+version: 9.4.5


### PR DESCRIPTION
### Description of the change

This PR improves Ginkgo tests reliability for Solr chart by replacing scaling down to 0 and up to the original number of replicas by running a "rollout restart" on the statefulset pods.

The former mechanism is problematic due to an existing mechanism on provisioning service that delete PVC(s) which status is available every 30 seconds (grace period).

### Possible drawbacks

N/A

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)