### PR TITLE
[bitnami/cilium] Fix typos with clusterName and certificates

### DIFF
--- a/bitnami/cilium/CHANGELOG.md
+++ b/bitnami/cilium/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.2.7 (2024-11-08)
+## 1.2.7 (2024-11-11)
 
 * [bitnami/cilium] Fix typos with clusterName and certificates ([#30316](https://github.com/bitnami/charts/pull/30316))
 

--- a/bitnami/cilium/CHANGELOG.md
+++ b/bitnami/cilium/CHANGELOG.md
@@ -1,8 +1,14 @@
 # Changelog
 
-## 1.2.6 (2024-11-07)
+## 1.2.7 (2024-11-08)
 
-* [bitnami/cilium] Release 1.2.6 ([#30257](https://github.com/bitnami/charts/pull/30257))
+* [bitnami/cilium] Fix typos with clusterName and certificates ([#30316](https://github.com/bitnami/charts/pull/30316))
+
+## <small>1.2.6 (2024-11-07)</small>
+
+* [bitnami/*] Remove wrong comment about imagePullPolicy (#30107) ([a51f9e4](https://github.com/bitnami/charts/commit/a51f9e4bb0fbf77199512d35de7ac8abe055d026)), closes [#30107](https://github.com/bitnami/charts/issues/30107)
+* [bitnami/cilium] Release 1.2.6 (#30257) ([3c229a3](https://github.com/bitnami/charts/commit/3c229a35932ce356dcaf81fd11897c45726f330b)), closes [#30257](https://github.com/bitnami/charts/issues/30257)
+* Update documentation links to techdocs.broadcom.com (#29931) ([f0d9ad7](https://github.com/bitnami/charts/commit/f0d9ad78f39f633d275fc576d32eae78ded4d0b8)), closes [#29931](https://github.com/bitnami/charts/issues/29931)
 
 ## <small>1.2.5 (2024-10-16)</small>
 

--- a/bitnami/cilium/Chart.yaml
+++ b/bitnami/cilium/Chart.yaml
@@ -52,4 +52,4 @@ sources:
 - https://github.com/bitnami/containers/tree/main/bitnami/hubble-relay
 - https://github.com/bitnami/containers/tree/main/bitnami/hubble-ui
 - https://github.com/bitnami/containers/tree/main/bitnami/hubble-ui-backend
-version: 1.2.6
+version: 1.2.7

--- a/bitnami/cilium/templates/hubble-relay/configmap.yaml
+++ b/bitnami/cilium/templates/hubble-relay/configmap.yaml
@@ -30,8 +30,8 @@ tls-relay-server-cert-file: /certs/relay/tls.crt
 tls-relay-server-key-file: /certs/relay/tls.key
 tls-relay-client-ca-files: /certs/relay/ca.crt
 tls-hubble-server-ca-files: /certs/relay/ca.crt
-tls-hubble-client-cert-file: /certs/client/tls.crt
-tls-hubble-client-key-file: /certs/client/tls.key
+tls-hubble-client-cert-file: /certs/relay/tls.crt
+tls-hubble-client-key-file: /certs/relay/tls.key
 {{- else }}
 disable-client-tls: true
 disable-server-tls: true

--- a/bitnami/cilium/templates/hubble-relay/configmap.yaml
+++ b/bitnami/cilium/templates/hubble-relay/configmap.yaml
@@ -10,7 +10,7 @@ Return the Hubbley Relay configuration.
 {{- if .Values.hubble.relay.configuration }}
 {{- include "common.tplvalues.render" (dict "value" .Values.hubble.relay.configuration .) }}
 {{- else }}
-cluster-name: default
+cluster-name: {{ .Values.clusterName | quote }}
 peer-service: {{ printf "%s.%s.svc.%s:%d" (printf "%s-hubble-peers" (include "common.names.fullname" .) | trunc 63 | trimSuffix "-") (include "common.names.namespace" .) .Values.clusterDomain (int .Values.hubble.peers.service.port) | quote }}
 listen-address: {{ printf ":%d" (int .Values.hubble.relay.containerPorts.grpc) | quote }}
 {{- if .Values.hubble.relay.metrics.enabled }}
@@ -26,12 +26,12 @@ pprof-listen-address: "localhost"
 pprof-port: {{ printf "%d" (int .Values.hubble.relay.containerPorts.pprof) | quote }}
 {{- end }}
 {{- if .Values.hubble.tls.enabled }}
-tls-hubble-client-cert-file: /certs/relay/tls.crt
-tls-hubble-client-key-file: /certs/relay/tls.key
-tls-hubble-server-ca-files: /certs/relay/ca.crt
 tls-relay-server-cert-file: /certs/relay/tls.crt
 tls-relay-server-key-file: /certs/relay/tls.key
 tls-relay-client-ca-files: /certs/relay/ca.crt
+tls-hubble-server-ca-files: /certs/relay/ca.crt
+tls-hubble-client-cert-file: /certs/client/tls.crt
+tls-hubble-client-key-file: /certs/client/tls.key
 {{- else }}
 disable-client-tls: true
 disable-server-tls: true


### PR DESCRIPTION
### Description of the change

This change allows the usage of a different cluster-name for hubble-relay configmap. Also set  `tls-hubble-client-cert-file` `tls-hubble-client-key-file` to use the client certificate.

### Benefits

* Allows setting cluster-name to a value different from 'default'.
* Use the expected certificates

### Possible drawbacks

N/A

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- Related #30264

### Additional information

Upstream logic
https://github.com/cilium/cilium/blob/3a988cd59c83355891f4d61815baf260caf6bf1f/install/kubernetes/cilium/templates/hubble-relay/configmap.yaml#L36-L38
https://github.com/cilium/cilium/blob/3a988cd59c83355891f4d61815baf260caf6bf1f/install/kubernetes/cilium/templates/_extensions.tpl#L20-L38

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
