### PR TITLE
[github-actions] Add test to check images warning list

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -89,14 +89,11 @@ jobs:
             } else {
               core.warning(message);
             }
-  check-images:
+  chart-tests:
     runs-on: ubuntu-latest
     needs: [get-chart]
     name: Look for hardcoded images
     if: needs.get-chart.outputs.result == 'ok'
-    outputs:
-      result: ${{ steps.check-images.outputs.result }}
-      error: ${{ steps.check-images.outputs.error }}
     steps:
       - name: Checkout bitnami/charts
         uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938
@@ -104,7 +101,7 @@ jobs:
           ref: ${{github.event.pull_request.head.ref}}
           repository: ${{github.event.pull_request.head.repo.full_name}}
           path: charts
-      - id: check-images
+      - id: check-hardcoded-images
         name: Look for hardcoded images
         env:
           CHART: ${{ needs.get-chart.outputs.chart }}
@@ -118,23 +115,52 @@ jobs:
 
           echo "${hardcoded_images[@]}"
           if [[ ${#hardcoded_images[@]} -gt 0 ]] ; then
-            echo "error=Found hardcoded images in the chart templates: ${hardcoded_images[@]}" >> $GITHUB_OUTPUT
-            echo "result=fail" >> $GITHUB_OUTPUT
-          else
-            echo "result=ok" >> $GITHUB_OUTPUT
+            echo "error=Found hardcoded images in the chart templates: ${hardcoded_images[@]}"
+            exit 1
           fi
-      - id: show-error
-        name: Show error
-        if: ${{ steps.check-images.outputs.result != 'ok' }}
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
-        with:
-          script: |
-            let message='${{ steps.check-images.outputs.error }}';
-            if ('${{ steps.check-images.outputs.result }}' === 'fail' ) {
-              core.setFailed(message);
-            } else {
-              core.warning(message);
-            }
+      - id: check-image-warning-list
+        name: Check image warning list
+        env:
+          CHART: ${{ needs.get-chart.outputs.chart }}
+        run: |
+          if [[ "$CHART" != "common" && "$CHART" != "fluentd" ]]; then
+            readarray -t tag_paths < <(yq e '.. | (path | join("."))' charts/bitnami/$CHART/values.yaml | grep -E '\.tag$' | sed 's/.tag$//g' | sort -u)
+            readarray -t registry_paths < <(yq e '.. | (path | join("."))' charts/bitnami/$CHART/values.yaml | grep '\.registry$' | sed 's/.registry$//g' | sort -u)
+
+            # We assume that image objects are those that contain both keys 'tag' and 'registry'
+            images_paths=()
+            for path in ${tag_paths[@]}; do
+              if echo "${registry_paths[@]}" | grep -w -q "$path"; then
+                if [[ -n "$path" ]]; then
+                  images_paths+=("$path")
+                fi
+              fi
+            done
+
+            # Get the images defined in the image warning helper
+            readarray -d ' ' -t images_list_tmp < <(grep -E 'common.warnings.modifiedImages' charts/bitnami/$CHART/templates/NOTES.txt | sed -E 's/.*\(list (.+)\) "context".*/\1/' | sed 's/.Values.//g')
+
+            # Remove any empty element from the array
+            images_list=()
+            for i in "${images_list_tmp[@]}"; do
+              if echo $i | grep -q -E "\S+"; then
+                images_list+=("$i")
+              fi
+            done
+
+            # Compare the image objects and the image warning list
+            if [[ ${#images_list[@]} -eq ${#images_paths[@]} ]]; then
+              for path in ${images_list[@]}; do
+                if ! echo ${images_paths[*]} | grep -w -q "$path"; then
+                  echo "Found inconsistencies in the images warning list: '${images_list[@]}' should be equal to '${images_paths[@]}'"
+                  exit 1
+                fi
+              done
+            else
+                echo "Found inconsistencies in the images warning list: '${images_list[@]}' should be equal to '${images_paths[@]}'"
+                exit 1
+            fi
+          fi
   update-pr:
     runs-on: ubuntu-latest
     needs: [get-chart]


### PR DESCRIPTION
### Description of the change

Add a step to the CI pipeline that checks the chart image warning list content is correct.

### Benefits

Helps avoiding accidents when adding new images to the chart.

### Possible drawbacks

It has issues with variables, which is the case of fluentd, which is a special case:
https://github.com/bitnami/charts/blob/005e0d696004dd972915f290b7caffb2bc332400/bitnami/fluentd/templates/NOTES.txt#L57-L64

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
