### PR TITLE
[bitnami/mariadb] add default binlog expiry configuration of 30 days

### DIFF
--- a/bitnami/mariadb/CHANGELOG.md
+++ b/bitnami/mariadb/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 19.0.8 (2024-10-09)
+## 19.1.0 (2024-10-10)
 
 * [bitnami/mariadb] add default binlog expiry configuration of 30 days ([#29841](https://github.com/bitnami/charts/pull/29841))
 

--- a/bitnami/mariadb/CHANGELOG.md
+++ b/bitnami/mariadb/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 19.0.7 (2024-09-23)
+## 19.0.8 (2024-10-09)
 
-* [bitnami/mariadb] Release 19.0.7 ([#29571](https://github.com/bitnami/charts/pull/29571))
+* [bitnami/mariadb] add default binlog expiry configuration of 30 days ([#29841](https://github.com/bitnami/charts/pull/29841))
+
+## <small>19.0.7 (2024-09-23)</small>
+
+* [bitnami/mariadb] Release 19.0.7 (#29571) ([a64fadf](https://github.com/bitnami/charts/commit/a64fadf42cc82f7468245ff87c61aa50356fbb47)), closes [#29571](https://github.com/bitnami/charts/issues/29571)
 
 ## <small>19.0.6 (2024-09-17)</small>
 

--- a/bitnami/mariadb/Chart.yaml
+++ b/bitnami/mariadb/Chart.yaml
@@ -34,4 +34,4 @@ maintainers:
 name: mariadb
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/mariadb
-version: 19.0.8
+version: 19.1.0

--- a/bitnami/mariadb/Chart.yaml
+++ b/bitnami/mariadb/Chart.yaml
@@ -34,4 +34,4 @@ maintainers:
 name: mariadb
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/mariadb
-version: 19.0.7
+version: 19.0.8

--- a/bitnami/mariadb/values.yaml
+++ b/bitnami/mariadb/values.yaml
@@ -223,6 +223,7 @@ primary:
     collation-server=utf8_general_ci
     slow_query_log=0
     long_query_time=10.0
+    binlog_expire_logs_seconds=2592000
 
     [client]
     port=3306
@@ -643,6 +644,7 @@ secondary:
     collation-server=utf8_general_ci
     slow_query_log=0
     long_query_time=10.0
+    binlog_expire_logs_seconds=2592000
 
     [client]
     port=3306

--- a/bitnami/mysql/Chart.yaml
+++ b/bitnami/mysql/Chart.yaml
@@ -34,4 +34,4 @@ maintainers:
 name: mysql
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/mysql
-version: 11.1.17
+version: 11.1.18

--- a/bitnami/mysql/Chart.yaml
+++ b/bitnami/mysql/Chart.yaml
@@ -34,4 +34,4 @@ maintainers:
 name: mysql
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/mysql
-version: 11.1.18
+version: 11.1.17


### PR DESCRIPTION
### Description of the change

- the change adds an entry `binlog_expire_logs_seconds=2592000` to the `primary.configuration` and `secondary.configuration` properties of values.yaml file
- this change will clean up binary logs older than 30 days, which currently does not happen (as discussed in #21886)

### Benefits

- old binary log files will not fill up the storage anymore

### Possible drawbacks

- binary log files, which are older than 30 days and are still needed, could get deleted

### Applicable issues

- fixes #21886

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
