### PR TITLE
[bitnami/kube-prometheus] Fix spec for thanos sidecar if no extraEnv is provided

### DIFF
--- a/bitnami/kube-prometheus/CHANGELOG.md
+++ b/bitnami/kube-prometheus/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
-## 9.6.4 (2024-10-24)
+## 9.6.5 (2024-10-29)
 
-* [bitnami/kube-prometheus] Release 9.6.4 ([#30073](https://github.com/bitnami/charts/pull/30073))
+* [bitnami/kube-prometheus] Fix spec for thanos sidecar if no extraEnv is provided ([#30127](https://github.com/bitnami/charts/pull/30127))
+
+## <small>9.6.4 (2024-10-24)</small>
+
+* [bitnami/kube-prometheus] Release 9.6.4 (#30073) ([d809c39](https://github.com/bitnami/charts/commit/d809c39849c5a04fb5928f37c5d9cf9da310f2bc)), closes [#30073](https://github.com/bitnami/charts/issues/30073)
+* Update documentation links to techdocs.broadcom.com (#29931) ([f0d9ad7](https://github.com/bitnami/charts/commit/f0d9ad78f39f633d275fc576d32eae78ded4d0b8)), closes [#29931](https://github.com/bitnami/charts/issues/29931)
 
 ## <small>9.6.3 (2024-10-02)</small>
 

--- a/bitnami/kube-prometheus/Chart.yaml
+++ b/bitnami/kube-prometheus/Chart.yaml
@@ -46,4 +46,4 @@ maintainers:
 name: kube-prometheus
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/kube-prometheus
-version: 9.6.4
+version: 9.6.5

--- a/bitnami/kube-prometheus/templates/prometheus/prometheus.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus/prometheus.yaml
@@ -294,6 +294,7 @@ spec:
         {{- if .Values.prometheus.thanos.extraEnvVars }}
         {{- include "common.tplvalues.render" (dict "value" .Values.prometheus.thanos.extraEnvVars "context" $) | nindent 8 }}
         {{- end }}
+      {{- if or .Values.prometheus.thanos.extraEnvVarsCM .Values.prometheus.thanos.extraEnvVarsSecret }}
       envFrom:
         {{- if .Values.prometheus.thanos.extraEnvVarsCM }}
         - configMapRef:
@@ -303,6 +304,7 @@ spec:
         - secretRef:
             name: {{ include "common.tplvalues.render" (dict "value" .Values.prometheus.thanos.extraEnvVarsSecret "context" $) }}
         {{- end }}
+      {{- end}}
       {{- if .Values.prometheus.thanos.resources }}
       resources: {{- toYaml .Values.prometheus.thanos.resources | nindent 8 }}
       {{- else if ne .Values.prometheus.thanos.resourcesPreset "none" }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

Helm will render a valid spec for the thanos-sidecar if `prometheus.thanos.extraEnvVarsCM` and `prometheus.thanos.extraEnvVarsSecret` are not set.

### Applicable issues

- fixes https://github.com/bitnami/charts/issues/29799

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
