### PR TITLE
[bitnami/wildfly] fix annotations merging for management ingress

### DIFF
--- a/bitnami/wildfly/CHANGELOG.md
+++ b/bitnami/wildfly/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 21.0.6 (2024-10-08)
+## 21.0.6 (2024-10-10)
 
 * [bitnami/wildfly] fix annotations merging for management ingress ([#29819](https://github.com/bitnami/charts/pull/29819))
 

--- a/bitnami/wildfly/CHANGELOG.md
+++ b/bitnami/wildfly/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 21.0.5 (2024-09-17)
+## 21.0.6 (2024-10-08)
 
-* [bitnami/wildfly] Release 21.0.5 ([#29487](https://github.com/bitnami/charts/pull/29487))
+* [bitnami/wildfly] fix annotations merging for management ingress ([#29819](https://github.com/bitnami/charts/pull/29819))
+
+## <small>21.0.5 (2024-09-17)</small>
+
+* [bitnami/wildfly] Release 21.0.5 (#29487) ([894aca0](https://github.com/bitnami/charts/commit/894aca0338ff3aa8f19f3ac5d9450d1973c70eb2)), closes [#29487](https://github.com/bitnami/charts/issues/29487)
 
 ## <small>21.0.4 (2024-08-23)</small>
 

--- a/bitnami/wildfly/Chart.yaml
+++ b/bitnami/wildfly/Chart.yaml
@@ -33,4 +33,4 @@ maintainers:
 name: wildfly
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/wildfly
-version: 21.0.5
+version: 21.0.6

--- a/bitnami/wildfly/templates/management-ingress.yaml
+++ b/bitnami/wildfly/templates/management-ingress.yaml
@@ -16,7 +16,7 @@ metadata:
     kubernetes.io/tls-acme: "true"
     {{- end }}
     {{- if or .Values.mgmtIngress.annotations .Values.commonAnnotations }}
-    {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.persistence.annotations .Values.commonAnnotations ) "context" . ) }}
+    {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.mgmtIngress.annotations .Values.commonAnnotations ) "context" . ) }}
     {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
     {{- end }}
   {{- end }}


### PR DESCRIPTION
Change "persistence" reference annotations to "mgmtIngress"

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

During the merge for management ingress annotations, they wrong takes annotations by "persistence" component instead "mgmtIngress".

### Benefits

Now the "mgmtIngress" component has right annonations.

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #29787

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
- [X] Version upgrade to 21.0.6
