### PR TITLE
[bitnami/whereabouts] Detect non-standard images

### DIFF
--- a/bitnami/whereabouts/Chart.lock
+++ b/bitnami/whereabouts/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.27.2
-digest: sha256:6fd86cc5a4b5094abca1f23c8ec064e75e51eceaded94a5e20977274b2abb576
-generated: "2024-12-04T04:22:56.117659061Z"
+  version: 2.28.0
+digest: sha256:5b30f0fa07bb89b01c55fd6258c8ce22a611b13623d4ad83e8fdd1d4490adc74
+generated: "2024-12-10T17:33:39.237875+01:00"

--- a/bitnami/whereabouts/Chart.yaml
+++ b/bitnami/whereabouts/Chart.yaml
@@ -29,4 +29,4 @@ maintainers:
 name: whereabouts
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/whereabouts
-version: 1.1.17
+version: 1.2.0

--- a/bitnami/whereabouts/README.md
+++ b/bitnami/whereabouts/README.md
@@ -239,6 +239,10 @@ Find more information about how to deal with common errors related to Bitnami's 
 
 ## Upgrading
 
+### To 1.2.0
+
+This version introduces image verification for security purposes. To disable it, set `global.security.allowInsecureImages` to `true`. More details at [GitHub issue](https://github.com/bitnami/charts/issues/30850).
+
 ### To 1.0.0
 
 This major bump changes the following security defaults:

--- a/bitnami/whereabouts/templates/NOTES.txt
+++ b/bitnami/whereabouts/templates/NOTES.txt
@@ -32,4 +32,5 @@ IMPORTANT: Please ensure that {{ .Values.hostCNIBinDir }} and {{ .Values.hostCNI
 
 {{ include "common.warnings.rollingTag" .Values.image }}
 {{- include "common.warnings.resources" (dict "sections" (list "") "context" $) }}
-{{- include "common.warnings.modifiedImages" (dict "images" (list .Values.image) "context" $) }}{{- include "common.errors.insecureImages" (dict "images" (list .Values.image) "context" $) }}
+{{- include "common.warnings.modifiedImages" (dict "images" (list .Values.image) "context" $) }}
+{{- include "common.errors.insecureImages" (dict "images" (list .Values.image) "context" $) }}

--- a/bitnami/whereabouts/templates/NOTES.txt
+++ b/bitnami/whereabouts/templates/NOTES.txt
@@ -32,4 +32,4 @@ IMPORTANT: Please ensure that {{ .Values.hostCNIBinDir }} and {{ .Values.hostCNI
 
 {{ include "common.warnings.rollingTag" .Values.image }}
 {{- include "common.warnings.resources" (dict "sections" (list "") "context" $) }}
-{{- include "common.warnings.modifiedImages" (dict "images" (list .Values.image) "context" $) }}
+{{- include "common.warnings.modifiedImages" (dict "images" (list .Values.image) "context" $) }}{{- include "common.errors.insecureImages" (dict "images" (list .Values.image) "context" $) }}

--- a/bitnami/whereabouts/values.yaml
+++ b/bitnami/whereabouts/values.yaml
@@ -21,6 +21,11 @@ global:
   imagePullSecrets: []
   defaultStorageClass: ""
   storageClass: ""
+  ## Security parameters
+  ##
+  security:
+    ## @param global.security.allowInsecureImages Allows skipping image verification
+    allowInsecureImages: false
   ## Compatibility adaptations for Kubernetes platforms
   ##
   compatibility:


### PR DESCRIPTION
You can find more information about this change at https://github.com/bitnami/charts/issues/30850.

Implemented thanks to [those changes](https://github.com/bitnami/charts/pull/30851) in btinami/common.