### PR TITLE
[bitnami/elasticsearch] test: :white_check_mark: Improve reliability of ginkgo tests

### DIFF
--- a/.vib/elasticsearch/ginkgo/elasticsearch_test.go
+++ b/.vib/elasticsearch/ginkgo/elasticsearch_test.go
@@ -10,6 +10,7 @@ import (
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
@@ -33,6 +34,7 @@ var _ = Describe("Elasticsearch", Ordered, func() {
 	When("an index is created and Elasticsearch is scaled down to 0 replicas and back up", func() {
 		It("should have access to the created index", func() {
 			getReplicaCount := func(ss *appsv1.StatefulSet) int32 { return ss.Status.Replicas }
+			getRestartedAtAnnotation := func(pod *v1.Pod) string { return pod.Annotations["kubectl.kubernetes.io/restartedAt"] }
 			getReadyReplicas := func(ss *appsv1.StatefulSet) int32 { return ss.Status.ReadyReplicas }
 			getSucceededJobs := func(j *batchv1.Job) int32 { return j.Status.Succeeded }
 			getOpts := metav1.GetOptions{}
@@ -71,19 +73,19 @@ var _ = Describe("Elasticsearch", Ordered, func() {
 				return c.BatchV1().Jobs(namespace).Get(ctx, createDBJobName, getOpts)
 			}, timeout, PollingInterval).Should(WithTransform(getSucceededJobs, Equal(int32(1))))
 
-			By("scaling down to 0 replicas")
-			ss, err = utils.StsScale(
-				ctx, c, ss, 0)
+			By("rollout restart the statefulset")
+			_, err = utils.StsRolloutRestart(ctx, c, ss)
 			Expect(err).NotTo(HaveOccurred())
+
+			for i := int(origReplicas) - 1; i >= 0; i-- {
+				Eventually(func() (*v1.Pod, error) {
+					return c.CoreV1().Pods(namespace).Get(ctx, fmt.Sprintf("%s-%d", stsName, i), getOpts)
+				}, timeout, PollingInterval).Should(WithTransform(getRestartedAtAnnotation, Not(BeEmpty())))
+			}
 
 			Eventually(func() (*appsv1.StatefulSet, error) {
 				return c.AppsV1().StatefulSets(namespace).Get(ctx, stsName, getOpts)
-			}, timeout, PollingInterval).Should(WithTransform(getReplicaCount, BeZero()))
-
-			By("scaling up to the original replicas")
-			ss, err = utils.StsScale(
-				ctx, c, ss, origReplicas)
-			Expect(err).NotTo(HaveOccurred())
+			}, timeout, PollingInterval).Should(WithTransform(getReplicaCount, Equal(origReplicas)))
 
 			Eventually(func() (*appsv1.StatefulSet, error) {
 				return c.AppsV1().StatefulSets(namespace).Get(ctx, stsName, getOpts)

--- a/bitnami/elasticsearch/CHANGELOG.md
+++ b/bitnami/elasticsearch/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 21.3.16 (2024-09-11)
+## 21.3.17 (2024-09-17)
 
-* [bitnami/elasticsearch] fix: add apiVersion and kind to volumeClaimTemplates ([#29362](https://github.com/bitnami/charts/pull/29362))
+* [bitnami/elasticsearch] test: :white_check_mark: Improve reliability of ginkgo tests ([#29465](https://github.com/bitnami/charts/pull/29465))
+
+## <small>21.3.16 (2024-09-12)</small>
+
+* [bitnami/elasticsearch] fix: add apiVersion and kind to volumeClaimTemplates (#29362) ([cf547d6](https://github.com/bitnami/charts/commit/cf547d6743e7db4e771ff1d7d6393c5f70a63799)), closes [#29362](https://github.com/bitnami/charts/issues/29362)
 
 ## <small>21.3.15 (2024-09-09)</small>
 

--- a/bitnami/elasticsearch/Chart.yaml
+++ b/bitnami/elasticsearch/Chart.yaml
@@ -34,4 +34,4 @@ maintainers:
 name: elasticsearch
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/elasticsearch
-version: 21.3.16
+version: 21.3.17


### PR DESCRIPTION
### Description of the change

This PR improves Ginkgo tests reliability for Elasticsearch chart by replacing scaling down to 0 and up to the original number of replicas by running a "rollout restart" on the statefulset pods.

The former mechanism is problematic due to an existing mechanism on provisioning service that delete PVC(s) which status is available every 30 seconds (grace period).

### Possible drawbacks

N/A

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)