### PR TITLE
[bitnami/rabbitmq] Use common password/secrets manager to handle credentials

### DIFF
--- a/bitnami/rabbitmq/CHANGELOG.md
+++ b/bitnami/rabbitmq/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 15.0.3 (2024-10-13)
+## 15.0.3 (2024-10-14)
 
 * [bitnami/rabbitmq] Use common password/secrets manager to handle credentials ([#29879](https://github.com/bitnami/charts/pull/29879))
 

--- a/bitnami/rabbitmq/CHANGELOG.md
+++ b/bitnami/rabbitmq/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 15.0.2 (2024-10-05)
+## 15.0.3 (2024-10-13)
 
-* [Bitnami/rabbitmq] - Fix duplicate key issue with Helm/FluxCD integration ([#29780](https://github.com/bitnami/charts/pull/29780))
+* [bitnami/rabbitmq] Use common password/secrets manager to handle credentials ([#29879](https://github.com/bitnami/charts/pull/29879))
+
+## <small>15.0.2 (2024-10-07)</small>
+
+* [Bitnami/rabbitmq] - Fix duplicate key issue with Helm/FluxCD integration (#29780) ([cea9e6c](https://github.com/bitnami/charts/commit/cea9e6c9ea4b97b5ec48c5156d8d6c9fcd1ded13)), closes [#29780](https://github.com/bitnami/charts/issues/29780)
 
 ## <small>15.0.1 (2024-09-25)</small>
 

--- a/bitnami/rabbitmq/Chart.yaml
+++ b/bitnami/rabbitmq/Chart.yaml
@@ -30,4 +30,4 @@ maintainers:
 name: rabbitmq
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/rabbitmq
-version: 15.0.2
+version: 15.0.3

--- a/bitnami/rabbitmq/templates/_helpers.tpl
+++ b/bitnami/rabbitmq/templates/_helpers.tpl
@@ -60,17 +60,6 @@ Get the password key to be retrieved from RabbitMQ secret.
 {{- end -}}
 
 {{/*
-Return RabbitMQ password
-*/}}
-{{- define "rabbitmq.password" -}}
-    {{- if not (empty .Values.auth.password) -}}
-        {{- .Values.auth.password -}}
-    {{- else -}}
-        {{- include "getValueFromSecret" (dict "Namespace" (include "common.names.namespace" .) "Name" (include "rabbitmq.secretPasswordName" .) "Length" 16 "Key" (include "rabbitmq.secretPasswordKey" .))  -}}
-    {{- end -}}
-{{- end }}
-
-{{/*
 Get the erlang secret.
 */}}
 {{- define "rabbitmq.secretErlangName" -}}
@@ -91,17 +80,6 @@ Get the erlang cookie key to be retrieved from RabbitMQ secret.
         {{- printf "rabbitmq-erlang-cookie" -}}
     {{- end -}}
 {{- end -}}
-
-{{/*
-Return RabbitMQ erlang cookie secret
-*/}}
-{{- define "rabbitmq.erlangCookie" -}}
-    {{- if not (empty .Values.auth.erlangCookie) -}}
-        {{- .Values.auth.erlangCookie -}}
-    {{- else -}}
-        {{- include "getValueFromSecret" (dict "Namespace" (include "common.names.namespace" .) "Name" (include "rabbitmq.secretErlangName" .) "Length" 32 "Key" (include "rabbitmq.secretErlangKey" .))  -}}
-    {{- end -}}
-{{- end }}
 
 {{/*
 Get the TLS secret.
@@ -283,37 +261,12 @@ Get the initialization scripts volume name.
 {{- end -}}
 
 {{/*
-Returns the available value for certain key in an existing secret (if it exists),
-otherwise it generates a random value.
-*/}}
-{{- define "getValueFromSecret" }}
-    {{- $len := (default 16 .Length) | int -}}
-    {{- $obj := (lookup "v1" "Secret" .Namespace .Name).data -}}
-    {{- if $obj }}
-        {{- index $obj .Key | trimAll "\"" | b64dec -}}
-    {{- else -}}
-        {{- randAlphaNum $len -}}
-    {{- end -}}
-{{- end }}
-
-{{/*
 Get the extraConfigurationExistingSecret secret.
 */}}
 {{- define "rabbitmq.extraConfiguration" -}}
 {{- if not (empty .Values.extraConfigurationExistingSecret) -}}
-    {{- include "getValueFromSecret" (dict "Namespace" .Release.Namespace "Name" .Values.extraConfigurationExistingSecret "Length" 10 "Key" "extraConfiguration")  -}}
+    {{- include "common.secrets.lookup" (dict "secret" .Values.extraConfigurationExistingSecret "key" "extraConfiguration" "context" $) | b64dec -}}
 {{- else -}}
     {{- tpl .Values.extraConfiguration . -}}
-{{- end -}}
-{{- end -}}
-
-{{/*
-Get the TLS.sslOptions.Password secret.
-*/}}
-{{- define "rabbitmq.tlsSslOptionsPassword" -}}
-{{- if not (empty .Values.auth.tls.sslOptionsPassword.password) -}}
-    {{- .Values.auth.tls.sslOptionsPassword.password -}}
-{{- else -}}
-    {{- include "getValueFromSecret" (dict "Namespace" .Release.Namespace "Name" .Values.auth.tls.sslOptionsPassword.existingSecret "Length" 10 "Key" .Values.auth.tls.sslOptionsPassword.key)  -}}
 {{- end -}}
 {{- end -}}

--- a/bitnami/rabbitmq/templates/secrets.yaml
+++ b/bitnami/rabbitmq/templates/secrets.yaml
@@ -6,8 +6,8 @@ SPDX-License-Identifier: APACHE-2.0
 {{- $host := printf "%s.%s.svc.%s" (include "common.names.fullname" .) (include "common.names.namespace" .) .Values.clusterDomain }}
 {{- $port := print .Values.service.ports.amqp }}
 {{- $user := print .Values.auth.username }}
-{{- $password := include "rabbitmq.password" . }}
-{{- $erlangCookie := include "rabbitmq.erlangCookie" . }}
+{{- $password := include "common.secrets.passwords.manage" (dict "secret" (include "rabbitmq.secretPasswordName" .) "key" (include "rabbitmq.secretPasswordKey" .) "length" 16 "providedValues" (list "auth.password") "skipB64enc" true "skipQuote" true "context" $) }}
+{{- $erlangCookie := include "common.secrets.passwords.manage" (dict "secret" (include "rabbitmq.secretErlangName" .) "key" (include "rabbitmq.secretErlangKey" .) "length" 32 "failOnNew" false "providedValues" (list "auth.erlangCookie") "context" $) }}
 {{- if or (not .Values.auth.existingErlangSecret) (not .Values.auth.existingPasswordSecret) }}
 apiVersion: v1
 kind: Secret
@@ -24,7 +24,7 @@ data:
   rabbitmq-password: {{ print $password | b64enc | quote }}
   {{- end }}
   {{- if (not .Values.auth.existingErlangSecret ) }}
-  rabbitmq-erlang-cookie: {{ print $erlangCookie | b64enc | quote }}
+  rabbitmq-erlang-cookie: {{ print $erlangCookie }}
   {{- end }}
 {{- end }}
 {{- range $key, $value := .Values.extraSecrets }}

--- a/bitnami/rabbitmq/values.yaml
+++ b/bitnami/rabbitmq/values.yaml
@@ -438,7 +438,7 @@ configuration: |-
   ssl_options.certfile = /opt/bitnami/rabbitmq/certs/server_certificate.pem
   ssl_options.keyfile = /opt/bitnami/rabbitmq/certs/server_key.pem
   {{- if .Values.auth.tls.sslOptionsPassword.enabled }}
-  ssl_options.password = {{ template "rabbitmq.tlsSslOptionsPassword" . }}
+  ssl_options.password = {{ include "common.secrets.passwords.manage" (dict "secret" .Values.auth.tls.sslOptionsPassword.existingSecret "key" .Values.auth.tls.sslOptionsPassword.key "providedValues" (list "auth.tls.sslOptionsPassword.password") "skipB64enc" true "failOnNew" false "context" $) }}
   {{- end }}
   {{- end }}
   {{- if .Values.ldap.enabled }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Switch to the common helpers `common.secrets.passwords.manage` & `common.secrets.lookup` for managing the password instead of the local undocumented helper.

### Benefits

* Streamline with the other charts
* Use documented helpers
* Benefit from the common helpers features and maintenance

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
