### PR TITLE
[bitnami/flux] Fix incorrect argument mapping and add missing events-addr argument

### DIFF
--- a/bitnami/flux/CHANGELOG.md
+++ b/bitnami/flux/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-## 2.3.22 (2024-11-19)
+## 2.3.22 (2024-11-29)
 
-* Fix Incorrect Argument Mapping and Add Missing events-addr Argument in Bitnami FluxCD Chart ([#30523](https://github.com/bitnami/charts/pull/30523))
+* [bitnami/flux] Fix incorrect argument mapping and add missing events-addr argument ([#30523](https://github.com/bitnami/charts/pull/30523))
 
 ## <small>2.3.21 (2024-11-07)</small>
 

--- a/bitnami/flux/CHANGELOG.md
+++ b/bitnami/flux/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
-## 2.3.21 (2024-11-07)
+## 2.3.22 (2024-11-19)
 
-* [bitnami/flux] Release 2.3.21 ([#30263](https://github.com/bitnami/charts/pull/30263))
+* Fix Incorrect Argument Mapping and Add Missing events-addr Argument in Bitnami FluxCD Chart ([#30523](https://github.com/bitnami/charts/pull/30523))
+
+## <small>2.3.21 (2024-11-07)</small>
+
+* [bitnami/*] Remove wrong comment about imagePullPolicy (#30107) ([a51f9e4](https://github.com/bitnami/charts/commit/a51f9e4bb0fbf77199512d35de7ac8abe055d026)), closes [#30107](https://github.com/bitnami/charts/issues/30107)
+* [bitnami/flux] Release 2.3.21 (#30263) ([0a49b81](https://github.com/bitnami/charts/commit/0a49b81709b631dcd2e3f4c71d2c33deb52fdd91)), closes [#30263](https://github.com/bitnami/charts/issues/30263)
 
 ## <small>2.3.20 (2024-10-02)</small>
 

--- a/bitnami/flux/Chart.yaml
+++ b/bitnami/flux/Chart.yaml
@@ -43,4 +43,4 @@ maintainers:
 name: flux
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/flux
-version: 2.3.21
+version: 2.3.22

--- a/bitnami/flux/templates/helm-controller/deployment.yaml
+++ b/bitnami/flux/templates/helm-controller/deployment.yaml
@@ -100,6 +100,7 @@ spec:
             {{- else }}
             - --log-level=info
             {{- end }}
+            - --events-addr=http://{{ include "flux.notification-controller.fullname" . }}.{{ include "common.names.namespace" . }}.svc.{{ .Values.clusterDomain }}.
             - --metrics-addr=:{{ .Values.helmController.containerPorts.metrics }}
             - --health-addr=:{{ .Values.helmController.containerPorts.health }}
             - --log-encoding=json

--- a/bitnami/flux/templates/image-automation-controller/deployment.yaml
+++ b/bitnami/flux/templates/image-automation-controller/deployment.yaml
@@ -94,6 +94,7 @@ spec:
           args: {{- include "common.tplvalues.render" (dict "value" .Values.imageAutomationController.args "context" $) | nindent 12 }}
           {{- else }}
           args:
+            - --events-addr=http://{{ include "flux.notification-controller.fullname" . }}.{{ include "common.names.namespace" . }}.svc.{{ .Values.clusterDomain }}.
             - --watch-all-namespaces={{ .Values.imageAutomationController.watchAllNamespaces }}
             {{- if .Values.imageAutomationController.image.debug }}
             - --log-level=debug

--- a/bitnami/flux/templates/image-reflector-controller/deployment.yaml
+++ b/bitnami/flux/templates/image-reflector-controller/deployment.yaml
@@ -125,6 +125,7 @@ spec:
             {{- else }}
             - --log-level=info
             {{- end }}
+            - --events-addr=http://{{ include "flux.notification-controller.fullname" . }}.{{ include "common.names.namespace" . }}.svc.{{ .Values.clusterDomain }}.
             - --metrics-addr=:{{ .Values.imageReflectorController.containerPorts.metrics }}
             - --health-addr=:{{ .Values.imageReflectorController.containerPorts.health }}
             - --storage-path={{ .Values.imageReflectorController.persistence.mountPath }}

--- a/bitnami/flux/templates/kustomize-controller/deployment.yaml
+++ b/bitnami/flux/templates/kustomize-controller/deployment.yaml
@@ -100,6 +100,7 @@ spec:
             {{- else }}
             - --log-level=info
             {{- end }}
+            - --events-addr=http://{{ include "flux.notification-controller.fullname" . }}.{{ include "common.names.namespace" . }}.svc.{{ .Values.clusterDomain }}.
             - --metrics-addr=:{{ .Values.kustomizeController.containerPorts.metrics }}
             - --health-addr=:{{ .Values.kustomizeController.containerPorts.health }}
             - --log-encoding=json

--- a/bitnami/flux/templates/notification-controller/deployment.yaml
+++ b/bitnami/flux/templates/notification-controller/deployment.yaml
@@ -102,8 +102,8 @@ spec:
             {{- end }}
             - --metrics-addr=:{{ .Values.notificationController.containerPorts.metrics }}
             - --health-addr=:{{ .Values.notificationController.containerPorts.health }}
-            - --events-addr=:{{ .Values.notificationController.containerPorts.webhook }}
-            - --receiverAddr=:{{ .Values.notificationController.containerPorts.receiver }}
+            - --events-addr=:{{ .Values.notificationController.containerPorts.receiver }}
+            - --receiverAddr=:{{ .Values.notificationController.containerPorts.webhook }}
             - --log-encoding=json
             - --enable-leader-election
           {{- end }}

--- a/bitnami/flux/templates/source-controller/deployment.yaml
+++ b/bitnami/flux/templates/source-controller/deployment.yaml
@@ -125,6 +125,7 @@ spec:
             {{- else }}
             - --log-level=info
             {{- end }}
+            - --events-addr=http://{{ include "flux.notification-controller.fullname" . }}.{{ include "common.names.namespace" . }}.svc.{{ .Values.clusterDomain }}.
             - --storage-addr=:{{ .Values.sourceController.containerPorts.http }}
             - --metrics-addr=:{{ .Values.sourceController.containerPorts.metrics }}
             - --health-addr=:{{ .Values.sourceController.containerPorts.health }}


### PR DESCRIPTION

## Description
This pull request addresses two key issues in the current Bitnami Helm chart for FluxCD:

### 1. Fix Argument Mapping for Notification Controller
- The Notification Controller uses two primary arguments to manage communication:
  - `events-addr`: The address where the controller listens for events from other controllers (e.g., `helm-controller`, `kustomize-controller`). Events received on this address trigger Alert objects.
  - `receiverAddr`: The address where the controller listens for webhooks from external sources (e.g., Git repositories). Requests sent to this address trigger Receiver objects.
- **Problem: Incorrect Mapping in Current Chart**
  - The `receiver` key maps to `receiverAddr`, which is correct.
  - However, the `webhook` key is incorrectly mapped to `events-addr`.
- **Impact of the Incorrect Mapping:**
  - Users configuring the chart with the `webhook` key would expect it to configure the webhook listener (`receiverAddr`), but instead, it configures the event listener (`events-addr`).
  - Similarly, the `receiver` key, which users would expect to configure the event listener (`events-addr`), instead configures the webhook listener (`receiverAddr`).
- **Solution (Applied in This PR):**
  - `webhook` key → `receiverAddr` (Webhook listener).
  - `receiver` key → `events-addr` (Event listener).
- This fix aligns the key mappings with their intended functionality, making the chart configuration more intuitive and accurate.

### 2. Add Missing `events-addr` Argument for Other Controllers
- The `events-addr` argument was not initialized for the following controllers:
  - `helm-controller`
  - `kustomize-controller`
  - `source-controller`
  - `image-automation-controller`
  - `image-reflector-controller`
- **Solution:**
  - This PR adds the `events-addr` argument for these controllers, with its value set to the address of the Notification Controller's service.

## Impact
- Fixes the misconfigured argument mapping for the Notification Controller, ensuring it works as intended.
- Ensures all controllers properly communicate with the Notification Controller by initializing the `events-addr` argument.

## Testing
- Verified that the Notification Controller correctly handles events via `events-addr` and webhooks via `receiverAddr`.
- Confirmed other controllers now correctly use the `events-addr` argument to communicate with the Notification Controller.

## Checklist
- [x] Updated argument mappings for `webhook` and `receiver` keys in the Notification Controller.
- [x] Added the `events-addr` argument to the relevant controllers.
- [x] Verified changes function correctly across all controllers.

## Notes
These changes ensure that all FluxCD controllers are correctly configured for communication and align with the expected behavior of the Notification Controller.