### PR TITLE
[bitnami/kuberay] Adding the list and watch for endpoints resource to the cluster role to solve #30648

### DIFF
--- a/bitnami/kuberay/templates/operator/clusterroles.yaml
+++ b/bitnami/kuberay/templates/operator/clusterroles.yaml
@@ -54,6 +54,13 @@ rules:
   - apiGroups:
       - ""
     resources:
+      - endpoints
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
       - pods
     verbs:
       - create


### PR DESCRIPTION
This change adds the necessary rules to the operator cluster role to get the Ray Service in Running state and also make the kuberay operator not to show the 

```bash
W1127 12:42:08.725162       1 reflector.go:539] pkg/mod/k8s.io/client-go@v0.29.6/tools/cache/reflector.go:229: failed to list *v1.Endpoints: endpoints is forbidden: User "system:serviceaccount:kuberay:kuberay-operator" cannot list resource "endpoints" in API group "" at the cluster scope
E1127 12:42:08.725465       1 reflector.go:147] pkg/mod/k8s.io/client-go@v0.29.6/tools/cache/reflector.go:229: Failed to watch *v1.Endpoints: failed to list *v1.Endpoints: endpoints is forbidden: User "system:serviceaccount:kuberay:kuberay-operator" cannot list resource "endpoints" in API group "" at the cluster scope
W1127 12:42:57.122692       1 reflector.go:539] pkg/mod/k8s.io/client-go@v0.29.6/tools/cache/reflector.go:229: failed to list *v1.Endpoints: endpoints is forbidden: User "system:serviceaccount:kuberay:kuberay-operator" cannot list resource "endpoints" in API group "" at the cluster scope
E1127 12:42:57.122732       1 reflector.go:147] pkg/mod/k8s.io/client-go@v0.29.6/tools/cache/reflector.go:229: Failed to watch *v1.Endpoints: failed to list *v1.Endpoints: endpoints is forbidden: User "system:serviceaccount:kuberay:kuberay-operator" cannot list resource "endpoints" in API group "" at the cluster scope
W1127 12:43:42.058024       1 reflector.go:539] pkg/mod/k8s.io/client-go@v0.29.6/tools/cache/reflector.go:229: failed to list *v1.Endpoints: endpoints is forbidden: User "system:serviceaccount:kuberay:kuberay-operator" cannot list resource "endpoints" in API group "" at the cluster scope
E1127 12:43:42.058075       1 reflector.go:147] pkg/mod/k8s.io/client-go@v0.29.6/tools/cache/reflector.go:229: Failed to watch *v1.Endpoints: failed to list *v1.Endpoints: endpoints is forbidden: User "system:serviceaccount:kuberay:kuberay-operator" cannot list resource "endpoints" in API group "" at the cluster scope
W1127 12:44:29.551260       1 reflector.go:539] pkg/mod/k8s.io/client-go@v0.29.6/tools/cache/reflector.go:229: failed to list *v1.Endpoints: endpoints is forbidden: User "system:serviceaccount:kuberay:kuberay-operator" cannot list resource "endpoints" in API group "" at the cluster scope
E1127 12:44:29.551308       1 reflector.go:147] pkg/mod/k8s.io/client-go@v0.29.6/tools/cache/reflector.go:229: Failed to watch *v1.Endpoints: failed to list *v1.Endpoints: endpoints is forbidden: User "system:serviceaccount:kuberay:kuberay-operator" cannot list resource "endpoints" in API group "" at the cluster scope
```
This issue has been seen in the operator's log and as I am not using the apiserver or cluster components 

### Description of the change

Adds RBAC rules to the Operator Cluster Role.

### Benefits

Ray Service will be in running state and also the Operator logs won't show the messages with the permissions.

### Possible drawbacks

None as far as I know. Just keep in mind this applies only to the operator not apiserver or cluster.

### Applicable issues

- fixes #30648

