### PR TITLE
[bitnami/spring-cloud-dataflow] Update kafka subchart to 31.0.0

### DIFF
--- a/bitnami/spring-cloud-dataflow/CHANGELOG.md
+++ b/bitnami/spring-cloud-dataflow/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 33.0.0 (2024-11-08)
+## 34.0.0 (2024-11-12)
 
-* [bitnami/spring-cloud-dataflow] chore!: :arrow_up: :boom: Bump MariaDB subchart to 20 ([#30359](https://github.com/bitnami/charts/pull/30359))
+* [bitnami/spring-cloud-dataflow] Update kafka subchart to 31.0.0 ([#30426](https://github.com/bitnami/charts/pull/30426))
+
+## 33.0.0 (2024-11-12)
+
+* [bitnami/spring-cloud-dataflow] chore!: :arrow_up: :boom: Bump MariaDB subchart to 20 (#30359) ([1369cbf](https://github.com/bitnami/charts/commit/1369cbfd07e26350d2b4fa91eeeb7c908fd49cca)), closes [#30359](https://github.com/bitnami/charts/issues/30359)
 
 ## <small>32.0.2 (2024-10-29)</small>
 

--- a/bitnami/spring-cloud-dataflow/Chart.lock
+++ b/bitnami/spring-cloud-dataflow/Chart.lock
@@ -1,15 +1,15 @@
 dependencies:
 - name: rabbitmq
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 15.0.5
+  version: 15.0.6
 - name: mariadb
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 20.0.0
 - name: kafka
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 30.1.8
+  version: 31.0.0
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 2.27.0
-digest: sha256:4de4514796f9a802813c6e3f70ab6e45cd7abf200995cabd5ca677e503c24865
-generated: "2024-11-08T16:28:35.057450428+01:00"
+digest: sha256:6afd9b2e3a3528a2479bb386b78dda42b12fc8a6be01f290413f72519f386d26
+generated: "2024-11-12T15:35:36.526658+01:00"

--- a/bitnami/spring-cloud-dataflow/Chart.yaml
+++ b/bitnami/spring-cloud-dataflow/Chart.yaml
@@ -33,7 +33,7 @@ dependencies:
 - condition: kafka.enabled
   name: kafka
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 30.x.x
+  version: 31.x.x
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
   tags:
@@ -53,4 +53,4 @@ maintainers:
 name: spring-cloud-dataflow
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/spring-cloud-dataflow
-version: 33.0.0
+version: 34.0.0

--- a/bitnami/spring-cloud-dataflow/README.md
+++ b/bitnami/spring-cloud-dataflow/README.md
@@ -765,6 +765,10 @@ Find more information about how to deal with common errors related to Bitnami He
 
 ## Upgrading
 
+### To 34.0.0
+
+This major updates the Kafka subchart to its newest major, 31.0.0. For more information on this subchart's major, please refer to [Kafka upgrade notes](https://github.com/bitnami/charts/tree/main/bitnami/kafka#to-3100).
+
 ### To 33.0.0
 
 This major bump updates the MariaDB subchart to version 20.0.0. This subchart updates the StatefulSet objects `serviceName` to use a headless service, as the current non-headless service attached to it was not providing DNS entries. This will cause an upgrade issue because it changes "immutable fields". To workaround it, delete the StatefulSet objects as follows (replace the RELEASE_NAME placeholder):


### PR DESCRIPTION
### Description of the change

Update kafka subchar to version 31.0.0 (appVersion 3.9.0).

### Benefits

Use the latest stable version of Kafka subchart.

### Possible drawbacks

N/A

### Additional information

https://downloads.apache.org/kafka/3.9.0/RELEASE_NOTES.html

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
