### PR TITLE
[bitnami/minio] Fix #29337: MinIO invalid ingress in network policy

### DIFF
--- a/bitnami/minio/CHANGELOG.md
+++ b/bitnami/minio/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 14.7.10 (2024-09-17)
+## 14.7.11 (2024-09-18)
 
-* [bitnami/minio] fix: :bug: Add sleep to avoid race condition in provisioning ([#29478](https://github.com/bitnami/charts/pull/29478))
+* [bitnami/minio] Fix #29337: MinIO invalid ingress in network policy ([#29493](https://github.com/bitnami/charts/pull/29493))
+
+## <small>14.7.10 (2024-09-17)</small>
+
+* [bitnami/minio] fix: :bug: Add sleep to avoid race condition in provisioning (#29478) ([c522a3c](https://github.com/bitnami/charts/commit/c522a3c203b3d2fc381698384c58e63ab2bba5c0)), closes [#29478](https://github.com/bitnami/charts/issues/29478)
 
 ## <small>14.7.9 (2024-09-16)</small>
 

--- a/bitnami/minio/Chart.yaml
+++ b/bitnami/minio/Chart.yaml
@@ -34,4 +34,4 @@ maintainers:
 name: minio
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/minio
-version: 14.7.10
+version: 14.7.11

--- a/bitnami/minio/templates/networkpolicy.yaml
+++ b/bitnami/minio/templates/networkpolicy.yaml
@@ -77,7 +77,4 @@ spec:
         {{- toYaml $extraIngress | nindent 6 }}
         {{- end }}
       {{- end }}
-    {{- if .Values.networkPolicy.extraIngress }}
-    {{- include "common.tplvalues.render" ( dict "value" .Values.networkPolicy.extraIngress "context" $ ) | nindent 4 }}
-    {{- end }}
 {{- end }}

--- a/bitnami/minio/templates/networkpolicy.yaml
+++ b/bitnami/minio/templates/networkpolicy.yaml
@@ -74,7 +74,7 @@ spec:
         {{- end }}
         {{- $extraIngress := coalesce .Values.networkPolicy.extraIngress .Values.networkPolicy.extraFromClauses }}
         {{- if $extraIngress }}
-        {{- toYaml $extraIngress | nindent 8 }}
+        {{- toYaml $extraIngress | nindent 6 }}
         {{- end }}
       {{- end }}
     {{- if .Values.networkPolicy.extraIngress }}


### PR DESCRIPTION
### Description of the change

This PR fixes two issues:
1. Removes duplicate `extraIngress` values in the NetworkPolicy
2. Fixed incorrect indentation for the `extraIngress` / `extraFromClauses` values

### Benefits

No more errors when installing the chart because of incorrectly formatted yaml

### Possible drawbacks

If somebody already took the incorrect indentation into account, and instead of making `extraIngress` values. they made `extraFromClauses` where they left out the `from` level, their output yaml will now be invalid.

### Applicable issues

- fixes #29337

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)