### PR TITLE
[github-actions] Fix issue with hardcoded-images check

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -111,10 +111,10 @@ jobs:
         run: |
           hardcoded_images=()
           while read -r image; do
-            if [[ $image != {{*}} ]]; then
+            if [[ -n "$image" && $image != {{*}} ]]; then
               hardcoded_images+=("${image}")
             fi
-          done <<< "$(grep -REoh "^\s*image:\s+[\"']*.+[\"']*\s*$" "charts/bitnami/${CHART}/templates" | sed "s/image: [\"']*//" | sed "s/[\"']*$//")"
+          done <<< "$(grep -REoh "\s*image:\s+[\"']*.+[\"']*\s*$" "charts/bitnami/${CHART}/templates" | sed "s/image: [\"']*//" | sed "s/[\"']*$//")"
 
           echo "${hardcoded_images[@]}"
           if [[ ${#hardcoded_images[@]} -gt 0 ]] ; then


### PR DESCRIPTION
### Description of the change

Fixes an issue with the hardcoded images check, where it would fail with the `bitnami/common` chart because it detects some empty image string.

Additionally fixes the regex by removing the `^` character that was added during code review.

At first I thought it was a good idea to prevent false positives, but in fact it may be used to bypass the test as it would fail to detect syntax as:

```
- image: test
```

### Benefits

Fixes issue with the CI pipeline affecting the `common` chart.

### Possible drawbacks

None known.

### Applicable issues

- This issue was affecting PR #29479

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
