### PR TITLE
[bitnami/sealed-secrets] Fix combination of additionalNamespaces, rbac.clusterRole=false and rbac.namespacedRoles=true

### DIFF
--- a/bitnami/sealed-secrets/CHANGELOG.md
+++ b/bitnami/sealed-secrets/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2.4.8 (2024-10-11)
+## 2.4.8 (2024-10-13)
 
 * [bitnami/sealed-secrets] Fix combination of additionalNamespaces, rbac.clusterRole=false and rbac.namespacedRoles=true ([#29872](https://github.com/bitnami/charts/pull/29872))
 

--- a/bitnami/sealed-secrets/CHANGELOG.md
+++ b/bitnami/sealed-secrets/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2.4.8 (2024-10-13)
+## 2.4.8 (2024-10-14)
 
 * [bitnami/sealed-secrets] Fix combination of additionalNamespaces, rbac.clusterRole=false and rbac.namespacedRoles=true ([#29872](https://github.com/bitnami/charts/pull/29872))
 

--- a/bitnami/sealed-secrets/CHANGELOG.md
+++ b/bitnami/sealed-secrets/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 2.4.7 (2024-10-02)
+## 2.4.8 (2024-10-11)
 
-* [bitnami/sealed-secrets] Release 2.4.7 ([#29718](https://github.com/bitnami/charts/pull/29718))
+* [bitnami/sealed-secrets] Fix combination of additionalNamespaces, rbac.clusterRole=false and rbac.namespacedRoles=true ([#29872](https://github.com/bitnami/charts/pull/29872))
+
+## <small>2.4.7 (2024-10-02)</small>
+
+* [bitnami/sealed-secrets] Release 2.4.7 (#29718) ([656a8f8](https://github.com/bitnami/charts/commit/656a8f88e3a3f9e4322d619e1547f67766df7363)), closes [#29718](https://github.com/bitnami/charts/issues/29718)
 
 ## <small>2.4.6 (2024-09-06)</small>
 

--- a/bitnami/sealed-secrets/Chart.yaml
+++ b/bitnami/sealed-secrets/Chart.yaml
@@ -29,4 +29,4 @@ name: sealed-secrets
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/sealed-secrets
 - https://github.com/bitnami-labs/sealed-secrets
-version: 2.4.7
+version: 2.4.8

--- a/bitnami/sealed-secrets/templates/role.yaml
+++ b/bitnami/sealed-secrets/templates/role.yaml
@@ -70,7 +70,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ printf "%s" (include "sealed-secrets.namespacedRoleName" .) }}
+  name: {{ printf "%s" (include "sealed-secrets.namespacedRoleName" $) }}
   namespace: {{ $additionalNamespace }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" $.Values.commonLabels "context" $ ) | nindent 4 }}
   {{- if $.Values.rbac.labels }}

--- a/bitnami/sealed-secrets/templates/rolebinding.yaml
+++ b/bitnami/sealed-secrets/templates/rolebinding.yaml
@@ -52,7 +52,7 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ printf "%s" (include "sealed-secrets.namespacedRoleName" .) }}
+  name: {{ printf "%s" (include "sealed-secrets.namespacedRoleName" $) }}
   namespace: {{ $additionalNamespace }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" $.Values.commonLabels "context" $ ) | nindent 4 }}
   {{- if $.Values.rbac.labels }}
@@ -64,11 +64,11 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ printf "%s" (include "sealed-secrets.namespacedRoleName" .) }}
+  name: {{ printf "%s" (include "sealed-secrets.namespacedRoleName" $) }}
 subjects:
   - apiGroup: ""
     kind: ServiceAccount
     name: {{ include "sealed-secrets.serviceAccountName" $ }}
-    namespace: {{ include "sealed-secrets.namespace" $ }}
+    namespace: {{ include "common.names.namespace" $ | quote }}
   {{ end }}
 {{ end }}


### PR DESCRIPTION
### Description of the change

Currently the sealed-secret chart fails to render with the following minimal values:
```yaml
additionalNamespaces: ["test"]
rbac:
  clusterRole: false
  namespacedRoles: true
```

This configuration causes namespaced roles to be created for every entry in `additionalNamespaces`. Within the definition of the namespaced roles some `include`s are called using `.` instead of `$`. Since this is happening within a `range` `.` does not reference the root context anymore.

The error message produced:

`Error: template: sealed-secrets/templates/rolebinding.yaml:55:24: executing "sealed-secrets/templates/rolebinding.yaml" at <include "sealed-secrets.namespacedRoleName" .>: error calling include: template: sealed-secrets/templates/_helpers.tpl:46:14: executing "sealed-secrets.namespacedRoleName" at <.Values.rbac.namespacedRolesName>: can't evaluate field Values in type string`

This PR fixes the creation of namespaced roles and role bindings.

### Benefits

The creation of namespaced roles and role bindings for `additionalNamespaces` works.

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
