### PR TITLE
[bitnami/common] Add common.tplvalues.merge-overwrite helper

### DIFF
--- a/bitnami/common/CHANGELOG.md
+++ b/bitnami/common/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2.24.0 (2024-09-30)
+## 2.24.0 (2024-10-01)
 
 * [bitnami/common] Add common.tplvalues.merge-overwrite helper ([#29668](https://github.com/bitnami/charts/pull/29668))
 

--- a/bitnami/common/CHANGELOG.md
+++ b/bitnami/common/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2.24.0 (2024-10-01)
+## 2.24.0 (2024-10-02)
 
 * [bitnami/common] Add common.tplvalues.merge-overwrite helper ([#29668](https://github.com/bitnami/charts/pull/29668))
 

--- a/bitnami/common/CHANGELOG.md
+++ b/bitnami/common/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
+## 2.24.0 (2024-09-30)
+
+* [bitnami/common] Add common.tplvalues.merge-overwrite helper ([#29668](https://github.com/bitnami/charts/pull/29668))
+
 ## 2.23.0 (2024-09-13)
 
-* [bitnami/common] Add option to remove empty seLinuxOptions from securityContext in non OpenShift environment ([#28945](https://github.com/bitnami/charts/pull/28945))
+* [bitnami/common] Add option to remove empty seLinuxOptions from securityContext in non OpenShift env ([7e44e64](https://github.com/bitnami/charts/commit/7e44e64626f5b1fc6d56889cdfdeadc1f62c7cf1)), closes [#28945](https://github.com/bitnami/charts/issues/28945)
 
 ## 2.22.0 (2024-08-08)
 

--- a/bitnami/common/Chart.yaml
+++ b/bitnami/common/Chart.yaml
@@ -6,7 +6,7 @@ annotations:
   licenses: Apache-2.0
 apiVersion: v2
 # Please make sure that version and appVersion are always the same.
-appVersion: 2.23.0
+appVersion: 2.24.0
 description: A Library Helm Chart for grouping common logic between bitnami charts. This chart is not deployable by itself.
 home: https://bitnami.com
 icon: https://bitnami.com/downloads/logos/bitnami-mark.png

--- a/bitnami/common/Chart.yaml
+++ b/bitnami/common/Chart.yaml
@@ -23,4 +23,4 @@ name: common
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/common
 type: library
-version: 2.23.0
+version: 2.24.0

--- a/bitnami/common/templates/_tplvalues.tpl
+++ b/bitnami/common/templates/_tplvalues.tpl
@@ -36,3 +36,17 @@ Usage:
 {{- end -}}
 {{ $dst | toYaml }}
 {{- end -}}
+
+{{/*
+Merge a list of values that contains template after rendering them.
+Merge precedence is consistent with https://masterminds.github.io/sprig/dicts.html#mergeoverwrite-mustmergeoverwrite
+Usage:
+{{ include "common.tplvalues.merge-overwrite" ( dict "values" (list .Values.path.to.the.Value1 .Values.path.to.the.Value2) "context" $ ) }}
+*/}}
+{{- define "common.tplvalues.merge-overwrite" -}}
+{{- $dst := dict -}}
+{{- range .values -}}
+{{- $dst = include "common.tplvalues.render" (dict "value" . "context" $.context "scope" $.scope) | fromYaml | mergeOverwrite $dst -}}
+{{- end -}}
+{{ $dst | toYaml }}
+{{- end -}}


### PR DESCRIPTION
### Description of the change

Adding a new helper to the Bitnami common chart. This helper uses the sprig function [mergeOverwrite](https://masterminds.github.io/sprig/dicts.html#mergeoverwrite-mustmergeoverwrite) to merge multiple dictionaries into one.

### Benefits

* merging two or more dicts with precedence consistent with [mergeOverwrite](https://masterminds.github.io/sprig/dicts.html#mergeoverwrite-mustmergeoverwrite)
   * precedence "from **right to left**"
* fixes issues, where it is not possible to overwrite "truthy" values with "falsy" values, even when the "falsy" values should have precedence according to the docs
   * for more see #29566 and https://github.com/Masterminds/sprig/issues/134

### Possible drawbacks

None

### Applicable issues

- needed for #27628 
- fixes #29566 
- Masterminds/sprig issue for reference https://github.com/Masterminds/sprig/issues/134

### Additional information

%

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
