### PR TITLE
[bitnami/scylladb] Fix existingConfiguration parameter for scylladb

### DIFF
--- a/bitnami/scylladb/CHANGELOG.md
+++ b/bitnami/scylladb/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 3.1.3 (2024-12-12)
+## 3.1.4 (2024-12-12)
 
-* [bitnami/scylladb] Release 3.1.3 ([#31012](https://github.com/bitnami/charts/pull/31012))
+* [bitnami/scylladb] Fix existingConfiguration parameter for scylladb ([#31014](https://github.com/bitnami/charts/pull/31014))
+
+## <small>3.1.3 (2024-12-12)</small>
+
+* [bitnami/scylladb] Release 3.1.3 (#31012) ([b6067b1](https://github.com/bitnami/charts/commit/b6067b1641d738898e0fd033ce38bec9ded58175)), closes [#31012](https://github.com/bitnami/charts/issues/31012)
 
 ## <small>3.1.2 (2024-12-12)</small>
 

--- a/bitnami/scylladb/Chart.yaml
+++ b/bitnami/scylladb/Chart.yaml
@@ -30,4 +30,4 @@ maintainers:
 name: scylladb
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/scylladb
-version: 3.1.3
+version: 3.1.4

--- a/bitnami/scylladb/README.md
+++ b/bitnami/scylladb/README.md
@@ -175,37 +175,37 @@ As the image run as non-root by default, it is necessary to adjust the ownership
 
 ### Scylladb parameters
 
-| Name                     | Description                                                                                                          | Value                      |
-| ------------------------ | -------------------------------------------------------------------------------------------------------------------- | -------------------------- |
-| `image.registry`         | Scylladb image registry                                                                                              | `REGISTRY_NAME`            |
-| `image.repository`       | Scylladb image repository                                                                                            | `REPOSITORY_NAME/scylladb` |
-| `image.digest`           | Scylladb image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag             | `""`                       |
-| `image.pullPolicy`       | image pull policy                                                                                                    | `IfNotPresent`             |
-| `image.pullSecrets`      | Scylladb image pull secrets                                                                                          | `[]`                       |
-| `image.debug`            | Enable image debug mode                                                                                              | `false`                    |
-| `dbUser.user`            | Scylladb admin user                                                                                                  | `cassandra`                |
-| `dbUser.forcePassword`   | Force the user to provide a non                                                                                      | `false`                    |
-| `dbUser.password`        | Password for `dbUser.user`. Randomly generated if empty                                                              | `""`                       |
-| `dbUser.existingSecret`  | Use an existing secret object for `dbUser.user` password (will ignore `dbUser.password`)                             | `""`                       |
-| `initDBConfigMap`        | ConfigMap with cql scripts. Useful for creating a keyspace and pre-populating data                                   | `""`                       |
-| `initDBSecret`           | Secret with cql script (with sensitive data). Useful for creating a keyspace and pre-populating data                 | `""`                       |
-| `existingConfiguration`  | ConfigMap with custom scylladb configuration files. This overrides any other Scylladb configuration set in the chart | `""`                       |
-| `cluster.name`           | Scylladb cluster name                                                                                                | `scylladb`                 |
-| `cluster.seedCount`      | Number of seed nodes                                                                                                 | `1`                        |
-| `cluster.numTokens`      | Number of tokens for each node                                                                                       | `256`                      |
-| `cluster.datacenter`     | Datacenter name                                                                                                      | `dc1`                      |
-| `cluster.rack`           | Rack name                                                                                                            | `rack1`                    |
-| `cluster.endpointSnitch` | Endpoint Snitch                                                                                                      | `SimpleSnitch`             |
-| `cluster.extraSeeds`     | For an external/second scylladb ring.                                                                                | `[]`                       |
-| `cluster.enableUDF`      | Enable User defined functions                                                                                        | `false`                    |
-| `jvm.extraOpts`          | Set the value for Java Virtual Machine extra options                                                                 | `""`                       |
-| `jvm.maxHeapSize`        | Set Java Virtual Machine maximum heap size (MAX_HEAP_SIZE). Calculated automatically if `nil`                        | `""`                       |
-| `jvm.newHeapSize`        | Set Java Virtual Machine new heap size (HEAP_NEWSIZE). Calculated automatically if `nil`                             | `""`                       |
-| `command`                | Command for running the container (set to default if not set). Use array form                                        | `[]`                       |
-| `args`                   | Args for running the container (set to default if not set). Use array form                                           | `[]`                       |
-| `extraEnvVars`           | Extra environment variables to be set on scylladb container                                                          | `[]`                       |
-| `extraEnvVarsCM`         | Name of existing ConfigMap containing extra env vars                                                                 | `""`                       |
-| `extraEnvVarsSecret`     | Name of existing Secret containing extra env vars                                                                    | `""`                       |
+| Name                     | Description                                                                                                            | Value                      |
+| ------------------------ | ---------------------------------------------------------------------------------------------------------------------- | -------------------------- |
+| `image.registry`         | Scylladb image registry                                                                                                | `REGISTRY_NAME`            |
+| `image.repository`       | Scylladb image repository                                                                                              | `REPOSITORY_NAME/scylladb` |
+| `image.digest`           | Scylladb image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag               | `""`                       |
+| `image.pullPolicy`       | image pull policy                                                                                                      | `IfNotPresent`             |
+| `image.pullSecrets`      | Scylladb image pull secrets                                                                                            | `[]`                       |
+| `image.debug`            | Enable image debug mode                                                                                                | `false`                    |
+| `dbUser.user`            | Scylladb admin user                                                                                                    | `cassandra`                |
+| `dbUser.forcePassword`   | Force the user to provide a non                                                                                        | `false`                    |
+| `dbUser.password`        | Password for `dbUser.user`. Randomly generated if empty                                                                | `""`                       |
+| `dbUser.existingSecret`  | Use an existing secret object for `dbUser.user` password (will ignore `dbUser.password`)                               | `""`                       |
+| `initDBConfigMap`        | ConfigMap with cql scripts. Useful for creating a keyspace and pre-populating data                                     | `""`                       |
+| `initDBSecret`           | Secret with cql script (with sensitive data). Useful for creating a keyspace and pre-populating data                   | `""`                       |
+| `existingConfiguration`  | ConfigMap with custom scylla.yaml configuration file. This overrides any other Scylladb configuration set in the chart | `""`                       |
+| `cluster.name`           | Scylladb cluster name                                                                                                  | `scylladb`                 |
+| `cluster.seedCount`      | Number of seed nodes                                                                                                   | `1`                        |
+| `cluster.numTokens`      | Number of tokens for each node                                                                                         | `256`                      |
+| `cluster.datacenter`     | Datacenter name                                                                                                        | `dc1`                      |
+| `cluster.rack`           | Rack name                                                                                                              | `rack1`                    |
+| `cluster.endpointSnitch` | Endpoint Snitch                                                                                                        | `SimpleSnitch`             |
+| `cluster.extraSeeds`     | For an external/second scylladb ring.                                                                                  | `[]`                       |
+| `cluster.enableUDF`      | Enable User defined functions                                                                                          | `false`                    |
+| `jvm.extraOpts`          | Set the value for Java Virtual Machine extra options                                                                   | `""`                       |
+| `jvm.maxHeapSize`        | Set Java Virtual Machine maximum heap size (MAX_HEAP_SIZE). Calculated automatically if `nil`                          | `""`                       |
+| `jvm.newHeapSize`        | Set Java Virtual Machine new heap size (HEAP_NEWSIZE). Calculated automatically if `nil`                               | `""`                       |
+| `command`                | Command for running the container (set to default if not set). Use array form                                          | `[]`                       |
+| `args`                   | Args for running the container (set to default if not set). Use array form                                             | `[]`                       |
+| `extraEnvVars`           | Extra environment variables to be set on scylladb container                                                            | `[]`                       |
+| `extraEnvVarsCM`         | Name of existing ConfigMap containing extra env vars                                                                   | `""`                       |
+| `extraEnvVarsSecret`     | Name of existing Secret containing extra env vars                                                                      | `""`                       |
 
 ### Statefulset parameters
 

--- a/bitnami/scylladb/templates/statefulset.yaml
+++ b/bitnami/scylladb/templates/statefulset.yaml
@@ -444,7 +444,7 @@ spec:
             {{- end }}
             {{ if .Values.existingConfiguration }}
             - name: configurations
-              mountPath: {{ printf "%s/etc" .Values.persistence.mountPath }}
+              mountPath: {{ printf "%s/etc/scylla" .Values.persistence.mountPath }}
             {{- end }}
             - name: empty-dir
               mountPath: /tmp

--- a/bitnami/scylladb/values.yaml
+++ b/bitnami/scylladb/values.yaml
@@ -137,7 +137,7 @@ initDBConfigMap: ""
 ## @param initDBSecret Secret with cql script (with sensitive data). Useful for creating a keyspace and pre-populating data
 ##
 initDBSecret: ""
-## @param existingConfiguration ConfigMap with custom scylladb configuration files. This overrides any other Scylladb configuration set in the chart
+## @param existingConfiguration ConfigMap with custom scylla.yaml configuration file. This overrides any other Scylladb configuration set in the chart
 ##
 existingConfiguration: ""
 ## Cluster parameters


### PR DESCRIPTION
### Description of the change

Fix existingConfiguration parameter for scylladb

### Benefits

Allow setting a custom configuration file

### Possible drawbacks

N/A

### Applicable issues

- fixes #30803

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
