### PR TITLE
[bitnami/redis] Fix preExecCmds parameter

### DIFF
--- a/bitnami/redis/CHANGELOG.md
+++ b/bitnami/redis/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 20.2.0 (2024-10-04)
+## 20.2.1 (2024-10-15)
 
-* [bitnami/redis] add extraPodSpec ([#29725](https://github.com/bitnami/charts/pull/29725))
+* [bitnami/redis] Fix preExecCmds parameter ([#29898](https://github.com/bitnami/charts/pull/29898))
+
+## 20.2.0 (2024-10-09)
+
+* [bitnami/redis] add extraPodSpec (#29725) ([0d2b826](https://github.com/bitnami/charts/commit/0d2b8269e0e5c1a287fcd8e44c623afa6311e761)), closes [#29725](https://github.com/bitnami/charts/issues/29725)
 
 ## <small>20.1.7 (2024-10-02)</small>
 

--- a/bitnami/redis/Chart.yaml
+++ b/bitnami/redis/Chart.yaml
@@ -36,4 +36,4 @@ maintainers:
 name: redis
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/redis
-version: 20.2.0
+version: 20.2.1

--- a/bitnami/redis/templates/scripts-configmap.yaml
+++ b/bitnami/redis/templates/scripts-configmap.yaml
@@ -232,7 +232,9 @@ data:
     {{- end }}
 
     {{- if .Values.replica.preExecCmds }}
-    {{- .Values.replica.preExecCmds | nindent 4 }}
+    {{- range $command := .Values.replica.preExecCmds }}
+    {{- $command | nindent 4 }}
+    {{- end }}
     {{- end }}
 
     {{- if .Values.replica.command }}
@@ -440,7 +442,9 @@ data:
     {{- end }}
     {{- end }}
     {{- if .Values.sentinel.preExecCmds }}
-    {{ .Values.sentinel.preExecCmds | nindent 4 }}
+    {{- range $command := .Values.sentinel.preExecCmds }}
+    {{- $command | nindent 4 }}
+    {{- end }}
     {{- end }}
     mv /opt/bitnami/redis-sentinel/etc/prepare-sentinel.conf /opt/bitnami/redis-sentinel/etc/sentinel.conf
     exec redis-server /opt/bitnami/redis-sentinel/etc/sentinel.conf {{- if .Values.tls.enabled }} "${ARGS[@]}" {{- end }} --sentinel
@@ -646,7 +650,9 @@ data:
     {{- end }}
     {{- end }}
     {{- if .Values.master.preExecCmds }}
-    {{ .Values.master.preExecCmds | nindent 4 }}
+    {{- range $command := .Values.master.preExecCmds }}
+    {{- $command | nindent 4 }}
+    {{- end }}
     {{- end }}
     {{- if .Values.master.command }}
     exec {{ .Values.master.command }} "${ARGS[@]}"
@@ -754,8 +760,9 @@ data:
     {{- end }}
     {{- end }}
     {{- if .Values.replica.preExecCmds }}
-    {{ .Values.replica.preExecCmds | nindent 4 }}
-    {{- end }}
+    {{- range $command := .Values.replica.preExecCmds }}
+    {{- $command | nindent 4 }}
+    {{- end }}    {{- end }}
     {{- if .Values.replica.command }}
     exec {{ .Values.replica.command }} "${ARGS[@]}"
     {{- else }}


### PR DESCRIPTION
### Description of the change
Fix `preExecCmds` to work as array.

### Benefits

Allow to use `preExecCmds` parameter.

### Possible drawbacks

N/A

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #29893


### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
