### PR TITLE
set imagePullPolicy of mlflow container to Always when latest tag is …

### DIFF
--- a/bitnami/mlflow/CHANGELOG.md
+++ b/bitnami/mlflow/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2.0.3 (2024-10-23)
+## 2.0.3 (2024-10-24)
 
 * set imagePullPolicy of mlflow container to Always when latest tag is … ([#30062](https://github.com/bitnami/charts/pull/30062))
 

--- a/bitnami/mlflow/CHANGELOG.md
+++ b/bitnami/mlflow/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 2.0.2 (2024-10-16)
+## 2.0.3 (2024-10-23)
 
-* [bitnami/mlflow] Release 2.0.2 ([#29945](https://github.com/bitnami/charts/pull/29945))
+* set imagePullPolicy of mlflow container to Always when latest tag is … ([#30062](https://github.com/bitnami/charts/pull/30062))
+
+## <small>2.0.2 (2024-10-16)</small>
+
+* [bitnami/mlflow] Release 2.0.2 (#29945) ([709da84](https://github.com/bitnami/charts/commit/709da84701cec3a9e448bd35ae4f6c288894eaf0)), closes [#29945](https://github.com/bitnami/charts/issues/29945)
 
 ## <small>2.0.1 (2024-10-16)</small>
 

--- a/bitnami/mlflow/Chart.yaml
+++ b/bitnami/mlflow/Chart.yaml
@@ -44,4 +44,4 @@ sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/mlflow
 - https://github.com/bitnami/containers/tree/main/bitnami/mlflow
 - https://github.com/mlflow/mlflow
-version: 2.0.2
+version: 2.0.3

--- a/bitnami/mlflow/templates/tracking/deployment.yaml
+++ b/bitnami/mlflow/templates/tracking/deployment.yaml
@@ -111,7 +111,11 @@ spec:
       containers:
         - name: mlflow
           image: {{ include "mlflow.v0.image" . }}
+          {{- if eq .Values.image.tag "latest"}}
+          imagePullPolicy: Always
+          {{- else }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- end }}
           {{- if .Values.tracking.containerSecurityContext.enabled }}
           securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.tracking.containerSecurityContext "context" $) | nindent 12 }}
           {{- end }}

--- a/bitnami/mlflow/values.yaml
+++ b/bitnami/mlflow/values.yaml
@@ -87,7 +87,7 @@ diagnosticMode:
 image:
   registry: docker.io
   repository: bitnami/mlflow
-  tag: 2.17.0-debian-12-r1
+  tag: latest
   digest: ""
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'


### PR DESCRIPTION
…used; fix #30061

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

According to the docstring the `imagePullPolicy` is supposed to be `Always` when the latest tag is used.
This is now the case with the change.

### Benefits

The latest image will always be used.

### Possible drawbacks

It might be unclear to the user why their `imagePullPolicy` value is not used. Maybe the logic should be changed so that it will be only `Always` if `imagePullPolicy` is empty as well?

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #30061 

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [ ] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [ ] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
