### PR TITLE
[bitnami/argo-cd] Remove subchart image from values.yaml

### DIFF
--- a/bitnami/argo-cd/Chart.yaml
+++ b/bitnami/argo-cd/Chart.yaml
@@ -11,8 +11,6 @@ annotations:
       image: docker.io/bitnami/dex:2.41.1-debian-12-r8
     - name: os-shell
       image: docker.io/bitnami/os-shell:12-debian-12-r33
-    - name: redis
-      image: docker.io/bitnami/redis:7.4.1-debian-12-r2
 apiVersion: v2
 appVersion: 2.13.1
 dependencies:
@@ -39,4 +37,4 @@ maintainers:
 name: argo-cd
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/argo-cd
-version: 7.0.25
+version: 7.0.26

--- a/bitnami/argo-cd/values.yaml
+++ b/bitnami/argo-cd/values.yaml
@@ -4055,32 +4055,6 @@ rbac:
 ## Redis parameters
 ##
 redis:
-  ## Bitnami Redis image
-  ## ref: https://hub.docker.com/r/bitnami/redis/tags/
-  ## @param redis.image.registry [default: REGISTRY_NAME] Redis image registry
-  ## @param redis.image.repository [default: REPOSITORY_NAME/redis] Redis image repository
-  ## @skip redis.image.tag Redis image tag (immutable tags are recommended)
-  ## @param redis.image.digest Redis image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
-  ## @param redis.image.pullPolicy Redis image pull policy
-  ## @param redis.image.pullSecrets Redis image pull secrets
-  ##
-  image:
-    registry: docker.io
-    repository: bitnami/redis
-    tag: 7.4.1-debian-12-r2
-    digest: ""
-    ## Specify a imagePullPolicy
-    ## ref: https://kubernetes.io/docs/concepts/containers/images/#pre-pulled-images
-    ##
-    pullPolicy: IfNotPresent
-    ## Optionally specify an array of imagePullSecrets.
-    ## Secrets must be manually created in the namespace.
-    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
-    ## e.g:
-    ## pullSecrets:
-    ##   - myRegistryKeySecretName
-    ##
-    pullSecrets: []
   ## @param redis.enabled Enable Redis dependency
   ##
   enabled: true


### PR DESCRIPTION
### Description of the change

This PR removes the subchart image from the values.yaml

### Benefits

The image tag will automatically use the version defined in the subchart.

### Possible drawbacks

None known

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
