### PR TITLE
[bitnami/airflow] bugfix: Fix Airflow HPA, VPA for Worker and Triggerer typo (#30834)

### DIFF
--- a/bitnami/airflow/CHANGELOG.md
+++ b/bitnami/airflow/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 ## 22.3.2 (2024-12-09)
 
-* [bitnami/airflow] bugfix: Fix Airflow HPA, VPA for Worker and Triggerer typo [#30834](https://github.com/bitnami/charts/issues/30834)
+* [bitnami/airflow] bugfix: Fix Airflow HPA, VPA for Worker and Triggerer typo (#30834) ([#30836](https://github.com/bitnami/charts/pull/30836))
 
-## 22.3.1 (2024-11-27)
+## <small>22.3.1 (2024-11-28)</small>
 
-* [bitnami/airflow] bugfix: extra volume/mounts should apply to setup-db job and wait-for-db init-container… ([#30646](https://github.com/bitnami/charts/pull/30646))
+* [bitnami/airflow] bugfix: extra volume/mounts should apply to setup-db job and wait-for-db init-cont ([442b7c4](https://github.com/bitnami/charts/commit/442b7c43d60ced7c7f0aaac3eb1d60b343bd07df)), closes [#30646](https://github.com/bitnami/charts/issues/30646)
 
 ## 22.3.0 (2024-11-26)
 

--- a/bitnami/airflow/CHANGELOG.md
+++ b/bitnami/airflow/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 22.3.2 (2024-12-09)
+
+* [bitnami/airflow] bugfix: Fix Airflow HPA, VPA for Worker and Triggerer typo [#30834](https://github.com/bitnami/charts/issues/30834)
+
 ## 22.3.1 (2024-11-27)
 
 * [bitnami/airflow] bugfix: extra volume/mounts should apply to setup-db job and wait-for-db init-container… ([#30646](https://github.com/bitnami/charts/pull/30646))

--- a/bitnami/airflow/Chart.yaml
+++ b/bitnami/airflow/Chart.yaml
@@ -39,4 +39,4 @@ maintainers:
 name: airflow
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/airflow
-version: 22.3.1
+version: 22.3.2

--- a/bitnami/airflow/templates/triggerer/hpa.yaml
+++ b/bitnami/airflow/templates/triggerer/hpa.yaml
@@ -17,7 +17,7 @@ metadata:
 spec:
   scaleTargetRef:
     apiVersion: {{ include "common.capabilities.statefulset.apiVersion" . }}
-    kind: Statefulset
+    kind: StatefulSet
     name: {{ template "airflow.triggerer.fullname" . }}
   minReplicas: {{ .Values.triggerer.autoscaling.hpa.minReplicas }}
   maxReplicas: {{ .Values.triggerer.autoscaling.hpa.maxReplicas }}

--- a/bitnami/airflow/templates/worker/hpa.yaml
+++ b/bitnami/airflow/templates/worker/hpa.yaml
@@ -17,7 +17,7 @@ metadata:
 spec:
   scaleTargetRef:
     apiVersion: {{ include "common.capabilities.statefulset.apiVersion" . }}
-    kind: Statefulset
+    kind: StatefulSet
     name: {{ template "airflow.worker.fullname" . }}
   minReplicas: {{ coalesce .Values.worker.autoscaling.hpa.minReplicas .Values.worker.autoscaling.minReplicas }}
   maxReplicas: {{ coalesce .Values.worker.autoscaling.hpa.maxReplicas .Values.worker.autoscaling.maxReplicas }}

--- a/bitnami/airflow/templates/worker/vpa.yaml
+++ b/bitnami/airflow/templates/worker/vpa.yaml
@@ -33,7 +33,7 @@ spec:
       {{- end }}
   targetRef:
     apiVersion: {{ include "common.capabilities.statefulset.apiVersion" . }}
-    kind: Statefulset
+    kind: StatefulSet
     name: {{ template "airflow.worker.fullname" . }}
   {{- if .Values.worker.autoscaling.vpa.updatePolicy }}
   updatePolicy:


### PR DESCRIPTION
https://github.com/bitnami/charts/issues/30834

### Description of the change

Fixes the typo preventing HPA to function for Airflow Worker and Triggerer.

### Benefits

HPA can find the target `StatefulSet` and manage scaling.

### Applicable issues

- Fixes https://github.com/bitnami/charts/issues/30834

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
