### PR TITLE
[bitnami/jupyterhub] Fix the service-metrics name from http to metrics for servicemonitor

### DIFF
--- a/bitnami/jupyterhub/CHANGELOG.md
+++ b/bitnami/jupyterhub/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 8.0.0 (2024-10-02)
+## 8.0.1 (2024-10-11)
 
-* [bitnami/jupyterhub] feat!: :arrow_up: :boom: Bump PostgreSQL to 17.x ([#29734](https://github.com/bitnami/charts/pull/29734))
+* [bitnami/jupyterhub] Fix the service-metrics name from http to metrics for servicemonitor ([#29869](https://github.com/bitnami/charts/pull/29869))
+
+## 8.0.0 (2024-10-03)
+
+* [bitnami/jupyterhub] feat!: :arrow_up: :boom: Bump PostgreSQL to 17.x (#29734) ([35c8281](https://github.com/bitnami/charts/commit/35c8281022485fa8e2c4debd1ccdf9ea07f2c76c)), closes [#29734](https://github.com/bitnami/charts/issues/29734)
 
 ## <small>7.2.18 (2024-09-30)</small>
 

--- a/bitnami/jupyterhub/Chart.yaml
+++ b/bitnami/jupyterhub/Chart.yaml
@@ -37,4 +37,4 @@ maintainers:
 name: jupyterhub
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/jupyterhub
-version: 8.0.0
+version: 8.0.1

--- a/bitnami/jupyterhub/templates/proxy/service-metrics.yaml
+++ b/bitnami/jupyterhub/templates/proxy/service-metrics.yaml
@@ -39,7 +39,7 @@ spec:
   sessionAffinityConfig: {{- include "common.tplvalues.render" (dict "value" .Values.proxy.service.metrics.sessionAffinityConfig "context" $) | nindent 4 }}
   {{- end }}
   ports:
-    - name: http
+    - name: metrics
       port: {{ .Values.proxy.service.metrics.ports.http }}
       targetPort: metrics
       protocol: TCP


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Rename the service-metrics service from http to metrics so that servicemonitor can collect metrics from the jupyterhub proxy.

### Benefits

This allows you to collect metrics when the Proxy metrics Service Monitor is enabled.

### Possible drawbacks

none noted

### Applicable issues

none noted

### Additional information

The service that the service monitor on the Jupiter Hub proxy collects is named http, so there are no metrics being collected. Therefore, change the name of the service to metrics so that the service monitor can collect metrics from the service in the current configuration.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
