### PR TITLE
[bitnami/argo-cd] Fix repo-server PDB label selector

### DIFF
--- a/bitnami/argo-cd/CHANGELOG.md
+++ b/bitnami/argo-cd/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 7.0.22 (2024-11-07)
+## 7.0.23 (2024-11-11)
 
-* [bitnami/argo-cd] Release 7.0.22 ([#30253](https://github.com/bitnami/charts/pull/30253))
+* [bitnami/argo-cd] Fix repo-server PDB label selector ([#30391](https://github.com/bitnami/charts/pull/30391))
+
+## <small>7.0.22 (2024-11-07)</small>
+
+* [bitnami/argo-cd] Release 7.0.22 (#30253) ([981c935](https://github.com/bitnami/charts/commit/981c9350763c152831eaa8dc310b3abd585fd705)), closes [#30253](https://github.com/bitnami/charts/issues/30253)
 
 ## <small>7.0.21 (2024-11-04)</small>
 

--- a/bitnami/argo-cd/Chart.yaml
+++ b/bitnami/argo-cd/Chart.yaml
@@ -39,4 +39,4 @@ maintainers:
 name: argo-cd
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/argo-cd
-version: 7.0.22
+version: 7.0.23

--- a/bitnami/argo-cd/templates/repo-server/pdb.yaml
+++ b/bitnami/argo-cd/templates/repo-server/pdb.yaml
@@ -10,7 +10,7 @@ metadata:
   name: {{ include "argocd.repo-server" . }}
   namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
-    app.kubernetes.io/component: repoServer
+    app.kubernetes.io/component: repo-server
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
@@ -24,5 +24,5 @@ spec:
   {{- $podLabels := include "common.tplvalues.merge" (dict "values" (list .Values.repoServer.podLabels .Values.commonLabels) "context" .) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
-      app.kubernetes.io/component: repoServer
+      app.kubernetes.io/component: repo-server
 {{- end }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Fix the label selector for the repo-server Deployment ("kubernetes.io/component: repo-server") used by the corresponding PDB (was: "kubernetes.io/component: repoServer").

### Benefits

The PDB is satisfied.

### Possible drawbacks

None.

### Applicable issues

- fixes #30228 

### Additional information

A better fix might be to put all component labels into values (or named templates) and using them where applicable.

Also, the component labels are a bit inconsistent right now: The application-set has "applicationSet", but the repo-server has "repo-server". But changing that would require a major release.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
