### PR TITLE
[bitnami/pytorch] Remove wrong entries from image verification

### DIFF
--- a/bitnami/pytorch/CHANGELOG.md
+++ b/bitnami/pytorch/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 4.2.18 (2024-09-19)
+## 4.2.19 (2024-10-16)
 
-* [bitnami/pytorch] Release 4.2.18 ([#29516](https://github.com/bitnami/charts/pull/29516))
+* [bitnami/pytorch] Remove wrong entries from image verification ([#29916](https://github.com/bitnami/charts/pull/29916))
+
+## <small>4.2.18 (2024-09-19)</small>
+
+* [bitnami/pytorch] Release 4.2.18 (#29516) ([6d40617](https://github.com/bitnami/charts/commit/6d4061783e317fd6bdb13116bb694f3d200684f2)), closes [#29516](https://github.com/bitnami/charts/issues/29516)
 
 ## <small>4.2.17 (2024-09-15)</small>
 

--- a/bitnami/pytorch/Chart.yaml
+++ b/bitnami/pytorch/Chart.yaml
@@ -33,4 +33,4 @@ maintainers:
 name: pytorch
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/pytorch
-version: 4.2.18
+version: 4.2.19

--- a/bitnami/pytorch/templates/NOTES.txt
+++ b/bitnami/pytorch/templates/NOTES.txt
@@ -65,4 +65,4 @@ Examples for the different methods can be found in the README.
 {{ include "pytorch.validateValues" . }}
 {{ include "pytorch.checkRollingTags" . }}
 {{- include "common.warnings.resources" (dict "sections" (list "" "volumePermissions") "context" $) }}
-{{- include "common.warnings.modifiedImages" (dict "images" (list .Values.image .Values.cloneFilesFromGit .Values.git .Values.volumePermissions.image) "context" $) }}
+{{- include "common.warnings.modifiedImages" (dict "images" (list .Values.image .Values.git .Values.volumePermissions.image) "context" $) }}


### PR DESCRIPTION
### Description of the change

Removes wrong entries from the `common.warnings.modifiedImages` helper list.

### Benefits

Fixes issues with image checking.

### Possible drawbacks

None known.

### Applicable issues

- related to #29871

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
