### PR TITLE
[bitnami/mysql] Drop unused `getValueFromSecret` local helper

### DIFF
--- a/bitnami/mysql/CHANGELOG.md
+++ b/bitnami/mysql/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 11.1.17 (2024-09-17)
+## 11.1.18 (2024-10-13)
 
-* [bitnami/mysql] test: :white_check_mark: Improve reliability of ginkgo tests ([#29470](https://github.com/bitnami/charts/pull/29470))
+* [bitnami/mysql] Drop unused `getValueFromSecret` local helper ([#29880](https://github.com/bitnami/charts/pull/29880))
+
+## <small>11.1.17 (2024-09-17)</small>
+
+* [bitnami/mysql] test: :white_check_mark: Improve reliability of ginkgo tests (#29470) ([a233966](https://github.com/bitnami/charts/commit/a233966beb176cddf29dfe71f19228873bd99bac)), closes [#29470](https://github.com/bitnami/charts/issues/29470)
 
 ## <small>11.1.16 (2024-09-03)</small>
 

--- a/bitnami/mysql/CHANGELOG.md
+++ b/bitnami/mysql/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 11.1.18 (2024-10-13)
+## 11.1.18 (2024-10-14)
 
 * [bitnami/mysql] Drop unused `getValueFromSecret` local helper ([#29880](https://github.com/bitnami/charts/pull/29880))
 

--- a/bitnami/mysql/Chart.yaml
+++ b/bitnami/mysql/Chart.yaml
@@ -34,4 +34,4 @@ maintainers:
 name: mysql
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/mysql
-version: 11.1.17
+version: 11.1.18

--- a/bitnami/mysql/templates/_helpers.tpl
+++ b/bitnami/mysql/templates/_helpers.tpl
@@ -142,20 +142,6 @@ Return true if a secret object should be created for MySQL
 {{- end -}}
 {{- end -}}
 
-{{/*
-Returns the available value for certain key in an existing secret (if it exists),
-otherwise it generates a random value.
-*/}}
-{{- define "getValueFromSecret" }}
-    {{- $len := (default 16 .Length) | int -}}
-    {{- $obj := (lookup "v1" "Secret" .Namespace .Name).data -}}
-    {{- if $obj }}
-        {{- index $obj .Key | b64dec -}}
-    {{- else -}}
-        {{- randAlphaNum $len -}}
-    {{- end -}}
-{{- end }}
-
 {{/* Check if there are rolling tags in the images */}}
 {{- define "mysql.checkRollingTags" -}}
 {{- include "common.warnings.rollingTag" .Values.image }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->
Remove the unused, undocumented, un-namespaced `getValueFromSecret` local helper for the following charts:
* https://github.com/bitnami/charts/pull/29880
* https://github.com/bitnami/charts/pull/29440

### Benefits

<!-- What benefits will be realized by the code change? -->
Promote the use of common helpers `common.secrets.passwords.manage`, properly defined.
Should also help to reduce errors/mismatches around secret lookups.

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
