### PR TITLE
[bitnami/clickhouse] Remove subchart image from values.yaml

### DIFF
--- a/bitnami/clickhouse/CHANGELOG.md
+++ b/bitnami/clickhouse/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 6.3.3 (2024-11-18)
+## 7.0.0 (2024-11-22)
 
-* [bitnami/clickhouse] Release 6.3.3 ([#30505](https://github.com/bitnami/charts/pull/30505))
+* [bitnami/clickhouse] Remove subchart image from values.yaml ([#30586](https://github.com/bitnami/charts/pull/30586))
+
+## <small>6.3.3 (2024-11-18)</small>
+
+* [bitnami/clickhouse] Release 6.3.3 (#30505) ([5f728aa](https://github.com/bitnami/charts/commit/5f728aaf56f76877c5f00b48e1f546bc2050614b)), closes [#30505](https://github.com/bitnami/charts/issues/30505)
 
 ## <small>6.3.2 (2024-11-08)</small>
 

--- a/bitnami/clickhouse/Chart.yaml
+++ b/bitnami/clickhouse/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: clickhouse
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/clickhouse
-version: 6.3.3
+version: 7.0.0

--- a/bitnami/clickhouse/README.md
+++ b/bitnami/clickhouse/README.md
@@ -543,16 +543,13 @@ The [Bitnami ClickHouse](https://github.com/bitnami/containers/tree/main/bitnami
 
 ### Zookeeper subchart parameters
 
-| Name                             | Description                                                                                                                                                                                                | Value                       |
-| -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------- |
-| `zookeeper.enabled`              | Deploy Zookeeper subchart                                                                                                                                                                                  | `true`                      |
-| `zookeeper.replicaCount`         | Number of Zookeeper instances                                                                                                                                                                              | `3`                         |
-| `zookeeper.service.ports.client` | Zookeeper client port                                                                                                                                                                                      | `2181`                      |
-| `zookeeper.image.registry`       | Zookeeper image registry                                                                                                                                                                                   | `REGISTRY_NAME`             |
-| `zookeeper.image.repository`     | Zookeeper image repository                                                                                                                                                                                 | `REPOSITORY_NAME/zookeeper` |
-| `zookeeper.image.pullPolicy`     | Zookeeper image pull policy                                                                                                                                                                                | `IfNotPresent`              |
-| `zookeeper.resourcesPreset`      | Set container resources according to one common preset (allowed values: none, nano, small, medium, large, xlarge, 2xlarge). This is ignored if resources is set (resources is recommended for production). | `micro`                     |
-| `zookeeper.resources`            | Set container requests and limits for different resources like CPU or memory (essential for production workloads)                                                                                          | `{}`                        |
+| Name                             | Description                                                                                                                                                                                                | Value   |
+| -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `zookeeper.enabled`              | Deploy Zookeeper subchart                                                                                                                                                                                  | `true`  |
+| `zookeeper.replicaCount`         | Number of Zookeeper instances                                                                                                                                                                              | `3`     |
+| `zookeeper.service.ports.client` | Zookeeper client port                                                                                                                                                                                      | `2181`  |
+| `zookeeper.resourcesPreset`      | Set container resources according to one common preset (allowed values: none, nano, small, medium, large, xlarge, 2xlarge). This is ignored if resources is set (resources is recommended for production). | `micro` |
+| `zookeeper.resources`            | Set container requests and limits for different resources like CPU or memory (essential for production workloads)                                                                                          | `{}`    |
 
 ### Network Policies
 

--- a/bitnami/clickhouse/README.md
+++ b/bitnami/clickhouse/README.md
@@ -600,6 +600,10 @@ Find more information about how to deal with common errors related to Bitnami's 
 
 ## Upgrading
 
+### To 7.0.0
+
+This major updates the Zookeeper version from 3.8.x to 3.9.x. Instead of overwritting it in this chart values, it will automatically use the version defined in the zookeeper subchart.
+
 ### To 6.0.0
 
 This major bump changes the following security defaults:

--- a/bitnami/clickhouse/templates/NOTES.txt
+++ b/bitnami/clickhouse/templates/NOTES.txt
@@ -57,4 +57,4 @@ Credentials:
 {{- include "common.warnings.rollingTag" .Values.image }}
 {{- include "clickhouse.validateValues" . }}
 {{- include "common.warnings.resources" (dict "sections" (list "" "volumePermissions") "context" $) }}
-{{- include "common.warnings.modifiedImages" (dict "images" (list .Values.image .Values.volumePermissions.image .Values.zookeeper.image) "context" $) }}
+{{- include "common.warnings.modifiedImages" (dict "images" (list .Values.image .Values.volumePermissions.image) "context" $) }}

--- a/bitnami/clickhouse/values.yaml
+++ b/bitnami/clickhouse/values.yaml
@@ -1142,17 +1142,6 @@ externalZookeeper:
 ##
 zookeeper:
   enabled: true
-  ## Override zookeeper default image as 3.9 is not supported https://github.com/ClickHouse/ClickHouse/issues/53749
-  ## ref: https://github.com/bitnami/containers/tree/main/bitnami/zookeeper
-  ## @param zookeeper.image.registry [default: REGISTRY_NAME] Zookeeper image registry
-  ## @param zookeeper.image.repository [default: REPOSITORY_NAME/zookeeper] Zookeeper image repository
-  ## @skip zookeeper.image.tag Zookeeper image tag (immutable tags are recommended)
-  ## @param zookeeper.image.pullPolicy Zookeeper image pull policy
-  image:
-    registry: docker.io
-    repository: bitnami/zookeeper
-    tag: 3.8.4-debian-12-r16
-    pullPolicy: IfNotPresent
   replicaCount: 3
   service:
     ports:


### PR DESCRIPTION
### Description of the change

This PR removes the subchart image from the values.yaml

### Benefits

The image tag will automatically use the version defined in the subchart.

### Possible drawbacks

None known

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
