### PR TITLE
[bitnami/keycloak] adds port 9000 to the default ingress policy

### DIFF
--- a/bitnami/keycloak/CHANGELOG.md
+++ b/bitnami/keycloak/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
+## 24.0.1 (2024-10-14)
+
+* [bitnami/keycloak] adds port 9000 to the default ingress policy ([#29889](https://github.com/bitnami/charts/pull/29889))
+
 ## 24.0.0 (2024-10-08)
 
-* [bitnami/keycloak] Release 24.0.0 ([#29815](https://github.com/bitnami/charts/pull/29815))
+* [bitnami/keycloak] Release 24.0.0 (#29815) ([02bf8f8](https://github.com/bitnami/charts/commit/02bf8f8821a875ca3605705f9c092a077ef29772)), closes [#29815](https://github.com/bitnami/charts/issues/29815)
 
 ## 23.0.0 (2024-10-03)
 

--- a/bitnami/keycloak/Chart.yaml
+++ b/bitnami/keycloak/Chart.yaml
@@ -33,4 +33,4 @@ maintainers:
 name: keycloak
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/keycloak
-version: 24.0.0
+version: 24.0.1

--- a/bitnami/keycloak/templates/networkpolicy.yaml
+++ b/bitnami/keycloak/templates/networkpolicy.yaml
@@ -66,6 +66,7 @@ spec:
     - ports:
         {{- /* Constant in code: https://github.com/keycloak/keycloak/blob/ce8e925c1ad9bf7a3180d1496e181aeea0ab5f8a/operator/src/main/java/org/keycloak/operator/Constants.java#L60 */}}
         - port: 7800
+        - port: 9000 # metrics and health
         - port: {{ .Values.containerPorts.http }}
         {{- if .Values.tls.enabled }}
         - port: {{ .Values.containerPorts.https }}


### PR DESCRIPTION
### Description of the change

Edits the network policy and allows port 9000 for ingress to keycloak. 

### Benefits

With Keycloak 25 the default ports for metrics and health endpoints changed from 8080/8443 to 9000. This minimal change allows for accessing the metrics and health endpoints, without automatically exposing them as service or to the world via an ingress.

### Possible drawbacks

This change basically opens port 9000 for all the clients that can access the keycloak server on the other ports. It may be favorable to create a special policy allowing only special resources, e.g. prometheus,  to access this port. However, this would need some discussion on how to do this best.

Further, this change does not create a service to access this port. However, metrics and health should be accessed per pod and not round-robin. I'm not that familiar what the best practice for this use case is. I'm happy to learn how to do it better.

### Applicable issues

[bitnami/keycloak] new ports for metrics and health endpoints #28630 

### Additional information

This minimal change basically should get the discussion going. I'm happy to learn and make it better.
I am a bit unsure if this fix should be counted as a patch or a minor version upgrade. I've decided to treat it like a patch.

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
