### PR TITLE
[bitnami/argo-cd] Detect non-standard images

### DIFF
--- a/bitnami/argo-cd/Chart.lock
+++ b/bitnami/argo-cd/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: redis
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 20.4.0
+  version: 20.4.1
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.27.2
-digest: sha256:8c8f6705351c5859f0423d3aa32f6511979d47b427c7d6293c721f7a47fe4d0e
-generated: "2024-12-03T21:56:00.770043147Z"
+  version: 2.28.0
+digest: sha256:54adf3da2dd64ec54b202df1939acea4c3b8d6adc2c715f52f7c76b729646d68
+generated: "2024-12-10T16:48:58.323293+01:00"

--- a/bitnami/argo-cd/Chart.yaml
+++ b/bitnami/argo-cd/Chart.yaml
@@ -39,4 +39,4 @@ maintainers:
 name: argo-cd
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/argo-cd
-version: 7.0.26
+version: 7.1.0

--- a/bitnami/argo-cd/README.md
+++ b/bitnami/argo-cd/README.md
@@ -1345,6 +1345,10 @@ Find more information about how to deal with common errors related to Bitnami's 
 
 ## Upgrading
 
+### To 7.1.0
+
+This version introduces image verification for security purposes. To disable it, set `global.security.allowInsecureImages` to `true`. More details at [GitHub issue](https://github.com/bitnami/charts/issues/30850).
+
 ### To 7.0.0
 
 This major updates the Redis&reg; subchart to its newest major, 20.0.0. [Here](https://github.com/bitnami/charts/tree/main/bitnami/redis#to-2000) you can find more information about the changes introduced in that version.

--- a/bitnami/argo-cd/templates/NOTES.txt
+++ b/bitnami/argo-cd/templates/NOTES.txt
@@ -61,4 +61,4 @@ WARNING: config.createExtraKnownHosts is disabled, a secret called "argocd-ssh-k
 
 {{- include "argocd.validateValues" . }}
 {{- include "common.warnings.resources" (dict "sections" (list "applicationSet" "controller" "dex" "notifications.bots.slack" "notifications" "repoServer" "server" "volumePermissions") "context" $) }}
-{{- include "common.warnings.modifiedImages" (dict "images" (list .Values.image .Values.dex.image .Values.volumePermissions.image .Values.redis.image) "context" $) }}
+{{- include "common.warnings.modifiedImages" (dict "images" (list .Values.image .Values.dex.image .Values.volumePermissions.image .Values.redis.image) "context" $) }}{{- include "common.errors.insecureImages" (dict "images" (list .Values.image .Values.dex.image .Values.volumePermissions.image .Values.redis.image) "context" $) }}

--- a/bitnami/argo-cd/values.yaml
+++ b/bitnami/argo-cd/values.yaml
@@ -20,6 +20,11 @@ global:
   imagePullSecrets: []
   defaultStorageClass: ""
   storageClass: ""
+  ## Security parameters
+  ##
+  security:
+    ## @param global.security.allowInsecureImages Allows skipping image verification
+    allowInsecureImages: false
   ## Compatibility adaptations for Kubernetes platforms
   ##
   compatibility:


### PR DESCRIPTION
You can find more information about this change at https://github.com/bitnami/charts/issues/30850.

Implemented thanks to [those changes](https://github.com/bitnami/charts/pull/30851) in btinami/common.