### PR TITLE
Revert "Bump actions/download-artifact from 3.0.2 to 4.1.8"

### DIFF
--- a/.github/workflows/cd-pipeline.yml
+++ b/.github/workflows/cd-pipeline.yml
@@ -91,7 +91,7 @@ jobs:
       - vib-publish
     name: Update charts index
     steps:
-      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
         with:
           path: ~/artifacts
       # If we perform a checkout of the main branch, we will find conflicts with the submodules


### PR DESCRIPTION
Reverts bitnami/charts#30389