### PR TITLE
[bitnami/sonarqube] chore(jmx-exporter): Upgrade image and change args

### DIFF
--- a/bitnami/sonarqube/Chart.yaml
+++ b/bitnami/sonarqube/Chart.yaml
@@ -6,7 +6,7 @@ annotations:
   licenses: Apache-2.0
   images: |
     - name: jmx-exporter
-      image: docker.io/bitnami/jmx-exporter:1.0.1-debian-12-r9
+      image: docker.io/bitnami/jmx-exporter:1.1.0-debian-12-r1
     - name: os-shell
       image: docker.io/bitnami/os-shell:12-debian-12-r32
     - name: sonarqube
@@ -37,4 +37,4 @@ maintainers:
 name: sonarqube
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/sonarqube
-version: 6.1.0
+version: 6.2.0

--- a/bitnami/sonarqube/templates/deployment.yaml
+++ b/bitnami/sonarqube/templates/deployment.yaml
@@ -432,7 +432,7 @@ spec:
             - -XX:MaxRAMPercentage=100
             - -XshowSettings:vm
             - -jar
-            - jmx_prometheus_httpserver.jar
+            - jmx_prometheus_standalone.jar
             - {{ .Values.metrics.jmx.containerPorts.metrics | quote }}
             - /etc/jmx/sonarqube-prometheus.yml
           {{- end }}
@@ -443,6 +443,17 @@ spec:
           resources: {{- toYaml .Values.metrics.jmx.resources | nindent 12 }}
           {{- else if ne .Values.metrics.jmx.resourcesPreset "none" }}
           resources: {{- include "common.resources.preset" (dict "type" .Values.metrics.jmx.resourcesPreset) | nindent 12 }}
+          {{- end }}
+          {{- if .Values.metrics.jmx.livenessProbe.enabled }}
+          livenessProbe: {{- omit .Values.metrics.jmx.livenessProbe "enabled" | toYaml | nindent 12 }}
+            tcpSocket:
+              port: metrics
+          {{- end }}
+          {{- if .Values.metrics.jmx.readinessProbe.enabled }}
+          readinessProbe: {{- omit .Values.metrics.jmx.readinessProbe "enabled" | toYaml | nindent 12 }}
+            httpGet:
+              path: /
+              port: metrics
           {{- end }}
           volumeMounts:
             - name: empty-dir

--- a/bitnami/sonarqube/values.yaml
+++ b/bitnami/sonarqube/values.yaml
@@ -1081,7 +1081,7 @@ metrics:
     image:
       registry: docker.io
       repository: bitnami/jmx-exporter
-      tag: 1.0.1-debian-12-r9
+      tag: 1.1.0-debian-12-r1
       digest: ""
       pullPolicy: IfNotPresent
       ## Optionally specify an array of imagePullSecrets.
@@ -1113,6 +1113,38 @@ metrics:
     ##     memory: 1024Mi
     ##
     resources: {}
+    ## Configure extra options for liveness probe
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
+    ## @param metrics.jmx.livenessProbe.enabled Enable livenessProbe
+    ## @param metrics.jmx.livenessProbe.initialDelaySeconds Initial delay seconds for livenessProbe
+    ## @param metrics.jmx.livenessProbe.periodSeconds Period seconds for livenessProbe
+    ## @param metrics.jmx.livenessProbe.timeoutSeconds Timeout seconds for livenessProbe
+    ## @param metrics.jmx.livenessProbe.failureThreshold Failure threshold for livenessProbe
+    ## @param metrics.jmx.livenessProbe.successThreshold Success threshold for livenessProbe
+    ##
+    livenessProbe:
+      enabled: true
+      initialDelaySeconds: 60
+      periodSeconds: 10
+      timeoutSeconds: 10
+      successThreshold: 1
+      failureThreshold: 3
+    ## Configure extra options for readiness probe
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
+    ## @param metrics.jmx.readinessProbe.enabled Enable readinessProbe
+    ## @param metrics.jmx.readinessProbe.initialDelaySeconds Initial delay seconds for readinessProbe
+    ## @param metrics.jmx.readinessProbe.periodSeconds Period seconds for readinessProbe
+    ## @param metrics.jmx.readinessProbe.timeoutSeconds Timeout seconds for readinessProbe
+    ## @param metrics.jmx.readinessProbe.failureThreshold Failure threshold for readinessProbe
+    ## @param metrics.jmx.readinessProbe.successThreshold Success threshold for readinessProbe
+    ##
+    readinessProbe:
+      enabled: true
+      initialDelaySeconds: 30
+      periodSeconds: 10
+      timeoutSeconds: 10
+      successThreshold: 1
+      failureThreshold: 3
     ## Configure Container Security Context
     ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
     ## @param metrics.jmx.containerSecurityContext.enabled Enabled containers' Security Context


### PR DESCRIPTION
### Description of the change

Upgrade jmx-exporter image and set liveness and readiness probes.

### Benefits

Keep chart updated.

### Possible drawbacks

None

### Additional information

File name for the java application was changed: https://github.com/prometheus/jmx_exporter/releases/tag/1.1.0

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
