### PR TITLE
[bitnami/milvus] feat: update chart deps

### DIFF
--- a/bitnami/milvus/CHANGELOG.md
+++ b/bitnami/milvus/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 10.0.2 (2024-11-22)
+## 10.0.3 (2024-11-27)
 
-* [bitnami/milvus] Release 10.0.2 ([#30580](https://github.com/bitnami/charts/pull/30580))
+* [bitnami/milvus] feat: update chart deps ([#30651](https://github.com/bitnami/charts/pull/30651))
+
+## <small>10.0.2 (2024-11-22)</small>
+
+* [bitnami/milvus] Release 10.0.2 (#30580) ([c3d8e1f](https://github.com/bitnami/charts/commit/c3d8e1f5f50f49e33f1f051baeb7c1b3d2e461b1)), closes [#30580](https://github.com/bitnami/charts/issues/30580)
 
 ## <small>10.0.1 (2024-11-19)</small>
 

--- a/bitnami/milvus/Chart.lock
+++ b/bitnami/milvus/Chart.lock
@@ -10,6 +10,6 @@ dependencies:
   version: 14.8.5
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.27.0
-digest: sha256:430f121754a3ae3b4a1752a168bbb58b31475f70516910dda3273ecef42b8252
-generated: "2024-11-19T20:24:49.844317746Z"
+  version: 2.27.2
+digest: sha256:0ddf24a7d0f4d21885912bb927d99f33ef8998887c729f93684aee184a46cbb6
+generated: "2024-11-27T18:47:08.28536+01:00"

--- a/bitnami/milvus/Chart.yaml
+++ b/bitnami/milvus/Chart.yaml
@@ -48,4 +48,4 @@ maintainers:
 name: milvus
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/milvus
-version: 10.0.2
+version: 10.0.3


### PR DESCRIPTION
### Description of the change

This PR update Milvus chart deps to use latest common version. This latest version comes with fixes for the VPA api version.

### Benefits

VPA API version is correct.

### Possible drawbacks

None

### Applicable issues

- fixes #https://github.com/bitnami/charts/issues/30583

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
