### PR TITLE
[bitnami/sealed-secrets] Fix namespace in PodDisruptionBudget

### DIFF
--- a/bitnami/sealed-secrets/CHANGELOG.md
+++ b/bitnami/sealed-secrets/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 2.4.11 (2024-11-08)
+## 2.4.12 (2024-11-18)
 
-* [bitnami/sealed-secrets] Unify seLinuxOptions default value ([#30324](https://github.com/bitnami/charts/pull/30324))
+* [bitnami/sealed-secrets] Fix namespace in PodDisruptionBudget ([#30453](https://github.com/bitnami/charts/pull/30453))
+
+## <small>2.4.11 (2024-11-08)</small>
+
+* [bitnami/sealed-secrets] Unify seLinuxOptions default value (#30324) ([a6d2a10](https://github.com/bitnami/charts/commit/a6d2a108b51b9e92f73775bf262e806a2993b9ec)), closes [#30324](https://github.com/bitnami/charts/issues/30324)
 
 ## <small>2.4.10 (2024-11-07)</small>
 

--- a/bitnami/sealed-secrets/Chart.yaml
+++ b/bitnami/sealed-secrets/Chart.yaml
@@ -29,4 +29,4 @@ name: sealed-secrets
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/sealed-secrets
 - https://github.com/bitnami-labs/sealed-secrets
-version: 2.4.11
+version: 2.4.12

--- a/bitnami/sealed-secrets/templates/pdb.yaml
+++ b/bitnami/sealed-secrets/templates/pdb.yaml
@@ -8,7 +8,7 @@ apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "common.names.fullname" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}


### PR DESCRIPTION
### Description of the change

Currently the PodDisruptionBudget in the sealed-secret chart is deployed to the release namespace. This however, is not necessarily the namespace the rest of the sealed-secrets manifests are deployed to (i.e. due to `.Values.namespaceOverride` being set).

That leads to a violated PodDisruptionBudget in the release namespace, as the pods it references are deployed to a different namespace.

This PR updates the namespace field in the PDB to have the same value as for example the deployment it references:

### Benefits

Setting `.Values.namespaceOverride` no longer breaks the PDB.

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
