### PR TITLE
[bitnami/airflow] Split init containers

### DIFF
--- a/bitnami/airflow/CHANGELOG.md
+++ b/bitnami/airflow/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
+## 21.0.1 (2024-10-31)
+
+* [bitnami/airflow] Split init containers ([#30155](https://github.com/bitnami/charts/pull/30155))
+
 ## 21.0.0 (2024-10-31)
 
-* [bitnami/airflow] Use a single Airflow image ([#30137](https://github.com/bitnami/charts/pull/30137))
+* [bitnami/airflow] Use a single Airflow image (#30137) ([e9aed1b](https://github.com/bitnami/charts/commit/e9aed1bfed27dddaff454760ef3318d81e3bb05a)), closes [#30137](https://github.com/bitnami/charts/issues/30137)
 
 ## <small>20.0.2 (2024-10-30)</small>
 

--- a/bitnami/airflow/Chart.yaml
+++ b/bitnami/airflow/Chart.yaml
@@ -39,4 +39,4 @@ maintainers:
 name: airflow
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/airflow
-version: 21.0.0
+version: 21.0.1

--- a/bitnami/airflow/templates/scheduler/deployment.yaml
+++ b/bitnami/airflow/templates/scheduler/deployment.yaml
@@ -70,8 +70,11 @@ spec:
       {{- end }}
       initContainers:
         {{- include "airflow.defaultInitContainers.createDefaultConfig" . | nindent 8 }}
-        {{- if or .Values.dags.enabled .Values.plugins.enabled }}
-        {{- include "airflow.defaultInitContainers.loadDAGsPlugins" . | nindent 8 }}
+        {{- if and .Values.dags.enabled }}
+        {{- include "airflow.defaultInitContainers.loadDAGs" . | nindent 8 }}
+        {{- end }}
+        {{- if .Values.plugins.enabled }}
+        {{- include "airflow.defaultInitContainers.loadPlugins" . | nindent 8 }}
         {{- end }}
         {{- if .Values.initContainers }}
         {{- include "common.tplvalues.render" (dict "value" .Values.initContainers "context" $) | trim | nindent 8 }}
@@ -219,8 +222,11 @@ spec:
               mountPath: /opt/bitnami/airflow/pod_template.yaml
               subPath: pod_template.yaml
             {{- end }}
-            {{- if or .Values.dags.enabled .Values.plugins.enabled }}
-            {{- include "airflow.dagsPlugins.volumeMounts" . | nindent 12 }}
+            {{- if and .Values.dags.enabled }}
+            {{- include "airflow.dags.volumeMounts" . | nindent 12 }}
+            {{- end }}
+            {{- if .Values.plugins.enabled }}
+            {{- include "airflow.plugins.volumeMounts" . | nindent 12 }}
             {{- end }}
             {{- if .Values.extraVolumeMounts }}
             {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumeMounts "context" $) | nindent 12 }}
@@ -228,8 +234,11 @@ spec:
             {{- if .Values.scheduler.extraVolumeMounts }}
             {{- include "common.tplvalues.render" (dict "value" .Values.scheduler.extraVolumeMounts "context" $) | nindent 12 }}
             {{- end }}
-        {{- if or .Values.dags.enabled .Values.plugins.enabled }}
-        {{- include "airflow.defaultSidecars.syncDAGsPlugins" . | nindent 8 }}
+        {{- if and .Values.dags.enabled }}
+        {{- include "airflow.defaultSidecars.syncDAGs" . | nindent 8 }}
+        {{- end }}
+        {{- if .Values.plugins.enabled }}
+        {{- include "airflow.defaultSidecars.syncPlugins" . | nindent 8 }}
         {{- end }}
         {{- if .Values.sidecars }}
         {{- include "common.tplvalues.render" (dict "value" .Values.sidecars "context" $) | trim | nindent 8 }}

--- a/bitnami/airflow/templates/web/deployment.yaml
+++ b/bitnami/airflow/templates/web/deployment.yaml
@@ -69,8 +69,8 @@ spec:
       {{- end }}
       initContainers:
         {{- include "airflow.defaultInitContainers.createDefaultConfig" . | nindent 8 }}
-        {{- if or .Values.dags.enabled .Values.plugins.enabled }}
-        {{- include "airflow.defaultInitContainers.loadDAGsPlugins" . | nindent 8 }}
+        {{- if .Values.plugins.enabled }}
+        {{- include "airflow.defaultInitContainers.loadPlugins" . | nindent 8 }}
         {{- end }}
         {{- if .Values.initContainers }}
         {{- include "common.tplvalues.render" (dict "value" .Values.initContainers "context" $) | trim | nindent 8 }}
@@ -269,8 +269,8 @@ spec:
               mountPath: {{ .Values.ldap.tls.certificatesMountPath }}
               readOnly: true
             {{- end }}
-            {{- if or .Values.dags.enabled .Values.plugins.enabled }}
-            {{- include "airflow.dagsPlugins.volumeMounts" . | nindent 12 }}
+            {{- if .Values.plugins.enabled }}
+            {{- include "airflow.plugins.volumeMounts" . | nindent 12 }}
             {{- end }}
             {{- if .Values.extraVolumeMounts }}
             {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumeMounts "context" $) | nindent 12 }}
@@ -278,8 +278,8 @@ spec:
             {{- if .Values.web.extraVolumeMounts }}
             {{- include "common.tplvalues.render" (dict "value" .Values.web.extraVolumeMounts "context" $) | nindent 12 }}
             {{- end }}
-        {{- if or .Values.dags.enabled .Values.plugins.enabled }}
-        {{- include "airflow.defaultSidecars.syncDAGsPlugins" . | nindent 8 }}
+        {{- if .Values.plugins.enabled }}
+        {{- include "airflow.defaultSidecars.syncPlugins" . | nindent 8 }}
         {{- end }}
         {{- if .Values.sidecars }}
         {{- include "common.tplvalues.render" (dict "value" .Values.sidecars "context" $) | trim | nindent 8 }}
@@ -290,11 +290,6 @@ spec:
       volumes:
         - name: empty-dir
           emptyDir: {}
-        {{- if and .Values.dags.enabled .Values.dags.existingConfigmap }}
-        - name: external-dags
-          configMap:
-            name: {{ tpl .Values.dags.existingConfigmap $ }}
-        {{- end }}
         {{- if or .Values.configuration .Values.existingConfigmap }}
         - name: custom-configuration-file
           configMap:

--- a/bitnami/airflow/templates/worker/statefulset.yaml
+++ b/bitnami/airflow/templates/worker/statefulset.yaml
@@ -74,8 +74,11 @@ spec:
       {{- end }}
       initContainers:
         {{- include "airflow.defaultInitContainers.createDefaultConfig" . | nindent 8 }}
-        {{- if or .Values.dags.enabled .Values.plugins.enabled }}
-        {{- include "airflow.defaultInitContainers.loadDAGsPlugins" . | nindent 8 }}
+        {{- if .Values.dags.enabled }}
+        {{- include "airflow.defaultInitContainers.loadDAGs" . | nindent 8 }}
+        {{- end }}
+        {{- if .Values.plugins.enabled }}
+        {{- include "airflow.defaultInitContainers.loadPlugins" . | nindent 8 }}
         {{- end }}
         {{- if .Values.initContainers }}
         {{- include "common.tplvalues.render" (dict "value" .Values.initContainers "context" $) | trim | nindent 8 }}
@@ -216,8 +219,11 @@ spec:
             - name: empty-dir
               mountPath: /opt/bitnami/airflow/webserver_config.py
               subPath: app-default-conf-dir/webserver_config.py
-            {{- if or .Values.dags.enabled .Values.plugins.enabled }}
-            {{- include "airflow.dagsPlugins.volumeMounts" . | nindent 12 }}
+            {{- if .Values.dags.enabled }}
+            {{- include "airflow.dags.volumeMounts" . | nindent 12 }}
+            {{- end }}
+            {{- if .Values.plugins.enabled }}
+            {{- include "airflow.plugins.volumeMounts" . | nindent 12 }}
             {{- end }}
             {{- if .Values.extraVolumeMounts }}
             {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumeMounts "context" $) | nindent 12 }}
