### PR TITLE
[bitnami/airflow] Fix wrong protocol for metrics network policy

### DIFF
--- a/bitnami/airflow/CHANGELOG.md
+++ b/bitnami/airflow/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 22.4.1 (2024-12-11)
+## 22.4.2 (2024-12-11)
 
-* [bitnami/airflow]  Fix LDAP configuration ([#30911](https://github.com/bitnami/charts/pull/30911))
+* [bitnami/airflow] Fix wrong protocol for metrics network policy ([#30990](https://github.com/bitnami/charts/pull/30990))
+
+## <small>22.4.1 (2024-12-11)</small>
+
+* [bitnami/airflow]  Fix LDAP configuration (#30911) ([70544cb](https://github.com/bitnami/charts/commit/70544cbb60d0a30393062c1cffe5d935cb3edcfb)), closes [#30911](https://github.com/bitnami/charts/issues/30911)
 
 ## 22.4.0 (2024-12-10)
 

--- a/bitnami/airflow/Chart.yaml
+++ b/bitnami/airflow/Chart.yaml
@@ -39,4 +39,4 @@ maintainers:
 name: airflow
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/airflow
-version: 22.4.1
+version: 22.4.2

--- a/bitnami/airflow/templates/metrics/networkpolicy.yaml
+++ b/bitnami/airflow/templates/metrics/networkpolicy.yaml
@@ -40,6 +40,7 @@ spec:
   ingress:
     - ports:
         - port: {{ .Values.metrics.containerPorts.ingest }}
+          protocol: UDP
         - port: {{ .Values.metrics.containerPorts.metrics }}
       {{- if not .Values.metrics.networkPolicy.allowExternal }}
       from:


### PR DESCRIPTION
### Description of the change

The pull request (#30459) that added StatsD for metrics specifies the wrong protocol. Interaction occurs over UDP, but TCP is being set (as the protocol is not explicitly defined). As a result, only StatsD's internal metrics are being collected, while Airflow metrics are absent. A workaround until this fix is to disable the Network Policy for metrics.

### Benefits

The collection of Airflow metrics is working again.

### Applicable issues

I didn’t find any issues, but I encountered this problem myself and also found [this comment](https://github.com/bitnami/charts/pull/30459#issuecomment-2536322196).

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)