### PR TITLE
[bitnami/keycloak] Add servicemonitor apiVersion value

### DIFF
--- a/bitnami/keycloak/CHANGELOG.md
+++ b/bitnami/keycloak/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 24.1.0 (2024-11-05)
+## 24.1.1 (2024-11-06)
 
-* [bitnami/keycloak] switches keycloak-metrics service to point to new port ([#30095](https://github.com/bitnami/charts/pull/30095))
+* Add servicemonitor apiVersion value ([#30236](https://github.com/bitnami/charts/pull/30236))
+
+## 24.1.0 (2024-11-06)
+
+* [bitnami/keycloak] switches keycloak-metrics service to point to new port (#30095) ([8ca86ae](https://github.com/bitnami/charts/commit/8ca86ae9ecb2b375735787001188e5c7757d181b)), closes [#30095](https://github.com/bitnami/charts/issues/30095)
 
 ## <small>24.0.5 (2024-11-04)</small>
 

--- a/bitnami/keycloak/CHANGELOG.md
+++ b/bitnami/keycloak/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 24.1.1 (2024-11-06)
 
-* Add servicemonitor apiVersion value ([#30236](https://github.com/bitnami/charts/pull/30236))
+* [bitnami/keycloak] Add servicemonitor apiVersion value ([#30236](https://github.com/bitnami/charts/pull/30236))
 
 ## 24.1.0 (2024-11-06)
 

--- a/bitnami/keycloak/CHANGELOG.md
+++ b/bitnami/keycloak/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 24.1.1 (2024-11-06)
+## 24.1.1 (2024-11-08)
 
 * [bitnami/keycloak] Add servicemonitor apiVersion value ([#30236](https://github.com/bitnami/charts/pull/30236))
 

--- a/bitnami/keycloak/Chart.yaml
+++ b/bitnami/keycloak/Chart.yaml
@@ -33,4 +33,4 @@ maintainers:
 name: keycloak
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/keycloak
-version: 24.1.0
+version: 24.1.1

--- a/bitnami/keycloak/README.md
+++ b/bitnami/keycloak/README.md
@@ -547,6 +547,7 @@ As an alternative, you can use of the preset configurations for pod affinity, po
 | `metrics.service.annotations`              | Annotations for enabling prometheus to access the metrics endpoints                                                       | `{}`    |
 | `metrics.service.extraPorts`               | Add additional ports to the keycloak metrics service (i.e. admin port 9000)                                               | `[]`    |
 | `metrics.serviceMonitor.enabled`           | Create ServiceMonitor Resource for scraping metrics using PrometheusOperator                                              | `false` |
+| `metrics.serviceMonitor.apiVersion`        | ServiceMonitor API version                                                                                                | `monitoring.coreos.com/v1` |
 | `metrics.serviceMonitor.port`              | Metrics service HTTP port                                                                                                 | `http`  |
 | `metrics.serviceMonitor.endpoints`         | The endpoint configuration of the ServiceMonitor. Path is mandatory. Interval, timeout and labellings can be overwritten. | `[]`    |
 | `metrics.serviceMonitor.path`              | Metrics service HTTP path. Deprecated: Use @param metrics.serviceMonitor.endpoints instead                                | `""`    |

--- a/bitnami/keycloak/README.md
+++ b/bitnami/keycloak/README.md
@@ -540,30 +540,30 @@ As an alternative, you can use of the preset configurations for pod affinity, po
 
 ### Metrics parameters
 
-| Name                                       | Description                                                                                                               | Value   |
-| ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------- | ------- |
-| `metrics.enabled`                          | Enable exposing Keycloak statistics                                                                                       | `false` |
-| `metrics.service.ports.http`               | Metrics service HTTP port                                                                                                 | `9000`  |
-| `metrics.service.annotations`              | Annotations for enabling prometheus to access the metrics endpoints                                                       | `{}`    |
-| `metrics.service.extraPorts`               | Add additional ports to the keycloak metrics service (i.e. admin port 9000)                                               | `[]`    |
-| `metrics.serviceMonitor.enabled`           | Create ServiceMonitor Resource for scraping metrics using PrometheusOperator                                              | `false` |
+| Name                                       | Description                                                                                                               | Value                      |
+| ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------- | -------------------------- |
+| `metrics.enabled`                          | Enable exposing Keycloak statistics                                                                                       | `false`                    |
+| `metrics.service.ports.http`               | Metrics service HTTP port                                                                                                 | `9000`                     |
+| `metrics.service.annotations`              | Annotations for enabling prometheus to access the metrics endpoints                                                       | `{}`                       |
+| `metrics.service.extraPorts`               | Add additional ports to the keycloak metrics service (i.e. admin port 9000)                                               | `[]`                       |
+| `metrics.serviceMonitor.enabled`           | Create ServiceMonitor Resource for scraping metrics using PrometheusOperator                                              | `false`                    |
 | `metrics.serviceMonitor.apiVersion`        | ServiceMonitor API version                                                                                                | `monitoring.coreos.com/v1` |
-| `metrics.serviceMonitor.port`              | Metrics service HTTP port                                                                                                 | `http`  |
-| `metrics.serviceMonitor.endpoints`         | The endpoint configuration of the ServiceMonitor. Path is mandatory. Interval, timeout and labellings can be overwritten. | `[]`    |
-| `metrics.serviceMonitor.path`              | Metrics service HTTP path. Deprecated: Use @param metrics.serviceMonitor.endpoints instead                                | `""`    |
-| `metrics.serviceMonitor.namespace`         | Namespace which Prometheus is running in                                                                                  | `""`    |
-| `metrics.serviceMonitor.interval`          | Interval at which metrics should be scraped                                                                               | `30s`   |
-| `metrics.serviceMonitor.scrapeTimeout`     | Specify the timeout after which the scrape is ended                                                                       | `""`    |
-| `metrics.serviceMonitor.labels`            | Additional labels that can be used so ServiceMonitor will be discovered by Prometheus                                     | `{}`    |
-| `metrics.serviceMonitor.selector`          | Prometheus instance selector labels                                                                                       | `{}`    |
-| `metrics.serviceMonitor.relabelings`       | RelabelConfigs to apply to samples before scraping                                                                        | `[]`    |
-| `metrics.serviceMonitor.metricRelabelings` | MetricRelabelConfigs to apply to samples before ingestion                                                                 | `[]`    |
-| `metrics.serviceMonitor.honorLabels`       | honorLabels chooses the metric's labels on collisions with target labels                                                  | `false` |
-| `metrics.serviceMonitor.jobLabel`          | The name of the label on the target service to use as the job name in prometheus.                                         | `""`    |
-| `metrics.prometheusRule.enabled`           | Create PrometheusRule Resource for scraping metrics using PrometheusOperator                                              | `false` |
-| `metrics.prometheusRule.namespace`         | Namespace which Prometheus is running in                                                                                  | `""`    |
-| `metrics.prometheusRule.labels`            | Additional labels that can be used so PrometheusRule will be discovered by Prometheus                                     | `{}`    |
-| `metrics.prometheusRule.groups`            | Groups, containing the alert rules.                                                                                       | `[]`    |
+| `metrics.serviceMonitor.port`              | Metrics service HTTP port                                                                                                 | `http`                     |
+| `metrics.serviceMonitor.endpoints`         | The endpoint configuration of the ServiceMonitor. Path is mandatory. Interval, timeout and labellings can be overwritten. | `[]`                       |
+| `metrics.serviceMonitor.path`              | Metrics service HTTP path. Deprecated: Use @param metrics.serviceMonitor.endpoints instead                                | `""`                       |
+| `metrics.serviceMonitor.namespace`         | Namespace which Prometheus is running in                                                                                  | `""`                       |
+| `metrics.serviceMonitor.interval`          | Interval at which metrics should be scraped                                                                               | `30s`                      |
+| `metrics.serviceMonitor.scrapeTimeout`     | Specify the timeout after which the scrape is ended                                                                       | `""`                       |
+| `metrics.serviceMonitor.labels`            | Additional labels that can be used so ServiceMonitor will be discovered by Prometheus                                     | `{}`                       |
+| `metrics.serviceMonitor.selector`          | Prometheus instance selector labels                                                                                       | `{}`                       |
+| `metrics.serviceMonitor.relabelings`       | RelabelConfigs to apply to samples before scraping                                                                        | `[]`                       |
+| `metrics.serviceMonitor.metricRelabelings` | MetricRelabelConfigs to apply to samples before ingestion                                                                 | `[]`                       |
+| `metrics.serviceMonitor.honorLabels`       | honorLabels chooses the metric's labels on collisions with target labels                                                  | `false`                    |
+| `metrics.serviceMonitor.jobLabel`          | The name of the label on the target service to use as the job name in prometheus.                                         | `""`                       |
+| `metrics.prometheusRule.enabled`           | Create PrometheusRule Resource for scraping metrics using PrometheusOperator                                              | `false`                    |
+| `metrics.prometheusRule.namespace`         | Namespace which Prometheus is running in                                                                                  | `""`                       |
+| `metrics.prometheusRule.labels`            | Additional labels that can be used so PrometheusRule will be discovered by Prometheus                                     | `{}`                       |
+| `metrics.prometheusRule.groups`            | Groups, containing the alert rules.                                                                                       | `[]`                       |
 
 ### keycloak-config-cli parameters
 

--- a/bitnami/keycloak/templates/servicemonitor.yaml
+++ b/bitnami/keycloak/templates/servicemonitor.yaml
@@ -4,7 +4,7 @@ SPDX-License-Identifier: APACHE-2.0
 */}}
 
 {{- if and .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled }}
-apiVersion: monitoring.coreos.com/v1
+apiVersion: {{ .Values.metrics.serviceMonitor.apiVersion}}
 kind: ServiceMonitor
 metadata:
   name: {{ template "common.names.fullname" . }}

--- a/bitnami/keycloak/templates/servicemonitor.yaml
+++ b/bitnami/keycloak/templates/servicemonitor.yaml
@@ -4,7 +4,7 @@ SPDX-License-Identifier: APACHE-2.0
 */}}
 
 {{- if and .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled }}
-apiVersion: {{ .Values.metrics.serviceMonitor.apiVersion}}
+apiVersion: {{ .Values.metrics.serviceMonitor.apiVersion }}
 kind: ServiceMonitor
 metadata:
   name: {{ template "common.names.fullname" . }}

--- a/bitnami/keycloak/values.yaml
+++ b/bitnami/keycloak/values.yaml
@@ -1026,6 +1026,9 @@ metrics:
     ## @param metrics.serviceMonitor.enabled Create ServiceMonitor Resource for scraping metrics using PrometheusOperator
     ##
     enabled: false
+    ## @param metrics.serviceMonitor.apiVersion ServiceMonitor API version
+    ##
+    apiVersion: monitoring.coreos.com/v1
     ## @param metrics.serviceMonitor.port Metrics service HTTP port
     ##
     port: http


### PR DESCRIPTION
### Description of the change

Adds a configurable apiVersion for ServiceMonitor, enabling compatibility with custom monitoring services like Azure’s azmonitoring.coreos.com/v1

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
