### PR TITLE
[bitnami/solr] chore: Increase ginkgo test timeout

### DIFF
--- a/.vib/solr/ginkgo/solr_suite_test.go
+++ b/.vib/solr/ginkgo/solr_suite_test.go
@@ -31,7 +31,7 @@ func init() {
 	flag.StringVar(&namespace, "namespace", "", "namespace where the application is running")
 	flag.StringVar(&username, "username", "", "database user")
 	flag.StringVar(&password, "password", "", "database password for username")
-	flag.IntVar(&timeoutSeconds, "timeout", 200, "timeout in seconds")
+	flag.IntVar(&timeoutSeconds, "timeout", 300, "timeout in seconds")
 	timeout = time.Duration(timeoutSeconds) * time.Second
 }
 
@@ -41,6 +41,8 @@ func TestSolr(t *testing.T) {
 }
 
 func createJob(ctx context.Context, c kubernetes.Interface, name string, port string, image string, args ...string) error {
+	// Default job TTL in seconds
+	ttl := int32(10)
 	securityContext := &v1.SecurityContext{
 		Privileged:               &[]bool{false}[0],
 		AllowPrivilegeEscalation: &[]bool{false}[0],
@@ -64,6 +66,7 @@ func createJob(ctx context.Context, c kubernetes.Interface, name string, port st
 			Kind: "Job",
 		},
 		Spec: batchv1.JobSpec{
+			TTLSecondsAfterFinished: &ttl,
 			Template: v1.PodTemplateSpec{
 				Spec: v1.PodSpec{
 					RestartPolicy: "Never",

--- a/bitnami/solr/CHANGELOG.md
+++ b/bitnami/solr/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
-## 9.4.6 (2024-10-20)
+## 9.4.7 (2024-10-28)
 
-* [bitnami/solr] Release 9.4.6 ([#30001](https://github.com/bitnami/charts/pull/30001))
+* [bitnami/solr] chore: Increase ginkgo test timeout ([#30109](https://github.com/bitnami/charts/pull/30109))
+
+## <small>9.4.6 (2024-10-20)</small>
+
+* [bitnami/solr] Release 9.4.6 (#30001) ([5e45cf2](https://github.com/bitnami/charts/commit/5e45cf25de1677d32d4b22ed09cbc8fc52e66611)), closes [#30001](https://github.com/bitnami/charts/issues/30001)
+* Update documentation links to techdocs.broadcom.com (#29931) ([f0d9ad7](https://github.com/bitnami/charts/commit/f0d9ad78f39f633d275fc576d32eae78ded4d0b8)), closes [#29931](https://github.com/bitnami/charts/issues/29931)
 
 ## <small>9.4.5 (2024-09-17)</small>
 

--- a/bitnami/solr/Chart.yaml
+++ b/bitnami/solr/Chart.yaml
@@ -34,4 +34,4 @@ maintainers:
 name: solr
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/solr
-version: 9.4.6
+version: 9.4.7


### PR DESCRIPTION
### Description of the change

* Increase default timeout for ginkgo tests.
* Add TimeToLive parameter to created jobs.

### Benefits

Avoid timeout errors that we are facing in some test environments.

### Possible drawbacks

None

### Additional information

https://kubernetes.io/docs/concepts/workloads/controllers/ttlafterfinished/

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
