### PR TITLE
[bitnami/discourse] Avoid looping on subdirectories on plugins instalation

### DIFF
--- a/bitnami/discourse/Chart.yaml
+++ b/bitnami/discourse/Chart.yaml
@@ -41,4 +41,4 @@ maintainers:
 name: discourse
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/discourse
-version: 15.0.2
+version: 15.0.3

--- a/bitnami/discourse/templates/deployment.yaml
+++ b/bitnami/discourse/templates/deployment.yaml
@@ -114,7 +114,7 @@ spec:
               RAILS_ENV=production LOAD_PLUGINS=0 bundle exec rake plugin:pull_compatible_all
               {{- end }}
               popd >/dev/null || exit 1
-              cp -r --preserve=mode /opt/bitnami/discourse/plugins /empty-dir/app-plugins-dir
+              cp -nr --preserve=mode /opt/bitnami/discourse/plugins/* /plugins
           {{- if .Values.discourse.resources }}
           resources: {{- toYaml .Values.discourse.resources | nindent 12 }}
           {{- else if ne .Values.discourse.resourcesPreset "none" }}
@@ -122,7 +122,7 @@ spec:
           {{- end }}
           volumeMounts:
             - name: empty-dir
-              mountPath: /empty-dir/app-plugins-dir
+              mountPath: /plugins
               subPath: app-plugins-dir
         {{- end }}
       containers:
@@ -148,7 +148,7 @@ spec:
           args:
             - -ec
             - |
-              cp -r --preserve=mode /plugins /opt/bitnami/discourse/plugins
+              cp -nr --preserve=mode /plugins/* /opt/bitnami/discourse/plugins
               /opt/bitnami/scripts/discourse/entrypoint.sh /opt/bitnami/scripts/discourse/run.sh
           {{- end }}
           env:


### PR DESCRIPTION
### Description of the change

This PR ensures fixes an issue with plugins installation when persistence is enabled for them given installed plugins end up at the `/opt/bitnami/discourse/plugins/plugins/plugins/` instead of `/opt/bitnami/discourse/plugins` due to wrong dest paths on `cp` commands.

### Benefits

Plugins installation works as expected.

### Possible drawbacks

None

### Applicable issues

- fixes https://github.com/bitnami/charts/issues/29990

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
