### PR TITLE
[bitnami/etcd]: Fix podLabels bug

### DIFF
--- a/bitnami/etcd/CHANGELOG.md
+++ b/bitnami/etcd/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
+## 10.4.1 (2024-10-23)
+
+* [bitnami/etcd]: Fix podLabels bug ([#30052](https://github.com/bitnami/charts/pull/30052))
+
 ## 10.4.0 (2024-10-22)
 
-* [bitnami/etcd]: Automatic etcd defragmentation ([#29967](https://github.com/bitnami/charts/pull/29967))
+* [bitnami/etcd]: Automatic etcd defragmentation (#29967) ([ea1683d](https://github.com/bitnami/charts/commit/ea1683dabaf7448a1e2fc6eca0a37a70899270e2)), closes [#29967](https://github.com/bitnami/charts/issues/29967)
+* Update documentation links to techdocs.broadcom.com (#29931) ([f0d9ad7](https://github.com/bitnami/charts/commit/f0d9ad78f39f633d275fc576d32eae78ded4d0b8)), closes [#29931](https://github.com/bitnami/charts/issues/29931)
 
 ## <small>10.3.1 (2024-10-16)</small>
 

--- a/bitnami/etcd/CHANGELOG.md
+++ b/bitnami/etcd/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 10.4.1 (2024-10-23)
+## 10.4.1 (2024-10-24)
 
 * [bitnami/etcd]: Fix podLabels bug ([#30052](https://github.com/bitnami/charts/pull/30052))
 

--- a/bitnami/etcd/Chart.yaml
+++ b/bitnami/etcd/Chart.yaml
@@ -32,4 +32,4 @@ maintainers:
 name: etcd
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/etcd
-version: 10.4.0
+version: 10.4.1

--- a/bitnami/etcd/templates/cronjob-defrag.yaml
+++ b/bitnami/etcd/templates/cronjob-defrag.yaml
@@ -28,8 +28,8 @@ spec:
     spec:
       template:
         metadata:
-          {{- $mergedLabels := mergeOverwrite (dict) .Values.commonLabels .Values.defrag.cronjob.podLabels -}}
-          labels: {{- include "common.labels.standard" ( dict "customLabels" $mergedLabels "context" $ ) | nindent 10 }}
+          {{- $mergedLabels := mergeOverwrite (dict) .Values.commonLabels .Values.defrag.cronjob.podLabels }}
+          labels: {{- include "common.labels.standard" ( dict "customLabels" $mergedLabels "context" $ ) | nindent 12 }}
           {{- if .Values.defrag.cronjob.podAnnotations }}
           annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.defrag.cronjob.podAnnotations "context" $) | nindent 12 }}
           {{- end }}


### PR DESCRIPTION
### Description of the change

The change fixes bitnami/etcd `defrag.cronjob.podLabels` bug, which breaks labels indentation.

### Benefits

Correct pod labels indentation.

### Possible drawbacks

None.

### Applicable issues

- fixes #30049 

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
