### PR TITLE
[bitnami/template] fix(template): hpa context and path to hpa settings

### DIFF
--- a/template/CHART_NAME/templates/hpa.yaml
+++ b/template/CHART_NAME/templates/hpa.yaml
@@ -4,7 +4,7 @@ SPDX-License-Identifier: APACHE-2.0
 */}}
 
 {{- if .Values.%%MAIN_OBJECT_BLOCK%%.autoscaling.hpa.enabled }}
-apiVersion: {{ include "common.capabilities.hpa.apiVersion" . }}
+apiVersion: {{ include "common.capabilities.hpa.apiVersion" ( dict "context" $ ) }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "common.names.fullname" . }}
@@ -31,7 +31,7 @@ spec:
         {{- else }}
         target:
           type: Utilization
-          averageUtilization: {{ .Values.worker.autoscaling.hpa.targetMemory }}
+          averageUtilization: {{ .Values.%%MAIN_OBJECT_BLOCK%%.autoscaling.hpa.targetMemory }}
         {{- end }}
     {{- end }}
     {{- if .Values.%%MAIN_OBJECT_BLOCK%%.autoscaling.hpa.targetCPU }}
@@ -43,7 +43,7 @@ spec:
         {{- else }}
         target:
           type: Utilization
-          averageUtilization: {{ .Values.worker.autoscaling.hpa.targetCPU }}
+          averageUtilization: {{ .Values.%%MAIN_OBJECT_BLOCK%%.autoscaling.hpa.targetCPU }}
         {{- end }}
     {{- end }}
 {{- end }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

This fixes the context passed to `common.capabilities.hpa.apiVersion` in hpa.yaml, and replace `.Values.worker.autoscaling.hpa.targetMemory` by `.Values.%%MAIN_OBJECT_BLOCK%%.autoscaling.hpa.targetMemory` in the same file.

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

- fixes #30713

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
