### PR TITLE
[bitnami/rabbitmq-cluster-operator] Fix msg topology operator PodDisruptionBudget

### DIFF
--- a/bitnami/rabbitmq-cluster-operator/CHANGELOG.md
+++ b/bitnami/rabbitmq-cluster-operator/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 4.3.27 (2024-11-08)
+## 4.3.28 (2024-11-13)
 
-* [bitnami/rabbitmq-cluster-operator] Unify seLinuxOptions default value ([#30332](https://github.com/bitnami/charts/pull/30332))
+* [bitnami/rabbitmq-cluster-operator] Fix msg topology operator PodDisruptionBudget ([#30445](https://github.com/bitnami/charts/pull/30445))
+
+## <small>4.3.27 (2024-11-08)</small>
+
+* [bitnami/rabbitmq-cluster-operator] Unify seLinuxOptions default value (#30332) ([1fabdf7](https://github.com/bitnami/charts/commit/1fabdf79e682fe49ac116aa65064bab744e6f429)), closes [#30332](https://github.com/bitnami/charts/issues/30332)
 
 ## <small>4.3.26 (2024-11-07)</small>
 

--- a/bitnami/rabbitmq-cluster-operator/Chart.yaml
+++ b/bitnami/rabbitmq-cluster-operator/Chart.yaml
@@ -37,4 +37,4 @@ maintainers:
 name: rabbitmq-cluster-operator
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/rabbitmq-cluster-operator
-version: 4.3.27
+version: 4.3.28

--- a/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/pdb.yaml
+++ b/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/pdb.yaml
@@ -3,7 +3,7 @@ Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- if .Values.msgTopologyOperator.pdb.create }}
+{{- if and .Values.msgTopologyOperator.enabled .Values.msgTopologyOperator.pdb.create }}
 apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:


### PR DESCRIPTION
### Description of the change

Fixes issue #30364 where PodDisruptionBudget for msg topology operator is created even though it is set to be disabled

### Applicable issues

- fixes #30364

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
