### PR TITLE
[bitnami/external-dns] Detect non-standard images

### DIFF
--- a/bitnami/external-dns/CHANGELOG.md
+++ b/bitnami/external-dns/CHANGELOG.md
@@ -1,8 +1,14 @@
 # Changelog
 
-## 8.6.1 (2024-12-03)
+## 8.7.0 (2024-12-10)
 
-* [bitnami/external-dns] Release 8.6.1 ([#30747](https://github.com/bitnami/charts/pull/30747))
+* [bitnami/external-dns] Detect non-standard images ([#30894](https://github.com/bitnami/charts/pull/30894))
+
+## <small>8.6.1 (2024-12-03)</small>
+
+* [bitnami/*] docs: :memo: Add "Backup & Restore" section (#30711) ([35ab536](https://github.com/bitnami/charts/commit/35ab5363741e7548f4076f04da6e62d10153c60c)), closes [#30711](https://github.com/bitnami/charts/issues/30711)
+* [bitnami/*] docs: :memo: Add "Prometheus metrics" (batch 2) (#30662) ([50e0570](https://github.com/bitnami/charts/commit/50e0570f98ab15308af7910b405baa4480e5fe3f)), closes [#30662](https://github.com/bitnami/charts/issues/30662)
+* [bitnami/external-dns] Release 8.6.1 (#30747) ([a0583f2](https://github.com/bitnami/charts/commit/a0583f223636dcaa284afd5b5068dffec7231f06)), closes [#30747](https://github.com/bitnami/charts/issues/30747)
 
 ## 8.6.0 (2024-11-19)
 

--- a/bitnami/external-dns/Chart.lock
+++ b/bitnami/external-dns/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.27.2
-digest: sha256:6fd86cc5a4b5094abca1f23c8ec064e75e51eceaded94a5e20977274b2abb576
-generated: "2024-12-03T22:30:53.911707217Z"
+  version: 2.28.0
+digest: sha256:5b30f0fa07bb89b01c55fd6258c8ce22a611b13623d4ad83e8fdd1d4490adc74
+generated: "2024-12-10T16:57:59.147157+01:00"

--- a/bitnami/external-dns/Chart.yaml
+++ b/bitnami/external-dns/Chart.yaml
@@ -28,4 +28,4 @@ maintainers:
 name: external-dns
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/external-dns
-version: 8.6.1
+version: 8.7.0

--- a/bitnami/external-dns/README.md
+++ b/bitnami/external-dns/README.md
@@ -488,6 +488,10 @@ Find more information about how to deal with common errors related to Bitnami's 
 
 ## Upgrading
 
+### To 8.7.0
+
+This version introduces image verification for security purposes. To disable it, set `global.security.allowInsecureImages` to `true`. More details at [GitHub issue](https://github.com/bitnami/charts/issues/30850).
+
 ### To 7.0.0
 
 This major bump changes the following security defaults:

--- a/bitnami/external-dns/templates/NOTES.txt
+++ b/bitnami/external-dns/templates/NOTES.txt
@@ -14,3 +14,4 @@ To verify that external-dns has started, run:
 {{ include "external-dns.checkRollingTags" . }}
 {{- include "common.warnings.resources" (dict "sections" (list "") "context" $) }}
 {{- include "common.warnings.modifiedImages" (dict "images" (list .Values.image) "context" $) }}
+{{- include "common.errors.insecureImages" (dict "images" (list .Values.image) "context" $) }}

--- a/bitnami/external-dns/values.yaml
+++ b/bitnami/external-dns/values.yaml
@@ -17,6 +17,11 @@ global:
   ##   - myRegistryKeySecretName
   ##
   imagePullSecrets: []
+  ## Security parameters
+  ##
+  security:
+    ## @param global.security.allowInsecureImages Allows skipping image verification
+    allowInsecureImages: false
   ## Compatibility adaptations for Kubernetes platforms
   ##
   compatibility:


### PR DESCRIPTION
You can find more information about this change at https://github.com/bitnami/charts/issues/30850.

Implemented thanks to [those changes](https://github.com/bitnami/charts/pull/30851) in btinami/common.