### PR TITLE
[bitnami/seaweedfs] Detect non-standard images

### DIFF
--- a/bitnami/seaweedfs/Chart.lock
+++ b/bitnami/seaweedfs/Chart.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 20.1.1
 - name: postgresql
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 16.2.4
+  version: 16.2.5
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.27.2
-digest: sha256:671ea8a89b7da17674d487d0849b007e0fa8f2c648917b662ccedcb336234e6e
-generated: "2024-12-04T04:04:10.540738656Z"
+  version: 2.28.0
+digest: sha256:cbd98cbda65a325af2a33ee1c4eebc7d3333079866c6b5abe3c4bd751cb77884
+generated: "2024-12-10T17:28:31.712053+01:00"

--- a/bitnami/seaweedfs/Chart.yaml
+++ b/bitnami/seaweedfs/Chart.yaml
@@ -50,4 +50,4 @@ name: seaweedfs
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/seawwedfs
 - https://github.com/bitnami/containers/tree/main/bitnami/seaweedfs
-version: 4.1.2
+version: 4.2.0

--- a/bitnami/seaweedfs/README.md
+++ b/bitnami/seaweedfs/README.md
@@ -1199,6 +1199,10 @@ helm install my-release -f values.yaml oci://REGISTRY_NAME/REPOSITORY_NAME/seawe
 
 ## Upgrading
 
+### To 4.2.0
+
+This version introduces image verification for security purposes. To disable it, set `global.security.allowInsecureImages` to `true`. More details at [GitHub issue](https://github.com/bitnami/charts/issues/30850).
+
 ### To 4.0.0
 
 This major bump updates the MariaDB subchart to version 20.0.0. This subchart updates the StatefulSet objects `serviceName` to use a headless service, as the current non-headless service attached to it was not providing DNS entries. This will cause an upgrade issue because it changes "immutable fields". To workaround it, delete the StatefulSet objects as follows (replace the RELEASE_NAME placeholder):

--- a/bitnami/seaweedfs/templates/NOTES.txt
+++ b/bitnami/seaweedfs/templates/NOTES.txt
@@ -172,3 +172,4 @@ The chart was deployed enabling WebDAV, to access it from outside the cluster fo
 {{- include "common.warnings.rollingTag" .Values.postgresql.image }}
 {{- include "seaweedfs.validateValues" . }}
 {{- include "common.warnings.modifiedImages" (dict "images" (list .Values.image .Values.volumePermissions.image .Values.mariadb.image .Values.postgresql.image) "context" $) }}
+{{- include "common.errors.insecureImages" (dict "images" (list .Values.image .Values.volumePermissions.image .Values.mariadb.image .Values.postgresql.image) "context" $) }}

--- a/bitnami/seaweedfs/values.yaml
+++ b/bitnami/seaweedfs/values.yaml
@@ -732,6 +732,11 @@ master:
     ##   GKE, AWS & OpenStack)
     ##
     storageClass: ""
+  ## Security parameters
+  ##
+  security:
+    ## @param global.security.allowInsecureImages Allows skipping image verification
+    allowInsecureImages: false
     ## @param master.persistence.annotations Persistent Volume Claim annotations
     ##
     annotations: {}

--- a/bitnami/seaweedfs/values.yaml
+++ b/bitnami/seaweedfs/values.yaml
@@ -19,6 +19,11 @@ global:
   ##
   imagePullSecrets: []
   defaultStorageClass: ""
+  ## Security parameters
+  ##
+  security:
+    ## @param global.security.allowInsecureImages Allows skipping image verification
+    allowInsecureImages: false
   ## Compatibility adaptations for Kubernetes platforms
   ##
   compatibility:
@@ -732,11 +737,6 @@ master:
     ##   GKE, AWS & OpenStack)
     ##
     storageClass: ""
-  ## Security parameters
-  ##
-  security:
-    ## @param global.security.allowInsecureImages Allows skipping image verification
-    allowInsecureImages: false
     ## @param master.persistence.annotations Persistent Volume Claim annotations
     ##
     annotations: {}


### PR DESCRIPTION
You can find more information about this change at https://github.com/bitnami/charts/issues/30850.

Implemented thanks to [those changes](https://github.com/bitnami/charts/pull/30851) in btinami/common.