### PR TITLE
[bitnami/harbor] Only set metric environment variables for exporter when enabled, set environment variables for jobservice when metrics are enabled to fix metric name

### DIFF
--- a/bitnami/harbor/CHANGELOG.md
+++ b/bitnami/harbor/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 24.1.1 (2024-12-19)
+## 24.1.1 (2024-12-23)
 
 * [bitnami/harbor] Only set metric environment variables for exporter when enabled, set environment variables for jobservice when metrics are enabled to fix metric name ([#31122](https://github.com/bitnami/charts/pull/31122))
 

--- a/bitnami/harbor/CHANGELOG.md
+++ b/bitnami/harbor/CHANGELOG.md
@@ -1,8 +1,16 @@
 # Changelog
 
+## 24.1.1 (2024-12-19)
+
+* [bitnami/harbor] Only set metric environment variables for exporter when enabled, set environment variables for jobservice when metrics are enabled to fix metric name ([#31122](https://github.com/bitnami/charts/pull/31122))
+
 ## 24.1.0 (2024-12-10)
 
-* [bitnami/harbor] Detect non-standard images ([#30883](https://github.com/bitnami/charts/pull/30883))
+* [bitnami/*] Add Bitnami Premium to NOTES.txt (#30854) ([3dfc003](https://github.com/bitnami/charts/commit/3dfc00376df6631f0ce54b8d440d477f6caa6186)), closes [#30854](https://github.com/bitnami/charts/issues/30854)
+* [bitnami/*] docs: :memo: Add "Backup & Restore" section (#30711) ([35ab536](https://github.com/bitnami/charts/commit/35ab5363741e7548f4076f04da6e62d10153c60c)), closes [#30711](https://github.com/bitnami/charts/issues/30711)
+* [bitnami/*] docs: :memo: Add "Prometheus metrics" (batch 2) (#30662) ([50e0570](https://github.com/bitnami/charts/commit/50e0570f98ab15308af7910b405baa4480e5fe3f)), closes [#30662](https://github.com/bitnami/charts/issues/30662)
+* [bitnami/*] docs: :memo: Unify "Securing Traffic using TLS" section (#30707) ([b572333](https://github.com/bitnami/charts/commit/b57233336e4fe9af928ecb4f2a5f334011efb1bc)), closes [#30707](https://github.com/bitnami/charts/issues/30707)
+* [bitnami/harbor] Detect non-standard images (#30883) ([95c2321](https://github.com/bitnami/charts/commit/95c232141f4d0e432da61c6b2d1331557a8e8acd)), closes [#30883](https://github.com/bitnami/charts/issues/30883)
 
 ## <small>24.0.2 (2024-11-14)</small>
 

--- a/bitnami/harbor/Chart.yaml
+++ b/bitnami/harbor/Chart.yaml
@@ -55,4 +55,4 @@ maintainers:
 name: harbor
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/harbor
-version: 24.1.0
+version: 24.1.1

--- a/bitnami/harbor/templates/exporter/exporter-cm-envvars.yaml
+++ b/bitnami/harbor/templates/exporter/exporter-cm-envvars.yaml
@@ -19,9 +19,11 @@ metadata:
 data:
   LOG_LEVEL: {{ .Values.logLevel | quote }}
   HARBOR_EXPORTER_PORT: {{ .Values.exporter.containerPorts.metrics | quote }}
+  {{- if .Values.metrics.enabled}}
   HARBOR_EXPORTER_METRICS_PATH: {{ .Values.metrics.path | quote }}
   HARBOR_METRIC_NAMESPACE: harbor
   HARBOR_METRIC_SUBSYSTEM: exporter
+  {{- end }}
   HARBOR_REDIS_NAMESPACE: {{ .Values.jobservice.redisNamespace | quote }}
   HARBOR_SERVICE_SCHEME: {{ ternary "https" "http" .Values.internalTLS.enabled | quote }}
   HARBOR_SERVICE_HOST: {{ include "harbor.core" . | quote }}

--- a/bitnami/harbor/templates/jobservice/jobservice-cm-envvars.yaml
+++ b/bitnami/harbor/templates/jobservice/jobservice-cm-envvars.yaml
@@ -27,6 +27,10 @@ data:
   NO_PROXY: {{ include "harbor.noProxy" . | quote }}
   {{- end }}
   LOG_LEVEL: {{ .Values.logLevel | quote }}
+  {{- if .Values.metrics.enabled}}
+  METRIC_NAMESPACE: harbor
+  METRIC_SUBSYSTEM: jobservice
+  {{- end }}
   {{- if .Values.tracing.enabled }}
   TRACE_SERVICE_NAME: "harbor-jobservice"
   {{- include "harbor.tracing.envvars" . | nindent 2}}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

- Only set metric environment variables for exporter when enabled
- Set environment variables for jobservice when metrics are enabled to fix metric name

Before this, metrics are named without `harbor_jobservice` prefix.

### Benefits

Metrics are exposed with the same naming as in the docs: https://goharbor.io/docs/main/administration/metrics/

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

If users are using this metrics for Dashboards, PrometheusRules, RecordingRules etc. they have to change the expressions.
<!-- Describe any known limitations with your change -->

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
