### PR TITLE
[bitnami/postgresql] use adminPassword for metrics user when custom user is not set

### DIFF
--- a/bitnami/postgresql/CHANGELOG.md
+++ b/bitnami/postgresql/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 16.2.3 (2024-11-27)
+## 16.2.4 (2024-12-03)
 
-* [bitnami/postgresql] Release 16.2.3 ([#30645](https://github.com/bitnami/charts/pull/30645))
+* [bitnami/postgresql] use adminPassword for metrics user when custom user is not set ([#30720](https://github.com/bitnami/charts/pull/30720))
+
+## <small>16.2.3 (2024-11-28)</small>
+
+* [bitnami/postgresql] Release 16.2.3 (#30645) ([22a4c51](https://github.com/bitnami/charts/commit/22a4c51dc3b85e73b017cb6f6c73e15e6e4b811c)), closes [#30645](https://github.com/bitnami/charts/issues/30645)
 
 ## <small>16.2.2 (2024-11-21)</small>
 

--- a/bitnami/postgresql/Chart.yaml
+++ b/bitnami/postgresql/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: postgresql
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/postgresql
-version: 16.2.3
+version: 16.2.4

--- a/bitnami/postgresql/templates/read/statefulset.yaml
+++ b/bitnami/postgresql/templates/read/statefulset.yaml
@@ -446,13 +446,13 @@ spec:
               value: {{ printf "127.0.0.1:%d/postgres?sslmode=disable" (int (include "postgresql.v1.service.port" .)) }}
             {{- if .Values.auth.usePasswordFiles }}
             - name: DATA_SOURCE_PASS_FILE
-              value: {{ printf "/opt/bitnami/postgresql/secrets/%s" (include "postgresql.v1.userPasswordKey" .) }}
+              value: {{ printf "/opt/bitnami/postgresql/secrets/%s" (include (ternary "postgresql.v1.adminPasswordKey" "postgresql.v1.userPasswordKey" (empty $customUser)) .) }}
             {{- else }}
             - name: DATA_SOURCE_PASS
               valueFrom:
                 secretKeyRef:
                   name: {{ include "postgresql.v1.secretName" . }}
-                  key: {{ include "postgresql.v1.userPasswordKey" . }}
+                  key: {{ include (ternary "postgresql.v1.adminPasswordKey" "postgresql.v1.userPasswordKey" (empty $customUser)) . }}
             {{- end }}
             - name: DATA_SOURCE_USER
               value: {{ default "postgres" $customUser | quote }}


### PR DESCRIPTION
### Description of the change

When `auth.username` is not set and `metrics.enabled: true`, it still looks up `auth.password` for metrics user, leading to `CreateContainerConfigError` on replication mode.

As the default value of `DATA_SOURCE_USER` is `postgres`, its value must be `auth.postgresPassword` if `auth.username` is not set.

### Benefits

Resolve error when creating replica postgresql pod with metrics enabled.

### Applicable issues

#30680
