### PR TITLE
[bitnami/rabbitmq] feat: :sparkles: Allow password updates

### DIFF
--- a/bitnami/rabbitmq/CHANGELOG.md
+++ b/bitnami/rabbitmq/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 15.0.7 (2024-11-22)
+## 15.1.0 (2024-11-25)
 
-* [bitnami/rabbitmq] Release 15.0.7 ([#30572](https://github.com/bitnami/charts/pull/30572))
+* [bitnami/rabbitmq] feat: :sparkles: Allow password updates ([#30615](https://github.com/bitnami/charts/pull/30615))
+
+## <small>15.0.7 (2024-11-22)</small>
+
+* [bitnami/rabbitmq] Release 15.0.7 (#30572) ([212993b](https://github.com/bitnami/charts/commit/212993b0c06a0f0a3ccafdc8c253fe260b525b73)), closes [#30572](https://github.com/bitnami/charts/issues/30572)
 
 ## <small>15.0.6 (2024-11-08)</small>
 

--- a/bitnami/rabbitmq/Chart.yaml
+++ b/bitnami/rabbitmq/Chart.yaml
@@ -8,7 +8,7 @@ annotations:
     - name: os-shell
       image: docker.io/bitnami/os-shell:12-debian-12-r33
     - name: rabbitmq
-      image: docker.io/bitnami/rabbitmq:4.0.4-debian-12-r0
+      image: docker.io/bitnami/rabbitmq:4.0.4-debian-12-r1
 apiVersion: v2
 appVersion: 4.0.4
 dependencies:
@@ -30,4 +30,4 @@ maintainers:
 name: rabbitmq
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/rabbitmq
-version: 15.0.7
+version: 15.1.0

--- a/bitnami/rabbitmq/README.md
+++ b/bitnami/rabbitmq/README.md
@@ -176,6 +176,13 @@ extraConfiguration: |
   load_definitions = /app/load_definition.json
 ```
 
+### Update credentials
+
+The Bitnami RabbitMQ chart, when upgrading, reuses the secret previously rendered by the chart or the one specified in `auth.existingSecret`. To update credentials, use one of the following:
+
+- Run `helm upgrade` specifying a new password in `auth.password` and `auth.updatePassword=true`.
+- Run `helm upgrade` specifying a new secret in `auth.existingSecret` and `auth.updatePassword=true`.
+
 ### Configure LDAP support
 
 LDAP support can be enabled in the chart by specifying the `ldap.*` parameters while creating a release. For example:
@@ -387,6 +394,7 @@ Because they expose different sets of data, a valid use case is to scrape metric
 | `auth.username`                              | RabbitMQ application username                                                                                                                                           | `user`                                            |
 | `auth.password`                              | RabbitMQ application password                                                                                                                                           | `""`                                              |
 | `auth.securePassword`                        | Whether to set the RabbitMQ password securely. This is incompatible with loading external RabbitMQ definitions and 'true' when not setting the auth.password parameter. | `true`                                            |
+| `auth.updatePassword`                        | Update RabbitMQ password on secret change                                                                                                                               | `false`                                           |
 | `auth.existingPasswordSecret`                | Existing secret with RabbitMQ credentials (existing secret must contain a value for `rabbitmq-password` key or override with setting auth.existingSecretPasswordKey)    | `""`                                              |
 | `auth.existingSecretPasswordKey`             | Password key to be retrieved from existing secret                                                                                                                       | `rabbitmq-password`                               |
 | `auth.enableLoopbackUser`                    | If enabled, the user `auth.username` can only connect from localhost                                                                                                    | `false`                                           |

--- a/bitnami/rabbitmq/templates/secrets.yaml
+++ b/bitnami/rabbitmq/templates/secrets.yaml
@@ -6,8 +6,8 @@ SPDX-License-Identifier: APACHE-2.0
 {{- $host := printf "%s.%s.svc.%s" (include "common.names.fullname" .) (include "common.names.namespace" .) .Values.clusterDomain }}
 {{- $port := print .Values.service.ports.amqp }}
 {{- $user := print .Values.auth.username }}
-{{- $password := include "common.secrets.passwords.manage" (dict "secret" (include "rabbitmq.secretPasswordName" .) "key" (include "rabbitmq.secretPasswordKey" .) "length" 16 "providedValues" (list "auth.password") "skipB64enc" true "skipQuote" true "context" $) }}
-{{- $erlangCookie := include "common.secrets.passwords.manage" (dict "secret" (include "rabbitmq.secretErlangName" .) "key" (include "rabbitmq.secretErlangKey" .) "length" 32 "failOnNew" false "providedValues" (list "auth.erlangCookie") "context" $) }}
+{{- $password := include "common.secrets.passwords.manage" (dict "secret" (include "rabbitmq.secretPasswordName" .) "key" (include "rabbitmq.secretPasswordKey" .) "length" 16 "providedValues" (list "auth.password") "skipB64enc" true "skipQuote" true "honorProvidedValues" true "context" $) }}
+{{- $erlangCookie := include "common.secrets.passwords.manage" (dict "secret" (include "rabbitmq.secretErlangName" .) "key" (include "rabbitmq.secretErlangKey" .) "length" 32 "failOnNew" false "providedValues" (list "auth.erlangCookie") "honorProvidedValues" true "context" $) }}
 {{- if or (not .Values.auth.existingErlangSecret) (not .Values.auth.existingPasswordSecret) }}
 apiVersion: v1
 kind: Secret

--- a/bitnami/rabbitmq/templates/statefulset.yaml
+++ b/bitnami/rabbitmq/templates/statefulset.yaml
@@ -222,6 +222,8 @@ spec:
             - name: RABBITMQ_NODE_NAME
               value: "rabbit@$(MY_POD_NAME)"
             {{- end }}
+            - name: RABBITMQ_UPDATE_PASSWORD
+              value: {{ ternary "yes" "no" .Values.auth.updatePassword | quote }}
             - name: RABBITMQ_MNESIA_DIR
               value: "{{ .Values.persistence.mountPath }}/$(RABBITMQ_NODE_NAME)"
             - name: RABBITMQ_LDAP_ENABLE

--- a/bitnami/rabbitmq/values.yaml
+++ b/bitnami/rabbitmq/values.yaml
@@ -44,7 +44,7 @@ global:
 image:
   registry: docker.io
   repository: bitnami/rabbitmq
-  tag: 4.0.4-debian-12-r0
+  tag: 4.0.4-debian-12-r1
   digest: ""
   ## set to true if you would like to see extra information on logs
   ## It turns BASH and/or NAMI debugging in the image
@@ -153,6 +153,10 @@ auth:
   ## ref: https://github.com/bitnami/containers/tree/main/bitnami/rabbitmq#environment-variables
   ##
   securePassword: true
+  ## @param auth.updatePassword Update RabbitMQ password on secret change
+  ## ref: https://github.com/bitnami/containers/tree/main/bitnami/rabbitmq#environment-variables
+  ##
+  updatePassword: false
   ## @param auth.existingPasswordSecret Existing secret with RabbitMQ credentials (existing secret must contain a value for `rabbitmq-password` key or override with setting auth.existingSecretPasswordKey)
   ## e.g:
   ## existingPasswordSecret: name-of-existing-secret


### PR DESCRIPTION
Signed-off-by: Javier J. Salmerón García <javier.salmeron@broadcom.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

This PR allows updating passwords in the RabbitMQ chart. In order to not break existing deployments, this must be set using `auth.updatePassword=true`. In future majors, once this is mature enough, we could consider enabling it by default.

It also adds a documentation section in the README.md file.

### Benefits

Better password management

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

Unexpected corner cases 

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [ ] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [ ] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
