### PR TITLE
[bitnami/valkey-cluster] the redis_url for redis_exporter should use rediss/redis scheme, not valkeys/valkey.

### DIFF
--- a/bitnami/valkey-cluster/CHANGELOG.md
+++ b/bitnami/valkey-cluster/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
+## 1.0.1 (2024-09-25)
+
+* [bitnami/valkey-cluster] the redis_url for redis_exporter should use rediss/redis scheme, not valkeys/valkey. ([#29589](https://github.com/bitnami/charts/pull/29589))
+
 ## 1.0.0 (2024-09-16)
 
-* [bitnami/valkey-cluster] Release 1.0.0 ([#29450](https://github.com/bitnami/charts/pull/29450))
+* [bitnami/valkey-cluster] Release 1.0.0 (#29450) ([a6c84c2](https://github.com/bitnami/charts/commit/a6c84c2362b2577ce78ead825292e6037e1a2c13)), closes [#29450](https://github.com/bitnami/charts/issues/29450)
 
 ## <small>0.1.11 (2024-09-09)</small>
 

--- a/bitnami/valkey-cluster/CHANGELOG.md
+++ b/bitnami/valkey-cluster/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.0.1 (2024-09-25)
+## 1.0.1 (2024-09-26)
 
 * [bitnami/valkey-cluster] the redis_url for redis_exporter should use rediss/redis scheme, not valkeys/valkey. ([#29589](https://github.com/bitnami/charts/pull/29589))
 

--- a/bitnami/valkey-cluster/Chart.yaml
+++ b/bitnami/valkey-cluster/Chart.yaml
@@ -33,4 +33,4 @@ name: valkey-cluster
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/valkey-cluster
 - https://github.com/bitnami/containers/tree/main/bitnami/vakey-cluster
-version: 1.0.0
+version: 1.0.1

--- a/bitnami/valkey-cluster/templates/valkey-statefulset.yaml
+++ b/bitnami/valkey-cluster/templates/valkey-statefulset.yaml
@@ -330,7 +330,7 @@ spec:
             - name: REDIS_ALIAS
               value: {{ template "common.names.fullname" . }}
             - name: REDIS_ADDR
-              value: {{ printf "%s://127.0.0.1:%g" (ternary "valkeys" "valkey" .Values.tls.enabled) .Values.valkey.containerPorts.valkey | quote }}
+              value: {{ printf "%s://127.0.0.1:%g" (ternary "rediss" "redis" .Values.tls.enabled) .Values.valkey.containerPorts.valkey | quote }}
             {{- if and .Values.usePassword (not .Values.usePasswordFile) }}
             - name: REDIS_PASSWORD
               valueFrom:


### PR DESCRIPTION

### Description of the change

change the scheme used to form the metrics target url

### Benefits

this makes metrics work, as redis_exporter does not support valkeys/valkey scheme 

### Possible drawbacks

### Applicable issues

### Additional information

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
