### PR TITLE
Redis Readme: fix typo in value key name

### DIFF
--- a/bitnami/redis/README.md
+++ b/bitnami/redis/README.md
@@ -212,7 +212,7 @@ kubectl create secret generic redis-password-secret --from-file=redis-password.y
 
 ```text
 usePassword=true
-usePasswordFile=true
+usePasswordFiles=true
 existingSecret=redis-password-secret
 sentinels.enabled=true
 metrics.enabled=true


### PR DESCRIPTION
The proper value key is 'usePasswordFiles', with a final `s`

