### PR TITLE
[birtnami/dremio] chore(jmx-exporter): Upgrade image and change args

### DIFF
--- a/bitnami/dremio/CHANGELOG.md
+++ b/bitnami/dremio/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
+## 0.3.0 (2024-12-19)
+
+* [birtnami/dremio] chore(jmx-exporter): Upgrade image and change args ([#31102](https://github.com/bitnami/charts/pull/31102))
+
 ## 0.2.0 (2024-12-10)
 
-* [bitnami/dremio] Detect non-standard images ([#30897](https://github.com/bitnami/charts/pull/30897))
+* [bitnami/*] Add Bitnami Premium to NOTES.txt (#30854) ([3dfc003](https://github.com/bitnami/charts/commit/3dfc00376df6631f0ce54b8d440d477f6caa6186)), closes [#30854](https://github.com/bitnami/charts/issues/30854)
+* [bitnami/dremio] Detect non-standard images (#30897) ([0d3f735](https://github.com/bitnami/charts/commit/0d3f73580fa63eeddee5b7f29cc937588c612003)), closes [#30897](https://github.com/bitnami/charts/issues/30897)
 
 ## <small>0.1.15 (2024-12-07)</small>
 

--- a/bitnami/dremio/Chart.yaml
+++ b/bitnami/dremio/Chart.yaml
@@ -8,7 +8,7 @@ annotations:
     - name: dremio
       image: docker.io/bitnami/dremio:25.2.0-debian-12-r1
     - name: jmx-exporter
-      image: docker.io/bitnami/jmx-exporter:1.0.1-debian-12-r10
+      image: docker.io/bitnami/jmx-exporter:1.1.0-debian-12-r1
     - name: os-shell
       image: docker.io/bitnami/os-shell:12-debian-12-r33
 apiVersion: v2
@@ -41,4 +41,4 @@ sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/dremio
 - https://github.com/bitnami/containers/tree/main/bitnami/dremio
 - https://github.com/dremio/dremio-oss
-version: 0.2.0
+version: 0.3.0

--- a/bitnami/dremio/templates/coordinator/statefulset.yaml
+++ b/bitnami/dremio/templates/coordinator/statefulset.yaml
@@ -258,7 +258,7 @@ spec:
             - -XX:MaxRAMPercentage=100
             - -XshowSettings:vm
             - -jar
-            - jmx_prometheus_httpserver.jar
+            - jmx_prometheus_standalone.jar
             - {{ .Values.metrics.containerPorts.metrics | quote }}
             - /etc/jmx-dremio/jmx-prometheus.yml
             {{- if .Values.metrics.extraArgs }}

--- a/bitnami/dremio/templates/executor/statefulset.yaml
+++ b/bitnami/dremio/templates/executor/statefulset.yaml
@@ -262,7 +262,7 @@ spec:
             - -XX:MaxRAMPercentage=100
             - -XshowSettings:vm
             - -jar
-            - jmx_prometheus_httpserver.jar
+            - jmx_prometheus_standalone.jar
             - {{ $.Values.metrics.containerPorts.metrics | quote }}
             - /etc/jmx-dremio/jmx-prometheus.yml
           {{- end }}

--- a/bitnami/dremio/templates/master-coordinator/statefulset.yaml
+++ b/bitnami/dremio/templates/master-coordinator/statefulset.yaml
@@ -262,7 +262,7 @@ spec:
             - -XX:MaxRAMPercentage=100
             - -XshowSettings:vm
             - -jar
-            - jmx_prometheus_httpserver.jar
+            - jmx_prometheus_standalone.jar
             - {{ .Values.metrics.containerPorts.metrics | quote }}
             - /etc/jmx-dremio/jmx-prometheus.yml
           {{- end }}

--- a/bitnami/dremio/values.yaml
+++ b/bitnami/dremio/values.yaml
@@ -2331,7 +2331,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/jmx-exporter
-    tag: 1.0.1-debian-12-r10
+    tag: 1.1.0-debian-12-r1
     digest: ""
     ## Specify a imagePullPolicy
     ## ref: https://kubernetes.io/docs/concepts/containers/images/#pre-pulled-images


### PR DESCRIPTION
### Description of the change

Upgrade jmx-exporter image

### Benefits

Keep chart updated.

### Possible drawbacks

None

### Additional information

File name for the java application was changed: https://github.com/prometheus/jmx_exporter/releases/tag/1.1.0

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
