### PR TITLE
[bitnami/mariadb] test: :white_check_mark: Improve reliability of ginkgo tests

### DIFF
--- a/bitnami/mariadb/CHANGELOG.md
+++ b/bitnami/mariadb/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 19.0.5 (2024-08-26)
+## 19.0.6 (2024-09-17)
 
-* [bitnami/mariadb] Fix deprecation warnings in checks ([#29021](https://github.com/bitnami/charts/pull/29021))
+* [bitnami/mariadb] test: :white_check_mark: Improve reliability of ginkgo tests ([#29467](https://github.com/bitnami/charts/pull/29467))
+
+## <small>19.0.5 (2024-08-27)</small>
+
+* [bitnami/mariadb] Fix deprecation warnings in checks (#29021) ([213786f](https://github.com/bitnami/charts/commit/213786f3f87836b41e2e70fcedd007f08a4a012f)), closes [#29021](https://github.com/bitnami/charts/issues/29021)
 
 ## <small>19.0.4 (2024-08-14)</small>
 

--- a/bitnami/mariadb/Chart.yaml
+++ b/bitnami/mariadb/Chart.yaml
@@ -34,4 +34,4 @@ maintainers:
 name: mariadb
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/mariadb
-version: 19.0.5
+version: 19.0.6


### PR DESCRIPTION
### Description of the change

This PR improves Ginkgo tests reliability for MariaDB chart by replacing scaling down to 0 and up to the original number of replicas by running a "rollout restart" on the statefulset pods.

The former mechanism is problematic due to an existing mechanism on provisioning service that delete PVC(s) which status is available every 30 seconds (grace period).

### Possible drawbacks

N/A

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)