### PR TITLE
[bitnami/seaweedfs] Mount security.toml regardless security enhancements are enabled

### DIFF
--- a/bitnami/seaweedfs/CHANGELOG.md
+++ b/bitnami/seaweedfs/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
-## 3.0.5 (2024-10-31)
+## 3.0.6 (2024-11-06)
 
-* [bitnami/seaweedfs] Release 3.0.5 ([#30149](https://github.com/bitnami/charts/pull/30149))
+* [bitnami/seaweedfs] Mount security.toml regardless security enhancements are enabled ([#30235](https://github.com/bitnami/charts/pull/30235))
+
+## <small>3.0.5 (2024-10-31)</small>
+
+* [bitnami/*] Remove wrong comment about imagePullPolicy (#30107) ([a51f9e4](https://github.com/bitnami/charts/commit/a51f9e4bb0fbf77199512d35de7ac8abe055d026)), closes [#30107](https://github.com/bitnami/charts/issues/30107)
+* [bitnami/seaweedfs] Release 3.0.5 (#30149) ([86395d9](https://github.com/bitnami/charts/commit/86395d98966d8ed6bd4a445e96ca112f7c0b0709)), closes [#30149](https://github.com/bitnami/charts/issues/30149)
 
 ## <small>3.0.4 (2024-10-28)</small>
 

--- a/bitnami/seaweedfs/Chart.lock
+++ b/bitnami/seaweedfs/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: mariadb
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 19.1.0
+  version: 19.1.2
 - name: postgresql
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 16.1.0
+  version: 16.1.1
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 2.26.0
-digest: sha256:b95f43eabd9f77029e4c050d4f58a100418fef7daf0c5e7314e98710c4ec4411
-generated: "2024-10-31T11:25:19.855853607Z"
+digest: sha256:f79101b48a4c6fc0caf4db928948a52339154dc8465cb1bf64ff92a25f47e4b6
+generated: "2024-11-06T12:11:20.995486+01:00"

--- a/bitnami/seaweedfs/Chart.yaml
+++ b/bitnami/seaweedfs/Chart.yaml
@@ -50,4 +50,4 @@ name: seaweedfs
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/seawwedfs
 - https://github.com/bitnami/containers/tree/main/bitnami/seaweedfs
-version: 3.0.5
+version: 3.0.6

--- a/bitnami/seaweedfs/templates/filer/statefulset.yaml
+++ b/bitnami/seaweedfs/templates/filer/statefulset.yaml
@@ -34,9 +34,7 @@ spec:
         {{- if and .Values.filer.config (empty .Values.filer.existingConfigmap) }}
         checksum/config: {{ include (print $.Template.BasePath "/filer/configmap.yaml") . | sha256sum }}
         {{- end }}
-        {{- if .Values.security.enabled }}
         checksum/security-config: {{ include (print $.Template.BasePath "/security-configmap.yaml") . | sha256sum }}
-        {{- end }}
         {{- if .Values.filer.podAnnotations }}
         {{- include "common.tplvalues.render" (dict "value" .Values.filer.podAnnotations "context" $) | nindent 8 }}
         {{- end }}
@@ -109,9 +107,7 @@ spec:
           args:
             - -logtostderr=true
             - -v={{ .Values.filer.logLevel }}
-            {{- if or .Values.security.enabled .Values.filer.config .Values.filer.existingConfigmap }}
             - -config_dir=/etc/seaweedfs
-            {{- end }}
             - filer
             - -ip.bind={{ .Values.filer.bindAddress }}
             - -ip=$(POD_NAME).{{ printf "%s-headless" (include "seaweedfs.filer.fullname" .) }}.$(NAMESPACE).svc.{{ .Values.clusterDomain }}
@@ -248,7 +244,6 @@ spec:
               subPath: filer.toml
               readOnly: true
             {{- end }}
-            {{- if .Values.security.enabled }}
             - name: security-config
               mountPath: /etc/seaweedfs/security.toml
               subPath: security.toml
@@ -270,7 +265,6 @@ spec:
               readOnly: true
               mountPath: /certs/client
             {{- end }}
-            {{- end }}
           {{- if .Values.filer.extraVolumeMounts }}
           {{- include "common.tplvalues.render" (dict "value" .Values.filer.extraVolumeMounts "context" $) | nindent 12 }}
           {{- end }}
@@ -291,7 +285,6 @@ spec:
           configMap:
             name: {{ template "seaweedfs.filer.configmapName" . }}
         {{- end }}
-        {{- if .Values.security.enabled }}
         - name: security-config
           configMap:
             name: {{ printf "%s-security" (include "common.names.fullname" .) }}
@@ -314,7 +307,6 @@ spec:
         - name: client-cert
           secret:
             secretName: {{ template "seaweedfs.security.mTLS.client.secretName" . }}
-        {{- end }}
         {{- end }}
         {{- if .Values.filer.extraVolumes }}
         {{- include "common.tplvalues.render" (dict "value" .Values.filer.extraVolumes "context" $) | nindent 8 }}

--- a/bitnami/seaweedfs/templates/master/statefulset.yaml
+++ b/bitnami/seaweedfs/templates/master/statefulset.yaml
@@ -33,9 +33,7 @@ spec:
         {{- if and .Values.master.config (empty .Values.master.existingConfigmap) }}
         checksum/config: {{ include (print $.Template.BasePath "/master/configmap.yaml") . | sha256sum }}
         {{- end }}
-        {{- if .Values.security.enabled }}
         checksum/security-config: {{ include (print $.Template.BasePath "/security-configmap.yaml") . | sha256sum }}
-        {{- end }}
         {{- if .Values.master.podAnnotations }}
         {{- include "common.tplvalues.render" (dict "value" .Values.master.podAnnotations "context" $) | nindent 8 }}
         {{- end }}
@@ -134,9 +132,7 @@ spec:
           args:
             - -logtostderr=true
             - -v={{ .Values.master.logLevel }}
-            {{- if or .Values.security.enabled .Values.master.config .Values.master.existingConfigmap }}
             - -config_dir=/etc/seaweedfs
-            {{- end }}
             - master
             - -mdir={{ .Values.master.persistence.mountPath }}
             - -ip.bind={{ .Values.master.bindAddress }}
@@ -235,7 +231,6 @@ spec:
               subPath: master.toml
               readOnly: true
             {{- end }}
-            {{- if .Values.security.enabled }}
             - name: security-config
               mountPath: /etc/seaweedfs/security.toml
               subPath: security.toml
@@ -259,7 +254,6 @@ spec:
               readOnly: true
               mountPath: /certs/client
             {{- end }}
-            {{- end }}
           {{- if .Values.master.extraVolumeMounts }}
           {{- include "common.tplvalues.render" (dict "value" .Values.master.extraVolumeMounts "context" $) | nindent 12 }}
           {{- end }}
@@ -274,7 +268,6 @@ spec:
           configMap:
             name: {{ template "seaweedfs.master.configmapName" . }}
         {{- end }}
-        {{- if .Values.security.enabled }}
         - name: security-config
           configMap:
             name: {{ printf "%s-security" (include "common.names.fullname" .) }}
@@ -299,7 +292,6 @@ spec:
         - name: client-cert
           secret:
             secretName: {{ template "seaweedfs.security.mTLS.client.secretName" . }}
-        {{- end }}
         {{- end }}
         {{- if .Values.master.extraVolumes }}
         {{- include "common.tplvalues.render" (dict "value" .Values.master.extraVolumes "context" $) | nindent 8 }}

--- a/bitnami/seaweedfs/templates/s3/deployment.yaml
+++ b/bitnami/seaweedfs/templates/s3/deployment.yaml
@@ -32,9 +32,7 @@ spec:
         {{- if and .Values.s3.auth.enabled (not .Values.s3.auth.existingSecret) }}
         checksum/auth-secret: {{ include (print $.Template.BasePath "/s3/auth-secret.yaml") . | sha256sum }}
         {{- end }}
-        {{- if .Values.security.enabled }}
         checksum/security-config: {{ include (print $.Template.BasePath "/security-configmap.yaml") . | sha256sum }}
-        {{- end }}
         {{- if .Values.s3.podAnnotations }}
         {{- include "common.tplvalues.render" (dict "value" .Values.s3.podAnnotations "context" $) | nindent 8 }}
         {{- end }}
@@ -202,7 +200,6 @@ spec:
               subPath: auth-dir
             {{- end }}
             {{- end }}
-            {{- if .Values.security.enabled }}
             - name: security-config
               mountPath: /etc/seaweedfs/security.toml
               subPath: security.toml
@@ -224,7 +221,6 @@ spec:
               readOnly: true
               mountPath: /certs/client
             {{- end }}
-            {{- end }}
           {{- if .Values.s3.extraVolumeMounts }}
           {{- include "common.tplvalues.render" (dict "value" .Values.s3.extraVolumeMounts "context" $) | nindent 12 }}
           {{- end }}
@@ -239,7 +235,6 @@ spec:
           secret:
             secretName: {{ print (tpl .Values.s3.auth.existingSecret .) }}
         {{- end }}
-        {{- if .Values.security.enabled }}
         - name: security-config
           configMap:
             name: {{ printf "%s-security" (include "common.names.fullname" .) }}
@@ -262,7 +257,6 @@ spec:
         - name: client-cert
           secret:
             secretName: {{ template "seaweedfs.security.mTLS.client.secretName" . }}
-        {{- end }}
         {{- end }}
         {{- if .Values.s3.extraVolumes }}
         {{- include "common.tplvalues.render" (dict "value" .Values.s3.extraVolumes "context" $) | nindent 8 }}

--- a/bitnami/seaweedfs/templates/security-configmap.yaml
+++ b/bitnami/seaweedfs/templates/security-configmap.yaml
@@ -3,7 +3,6 @@ Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- if .Values.security.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -17,7 +16,7 @@ data:
   security.toml: |-
     # Security configuration
     # Shared between master, volume and filer servers
-
+  {{- if .Values.security.enabled }}
     # comma separated origins allowed to make requests to the filer and s3 gateway. 
     # enter in this format: https://domain.com, or http://localhost:port
     [cors.allowed_origins]
@@ -86,4 +85,9 @@ data:
     cert = "/certs/client/tls.crt"
     key  = "/certs/client/tls.key"
     {{- end }}
-{{- end }}
+  {{- else }}
+    # comma separated origins allowed to make requests to the filer and s3 gateway. 
+    # enter in this format: https://domain.com, or http://localhost:port
+    [cors.allowed_origins]
+    values = "*"
+  {{- end }}

--- a/bitnami/seaweedfs/templates/volume/statefulset.yaml
+++ b/bitnami/seaweedfs/templates/volume/statefulset.yaml
@@ -33,9 +33,7 @@ spec:
         {{- if and .Values.volume.config (empty .Values.volume.existingConfigmap) }}
         checksum/config: {{ include (print $.Template.BasePath "/volume/configmap.yaml") . | sha256sum }}
         {{- end }}
-        {{- if .Values.security.enabled }}
         checksum/security-config: {{ include (print $.Template.BasePath "/security-configmap.yaml") . | sha256sum }}
-        {{- end }}
         {{- if .Values.volume.podAnnotations }}
         {{- include "common.tplvalues.render" (dict "value" .Values.volume.podAnnotations "context" $) | nindent 8 }}
         {{- end }}
@@ -139,9 +137,7 @@ spec:
           args:
             - -logtostderr=true
             - -v={{ .Values.volume.logLevel }}
-            {{- if or .Values.security.enabled .Values.volume.config .Values.volume.existingConfigmap }}
             - -config_dir=/etc/seaweedfs
-            {{- end }}
             - volume
             {{- $dataDirs := list }}
             {{- range .Values.volume.dataVolumes }}
@@ -248,7 +244,6 @@ spec:
               subPath: volume.toml
               readOnly: true
             {{- end }}
-            {{- if .Values.security.enabled }}
             - name: security-config
               mountPath: /etc/seaweedfs/security.toml
               subPath: security.toml
@@ -272,7 +267,6 @@ spec:
               readOnly: true
               mountPath: /certs/client
             {{- end }}
-            {{- end }}
           {{- if .Values.volume.extraVolumeMounts }}
           {{- include "common.tplvalues.render" (dict "value" .Values.volume.extraVolumeMounts "context" $) | nindent 12 }}
           {{- end }}
@@ -287,7 +281,6 @@ spec:
           configMap:
             name: {{ template "seaweedfs.volume.configmapName" . }}
         {{- end }}
-        {{- if .Values.security.enabled }}
         - name: security-config
           configMap:
             name: {{ printf "%s-security" (include "common.names.fullname" .) }}
@@ -312,7 +305,6 @@ spec:
         - name: client-cert
           secret:
             secretName: {{ template "seaweedfs.security.mTLS.client.secretName" . }}
-        {{- end }}
         {{- end }}
         {{- if .Values.volume.extraVolumes }}
         {{- include "common.tplvalues.render" (dict "value" .Values.volume.extraVolumes "context" $) | nindent 8 }}

--- a/bitnami/seaweedfs/templates/webadv/deployment.yaml
+++ b/bitnami/seaweedfs/templates/webadv/deployment.yaml
@@ -29,9 +29,7 @@ spec:
   template:
     metadata:
       annotations:
-        {{- if .Values.security.enabled }}
         checksum/security-config: {{ include (print $.Template.BasePath "/security-configmap.yaml") . | sha256sum }}
-        {{- end }}
         {{- if .Values.webdav.podAnnotations }}
         {{- include "common.tplvalues.render" (dict "value" .Values.webdav.podAnnotations "context" $) | nindent 8 }}
         {{- end }}
@@ -183,7 +181,6 @@ spec:
               mountPath: /certs/tls
               readOnly: true
             {{- end }}
-            {{- if .Values.security.enabled }}
             - name: security-config
               mountPath: /etc/seaweedfs/security.toml
               subPath: security.toml
@@ -205,7 +202,6 @@ spec:
               readOnly: true
               mountPath: /certs/client
             {{- end }}
-            {{- end }}
           {{- if .Values.webdav.extraVolumeMounts }}
           {{- include "common.tplvalues.render" (dict "value" .Values.webdav.extraVolumeMounts "context" $) | nindent 12 }}
           {{- end }}
@@ -220,7 +216,6 @@ spec:
           secret:
             secretName: {{ template "seaweedfs.webdav.tls.secretName" . }}
         {{- end }}
-        {{- if .Values.security.enabled }}
         - name: security-config
           configMap:
             name: {{ printf "%s-security" (include "common.names.fullname" .) }}
@@ -243,7 +238,6 @@ spec:
         - name: client-cert
           secret:
             secretName: {{ template "seaweedfs.security.mTLS.client.secretName" . }}
-        {{- end }}
         {{- end }}
         {{- if .Values.webdav.extraVolumes }}
         {{- include "common.tplvalues.render" (dict "value" .Values.webdav.extraVolumes "context" $) | nindent 8 }}


### PR DESCRIPTION
### Description of the change

This PR ensures we always mount the `security.toml` file at SeaweedFS components regardless security enhancements are enabled or not. When `security.enabled=false` we mount a dummy file like the one below:

```toml
# Security configuration
# Shared between master, volume and filer servers

# comma separated origins allowed to make requests to the filer and s3 gateway. 
# enter in this format: https://domain.com, or http://localhost:port
[cors.allowed_origins]
values = "*"
```

### Benefits

Avoids the warning below on SeaweedFS components' logs which leads users to confusion:

```console
I1106 05:53:12.968388 config.go:53 Reading : Config File "security" Not Found in "[/opt/bitnami/seaweedfs /opt/bitnami/seaweedfs/.seaweedfs /usr/local/etc/seaweedfs /etc/seaweedfs]"
```

### Possible drawbacks

None

### Applicable issues

None

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
