### PR TITLE
[bitnami/milvus] Update kafka subchart to 31.0.0

### DIFF
--- a/bitnami/milvus/CHANGELOG.md
+++ b/bitnami/milvus/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 9.0.12 (2024-11-07)
+## 10.0.0 (2024-11-12)
 
-* [bitnami/milvus] Release 9.0.12 ([#30282](https://github.com/bitnami/charts/pull/30282))
+* [bitnami/milvus] Update kafka subchart to 31.0.0 ([#30428](https://github.com/bitnami/charts/pull/30428))
+
+## <small>9.0.12 (2024-11-07)</small>
+
+* [bitnami/milvus] Release 9.0.12 (#30282) ([f175ffc](https://github.com/bitnami/charts/commit/f175ffc8b28e02cc24dc6b60d447facd550a2cea)), closes [#30282](https://github.com/bitnami/charts/issues/30282)
 
 ## <small>9.0.11 (2024-11-06)</small>
 

--- a/bitnami/milvus/Chart.lock
+++ b/bitnami/milvus/Chart.lock
@@ -1,15 +1,15 @@
 dependencies:
 - name: etcd
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 10.5.1
+  version: 10.5.2
 - name: kafka
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 30.1.8
+  version: 31.0.0
 - name: minio
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 14.8.3
+  version: 14.8.5
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.26.0
-digest: sha256:41325d86731770ca68cc3144f8597e9740ba222db1e3b3ddd4250d1ddd713f03
-generated: "2024-11-07T07:47:50.377417452Z"
+  version: 2.27.0
+digest: sha256:9943a08ac041bd2dd65fde971bb0cae6ca2fcb883f8dce3d0288b1a8807dfd7d
+generated: "2024-11-12T15:47:27.842392+01:00"

--- a/bitnami/milvus/Chart.yaml
+++ b/bitnami/milvus/Chart.yaml
@@ -23,7 +23,7 @@ dependencies:
 - condition: kafka.enabled
   name: kafka
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 30.x.x
+  version: 31.x.x
 - condition: minio.enabled
   name: minio
   repository: oci://registry-1.docker.io/bitnamicharts
@@ -48,4 +48,4 @@ maintainers:
 name: milvus
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/milvus
-version: 9.0.12
+version: 10.0.0

--- a/bitnami/milvus/README.md
+++ b/bitnami/milvus/README.md
@@ -1842,6 +1842,10 @@ Find more information about how to deal with common errors related to Bitnami's 
 
 ## Upgrading
 
+### To 10.0.0
+
+This major updates the Kafka subchart to its newest major, 31.0.0. For more information on this subchart's major, please refer to [Kafka upgrade notes](https://github.com/bitnami/charts/tree/main/bitnami/kafka#to-3100).
+
 ### To 9.0.0
 
 This major updates the Kafka subchart to its newest major, 30.0.0. For more information on this subchart's major, please refer to [Kafka upgrade notes](https://github.com/bitnami/charts/tree/main/bitnami/kafka#to-3000).


### PR DESCRIPTION
### Description of the change

Update kafka subchar to version 31.0.0 (appVersion 3.9.0).

### Benefits

Use the latest stable version of Kafka subchart.

### Possible drawbacks

N/A

### Additional information

https://downloads.apache.org/kafka/3.9.0/RELEASE_NOTES.html

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
