### PR TITLE
[bitnami/zookeeper] Increase resources to avoid OOMKilled reason executing tests

### DIFF
--- a/.vib/zookeeper/runtime-parameters.yaml
+++ b/.vib/zookeeper/runtime-parameters.yaml
@@ -5,3 +5,8 @@ service:
 preAllocSize: 65536
 containerPorts:
   client: 2181
+resources:
+  requests:
+    memory: 512Mi
+  limits:
+    memory: 1024Mi

--- a/bitnami/zookeeper/CHANGELOG.md
+++ b/bitnami/zookeeper/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
+## 13.7.1 (2024-12-13)
+
+* [bitnami/zookeeper] Increase resources to avoid OOMKilled reason executing tests ([#31035](https://github.com/bitnami/charts/pull/31035))
+
 ## 13.7.0 (2024-12-10)
 
-* [bitnami/zookeeper] Detect non-standard images ([#30915](https://github.com/bitnami/charts/pull/30915))
+* [bitnami/*] Add Bitnami Premium to NOTES.txt (#30854) ([3dfc003](https://github.com/bitnami/charts/commit/3dfc00376df6631f0ce54b8d440d477f6caa6186)), closes [#30854](https://github.com/bitnami/charts/issues/30854)
+* [bitnami/zookeeper] Detect non-standard images (#30915) ([8168ae4](https://github.com/bitnami/charts/commit/8168ae4c69fac2433cc3f4b2e464c819f76a2420)), closes [#30915](https://github.com/bitnami/charts/issues/30915)
 
 ## <small>13.6.1 (2024-12-04)</small>
 

--- a/bitnami/zookeeper/Chart.yaml
+++ b/bitnami/zookeeper/Chart.yaml
@@ -28,4 +28,4 @@ maintainers:
 name: zookeeper
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/zookeeper
-version: 13.7.0
+version: 13.7.1


### PR DESCRIPTION
### Description of the change

Fix tests to release our charts.

