### PR TITLE
[bitnami/redis] - fix additionalEndpoints in servicemonitor

### DIFF
--- a/bitnami/redis/CHANGELOG.md
+++ b/bitnami/redis/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 20.1.4 (2024-09-19)
+## 20.1.5 (2024-09-25)
 
-* [bitnami/redis] Release 20.1.4 ([#29530](https://github.com/bitnami/charts/pull/29530))
+* [bitnami/redis] - fix additionalEndpoints in servicemonitor ([#29595](https://github.com/bitnami/charts/pull/29595))
+
+## <small>20.1.4 (2024-09-19)</small>
+
+* [bitnami/redis] Release 20.1.4 (#29530) ([8053b1a](https://github.com/bitnami/charts/commit/8053b1a13272f5485ca5c6ec0ace6741cf202262)), closes [#29530](https://github.com/bitnami/charts/issues/29530)
 
 ## <small>20.1.3 (2024-09-14)</small>
 

--- a/bitnami/redis/Chart.yaml
+++ b/bitnami/redis/Chart.yaml
@@ -36,4 +36,4 @@ maintainers:
 name: redis
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/redis
-version: 20.1.4
+version: 20.1.5

--- a/bitnami/redis/templates/servicemonitor.yaml
+++ b/bitnami/redis/templates/servicemonitor.yaml
@@ -45,7 +45,7 @@ spec:
       {{- if .honorLabels }}
       honorLabels: {{ .honorLabels }}
       {{- end }}
-      {{- with concat .Values.metrics.serviceMonitor.relabelings .Values.metrics.serviceMonitor.relabellings }}
+      {{- with concat $.Values.metrics.serviceMonitor.relabelings $.Values.metrics.serviceMonitor.relabellings }}
       relabelings: {{- toYaml . | nindent 6 }}
       {{- end }}
       {{- if .metricRelabelings }}

--- a/bitnami/redis/values.yaml
+++ b/bitnami/redis/values.yaml
@@ -1928,7 +1928,7 @@ metrics:
     # add metricRelabelings with label like app=redis to main redis pod-monitor port
     # - interval: "30s"
     #   path: "/scrape"
-    #   port: "metrics"
+    #   port: "http-metrics"
     #   params:
     #     target: ["localhost:26379"]
     #   metricRelabelings:


### PR DESCRIPTION
### Description of the change
When setting the additionalEndpoints option for ServiceMonitor (to scrape metrics of the sentinel container) the generated chart is invalid.
To reproduce do the following in the `bitnami/redis` folder on main:

2. in `values.yaml` enable metrics ie set `metrics.enabled` to `true`
3. in `values.yaml` enable serviceMonitor ie set `metrics.serviceMonitor.enabled` to `true`
4. uncomment the example under `metrics.serviceMonitor.additionalEndpoints` (also delete the `[]` after `additionalEndpoints:` itself)
5. run `helm template . -f values.yaml --debug` and you get the error below:
```
install.go:222: [debug] Original chart version: ""
install.go:239: [debug] CHART PATH: /Users/user1/git/charts/bitnami/redis


Error: template: redis/templates/servicemonitor.yaml:48:29: executing "redis/templates/servicemonitor.yaml" at <.Values.metrics.serviceMonitor.relabelings>: nil pointer evaluating interface {}.metrics
helm.go:84: [debug] template: redis/templates/servicemonitor.yaml:48:29: executing "redis/templates/servicemonitor.yaml" at <.Values.metrics.serviceMonitor.relabelings>: nil pointer evaluating interface {}.metrics
```

My change fixes a bug in the `servicemonitor.yaml` (missing dollar signs) and updating the port in the `additionalEndpoints` example (most likely it was copied from the PodMonitor section previously).

After my changes a valid chart can be generated, deployed and the metrics are scraped and relabeled as expected.

Output of `helm template . -f values.yaml --debug` after my changes:
```
... full output redacted here...  
---
# Source: redis/templates/servicemonitor.yaml
apiVersion: monitoring.coreos.com/v1
kind: ServiceMonitor
metadata:
  name: release-name-redis
  namespace: "default"
  labels:
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: redis
    app.kubernetes.io/version: 7.4.0
    helm.sh/chart: redis-20.1.5
spec:
  endpoints:
    - port: http-metrics
      interval: 30s
    - port: http-metrics
      interval: 30s
      metricRelabelings:
      - replacement: sentinel
        targetLabel: app
      path: /scrape
      params:
        target:
          - "localhost:26379"
  namespaceSelector:
    matchNames:
      - "default"
  selector:
    matchLabels:
      app.kubernetes.io/instance: release-name
      app.kubernetes.io/name: redis
      app.kubernetes.io/component: metrics
```

### Benefits
The additional metric scraping functionality works now.

### Possible drawbacks
Can't think of any.

### Applicable issues
Did not found an existing issue for this.

### Additional information
None.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
