### PR TITLE
[bitnami/contour]: Fix invalid extraVolumeMounts

### DIFF
--- a/bitnami/contour/CHANGELOG.md
+++ b/bitnami/contour/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 19.0.4 (2024-10-04)
+## 19.0.5 (2024-10-08)
 
-* [bitnami/contour] Release 19.0.4 ([#29688](https://github.com/bitnami/charts/pull/29688))
+* [bitnami/contour]: Fix invalid extraVolumeMounts ([#29817](https://github.com/bitnami/charts/pull/29817))
+
+## <small>19.0.4 (2024-10-04)</small>
+
+* [bitnami/contour] Release 19.0.4 (#29688) ([ad308c2](https://github.com/bitnami/charts/commit/ad308c2fcc162182933038eeff9a8880c0923991)), closes [#29688](https://github.com/bitnami/charts/issues/29688)
 
 ## <small>19.0.3 (2024-09-05)</small>
 

--- a/bitnami/contour/Chart.yaml
+++ b/bitnami/contour/Chart.yaml
@@ -32,4 +32,4 @@ maintainers:
 name: contour
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/contour
-version: 19.0.4
+version: 19.0.5

--- a/bitnami/contour/templates/default-backend/deployment.yaml
+++ b/bitnami/contour/templates/default-backend/deployment.yaml
@@ -161,7 +161,7 @@ spec:
           resources: {{- include "common.resources.preset" (dict "type" .Values.defaultBackend.resourcesPreset) | nindent 12 }}
           {{- end }}
           {{- if .Values.defaultBackend.extraVolumeMounts }}
-          volumeMounts: {{- include "common.tplvalues.render" ( dict "value" .Values.contour.extraVolumeMounts "context" $ ) | nindent 12 }}
+          volumeMounts: {{- include "common.tplvalues.render" ( dict "value" .Values.defaultBackend.extraVolumeMounts "context" $ ) | nindent 12 }}
           {{- end }}
         {{- if .Values.defaultBackend.sidecars }}
         {{- include "common.tplvalues.render" ( dict "value" .Values.defaultBackend.sidecars "context" $) | nindent 8 }}


### PR DESCRIPTION
### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->
The default backend's deployment.yaml currently contains the following code:
```yaml
          {{- if .Values.defaultBackend.extraVolumeMounts }}
          volumeMounts: {{- include "common.tplvalues.render" ( dict "value" .Values.contour.extraVolumeMounts "context" $ ) | nindent 12 }}
          {{- end }}
```
Note that the if condition uses the correct variable (`defaultBackend.extraVolumeMounts`) whereas the render call uses the incorrect one (`contour.extraVolumeMounts`). This looks like a simple copy and paste mistake.

### Benefits

The default backends' volumes get rendered correctly.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
