### PR TITLE
[bitnami/apache] Remove wrong entries from image verification

### DIFF
--- a/bitnami/apache/CHANGELOG.md
+++ b/bitnami/apache/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 11.2.20 (2024-09-19)
+## 11.2.21 (2024-10-16)
 
-* [bitnami/apache] Release 11.2.20 ([#29501](https://github.com/bitnami/charts/pull/29501))
+* [bitnami/apache] Remove wrong entries from image verification ([#29911](https://github.com/bitnami/charts/pull/29911))
+
+## <small>11.2.20 (2024-09-19)</small>
+
+* [bitnami/apache] Release 11.2.20 (#29501) ([efd2c8f](https://github.com/bitnami/charts/commit/efd2c8f6e18240f7cde27a915627d5cf4f77189c)), closes [#29501](https://github.com/bitnami/charts/issues/29501)
 
 ## <small>11.2.19 (2024-09-18)</small>
 

--- a/bitnami/apache/Chart.yaml
+++ b/bitnami/apache/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: apache
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/apache
-version: 11.2.20
+version: 11.2.21

--- a/bitnami/apache/templates/NOTES.txt
+++ b/bitnami/apache/templates/NOTES.txt
@@ -44,4 +44,4 @@ WARNING: Rolling tag detected ({{ .Values.image.repository }}:{{ .Values.image.t
 
 {{ include "apache.validateValues" . }}
 {{- include "common.warnings.resources" (dict "sections" (list "cloneHtdocsFromGit" "metrics" "") "context" $) }}
-{{- include "common.warnings.modifiedImages" (dict "images" (list .Values.image .Values.git .Values.cloneHtdocsFromGit .Values.metrics.image) "context" $) }}
+{{- include "common.warnings.modifiedImages" (dict "images" (list .Values.image .Values.git .Values.metrics.image) "context" $) }}


### PR DESCRIPTION
### Description of the change

Removes wrong entries from the `common.warnings.modifiedImages` helper list.

### Benefits

Fixes issues with image checking.

### Possible drawbacks

None known.

### Applicable issues

- related to #29871

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
