### PR TITLE
[actions] CI pipeline: Check hardcoded images

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -114,7 +114,7 @@ jobs:
             if [[ $image != {{*}} ]]; then
               hardcoded_images+=("${image}")
             fi
-          done <<< "$(grep -REoh "image:\s+[\"']*.+[\"']*\s*$" "charts/bitnami/${CHART}/templates" | sed "s/image: [\"']*//" | sed "s/[\"']*$//")"
+          done <<< "$(grep -REoh "^\s*image:\s+[\"']*.+[\"']*\s*$" "charts/bitnami/${CHART}/templates" | sed "s/image: [\"']*//" | sed "s/[\"']*$//")"
 
           echo "${hardcoded_images[@]}"
           if [[ ${#hardcoded_images[@]} -gt 0 ]] ; then

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -89,6 +89,52 @@ jobs:
             } else {
               core.warning(message);
             }
+  check-images:
+    runs-on: ubuntu-latest
+    needs: [get-chart]
+    name: Look for hardcoded images
+    if: needs.get-chart.outputs.result == 'ok'
+    outputs:
+      result: ${{ steps.check-images.outputs.result }}
+      error: ${{ steps.check-images.outputs.error }}
+    steps:
+      - name: Checkout bitnami/charts
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+        with:
+          ref: ${{github.event.pull_request.head.ref}}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
+          path: charts
+      - id: check-images
+        name: Look for hardcoded images
+        env:
+          CHART: ${{ needs.get-chart.outputs.chart }}
+        run: |
+          hardcoded_images=()
+          while read -r image; do
+            if [[ $image != {{*}} ]]; then
+              hardcoded_images+=("${image}")
+            fi
+          done <<< "$(grep -REoh "image:\s+[\"']*.+[\"']*\s*$" "charts/bitnami/${CHART}/templates" | sed "s/image: [\"']*//" | sed "s/[\"']*$//")"
+
+          echo "${hardcoded_images[@]}"
+          if [[ ${#hardcoded_images[@]} -gt 0 ]] ; then
+            echo "error=Found hardcoded images in the chart templates: ${hardcoded_images[@]}" >> $GITHUB_OUTPUT
+            echo "result=fail" >> $GITHUB_OUTPUT
+          else
+            echo "result=ok" >> $GITHUB_OUTPUT
+          fi
+      - id: show-error
+        name: Show error
+        if: ${{ steps.check-images.outputs.result != 'ok' }}
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
+        with:
+          script: |
+            let message='${{ steps.check-images.outputs.error }}';
+            if ('${{ steps.check-images.outputs.result }}' === 'fail' ) {
+              core.setFailed(message);
+            } else {
+              core.warning(message);
+            }
   update-pr:
     runs-on: ubuntu-latest
     needs: [get-chart]


### PR DESCRIPTION
### Description of the change

Adds a new step to the CI pipeline that checks the chart does not include hardcoded images in its templates.

The goal of this feature is to avoid accidentally merging charts that have containers defined directly in the manifests instead of using the values.yaml.

The action searches for any `image:` key in the `${CHART}/templates` folder and checks it is formatted as `image: {{ ... }}`.

Images formatted as plain text will cause the workflow to fail, e.g. `image: foo/bar`

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
