### PR TITLE
[bitnami/mongodb] Fixed arbiter anti affinity rules to prevent it from running on the same node of a primary/secondary replica

### DIFF
--- a/bitnami/mongodb/Chart.yaml
+++ b/bitnami/mongodb/Chart.yaml
@@ -39,4 +39,4 @@ maintainers:
 name: mongodb
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/mongodb
-version: 15.6.25
+version: 15.6.26

--- a/bitnami/mongodb/templates/arbiter/statefulset.yaml
+++ b/bitnami/mongodb/templates/arbiter/statefulset.yaml
@@ -50,8 +50,8 @@ spec:
       affinity: {{- include "common.tplvalues.render" (dict "value" .Values.arbiter.affinity "context" $) | nindent 8 }}
       {{- else }}
       affinity:
-        podAffinity: {{- include "common.affinities.pods" (dict "type" .Values.arbiter.podAffinityPreset "component" "arbiter" "customLabels" $podLabels "topologyKey" .Values.topologyKey "context" $) | nindent 10 }}
-        podAntiAffinity: {{- include "common.affinities.pods" (dict "type" .Values.arbiter.podAntiAffinityPreset "component" "arbiter" "customLabels" $podLabels "topologyKey" .Values.topologyKey "context" $) | nindent 10 }}
+        podAffinity: {{- include "common.affinities.pods" (dict "type" .Values.arbiter.podAffinityPreset "component" "mongodb" "customLabels" $podLabels "topologyKey" .Values.topologyKey "context" $) | nindent 10 }}
+        podAntiAffinity: {{- include "common.affinities.pods" (dict "type" .Values.arbiter.podAntiAffinityPreset "component" "mongodb" "customLabels" $podLabels "topologyKey" .Values.topologyKey "context" $) | nindent 10 }}
         nodeAffinity: {{- include "common.affinities.nodes" (dict "type" .Values.arbiter.nodeAffinityPreset.type "key" .Values.arbiter.nodeAffinityPreset.key "values" .Values.arbiter.nodeAffinityPreset.values) | nindent 10 }}
       {{- end }}
       {{- if .Values.arbiter.nodeSelector }}

--- a/bitnami/mongodb/templates/arbiter/statefulset.yaml
+++ b/bitnami/mongodb/templates/arbiter/statefulset.yaml
@@ -19,6 +19,7 @@ metadata:
 spec:
   serviceName: {{ include "mongodb.arbiter.service.nameOverride" . }}
   podManagementPolicy: {{ .Values.arbiter.podManagementPolicy }}
+  replicas: 1
   {{- if .Values.arbiter.updateStrategy }}
   updateStrategy: {{- toYaml .Values.arbiter.updateStrategy | nindent 4 }}
   {{- end }}


### PR DESCRIPTION
### Description of the change

Modified arbiter `podAntiAffinity` to prevent it from running on the same node of a primary/secondary replica

### Benefits

When deploying the chart using `architecture=replicaset`, a replicaset with 1 primary, 1 secondary and 1 arbiter is created by default.
Primary and secondary pod are created on the `mongodb` statefulset and the arbiter is created on `mongo-arbiter` statefulset.
Primary/secondary and arbiter have different `antiAffinity` rules, so it may happen that the arbiter is scheduled on the same node of the primary/secondary replica.

This is a problem since, if a node with a primary/secondary replica goes down, the arbiter is supposed to participate in  election for primary.
If both the regular replica and the arbiter goes down, the replicaset can't elect a new primary and this defect the whole purpose of having an arbiter.

This change will allow for a better resiliency against node crashes. 

### Possible drawbacks

None

### Additional information

I've also hardcoded 1 replica in arbiter, since it's not safe nor advised to use multiple arbiters.
see: https://www.mongodb.com/docs/manual/core/replica-set-arbiter/#concerns-with-multiple-arbiters

Arbiter replica was already defaulting to 1, I just made it explicit. 

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
