### PR TITLE
[bitnami/appsmith] Enable redis flush commands when using redis subchart

### DIFF
--- a/bitnami/appsmith/CHANGELOG.md
+++ b/bitnami/appsmith/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
+## 5.0.1 (2024-10-11)
+
+* [bitnami/appsmith] Enable redis flush commands when using redis subchart ([#29867](https://github.com/bitnami/charts/pull/29867))
+
 ## 5.0.0 (2024-10-08)
 
-* [bitnami/appsmith] Update MongoDB chart to 16.0.0 ([#29805](https://github.com/bitnami/charts/pull/29805))
+* [bitnami/appsmith] Update MongoDB chart to 16.0.0 (#29805) ([9ce2496](https://github.com/bitnami/charts/commit/9ce24968c5f5d959dc99bce67099e78e54dcfe9e)), closes [#29805](https://github.com/bitnami/charts/issues/29805)
 
 ## <small>4.0.10 (2024-10-02)</small>
 

--- a/bitnami/appsmith/Chart.yaml
+++ b/bitnami/appsmith/Chart.yaml
@@ -39,4 +39,4 @@ maintainers:
 name: appsmith
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/appsmith
-version: 5.0.0
+version: 5.0.1

--- a/bitnami/appsmith/README.md
+++ b/bitnami/appsmith/README.md
@@ -689,9 +689,11 @@ The [Bitnami appsmith](https://github.com/bitnami/containers/tree/main/bitnami/a
 | `redis.master.service.ports.redis` | Redis port                                                                                                                                                                                                               | `6379`       |
 | `redis.master.resourcesPreset`     | Set container resources according to one common preset (allowed values: none, nano, small, medium, large, xlarge, 2xlarge). This is ignored if master.resources is set (master.resources is recommended for production). | `nano`       |
 | `redis.master.resources`           | Set container requests and limits for different resources like CPU or memory (essential for production workloads)                                                                                                        | `{}`         |
+| `redis.master.disableCommands`     | Array with Redis commands to disable on master nodes                                                                                                                                                                     | `[]`         |
 | `redis.auth.enabled`               | Enable Redis auth                                                                                                                                                                                                        | `true`       |
 | `redis.auth.password`              | Redis password                                                                                                                                                                                                           | `""`         |
 | `redis.auth.existingSecret`        | Name of a secret containing the Redis password                                                                                                                                                                           | `""`         |
+| `redis.replica.disableCommands`    | Array with Redis commands to disable on master nodes                                                                                                                                                                     | `[]`         |
 
 ### MongoDB sub-chart parameters
 

--- a/bitnami/appsmith/README.md
+++ b/bitnami/appsmith/README.md
@@ -693,7 +693,7 @@ The [Bitnami appsmith](https://github.com/bitnami/containers/tree/main/bitnami/a
 | `redis.auth.enabled`               | Enable Redis auth                                                                                                                                                                                                        | `true`       |
 | `redis.auth.password`              | Redis password                                                                                                                                                                                                           | `""`         |
 | `redis.auth.existingSecret`        | Name of a secret containing the Redis password                                                                                                                                                                           | `""`         |
-| `redis.replica.disableCommands`    | Array with Redis commands to disable on master nodes                                                                                                                                                                     | `[]`         |
+| `redis.replica.disableCommands`    | Array with Redis commands to disable on replicas nodes                                                                                                                                                                   | `[]`         |
 
 ### MongoDB sub-chart parameters
 

--- a/bitnami/appsmith/values.yaml
+++ b/bitnami/appsmith/values.yaml
@@ -1662,6 +1662,10 @@ redis:
     service:
       ports:
         redis: 6379
+    ## Enable Flush commands (FLUSHDB, FLUSHALL)
+    ## Appsmith flushes when booting
+    disableCommands: []
+
     ## Redis&reg; master resource requests and limits
     ## ref: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
     ## @param redis.master.resourcesPreset Set container resources according to one common preset (allowed values: none, nano, small, medium, large, xlarge, 2xlarge). This is ignored if master.resources is set (master.resources is recommended for production).

--- a/bitnami/appsmith/values.yaml
+++ b/bitnami/appsmith/values.yaml
@@ -1679,6 +1679,9 @@ redis:
     ##     memory: 1024Mi
     ##
     resources: {}
+    ## Enable Flush commands (FLUSHDB, FLUSHALL)
+    ## Appsmith needs flush when booting
+    disableCommands: []
   ## @param redis.auth.enabled Enable Redis auth
   ## @param redis.auth.password Redis password
   ## @param redis.auth.existingSecret Name of a secret containing the Redis password
@@ -1687,6 +1690,10 @@ redis:
     enabled: true
     password: ""
     existingSecret: ""
+  replica:
+    ## Enable Flush commands (FLUSHDB, FLUSHALL)
+    ## Appsmith needs flush when booting
+    disableCommands: []
 ## @section MongoDB sub-chart parameters
 ##
 mongodb:

--- a/bitnami/appsmith/values.yaml
+++ b/bitnami/appsmith/values.yaml
@@ -1662,9 +1662,6 @@ redis:
     service:
       ports:
         redis: 6379
-    ## Enable Flush commands (FLUSHDB, FLUSHALL)
-    ## Appsmith flushes when booting
-    disableCommands: []
 
     ## Redis&reg; master resource requests and limits
     ## ref: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/

--- a/bitnami/appsmith/values.yaml
+++ b/bitnami/appsmith/values.yaml
@@ -1680,6 +1680,10 @@ redis:
     ##     memory: 1024Mi
     ##
     resources: {}
+    ## @param redis.master.disableCommands Array with Redis commands to disable on master nodes
+    ## Commands will be completely disabled by renaming each to an empty string.
+    ## ref: https://redis.io/topics/security#disabling-of-specific-commands
+    ##
     ## Enable Flush commands (FLUSHDB, FLUSHALL)
     ## Appsmith needs flush when booting
     disableCommands: []
@@ -1692,6 +1696,10 @@ redis:
     password: ""
     existingSecret: ""
   replica:
+    ## @param redis.replica.disableCommands Array with Redis commands to disable on replicas nodes
+    ## Commands will be completely disabled by renaming each to an empty string.
+    ## ref: https://redis.io/topics/security#disabling-of-specific-commands
+    ##
     ## Enable Flush commands (FLUSHDB, FLUSHALL)
     ## Appsmith needs flush when booting
     disableCommands: []


### PR DESCRIPTION
### Description of the change
Enable redis flush commands when appsmith using redis subchart.

### Benefits
Prevent misleading users who uses appsmith chart with redis subchart.

### Possible drawbacks
nothing

### Applicable issues
none

### Additional information
Appsmith execute flush and it can cause exceptions when flush commands are disabled.
It should be enabled when use redis as internal service with kubernetes pods.
```
backend stdout | [2024-10-11 00:53:08,816] [main] requestId= userEmail= traceId= spanId= -
backend stdout |
backend stdout | Error starting ApplicationContext. To display the condition evaluation report re-run your application with 'debug' enabled.
backend stdout | [2024-10-11 00:53:08,840] [main] requestId= userEmail= traceId= spanId= - Application run failed
backend stdout | org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'mongockInitializingBeanRunner' defined in class path resource [com/appsmith/server/configurations/MongoConfig.class]: io.mongock.api.exception.MongockException: Error in method[Migration063CacheBustSpringBoot3_3.execute] : Error in execution
backend stdout | 	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.initializeBean(AbstractAutowireCapableBeanFactory.java:1806)
backend stdout | 	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:600)
backend stdout | 	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:522)
backend stdout | 	at org.springframework.beans.factory.support.AbstractBeanFactory.lambda$doGetBean$0(AbstractBeanFactory.java:337)
backend stdout | 	at org.springframework.beans.factory.support.DefaultSingletonBeanRegistry.getSingleton(DefaultSingletonBeanRegistry.java:234)
backend stdout | 	at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:335)
backend stdout | 	at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:200)
backend stdout | 	at org.springframework.beans.factory.support.DefaultListableBeanFactory.preInstantiateSingletons(DefaultListableBeanFactory.java:975)
backend stdout | 	at org.springframework.context.support.AbstractApplicationContext.finishBeanFactoryInitialization(AbstractApplicationContext.java:971)
backend stdout | 	at org.springframework.context.support.AbstractApplicationContext.refresh(AbstractApplicationContext.java:625)
backend stdout | 	at org.springframework.boot.web.reactive.context.ReactiveWebServerApplicationContext.refresh(ReactiveWebServerApplicationContext.java:66)
backend stdout | 	at org.springframework.boot.SpringApplication.refresh(SpringApplication.java:754)
backend stdout | 	at org.springframework.boot.SpringApplication.refreshContext(SpringApplication.java:456)
backend stdout | 	at org.springframework.boot.SpringApplication.run(SpringApplication.java:335)
backend stdout | 	at org.springframework.boot.builder.SpringApplicationBuilder.run(SpringApplicationBuilder.java:149)
backend stdout | 	at com.appsmith.server.ServerApplication.main(ServerApplication.java:27)
backend stdout | 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
backend stdout | 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
backend stdout | 	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
backend stdout | 	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
backend stdout | 	at org.springframework.boot.loader.launch.Launcher.launch(Launcher.java:102)
backend stdout | 	at org.springframework.boot.loader.launch.Launcher.launch(Launcher.java:64)
backend stdout | 	at org.springframework.boot.loader.launch.JarLauncher.main(JarLauncher.java:40)
backend stdout | Caused by: io.mongock.api.exception.MongockException: io.mongock.api.exception.MongockException: Error in method[Migration063CacheBustSpringBoot3_3.execute] : Error in execution
backend stdout | 	at io.mongock.driver.mongodb.reactive.driver.MongoReactiveDriverBase.executeInTransaction(MongoReactiveDriverBase.java:66)
backend stdout | 	at io.mongock.runner.core.executor.operation.migrate.MigrateExecutorBase.processChangeLogInTransactionIfApplies(MigrateExecutorBase.java:162)
backend stdout | 	at io.mongock.runner.core.executor.operation.migrate.MigrateExecutorBase.processSingleChangeLog(MigrateExecutorBase.java:136)
backend stdout | 	at io.mongock.runner.core.executor.operation.migrate.MigrateExecutorBase.processChangeLogs(MigrateExecutorBase.java:126)
backend stdout | 	at io.mongock.runner.core.executor.operation.migrate.MigrateExecutorBase.lambda$processMigration$1(MigrateExecutorBase.java:121)
backend stdout | 	at io.mongock.runner.core.executor.NonTransactioner.executeInTransaction(NonTransactioner.java:17)
backend stdout | 	at io.mongock.runner.core.executor.operation.migrate.MigrateExecutorBase.processMigration(MigrateExecutorBase.java:121)
backend stdout | 	at io.mongock.runner.core.executor.operation.migrate.MigrateExecutorBase.executeMigration(MigrateExecutorBase.java:103)
backend stdout | 	at io.mongock.runner.core.executor.operation.migrate.MigrateExecutorBase.executeMigration(MigrateExecutorBase.java:46)
backend stdout | 	at io.mongock.runner.core.executor.MongockRunnerImpl.execute(MongockRunnerImpl.java:53)
backend stdout | 	at io.mongock.runner.springboot.base.MongockInitializingBeanRunner.afterPropertiesSet(MongockInitializingBeanRunner.java:17)
backend stdout | 	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.invokeInitMethods(AbstractAutowireCapableBeanFactory.java:1853)
backend stdout | 	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.initializeBean(AbstractAutowireCapableBeanFactory.java:1802)
backend stdout | 	... 22 common frames omitted
backend stdout | Caused by: io.mongock.api.exception.MongockException: Error in method[Migration063CacheBustSpringBoot3_3.execute] : Error in execution
backend stdout | 	at io.mongock.runner.core.executor.operation.migrate.MigrateExecutorBase.processExceptionOnChangeSetExecution(MigrateExecutorBase.java:398)
backend stdout | 	at io.mongock.runner.core.executor.operation.migrate.MigrateExecutorBase.processSingleChangeSet(MigrateExecutorBase.java:207)
backend stdout | 	at io.mongock.runner.core.executor.operation.migrate.MigrateExecutorBase.loopRawChangeSets(MigrateExecutorBase.java:172)
backend stdout | 	at io.mongock.runner.core.executor.operation.migrate.MigrateExecutorBase.lambda$processChangeLogInTransactionIfApplies$3(MigrateExecutorBase.java:162)
backend stdout | 	at io.mongock.driver.mongodb.reactive.driver.MongoReactiveDriverBase.executeInTransaction(MongoReactiveDriverBase.java:62)
backend stdout | 	... 34 common frames omitted
backend stdout | Caused by: java.lang.reflect.InvocationTargetException: null
backend stdout | 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
backend stdout | 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
backend stdout | 	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
backend stdout | 	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
backend stdout | 	at io.mongock.runner.core.executor.ChangeLogRuntimeImpl.runChangeSet(ChangeLogRuntimeImpl.java:79)
backend stdout | 	at io.mongock.runner.core.executor.operation.migrate.MigrateExecutorBase.executeChangeSetMethod(MigrateExecutorBase.java:386)
backend stdout | 	at io.mongock.runner.core.executor.operation.migrate.MigrateExecutorBase.executeAndLogChangeSet(MigrateExecutorBase.java:244)
backend stdout | 	at io.mongock.runner.core.executor.operation.migrate.MigrateExecutorBase.processSingleChangeSet(MigrateExecutorBase.java:205)
backend stdout | 	... 37 common frames omitted
backend stdout | Caused by: org.springframework.data.redis.RedisSystemException: Error in execution
backend stdout | 	at org.springframework.data.redis.connection.lettuce.LettuceExceptionConverter.convert(LettuceExceptionConverter.java:52)
backend stdout | 	at org.springframework.data.redis.connection.lettuce.LettuceReactiveRedisConnection.lambda$translateException$0(LettuceReactiveRedisConnection.java:242)
backend stdout | 	at reactor.core.publisher.Flux.lambda$onErrorMap$28(Flux.java:7275)
backend stdout | 	at reactor.core.publisher.FluxOnErrorResume$ResumeSubscriber.onError(FluxOnErrorResume.java:94)
backend stdout | 	at com.appsmith.server.configurations.MDCConfig$MdcContextLifter.onError(MDCConfig.java:64)
backend stdout | 	at reactor.core.publisher.MonoFlatMapMany$FlatMapManyInner.onError(MonoFlatMapMany.java:256)
backend stdout | 	at com.appsmith.server.configurations.MDCConfig$MdcContextLifter.onError(MDCConfig.java:64)
backend stdout | 	at reactor.core.publisher.MonoNext$NextSubscriber.onError(MonoNext.java:93)
backend stdout | 	at reactor.core.publisher.MonoNext$NextSubscriber.onError(MonoNext.java:93)
backend stdout | 	at io.lettuce.core.RedisPublisher$ImmediateSubscriber.onError(RedisPublisher.java:895)
backend stdout | 	at io.lettuce.core.RedisPublisher$State.onError(RedisPublisher.java:716)
backend stdout | 	at io.lettuce.core.RedisPublisher$RedisSubscription.onError(RedisPublisher.java:357)
backend stdout | 	at io.lettuce.core.RedisPublisher$SubscriptionCommand.onError(RedisPublisher.java:801)
backend stdout | 	at io.lettuce.core.RedisPublisher$SubscriptionCommand.doOnComplete(RedisPublisher.java:761)
backend stdout | 	at io.lettuce.core.protocol.CommandWrapper.complete(CommandWrapper.java:65)
backend stdout | 	at io.lettuce.core.protocol.CommandWrapper.complete(CommandWrapper.java:63)
backend stdout | 	at io.lettuce.core.protocol.CommandHandler.complete(CommandHandler.java:745)
backend stdout | 	at io.lettuce.core.protocol.CommandHandler.decode(CommandHandler.java:680)
backend stdout | 	at io.lettuce.core.protocol.CommandHandler.channelRead(CommandHandler.java:597)
backend stdout | 	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:442)
backend stdout | 	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
backend stdout | 	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
backend stdout | 	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1407)
backend stdout | 	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:440)
backend stdout | 	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
backend stdout | 	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:918)
backend stdout | 	at io.netty.channel.epoll.AbstractEpollStreamChannel$EpollStreamUnsafe.epollInReady(AbstractEpollStreamChannel.java:799)
backend stdout | 	at io.netty.channel.epoll.EpollEventLoop.processReady(EpollEventLoop.java:501)
backend stdout | 	at io.netty.channel.epoll.EpollEventLoop.run(EpollEventLoop.java:399)
backend stdout | 	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:994)
backend stdout | 	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
backend stdout | 	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
backend stdout | 	at java.base/java.lang.Thread.run(Thread.java:840)
backend stdout | 	Suppressed: java.lang.Exception: #block terminated with an error
backend stdout | 		at reactor.core.publisher.BlockingSingleSubscriber.blockingGet(BlockingSingleSubscriber.java:104)
backend stdout | 		at reactor.core.publisher.Mono.block(Mono.java:1779)
backend stdout | 		at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
backend stdout | 		at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
backend stdout | 		at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
backend stdout | 		at java.base/java.lang.reflect.Method.invoke(Method.java:568)
backend stdout | 		at io.mongock.driver.api.lock.guard.proxy.LockGuardProxy.invoke(LockGuardProxy.java:55)
backend stdout | 		at io.mongock.driver.api.lock.guard.proxy.LockGuardMethodHandler.invoke(LockGuardMethodHandler.java:25)
backend stdout | 		at reactor.core.publisher.Mono_$$_mongock_7be_d.block(Mono_$$_mongock_7be_d.java)
backend stdout | 		at com.appsmith.server.migrations.db.ce.Migration063CacheBustSpringBoot3_3.execute(Migration063CacheBustSpringBoot3_3.java:25)
backend stdout | 		at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
backend stdout | 		at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
backend stdout | 		at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
backend stdout | 		at java.base/java.lang.reflect.Method.invoke(Method.java:568)
backend stdout | 		at io.mongock.runner.core.executor.ChangeLogRuntimeImpl.runChangeSet(ChangeLogRuntimeImpl.java:79)
backend stdout | 		at io.mongock.runner.core.executor.operation.migrate.MigrateExecutorBase.executeChangeSetMethod(MigrateExecutorBase.java:386)
backend stdout | 		at io.mongock.runner.core.executor.operation.migrate.MigrateExecutorBase.executeAndLogChangeSet(MigrateExecutorBase.java:244)
backend stdout | 		at io.mongock.runner.core.executor.operation.migrate.MigrateExecutorBase.processSingleChangeSet(MigrateExecutorBase.java:205)
backend stdout | 		at io.mongock.runner.core.executor.operation.migrate.MigrateExecutorBase.loopRawChangeSets(MigrateExecutorBase.java:172)
backend stdout | 		at io.mongock.runner.core.executor.operation.migrate.MigrateExecutorBase.lambda$processChangeLogInTransactionIfApplies$3(MigrateExecutorBase.java:162)
backend stdout | 		at io.mongock.driver.mongodb.reactive.driver.MongoReactiveDriverBase.executeInTransaction(MongoReactiveDriverBase.java:62)
backend stdout | 		at io.mongock.runner.core.executor.operation.migrate.MigrateExecutorBase.processChangeLogInTransactionIfApplies(MigrateExecutorBase.java:162)
backend stdout | 		at io.mongock.runner.core.executor.operation.migrate.MigrateExecutorBase.processSingleChangeLog(MigrateExecutorBase.java:136)
backend stdout | 		at io.mongock.runner.core.executor.operation.migrate.MigrateExecutorBase.processChangeLogs(MigrateExecutorBase.java:126)
backend stdout | 		at io.mongock.runner.core.executor.operation.migrate.MigrateExecutorBase.lambda$processMigration$1(MigrateExecutorBase.java:121)
backend stdout | 		at io.mongock.runner.core.executor.NonTransactioner.executeInTransaction(NonTransactioner.java:17)
backend stdout | 		at io.mongock.runner.core.executor.operation.migrate.MigrateExecutorBase.processMigration(MigrateExecutorBase.java:121)
backend stdout | 		at io.mongock.runner.core.executor.operation.migrate.MigrateExecutorBase.executeMigration(MigrateExecutorBase.java:103)
backend stdout | 		at io.mongock.runner.core.executor.operation.migrate.MigrateExecutorBase.executeMigration(MigrateExecutorBase.java:46)
backend stdout | 		at io.mongock.runner.core.executor.MongockRunnerImpl.execute(MongockRunnerImpl.java:53)
backend stdout | 		at io.mongock.runner.springboot.base.MongockInitializingBeanRunner.afterPropertiesSet(MongockInitializingBeanRunner.java:17)
backend stdout | 		at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.invokeInitMethods(AbstractAutowireCapableBeanFactory.java:1853)
backend stdout | 		at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.initializeBean(AbstractAutowireCapableBeanFactory.java:1802)
backend stdout | 		at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:600)
backend stdout | 		at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:522)
backend stdout | 		at org.springframework.beans.factory.support.AbstractBeanFactory.lambda$doGetBean$0(AbstractBeanFactory.java:337)
backend stdout | 		at org.springframework.beans.factory.support.DefaultSingletonBeanRegistry.getSingleton(DefaultSingletonBeanRegistry.java:234)
backend stdout | 		at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:335)
backend stdout | 		at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:200)
backend stdout | 		at org.springframework.beans.factory.support.DefaultListableBeanFactory.preInstantiateSingletons(DefaultListableBeanFactory.java:975)
backend stdout | 		at org.springframework.context.support.AbstractApplicationContext.finishBeanFactoryInitialization(AbstractApplicationContext.java:971)
backend stdout | 		at org.springframework.context.support.AbstractApplicationContext.refresh(AbstractApplicationContext.java:625)
backend stdout | 		at org.springframework.boot.web.reactive.context.ReactiveWebServerApplicationContext.refresh(ReactiveWebServerApplicationContext.java:66)
backend stdout | 		at org.springframework.boot.SpringApplication.refresh(SpringApplication.java:754)
backend stdout | 		at org.springframework.boot.SpringApplication.refreshContext(SpringApplication.java:456)
backend stdout | 		at org.springframework.boot.SpringApplication.run(SpringApplication.java:335)
backend stdout | 		at org.springframework.boot.builder.SpringApplicationBuilder.run(SpringApplicationBuilder.java:149)
backend stdout | 		at com.appsmith.server.ServerApplication.main(ServerApplication.java:27)
backend stdout | 		at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
backend stdout | 		at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
backend stdout | 		at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
backend stdout | 		at java.base/java.lang.reflect.Method.invoke(Method.java:568)
backend stdout | 		at org.springframework.boot.loader.launch.Launcher.launch(Launcher.java:102)
backend stdout | 		at org.springframework.boot.loader.launch.Launcher.launch(Launcher.java:64)
backend stdout | 		at org.springframework.boot.loader.launch.JarLauncher.main(JarLauncher.java:40)
backend stdout | Caused by: io.lettuce.core.RedisCommandExecutionException: ERR unknown command 'FLUSHDB', with args beginning with:
backend stdout | 	at io.lettuce.core.internal.ExceptionFactory.createExecutionException(ExceptionFactory.java:147)
backend stdout | 	at io.lettuce.core.internal.ExceptionFactory.createExecutionException(ExceptionFactory.java:116)
backend stdout | 	... 20 common frames omitted
```
### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
