### PR TITLE
[bitnami/mastodon] Mastodon initjob always tries to create admin on upgrade

### DIFF
--- a/bitnami/mastodon/CHANGELOG.md
+++ b/bitnami/mastodon/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 9.0.1 (2024-10-21)
+## 9.0.2 (2024-11-01)
 
-* [bitnami/mastodon] Release 9.0.1 ([#30019](https://github.com/bitnami/charts/pull/30019))
+* [bitnami/mastodon] Mastodon initjob always tries to create admin on upgrade ([#30171](https://github.com/bitnami/charts/pull/30171))
+
+## <small>9.0.1 (2024-10-21)</small>
+
+* [bitnami/mastodon] Release 9.0.1 (#30019) ([3ab0d63](https://github.com/bitnami/charts/commit/3ab0d63af56499b5072e7d82c168ce42b3e55c84)), closes [#30019](https://github.com/bitnami/charts/issues/30019)
 
 ## 9.0.0 (2024-10-17)
 

--- a/bitnami/mastodon/Chart.yaml
+++ b/bitnami/mastodon/Chart.yaml
@@ -49,4 +49,4 @@ maintainers:
 name: mastodon
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/mastodon
-version: 9.0.1
+version: 9.0.2

--- a/bitnami/mastodon/templates/init-job/init-job-configmap.yaml
+++ b/bitnami/mastodon/templates/init-job/init-job-configmap.yaml
@@ -14,7 +14,7 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 data:
-  {{- if or .Values.initJob.migrateAndCreateAdmin.migrateDB .Values.initJob.migrateAndCreateAdmin .Values.initJob.migrateAndCreateAdmin.migrateElasticsearch }}
+  {{- if or .Values.initJob.migrateAndCreateAdmin.migrateDB .Values.initJob.migrateAndCreateAdmin.createAdmin .Values.initJob.migrateAndCreateAdmin.migrateElasticsearch }}
   # All these operations require access to PostgreSQL (including Elasticsearch migration) and Redis. In order to avoid
   # potential race conditions we include them in the same script.
   migrate-and-create-admin.sh: |-
@@ -47,7 +47,7 @@ data:
     mastodon_rake_execute chewy:upgrade
     {{- end }}
 
-    {{- if .Values.initJob.migrateAndCreateAdmin }}
+    {{- if .Values.initJob.migrateAndCreateAdmin.createAdmin }}
     mastodon_ensure_admin_user_exists
     {{- end }}
   {{- end }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

The version 9.0.0 bitnami/mastodon introduced a regression where the admin account is allows created.  This is fine for a new installs but needs to be set to false on upgrades.  Prior to Chart version 9.0.0 the creation of the admin account was controlled by .Values.initJob.createAdmin set as a boolean.  In version 9.0.0 this was moved to .Values.initJob.migrateAndCreateAdmin.createAdmin but configmap template referenced .Values.initJob.migrateAndCreateAdmin.  As a result https://github.com/bitnami/charts/blob/356941ddb5c6ebbd08867aae2b07dfa21ff0e394/bitnami/mastodon/templates/init-job/init-job-configmap.yaml#L51 was always inserted to the ConfigMap generated for init-job.  This means on upgrade when an admin account already exists init-job fails and the helm chart upgrade fails.

The error can be seen below. On an upgrade the admin user is already defined and creating the admin user fails.

```
kubectl -n test-mastodon logs mastodon-init-pcgrl
Defaulted container "migrate-and-create-admin" out of: migrate-and-create-admin, mastodon-assets-precompile, copy-assets-dir (init), wait-for-backend (init)
mastodon 00:13:50.46 INFO  ==> Migrating database
mastodon 00:13:50.46 INFO  ==> Waiting for PostgreSQL to be ready at test-postgresql:5432/bitnami_mastodon
mastodon 00:13:50.52 INFO  ==> PostgreSQL instance is ready
mastodon 00:13:54.51 INFO  ==> Creating admin user
Failure/Error: email
    taken
Failure/Error: account.username
    taken
mastodon 00:14:01.83 ERROR ==> Error creating admin user
```

### Benefits

<!-- What benefits will be realized by the code change? -->
Upgrades work again provided you set .Values.initJob.migrateAndCreateAdmin.createAdmin to false.  Note that the documentation already referenced .Values.initJob.migrateAndCreateAdmin.createAdmin for this purpose.

### Possible drawbacks

<!-- Describe any known limitations with your change -->
None

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes ##29982
-

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [ X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [ X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
