### PR TITLE
[bitnam/influxdb] gcloud backups, replace gsutil

### DIFF
--- a/bitnami/influxdb/CHANGELOG.md
+++ b/bitnami/influxdb/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 6.3.23 (2024-11-27)
+## 6.3.23 (2024-11-28)
 
 * [bitnam/influxdb] gcloud backups, replace gsutil ([#30595](https://github.com/bitnami/charts/pull/30595))
 

--- a/bitnami/influxdb/CHANGELOG.md
+++ b/bitnami/influxdb/CHANGELOG.md
@@ -1,8 +1,14 @@
 # Changelog
 
-## 6.3.22 (2024-11-07)
+## 6.3.23 (2024-11-27)
 
-* [bitnami/influxdb] Release 6.3.22 ([#30272](https://github.com/bitnami/charts/pull/30272))
+* [bitnam/influxdb] gcloud backups, replace gsutil ([#30595](https://github.com/bitnami/charts/pull/30595))
+
+## <small>6.3.22 (2024-11-07)</small>
+
+* [bitnami/*] Remove wrong comment about imagePullPolicy (#30107) ([a51f9e4](https://github.com/bitnami/charts/commit/a51f9e4bb0fbf77199512d35de7ac8abe055d026)), closes [#30107](https://github.com/bitnami/charts/issues/30107)
+* [bitnami/influxdb] Release 6.3.22 (#30272) ([761fe02](https://github.com/bitnami/charts/commit/761fe022b2837b47c4d6174b6c0ace93a600ea4a)), closes [#30272](https://github.com/bitnami/charts/issues/30272)
+* Update documentation links to techdocs.broadcom.com (#29931) ([f0d9ad7](https://github.com/bitnami/charts/commit/f0d9ad78f39f633d275fc576d32eae78ded4d0b8)), closes [#29931](https://github.com/bitnami/charts/issues/29931)
 
 ## <small>6.3.21 (2024-10-02)</small>
 

--- a/bitnami/influxdb/Chart.yaml
+++ b/bitnami/influxdb/Chart.yaml
@@ -37,4 +37,4 @@ maintainers:
 name: influxdb
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/influxdb
-version: 6.3.22
+version: 6.3.23

--- a/bitnami/influxdb/templates/configmap-backup.yaml
+++ b/bitnami/influxdb/templates/configmap-backup.yaml
@@ -54,7 +54,7 @@ data:
     set -e
 
     gcloud auth activate-service-account --key-file /var/secrets/google/{{ .Values.backup.uploadProviders.google.secretKey }}
-    gsutil -m rsync -r -d {{ .Values.backup.directory }}/ {{ .Values.backup.uploadProviders.google.bucketName }}
+    gcloud storage rsync -r {{ .Values.backup.directory }}/ {{ .Values.backup.uploadProviders.google.bucketName }} --delete-unmatched-destination-objects
   upload-azure.sh: |-
     #!/bin/sh
 


### PR DESCRIPTION
gsutil depends on python 3.11 which is not availlable on newer gcloud sdk images. Also, google now recommends using gcloud storage (which does support newer python versions).

### Description of the change

This change updates the gcloud upload script for the influxdb backup so that it replaces the deprecated gsutil with the corresponding gcloud storage invocation.

### Benefits

On the current bitnami/google-cloud-sdk image (used by the influxdb backup to upload the backup to google), gsutil fails as it requires python 3.11 to be present on the image, which was replaced by 3.12 on the release 489r1. Using `gcloud storage` instead of `gsutil` the invocation works with the python version supported by gcloud.

### Possible drawbacks

gcloud storage rsync was added on gcloud 437 (current release is 502), an older version of gcloud will fail.

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