@@ -225,8 +231,11 @@ spec:
             {{- if .Values.worker.extraVolumeMounts }}
             {{- include "common.tplvalues.render" (dict "value" .Values.worker.extraVolumeMounts "context" $) | nindent 12 }}
             {{- end }}
-        {{- if or .Values.dags.enabled .Values.plugins.enabled }}
-        {{- include "airflow.defaultSidecars.syncDAGsPlugins" . | nindent 8 }}
+        {{- if .Values.dags.enabled }}
+        {{- include "airflow.defaultSidecars.syncDAGs" . | nindent 8 }}
+        {{- end }}
+        {{- if .Values.plugins.enabled }}
+        {{- include "airflow.defaultSidecars.syncPlugins" . | nindent 8 }}
         {{- end }}
         {{- if .Values.sidecars }}
         {{- include "common.tplvalues.render" (dict "value" .Values.sidecars "context" $) | trim | nindent 8 }}

--- a/bitnami/airflow/values.yaml
+++ b/bitnami/airflow/values.yaml
@@ -396,6 +396,7 @@ extraVolumeMounts: []
 extraVolumes: []
 
 ## @section Airflow web parameters
+##
 web:
   ## @param web.baseUrl URL used to access to Airflow web ui
   ##
@@ -709,7 +710,9 @@ web:
     ##
     ingressNSMatchLabels: {}
     ingressNSPodMatchLabels: {}
+
 ## @section Airflow scheduler parameters
+##
 scheduler:
   ## @param scheduler.replicaCount Number of scheduler replicas
   ##
@@ -1013,7 +1016,9 @@ scheduler:
     ##
     ingressNSMatchLabels: {}
     ingressNSPodMatchLabels: {}
+
 ## @section Airflow worker parameters
+##
 worker:
   ## @param worker.command Override default container command (useful when using custom images)
   ##


### PR DESCRIPTION
### Description of the change

This PR splits the logic to load DAGs and plugins into different init containers and sidecars. Then, it ensure that only the ones related to plugins are used for Airflow Web server

### Benefits

The goal is simple: ensure we don't load/sync DAGs on this component given it doesn't need them.

### Possible drawbacks

None

### Applicable issues

None

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
