### PR TITLE
[bitnami/kafka] test: :white_check_mark: Improve reliability of ginkgo tests

### DIFF
--- a/.vib/kafka/ginkgo/kafka_test.go
+++ b/.vib/kafka/ginkgo/kafka_test.go
@@ -10,6 +10,7 @@ import (
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
@@ -34,6 +35,7 @@ var _ = Describe("Kafka", Ordered, func() {
 		It("should have access to the created topic", func() {
 
 			getAvailableReplicas := func(ss *appsv1.StatefulSet) int32 { return ss.Status.AvailableReplicas }
+			getRestartedAtAnnotation := func(pod *v1.Pod) string { return pod.Annotations["kubectl.kubernetes.io/restartedAt"] }
 			getSucceededJobs := func(j *batchv1.Job) int32 { return j.Status.Succeeded }
 			getOpts := metav1.GetOptions{}
 
@@ -71,19 +73,15 @@ var _ = Describe("Kafka", Ordered, func() {
 				return c.BatchV1().Jobs(namespace).Get(ctx, createTPJobName, getOpts)
 			}, timeout, PollingInterval).Should(WithTransform(getSucceededJobs, Equal(int32(1))))
 
-			By("scaling down to 0 replicas")
-			ss, err = utils.StsScale(
-				ctx, c, ss, 0)
+			By("rollout restart the statefulset")
+			_, err = utils.StsRolloutRestart(ctx, c, ss)
 			Expect(err).NotTo(HaveOccurred())
 
-			Eventually(func() (*appsv1.StatefulSet, error) {
-				return c.AppsV1().StatefulSets(namespace).Get(ctx, stsName, getOpts)
-			}, timeout, PollingInterval).Should(WithTransform(getAvailableReplicas, BeZero()))
-
-			By("scaling up to the original replicas")
-			ss, err = utils.StsScale(
-				ctx, c, ss, origReplicas)
-			Expect(err).NotTo(HaveOccurred())
+			for i := int(origReplicas) - 1; i >= 0; i-- {
+				Eventually(func() (*v1.Pod, error) {
+					return c.CoreV1().Pods(namespace).Get(ctx, fmt.Sprintf("%s-%d", stsName, i), getOpts)
+				}, timeout, PollingInterval).Should(WithTransform(getRestartedAtAnnotation, Not(BeEmpty())))
+			}
 
 			Eventually(func() (*appsv1.StatefulSet, error) {
 				return c.AppsV1().StatefulSets(namespace).Get(ctx, stsName, getOpts)

--- a/bitnami/kafka/CHANGELOG.md
+++ b/bitnami/kafka/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 30.1.1 (2024-09-14)
+## 30.1.2 (2024-09-17)
 
-* [bitnami/kafka] Release 30.1.1 ([#29417](https://github.com/bitnami/charts/pull/29417))
+* [bitnami/kafka] test: :white_check_mark: Improve reliability of ginkgo tests ([#29466](https://github.com/bitnami/charts/pull/29466))
+
+## <small>30.1.1 (2024-09-14)</small>
+
+* [bitnami/kafka] Release 30.1.1 (#29417) ([798c4df](https://github.com/bitnami/charts/commit/798c4dfd7e236ac6f8d508e2f3ccf5fd405bd26c)), closes [#29417](https://github.com/bitnami/charts/issues/29417)
 
 ## 30.1.0 (2024-09-13)
 

--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -40,4 +40,4 @@ maintainers:
 name: kafka
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/kafka
-version: 30.1.1
+version: 30.1.2


### PR DESCRIPTION
### Description of the change

This PR improves Ginkgo tests reliability for Kafka chart by replacing scaling down to 0 and up to the original number of replicas by running a "rollout restart" on the statefulset pods.

The former mechanism is problematic due to an existing mechanism on provisioning service that delete PVC(s) which status is available every 30 seconds (grace period).

### Possible drawbacks

N/A

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)