### PR TITLE
[bitnami/keycloak] Fix metrics ports and servicemonitor

### DIFF
--- a/bitnami/keycloak/CHANGELOG.md
+++ b/bitnami/keycloak/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 24.1.0 (2024-11-05)
+## 24.2.0 (2024-11-07)
 
-* [bitnami/keycloak] switches keycloak-metrics service to point to new port ([#30095](https://github.com/bitnami/charts/pull/30095))
+* [bitnami/keycloak] Fix metrics ports and servicemonitor ([#30303](https://github.com/bitnami/charts/pull/30303))
+
+## 24.1.0 (2024-11-06)
+
+* [bitnami/keycloak] switches keycloak-metrics service to point to new port (#30095) ([8ca86ae](https://github.com/bitnami/charts/commit/8ca86ae9ecb2b375735787001188e5c7757d181b)), closes [#30095](https://github.com/bitnami/charts/issues/30095)
 
 ## <small>24.0.5 (2024-11-04)</small>
 

--- a/bitnami/keycloak/CHANGELOG.md
+++ b/bitnami/keycloak/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 24.2.0 (2024-11-07)
+## 24.2.0 (2024-11-08)
 
 * [bitnami/keycloak] Fix metrics ports and servicemonitor ([#30303](https://github.com/bitnami/charts/pull/30303))
 

--- a/bitnami/keycloak/Chart.yaml
+++ b/bitnami/keycloak/Chart.yaml
@@ -33,4 +33,4 @@ maintainers:
 name: keycloak
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/keycloak
-version: 24.1.0
+version: 24.2.0

--- a/bitnami/keycloak/README.md
+++ b/bitnami/keycloak/README.md
@@ -540,29 +540,33 @@ As an alternative, you can use of the preset configurations for pod affinity, po
 
 ### Metrics parameters
 
-| Name                                       | Description                                                                                                               | Value   |
-| ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------- | ------- |
-| `metrics.enabled`                          | Enable exposing Keycloak statistics                                                                                       | `false` |
-| `metrics.service.ports.http`               | Metrics service HTTP port                                                                                                 | `9000`  |
-| `metrics.service.annotations`              | Annotations for enabling prometheus to access the metrics endpoints                                                       | `{}`    |
-| `metrics.service.extraPorts`               | Add additional ports to the keycloak metrics service (i.e. admin port 9000)                                               | `[]`    |
-| `metrics.serviceMonitor.enabled`           | Create ServiceMonitor Resource for scraping metrics using PrometheusOperator                                              | `false` |
-| `metrics.serviceMonitor.port`              | Metrics service HTTP port                                                                                                 | `http`  |
-| `metrics.serviceMonitor.endpoints`         | The endpoint configuration of the ServiceMonitor. Path is mandatory. Interval, timeout and labellings can be overwritten. | `[]`    |
-| `metrics.serviceMonitor.path`              | Metrics service HTTP path. Deprecated: Use @param metrics.serviceMonitor.endpoints instead                                | `""`    |
-| `metrics.serviceMonitor.namespace`         | Namespace which Prometheus is running in                                                                                  | `""`    |
-| `metrics.serviceMonitor.interval`          | Interval at which metrics should be scraped                                                                               | `30s`   |
-| `metrics.serviceMonitor.scrapeTimeout`     | Specify the timeout after which the scrape is ended                                                                       | `""`    |
-| `metrics.serviceMonitor.labels`            | Additional labels that can be used so ServiceMonitor will be discovered by Prometheus                                     | `{}`    |
-| `metrics.serviceMonitor.selector`          | Prometheus instance selector labels                                                                                       | `{}`    |
-| `metrics.serviceMonitor.relabelings`       | RelabelConfigs to apply to samples before scraping                                                                        | `[]`    |
-| `metrics.serviceMonitor.metricRelabelings` | MetricRelabelConfigs to apply to samples before ingestion                                                                 | `[]`    |
-| `metrics.serviceMonitor.honorLabels`       | honorLabels chooses the metric's labels on collisions with target labels                                                  | `false` |
-| `metrics.serviceMonitor.jobLabel`          | The name of the label on the target service to use as the job name in prometheus.                                         | `""`    |
-| `metrics.prometheusRule.enabled`           | Create PrometheusRule Resource for scraping metrics using PrometheusOperator                                              | `false` |
-| `metrics.prometheusRule.namespace`         | Namespace which Prometheus is running in                                                                                  | `""`    |
-| `metrics.prometheusRule.labels`            | Additional labels that can be used so PrometheusRule will be discovered by Prometheus                                     | `{}`    |
-| `metrics.prometheusRule.groups`            | Groups, containing the alert rules.                                                                                       | `[]`    |
+| Name                                       | Description                                                                                                                                        | Value     |
+| ------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------- | --------- |
+| `metrics.enabled`                          | Enable exposing Keycloak statistics                                                                                                                | `false`   |
+| `metrics.service.ports.http`               | Metrics service HTTP port                                                                                                                          | `8080`    |
+| `metrics.service.ports.https`              | Metrics service HTTPS port                                                                                                                         | `8443`    |
+| `metrics.service.ports.metrics`            | Metrics service Metrics port                                                                                                                       | `9000`    |
+| `metrics.service.annotations`              | Annotations for enabling prometheus to access the metrics endpoints                                                                                | `{}`      |
+| `metrics.service.extraPorts`               | Add additional ports to the keycloak metrics service (i.e. admin port 9000)                                                                        | `[]`      |
+| `metrics.serviceMonitor.enabled`           | Create ServiceMonitor Resource for scraping metrics using PrometheusOperator                                                                       | `false`   |
+| `metrics.serviceMonitor.port`              | Metrics service HTTP port                                                                                                                          | `metrics` |
+| `metrics.serviceMonitor.scheme`            | Metrics service scheme                                                                                                                             | `http`    |
+| `metrics.serviceMonitor.tlsConfig`         | Metrics service TLS configuration                                                                                                                  | `{}`      |
+| `metrics.serviceMonitor.endpoints`         | The endpoint configuration of the ServiceMonitor. Path is mandatory. Port, scheme, tlsConfig, interval, timeout and labellings can be overwritten. | `[]`      |
+| `metrics.serviceMonitor.path`              | Metrics service HTTP path. Deprecated: Use @param metrics.serviceMonitor.endpoints instead                                                         | `""`      |
+| `metrics.serviceMonitor.namespace`         | Namespace which Prometheus is running in                                                                                                           | `""`      |
+| `metrics.serviceMonitor.interval`          | Interval at which metrics should be scraped                                                                                                        | `30s`     |
+| `metrics.serviceMonitor.scrapeTimeout`     | Specify the timeout after which the scrape is ended                                                                                                | `""`      |
+| `metrics.serviceMonitor.labels`            | Additional labels that can be used so ServiceMonitor will be discovered by Prometheus                                                              | `{}`      |
+| `metrics.serviceMonitor.selector`          | Prometheus instance selector labels                                                                                                                | `{}`      |
+| `metrics.serviceMonitor.relabelings`       | RelabelConfigs to apply to samples before scraping                                                                                                 | `[]`      |
+| `metrics.serviceMonitor.metricRelabelings` | MetricRelabelConfigs to apply to samples before ingestion                                                                                          | `[]`      |
+| `metrics.serviceMonitor.honorLabels`       | honorLabels chooses the metric's labels on collisions with target labels                                                                           | `false`   |
+| `metrics.serviceMonitor.jobLabel`          | The name of the label on the target service to use as the job name in prometheus.                                                                  | `""`      |
+| `metrics.prometheusRule.enabled`           | Create PrometheusRule Resource for scraping metrics using PrometheusOperator                                                                       | `false`   |
+| `metrics.prometheusRule.namespace`         | Namespace which Prometheus is running in                                                                                                           | `""`      |
+| `metrics.prometheusRule.labels`            | Additional labels that can be used so PrometheusRule will be discovered by Prometheus                                                              | `{}`      |
+| `metrics.prometheusRule.groups`            | Groups, containing the alert rules.                                                                                                                | `[]`      |
 
 ### keycloak-config-cli parameters
 

--- a/bitnami/keycloak/templates/NOTES.txt
+++ b/bitnami/keycloak/templates/NOTES.txt
@@ -89,7 +89,7 @@ You can access the Prometheus metrics following the steps below:
 
 1. Get the Keycloak Prometheus metrics URL by running:
 
-    {{- $metricsPort := coalesce .Values.metrics.service.ports.http .Values.metrics.service.port | toString }}
+    {{- $metricsPort := coalesce .Values.metrics.service.ports.metrics .Values.metrics.service.port | toString }}
     kubectl port-forward --namespace {{ include "common.names.namespace" . }} svc/{{ printf "%s-metrics" (include "common.names.fullname" .) }} {{ $metricsPort }}:{{ $metricsPort }} &
     echo "Keycloak Prometheus metrics URL: http://127.0.0.1:{{ $metricsPort }}/metrics"
 

--- a/bitnami/keycloak/templates/metrics-service.yaml
+++ b/bitnami/keycloak/templates/metrics-service.yaml
@@ -18,10 +18,20 @@ metadata:
 spec:
   type: ClusterIP
   ports:
+    - name: metrics
+      port: {{ .Values.metrics.service.ports.metrics }}
+      protocol: TCP
+      targetPort: {{ .Values.containerPorts.metrics }}
     - name: http
       port: {{ .Values.metrics.service.ports.http }}
       protocol: TCP
-      targetPort: {{ .Values.containerPorts.metrics }}
+      targetPort: {{ .Values.containerPorts.http }}
+    {{- if .Values.tls.enabled }}
+    - name: https
+      port: {{ .Values.metrics.service.ports.https }}
+      protocol: TCP
+      targetPort: {{ .Values.containerPorts.https }}
+    {{- end }}
     {{- if .Values.metrics.service.extraPorts }}
     {{- include "common.tplvalues.render" (dict "value" .Values.metrics.service.extraPorts "context" $) | nindent 4 }}
     {{- end }}      

--- a/bitnami/keycloak/templates/servicemonitor.yaml
+++ b/bitnami/keycloak/templates/servicemonitor.yaml
@@ -20,11 +20,15 @@ spec:
   jobLabel: {{ .Values.metrics.serviceMonitor.jobLabel }}
   {{- end }}
   endpoints:
-    {{- $defaultEndpoint := pick .Values.metrics.serviceMonitor "port" "interval" "scrapeTimeout" "relabelings" "metricRelabelings" "honorLabels" }}
+    {{- $defaultEndpoint := pick .Values.metrics.serviceMonitor "port" "scheme" "tlsConfig" "interval" "scrapeTimeout" "relabelings" "metricRelabelings" "honorLabels" }}
     {{- $endpoints := ternary (.Values.metrics.serviceMonitor.endpoints) (list (dict "path" .Values.metrics.serviceMonitor.path)) (empty .Values.metrics.serviceMonitor.path) }}
     {{- range $endpoints }}
     {{- $endpoint := merge . $defaultEndpoint }}
     - port: {{ $endpoint.port | quote }}
+      scheme: {{ $endpoint.scheme | quote }}
+      {{- if $endpoint.tlsConfig }}
+      tlsConfig: {{- include "common.tplvalues.render" ( dict "value" $endpoint.tlsConfig "context" $) | nindent 8 }}
+      {{- end }}
       path: {{ include "common.tplvalues.render" ( dict "value" $endpoint.path "context" $) }}
       {{- if $endpoint.interval }}
       interval: {{ $endpoint.interval }}

--- a/bitnami/keycloak/values.yaml
+++ b/bitnami/keycloak/values.yaml
@@ -1008,15 +1008,21 @@ metrics:
   ## Keycloak metrics service parameters
   ##
   service:
-    ## @param metrics.service.ports.http Metrics service HTTP port
-    ##
     ports:
-      http: 9000
+      ## @param metrics.service.ports.http Metrics service HTTP port
+      ##
+      http: 8080
+      ## @param metrics.service.ports.https Metrics service HTTPS port
+      ##
+      https: 8443
+      ## @param metrics.service.ports.metrics Metrics service Metrics port
+      ##
+      metrics: 9000
     ## @param metrics.service.annotations [object] Annotations for enabling prometheus to access the metrics endpoints
     ##
     annotations:
       prometheus.io/scrape: "true"
-      prometheus.io/port: "{{ .Values.metrics.service.ports.http }}"
+      prometheus.io/port: "{{ .Values.metrics.service.ports.metrics }}"
     ## @param metrics.service.extraPorts [array] Add additional ports to the keycloak metrics service (i.e. admin port 9000)
     ##
     extraPorts: []
@@ -1028,12 +1034,19 @@ metrics:
     enabled: false
     ## @param metrics.serviceMonitor.port Metrics service HTTP port
     ##
-    port: http
-    ## @param metrics.serviceMonitor.endpoints [array] The endpoint configuration of the ServiceMonitor. Path is mandatory. Interval, timeout and labellings can be overwritten.
+    port: metrics
+    ## @param metrics.serviceMonitor.scheme Metrics service scheme
+    ##
+    scheme: http
+    ## @param metrics.serviceMonitor.tlsConfig Metrics service TLS configuration
+    ##
+    tlsConfig: {}
+    ## @param metrics.serviceMonitor.endpoints [array] The endpoint configuration of the ServiceMonitor. Path is mandatory. Port, scheme, tlsConfig, interval, timeout and labellings can be overwritten.
     ##
     endpoints:
       - path: '{{ include "keycloak.httpPath" . }}metrics'
       - path: '{{ include "keycloak.httpPath" . }}realms/{{ .Values.adminRealm }}/metrics'
+        port: http
     ## @param metrics.serviceMonitor.path Metrics service HTTP path. Deprecated: Use @param metrics.serviceMonitor.endpoints instead
     ##
     path: ""


### PR DESCRIPTION
### Description of the change

Fixes metrics collection by:
* adding the possibility to overwrite the ```port``` for each serviceMonitor's endpoint
* adding ```scheme``` and ```tlsConfig``` support to serviceMonitor
* adding all required ports to ```keycloak-metrics``` service

As explained in #28975, a recent update changed ```/metrics``` to be exposed through the management port (9000). However, the realms' metrics (```/realms/<realm>/metrics```) are still exposed through the http (8080), or https (8443) ports.
This causes 2 issues:
* Metrics service only expose the 9000 port, and the service monitor has both ```/metrics``` and ```/realms/master/metrics``` endpoints configured in default values. The latter fails as it's not exposed on the management port, and http port isn't present in the service (nor serviceMonitor)
* When ```tls.enabled=true``` is defined, ```/metrics``` also fails because the management port is now exposed over HTTPS. Since there is no ```scheme``` defined in the service monitor, it tries over HTTP, which ends up in an error.

### Benefits

ServiceMonitor now works out of the box with default values.yaml, for both endpoints.
Also, serviceMonitor now works when `tls.enabled=true`.


### Possible drawbacks

The metrics service port's name changed. With default values, previously the port named ```http``` was 9000. Now it's the actual http port from the container (8080). Port 9000 has been named ```metrics```, the same as in the container. The first port of the service is still the 9000, and `metrics` has been defined as default in the serviceMonitor to ensure backward compatibility.   
It should be transparent in most cases, but it might be a breaking change for some users who use that service for something else (outside the chart) and expect port 9000 to be named `http`.


### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #28975

### Additional information

Note that, as of now, realms metrics are exposed on both HTTP and HTTPS when TLS is enabled (HTTP isn't disabled), so the serviceMonitor can collect these through any, as long as the right port and scheme are defined. Example of values below:
```yaml
tls:
  enabled: true
  usePem: true
  existingSecret: keycloak-internal-tls
metrics:
  enabled: true
  serviceMonitor:
    enabled: true
    endpoints:
      - path: '/metrics'
        scheme: https
        tlsConfig:
          insecureSkipVerify: true
      - path: '/realms/master/metrics'
        port: http
      - path: '/realms/<my-realm>/metrics'
        port: https
        scheme: https
        tlsConfig:
          insecureSkipVerify: true
```

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
