### PR TITLE
[bitnami/etcd]: Fix volume indentation for defrag cronjob

### DIFF
--- a/bitnami/etcd/CHANGELOG.md
+++ b/bitnami/etcd/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
-## 10.5.0 (2024-11-04)
+## 10.5.1 (2024-11-06)
 
-* [bitnami/etcd]: Fix Defrag "bug" and prevent CronJob templates ambiguity ([#30077](https://github.com/bitnami/charts/pull/30077))
+* [bitnami/etcd]: Fix volume indentation for defrag cronjob ([#30192](https://github.com/bitnami/charts/pull/30192))
+
+## 10.5.0 (2024-11-05)
+
+* [bitnami/*] Remove wrong comment about imagePullPolicy (#30107) ([a51f9e4](https://github.com/bitnami/charts/commit/a51f9e4bb0fbf77199512d35de7ac8abe055d026)), closes [#30107](https://github.com/bitnami/charts/issues/30107)
+* [bitnami/etcd]: Fix Defrag "bug" and prevent CronJob templates ambiguity (#30077) ([15e3fea](https://github.com/bitnami/charts/commit/15e3feae76b32ac9c6af4588c7b12a14cb76c3b2)), closes [#30077](https://github.com/bitnami/charts/issues/30077) [#30053](https://github.com/bitnami/charts/issues/30053) [#30053](https://github.com/bitnami/charts/issues/30053)
 
 ## <small>10.4.2 (2024-10-28)</small>
 

--- a/bitnami/etcd/Chart.yaml
+++ b/bitnami/etcd/Chart.yaml
@@ -32,4 +32,4 @@ maintainers:
 name: etcd
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/etcd
-version: 10.5.0
+version: 10.5.1

--- a/bitnami/etcd/templates/cronjob-defrag.yaml
+++ b/bitnami/etcd/templates/cronjob-defrag.yaml
@@ -121,11 +121,11 @@ spec:
                   mountPath: /opt/bitnami/etcd/certs/client/
                   readOnly: true
               {{- end }}
-        {{- if or .Values.auth.client.enableAuthentication (and .Values.auth.client.secureTransport (not .Values.auth.client.useAutoTLS )) }}
-        volumes:
-          - name: etcd-client-certs
-            secret:
-              secretName: {{ required "A secret containing the client certificates is required" (tpl .Values.auth.client.existingSecret .) }}
-              defaultMode: 256
-        {{- end }}
+          {{- if or .Values.auth.client.enableAuthentication (and .Values.auth.client.secureTransport (not .Values.auth.client.useAutoTLS )) }}
+          volumes:
+            - name: etcd-client-certs
+              secret:
+                secretName: {{ required "A secret containing the client certificates is required" (tpl .Values.auth.client.existingSecret .) }}
+                defaultMode: 256
+          {{- end }}
 {{- end }}


### PR DESCRIPTION
Dear maintainers,

### Description of the change

Fix volume indentation for defrag cronjob. Volume should have the path `jobTemplate.spec.template.spec.volumes` not `jobTemplate.spec.template.volumes`

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
