### PR TITLE
[bitnami/cillium] Bump version due to errors in the release process

### DIFF
--- a/bitnami/cilium/CHANGELOG.md
+++ b/bitnami/cilium/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 1.2.7 (2024-11-11)
+## 1.2.8 (2024-11-11)
 
-* [bitnami/cilium] Fix typos with clusterName and certificates ([#30316](https://github.com/bitnami/charts/pull/30316))
+* [bitnami/cillium] Bump version due to errors in the release process ([#30398](https://github.com/bitnami/charts/pull/30398))
+
+## <small>1.2.7 (2024-11-11)</small>
+
+* [bitnami/cilium] Fix typos with clusterName and certificates (#30316) ([1024066](https://github.com/bitnami/charts/commit/1024066f65e09505b31925b504a9457ed6a49c0c)), closes [#30316](https://github.com/bitnami/charts/issues/30316)
 
 ## <small>1.2.6 (2024-11-07)</small>
 

--- a/bitnami/cilium/Chart.yaml
+++ b/bitnami/cilium/Chart.yaml
@@ -52,4 +52,4 @@ sources:
 - https://github.com/bitnami/containers/tree/main/bitnami/hubble-relay
 - https://github.com/bitnami/containers/tree/main/bitnami/hubble-ui
 - https://github.com/bitnami/containers/tree/main/bitnami/hubble-ui-backend
-version: 1.2.7
+version: 1.2.8


### PR DESCRIPTION
### Description of the change

Bump version

### Benefits

Previous version was not released properly.

### Possible drawbacks

None

### Applicable issues

- fixes https://github.com/bitnami/charts/actions/runs/11776751872

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [ ] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [ ] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
