### PR TITLE
[bitnami/metallb] Detect non-standard images

### DIFF
--- a/bitnami/metallb/CHANGELOG.md
+++ b/bitnami/metallb/CHANGELOG.md
@@ -1,8 +1,14 @@
 # Changelog
 
-## 6.3.16 (2024-12-04)
+## 6.4.0 (2024-12-10)
 
-* [bitnami/metallb] Release 6.3.16 ([#30763](https://github.com/bitnami/charts/pull/30763))
+* [bitnami/metallb] Detect non-standard images ([#30923](https://github.com/bitnami/charts/pull/30923))
+
+## <small>6.3.16 (2024-12-04)</small>
+
+* [bitnami/*] docs: :memo: Add "Backup & Restore" section (#30711) ([35ab536](https://github.com/bitnami/charts/commit/35ab5363741e7548f4076f04da6e62d10153c60c)), closes [#30711](https://github.com/bitnami/charts/issues/30711)
+* [bitnami/*] docs: :memo: Add "Prometheus metrics" (batch 4) (#30669) ([a4ec006](https://github.com/bitnami/charts/commit/a4ec00624589023a70a7094fcfb9f12e382bc280)), closes [#30669](https://github.com/bitnami/charts/issues/30669)
+* [bitnami/metallb] Release 6.3.16 (#30763) ([2b81e7f](https://github.com/bitnami/charts/commit/2b81e7f231fd340f909f3bc5c0fbb96ecfa0bb3a)), closes [#30763](https://github.com/bitnami/charts/issues/30763)
 
 ## <small>6.3.15 (2024-11-08)</small>
 

--- a/bitnami/metallb/Chart.lock
+++ b/bitnami/metallb/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.27.2
-digest: sha256:6fd86cc5a4b5094abca1f23c8ec064e75e51eceaded94a5e20977274b2abb576
-generated: "2024-12-04T02:04:21.84057185Z"
+  version: 2.28.0
+digest: sha256:5b30f0fa07bb89b01c55fd6258c8ce22a611b13623d4ad83e8fdd1d4490adc74
+generated: "2024-12-10T17:14:16.005317+01:00"

--- a/bitnami/metallb/Chart.yaml
+++ b/bitnami/metallb/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: metallb
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/metallb
-version: 6.3.16
+version: 6.4.0

--- a/bitnami/metallb/README.md
+++ b/bitnami/metallb/README.md
@@ -439,6 +439,10 @@ Find more information about how to deal with common errors related to Bitnami's 
 
 ## Upgrading
 
+### To 6.4.0
+
+This version introduces image verification for security purposes. To disable it, set `global.security.allowInsecureImages` to `true`. More details at [GitHub issue](https://github.com/bitnami/charts/issues/30850).
+
 ### To 6.0.0
 
 This major release includes the changes and features available in MetalLB from version 0.14.x. This new version includes some breaking changes like AddressPool removal or the several changes about the `webhook-server-cert secret`. For more details about MetaLB changes please visit [the release notes](https://metallb.universe.tf/release-notes/).

--- a/bitnami/metallb/templates/NOTES.txt
+++ b/bitnami/metallb/templates/NOTES.txt
@@ -52,4 +52,5 @@ If it is missing create it with:
 {{- end }}
 {{- end }}
 {{- include "common.warnings.resources" (dict "sections" (list "controller" "speaker") "context" $) }}
-{{- include "common.warnings.modifiedImages" (dict "images" (list .Values.controller.image .Values.speaker.image .Values.speaker.frr.image) "context" $) }}{{- include "common.errors.insecureImages" (dict "images" (list .Values.controller.image .Values.speaker.image .Values.speaker.frr.image) "context" $) }}
+{{- include "common.warnings.modifiedImages" (dict "images" (list .Values.controller.image .Values.speaker.image .Values.speaker.frr.image) "context" $) }}
+{{- include "common.errors.insecureImages" (dict "images" (list .Values.controller.image .Values.speaker.image .Values.speaker.frr.image) "context" $) }}

--- a/bitnami/metallb/templates/NOTES.txt
+++ b/bitnami/metallb/templates/NOTES.txt
@@ -52,4 +52,4 @@ If it is missing create it with:
 {{- end }}
 {{- end }}
 {{- include "common.warnings.resources" (dict "sections" (list "controller" "speaker") "context" $) }}
-{{- include "common.warnings.modifiedImages" (dict "images" (list .Values.controller.image .Values.speaker.image .Values.speaker.frr.image) "context" $) }}
+{{- include "common.warnings.modifiedImages" (dict "images" (list .Values.controller.image .Values.speaker.image .Values.speaker.frr.image) "context" $) }}{{- include "common.errors.insecureImages" (dict "images" (list .Values.controller.image .Values.speaker.image .Values.speaker.frr.image) "context" $) }}


### PR DESCRIPTION
You can find more information about this change at https://github.com/bitnami/charts/issues/30850.

Implemented thanks to [those changes](https://github.com/bitnami/charts/pull/30851) in btinami/common.