### PR TITLE
[bitnami/kubernetes-event-exporter] Add  to leader election RoleBinding

### DIFF
--- a/bitnami/kubernetes-event-exporter/CHANGELOG.md
+++ b/bitnami/kubernetes-event-exporter/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 3.2.13 (2024-10-02)
+## 3.2.14 (2024-10-07)
 
-* [bitnami/kubernetes-event-exporter] Release 3.2.13 ([#29704](https://github.com/bitnami/charts/pull/29704))
+* [bitnami/kubernetes-event-exporter] Add  to leader election RoleBinding ([#29804](https://github.com/bitnami/charts/pull/29804))
+
+## <small>3.2.13 (2024-10-02)</small>
+
+* [bitnami/kubernetes-event-exporter] Release 3.2.13 (#29704) ([6eae2ee](https://github.com/bitnami/charts/commit/6eae2eef6d1ebef26305ec5238b49adf650cc359)), closes [#29704](https://github.com/bitnami/charts/issues/29704)
 
 ## <small>3.2.12 (2024-09-06)</small>
 

--- a/bitnami/kubernetes-event-exporter/Chart.yaml
+++ b/bitnami/kubernetes-event-exporter/Chart.yaml
@@ -31,4 +31,4 @@ maintainers:
 name: kubernetes-event-exporter
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/kubernetes-event-exporter
-version: 3.2.13
+version: 3.2.14

--- a/bitnami/kubernetes-event-exporter/templates/rbac-leader-election.yaml
+++ b/bitnami/kubernetes-event-exporter/templates/rbac-leader-election.yaml
@@ -56,6 +56,7 @@ metadata:
   {{- end }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
   name: {{ include "common.names.fullname" . }}-leader-election
+  namespace: {{ .Release.Namespace | quote }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role


### PR DESCRIPTION
### Description of the change

This PR adds the `metadata.namespace` value to the leader election `RoleBinding` to align with the other resources deployed by this chart.

### Benefits

In addition to aligning better with the other resources. This fixes integration with ArgoCD, which requires an explicit namespace to be specific on all namespaced resources.

### Possible drawbacks

N/A

### Additional information

Roughly identical MR I put up earlier for bitnami/schema-registry https://github.com/bitnami/charts/pull/24284

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
