### PR TITLE
[bitnami/airflow] bugfix: extra volume/mounts should apply to setup-db job and wait-for-db init-container

### DIFF
--- a/bitnami/airflow/CHANGELOG.md
+++ b/bitnami/airflow/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
+## 22.3.1 (2024-11-27)
+
+* [bitnami/airflow] bugfix: extra volume/mounts should apply to setup-db job and wait-for-db init-container… ([#30646](https://github.com/bitnami/charts/pull/30646))
+
 ## 22.3.0 (2024-11-26)
 
-* [bitnami/airflow] Support extra customizations at setup-db job ([#30624](https://github.com/bitnami/charts/pull/30624))
+* [bitnami/airflow] Support extra customizations at setup-db job (#30624) ([0397460](https://github.com/bitnami/charts/commit/03974600c3d801ab8b747c5f4daf3b5069293809)), closes [#30624](https://github.com/bitnami/charts/issues/30624)
 
 ## 22.2.0 (2024-11-19)
 

--- a/bitnami/airflow/Chart.yaml
+++ b/bitnami/airflow/Chart.yaml
@@ -39,4 +39,4 @@ maintainers:
 name: airflow
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/airflow
-version: 22.3.0
+version: 22.3.1

--- a/bitnami/airflow/templates/_init_containers_sidecars.tpl
+++ b/bitnami/airflow/templates/_init_containers_sidecars.tpl
@@ -203,6 +203,9 @@ Returns an init-container that waits for db migrations to be ready
     - name: empty-dir
       mountPath: /opt/bitnami/airflow/airflow.cfg
       subPath: app-base-dir/airflow.cfg
+    {{- if .Values.extraVolumeMounts }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumeMounts "context" $) | nindent 4 }}
+    {{- end }}
 {{- end -}}
 
 {{/*

--- a/bitnami/airflow/templates/setup-db-job.yaml
+++ b/bitnami/airflow/templates/setup-db-job.yaml
@@ -122,6 +122,9 @@ spec:
             {{- if .Values.setupDBJob.extraVolumeMounts }}
             {{- include "common.tplvalues.render" (dict "value" .Values.setupDBJob.extraVolumeMounts "context" $) | nindent 12 }}
             {{- end }}
+            {{- if .Values.extraVolumeMounts }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumeMounts "context" $) | nindent 12 }}
+            {{- end }}
       volumes:
         - name: empty-dir
           emptyDir: {}
@@ -131,5 +134,8 @@ spec:
             optional: true
         {{- if .Values.setupDBJob.extraVolumes }}
         {{- include "common.tplvalues.render" (dict "value" .Values.setupDBJob.extraVolumes "context" $) | nindent 8 }}
+        {{- end }}
+        {{- if .Values.extraVolumes }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumes "context" $) | nindent 8 }}
         {{- end }}
 {{- end }}


### PR DESCRIPTION
### Description of the change

This PR ensures the `extraVolumeMounts` and `extraVolumes` parameters are considered also for the setup-db k8s job and the wait-for-db init container.

### Benefits

Users that use a external database with TLS encryption enabled setting a custom SQL connection string via the `externalDatabase.sqlConnection` parameters might need to use `extraVolumeMounts` and `extraVolumes` parameters to mount the TLS client certs. If that't the case, it's needed to mount them on setup-db k8s job and the wait-for-db init container too.

### Possible drawbacks

None

### Applicable issues

None

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
