### PR TITLE
[bitnami/grafana-operator] Fixed envFrom examples

### DIFF
--- a/bitnami/grafana-operator/CHANGELOG.md
+++ b/bitnami/grafana-operator/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 4.7.2 (2024-10-05)
+## 4.7.2 (2024-10-07)
 
 * [bitnami/grafana-operator] Fixed envFrom examples ([#29783](https://github.com/bitnami/charts/pull/29783))
 

--- a/bitnami/grafana-operator/CHANGELOG.md
+++ b/bitnami/grafana-operator/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 4.7.1 (2024-10-02)
+## 4.7.2 (2024-10-05)
 
-* [bitnami/grafana-operator] Release 4.7.1 ([#29694](https://github.com/bitnami/charts/pull/29694))
+* [bitnami/grafana-operator] Fixed envFrom examples ([#29783](https://github.com/bitnami/charts/pull/29783))
+
+## <small>4.7.1 (2024-10-02)</small>
+
+* [bitnami/grafana-operator] Release 4.7.1 (#29694) ([0a1e9b7](https://github.com/bitnami/charts/commit/0a1e9b7a0d44c76d7a7edef1d72e6e6ba968e885)), closes [#29694](https://github.com/bitnami/charts/issues/29694)
 
 ## 4.7.0 (2024-09-23)
 

--- a/bitnami/grafana-operator/Chart.yaml
+++ b/bitnami/grafana-operator/Chart.yaml
@@ -30,4 +30,4 @@ maintainers:
 name: grafana-operator
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/grafana-operator
-version: 4.7.1
+version: 4.7.2

--- a/bitnami/grafana-operator/values.yaml
+++ b/bitnami/grafana-operator/values.yaml
@@ -678,9 +678,9 @@ grafana:
   ## e.g:
   ## envFrom:
   ## - configMapRef:
-  ##   name: grafana-configmap
+  ##     name: grafana-configmap
   ## - secretRef:
-  ##   name: grafana-secrets
+  ##     name: grafana-secrets
   ##
   envFrom: []
   ## The grafana-operator client-configuration for this grafana instance


### PR DESCRIPTION
Provided default samples didn't work.

### Description of the change

Fixes envFrom examples.

### Benefits

Allowing Grafana deployment to consume the environment from preprovisioned secrets/configmaps.

### Possible drawbacks

N/A

### Applicable issues

N/A

### Additional information

N/A

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
