### PR TITLE
[bitnami/airflow] fix: redis service name

### DIFF
--- a/bitnami/airflow/CHANGELOG.md
+++ b/bitnami/airflow/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 20.0.0 (2024-10-02)
+## 20.0.1 (2024-10-29)
 
-* [bitnami/airflow] feat!: :arrow_up: :boom: Bump PostgreSQL to 17.x ([#29727](https://github.com/bitnami/charts/pull/29727))
+* [bitnami/airflow] fix: redis service name ([#30117](https://github.com/bitnami/charts/pull/30117))
+
+## 20.0.0 (2024-10-03)
+
+* [bitnami/airflow] feat!: :arrow_up: :boom: Bump PostgreSQL to 17.x (#29727) ([f70e935](https://github.com/bitnami/charts/commit/f70e93590e1f9247332f76d25abf81f562d8eb1f)), closes [#29727](https://github.com/bitnami/charts/issues/29727)
 
 ## <small>19.0.10 (2024-09-23)</small>
 

--- a/bitnami/airflow/Chart.yaml
+++ b/bitnami/airflow/Chart.yaml
@@ -47,4 +47,4 @@ maintainers:
 name: airflow
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/airflow
-version: 20.0.0
+version: 20.0.1

--- a/bitnami/airflow/templates/_helpers.tpl
+++ b/bitnami/airflow/templates/_helpers.tpl
@@ -126,7 +126,7 @@ Create a default fully qualified redis name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "airflow.redis.fullname" -}}
-{{- include "common.names.dependency.fullname" (dict "chartName" "redis-master" "chartValues" .Values.redis "context" $) -}}
+{{- printf "%s-master" (include "common.names.dependency.fullname" (dict "chartName" "redis" "chartValues" .Values.redis "context" $)) | trunc 63 | trimSuffix "-"  -}}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
### Description of the change

Main service in redis chart is called `{{ include "common.names.fullname" . }}-master` https://github.com/bitnami/charts/blob/15c8fa0ff4bcb0b36d8504a6b0b0104634c6ba6c/bitnami/redis/templates/master/service.yaml#L10

To access properly to the service we need to append `-master` to the release name.

### Benefits

Use the right redis service name if we override the release name.

### Possible drawbacks

None

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #30000

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
