### PR TITLE
[bitnami/consul] test: :white_check_mark: Improve reliability of ginkgo tests

### DIFF
--- a/.vib/consul/ginkgo/consul_test.go
+++ b/.vib/consul/ginkgo/consul_test.go
@@ -10,6 +10,7 @@ import (
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
@@ -35,6 +36,7 @@ var _ = Describe("Consul", Ordered, func() {
 
 			getAvailableReplicas := func(ss *appsv1.StatefulSet) int32 { return ss.Status.AvailableReplicas }
 			getSucceededJobs := func(j *batchv1.Job) int32 { return j.Status.Succeeded }
+			getRestartedAtAnnotation := func(pod *v1.Pod) string { return pod.Annotations["kubectl.kubernetes.io/restartedAt"] }
 			getOpts := metav1.GetOptions{}
 
 			By("checking all the replicas are available")
@@ -72,19 +74,19 @@ var _ = Describe("Consul", Ordered, func() {
 				return c.BatchV1().Jobs(namespace).Get(ctx, putKVJobName, getOpts)
 			}, timeout, PollingInterval).Should(WithTransform(getSucceededJobs, Equal(int32(1))))
 
-			By("scaling down to 0 replicas")
-			ss, err = utils.StsScale(
-				ctx, c, ss, 0)
+			By("rollout restart the statefulset")
+			_, err = utils.StsRolloutRestart(ctx, c, ss)
 			Expect(err).NotTo(HaveOccurred())
+
+			for i := int(origReplicas) - 1; i >= 0; i-- {
+				Eventually(func() (*v1.Pod, error) {
+					return c.CoreV1().Pods(namespace).Get(ctx, fmt.Sprintf("%s-%d", stsName, i), getOpts)
+				}, timeout, PollingInterval).Should(WithTransform(getRestartedAtAnnotation, Not(BeEmpty())))
+			}
 
 			Eventually(func() (*appsv1.StatefulSet, error) {
 				return c.AppsV1().StatefulSets(namespace).Get(ctx, stsName, getOpts)
-			}, timeout, PollingInterval).Should(WithTransform(getAvailableReplicas, BeZero()))
-
-			By("scaling up to the original replicas")
-			ss, err = utils.StsScale(
-				ctx, c, ss, origReplicas)
-			Expect(err).NotTo(HaveOccurred())
+			}, timeout, PollingInterval).Should(WithTransform(getAvailableReplicas, Equal(origReplicas)))
 
 			Eventually(func() (*appsv1.StatefulSet, error) {
 				return c.AppsV1().StatefulSets(namespace).Get(ctx, stsName, getOpts)

--- a/bitnami/consul/CHANGELOG.md
+++ b/bitnami/consul/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 11.3.14 (2024-09-05)
+## 11.3.15 (2024-09-17)
 
-* [bitnami/consul] Release 11.3.14 ([#29228](https://github.com/bitnami/charts/pull/29228))
+* [bitnami/consul] test: :white_check_mark: Improve reliability of ginkgo tests ([#29464](https://github.com/bitnami/charts/pull/29464))
+
+## <small>11.3.14 (2024-09-05)</small>
+
+* [bitnami/consul] Release 11.3.14 (#29228) ([ceb5750](https://github.com/bitnami/charts/commit/ceb5750e92b1324bd7f33f80d7013678ef8db5a3)), closes [#29228](https://github.com/bitnami/charts/issues/29228)
 
 ## <small>11.3.13 (2024-08-27)</small>
 

--- a/bitnami/consul/Chart.yaml
+++ b/bitnami/consul/Chart.yaml
@@ -32,4 +32,4 @@ maintainers:
 name: consul
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/consul
-version: 11.3.14
+version: 11.3.15


### PR DESCRIPTION
### Description of the change

This PR improves Ginkgo tests reliability for Consul chart by replacing scaling down to 0 and up to the original number of replicas by running a "rollout restart" on the statefulset pods.

The former mechanism is problematic due to an existing mechanism on provisioning service that delete PVC(s) which status is available every 30 seconds (grace period).

### Possible drawbacks

N/A

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)