### PR TITLE
[bitnami/common] Fix VPA apiVersion

### DIFF
--- a/bitnami/common/CHANGELOG.md
+++ b/bitnami/common/CHANGELOG.md
@@ -1,8 +1,14 @@
 # Changelog
 
-## 2.27.0 (2024-11-06)
+## 2.27.1 (2024-11-26)
 
-* [bitnami/common] feat: :sparkles: Add honorProvidedValues in common.secrets.manage ([#30243](https://github.com/bitnami/charts/pull/30243))
+* [bitnami/common] Fix VPA apiVersion ([#30625](https://github.com/bitnami/charts/pull/30625))
+
+## 2.27.0 (2024-11-07)
+
+* [bitnami/*] Remove wrong comment about imagePullPolicy (#30107) ([a51f9e4](https://github.com/bitnami/charts/commit/a51f9e4bb0fbf77199512d35de7ac8abe055d026)), closes [#30107](https://github.com/bitnami/charts/issues/30107)
+* [bitnami/common] feat: :sparkles: Add honorProvidedValues in common.secrets.manage (#30243) ([3d76a49](https://github.com/bitnami/charts/commit/3d76a4955c11fa4d2464da2c4d2096e1e3c6fa37)), closes [#30243](https://github.com/bitnami/charts/issues/30243)
+* Update documentation links to techdocs.broadcom.com (#29931) ([f0d9ad7](https://github.com/bitnami/charts/commit/f0d9ad78f39f633d275fc576d32eae78ded4d0b8)), closes [#29931](https://github.com/bitnami/charts/issues/29931)
 
 ## 2.26.0 (2024-10-14)
 

--- a/bitnami/common/Chart.yaml
+++ b/bitnami/common/Chart.yaml
@@ -23,4 +23,4 @@ name: common
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/common
 type: library
-version: 2.27.0
+version: 2.27.1

--- a/bitnami/common/templates/_capabilities.tpl
+++ b/bitnami/common/templates/_capabilities.tpl
@@ -157,14 +157,12 @@ Return the appropriate apiVersion for Vertical Pod Autoscaler.
 */}}
 {{- define "common.capabilities.vpa.apiVersion" -}}
 {{- $kubeVersion := include "common.capabilities.kubeVersion" .context -}}
-{{- if and (not (empty $kubeVersion)) (semverCompare "<1.23-0" $kubeVersion) -}}
-{{- if .beta2 -}}
-{{- print "autoscaling/v2beta2" -}}
+{{- if and (not (empty $kubeVersion)) (semverCompare "<1.11-0" $kubeVersion) -}}
+{{- print "autoscaling/v1beta1" -}}
+{{- else if and (not (empty $kubeVersion)) (semverCompare "<1.25-0" $kubeVersion) -}}
+{{- print "autoscaling/v1beta2" -}}
 {{- else -}}
-{{- print "autoscaling/v2beta1" -}}
-{{- end -}}
-{{- else -}}
-{{- print "autoscaling/v2" -}}
+{{- print "autoscaling/v1" -}}
 {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
### Description of the change

This PR fixes the `common.capabilities.vpa.apiVersion` helper that is returning `v2` and `v2betaX` API versions based on the K8s version when it should be returning `v1` and `v1betaX` instead, see:

- https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler#compatibility
- https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler#notice-on-deprecation-of-v1beta2-version-0130
- https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler#notice-on-removal-of-v1beta1-version-050

### Benefits

VPA objects are compatible with Vertical Pod Autoscaler.

### Possible drawbacks

None

### Applicable issues

Reported at https://github.com/bitnami/charts/issues/30583

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
