### PR TITLE
[bitnami/keycloak] KEYCLOAK_HOSTNAME present even if KEYCLOAK_PROXY_HEADERS is set

### DIFF
--- a/bitnami/keycloak/Chart.yaml
+++ b/bitnami/keycloak/Chart.yaml
@@ -33,4 +33,4 @@ maintainers:
 name: keycloak
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/keycloak
-version: 24.1.0
+version: 24.1.1

--- a/bitnami/keycloak/templates/configmap-env-vars.yaml
+++ b/bitnami/keycloak/templates/configmap-env-vars.yaml
@@ -35,7 +35,7 @@ data:
       {{- include "common.tplvalues.render" (dict "value" $path "context" $) }}
     {{- end }}
   {{- end }}
-  {{- if and .Values.ingress.enabled .Values.ingress.hostname }}
+  {{- if and .Values.ingress.enabled (and .Values.ingress.hostname (not (empty .Values.proxyHeaders))) }}
   KEYCLOAK_HOSTNAME: |-
     {{ ternary "https://" "http://" ( or .Values.ingress.tls (eq .Values.proxy "edge") (not (empty .Values.proxyHeaders)) ) -}}
     {{- include "common.tplvalues.render" (dict "value" .Values.ingress.hostname "context" $) -}}


### PR DESCRIPTION
### Description of the change

When the helm proxyHeaders variable is set, the KEYCLOAK_HOSTNAME into the config map should not be set.

### Benefits

Improve chart to respect the keycloak documentation.

### Possible drawbacks

None

### Applicable issues

- fixes #30182

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
