### PR TITLE
[bitnami/nats] Expose `publishNotReadyAddresses` on headless service

### DIFF
--- a/bitnami/nats/CHANGELOG.md
+++ b/bitnami/nats/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 8.4.9 (2024-11-11)
 
-* [bitnami/nats] Expose `publishNotReadyAddresses` headless service ([#30393](https://github.com/bitnami/charts/pull/30393))
+* [bitnami/nats] Expose `publishNotReadyAddresses` on headless service ([#30393](https://github.com/bitnami/charts/pull/30393))
 
 ## <small>8.4.8 (2024-11-08)</small>
 

--- a/bitnami/nats/CHANGELOG.md
+++ b/bitnami/nats/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 8.4.8 (2024-11-08)
+## 8.4.9 (2024-11-11)
 
-* [bitnami/nats] Unify seLinuxOptions default value ([#30340](https://github.com/bitnami/charts/pull/30340))
+* [bitnami/nats] Expose `publishNotReadyAddresses` headless service ([#30393](https://github.com/bitnami/charts/pull/30393))
+
+## <small>8.4.8 (2024-11-08)</small>
+
+* [bitnami/nats] Unify seLinuxOptions default value (#30340) ([697dc7b](https://github.com/bitnami/charts/commit/697dc7bf0d5d8f8059fb1c32207fb81e712ab6a9)), closes [#30340](https://github.com/bitnami/charts/issues/30340)
 
 ## <small>8.4.7 (2024-11-07)</small>
 

--- a/bitnami/nats/Chart.yaml
+++ b/bitnami/nats/Chart.yaml
@@ -31,4 +31,4 @@ maintainers:
 name: nats
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/nats
-version: 8.4.8
+version: 8.4.9

--- a/bitnami/nats/README.md
+++ b/bitnami/nats/README.md
@@ -259,45 +259,46 @@ As an alternative, you can use of the preset configurations for pod affinity, po
 
 ### Traffic Exposure parameters
 
-| Name                                    | Description                                                                                                                      | Value                    |
-| --------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- | ------------------------ |
-| `service.type`                          | NATS service type                                                                                                                | `ClusterIP`              |
-| `service.ports.client`                  | NATS client service port                                                                                                         | `4222`                   |
-| `service.ports.cluster`                 | NATS cluster service port                                                                                                        | `6222`                   |
-| `service.ports.monitoring`              | NATS monitoring service port                                                                                                     | `8222`                   |
-| `service.nodePorts.client`              | Node port for clients                                                                                                            | `""`                     |
-| `service.nodePorts.cluster`             | Node port for clustering                                                                                                         | `""`                     |
-| `service.nodePorts.monitoring`          | Node port for monitoring                                                                                                         | `""`                     |
-| `service.sessionAffinity`               | Control where client requests go, to the same pod or round-robin                                                                 | `None`                   |
-| `service.sessionAffinityConfig`         | Additional settings for the sessionAffinity                                                                                      | `{}`                     |
-| `service.clusterIP`                     | NATS service Cluster IP                                                                                                          | `""`                     |
-| `service.loadBalancerIP`                | NATS service Load Balancer IP                                                                                                    | `""`                     |
-| `service.loadBalancerSourceRanges`      | NATS service Load Balancer sources                                                                                               | `[]`                     |
-| `service.externalTrafficPolicy`         | NATS service external traffic policy                                                                                             | `Cluster`                |
-| `service.annotations`                   | Additional custom annotations for NATS service                                                                                   | `{}`                     |
-| `service.extraPorts`                    | Extra ports to expose in the NATS service (normally used with the `sidecar` value)                                               | `[]`                     |
-| `service.headless.annotations`          | Annotations for the headless service.                                                                                            | `{}`                     |
-| `ingress.enabled`                       | Set to true to enable ingress record generation                                                                                  | `false`                  |
-| `ingress.pathType`                      | Ingress Path type                                                                                                                | `ImplementationSpecific` |
-| `ingress.apiVersion`                    | Override API Version (automatically detected if not set)                                                                         | `""`                     |
-| `ingress.hostname`                      | When the ingress is enabled, a host pointing to this will be created                                                             | `nats.local`             |
-| `ingress.path`                          | The Path to NATS. You may need to set this to '/*' in order to use this with ALB ingress controllers.                            | `/`                      |
-| `ingress.ingressClassName`              | IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)                                                    | `""`                     |
-| `ingress.annotations`                   | Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations. | `{}`                     |
-| `ingress.tls`                           | Enable TLS configuration for the host defined at `ingress.hostname` parameter                                                    | `false`                  |
-| `ingress.selfSigned`                    | Create a TLS secret for this ingress record using self-signed certificates generated by Helm                                     | `false`                  |
-| `ingress.extraHosts`                    | The list of additional hostnames to be covered with this ingress record.                                                         | `[]`                     |
-| `ingress.extraPaths`                    | Any additional arbitrary paths that may need to be added to the ingress under the main host.                                     | `[]`                     |
-| `ingress.extraTls`                      | The tls configuration for additional hostnames to be covered with this ingress record.                                           | `[]`                     |
-| `ingress.secrets`                       | If you're providing your own certificates, please use this to add the certificates as secrets                                    | `[]`                     |
-| `ingress.extraRules`                    | Additional rules to be covered with this ingress record                                                                          | `[]`                     |
-| `networkPolicy.enabled`                 | Enable creation of NetworkPolicy resources                                                                                       | `true`                   |
-| `networkPolicy.allowExternal`           | The Policy model to apply                                                                                                        | `true`                   |
-| `networkPolicy.allowExternalEgress`     | Allow the pod to access any range of port and all destinations.                                                                  | `true`                   |
-| `networkPolicy.extraIngress`            | Add extra ingress rules to the NetworkPolicy                                                                                     | `[]`                     |
-| `networkPolicy.extraEgress`             | Add extra ingress rules to the NetworkPolicy                                                                                     | `[]`                     |
-| `networkPolicy.ingressNSMatchLabels`    | Labels to match to allow traffic from other namespaces                                                                           | `{}`                     |
-| `networkPolicy.ingressNSPodMatchLabels` | Pod labels to match to allow traffic from other namespaces                                                                       | `{}`                     |
+| Name                                        | Description                                                                                                                      | Value                    |
+| ------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- | ------------------------ |
+| `service.type`                              | NATS service type                                                                                                                | `ClusterIP`              |
+| `service.ports.client`                      | NATS client service port                                                                                                         | `4222`                   |
+| `service.ports.cluster`                     | NATS cluster service port                                                                                                        | `6222`                   |
+| `service.ports.monitoring`                  | NATS monitoring service port                                                                                                     | `8222`                   |
+| `service.nodePorts.client`                  | Node port for clients                                                                                                            | `""`                     |
+| `service.nodePorts.cluster`                 | Node port for clustering                                                                                                         | `""`                     |
+| `service.nodePorts.monitoring`              | Node port for monitoring                                                                                                         | `""`                     |
+| `service.sessionAffinity`                   | Control where client requests go, to the same pod or round-robin                                                                 | `None`                   |
+| `service.sessionAffinityConfig`             | Additional settings for the sessionAffinity                                                                                      | `{}`                     |
+| `service.clusterIP`                         | NATS service Cluster IP                                                                                                          | `""`                     |
+| `service.loadBalancerIP`                    | NATS service Load Balancer IP                                                                                                    | `""`                     |
+| `service.loadBalancerSourceRanges`          | NATS service Load Balancer sources                                                                                               | `[]`                     |
+| `service.externalTrafficPolicy`             | NATS service external traffic policy                                                                                             | `Cluster`                |
+| `service.annotations`                       | Additional custom annotations for NATS service                                                                                   | `{}`                     |
+| `service.extraPorts`                        | Extra ports to expose in the NATS service (normally used with the `sidecar` value)                                               | `[]`                     |
+| `service.headless.annotations`              | Annotations for the headless service.                                                                                            | `{}`                     |
+| `service.headless.publishNotReadyAddresses` | Publishes the addresses of not ready Pods                                                                                        | `false`                  |
+| `ingress.enabled`                           | Set to true to enable ingress record generation                                                                                  | `false`                  |
+| `ingress.pathType`                          | Ingress Path type                                                                                                                | `ImplementationSpecific` |
+| `ingress.apiVersion`                        | Override API Version (automatically detected if not set)                                                                         | `""`                     |
+| `ingress.hostname`                          | When the ingress is enabled, a host pointing to this will be created                                                             | `nats.local`             |
+| `ingress.path`                              | The Path to NATS. You may need to set this to '/*' in order to use this with ALB ingress controllers.                            | `/`                      |
+| `ingress.ingressClassName`                  | IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)                                                    | `""`                     |
+| `ingress.annotations`                       | Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations. | `{}`                     |
+| `ingress.tls`                               | Enable TLS configuration for the host defined at `ingress.hostname` parameter                                                    | `false`                  |
+| `ingress.selfSigned`                        | Create a TLS secret for this ingress record using self-signed certificates generated by Helm                                     | `false`                  |
+| `ingress.extraHosts`                        | The list of additional hostnames to be covered with this ingress record.                                                         | `[]`                     |
+| `ingress.extraPaths`                        | Any additional arbitrary paths that may need to be added to the ingress under the main host.                                     | `[]`                     |
+| `ingress.extraTls`                          | The tls configuration for additional hostnames to be covered with this ingress record.                                           | `[]`                     |
+| `ingress.secrets`                           | If you're providing your own certificates, please use this to add the certificates as secrets                                    | `[]`                     |
+| `ingress.extraRules`                        | Additional rules to be covered with this ingress record                                                                          | `[]`                     |
+| `networkPolicy.enabled`                     | Enable creation of NetworkPolicy resources                                                                                       | `true`                   |
+| `networkPolicy.allowExternal`               | The Policy model to apply                                                                                                        | `true`                   |
+| `networkPolicy.allowExternalEgress`         | Allow the pod to access any range of port and all destinations.                                                                  | `true`                   |
+| `networkPolicy.extraIngress`                | Add extra ingress rules to the NetworkPolicy                                                                                     | `[]`                     |
+| `networkPolicy.extraEgress`                 | Add extra ingress rules to the NetworkPolicy                                                                                     | `[]`                     |
+| `networkPolicy.ingressNSMatchLabels`        | Labels to match to allow traffic from other namespaces                                                                           | `{}`                     |
+| `networkPolicy.ingressNSPodMatchLabels`     | Pod labels to match to allow traffic from other namespaces                                                                       | `{}`                     |
 
 ### Metrics parameters
 

--- a/bitnami/nats/templates/headless-svc.yaml
+++ b/bitnami/nats/templates/headless-svc.yaml
@@ -26,5 +26,6 @@ spec:
     - name: tcp-monitoring
       port: {{ .Values.service.ports.monitoring }}
       targetPort: monitoring
+  publishNotReadyAddresses: {{ .Values.service.headless.publishNotReadyAddresses }}
   {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}

--- a/bitnami/nats/values.yaml
+++ b/bitnami/nats/values.yaml
@@ -621,6 +621,9 @@ service:
     ## @param service.headless.annotations Annotations for the headless service.
     ##
     annotations: {}
+    ## @param service.headless.publishNotReadyAddresses Publishes the addresses of not ready Pods
+    ##
+    publishNotReadyAddresses: false
 ## NATS ingress parameters
 ## ref: https://kubernetes.io/docs/concepts/services-networking/ingress/
 ##


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

* Add the `publishNotReadyAddresses` config to NATS Headless Service
* Default to `false` (existing behavior)

### Benefits

Allow operators to specify `service.headless.publishNotReadyAddresses=true` if desired.

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #30392 

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
