### PR TITLE
[bitnami/external-dns] fix: secret not getting created when pihole password value is set

### DIFF
--- a/bitnami/external-dns/CHANGELOG.md
+++ b/bitnami/external-dns/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
-## 8.3.10 (2024-10-03)
+## 8.3.11 (2024-10-28)
 
-* [bitnami/external-dns] chore: :wrench: :construction_worker: Re-enable CRD automation ([#29266](https://github.com/bitnami/charts/pull/29266))
+* [bitnami/external-dns] fix: secret not getting created when pihole password value is set ([#30114](https://github.com/bitnami/charts/pull/30114))
+
+## <small>8.3.10 (2024-10-28)</small>
+
+* [bitnami/external-dns] chore: :wrench: :construction_worker: Re-enable CRD automation (#29266) ([9e50d55](https://github.com/bitnami/charts/commit/9e50d55475410d956d5d048b2443759050b8183e)), closes [#29266](https://github.com/bitnami/charts/issues/29266)
+* Update documentation links to techdocs.broadcom.com (#29931) ([f0d9ad7](https://github.com/bitnami/charts/commit/f0d9ad78f39f633d275fc576d32eae78ded4d0b8)), closes [#29931](https://github.com/bitnami/charts/issues/29931)
 
 ## <small>8.3.9 (2024-10-02)</small>
 

--- a/bitnami/external-dns/CHANGELOG.md
+++ b/bitnami/external-dns/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 8.3.11 (2024-10-28)
+## 8.3.11 (2024-10-29)
 
 * [bitnami/external-dns] fix: secret not getting created when pihole password value is set ([#30114](https://github.com/bitnami/charts/pull/30114))
 

--- a/bitnami/external-dns/Chart.yaml
+++ b/bitnami/external-dns/Chart.yaml
@@ -28,4 +28,4 @@ maintainers:
 name: external-dns
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/external-dns
-version: 8.3.10
+version: 8.3.11

--- a/bitnami/external-dns/templates/_helpers.tpl
+++ b/bitnami/external-dns/templates/_helpers.tpl
@@ -130,7 +130,7 @@ Return true if a secret object should be created
     {{- true -}}
 {{- else if and (eq .Values.provider "civo") .Values.civo.apiToken (not .Values.civo.secretName) -}}
     {{- true -}}
-{{- else if and (eq .Values.provider "pihole") .Values.pihole.secretName (not .Values.pihole.secretName) -}}
+{{- else if and (eq .Values.provider "pihole") .Values.pihole.password (not .Values.pihole.secretName) -}}
     {{- true -}}
 {{- else if and .Values.txtEncrypt.enabled (not .Values.txtEncrypt.secretName) -}}
     {{- true -}}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

This fixes a bug where the secret containing the pihole secret was not created when the password value was set.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
