### PR TITLE
[bitnami/nginx] Remove duplicated (and wrong) image in verification

### DIFF
--- a/bitnami/nginx/CHANGELOG.md
+++ b/bitnami/nginx/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 18.2.2 (2024-10-02)
+## 18.2.3 (2024-10-11)
 
-* [bitnami/nginx] Release 18.2.2 ([#29751](https://github.com/bitnami/charts/pull/29751))
+* [bitnami/nginx] Remove duplicated (and wrong) image in verification ([#29871](https://github.com/bitnami/charts/pull/29871))
+
+## <small>18.2.2 (2024-10-02)</small>
+
+* [bitnami/nginx] Release 18.2.2 (#29751) ([4d4d930](https://github.com/bitnami/charts/commit/4d4d9301a856bd77ef908530ca99a3f5828906c0)), closes [#29751](https://github.com/bitnami/charts/issues/29751)
 
 ## <small>18.2.1 (2024-10-01)</small>
 

--- a/bitnami/nginx/Chart.yaml
+++ b/bitnami/nginx/Chart.yaml
@@ -34,4 +34,4 @@ maintainers:
 name: nginx
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/nginx
-version: 18.2.2
+version: 18.2.3

--- a/bitnami/nginx/templates/NOTES.txt
+++ b/bitnami/nginx/templates/NOTES.txt
@@ -71,4 +71,4 @@ To access NGINX from outside the cluster, follow the steps below:
 {{- include "nginx.validateValues" . }}
 {{- end }}
 {{- include "common.warnings.resources" (dict "sections" (list "cloneStaticSiteFromGit.gitSync" "metrics" "") "context" $) }}
-{{- include "common.warnings.modifiedImages" (dict "images" (list .Values.image .Values.cloneStaticSiteFromGit.image .Values.cloneStaticSiteFromGit .Values.metrics.image) "context" $) }}
+{{- include "common.warnings.modifiedImages" (dict "images" (list .Values.image .Values.cloneStaticSiteFromGit.image .Values.metrics.image) "context" $) }}


### PR DESCRIPTION
When this verification was added (https://github.com/bitnami/charts/pull/26253/files), one of the images was added twice and using the wrong path, see https://github.com/bitnami/charts/pull/26253/files#diff-c1f6a431b1044866e4a53647d8ad582071b14f7424a968be5deed26d6edfed8eR74.

This is causing the following error given that this unexisting image is interpreted as a container substitution:
```
⚠ SECURITY WARNING: Original containers have been substituted. This Helm chart was designed, tested, and validated on multiple platforms using a specific set of Bitnami and Tanzu Application Catalog containers. Substituting other containers is likely to cause degraded security and performance, broken chart features, and missing environment variables.

Substituted images detected:
  - %!s(<nil>)/:%!s(<nil>)
```