### PR TITLE
[bitnami/argo-workflows] Update Workflow RBAC to Use Recommended `workflowtaskresults` CRD

### DIFF
--- a/bitnami/argo-workflows/CHANGELOG.md
+++ b/bitnami/argo-workflows/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 9.1.16 (2024-09-23)
+## 9.1.17 (2024-09-26)
 
-* [bitnami/argo-workflows] Release 9.1.16 ([#29576](https://github.com/bitnami/charts/pull/29576))
+* [bitnami/argo-workflows] Update Workflow RBAC to Use Recommended `workflowtaskresults` CRD ([#29620](https://github.com/bitnami/charts/pull/29620))
+
+## <small>9.1.16 (2024-09-23)</small>
+
+* [bitnami/argo-workflows] Release 9.1.16 (#29576) ([c07a61e](https://github.com/bitnami/charts/commit/c07a61e36623a0bf4816790a65f376452a4bdc6d)), closes [#29576](https://github.com/bitnami/charts/issues/29576)
 
 ## <small>9.1.15 (2024-09-05)</small>
 

--- a/bitnami/argo-workflows/Chart.yaml
+++ b/bitnami/argo-workflows/Chart.yaml
@@ -42,4 +42,4 @@ maintainers:
 name: argo-workflows
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/argo-workflows
-version: 9.1.16
+version: 9.1.17

--- a/bitnami/argo-workflows/templates/controller/workflow-role.yaml
+++ b/bitnami/argo-workflows/templates/controller/workflow-role.yaml
@@ -25,21 +25,11 @@ metadata:
   {{- end }}
 rules:
   - apiGroups:
-      - ""
+      - argoproj.io
     resources:
-      - pods
-      - configmaps
+      - workflowtaskresults
     verbs:
-      - list
-      - get
-      - watch
+      - create
       - patch
-  - apiGroups:
-      - ""
-    resources:
-      - pods/log
-    verbs:
-      - get
-      - watch
   {{- end }}
 {{- end }}

--- a/bitnami/argo-workflows/templates/controller/workflow-role.yaml
+++ b/bitnami/argo-workflows/templates/controller/workflow-role.yaml
@@ -31,5 +31,29 @@ rules:
     verbs:
       - create
       - patch
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - list
+      - get
+      - watch
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - list
+      - get
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - pods/log
+    verbs:
+      - get
+      - watch
   {{- end }}
 {{- end }}


### PR DESCRIPTION
### Description of the change

Updates the workflow `Role` to use the recommended CRDs in the workflow RBAC as per: https://argo-workflows.readthedocs.io/en/release-3.5/workflow-rbac/

When deploying the chart I noticed warnings in the `wait` container of the tasks:
```level=warning msg="failed to patch task result, falling back to legacy/insecure pod patch, see https://argo-workflows.readthedocs.io/en/release-3.5/workflow-rbac/" error="[workflowtaskresults.argoproj.io](http://workflowtaskresults.argoproj.io/) is forbidden: User \"system:serviceaccount:argo:argo-test-argo-workflows-workflows\" cannot create resource \"workflowtaskresults\" in API group \"[argoproj.io](http://argoproj.io/)\" in the namespace \"argo\"```

Minimal `values.yaml`:
```yaml
workflows:
    serviceAccount:
        create: true
        automountServiceAccountToken: true

controller:
    workflowDefaults:
        spec:
            serviceAccountName: <helm-deployment-name>-argo-workflows-workflows
    workflowNamespaces:
    - "argo"

```

### Benefits

This improves security and prevents the above-mentioned warnings.

### Possible drawbacks

None that I am aware of.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
