### PR TITLE
[bitnami/aspnet-core] Remove wrong entries from image verification

### DIFF
--- a/bitnami/aspnet-core/CHANGELOG.md
+++ b/bitnami/aspnet-core/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 6.2.16 (2024-10-08)
+## 6.2.17 (2024-10-16)
 
-* [bitnami/aspnet-core] Release 6.2.16 ([#29825](https://github.com/bitnami/charts/pull/29825))
+* [bitnami/aspnet-core] Remove wrong entries from image verification ([#29912](https://github.com/bitnami/charts/pull/29912))
+
+## <small>6.2.16 (2024-10-08)</small>
+
+* [bitnami/aspnet-core] Release 6.2.16 (#29825) ([bf9676c](https://github.com/bitnami/charts/commit/bf9676c5a8a7b8db2da364ed1a01ee66cd38d7e3)), closes [#29825](https://github.com/bitnami/charts/issues/29825)
 
 ## <small>6.2.15 (2024-09-19)</small>
 

--- a/bitnami/aspnet-core/Chart.yaml
+++ b/bitnami/aspnet-core/Chart.yaml
@@ -31,4 +31,4 @@ maintainers:
 name: aspnet-core
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/aspnet-core
-version: 6.2.16
+version: 6.2.17

--- a/bitnami/aspnet-core/templates/NOTES.txt
+++ b/bitnami/aspnet-core/templates/NOTES.txt
@@ -53,4 +53,4 @@ To access ASP.NET Core from outside the cluster execute the following commands:
 {{- include "common.warnings.rollingTag" .Values.appFromExternalRepo.publish.image }}
 {{- include "aspnet-core.validateValues" . }}
 {{- include "common.warnings.resources" (dict "sections" (list "") "context" $) }}
-{{- include "common.warnings.modifiedImages" (dict "images" (list .Values.image .Values.appFromExternalRepo.clone.image .Values.appFromExternalRepo.clone .Values.appFromExternalRepo.publish.image) "context" $) }}
+{{- include "common.warnings.modifiedImages" (dict "images" (list .Values.image .Values.appFromExternalRepo.clone.image .Values.appFromExternalRepo.publish.image) "context" $) }}


### PR DESCRIPTION
### Description of the change

Removes wrong entries from the `common.warnings.modifiedImages` helper list.

### Benefits

Fixes issues with image checking.

### Possible drawbacks

None known.

### Applicable issues

- related to #29871

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
