### PR TITLE
[bitnami/seaweedfs] Support configuring max number of volumes per disk

### DIFF
--- a/bitnami/seaweedfs/CHANGELOG.md
+++ b/bitnami/seaweedfs/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 3.0.7 (2024-11-07)
+## 3.1.0 (2024-11-07)
 
-* [bitnami/seaweedfs] Release 3.0.7 ([#30292](https://github.com/bitnami/charts/pull/30292))
+* [bitnami/seaweedfs] Support configuring max number of volumes per disk ([#30294](https://github.com/bitnami/charts/pull/30294))
+
+## <small>3.0.7 (2024-11-07)</small>
+
+* [bitnami/seaweedfs] Release 3.0.7 (#30292) ([cc3cbf6](https://github.com/bitnami/charts/commit/cc3cbf69cc6523de1b28de138cbe38afda75a00f)), closes [#30292](https://github.com/bitnami/charts/issues/30292)
 
 ## <small>3.0.6 (2024-11-06)</small>
 

--- a/bitnami/seaweedfs/Chart.yaml
+++ b/bitnami/seaweedfs/Chart.yaml
@@ -50,4 +50,4 @@ name: seaweedfs
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/seawwedfs
 - https://github.com/bitnami/containers/tree/main/bitnami/seaweedfs
-version: 3.0.7
+version: 3.1.0

--- a/bitnami/seaweedfs/README.md
+++ b/bitnami/seaweedfs/README.md
@@ -564,19 +564,20 @@ If you encounter errors when working with persistent volumes, refer to our [trou
 
 ### Volume Server Persistence Parameters
 
-| Name                                              | Description                                                                                             | Value               |
-| ------------------------------------------------- | ------------------------------------------------------------------------------------------------------- | ------------------- |
-| `volume.dataVolumes[0].name`                      | Name of the data volume                                                                                 | `data-0`            |
-| `volume.dataVolumes[0].mountPath`                 | Path to mount the volume at.                                                                            | `/data-0`           |
-| `volume.dataVolumes[0].subPath`                   | The subdirectory of the volume to mount to, useful in dev environments and one PV for multiple services | `""`                |
-| `volume.dataVolumes[0].persistence.enabled`       | Enable persistence on Volume Server using Persistent Volume Claims                                      | `true`              |
-| `volume.dataVolumes[0].persistence.storageClass`  | Storage class of backing PVC                                                                            | `""`                |
-| `volume.dataVolumes[0].persistence.annotations`   | Persistent Volume Claim annotations                                                                     | `{}`                |
-| `volume.dataVolumes[0].persistence.accessModes`   | Persistent Volume Access Modes                                                                          | `["ReadWriteOnce"]` |
-| `volume.dataVolumes[0].persistence.size`          | Size of data volume                                                                                     | `8Gi`               |
-| `volume.dataVolumes[0].persistence.existingClaim` | The name of an existing PVC to use for persistence                                                      | `""`                |
-| `volume.dataVolumes[0].persistence.selector`      | Selector to match an existing Persistent Volume for data PVC                                            | `{}`                |
-| `volume.dataVolumes[0].persistence.dataSource`    | Custom PVC data source                                                                                  | `{}`                |
+| Name                                              | Description                                                                                                                                                                   | Value               |
+| ------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------- |
+| `volume.dataVolumes[0].name`                      | Name of the data volume                                                                                                                                                       | `data-0`            |
+| `volume.dataVolumes[0].mountPath`                 | Path to mount the volume at.                                                                                                                                                  | `/data-0`           |
+| `volume.dataVolumes[0].subPath`                   | The subdirectory of the volume to mount to, useful in dev environments and one PV for multiple services                                                                       | `""`                |
+| `volume.dataVolumes[0].maxVolumes`                | Max number of SeaweedFS volumes this data volume can be divided into. If set to 0, the limit will be auto configured as free disk space divided by default volume size (30GB) | `8`                 |
+| `volume.dataVolumes[0].persistence.enabled`       | Enable persistence on Volume Server using Persistent Volume Claims                                                                                                            | `true`              |
+| `volume.dataVolumes[0].persistence.storageClass`  | Storage class of backing PVC                                                                                                                                                  | `""`                |
+| `volume.dataVolumes[0].persistence.annotations`   | Persistent Volume Claim annotations                                                                                                                                           | `{}`                |
+| `volume.dataVolumes[0].persistence.accessModes`   | Persistent Volume Access Modes                                                                                                                                                | `["ReadWriteOnce"]` |
+| `volume.dataVolumes[0].persistence.size`          | Size of data volume                                                                                                                                                           | `8Gi`               |
+| `volume.dataVolumes[0].persistence.existingClaim` | The name of an existing PVC to use for persistence                                                                                                                            | `""`                |
+| `volume.dataVolumes[0].persistence.selector`      | Selector to match an existing Persistent Volume for data PVC                                                                                                                  | `{}`                |
+| `volume.dataVolumes[0].persistence.dataSource`    | Custom PVC data source                                                                                                                                                        | `{}`                |
 
 ### Volume Server Metrics Parameters
 

--- a/bitnami/seaweedfs/templates/volume/statefulset.yaml
+++ b/bitnami/seaweedfs/templates/volume/statefulset.yaml
@@ -140,10 +140,17 @@ spec:
             - -config_dir=/etc/seaweedfs
             - volume
             {{- $dataDirs := list }}
+            {{- $maxVolumes := list }}
             {{- range .Values.volume.dataVolumes }}
             {{- $dataDirs = append $dataDirs .mountPath }}
+            {{- if eq (.maxVolumes | toString) "0" }}
+            {{- $maxVolumes = append $maxVolumes 0 }}
+            {{- else }}
+            {{- $maxVolumes = append $maxVolumes (default 8 .maxVolumes) }}
+            {{- end }}
             {{- end }}
             - -dir={{ join "," $dataDirs }}
+            - -max={{ join "," $maxVolumes }}
             - -ip.bind={{ .Values.volume.bindAddress }}
             - -ip=$(POD_NAME).{{ printf "%s-headless" (include "seaweedfs.volume.fullname" .) }}.$(NAMESPACE).svc.{{ .Values.clusterDomain }}
             - -port={{ .Values.volume.containerPorts.http }}

--- a/bitnami/seaweedfs/values.yaml
+++ b/bitnami/seaweedfs/values.yaml
@@ -1361,6 +1361,11 @@ volume:
       ## @param volume.dataVolumes[0].subPath The subdirectory of the volume to mount to, useful in dev environments and one PV for multiple services
       ##
       subPath: ""
+      ## @param volume.dataVolumes[0].maxVolumes Max number of SeaweedFS volumes this data volume can be divided into. If set to 0, the limit will be auto configured as free disk space divided by default volume size (30GB)
+      ## ref: https://github.com/seaweedfs/seaweedfs/wiki/FAQ#how-many-volumes-do-i-need
+      ## ref: https://github.com/seaweedfs/seaweedfs/blob/master/weed/util/constants_4bytes.go#L8
+      ##
+      maxVolumes: 8
       ## Enable persistence using Persistent Volume Claims
       ## ref: https://kubernetes.io/docs/concepts/storage/persistent-volumes/
       ##


### PR DESCRIPTION
### Description of the change

This PR adds support for configuring the max. number of volume for each disk mounted on SeaweedFS Volume server.

### Benefits

Number of volumes can be properly customized, see:

- https://github.com/seaweedfs/seaweedfs/wiki/FAQ#how-many-volumes-do-i-need

### Possible drawbacks

None

### Applicable issues

None

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
