### PR TITLE
[bitnami/mongodb-sharded] Fix uncapacity to disable persistence

### DIFF
--- a/bitnami/mongodb-sharded/CHANGELOG.md
+++ b/bitnami/mongodb-sharded/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 8.3.8 (2024-09-25)
+## 8.3.8 (2024-09-26)
 
 * [bitnami/mongodb-sharded] Fix uncapacity to disable persistence ([#29599](https://github.com/bitnami/charts/pull/29599))
 

--- a/bitnami/mongodb-sharded/CHANGELOG.md
+++ b/bitnami/mongodb-sharded/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 8.3.8 (2024-09-26)
+## 8.3.8 (2024-09-30)
 
 * [bitnami/mongodb-sharded] Fix uncapacity to disable persistence ([#29599](https://github.com/bitnami/charts/pull/29599))
 

--- a/bitnami/mongodb-sharded/CHANGELOG.md
+++ b/bitnami/mongodb-sharded/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 8.3.7 (2024-09-01)
+## 8.3.8 (2024-09-25)
 
-* [bitnami/mongodb-sharded] Changed to use namespaceOverride value when defining primaryhost in configsvr ([#29145](https://github.com/bitnami/charts/pull/29145))
+* [bitnami/mongodb-sharded] Fix uncapacity to disable persistence ([#29599](https://github.com/bitnami/charts/pull/29599))
+
+## <small>8.3.7 (2024-09-11)</small>
+
+* [bitnami/mongodb-sharded] Changed to use namespaceOverride value when defining primaryhost in config ([2244aef](https://github.com/bitnami/charts/commit/2244aefaff5e48f8b708c2d0b9592e6802ceb6b1)), closes [#29145](https://github.com/bitnami/charts/issues/29145)
 
 ## <small>8.3.6 (2024-08-26)</small>
 

--- a/bitnami/mongodb-sharded/Chart.yaml
+++ b/bitnami/mongodb-sharded/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: mongodb-sharded
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/mongodb-sharded
-version: 8.3.7
+version: 8.3.8

--- a/bitnami/mongodb-sharded/templates/config-server/config-server-statefulset.yaml
+++ b/bitnami/mongodb-sharded/templates/config-server/config-server-statefulset.yaml
@@ -421,7 +421,10 @@ spec:
         {{- if .Values.configsvr.extraVolumes }}
           {{- include "common.tplvalues.render" ( dict "value" .Values.configsvr.extraVolumes "context" $ ) | nindent 8 }}
         {{- end }}
-  {{- if .Values.configsvr.persistence.enabled }}
+  {{- if not .Values.configsvr.persistence.enabled }}
+        - name: datadir
+          emptyDir: {}
+  {{- else }}
   {{- if .Values.configsvr.persistentVolumeClaimRetentionPolicy.enabled }}
   persistentVolumeClaimRetentionPolicy:
     whenDeleted: {{ .Values.configsvr.persistentVolumeClaimRetentionPolicy.whenDeleted }}
@@ -452,8 +455,5 @@ spec:
           requests:
             storage: {{ .Values.configsvr.persistence.size | quote }}
         {{- include "common.storage.class" (dict "persistence" .Values.configsvr.persistence "global" .Values.global) | nindent 8 }}
-  {{- else }}
-    - name: datadir
-      emptyDir: {}
   {{- end }}
 {{- end }}

--- a/bitnami/mongodb-sharded/templates/shard/shard-data-statefulset.yaml
+++ b/bitnami/mongodb-sharded/templates/shard/shard-data-statefulset.yaml
@@ -428,7 +428,7 @@ spec:
         {{- if $.Values.shardsvr.dataNode.extraVolumes }}
           {{- include "common.tplvalues.render" ( dict "value" $.Values.shardsvr.dataNode.extraVolumes "context" $ ) | nindent 8 }}
         {{- end }}
-  {{if not $.Values.shardsvr.persistence.enabled}}      
+  {{- if not $.Values.shardsvr.persistence.enabled }}
         - name: datadir
           emptyDir: {}
   {{- else }}

--- a/bitnami/mongodb-sharded/templates/shard/shard-data-statefulset.yaml
+++ b/bitnami/mongodb-sharded/templates/shard/shard-data-statefulset.yaml
@@ -428,7 +428,10 @@ spec:
         {{- if $.Values.shardsvr.dataNode.extraVolumes }}
           {{- include "common.tplvalues.render" ( dict "value" $.Values.shardsvr.dataNode.extraVolumes "context" $ ) | nindent 8 }}
         {{- end }}
-  {{- if $.Values.shardsvr.persistence.enabled }}
+  {{if not $.Values.shardsvr.persistence.enabled}}      
+        - name: datadir
+          emptyDir: {}
+  {{- else }}
   {{- if $.Values.shardsvr.persistentVolumeClaimRetentionPolicy.enabled }}
   persistentVolumeClaimRetentionPolicy:
     whenDeleted: {{ $.Values.shardsvr.persistentVolumeClaimRetentionPolicy.whenDeleted }}
@@ -459,9 +462,6 @@ spec:
           requests:
             storage: {{ $.Values.shardsvr.persistence.size | quote }}
         {{- include "common.storage.class" (dict "persistence" $.Values.shardsvr.persistence "global" $.Values.global) | nindent 8 }}
-  {{- else }}
-    - name: datadir
-      emptyDir: {}
   {{- end }}
 {{- if lt $i (sub $replicas 1) }}
 ---


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->
This PR modifies how the `datadir` volume is created and mounted when `persistence.enabled` parameter is set to false within statefulset manifests for both config server and shard server. It also removes some bad lines of code.
### Benefits

<!-- What benefits will be realized by the code change? -->
Persistence can now be disabled for both config server and shard server without resulting in a YAML parse error.
### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #29127 

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
Disabling persistence can be useful when the default configuration to be set doesn't fit your cluster.
### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X ] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X ] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
