### PR TITLE
[bitnami/influxdb] Fix aws s3 sync command

### DIFF
--- a/bitnami/influxdb/CHANGELOG.md
+++ b/bitnami/influxdb/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
+## 6.5.1 (2024-12-18)
+
+* [bitnami/influxdb] Fix aws s3 sync command ([#31087](https://github.com/bitnami/charts/pull/31087))
+
 ## 6.5.0 (2024-12-10)
 
-* [bitnami/influxdb] Detect non-standard images ([#30882](https://github.com/bitnami/charts/pull/30882))
+* [bitnami/*] Add Bitnami Premium to NOTES.txt (#30854) ([3dfc003](https://github.com/bitnami/charts/commit/3dfc00376df6631f0ce54b8d440d477f6caa6186)), closes [#30854](https://github.com/bitnami/charts/issues/30854)
+* [bitnami/influxdb] Detect non-standard images (#30882) ([9406b31](https://github.com/bitnami/charts/commit/9406b319964695555717ff20832743fd65c35c40)), closes [#30882](https://github.com/bitnami/charts/issues/30882)
 
 ## <small>6.4.2 (2024-12-04)</small>
 

--- a/bitnami/influxdb/Chart.yaml
+++ b/bitnami/influxdb/Chart.yaml
@@ -37,4 +37,4 @@ maintainers:
 name: influxdb
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/influxdb
-version: 6.5.0
+version: 6.5.1

--- a/bitnami/influxdb/templates/configmap-backup.yaml
+++ b/bitnami/influxdb/templates/configmap-backup.yaml
@@ -66,5 +66,5 @@ data:
 
     set -e
 
-    aws s3 sync {{ .Values.backup.directory }} {{ .Values.backup.uploadProviders.aws.bucketName }}
+    aws s3 sync --delete {{ .Values.backup.directory }} {{ .Values.backup.uploadProviders.aws.bucketName }}
 {{ end }}


### PR DESCRIPTION
Fix old backup files in AWS S3 storage not being deleted during sync

### Description of the change
This update fix the aws sync command so the old backup in AWS S3 storage also deleted according to `retentionDays` parameter.

<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits
The old backup that deleted in local container storage also deleted in AWS S3 storage
<!-- What benefits will be realized by the code change? -->

### Possible drawbacks
_None_
<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes  [[bitnami/Influxdb] RetentionDays parameter does not work on AWS S3 Storage #31084](https://github.com/bitnami/charts/issues/31084)

### Additional information
_None_
<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
