### PR TITLE
[bitnami/keycloak] Fix underlying env var for `.Values.proxyHeaders`

### DIFF
--- a/bitnami/keycloak/CHANGELOG.md
+++ b/bitnami/keycloak/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 22.2.6 (2024-09-19)
+## 22.2.7 (2024-09-23)
 
-* [bitnami/keycloak] Release 22.2.6 ([#29542](https://github.com/bitnami/charts/pull/29542))
+* [bitnami/keycloak] Fix underlying env var for `.Values.proxyHeaders` ([#29573](https://github.com/bitnami/charts/pull/29573))
+
+## <small>22.2.6 (2024-09-19)</small>
+
+* [bitnami/keycloak] Release 22.2.6 (#29542) ([754f9e2](https://github.com/bitnami/charts/commit/754f9e2365ab6d0786a997e4d582e2b6ce92c237)), closes [#29542](https://github.com/bitnami/charts/issues/29542)
 
 ## <small>22.2.5 (2024-09-16)</small>
 

--- a/bitnami/keycloak/CHANGELOG.md
+++ b/bitnami/keycloak/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 22.2.7 (2024-09-23)
+## 22.2.7 (2024-09-24)
 
 * [bitnami/keycloak] Fix underlying env var for `.Values.proxyHeaders` ([#29573](https://github.com/bitnami/charts/pull/29573))
 

--- a/bitnami/keycloak/Chart.yaml
+++ b/bitnami/keycloak/Chart.yaml
@@ -33,4 +33,4 @@ maintainers:
 name: keycloak
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/keycloak
-version: 22.2.6
+version: 22.2.7

--- a/bitnami/keycloak/templates/configmap-env-vars.yaml
+++ b/bitnami/keycloak/templates/configmap-env-vars.yaml
@@ -17,9 +17,9 @@ data:
   KEYCLOAK_ADMIN: {{ .Values.auth.adminUser | quote }}
   KEYCLOAK_HTTP_PORT: {{ .Values.containerPorts.http | quote }}
   {{- if and .Values.proxy (empty .Values.proxyHeaders) }}
-  KEYCLOAK_PROXY_HEADERS: {{ ternary "" "xforwarded" (eq .Values.proxy "passthrough") }}
+  KC_PROXY_HEADERS: {{ ternary "" "xforwarded" (eq .Values.proxy "passthrough") }}
   {{- else }}
-  KEYCLOAK_PROXY_HEADERS: {{ .Values.proxyHeaders | quote }}
+  KC_PROXY_HEADERS: {{ .Values.proxyHeaders | quote }}
   {{- end }}
   {{- if and .Values.adminIngress.enabled .Values.adminIngress.hostname }}
   KEYCLOAK_HOSTNAME_ADMIN: |-


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

This PR aims to fix the naming of a keycloak env var that allows the client IP to be read from forwarded headers when using a reverse-proxy. The naming of the env var was incorrect meaning that the value `proxyHeaders` set in `values.yaml` did not achieve its intended goal. After this fix the client IP is correctly set in the keycloak logs.

The relevant keycloak documentation page can be found here: https://www.keycloak.org/server/reverseproxy#_configure_the_reverse_proxy_headers

### Benefits

The client IP forwarded by a reverse proxy in either the `Forwarded` header or the `X-Forwarded-*` headers can now successfully be read by keycloak.

### Possible drawbacks

No known drawbacks.

### Applicable issues

- fixes #29533 

### Additional information

It might be valuable to do a check of all env vars set by this chart. The keycloak docs say that all keycloak env vars are prefixed with `KC_*` rather than with `KEYCLOAK_*`. The relevant keycloak docs are here: https://www.keycloak.org/server/configuration#_formats_for_configuration

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
