### PR TITLE
[bitnami/thanos] Revert #29673

### DIFF
--- a/bitnami/thanos/CHANGELOG.md
+++ b/bitnami/thanos/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 15.7.27 (2024-10-02)
+## 15.7.28 (2024-10-03)
 
-* [bitnami/thanos] Release 15.7.27 ([#29720](https://github.com/bitnami/charts/pull/29720))
+* [bitnami/thanos] Revert #29673 ([#29763](https://github.com/bitnami/charts/pull/29763))
+
+## <small>15.7.27 (2024-10-02)</small>
+
+* [bitnami/thanos] Release 15.7.27 (#29720) ([cd99907](https://github.com/bitnami/charts/commit/cd999075fe633956019ac142dd7965deba5aea09)), closes [#29720](https://github.com/bitnami/charts/issues/29720)
 
 ## <small>15.7.26 (2024-10-02)</small>
 

--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: thanos
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/thanos
-version: 15.7.27
+version: 15.7.28

--- a/bitnami/thanos/templates/receive/statefulset.yaml
+++ b/bitnami/thanos/templates/receive/statefulset.yaml
@@ -23,9 +23,7 @@ spec:
   {{- end }}
   revisionHistoryLimit: {{ .Values.receive.revisionHistoryLimit }}
   podManagementPolicy: {{ .Values.receive.podManagementPolicy }}
-  {{- if .Values.receive.service.additionalHeadless }}
   serviceName: {{ include "thanos.receive.fullname" . }}-headless
-  {{- end }}
   {{- if .Values.receive.updateStrategy }}
   updateStrategy: {{- toYaml .Values.receive.updateStrategy | nindent 4 }}
   {{- end }}

--- a/bitnami/thanos/templates/ruler/statefulset.yaml
+++ b/bitnami/thanos/templates/ruler/statefulset.yaml
@@ -20,9 +20,7 @@ spec:
   {{- end }}
   revisionHistoryLimit: {{ .Values.ruler.revisionHistoryLimit }}
   podManagementPolicy: {{ .Values.ruler.podManagementPolicy }}
-  {{- if .Values.ruler.service.additionalHeadless }}
   serviceName: {{ include "thanos.ruler.fullname" . }}-headless
-  {{- end }}
   {{- if .Values.ruler.updateStrategy }}
   updateStrategy: {{- toYaml .Values.ruler.updateStrategy | nindent 4 }}
   {{- end }}

--- a/bitnami/thanos/templates/storegateway/statefulset.yaml
+++ b/bitnami/thanos/templates/storegateway/statefulset.yaml
@@ -20,9 +20,7 @@ spec:
   {{- end }}
   revisionHistoryLimit: {{ .Values.storegateway.revisionHistoryLimit }}
   podManagementPolicy: {{ .Values.storegateway.podManagementPolicy }}
-  {{- if .Values.storegateway.service.additionalHeadless }}
   serviceName: {{ include "thanos.storegateway.fullname" . }}-headless
-  {{- end }}
   {{- if .Values.storegateway.updateStrategy }}
   updateStrategy: {{- toYaml .Values.storegateway.updateStrategy | nindent 4 }}
   {{- end }}


### PR DESCRIPTION
### Description of the change

Reverts #29673

### Additional information

Fixes #29749

Although the fix is correct, modifying the Statefulset immutable fields is problematic and should not have been included in a patch release.

Reverting the change so users do not have to face issues while upgrading, we may include this in the next thanos major.

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
