### PR TITLE
[bitnami/discourse] include discourse.extraEnvVars in the "install-plugins" init-container

### DIFF
--- a/bitnami/discourse/CHANGELOG.md
+++ b/bitnami/discourse/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
-## 15.0.3 (2024-10-21)
+## 15.0.4 (2024-10-21)
 
-* [bitnami/discourse] Avoid looping on subdirectories on plugins instalation ([#30022](https://github.com/bitnami/charts/pull/30022))
+* [bitnami/discourse] include discourse.extraEnvVars in the "install-plugins" init-container ([#30026](https://github.com/bitnami/charts/pull/30026))
+
+## <small>15.0.3 (2024-10-21)</small>
+
+* [bitnami/discourse] Avoid looping on subdirectories on plugins instalation (#30022) ([4bb0481](https://github.com/bitnami/charts/commit/4bb0481e66a9a52557d938d24561cc392ddc3482)), closes [#30022](https://github.com/bitnami/charts/issues/30022)
+* Update documentation links to techdocs.broadcom.com (#29931) ([f0d9ad7](https://github.com/bitnami/charts/commit/f0d9ad78f39f633d275fc576d32eae78ded4d0b8)), closes [#29931](https://github.com/bitnami/charts/issues/29931)
 
 ## <small>15.0.2 (2024-10-14)</small>
 

--- a/bitnami/discourse/Chart.yaml
+++ b/bitnami/discourse/Chart.yaml
@@ -41,4 +41,4 @@ maintainers:
 name: discourse
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/discourse
-version: 15.0.3
+version: 15.0.4

--- a/bitnami/discourse/templates/deployment.yaml
+++ b/bitnami/discourse/templates/deployment.yaml
@@ -115,6 +115,10 @@ spec:
               {{- end }}
               popd >/dev/null || exit 1
               cp -nr --preserve=mode /opt/bitnami/discourse/plugins/* /plugins
+          {{- if .Values.discourse.extraEnvVars }}
+          env:
+            {{- include "common.tplvalues.render" (dict "value" .Values.discourse.extraEnvVars "context" $) | nindent 12 }}
+          {{- end }}
           {{- if .Values.discourse.resources }}
           resources: {{- toYaml .Values.discourse.resources | nindent 12 }}
           {{- else if ne .Values.discourse.resourcesPreset "none" }}


### PR DESCRIPTION
### Description of the change

When installing discourse behind a firewall, the "install-plugins" init-container cannot download the plugins without the proxy-settings defined in “discourse.extraEnvVars”:

```
discourse:
  extraEnvVars:
  - name: http_proxy
    value: http://my.proxy
  - name: https_proxy
    value: http://my.proxy
  - name: no_proxy
    value: '.svc,.svc.cluster.local'
```

### Benefits

The "install-plugins" init-container can download the plugins.

See: https://github.com/bitnami/charts/pull/29986