### PR TITLE
[bitnami/moodle] Fix moodle pv and pvc templates

### DIFF
--- a/bitnami/moodle/CHANGELOG.md
+++ b/bitnami/moodle/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
+## 25.1.1 (2024-12-13)
+
+* [bitnami/moodle] Fix moodle pv and pvc templates ([#31026](https://github.com/bitnami/charts/pull/31026))
+
 ## 25.1.0 (2024-12-10)
 
-* [bitnami/moodle] Detect non-standard images ([#30960](https://github.com/bitnami/charts/pull/30960))
+* [bitnami/*] Add Bitnami Premium to NOTES.txt (#30854) ([3dfc003](https://github.com/bitnami/charts/commit/3dfc00376df6631f0ce54b8d440d477f6caa6186)), closes [#30854](https://github.com/bitnami/charts/issues/30854)
+* [bitnami/moodle] Detect non-standard images (#30960) ([3438d77](https://github.com/bitnami/charts/commit/3438d776d1fe43b64779e83fbccd69d7c67accdd)), closes [#30960](https://github.com/bitnami/charts/issues/30960)
 
 ## <small>25.0.2 (2024-12-09)</small>
 

--- a/bitnami/moodle/Chart.yaml
+++ b/bitnami/moodle/Chart.yaml
@@ -36,4 +36,4 @@ maintainers:
 name: moodle
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/moodle
-version: 25.1.0
+version: 25.1.1

--- a/bitnami/moodle/templates/pv.yaml
+++ b/bitnami/moodle/templates/pv.yaml
@@ -15,7 +15,13 @@ metadata:
   {{- end }}
 spec:
   accessModes:
-    - {{ .Values.persistence.accessMode | quote }}
+  {{- if not (empty .Values.persistence.accessModes) }}
+  {{- range .Values.persistence.accessModes }}
+    - {{ . | quote }}
+  {{- end }}
+  {{- else }}
+    - {{ .Values.persistence.accessModes | quote }}
+  {{- end }}
   capacity:
     storage: {{ .Values.persistence.size | quote }}
   hostPath:

--- a/bitnami/moodle/templates/pvc.yaml
+++ b/bitnami/moodle/templates/pvc.yaml
@@ -24,7 +24,7 @@ spec:
     - {{ . | quote }}
   {{- end }}
   {{- else }}
-    - {{ .Values.persistence.accessMode | quote }}
+    - {{ .Values.persistence.accessModes | quote }}
   {{- end }}
   resources:
     requests:


### PR DESCRIPTION
This patch is to fix the typo in the moodle templates for volumes. 
pvc has been updated to add the 's' on accessModes. pv has been updated to match the pvc.
IE: Support both arrays and a single string.

### Description of the change

Update the moodle Volume templates

### Benefits

Fix a bug for referencing local disk

### Possible drawbacks

None that I can see

### Applicable issues

https://github.com/bitnami/charts/issues/30976
- fixes #30976

### Additional information

N/A

### Checklist

- [ X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [ ] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
