### PR TITLE
[bitnami/redis] adds kind & apiVersion for pvc template in statefulset

### DIFF
--- a/bitnami/redis/templates/sentinel/statefulset.yaml
+++ b/bitnami/redis/templates/sentinel/statefulset.yaml
@@ -809,7 +809,9 @@ spec:
         {{- end }}
         {{- include "common.storage.class" (dict "persistence" .Values.replica.persistence "global" .Values.global) | nindent 8 }}
     {{- if .Values.sentinel.persistence.enabled }}
-    - metadata:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
         name: sentinel-data
         {{- $claimLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.sentinel.persistence.labels .Values.commonLabels ) "context" . ) }}
         labels: {{- include "common.labels.matchLabels" ( dict "customLabels" $claimLabels "context" $ ) | nindent 10 }}


### PR DESCRIPTION
Description of the change
The Redis chart is missing kind & apiVersion on one of the stateful sets (others are ok). This causes an unwanted diff in ArgoCD etc. It was already fixed in one place #19484, but here we go again:

<img width="1469" alt="image" src="https://github.com/user-attachments/assets/99b6594b-d79f-421c-b7e1-89c35d171b6a">


Benefits
Fixes the diff so applications will show as in sync

Possible drawbacks
Not known

Applicable issues
Not known

Additional information
Checklist

- [x] Chart version bumped in Chart.yaml according to [semver](http://semver.org/). This is not necessary when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
