### PR TITLE
[bitnami/mongodb] test: :white_check_mark: Improve reliability of ginkgo tests

### DIFF
--- a/.vib/mongodb/ginkgo/mongodb_test.go
+++ b/.vib/mongodb/ginkgo/mongodb_test.go
@@ -10,6 +10,7 @@ import (
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
@@ -34,6 +35,7 @@ var _ = Describe("MongoDB", Ordered, func() {
 		It("should have access to the created database", func() {
 
 			getAvailableReplicas := func(ss *appsv1.Deployment) int32 { return ss.Status.AvailableReplicas }
+			getRestartedAtAnnotation := func(pod *v1.Pod) string { return pod.Annotations["kubectl.kubernetes.io/restartedAt"] }
 			getSucceededJobs := func(j *batchv1.Job) int32 { return j.Status.Succeeded }
 			getOpts := metav1.GetOptions{}
 			By("checking all the replicas are available")
@@ -69,20 +71,18 @@ var _ = Describe("MongoDB", Ordered, func() {
 				return c.BatchV1().Jobs(namespace).Get(ctx, createDBJobName, getOpts)
 			}, timeout, PollingInterval).Should(WithTransform(getSucceededJobs, Equal(int32(1))))
 
-			By("scaling down to 0 replicas")
-			dpl, err = utils.DplScale(ctx, c, dpl, 0)
+			By("rollout restart the statefulset")
+			_, err = utils.StsRolloutRestart(ctx, c, ss)
 			Expect(err).NotTo(HaveOccurred())
 
-			Eventually(func() (*appsv1.Deployment, error) {
-				return c.AppsV1().Deployments(namespace).Get(ctx, deployName, getOpts)
-			}, timeout, PollingInterval).Should(WithTransform(getAvailableReplicas, BeZero()))
+			for i := int(origReplicas) - 1; i >= 0; i-- {
+				Eventually(func() (*v1.Pod, error) {
+					return c.CoreV1().Pods(namespace).Get(ctx, fmt.Sprintf("%s-%d", stsName, i), getOpts)
+				}, timeout, PollingInterval).Should(WithTransform(getRestartedAtAnnotation, Not(BeEmpty())))
+			}
 
-			By("scaling up to the original replicas")
-			dpl, err = utils.DplScale(ctx, c, dpl, origReplicas)
-			Expect(err).NotTo(HaveOccurred())
-
-			Eventually(func() (*appsv1.Deployment, error) {
-				return c.AppsV1().Deployments(namespace).Get(ctx, deployName, getOpts)
+			Eventually(func() (*appsv1.StatefulSet, error) {
+				return c.AppsV1().StatefulSets(namespace).Get(ctx, stsName, getOpts)
 			}, timeout, PollingInterval).Should(WithTransform(getAvailableReplicas, Equal(origReplicas)))
 
 			By("creating a job to drop the test database")

--- a/bitnami/mongodb/CHANGELOG.md
+++ b/bitnami/mongodb/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 15.6.24 (2024-09-14)
+## 15.6.25 (2024-09-17)
 
-* [bitnami/mongodb] Release 15.6.24 ([#29414](https://github.com/bitnami/charts/pull/29414))
+* [bitnami/mongodb] test: :white_check_mark: Improve reliability of ginkgo tests ([#29469](https://github.com/bitnami/charts/pull/29469))
+
+## <small>15.6.24 (2024-09-14)</small>
+
+* [bitnami/mongodb] Release 15.6.24 (#29414) ([dd49bc9](https://github.com/bitnami/charts/commit/dd49bc9b8e14aef99705e0c9eba76ac01de93d5f)), closes [#29414](https://github.com/bitnami/charts/issues/29414)
 
 ## <small>15.6.23 (2024-09-11)</small>
 

--- a/bitnami/mongodb/Chart.yaml
+++ b/bitnami/mongodb/Chart.yaml
@@ -39,4 +39,4 @@ maintainers:
 name: mongodb
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/mongodb
-version: 15.6.24
+version: 15.6.25


### PR DESCRIPTION
### Description of the change

This PR improves Ginkgo tests reliability for MongoDB chart by replacing scaling down to 0 and up to the original number of replicas by running a "rollout restart" on the statefulset pods.

The former mechanism is problematic due to an existing mechanism on provisioning service that delete PVC(s) which status is available every 30 seconds (grace period).

### Possible drawbacks

N/A

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)