### PR TITLE
[bitnami/airflow] bugfix: pod template

### DIFF
--- a/bitnami/airflow/CHANGELOG.md
+++ b/bitnami/airflow/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
+## 21.2.1 (2024-11-05)
+
+* [bitnami/airflow] bugfix: pod template ([#30216](https://github.com/bitnami/charts/pull/30216))
+
 ## 21.2.0 (2024-11-05)
 
-* [bitnami/airflow] Add support for Triggerer ([#30211](https://github.com/bitnami/charts/pull/30211))
+* [bitnami/airflow] Add support for Triggerer (#30211) ([fe4e81f](https://github.com/bitnami/charts/commit/fe4e81f3e56101d429903b805b3c487095492a5d)), closes [#30211](https://github.com/bitnami/charts/issues/30211)
 
 ## <small>21.1.1 (2024-11-04)</small>
 

--- a/bitnami/airflow/Chart.yaml
+++ b/bitnami/airflow/Chart.yaml
@@ -39,4 +39,4 @@ maintainers:
 name: airflow
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/airflow
-version: 21.2.0
+version: 21.2.1

--- a/bitnami/airflow/templates/config/configmap.yaml
+++ b/bitnami/airflow/templates/config/configmap.yaml
@@ -112,8 +112,11 @@ data:
             - name: empty-dir
               mountPath: /k8s-executor-conf
               subPath: app-k8s-executor-conf-dir
-        {{- if or .Values.dags.enabled .Values.plugins.enabled }}
-        {{- include "airflow.defaultInitContainers.loadDAGsPlugins" . | nindent 8 }}
+        {{- if .Values.dags.enabled }}
+        {{- include "airflow.defaultInitContainers.loadDAGs" . | nindent 8 }}
+        {{- end }}
+        {{- if .Values.plugins.enabled }}
+        {{- include "airflow.defaultInitContainers.loadPlugins" . | nindent 8 }}
         {{- end }}
         {{- if .Values.initContainers }}
         {{- include "common.tplvalues.render" (dict "value" .Values.initContainers "context" $) | trim | nindent 8 }}
@@ -245,8 +248,11 @@ data:
               mountPath: /opt/bitnami/airflow/airflow.cfg
               subPath: app-k8s-executor-conf-dir/airflow.cfg
             {{- end }}
-            {{- if or .Values.dags.enabled .Values.plugins.enabled }}
-            {{- include "airflow.dagsPlugins.volumeMounts" . | nindent 12 }}
+            {{- if .Values.dags.enabled }}
+            {{- include "airflow.dags.volumeMounts" . | nindent 12 }}
+            {{- end }}
+            {{- if .Values.plugins.enabled }}
+            {{- include "airflow.plugins.volumeMounts" . | nindent 12 }}
             {{- end }}
             {{- if .Values.extraVolumeMounts }}
             {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumeMounts "context" $) | nindent 12 }}
@@ -254,9 +260,12 @@ data:
             {{- if .Values.worker.extraVolumeMounts }}
             {{- include "common.tplvalues.render" (dict "value" .Values.worker.extraVolumeMounts "context" $) | nindent 12 }}
             {{- end }}
-        {{- if or .Values.dags.enabled .Values.plugins.enabled }}
-        {{- include "airflow.defaultSidecars.syncDAGsPlugins" . | nindent 8 }}
-        {{- end }}            
+        {{- if .Values.dags.enabled }}
+        {{- include "airflow.defaultSidecars.syncDAGs" . | nindent 8 }}
+        {{- end }}
+        {{- if .Values.plugins.enabled }}
+        {{- include "airflow.defaultSidecars.syncPlugins" . | nindent 8 }}
+        {{- end }}
         {{- if .Values.sidecars }}
         {{- include "common.tplvalues.render" (dict "value" .Values.sidecars "context" $) | trim | nindent 8 }}
         {{- end }}


### PR DESCRIPTION
### Description of the change

This PR fixes a bug introduced at https://github.com/bitnami/charts/pull/30155 given we didn't update accordingly the Pod Templates.

### Benefits

Users can use the `KubernetesExecutor` executor.

### Possible drawbacks

None

### Applicable issues

- fixes https://github.com/bitnami/charts/issues/30210

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
