### PR TITLE
[bitnami/spark] Fix extraEgress being applied from master instead of worker

### DIFF
--- a/bitnami/spark/CHANGELOG.md
+++ b/bitnami/spark/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 * [bitnami/spark] Fix extraEgress being applied from master instead of worker ([#29591](https://github.com/bitnami/charts/pull/29591))
 
-## 9.2.11 (2024-09-25)
+## <small>9.2.11 (2024-09-25)</small>
 
-* [bitnami/spark] Release 9.2.11 ([#29593](https://github.com/bitnami/charts/pull/29593))
+* [bitnami/spark] Release 9.2.11 (#29593) ([733c5e8](https://github.com/bitnami/charts/commit/733c5e8a5516fa46c6f86c5d503edc388fae2d7e)), closes [#29593](https://github.com/bitnami/charts/issues/29593)
 
 ## <small>9.2.10 (2024-08-24)</small>
 

--- a/bitnami/spark/CHANGELOG.md
+++ b/bitnami/spark/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 9.2.10 (2024-08-23)
+## 9.2.11 (2024-09-25)
 
-* [bitnami/spark] Release 9.2.10 ([#29011](https://github.com/bitnami/charts/pull/29011))
+* [bitnami/spark] Fix extraEgress being applied from master instead of worker ([#29591](https://github.com/bitnami/charts/pull/29591))
+
+## <small>9.2.10 (2024-08-24)</small>
+
+* [bitnami/spark] Release 9.2.10 (#29011) ([2c919dc](https://github.com/bitnami/charts/commit/2c919dc748aba27b595f4aaf0a4c7f4270ff0ba7)), closes [#29011](https://github.com/bitnami/charts/issues/29011)
 
 ## <small>9.2.9 (2024-08-12)</small>
 

--- a/bitnami/spark/Chart.yaml
+++ b/bitnami/spark/Chart.yaml
@@ -27,4 +27,4 @@ maintainers:
 name: spark
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/spark
-version: 9.2.10
+version: 9.2.11

--- a/bitnami/spark/Chart.yaml
+++ b/bitnami/spark/Chart.yaml
@@ -27,4 +27,4 @@ maintainers:
 name: spark
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/spark
-version: 9.2.11
+version: 9.2.12

--- a/bitnami/spark/templates/networkpolicy-worker.yaml
+++ b/bitnami/spark/templates/networkpolicy-worker.yaml
@@ -53,8 +53,8 @@ spec:
         - podSelector:
             matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 14 }}
               app.kubernetes.io/component: master
-    {{- if .Values.master.networkPolicy.extraEgress }}
-    {{- include "common.tplvalues.render" ( dict "value" .Values.master.networkPolicy.extraEgress "context" $ ) | nindent 4 }}
+    {{- if .Values.worker.networkPolicy.extraEgress }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.worker.networkPolicy.extraEgress "context" $ ) | nindent 4 }}
     {{- end }}
   {{- end }}
   ingress:


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Fix wrong application of `extraIngress` configuration value from master to workers in Spark chart.

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
