### PR TITLE
[bitnami/discourse]: (bugfix) fix mount path on install-plugins init-container

### DIFF
--- a/bitnami/discourse/CHANGELOG.md
+++ b/bitnami/discourse/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 15.0.1 (2024-10-08)
+## 15.0.2 (2024-10-11)
 
-* [bitnami/discourse] Release 15.0.1 ([#29827](https://github.com/bitnami/charts/pull/29827))
+* [bitnami/discourse]: (bugfix) fix mount path on install-plugins init-container ([#29874](https://github.com/bitnami/charts/pull/29874))
+
+## <small>15.0.1 (2024-10-08)</small>
+
+* [bitnami/discourse] Release 15.0.1 (#29827) ([0fffd76](https://github.com/bitnami/charts/commit/0fffd7689f20e475cfc7e460a4ff6b3b8c451103)), closes [#29827](https://github.com/bitnami/charts/issues/29827)
 
 ## 15.0.0 (2024-10-03)
 

--- a/bitnami/discourse/CHANGELOG.md
+++ b/bitnami/discourse/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 15.0.2 (2024-10-11)
+## 15.0.2 (2024-10-14)
 
 * [bitnami/discourse]: (bugfix) fix mount path on install-plugins init-container ([#29874](https://github.com/bitnami/charts/pull/29874))
 

--- a/bitnami/discourse/Chart.yaml
+++ b/bitnami/discourse/Chart.yaml
@@ -41,4 +41,4 @@ maintainers:
 name: discourse
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/discourse
-version: 15.0.1
+version: 15.0.2

--- a/bitnami/discourse/templates/deployment.yaml
+++ b/bitnami/discourse/templates/deployment.yaml
@@ -122,7 +122,8 @@ spec:
           {{- end }}
           volumeMounts:
             - name: empty-dir
-              mountPath: /empty-dir
+              mountPath: /empty-dir/app-plugins-dir
+              subPath: app-plugins-dir
         {{- end }}
       containers:
         - name: discourse

--- a/bitnami/discourse/templates/deployment.yaml
+++ b/bitnami/discourse/templates/deployment.yaml
@@ -122,7 +122,7 @@ spec:
           {{- end }}
           volumeMounts:
             - name: empty-dir
-              mountPath: /empty-dir/app-plugins-dir
+              mountPath: /empty-dir
         {{- end }}
       containers:
         - name: discourse


### PR DESCRIPTION
### Description of the change

Fixes the mount path to use on the "install-plugins" init-container, so plugins are copied to the right folder.

This bug was introduced by myself at https://github.com/bitnami/charts/pull/29568 as reported by @netdata-be and @notz

### Benefits

Plugins' installation works as expected.

### Possible drawbacks

None

### Applicable issues

- fixes https://github.com/bitnami/charts/issues/29169

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
