### PR TITLE
[bitnami/seaweedfs] test: :white_check_mark: Improve reliability of ginkgo tests

### DIFF
--- a/.vib/seaweedfs/ginkgo/seaweedfs_test.go
+++ b/.vib/seaweedfs/ginkgo/seaweedfs_test.go
@@ -97,7 +97,7 @@ var _ = Describe("SeaweedFS", Ordered, func() {
 
 			Eventually(func() (*appsv1.StatefulSet, error) {
 				return c.AppsV1().StatefulSets(namespace).Get(ctx, masterStsName, getOpts)
-			}, timeout, PollingInterval).Should(WithTransform(getAvailableReplicas, Equal(origReplicas)))
+			}, timeout, PollingInterval).Should(WithTransform(getAvailableReplicas, Equal(masterOrigReplicas)))
 
 			_, err = utils.StsRolloutRestart(ctx, c, volumeSts)
 			Expect(err).NotTo(HaveOccurred())
@@ -110,7 +110,7 @@ var _ = Describe("SeaweedFS", Ordered, func() {
 
 			Eventually(func() (*appsv1.StatefulSet, error) {
 				return c.AppsV1().StatefulSets(namespace).Get(ctx, volumeStsName, getOpts)
-			}, timeout, PollingInterval).Should(WithTransform(getAvailableReplicas, Equal(origReplicas)))
+			}, timeout, PollingInterval).Should(WithTransform(getAvailableReplicas, Equal(volumeOrigReplicas)))
 
 			By("creating a job to download the file")
 			downloadJobName := fmt.Sprintf("weed-download-%s", jobSuffix)

--- a/.vib/seaweedfs/ginkgo/seaweedfs_test.go
+++ b/.vib/seaweedfs/ginkgo/seaweedfs_test.go
@@ -10,6 +10,7 @@ import (
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
@@ -34,6 +35,7 @@ var _ = Describe("SeaweedFS", Ordered, func() {
 		It("should have access to the uploaded file", func() {
 
 			getAvailableReplicas := func(ss *appsv1.StatefulSet) int32 { return ss.Status.AvailableReplicas }
+			getRestartedAtAnnotation := func(pod *v1.Pod) string { return pod.Annotations["kubectl.kubernetes.io/restartedAt"] }
 			getSucceededJobs := func(j *batchv1.Job) int32 { return j.Status.Succeeded }
 			getOpts := metav1.GetOptions{}
 
@@ -83,31 +85,32 @@ var _ = Describe("SeaweedFS", Ordered, func() {
 				return c.BatchV1().Jobs(namespace).Get(ctx, uploadJobName, getOpts)
 			}, timeout, PollingInterval).Should(WithTransform(getSucceededJobs, Equal(int32(1))))
 
-			By("scaling down to 0 replicas both master & volume servers")
-			masterSts, err = utils.StsScale(ctx, c, masterSts, 0)
+			By("rollout restart the master & volume servers")
+			_, err = utils.StsRolloutRestart(ctx, c, masterSts)
 			Expect(err).NotTo(HaveOccurred())
-			volumeSts, err = utils.StsScale(ctx, c, volumeSts, 0)
-			Expect(err).NotTo(HaveOccurred())
+
+			for i := int(masterOrigReplicas) - 1; i >= 0; i-- {
+				Eventually(func() (*v1.Pod, error) {
+					return c.CoreV1().Pods(namespace).Get(ctx, fmt.Sprintf("%s-%d", masterStsName, i), getOpts)
+				}, timeout, PollingInterval).Should(WithTransform(getRestartedAtAnnotation, Not(BeEmpty())))
+			}
 
 			Eventually(func() (*appsv1.StatefulSet, error) {
 				return c.AppsV1().StatefulSets(namespace).Get(ctx, masterStsName, getOpts)
-			}, timeout, PollingInterval).Should(WithTransform(getAvailableReplicas, BeZero()))
-			Eventually(func() (*appsv1.StatefulSet, error) {
-				return c.AppsV1().StatefulSets(namespace).Get(ctx, volumeStsName, getOpts)
-			}, timeout, PollingInterval).Should(WithTransform(getAvailableReplicas, BeZero()))
+			}, timeout, PollingInterval).Should(WithTransform(getAvailableReplicas, Equal(origReplicas)))
 
-			By("scaling up to the original replicas")
-			_, err = utils.StsScale(ctx, c, masterSts, masterOrigReplicas)
-			Expect(err).NotTo(HaveOccurred())
-			_, err = utils.StsScale(ctx, c, volumeSts, volumeOrigReplicas)
+			_, err = utils.StsRolloutRestart(ctx, c, volumeSts)
 			Expect(err).NotTo(HaveOccurred())
 
-			Eventually(func() (*appsv1.StatefulSet, error) {
-				return c.AppsV1().StatefulSets(namespace).Get(ctx, masterStsName, getOpts)
-			}, timeout, PollingInterval).Should(WithTransform(getAvailableReplicas, Equal(masterOrigReplicas)))
+			for i := int(volumeOrigReplicas) - 1; i >= 0; i-- {
+				Eventually(func() (*v1.Pod, error) {
+					return c.CoreV1().Pods(namespace).Get(ctx, fmt.Sprintf("%s-%d", volumeStsName, i), getOpts)
+				}, timeout, PollingInterval).Should(WithTransform(getRestartedAtAnnotation, Not(BeEmpty())))
+			}
+
 			Eventually(func() (*appsv1.StatefulSet, error) {
 				return c.AppsV1().StatefulSets(namespace).Get(ctx, volumeStsName, getOpts)
-			}, timeout, PollingInterval).Should(WithTransform(getAvailableReplicas, Equal(volumeOrigReplicas)))
+			}, timeout, PollingInterval).Should(WithTransform(getAvailableReplicas, Equal(origReplicas)))
 
 			By("creating a job to download the file")
 			downloadJobName := fmt.Sprintf("weed-download-%s", jobSuffix)

--- a/bitnami/seaweedfs/CHANGELOG.md
+++ b/bitnami/seaweedfs/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
+## 2.0.1 (2024-09-17)
+
+* [bitnami/seaweedfs] test: :white_check_mark: Improve reliability of ginkgo tests ([#29473](https://github.com/bitnami/charts/pull/29473))
+
 ## 2.0.0 (2024-09-16)
 
-* [bitnami/seaweedfs] Add support for PostgreSQL as alternative db ([#29400](https://github.com/bitnami/charts/pull/29400))
+* [bitnami/seaweedfs] Add support for PostgreSQL as alternative db (#29400) ([c43d3ba](https://github.com/bitnami/charts/commit/c43d3bac08541808d8b0d4f0e86f7870ed7a5411)), closes [#29400](https://github.com/bitnami/charts/issues/29400)
 
 ## <small>1.1.2 (2024-09-13)</small>
 

--- a/bitnami/seaweedfs/Chart.yaml
+++ b/bitnami/seaweedfs/Chart.yaml
@@ -50,4 +50,4 @@ name: seaweedfs
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/seawwedfs
 - https://github.com/bitnami/containers/tree/main/bitnami/seaweedfs
-version: 2.0.0
+version: 2.0.1


### PR DESCRIPTION
### Description of the change

This PR improves Ginkgo tests reliability for SeaweedFS chart by replacing scaling down to 0 and up to the original number of replicas by running a "rollout restart" on the statefulset pods.

The former mechanism is problematic due to an existing mechanism on provisioning service that delete PVC(s) which status is available every 30 seconds (grace period).

### Possible drawbacks

N/A

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)