### PR TITLE
[bitnami/thanos] Fix serviceNames based on additionalHeadless

### DIFF
--- a/bitnami/thanos/templates/receive/statefulset.yaml
+++ b/bitnami/thanos/templates/receive/statefulset.yaml
@@ -23,7 +23,9 @@ spec:
   {{- end }}
   revisionHistoryLimit: {{ .Values.receive.revisionHistoryLimit }}
   podManagementPolicy: {{ .Values.receive.podManagementPolicy }}
+  {{- if .Values.receive.service.additionalHeadless }}
   serviceName: {{ include "thanos.receive.fullname" . }}-headless
+  {{- end }}
   {{- if .Values.receive.updateStrategy }}
   updateStrategy: {{- toYaml .Values.receive.updateStrategy | nindent 4 }}
   {{- end }}

--- a/bitnami/thanos/templates/ruler/statefulset.yaml
+++ b/bitnami/thanos/templates/ruler/statefulset.yaml
@@ -20,7 +20,9 @@ spec:
   {{- end }}
   revisionHistoryLimit: {{ .Values.ruler.revisionHistoryLimit }}
   podManagementPolicy: {{ .Values.ruler.podManagementPolicy }}
+  {{- if .Values.ruler.service.additionalHeadless }}
   serviceName: {{ include "thanos.ruler.fullname" . }}-headless
+  {{- end }}
   {{- if .Values.ruler.updateStrategy }}
   updateStrategy: {{- toYaml .Values.ruler.updateStrategy | nindent 4 }}
   {{- end }}

--- a/bitnami/thanos/templates/storegateway/statefulset.yaml
+++ b/bitnami/thanos/templates/storegateway/statefulset.yaml
@@ -20,7 +20,9 @@ spec:
   {{- end }}
   revisionHistoryLimit: {{ .Values.storegateway.revisionHistoryLimit }}
   podManagementPolicy: {{ .Values.storegateway.podManagementPolicy }}
+  {{- if .Values.storegateway.service.additionalHeadless }}
   serviceName: {{ include "thanos.storegateway.fullname" . }}-headless
+  {{- end }}
   {{- if .Values.storegateway.updateStrategy }}
   updateStrategy: {{- toYaml .Values.storegateway.updateStrategy | nindent 4 }}
   {{- end }}


### PR DESCRIPTION
First of all, thank you so much for providing these open-source Helm charts! :slightly_smiling_face:

Actually this PR is very simple, so I skipped some sections of the description template for simplicity.

### Description of the change

Currently, when `additionalHeadless` is set to `false` (which is [the default](https://github.com/bitnami/charts/blob/4f431961e951bc9916b9ced0d9fcf12a55a8467d/bitnami/thanos/values.yaml#L609)), the StatefulSets still have `serviceName` set to `xxx-headless`, even if the headless Service is not created.

This PR fixes that, by preventing setting the `serviceName` in such case.
