### PR TITLE
[bitnami/argo-cd] fix: provide a functional validation function for validation

### DIFF
--- a/bitnami/argo-cd/CHANGELOG.md
+++ b/bitnami/argo-cd/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 7.0.15 (2024-10-01)
+## 7.0.16 (2024-10-08)
 
-* [bitnami/argo-cd] Release 7.0.15 ([#29682](https://github.com/bitnami/charts/pull/29682))
+* [bitnami/argo-cd] fix: provide a functional validation function for validation ([#29724](https://github.com/bitnami/charts/pull/29724))
+
+## <small>7.0.15 (2024-10-01)</small>
+
+* [bitnami/argo-cd] Release 7.0.15 (#29682) ([6b89f04](https://github.com/bitnami/charts/commit/6b89f04f14ccd7aa78811dea9642754899c102da)), closes [#29682](https://github.com/bitnami/charts/issues/29682)
 
 ## <small>7.0.14 (2024-09-26)</small>
 

--- a/bitnami/argo-cd/Chart.yaml
+++ b/bitnami/argo-cd/Chart.yaml
@@ -39,4 +39,4 @@ maintainers:
 name: argo-cd
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/argo-cd
-version: 7.0.15
+version: 7.0.16

--- a/bitnami/argo-cd/templates/_helpers.tpl
+++ b/bitnami/argo-cd/templates/_helpers.tpl
@@ -289,7 +289,12 @@ Validate external Redis config
 */}}
 {{- define "argocd.validateValues.externalRedis" -}}
 {{- if not .Values.redis.enabled -}}
+    {{- if not .Values.externalRedis.port -}}
 Argo CD: If the redis dependency is disabled you need to add an external redis port
+    {{- end -}}
+    {{- if not .Values.externalRedis.host -}}
+Argo CD: If the redis dependency is disabled you need to add an external redis host
+    {{- end -}}
 {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
### Description of the change

Since a [change](https://github.com/mFranz82/charts/commit/8d231f86e78a6ad07b5f588a0eedebf7c21d0f9b) made 3 month before the templating fails if using ` redis.enabled=false `

```
Error: 
execution error at (argo-cd/templates/server/deployment.yaml:100:50): 
If the redis dependency is disabled you need to add an external redis host
```

The error is triggered at this point in Notes.txt
```
{{- if $message -}}
{{-   printf "\nVALUES VALIDATION:\n%s" $message | fail -}}
{{- end -}}
```

And occurs because the validation function could never be successful:
```
{{/*
Validate external Redis config
*/}}
{{- define "argocd.validateValues.externalRedis" -}}
{{- if not .Values.redis.enabled -}}
Argo CD: If the redis dependency is disabled you need to add an external redis port
{{- end -}}
{{- end -}}
```

As you can see in the snippet above the validating function always fails if ```redis.enabled = false```

### Benefits

You should be able again to install the chart without using internal redis.

### Possible drawbacks

No

### Applicable issues

No

### Additional information

Generally I think that the validation should just produce warnings and the templating should not fail. I am not sure why @maxnitze introduced the pattern. 

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
