### PR TITLE
[bitnami/mongodb] Fix render values of resources on init container

### DIFF
--- a/bitnami/mongodb/CHANGELOG.md
+++ b/bitnami/mongodb/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
+## 16.2.1 (2024-10-29)
+
+* [bitnami/mongodb] Fix render values of resources on log dir init container ([#30115](https://github.com/bitnami/charts/pull/30115))
+
 ## 16.2.0 (2024-10-28)
 
-* [bitnami/mongodb] fix: initial primary host variable for arbiter and hidden replicas ([#29584](https://github.com/bitnami/charts/pull/29584))
+* [bitnami/mongodb] fix: initial primary host variable for arbiter and hidden replicas (#29584) ([a1df969](https://github.com/bitnami/charts/commit/a1df96944f48ea2cde075396d235a07a6d7aa165)), closes [#29584](https://github.com/bitnami/charts/issues/29584)
 
 ## <small>16.1.1 (2024-10-25)</small>
 

--- a/bitnami/mongodb/Chart.yaml
+++ b/bitnami/mongodb/Chart.yaml
@@ -39,4 +39,4 @@ maintainers:
 name: mongodb
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/mongodb
-version: 16.2.0
+version: 16.2.1

--- a/bitnami/mongodb/templates/_helpers.tpl
+++ b/bitnami/mongodb/templates/_helpers.tpl
@@ -267,7 +267,7 @@ Init container definition to change/establish volume permissions.
   securityContext: {{- .Values.volumePermissions.securityContext | toYaml | nindent 12 }}
   {{- end }}
   {{- if .Values.volumePermissions.resources }}
-  resources: {{- toYaml .Values.volumePermissions.resources | nindent 12 }}
+  resources: {{- include "common.tplvalues.render" (dict "value" .Values.volumePermissions.resources "context" $) | nindent 12 }}
   {{- else if ne .Values.volumePermissions.resourcesPreset "none" }}
   resources: {{- include "common.resources.preset" (dict "type" .Values.volumePermissions.resourcesPreset) | nindent 12 }}
   {{- end }}
@@ -324,7 +324,7 @@ Init container definition to get external IP addresses.
     - name: SHARED_FILE
       value: "/shared/info.txt"
   {{- if .Values.externalAccess.autoDiscovery.resources }}
-  resources: {{- toYaml .Values.externalAccess.autoDiscovery.resources | nindent 12 }}
+  resources: {{- include "common.tplvalues.render" (dict "value" .Values.externalAccess.autoDiscovery.resources "context" $) | nindent 12 }}
   {{- else if ne .Values.externalAccess.autoDiscovery.resourcesPreset "none" }}
   resources: {{- include "common.resources.preset" (dict "type" .Values.externalAccess.autoDiscovery.resourcesPreset) | nindent 12 }}
   {{- end }}

--- a/bitnami/mongodb/templates/_helpers.tpl
+++ b/bitnami/mongodb/templates/_helpers.tpl
@@ -296,7 +296,7 @@ Init container definition to recover log dir.
   securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.containerSecurityContext "context" $) | nindent 12 }}
   {{- end }}
   {{- if .Values.resources }}
-  resources: {{- toYaml .Values.resources | nindent 12 }}
+  resources: {{- include "common.tplvalues.render" (dict "value" .Values.resources "context" $) | nindent 12 }}
   {{- else if ne .Values.resourcesPreset "none" }}
   resources: {{- include "common.resources.preset" (dict "type" .Values.resourcesPreset) | nindent 12 }}
   {{- end }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Use `common.tplvalues.render` to render resources of log dir, volume permissions and auto discovery init container as it's done for workload manifest statefulset or deployment.

### Benefits

This will allow us to be consistent on render of `.Values.resources` on every manifest.

### Possible drawbacks

None noted

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
