### PR TITLE
[bitnami/minio] fix secret creation check

### DIFF
--- a/bitnami/minio/CHANGELOG.md
+++ b/bitnami/minio/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
-## 14.8.1 (2024-10-31)
+## 14.8.2 (2024-10-31)
 
-* [bitnami/minio] Release 14.8.1 ([#30140](https://github.com/bitnami/charts/pull/30140))
+* [bitnami/minio] fix secret creation check ([#30135](https://github.com/bitnami/charts/pull/30135))
+
+## <small>14.8.1 (2024-10-31)</small>
+
+* [bitnami/*] Remove wrong comment about imagePullPolicy (#30107) ([a51f9e4](https://github.com/bitnami/charts/commit/a51f9e4bb0fbf77199512d35de7ac8abe055d026)), closes [#30107](https://github.com/bitnami/charts/issues/30107)
+* [bitnami/minio] Release 14.8.1 (#30140) ([baef6e7](https://github.com/bitnami/charts/commit/baef6e77282c85b2689cc72415669b7db6666e63)), closes [#30140](https://github.com/bitnami/charts/issues/30140)
 
 ## 14.8.0 (2024-10-18)
 

--- a/bitnami/minio/Chart.yaml
+++ b/bitnami/minio/Chart.yaml
@@ -34,4 +34,4 @@ maintainers:
 name: minio
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/minio
-version: 14.8.1
+version: 14.8.2

--- a/bitnami/minio/templates/_helpers.tpl
+++ b/bitnami/minio/templates/_helpers.tpl
@@ -93,9 +93,8 @@ Get the root password key.
 Return true if a secret object should be created
 */}}
 {{- define "minio.createSecret" -}}
-{{- if .Values.auth.existingSecret -}}
-{{- else -}}
-    {{- .Values.auth.useSecret -}}
+{{- if and (not .Values.auth.existingSecret) .Values.auth.useSecret -}}
+    {{- true -}}
 {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

The "Option to use a secret" introduced in `14.7.0` also brought a small bug with it: The [check if the secret should be created](https://github.com/bitnami/charts/blob/minio/14.8.0/bitnami/minio/templates/secrets.yaml#L6) expects a boolean, but ["include" always returns a string ](https://github.com/helm/helm/issues/11231). Because it is not used directly (only in the [minio.createSecret](https://github.com/bitnami/charts/blob/minio/14.8.0/bitnami/minio/templates/_helpers.tpl#L95) template), even setting `auth.useSecret` to `false` will result in the string "false". This string is then interpreted as / casted to a boolean in the corresponding `if`-clause, where it always is translated to `true` because it is not empty. (If you set `auth.useSecret` to an empty string, the secret will not be created)

### Benefits

`auth.useSecret` actually works as expected:
* If set to `true` the secret will be created (if `existingSecret` is empty)
* If set to `false` the secret won't be created

### Possible drawbacks
I don't see any (yet)

### Applicable issues
-

### Additional information
There would also be the option to change all `if (include "minio.createSecret" .)`s so that they check the string's content instead of only for emptiness. But this would create a larger diff, so I chose not to do it that way.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
