### PR TITLE
[bitnami/harbor] Fix REGISTRY_HTTP_SECRET encoding when declared on an existing secret

### DIFF
--- a/bitnami/harbor/CHANGELOG.md
+++ b/bitnami/harbor/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 23.0.3 (2024-09-11)
+## 23.0.4 (2024-09-18)
 
-* [bitnami/harbor] Release 23.0.3 ([#29349](https://github.com/bitnami/charts/pull/29349))
+* [bitnami/harbor] Fix REGISTRY_HTTP_SECRET encoding when declared on an existing secret ([#29494](https://github.com/bitnami/charts/pull/29494))
+
+## <small>23.0.3 (2024-09-11)</small>
+
+* [bitnami/harbor] Release 23.0.3 (#29349) ([1f523e4](https://github.com/bitnami/charts/commit/1f523e4fcd930b31748457de8ee95289e72064da)), closes [#29349](https://github.com/bitnami/charts/issues/29349)
 
 ## <small>23.0.2 (2024-09-03)</small>
 
@@ -11,6 +15,9 @@
 ## <small>23.0.1 (2024-08-24)</small>
 
 * [bitnami/harbor] Release 23.0.1 (#29012) ([e8508d7](https://github.com/bitnami/charts/commit/e8508d7e47f9d7f88ae3081067451df61320792c)), closes [#29012](https://github.com/bitnami/charts/issues/29012)
+
+## 23.0.0 (2024-08-13)
+
 * [bitnami/harbor] Update dependencies (#28853) ([52607e4](https://github.com/bitnami/charts/commit/52607e4c3580532b172089da96302513014af1f4)), closes [#28853](https://github.com/bitnami/charts/issues/28853)
 
 ## <small>22.0.12 (2024-08-08)</small>

--- a/bitnami/harbor/CHANGELOG.md
+++ b/bitnami/harbor/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 23.0.4 (2024-09-18)
+## 23.0.4 (2024-09-19)
 
 * [bitnami/harbor] Fix REGISTRY_HTTP_SECRET encoding when declared on an existing secret ([#29494](https://github.com/bitnami/charts/pull/29494))
 

--- a/bitnami/harbor/Chart.yaml
+++ b/bitnami/harbor/Chart.yaml
@@ -55,4 +55,4 @@ maintainers:
 name: harbor
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/harbor
-version: 23.0.3
+version: 23.0.4

--- a/bitnami/harbor/templates/registry/registry-secret.yaml
+++ b/bitnami/harbor/templates/registry/registry-secret.yaml
@@ -48,7 +48,7 @@ metadata:
 type: Opaque
 data:
   REGISTRY_HTPASSWD: {{ $existingEnvVarsSecretRegistry.REGISTRY_HTPASSWD | default .Values.registry.credentials.htpasswd | b64enc | quote }}
-  {{ $registryHttpSecret := $existingEnvVarsSecretRegistry.REGISTRY_HTTP_SECRET }}
+  {{- $registryHttpSecret := $existingEnvVarsSecretRegistry.REGISTRY_HTTP_SECRET }}
   {{- if eq $registryHttpSecret "" }}
   REGISTRY_HTTP_SECRET: {{ include "common.secrets.passwords.manage" ( dict "secret" (include "harbor.registry" .) "key" "REGISTRY_HTTP_SECRET" "length" 16 "providedValues" (list "registry.secret") "context" $ ) }}
   {{- else }}

--- a/bitnami/harbor/templates/registry/registry-secret.yaml
+++ b/bitnami/harbor/templates/registry/registry-secret.yaml
@@ -48,7 +48,13 @@ metadata:
 type: Opaque
 data:
   REGISTRY_HTPASSWD: {{ $existingEnvVarsSecretRegistry.REGISTRY_HTPASSWD | default .Values.registry.credentials.htpasswd | b64enc | quote }}
-  REGISTRY_HTTP_SECRET: {{ $existingEnvVarsSecretRegistry.REGISTRY_HTTP_SECRET | default (include "common.secrets.passwords.manage" (dict "secret" (include "harbor.registry" .) "key" "REGISTRY_HTTP_SECRET" "length" 16 "providedValues" (list "registry.secret") "context" $)) }}
+  {{ $registryHttpSecret := $existingEnvVarsSecretRegistry.REGISTRY_HTTP_SECRET }}
+  {{- if eq $registryHttpSecret "" }}
+  REGISTRY_HTTP_SECRET: {{ include "common.secrets.passwords.manage" ( dict "secret" (include "harbor.registry" .) "key" "REGISTRY_HTTP_SECRET" "length" 16 "providedValues" (list "registry.secret") "context" $ ) }}
+  {{- else }}
+  REGISTRY_HTTP_SECRET: {{ $registryHttpSecret | b64enc | quote }}
+  {{- end }}
+  REGISTRY_HTTP_SECRET: {{ $existingEnvVarsSecretRegistry.REGISTRY_HTTP_SECRET | default ()) }}
   REGISTRY_REDIS_PASSWORD: {{ $existingEnvVarsSecretRegistry.REGISTRY_REDIS_PASSWORD | default (include "harbor.redis.rawPassword" .) | b64enc | quote }}
   {{- if eq .Values.persistence.imageChartStorage.type "azure" }}
   REGISTRY_STORAGE_AZURE_ACCOUNTKEY: {{ $existingEnvVarsSecretRegistry.REGISTRY_STORAGE_AZURE_ACCOUNTKEY | default .Values.persistence.imageChartStorage.azure.accountkey | b64enc | quote }}

--- a/bitnami/harbor/templates/registry/registry-secret.yaml
+++ b/bitnami/harbor/templates/registry/registry-secret.yaml
@@ -52,7 +52,7 @@ data:
   {{- if eq $registryHttpSecret "" }}
   REGISTRY_HTTP_SECRET: {{ include "common.secrets.passwords.manage" ( dict "secret" (include "harbor.registry" .) "key" "REGISTRY_HTTP_SECRET" "length" 16 "providedValues" (list "registry.secret") "context" $ ) }}
   {{- else }}
-  REGISTRY_HTTP_SECRET: {{ $registryHttpSecret | b64enc | quote }}
+  REGISTRY_HTTP_SECRET: {{ print $registryHttpSecret | b64enc | quote }}
   {{- end }}
   REGISTRY_REDIS_PASSWORD: {{ $existingEnvVarsSecretRegistry.REGISTRY_REDIS_PASSWORD | default (include "harbor.redis.rawPassword" .) | b64enc | quote }}
   {{- if eq .Values.persistence.imageChartStorage.type "azure" }}

--- a/bitnami/harbor/templates/registry/registry-secret.yaml
+++ b/bitnami/harbor/templates/registry/registry-secret.yaml
@@ -54,7 +54,6 @@ data:
   {{- else }}
   REGISTRY_HTTP_SECRET: {{ $registryHttpSecret | b64enc | quote }}
   {{- end }}
-  REGISTRY_HTTP_SECRET: {{ $existingEnvVarsSecretRegistry.REGISTRY_HTTP_SECRET | default ()) }}
   REGISTRY_REDIS_PASSWORD: {{ $existingEnvVarsSecretRegistry.REGISTRY_REDIS_PASSWORD | default (include "harbor.redis.rawPassword" .) | b64enc | quote }}
   {{- if eq .Values.persistence.imageChartStorage.type "azure" }}
   REGISTRY_STORAGE_AZURE_ACCOUNTKEY: {{ $existingEnvVarsSecretRegistry.REGISTRY_STORAGE_AZURE_ACCOUNTKEY | default .Values.persistence.imageChartStorage.azure.accountkey | b64enc | quote }}


### PR DESCRIPTION
### Description of the change

`REGISTRY_HTTP_SECRET` value should be base64 encoded when taken from an existing secret

### Benefits

The chart does not generate an invalid secret definition when `registry.existingSecret` value is specified.

### Possible drawbacks

The should be none.

### Applicable issues

- fixes #29372

### Additional information

None

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
