### PR TITLE
[bitnami/janusgraph] Remove subchart image from values.yaml

### DIFF
--- a/bitnami/janusgraph/CHANGELOG.md
+++ b/bitnami/janusgraph/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 0.3.26 (2024-11-09)
+## 1.0.0 (2024-11-22)
 
-* [bitnami/janusgraph] Release 0.3.26 ([#30371](https://github.com/bitnami/charts/pull/30371))
+* [bitnami/janusgraph] Remove subchart image from values.yaml ([#30590](https://github.com/bitnami/charts/pull/30590))
+
+## <small>0.3.26 (2024-11-09)</small>
+
+* [bitnami/janusgraph] Release 0.3.26 (#30371) ([08aa903](https://github.com/bitnami/charts/commit/08aa90318373c7f80c7c3da009b93bbe5d1728fb)), closes [#30371](https://github.com/bitnami/charts/issues/30371)
 
 ## <small>0.3.25 (2024-11-08)</small>
 

--- a/bitnami/janusgraph/Chart.yaml
+++ b/bitnami/janusgraph/Chart.yaml
@@ -5,8 +5,6 @@ annotations:
   category: Database
   licenses: Apache-2.0
   images: |
-    - name: cassandra
-      image: docker.io/bitnami/cassandra:4.1.7-debian-12-r1
     - name: janusgraph
       image: docker.io/bitnami/janusgraph:1.1.0-debian-12-r0
     - name: jmx-exporter
@@ -40,4 +38,4 @@ sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/janusgraph
 - https://github.com/bitnami/containers/tree/main/bitnami/janusgraph
 - https://github.com/janusgraph/janusgraph
-version: 0.3.26
+version: 1.0.0

--- a/bitnami/janusgraph/README.md
+++ b/bitnami/janusgraph/README.md
@@ -440,6 +440,12 @@ As an alternative, use one of the preset configurations for pod affinity, pod an
 
 Find more information about how to deal with common errors related to Bitnami's Helm charts in [this troubleshooting guide](https://docs.bitnami.com/general/how-to/troubleshoot-helm-chart-issues).
 
+## Upgrading
+
+### To 1.0.0
+
+This major updates the Cassandra version from 4.1.x to 5.0.x. Instead of overwritting it in this chart values, it will automatically use the version defined in the cassandra subchart.
+
 ## License
 
 Copyright &copy; 2024 Broadcom. The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.

--- a/bitnami/janusgraph/README.md
+++ b/bitnami/janusgraph/README.md
@@ -314,15 +314,12 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Cassandra storage sub-chart
 
-| Name                          | Description                                                                                               | Value                       |
-| ----------------------------- | --------------------------------------------------------------------------------------------------------- | --------------------------- |
-| `cassandra.image.registry`    | Cassandra image registry                                                                                  | `REGISTRY_NAME`             |
-| `cassandra.image.repository`  | Cassandra image repository                                                                                | `REPOSITORY_NAME/cassandra` |
-| `cassandra.image.digest`      | Cassandra image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                        |
-| `cassandra.keyspace`          | Name for cassandra's janusgraph keyspace                                                                  | `bitnami_janusgraph`        |
-| `cassandra.dbUser.user`       | Cassandra admin user                                                                                      | `bn_janusgraph`             |
-| `cassandra.dbUser.password`   | Password for `dbUser.user`. Randomly generated if empty                                                   | `""`                        |
-| `cassandra.service.ports.cql` | Cassandra cql port                                                                                        | `9043`                      |
+| Name                          | Description                                             | Value                |
+| ----------------------------- | ------------------------------------------------------- | -------------------- |
+| `cassandra.keyspace`          | Name for cassandra's janusgraph keyspace                | `bitnami_janusgraph` |
+| `cassandra.dbUser.user`       | Cassandra admin user                                    | `bn_janusgraph`      |
+| `cassandra.dbUser.password`   | Password for `dbUser.user`. Randomly generated if empty | `""`                 |
+| `cassandra.service.ports.cql` | Cassandra cql port                                      | `9043`               |
 
 See <https://github.com/bitnami/readme-generator-for-helm> to create the table
 

--- a/bitnami/janusgraph/templates/NOTES.txt
+++ b/bitnami/janusgraph/templates/NOTES.txt
@@ -67,4 +67,4 @@ To access Janusgraph from outside the cluster follow the steps below:
 
 {{- include "common.warnings.rollingTag" .Values.image }}
 {{- include "janusgraph.validateValues" . }}
-{{- include "common.warnings.modifiedImages" (dict "images" (list .Values.image .Values.metrics.image .Values.volumePermissions.image .Values.cassandra.image) "context" $) }}
+{{- include "common.warnings.modifiedImages" (dict "images" (list .Values.image .Values.metrics.image .Values.volumePermissions.image) "context" $) }}

--- a/bitnami/janusgraph/values.yaml
+++ b/bitnami/janusgraph/values.yaml
@@ -942,17 +942,6 @@ networkPolicy:
 ## Controlled by value storageBackend.cassandra.enabled
 ##
 cassandra:
-  ## Override Cassandra default image as version 5.0 is not supported
-  ## @param cassandra.image.registry [default: REGISTRY_NAME] Cassandra image registry
-  ## @param cassandra.image.repository [default: REPOSITORY_NAME/cassandra] Cassandra image repository
-  ## @skip cassandra.image.tag Cassandra image tag (immutable tags are recommended)
-  ## @param cassandra.image.digest Cassandra image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
-  ##
-  image:
-    registry: docker.io
-    repository: bitnami/cassandra
-    tag: 4.1.7-debian-12-r1
-    digest: ""
   ## @param cassandra.keyspace Name for cassandra's janusgraph keyspace
   ##
   keyspace: "bitnami_janusgraph"


### PR DESCRIPTION
### Description of the change

This PR removes the subchart image from the values.yaml

### Benefits

The image tag will automatically use the version defined in the subchart.

### Possible drawbacks

None known

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
