### PR TITLE
[bitnami/mlflow] fix mlflow external s3 host example

### DIFF
--- a/bitnami/mlflow/CHANGELOG.md
+++ b/bitnami/mlflow/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 2.0.0 (2024-10-02)
+## 2.0.1 (2024-10-07)
 
-* [bitnami/mlflow] feat!: :arrow_up: :boom: Bump PostgreSQL to 17.x ([#29740](https://github.com/bitnami/charts/pull/29740))
+* bitnami/mlflow: fix mlflow external s3 host example ([#29794](https://github.com/bitnami/charts/pull/29794))
+
+## 2.0.0 (2024-10-03)
+
+* [bitnami/mlflow] feat!: :arrow_up: :boom: Bump PostgreSQL to 17.x (#29740) ([366ae2b](https://github.com/bitnami/charts/commit/366ae2be83024c1fdbf09db44c6e99057e67c150)), closes [#29740](https://github.com/bitnami/charts/issues/29740)
 
 ## <small>1.5.7 (2024-09-19)</small>
 

--- a/bitnami/mlflow/CHANGELOG.md
+++ b/bitnami/mlflow/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.0.1 (2024-10-07)
 
-* bitnami/mlflow: fix mlflow external s3 host example ([#29794](https://github.com/bitnami/charts/pull/29794))
+* [bitnami/mlflow] fix mlflow external s3 host example ([#29794](https://github.com/bitnami/charts/pull/29794))
 
 ## 2.0.0 (2024-10-03)
 

--- a/bitnami/mlflow/Chart.yaml
+++ b/bitnami/mlflow/Chart.yaml
@@ -44,4 +44,4 @@ sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/mlflow
 - https://github.com/bitnami/containers/tree/main/bitnami/mlflow
 - https://github.com/mlflow/mlflow
-version: 2.0.0
+version: 2.0.1

--- a/bitnami/mlflow/README.md
+++ b/bitnami/mlflow/README.md
@@ -446,19 +446,19 @@ The command deploys mlflow on the Kubernetes cluster in the default configuratio
 
 ### External S3 parameters
 
-| Name                                      | Description                                                                                                                                                                 | Value           |
-| ----------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------- |
-| `externalS3.host`                         | External S3 host. When using AWS S3, include appropriate [regional code](https://docs.aws.amazon.com/general/latest/gr/s3.html#s3_region), e.g. "eu-central-1.amazonaws.com | `""`            |
-| `externalS3.port`                         | External S3 port number                                                                                                                                                     | `443`           |
-| `externalS3.useCredentialsInSecret`       | Whether to use a secret to store the S3 credentials                                                                                                                         | `true`          |
-| `externalS3.accessKeyID`                  | External S3 access key ID                                                                                                                                                   | `""`            |
-| `externalS3.accessKeySecret`              | External S3 access key secret                                                                                                                                               | `""`            |
-| `externalS3.existingSecret`               | Name of an existing secret resource containing the S3 credentials                                                                                                           | `""`            |
-| `externalS3.existingSecretAccessKeyIDKey` | Name of an existing secret key containing the S3 access key ID                                                                                                              | `root-user`     |
-| `externalS3.existingSecretKeySecretKey`   | Name of an existing secret key containing the S3 access key secret                                                                                                          | `root-password` |
-| `externalS3.protocol`                     | External S3 protocol                                                                                                                                                        | `https`         |
-| `externalS3.bucket`                       | External S3 bucket                                                                                                                                                          | `mlflow`        |
-| `externalS3.serveArtifacts`               | Whether artifact serving is enabled                                                                                                                                         | `true`          |
+| Name                                      | Description                                                                                                                                                                    | Value           |
+| ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------- |
+| `externalS3.host`                         | External S3 host. When using AWS S3, include appropriate [regional code](https://docs.aws.amazon.com/general/latest/gr/s3.html#s3_region), e.g. "eu-central-1.s3.amazonaws.com | `""`            |
+| `externalS3.port`                         | External S3 port number                                                                                                                                                        | `443`           |
+| `externalS3.useCredentialsInSecret`       | Whether to use a secret to store the S3 credentials                                                                                                                            | `true`          |
+| `externalS3.accessKeyID`                  | External S3 access key ID                                                                                                                                                      | `""`            |
+| `externalS3.accessKeySecret`              | External S3 access key secret                                                                                                                                                  | `""`            |
+| `externalS3.existingSecret`               | Name of an existing secret resource containing the S3 credentials                                                                                                              | `""`            |
+| `externalS3.existingSecretAccessKeyIDKey` | Name of an existing secret key containing the S3 access key ID                                                                                                                 | `root-user`     |
+| `externalS3.existingSecretKeySecretKey`   | Name of an existing secret key containing the S3 access key secret                                                                                                             | `root-password` |
+| `externalS3.protocol`                     | External S3 protocol                                                                                                                                                           | `https`         |
+| `externalS3.bucket`                       | External S3 bucket                                                                                                                                                             | `mlflow`        |
+| `externalS3.serveArtifacts`               | Whether artifact serving is enabled                                                                                                                                            | `true`          |
 
 ### External Google Cloud Storage parameters
 

--- a/bitnami/mlflow/values.yaml
+++ b/bitnami/mlflow/values.yaml
@@ -1398,7 +1398,7 @@ minio:
 
 ## @section External S3 parameters
 ## All of these values are only used when minio.enabled is set to false
-## @param externalS3.host External S3 host. When using AWS S3, include appropriate [regional code](https://docs.aws.amazon.com/general/latest/gr/s3.html#s3_region), e.g. "eu-central-1.amazonaws.com
+## @param externalS3.host External S3 host. When using AWS S3, include appropriate [regional code](https://docs.aws.amazon.com/general/latest/gr/s3.html#s3_region), e.g. "eu-central-1.s3.amazonaws.com
 ## @param externalS3.port External S3 port number
 ## @param externalS3.useCredentialsInSecret Whether to use a secret to store the S3 credentials
 ## @param externalS3.accessKeyID External S3 access key ID


### PR DESCRIPTION

### Description of the change

The default url for mlflow externals3host does not work, the correct host has a `.s3`

### Benefits

Fix the external s3 host example

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [ ] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
