### PR TITLE
[bitnami/nginx] templates/ingress.yaml: fix wrong www.www tls name

### DIFF
--- a/bitnami/nginx/CHANGELOG.md
+++ b/bitnami/nginx/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 18.2.1 (2024-09-22)
+## 18.2.1 (2024-09-23)
 
 * [bitnami/nginx] templates/ingress.yaml: fix wrong www.www tls name ([#29563](https://github.com/bitnami/charts/pull/29563))
 

--- a/bitnami/nginx/CHANGELOG.md
+++ b/bitnami/nginx/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 18.2.1 (2024-09-23)
+## 18.2.1 (2024-09-29)
 
 * [bitnami/nginx] templates/ingress.yaml: fix wrong www.www tls name ([#29563](https://github.com/bitnami/charts/pull/29563))
 

--- a/bitnami/nginx/CHANGELOG.md
+++ b/bitnami/nginx/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
+## 18.2.1 (2024-09-22)
+
+* [bitnami/nginx] templates/ingress.yaml: fix wrong www.www tls name ([#29563](https://github.com/bitnami/charts/pull/29563))
+
 ## 18.2.0 (2024-09-20)
 
-* [bitnami/nginx] stream server blocks ([#29491](https://github.com/bitnami/charts/pull/29491))
+* [bitnami/nginx] stream server blocks (#29491) ([89e5604](https://github.com/bitnami/charts/commit/89e5604be18dff45ac2da9ff48383b97cb20a23d)), closes [#29491](https://github.com/bitnami/charts/issues/29491)
 
 ## <small>18.1.15 (2024-09-19)</small>
 

--- a/bitnami/nginx/Chart.yaml
+++ b/bitnami/nginx/Chart.yaml
@@ -34,4 +34,4 @@ maintainers:
 name: nginx
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/nginx
-version: 18.2.0
+version: 18.2.1

--- a/bitnami/nginx/templates/ingress.yaml
+++ b/bitnami/nginx/templates/ingress.yaml
@@ -61,10 +61,8 @@ spec:
     {{- if and .Values.ingress.tls (or (include "common.ingress.certManagerRequest" ( dict "annotations" .Values.ingress.annotations )) .Values.ingress.selfSigned (not (empty .Values.ingress.secrets))) }}
     - hosts:
         - {{ .Values.ingress.hostname | quote }}
-        {{- if or (.Values.ingress.tlsWwwPrefix) (eq (index .Values.ingress.annotations "nginx.ingress.kubernetes.io/from-to-www-redirect") "true" ) }}
-        {{- if not (contains "www." .Values.ingress.hostname) }}
+        {{- if and (or (.Values.ingress.tlsWwwPrefix) (eq (index .Values.ingress.annotations "nginx.ingress.kubernetes.io/from-to-www-redirect") "true" )) (not (contains "www." .Values.ingress.hostname))  }}
         - {{ printf "www.%s" (tpl .Values.ingress.hostname $) | quote }}
-        {{- end }}
         {{- end }}
       secretName: {{ printf "%s-tls" .Values.ingress.hostname }}
     {{- end }}

--- a/bitnami/nginx/templates/ingress.yaml
+++ b/bitnami/nginx/templates/ingress.yaml
@@ -62,7 +62,9 @@ spec:
     - hosts:
         - {{ .Values.ingress.hostname | quote }}
         {{- if or (.Values.ingress.tlsWwwPrefix) (eq (index .Values.ingress.annotations "nginx.ingress.kubernetes.io/from-to-www-redirect") "true" ) }}
+        {{- if not (contains "www." .Values.ingress.hostname) }}
         - {{ printf "www.%s" (tpl .Values.ingress.hostname $) | quote }}
+        {{- end }}
         {{- end }}
       secretName: {{ printf "%s-tls" .Values.ingress.hostname }}
     {{- end }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

This should fix the issue mentioned in #29190, which impacts the **nginx**, **wordpress** and **drupal** charts.

### Benefits

<!-- What benefits will be realized by the code change? -->

It should now be possible to use an ingress.hostname value of [www.example.com](http://www.example.com/) and set the nginx.ingress.kubernetes.io/from-to-www-redirect annotation, without a TLS host for [www.www.example.com](http://www.www.example.com/) being added.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
