### PR TITLE
[bitnami/deepspeed] chore: increase client memory

### DIFF
--- a/.vib/deepspeed/runtime-parameters.yaml
+++ b/.vib/deepspeed/runtime-parameters.yaml
@@ -14,6 +14,7 @@ client:
   serviceAccount:
     create: true
   automountServiceAccountToken: true
+  resourcesPreset: large
   persistence:
     enabled: true
     mountPath: /bitnami/deepspeed/vib-test

--- a/bitnami/deepspeed/CHANGELOG.md
+++ b/bitnami/deepspeed/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 2.2.23 (2024-10-23)
+## 2.2.24 (2024-10-29)
 
-* [bitnami/deepspeed] Release 2.2.23 ([#30050](https://github.com/bitnami/charts/pull/30050))
+* [bitnami/deepspeed] chore: increase client memory ([#30126](https://github.com/bitnami/charts/pull/30126))
+
+## <small>2.2.23 (2024-10-23)</small>
+
+* [bitnami/deepspeed] Release 2.2.23 (#30050) ([3ff6f15](https://github.com/bitnami/charts/commit/3ff6f151a462020c7f88f7c5dc8c6c50df3a4038)), closes [#30050](https://github.com/bitnami/charts/issues/30050)
 
 ## <small>2.2.22 (2024-10-21)</small>
 

--- a/bitnami/deepspeed/Chart.yaml
+++ b/bitnami/deepspeed/Chart.yaml
@@ -35,4 +35,4 @@ name: deepspeed
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/deepspeed
 - https://github.com/bitnami/charts/tree/main/bitnami/pytorch
-version: 2.2.23
+version: 2.2.24


### PR DESCRIPTION
### Description of the change

Increase client resources by default.

### Benefits

Some tests were failing randomly because client pods were being killed because the were running out of memory. OOMKilled (error 137)

### Possible drawbacks

None

### Applicable issues

- Fix random OOMKilled pods detected on tests.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
