### PR TITLE
Fixed cronjob to allow backup while tls is enabled.

### DIFF
--- a/bitnami/postgresql-ha/CHANGELOG.md
+++ b/bitnami/postgresql-ha/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
+## 15.1.1 (2024-12-11)
+
+* Fixed cronjob to allow backup while tls is enabled. ([#30980](https://github.com/bitnami/charts/pull/30980))
+
 ## 15.1.0 (2024-12-10)
 
-* [bitnami/postgresql-ha] Detect non-standard images ([#30937](https://github.com/bitnami/charts/pull/30937))
+* [bitnami/*] Add Bitnami Premium to NOTES.txt (#30854) ([3dfc003](https://github.com/bitnami/charts/commit/3dfc00376df6631f0ce54b8d440d477f6caa6186)), closes [#30854](https://github.com/bitnami/charts/issues/30854)
+* [bitnami/postgresql-ha] Detect non-standard images (#30937) ([5149845](https://github.com/bitnami/charts/commit/51498454247984c12b9b60ba51bad0b7e72ac36c)), closes [#30937](https://github.com/bitnami/charts/issues/30937)
 
 ## <small>15.0.4 (2024-12-03)</small>
 

--- a/bitnami/postgresql-ha/Chart.yaml
+++ b/bitnami/postgresql-ha/Chart.yaml
@@ -40,4 +40,4 @@ maintainers:
 name: postgresql-ha
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/postgresql-ha
-version: 15.1.0
+version: 15.1.1

--- a/bitnami/postgresql-ha/templates/backup/cronjob.yaml
+++ b/bitnami/postgresql-ha/templates/backup/cronjob.yaml
@@ -96,8 +96,8 @@ spec:
                 mountPath: /tmp
                 subPath: tmp-dir
               {{- if .Values.postgresql.tls.enabled }}
-              - name: certs
-                mountPath: /certs
+              - name: raw-certificates
+                mountPath: /tmp/certs
               {{- end }}
               - name: datadir
                 mountPath: {{ .Values.backup.cronjob.storage.mountPath }}
@@ -114,6 +114,11 @@ spec:
             fsGroup: {{ .Values.backup.cronjob.podSecurityContext.fsGroup }}
           {{- end }}
           volumes:
+            {{- if .Values.postgresql.tls.enabled }}
+            - name: raw-certificates
+              secret:
+                secretName: {{include "postgresql-ha.tlsSecretName" .}}
+            {{- end }}
             - name: empty-dir
               emptyDir: {}
             {{- if .Values.backup.cronjob.storage.existingClaim }}


### PR DESCRIPTION


### Description of the change

Fixed the certs directory issue in cronjob.yaml

### Benefits
Allows backup with tls

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #30837 


