### PR TITLE
[Bitnami/rabbitmq] - Fix duplicate key issue with Helm/FluxCD integration

### DIFF
--- a/bitnami/rabbitmq/CHANGELOG.md
+++ b/bitnami/rabbitmq/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 15.0.2 (2024-10-04)
 
-* [bitnami/rabbitmq] Fix duplicate key issue with Helm/FluxCD integration ([#29600](https://github.com/bitnami/charts/pull/29600))
+* [bitnami/rabbitmq] Fix duplicate key issue with Helm/FluxCD integration ([#29779](https://github.com/bitnami/charts/pull/29779))
 
 ## 15.0.1 (2024-09-25)
 

--- a/bitnami/rabbitmq/CHANGELOG.md
+++ b/bitnami/rabbitmq/CHANGELOG.md
@@ -2,11 +2,12 @@
 
 ## 15.0.2 (2024-10-04)
 
-* [bitnami/rabbitmq] Fix duplicate key issue with Helm/FluxCD integration ([#29779](https://github.com/bitnami/charts/pull/29779))
+* Fix duplicate key issue with Helm/FluxCD integration ([#29779](https://github.com/bitnami/charts/pull/29779))
 
-## 15.0.1 (2024-09-25)
+## <small>15.0.1 (2024-09-25)</small>
 
-* [bitnami/rabbitmq] Release 15.0.1 ([#29600](https://github.com/bitnami/charts/pull/29600))
+* [bitnami/rabbitmq] docs: :memo: Add upgrade notes for version 15.x.x ([012685d](https://github.com/bitnami/charts/commit/012685db9831eefe1a77be9122fbcdf5933198a1))
+* [bitnami/rabbitmq] Release 15.0.1 (#29600) ([f0bcc5c](https://github.com/bitnami/charts/commit/f0bcc5cb258b5329bcb6cacd998d4f4170d3b06a)), closes [#29600](https://github.com/bitnami/charts/issues/29600)
 
 ## 15.0.0 (2024-09-20)
 

--- a/bitnami/rabbitmq/CHANGELOG.md
+++ b/bitnami/rabbitmq/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 15.0.2 (2024-10-04)
+
+* [bitnami/rabbitmq] Fix duplicate key issue with Helm/FluxCD integration ([#29600](https://github.com/bitnami/charts/pull/29600))
+
 ## 15.0.1 (2024-09-25)
 
 * [bitnami/rabbitmq] Release 15.0.1 ([#29600](https://github.com/bitnami/charts/pull/29600))

--- a/bitnami/rabbitmq/Chart.yaml
+++ b/bitnami/rabbitmq/Chart.yaml
@@ -30,4 +30,4 @@ maintainers:
 name: rabbitmq
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/rabbitmq
-version: 15.0.1
+version: 15.0.2

--- a/bitnami/rabbitmq/templates/statefulset.yaml
+++ b/bitnami/rabbitmq/templates/statefulset.yaml
@@ -33,7 +33,7 @@ spec:
         {{- end }}
         checksum/config: {{ include (print $.Template.BasePath "/config-secret.yaml") . | sha256sum }}
         {{- if (include "rabbitmq.createTlsSecret" . ) }}
-        checksum/config: {{ include (print $.Template.BasePath "/tls-secrets.yaml") . | sha256sum }}
+        checksum/configTLS: {{ include (print $.Template.BasePath "/tls-secrets.yaml") . | sha256sum }}
         {{- end }}
         {{- if or (not .Values.auth.existingErlangSecret) (not .Values.auth.existingPasswordSecret) .Values.extraSecrets }}
         checksum/secret: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}


### PR DESCRIPTION
### Description of the change

Introduced at
https://github.com/bitnami/charts/pull/17537

This causes an issue when running version 12.05 or higher (with Helm/Flux deployment) because of the two `checksum/config` keys.

 Helm says you can use whatever you like as keys: https://github.com/helm/helm/issues/3418

### Benefits

Being able to successfully integrate the bitnami RMQ chart (above version 12.0.4) with Helm/Flux deployment.

### Possible drawbacks


### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

### Additional information

helm error message:

`Helm install failed: error while running post render on files: map[string]interface {}(nil): yaml: unmarshal errors: line 35: mapping key "checksum/config" already defined at line 34 Last Helm logs:`

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)