### PR TITLE
[bitnami/jaeger] Detect non-standard images

### DIFF
--- a/bitnami/jaeger/CHANGELOG.md
+++ b/bitnami/jaeger/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
-## 5.0.1 (2024-12-04)
+## 5.1.0 (2024-12-10)
 
-* [bitnami/jaeger] Release 5.0.1 ([#30758](https://github.com/bitnami/charts/pull/30758))
+* [bitnami/jaeger] Detect non-standard images ([#30881](https://github.com/bitnami/charts/pull/30881))
+
+## <small>5.0.1 (2024-12-04)</small>
+
+* [bitnami/*] docs: :memo: Add "Backup & Restore" section (#30711) ([35ab536](https://github.com/bitnami/charts/commit/35ab5363741e7548f4076f04da6e62d10153c60c)), closes [#30711](https://github.com/bitnami/charts/issues/30711)
+* [bitnami/jaeger] Release 5.0.1 (#30758) ([1672922](https://github.com/bitnami/charts/commit/16729228545387e22171fe81cb0982202363a1db)), closes [#30758](https://github.com/bitnami/charts/issues/30758)
 
 ## 5.0.0 (2024-11-20)
 

--- a/bitnami/jaeger/Chart.lock
+++ b/bitnami/jaeger/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.27.2
+  version: 2.28.0
 - name: cassandra
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 12.0.5
-digest: sha256:17a19718885218d61eea918c0781a7204f32d823f51e214920def9346a242acc
-generated: "2024-12-04T00:38:06.636137874Z"
+digest: sha256:108a18a629a4026856d98e502aca970158c247097a6a3fe8a1a509ba150660eb
+generated: "2024-12-10T17:04:37.932372+01:00"

--- a/bitnami/jaeger/Chart.yaml
+++ b/bitnami/jaeger/Chart.yaml
@@ -34,4 +34,4 @@ maintainers:
 name: jaeger
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/jaeger
-version: 5.0.1
+version: 5.1.0

--- a/bitnami/jaeger/README.md
+++ b/bitnami/jaeger/README.md
@@ -476,6 +476,10 @@ Find more information about how to deal with common errors related to Bitnami's 
 
 ## Upgrading
 
+### To 5.1.0
+
+This version introduces image verification for security purposes. To disable it, set `global.security.allowInsecureImages` to `true`. More details at [GitHub issue](https://github.com/bitnami/charts/issues/30850).
+
 ### To 4.0.0
 
 This major updates Jaeger to version 1.63.0, which fully deprecates the [jaeger-agent component](https://github.com/jaegertracing/jaeger/issues/4739). When upgrading, all the jaeger-agent components will be fully removed. Check the [upstream documentation](https://www.jaegertracing.io/docs/1.62/architecture/) for alternatives.

--- a/bitnami/jaeger/templates/NOTES.txt
+++ b/bitnami/jaeger/templates/NOTES.txt
@@ -24,4 +24,4 @@ Did you know there are enterprise versions of the Bitnami catalog? For enhanced 
 
 {{- include "common.warnings.rollingTag" .Values.image }}
 {{- include "common.warnings.resources" (dict "sections" (list "collector" "migration" "query") "context" $) }}
-{{- include "common.warnings.modifiedImages" (dict "images" (list .Values.image .Values.cqlshImage) "context" $) }}
+{{- include "common.warnings.modifiedImages" (dict "images" (list .Values.image .Values.cqlshImage) "context" $) }}{{- include "common.errors.insecureImages" (dict "images" (list .Values.image .Values.cqlshImage) "context" $) }}

--- a/bitnami/jaeger/values.yaml
+++ b/bitnami/jaeger/values.yaml
@@ -19,6 +19,11 @@ global:
   ##
   imagePullSecrets: []
   defaultStorageClass: ""
+  ## Security parameters
+  ##
+  security:
+    ## @param global.security.allowInsecureImages Allows skipping image verification
+    allowInsecureImages: false
   ## Compatibility adaptations for Kubernetes platforms
   ##
   compatibility:


### PR DESCRIPTION
You can find more information about this change at https://github.com/bitnami/charts/issues/30850.

Implemented thanks to [those changes](https://github.com/bitnami/charts/pull/30851) in btinami/common.