### PR TITLE
[bitnami/mongodb] fix: Modify access modes to match YAML 1.2 schema

### DIFF
--- a/bitnami/mongodb/templates/arbiter/statefulset.yaml
+++ b/bitnami/mongodb/templates/arbiter/statefulset.yaml
@@ -287,7 +287,7 @@ spec:
         - name: common-scripts
           configMap:
             name: {{ printf "%s-common-scripts" (include "mongodb.fullname" .) }}
-            defaultMode: 0555
+            defaultMode: 0o555
         {{- if or .Values.arbiter.configuration .Values.arbiter.existingConfigmap }}
         - name: config
           configMap:
@@ -303,10 +303,10 @@ spec:
             items:
             - key: mongodb-ca-cert
               path: mongodb-ca-cert
-              mode: 0600
+              mode: 0o600
             - key: mongodb-ca-key
               path: mongodb-ca-key
-              mode: 0600
+              mode: 0o600
         {{- else }}
         - name: mongodb-certs-0
           secret:

--- a/bitnami/mongodb/templates/backup/cronjob.yaml
+++ b/bitnami/mongodb/templates/backup/cronjob.yaml
@@ -181,7 +181,7 @@ spec:
             - name: common-scripts
               configMap:
                 name: {{ printf "%s-common-scripts" (include "mongodb.fullname" .) }}
-                defaultMode: 0550
+                defaultMode: 0o550
             {{- if .Values.tls.enabled }}
             - name: certs
               emptyDir: {}
@@ -192,10 +192,10 @@ spec:
                 items:
                 - key: mongodb-ca-cert
                   path: mongodb-ca-cert
-                  mode: 0600
+                  mode: 0o600
                 - key: mongodb-ca-key
                   path: mongodb-ca-key
-                  mode: 0600
+                  mode: 0o600
             {{- else }}
             - name: mongodb-certs-0
               secret:

--- a/bitnami/mongodb/templates/hidden/statefulset.yaml
+++ b/bitnami/mongodb/templates/hidden/statefulset.yaml
@@ -468,7 +468,7 @@ spec:
         - name: common-scripts
           configMap:
             name: {{ printf "%s-common-scripts" (include "mongodb.fullname" .) }}
-            defaultMode: 0555
+            defaultMode: 0o555
         {{- if or .Values.initdbScriptsConfigMap .Values.initdbScripts }}
         - name: custom-init-scripts
           configMap:
@@ -486,7 +486,7 @@ spec:
         - name: scripts
           configMap:
             name: {{ printf "%s-scripts" (include "mongodb.fullname" .) }}
-            defaultMode: 0755
+            defaultMode: 0o755
         {{- if .Values.hidden.extraVolumes }}
         {{- include "common.tplvalues.render" (dict "value" .Values.hidden.extraVolumes "context" $) | nindent 8 }}
         {{- end }}
@@ -500,10 +500,10 @@ spec:
             items:
             - key: mongodb-ca-cert
               path: mongodb-ca-cert
-              mode: 0600
+              mode: 0o600
             - key: mongodb-ca-key
               path: mongodb-ca-key
-              mode: 0600
+              mode: 0o600
         {{- else }}
         {{- range $index, $secret := .Values.tls.hidden.existingSecrets }}
         - name: mongodb-certs-{{ $index }}

--- a/bitnami/mongodb/templates/replicaset/statefulset.yaml
+++ b/bitnami/mongodb/templates/replicaset/statefulset.yaml
@@ -472,7 +472,7 @@ spec:
         - name: common-scripts
           configMap:
             name: {{ printf "%s-common-scripts" (include "mongodb.fullname" .) }}
-            defaultMode: 0550
+            defaultMode: 0o550
         {{- if or .Values.initdbScriptsConfigMap .Values.initdbScripts }}
         - name: custom-init-scripts
           configMap:
@@ -490,7 +490,7 @@ spec:
         - name: scripts
           configMap:
             name: {{ printf "%s-scripts" (include "mongodb.fullname" .) }}
-            defaultMode: 0755
+            defaultMode: 0o755
         {{- if .Values.extraVolumes }}
         {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumes "context" $) | nindent 8 }}
         {{- end }}
@@ -504,10 +504,10 @@ spec:
             items:
             - key: mongodb-ca-cert
               path: mongodb-ca-cert
-              mode: 0600
+              mode: 0o600
             - key: mongodb-ca-key
               path: mongodb-ca-key
-              mode: 0600
+              mode: 0o600
         {{- else }}
         {{- range $index, $secret := .Values.tls.replicaset.existingSecrets }}
         - name: mongodb-certs-{{ $index }}

--- a/bitnami/mongodb/templates/standalone/dep-sts.yaml
+++ b/bitnami/mongodb/templates/standalone/dep-sts.yaml
@@ -419,7 +419,7 @@ spec:
         - name: common-scripts
           configMap:
             name: {{ printf "%s-common-scripts" (include "mongodb.fullname" .) }}
-            defaultMode: 0550
+            defaultMode: 0o550
         {{- if or .Values.initdbScriptsConfigMap .Values.initdbScripts }}
         - name: custom-init-scripts
           configMap:
@@ -443,10 +443,10 @@ spec:
             items:
             - key: mongodb-ca-cert
               path: mongodb-ca-cert
-              mode: 0600
+              mode: 0o600
             - key: mongodb-ca-key
               path: mongodb-ca-key
-              mode: 0600
+              mode: 0o600
         {{- else }}
         - name: mongodb-certs-0
           secret:


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change.
This change updates the access modes to match the [YAML 1.2 schema](https://yaml.org/spec/1.2-old/spec.html#id2805071)
 - Describe any known limitations with your change.
No limitations as far as I know
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

This change updates the access modes to match the YAML 1.2 schema

### Benefits

This change is preventing manifests from being malformed due to using YAML autoformatters that comply with the YAML 1.2 schema.

### Possible drawbacks

None

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
