### PR TITLE
[bitnami/zipkin] Unify seLinuxOptions default value

### DIFF
--- a/bitnami/zipkin/Chart.yaml
+++ b/bitnami/zipkin/Chart.yaml
@@ -35,4 +35,4 @@ sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/zipkin
 - https://github.com/bitnami/containers/tree/main/bitnami/zipkin
 - https://github.com/openzipkin/zipkin
-version: 1.0.2
+version: 1.0.3

--- a/bitnami/zipkin/values.yaml
+++ b/bitnami/zipkin/values.yaml
@@ -300,7 +300,7 @@ podSecurityContext:
 ##
 containerSecurityContext:
   enabled: true
-  seLinuxOptions: null
+  seLinuxOptions: {}
   runAsUser: 1001
   runAsGroup: 1001
   runAsNonRoot: true


### PR DESCRIPTION
### Description of the change

Unify the usage of `seLinuxOptions: {}` instead of using `seLinuxOptions: null`. It is the one used in our [templates](https://github.com/bitnami/charts/blob/0dc86e09237ecaabf57d6c7b66d53dd461256e69/template/CHART_NAME/values.yaml#L223);

### Benefits

Code consistency.

### Possible drawbacks

N/A

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
