### PR TITLE
[bitnami/drupal] templates/ingress.yaml: fix wrong www.www tls name

### DIFF
--- a/bitnami/drupal/CHANGELOG.md
+++ b/bitnami/drupal/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 20.0.8 (2024-09-22)
+## 20.0.8 (2024-09-23)
 
 * [bitnami/drupal] templates/ingress.yaml: fix wrong www.www tls name ([#29564](https://github.com/bitnami/charts/pull/29564))
 

--- a/bitnami/drupal/CHANGELOG.md
+++ b/bitnami/drupal/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 20.0.7 (2024-09-19)
+## 20.0.8 (2024-09-22)
 
-* [bitnami/drupal] Release 20.0.7 ([#29515](https://github.com/bitnami/charts/pull/29515))
+* [bitnami/drupal] templates/ingress.yaml: fix wrong www.www tls name ([#29564](https://github.com/bitnami/charts/pull/29564))
+
+## <small>20.0.7 (2024-09-19)</small>
+
+* [bitnami/drupal] Release 20.0.7 (#29515) ([cfcfb7f](https://github.com/bitnami/charts/commit/cfcfb7fd7ae06eb0f766a71230bafb788893bc3c)), closes [#29515](https://github.com/bitnami/charts/issues/29515)
 
 ## <small>20.0.6 (2024-09-17)</small>
 

--- a/bitnami/drupal/CHANGELOG.md
+++ b/bitnami/drupal/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 20.0.8 (2024-09-23)
+## 20.0.8 (2024-09-29)
 
 * [bitnami/drupal] templates/ingress.yaml: fix wrong www.www tls name ([#29564](https://github.com/bitnami/charts/pull/29564))
 

--- a/bitnami/drupal/Chart.yaml
+++ b/bitnami/drupal/Chart.yaml
@@ -40,4 +40,4 @@ maintainers:
 name: drupal
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/drupal
-version: 20.0.7
+version: 20.0.8

--- a/bitnami/drupal/templates/ingress.yaml
+++ b/bitnami/drupal/templates/ingress.yaml
@@ -54,10 +54,8 @@ spec:
      {{- if .Values.ingress.tls }}
     - hosts:
         - {{ .Values.ingress.hostname | quote }}
-        {{- if or (.Values.ingress.tlsWwwPrefix) (eq (index .Values.ingress.annotations "nginx.ingress.kubernetes.io/from-to-www-redirect") "true" ) }}
-        {{- if not (contains "www." .Values.ingress.hostname) }}
+        {{- if and (or (.Values.ingress.tlsWwwPrefix) (eq (index .Values.ingress.annotations "nginx.ingress.kubernetes.io/from-to-www-redirect") "true" )) (not (contains "www." .Values.ingress.hostname))  }}
         - {{ printf "www.%s" (tpl .Values.ingress.hostname $) | quote }}
-        {{- end }}
         {{- end }}
       secretName: {{ printf "%s-tls" .Values.ingress.hostname }}
     {{- end }}

--- a/bitnami/drupal/templates/ingress.yaml
+++ b/bitnami/drupal/templates/ingress.yaml
@@ -55,7 +55,9 @@ spec:
     - hosts:
         - {{ .Values.ingress.hostname | quote }}
         {{- if or (.Values.ingress.tlsWwwPrefix) (eq (index .Values.ingress.annotations "nginx.ingress.kubernetes.io/from-to-www-redirect") "true" ) }}
+        {{- if not (contains "www." .Values.ingress.hostname) }}
         - {{ printf "www.%s" (tpl .Values.ingress.hostname $) | quote }}
+        {{- end }}
         {{- end }}
       secretName: {{ printf "%s-tls" .Values.ingress.hostname }}
     {{- end }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

This should fix the issue mentioned in https://github.com/bitnami/charts/issues/29190, which impacts the nginx, wordpress and drupal charts.

### Benefits

<!-- What benefits will be realized by the code change? -->

It should now be possible to use an ingress.hostname value of www.example.com and set the nginx.ingress.kubernetes.io/from-to-www-redirect annotation, without a TLS host for www.www.example.com being added.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
