### PR TITLE
[bitnami/schema-registry] Update kafka subchart to 31.0.0

### DIFF
--- a/bitnami/schema-registry/CHANGELOG.md
+++ b/bitnami/schema-registry/CHANGELOG.md
@@ -1,8 +1,14 @@
 # Changelog
 
-## 21.0.3 (2024-11-04)
+## 22.0.0 (2024-11-12)
 
-* [bitnami/schema-registry] Release 21.0.3 ([#30190](https://github.com/bitnami/charts/pull/30190))
+* [bitnami/schema-registry] Update kafka subchart to 31.0.0 ([#30425](https://github.com/bitnami/charts/pull/30425))
+
+## <small>21.0.3 (2024-11-04)</small>
+
+* [bitnami/*] Remove wrong comment about imagePullPolicy (#30107) ([a51f9e4](https://github.com/bitnami/charts/commit/a51f9e4bb0fbf77199512d35de7ac8abe055d026)), closes [#30107](https://github.com/bitnami/charts/issues/30107)
+* [bitnami/schema-registry] Release 21.0.3 (#30190) ([e0c7e61](https://github.com/bitnami/charts/commit/e0c7e6100c124751454fb670e200220972c662e4)), closes [#30190](https://github.com/bitnami/charts/issues/30190)
+* Update documentation links to techdocs.broadcom.com (#29931) ([f0d9ad7](https://github.com/bitnami/charts/commit/f0d9ad78f39f633d275fc576d32eae78ded4d0b8)), closes [#29931](https://github.com/bitnami/charts/issues/29931)
 
 ## <small>21.0.2 (2024-09-25)</small>
 

--- a/bitnami/schema-registry/Chart.lock
+++ b/bitnami/schema-registry/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: kafka
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 30.1.8
+  version: 31.0.0
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.26.0
-digest: sha256:f5d34388298f1ad906ff393b7b8d33bd0b798017058a400794f25d7a681f890a
-generated: "2024-11-04T11:56:25.308840253Z"
+  version: 2.27.0
+digest: sha256:64e960c15f0ccf2a46ce96045a78ae8330e03349d0bd2b7a4704282baf64aa5c
+generated: "2024-11-12T15:43:32.935821+01:00"

--- a/bitnami/schema-registry/Chart.yaml
+++ b/bitnami/schema-registry/Chart.yaml
@@ -13,7 +13,7 @@ dependencies:
 - condition: kafka.enabled
   name: kafka
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 30.x.x
+  version: 31.x.x
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
   tags:
@@ -34,4 +34,4 @@ maintainers:
 name: schema-registry
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/schema-registry
-version: 21.0.3
+version: 22.0.0

--- a/bitnami/schema-registry/README.md
+++ b/bitnami/schema-registry/README.md
@@ -429,6 +429,10 @@ Find more information about how to deal with common errors related to Bitnami's 
 
 ## Upgrading
 
+### To 22.0.0
+
+This major updates the Kafka subchart to its newest major, 31.0.0. For more information on this subchart's major, please refer to [Kafka upgrade notes](https://github.com/bitnami/charts/tree/main/bitnami/kafka#to-3100).
+
 ### To 21.0.0
 
 This major updates the Kafka subchart to its newest major, 30.0.0. For more information on this subchart's major, please refer to [Kafka upgrade notes](https://github.com/bitnami/charts/tree/main/bitnami/kafka#to-3000).


### PR DESCRIPTION
### Description of the change

Update kafka subchar to version 31.0.0 (appVersion 3.9.0).

### Benefits

Use the latest stable version of Kafka subchart.

### Possible drawbacks

N/A

### Additional information

https://downloads.apache.org/kafka/3.9.0/RELEASE_NOTES.html

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
