### PR TITLE
[bitnami/etcd] test: :white_check_mark: Improve reliability of ginkgo tests

### DIFF
--- a/.vib/etcd/ginkgo/etcd_test.go
+++ b/.vib/etcd/ginkgo/etcd_test.go
@@ -10,6 +10,7 @@ import (
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
@@ -34,6 +35,7 @@ var _ = Describe("etcd", Ordered, func() {
 		It("should have access to the created database", func() {
 
 			getAvailableReplicas := func(ss *appsv1.StatefulSet) int32 { return ss.Status.AvailableReplicas }
+			getRestartedAtAnnotation := func(pod *v1.Pod) string { return pod.Annotations["kubectl.kubernetes.io/restartedAt"] }
 			getSucceededJobs := func(j *batchv1.Job) int32 { return j.Status.Succeeded }
 			getOpts := metav1.GetOptions{}
 
@@ -71,27 +73,15 @@ var _ = Describe("etcd", Ordered, func() {
 				return c.BatchV1().Jobs(namespace).Get(ctx, createKeyJobName, getOpts)
 			}, timeout, PollingInterval).Should(WithTransform(getSucceededJobs, Equal(int32(1))))
 
-			// We cannot scale the cluster to 0 because etcd needs a minimum quorum to work. Therefore
-			// we will delete one pod, ensure it's back in the cluster, and then move onto the next
-			// https://etcd.io/docs/v3.5/op-guide/recovery/
-			for i := 0; i < int(origReplicas); i++ {
-				By(fmt.Sprintf("Redeploying replica %d", i))
-				podName := fmt.Sprintf("%s-%d", stsName, i)
-				err = c.CoreV1().Pods(namespace).Delete(ctx, podName, metav1.DeleteOptions{})
-				Expect(err).NotTo(HaveOccurred())
-				// In order to avoid race conditions, we ensure that the number of available replicas is N-1
-				// and then we check that it's back to N
-				Eventually(func() (*appsv1.StatefulSet, error) {
-					return c.AppsV1().StatefulSets(namespace).Get(ctx, stsName, getOpts)
-				}, timeout, PollingInterval).Should(WithTransform(getAvailableReplicas, Equal(origReplicas-1)))
-				Eventually(func() (*appsv1.StatefulSet, error) {
-					return c.AppsV1().StatefulSets(namespace).Get(ctx, stsName, getOpts)
-				}, timeout, PollingInterval).Should(WithTransform(getAvailableReplicas, Equal(origReplicas)))
-			}
-
-			By("scaling up to the original replicas")
-			ss, err = utils.StsScale(ctx, c, ss, origReplicas)
+			By("rollout restart the statefulset")
+			_, err = utils.StsRolloutRestart(ctx, c, ss)
 			Expect(err).NotTo(HaveOccurred())
+
+			for i := int(origReplicas) - 1; i >= 0; i-- {
+				Eventually(func() (*v1.Pod, error) {
+					return c.CoreV1().Pods(namespace).Get(ctx, fmt.Sprintf("%s-%d", stsName, i), getOpts)
+				}, timeout, PollingInterval).Should(WithTransform(getRestartedAtAnnotation, Not(BeEmpty())))
+			}
 
 			Eventually(func() (*appsv1.StatefulSet, error) {
 				return c.AppsV1().StatefulSets(namespace).Get(ctx, stsName, getOpts)

--- a/bitnami/etcd/CHANGELOG.md
+++ b/bitnami/etcd/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 10.2.16 (2024-09-12)
+## 10.2.17 (2024-09-17)
 
-* [bitnami/etcd] Release 10.2.16 ([#29380](https://github.com/bitnami/charts/pull/29380))
+* [bitnami/etcd] test: :white_check_mark: Improve reliability of ginkgo tests ([#29476](https://github.com/bitnami/charts/pull/29476))
+
+## <small>10.2.16 (2024-09-12)</small>
+
+* [bitnami/etcd] Release 10.2.16 (#29380) ([250df75](https://github.com/bitnami/charts/commit/250df756b74ba578a9e4521c2a958e3860ec1166)), closes [#29380](https://github.com/bitnami/charts/issues/29380)
 
 ## <small>10.2.15 (2024-09-12)</small>
 

--- a/bitnami/etcd/Chart.yaml
+++ b/bitnami/etcd/Chart.yaml
@@ -32,4 +32,4 @@ maintainers:
 name: etcd
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/etcd
-version: 10.2.16
+version: 10.2.17


### PR DESCRIPTION
### Description of the change

This PR improves Ginkgo tests reliability for etcd chart by replacing scaling down to 0 and up to the original number of replicas by running a "rollout restart" on the statefulset pods.

The former mechanism is problematic due to an existing mechanism on provisioning service that delete PVC(s) which status is available every 30 seconds (grace period).

### Possible drawbacks

N/A

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)