### PR TITLE
[bitnami/contour]: Fix invalid volume indentation

### DIFF
--- a/bitnami/contour/CHANGELOG.md
+++ b/bitnami/contour/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 19.2.0 (2024-10-11)
+## 19.2.1 (2024-10-15)
 
-*  [bitnami/contour] fixed wrong envoy-service-name arg value in contour when envoy service name is changed ([#29556](https://github.com/bitnami/charts/pull/29556))
+* [bitnami/contour]: Fix invalid volume indentation ([#29890](https://github.com/bitnami/charts/pull/29890))
+
+## 19.2.0 (2024-10-14)
+
+* fixed wrong envoy-service-name arg value in contour when envoy service name is changed (#29556) ([268d5b8](https://github.com/bitnami/charts/commit/268d5b84cba4ce10cc6132de86f6e209cd0068f6)), closes [#29556](https://github.com/bitnami/charts/issues/29556)
 
 ## 19.1.0 (2024-10-10)
 

--- a/bitnami/contour/CHANGELOG.md
+++ b/bitnami/contour/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 19.2.1 (2024-10-15)
+## 19.2.1 (2024-10-21)
 
 * [bitnami/contour]: Fix invalid volume indentation ([#29890](https://github.com/bitnami/charts/pull/29890))
 

--- a/bitnami/contour/Chart.yaml
+++ b/bitnami/contour/Chart.yaml
@@ -32,4 +32,4 @@ maintainers:
 name: contour
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/contour
-version: 19.2.0
+version: 19.2.1

--- a/bitnami/contour/templates/default-backend/deployment.yaml
+++ b/bitnami/contour/templates/default-backend/deployment.yaml
@@ -166,7 +166,7 @@ spec:
         {{- if .Values.defaultBackend.sidecars }}
         {{- include "common.tplvalues.render" ( dict "value" .Values.defaultBackend.sidecars "context" $) | nindent 8 }}
         {{- end }}
-        {{- if .Values.defaultBackend.extraVolumes }}
-        volumes: {{- include "common.tplvalues.render" ( dict "value" .Values.defaultBackend.extraVolumes "context" $ ) | nindent 8 }}
-        {{- end }}
+      {{- if .Values.defaultBackend.extraVolumes }}
+      volumes: {{- include "common.tplvalues.render" ( dict "value" .Values.defaultBackend.extraVolumes "context" $ ) | nindent 6 }}
+      {{- end }}
 {{- end }}


### PR DESCRIPTION
The defaultBackend currently indents volumes to the same level as an individual container (8), however, it actually needs to be one level further up (6).

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change
Currently, we have 
```
      containers:
        - name: default-backend
          <snip>
        {{- if .Values.defaultBackend.sidecars }}
        {{- include "common.tplvalues.render" ( dict "value" .Values.defaultBackend.sidecars "context" $) | nindent 8 }}
        {{- end }}
        {{- if .Values.defaultBackend.extraVolumes }}
        volumes: {{- include "common.tplvalues.render" ( dict "value" .Values.defaultBackend.extraVolumes "context" $ ) | nindent 8 }}
        {{- end }}
```
... note that volumes is on the same indent level as an individual container. It should actually be one level up. This change does just that. I unfortunately missed this when upstreaming the original fix in bitnami/charts#29817.

### Benefits

Extra volumes for the default backends no longer lead to errors.

### Possible drawbacks

None.

### Applicable issues

None.

### Additional information

None.

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
