### PR TITLE
[bitnami/opensearch] Plugin installation as non-root user

### DIFF
--- a/bitnami/opensearch/CHANGELOG.md
+++ b/bitnami/opensearch/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 1.3.5 (2024-09-26)
+## 1.3.6 (2024-09-26)
 
-* [bitnami/opensearch] Release 1.3.5 ([#29613](https://github.com/bitnami/charts/pull/29613))
+* [bitnami/opensearch] Plugin installation as non-root user ([#29624](https://github.com/bitnami/charts/pull/29624))
+
+## <small>1.3.5 (2024-09-26)</small>
+
+* [bitnami/opensearch] Release 1.3.5 (#29613) ([5a97a83](https://github.com/bitnami/charts/commit/5a97a83840a4811eae90ad74722f1f4fc7d39851)), closes [#29613](https://github.com/bitnami/charts/issues/29613)
 
 ## <small>1.3.4 (2024-09-24)</small>
 

--- a/bitnami/opensearch/Chart.yaml
+++ b/bitnami/opensearch/Chart.yaml
@@ -30,4 +30,4 @@ maintainers:
 name: opensearch
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/opensearch
-version: 1.3.5
+version: 1.3.6


### PR DESCRIPTION
### Description of the change

This PR follows up https://github.com/bitnami/charts/pull/29586 allowing the init-container to be executed as a non-root user.

### Benefits

The chart can be installed in restrictive environment such as Openshift where only non-root containers are allowed

### Possible drawbacks

None

### Applicable issues

None

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
