### PR TITLE
[bitnami/minio] fix: :bug: Add sleep to avoid race condition in provisioning

### DIFF
--- a/bitnami/minio/CHANGELOG.md
+++ b/bitnami/minio/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 14.7.9 (2024-09-16)
+## 14.7.10 (2024-09-17)
 
-* [bitnami/minio] Release 14.7.9 ([#29455](https://github.com/bitnami/charts/pull/29455))
+* [bitnami/minio] fix: :bug: Add sleep to avoid race condition in provisioning ([#29478](https://github.com/bitnami/charts/pull/29478))
+
+## <small>14.7.9 (2024-09-16)</small>
+
+* [bitnami/minio] Release 14.7.9 (#29455) ([f0e7a10](https://github.com/bitnami/charts/commit/f0e7a10b383dac974d6704604e7cebbb355cccef)), closes [#29455](https://github.com/bitnami/charts/issues/29455)
 
 ## <small>14.7.8 (2024-09-11)</small>
 
@@ -38,8 +42,11 @@
 
 ## 14.7.0 (2024-08-12)
 
-* [bitnami/minio] Release 14.6.33 (#28731) ([558c1f8](https://github.com/bitnami/charts/commit/558c1f8056152e5d16fdf35db29c4028a31453fe)), closes [#28731](https://github.com/bitnami/charts/issues/28731)
 * [bitnami/minio]: Option to use a secret. (#27837) ([5c21623](https://github.com/bitnami/charts/commit/5c2162370dd5d99d4df91f36b1fcc778ac604673)), closes [#27837](https://github.com/bitnami/charts/issues/27837)
+
+## <small>14.6.33 (2024-08-07)</small>
+
+* [bitnami/minio] Release 14.6.33 (#28731) ([558c1f8](https://github.com/bitnami/charts/commit/558c1f8056152e5d16fdf35db29c4028a31453fe)), closes [#28731](https://github.com/bitnami/charts/issues/28731)
 
 ## <small>14.6.32 (2024-08-03)</small>
 

--- a/bitnami/minio/Chart.yaml
+++ b/bitnami/minio/Chart.yaml
@@ -34,4 +34,4 @@ maintainers:
 name: minio
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/minio
-version: 14.7.9
+version: 14.7.10

--- a/bitnami/minio/templates/provisioning-job.yaml
+++ b/bitnami/minio/templates/provisioning-job.yaml
@@ -79,7 +79,7 @@ spec:
           command:
             - /bin/bash
             - -c
-            - >-
+            - |-
               set -e;
               echo "Start Minio provisioning";
 
@@ -146,7 +146,7 @@ spec:
               # Adding a sleep to ensure that the check below does not cause
               # a race condition. We check for the MinIO port because the
               # "mc admin service restart --wait" command is not working as expected
-              sleep 5
+              sleep 5;
               echo "Waiting for Minio to be available after restart";
               wait-for-port \
                 --host={{ include "common.names.fullname" . }} \

--- a/bitnami/minio/templates/provisioning-job.yaml
+++ b/bitnami/minio/templates/provisioning-job.yaml
@@ -143,6 +143,18 @@ spec:
 
               mc admin service restart {{ $minioAlias }} --wait --json;
 
+              # Adding a sleep to ensure that the check below does not cause
+              # a race condition. We check for the MinIO port because the
+              # "mc admin service restart --wait" command is not working as expected
+              sleep 5
+              echo "Waiting for Minio to be available after restart";
+              wait-for-port \
+                --host={{ include "common.names.fullname" . }} \
+                --state=inuse \
+                --timeout=120 \
+                {{ .Values.service.ports.api | int64 }};
+              echo "Minio is available. Executing provisioning commands";
+
               {{- range $policy := .Values.provisioning.policies }}
               mc admin policy create {{ $minioAlias }} {{ $policy.name }} /etc/ilm/policy-{{ $policy.name }}.json;
               {{- end }}


### PR DESCRIPTION

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

This PR adds an extra wait because of an issue starting with this version https://github.com/bitnami/charts/pull/28118. It seems that the `--wait` and `--json` commands are not honored at the same time, causing a deployment issue in apps that have minio like grafana-mimir or mastodon. We add an extra wait to ensure that the restart finishes successfully.

<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [ ] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [ ] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
