### PR TITLE
[grafana-loki] Fix loki config results_cache type embedded-cache

### DIFF
--- a/bitnami/grafana-loki/CHANGELOG.md
+++ b/bitnami/grafana-loki/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 4.6.19 (2024-10-12)
+## 4.6.19 (2024-10-13)
 
 * [grafana-loki] Fix loki config results_cache type embedded-cache ([#29878](https://github.com/bitnami/charts/pull/29878))
 

--- a/bitnami/grafana-loki/CHANGELOG.md
+++ b/bitnami/grafana-loki/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 4.6.18 (2024-10-02)
+## 4.6.19 (2024-10-12)
 
-* [bitnami/grafana-loki] Release 4.6.18 ([#29695](https://github.com/bitnami/charts/pull/29695))
+* [grafana-loki] Fix loki config results_cache type embedded-cache ([#29878](https://github.com/bitnami/charts/pull/29878))
+
+## <small>4.6.18 (2024-10-02)</small>
+
+* [bitnami/grafana-loki] Release 4.6.18 (#29695) ([cbbfbba](https://github.com/bitnami/charts/commit/cbbfbba37e3dd37337bfbcc0bfd8c45ad31f6d57)), closes [#29695](https://github.com/bitnami/charts/issues/29695)
 
 ## <small>4.6.17 (2024-09-24)</small>
 

--- a/bitnami/grafana-loki/Chart.yaml
+++ b/bitnami/grafana-loki/Chart.yaml
@@ -55,4 +55,4 @@ maintainers:
 name: grafana-loki
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/grafana-loki
-version: 4.6.18
+version: 4.6.19

--- a/bitnami/grafana-loki/values.yaml
+++ b/bitnami/grafana-loki/values.yaml
@@ -1,4 +1,4 @@
-results_cache# Copyright Broadcom, Inc. All Rights Reserved.
+# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters

--- a/bitnami/grafana-loki/values.yaml
+++ b/bitnami/grafana-loki/values.yaml
@@ -1,4 +1,4 @@
-# Copyright Broadcom, Inc. All Rights Reserved.
+results_cache# Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
 ## @section Global parameters
@@ -236,10 +236,10 @@ loki:
             timeout: 500ms
             update_interval: 1m
           {{- else }}
-          embedded-cache:
+          embedded_cache:
             enabled: true
-            max_size_items: 1024
-            validity: 24h
+            max_size_mb: 4096
+            ttl: 24h
           {{- end }}
     {{- if not .Values.queryScheduler.enabled }}
     frontend_worker:


### PR DESCRIPTION
Loki default configuration failed to start.
field embedded_cache not found in type cache.Config
<img width="1229" alt="image" src="https://github.com/user-attachments/assets/9d635c9c-c162-4d45-9050-c21235a88b39">

The official configuration has written the wrong parameters before.
Fixed after v3.2.x version.

[cache_config](https://grafana.com/docs/loki/v3.2.x/configure/#cache_config)
<img width="1548" alt="image" src="https://github.com/user-attachments/assets/73a53531-c436-47c0-8886-492bedacfe6f">


relevant issues [issues](https://github.com/grafana/loki/issues/6915#issuecomment-1369488273)

Run successfully after modification.

<img width="887" alt="image" src="https://github.com/user-attachments/assets/592c1be5-91b0-4d4e-b1e2-d1cff328f8bd">
<img width="1519" alt="image" src="https://github.com/user-attachments/assets/136b6dc7-4eb4-4947-9f63-f267253ffaa2">
