### PR TITLE
fix: azure secrets

### DIFF
--- a/bitnami/mlflow/CHANGELOG.md
+++ b/bitnami/mlflow/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2.2.2 (2024-12-05)
+## 2.2.2 (2024-12-06)
 
 * fix: azure secrets ([#30802](https://github.com/bitnami/charts/pull/30802))
 

--- a/bitnami/mlflow/CHANGELOG.md
+++ b/bitnami/mlflow/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 2.2.1 (2024-11-18)
+## 2.2.2 (2024-12-05)
 
-* [bitnami/mlflow] Release 2.2.1 ([#30503](https://github.com/bitnami/charts/pull/30503))
+* fix: azure secrets ([#30802](https://github.com/bitnami/charts/pull/30802))
+
+## <small>2.2.1 (2024-11-18)</small>
+
+* [bitnami/mlflow] Release 2.2.1 (#30503) ([2028aad](https://github.com/bitnami/charts/commit/2028aad4277a9a6c6e57219f67f457659c13da0a)), closes [#30503](https://github.com/bitnami/charts/issues/30503)
 
 ## 2.2.0 (2024-11-15)
 

--- a/bitnami/mlflow/Chart.yaml
+++ b/bitnami/mlflow/Chart.yaml
@@ -12,7 +12,7 @@ annotations:
     - name: os-shell
       image: docker.io/bitnami/os-shell:12-debian-12-r33
 apiVersion: v2
-appVersion: 2.18.1
+appVersion: 2.18.0
 dependencies:
 - condition: minio.enabled
   name: minio
@@ -44,4 +44,4 @@ sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/mlflow
 - https://github.com/bitnami/containers/tree/main/bitnami/mlflow
 - https://github.com/mlflow/mlflow
-version: 2.2.1
+version: 2.2.2

--- a/bitnami/mlflow/Chart.yaml
+++ b/bitnami/mlflow/Chart.yaml
@@ -12,7 +12,7 @@ annotations:
     - name: os-shell
       image: docker.io/bitnami/os-shell:12-debian-12-r33
 apiVersion: v2
-appVersion: 2.18.0
+appVersion: 2.18.1
 dependencies:
 - condition: minio.enabled
   name: minio

--- a/bitnami/mlflow/templates/tracking/deployment.yaml
+++ b/bitnami/mlflow/templates/tracking/deployment.yaml
@@ -209,21 +209,27 @@ spec:
 
             {{- if (include "mlflow.v0.azureBlob.enabled" .) }}
             {{- if .Values.externalAzureBlob.useCredentialsInSecret }}
+            {{- if .Values.externalAzureBlob.existingConnectionStringKey }}
             - name: AZURE_STORAGE_CONNECTION_STRING
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.externalAzureBlob.existingSecret }}
                   key: {{ .Values.externalAzureBlob.existingConnectionStringKey }}
+            {{- end }}
+            {{- if .Values.externalAzureBlob.existingAccessKeyKey }}
             - name: AZURE_STORAGE_ACCESS_KEY
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.externalAzureBlob.existingSecret }}
                   key: {{ .Values.externalAzureBlob.existingAccessKeyKey }}
+            {{- end }}
+            {{- if .Values.externalAzureBlob.clientSecretKey }}
             - name: AZURE_CLIENT_SECRET
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.externalAzureBlob.existingSecret }}
                   key: {{ .Values.externalAzureBlob.clientSecretKey }}
+            {{- end }}
             {{- else }}
             {{- if .Values.externalAzureBlob.connectionString }}
             - name: AZURE_STORAGE_CONNECTION_STRING


### PR DESCRIPTION
Currently when you set useCredentialsInSecret it will require all secrets to be set, but this doesn't make sense since you only want 1 out of the 3 (connection_String, access_key or client_secret) to be set. This PR adds a conditional check if they key is provided in the values.yaml otherwise the env secret is not defined.