### PR TITLE
[bitnami/common] Add "common.capabilities.job.apiVersion" template

### DIFF
--- a/bitnami/common/CHANGELOG.md
+++ b/bitnami/common/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2.29.0 (2024-12-30)
+## 2.29.0 (2025-01-02)
 
 * [bitnami/common] Add "common.capabilities.job.apiVersion" template ([#31164](https://github.com/bitnami/charts/pull/31164))
 

--- a/bitnami/common/Chart.yaml
+++ b/bitnami/common/Chart.yaml
@@ -23,4 +23,4 @@ name: common
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/common
 type: library
-version: 2.28.0
+version: 2.29.0

--- a/bitnami/common/Chart.yaml
+++ b/bitnami/common/Chart.yaml
@@ -7,9 +7,7 @@ annotations:
 apiVersion: v2
 # Please make sure that version and appVersion are always the same.
 appVersion: 2.29.0
-description:
-  A Library Helm Chart for grouping common logic between bitnami charts. This
-  chart is not deployable by itself.
+description: A Library Helm Chart for grouping common logic between bitnami charts. This chart is not deployable by itself.
 home: https://bitnami.com
 icon: https://bitnami.com/downloads/logos/bitnami-mark.png
 keywords:

--- a/bitnami/common/Chart.yaml
+++ b/bitnami/common/Chart.yaml
@@ -6,8 +6,10 @@ annotations:
   licenses: Apache-2.0
 apiVersion: v2
 # Please make sure that version and appVersion are always the same.
-appVersion: 2.28.0
-description: A Library Helm Chart for grouping common logic between bitnami charts. This chart is not deployable by itself.
+appVersion: 2.29.0
+description:
+  A Library Helm Chart for grouping common logic between bitnami charts. This
+  chart is not deployable by itself.
 home: https://bitnami.com
 icon: https://bitnami.com/downloads/logos/bitnami-mark.png
 keywords:

--- a/bitnami/common/templates/_capabilities.tpl
+++ b/bitnami/common/templates/_capabilities.tpl
@@ -37,6 +37,18 @@ Return the appropriate apiVersion for networkpolicy.
 {{- end -}}
 
 {{/*
+Return the appropriate apiVersion for job.
+*/}}
+{{- define "common.capabilities.job.apiVersion" -}}
+{{- $kubeVersion := include "common.capabilities.kubeVersion" . -}}
+{{- if and (not (empty $kubeVersion)) (semverCompare "<1.21-0" $kubeVersion) -}}
+{{- print "batch/v1beta1" -}}
+{{- else -}}
+{{- print "batch/v1" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Return the appropriate apiVersion for cronjob.
 */}}
 {{- define "common.capabilities.cronjob.apiVersion" -}}
@@ -81,18 +93,6 @@ Return the appropriate apiVersion for statefulset.
 {{- print "apps/v1beta1" -}}
 {{- else -}}
 {{- print "apps/v1" -}}
-{{- end -}}
-{{- end -}}
-
-{{/*
-Return the appropriate apiVersion for job.
-*/}}
-{{- define "common.capabilities.job.apiVersion" -}}
-{{- $kubeVersion := include "common.capabilities.kubeVersion" . -}}
-{{- if and (not (empty $kubeVersion)) (semverCompare "<1.21-0" $kubeVersion) -}}
-{{- print "batch/v1beta1" -}}
-{{- else -}}
-{{- print "batch/v1" -}}
 {{- end -}}
 {{- end -}}
 

--- a/bitnami/common/templates/_capabilities.tpl
+++ b/bitnami/common/templates/_capabilities.tpl
@@ -85,6 +85,18 @@ Return the appropriate apiVersion for statefulset.
 {{- end -}}
 
 {{/*
+Return the appropriate apiVersion for job.
+*/}}
+{{- define "common.capabilities.job.apiVersion" -}}
+{{- $kubeVersion := include "common.capabilities.kubeVersion" . -}}
+{{- if and (not (empty $kubeVersion)) (semverCompare "<1.21-0" $kubeVersion) -}}
+{{- print "batch/v1beta1" -}}
+{{- else -}}
+{{- print "batch/v1" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Return the appropriate apiVersion for ingress.
 */}}
 {{- define "common.capabilities.ingress.apiVersion" -}}


### PR DESCRIPTION
### Description of the change

- Add "common.capabilities.job.apiVersion" template

### Benefits

- Encapsulate job API version string logic

### Applicable issues

It's related to https://github.com/bitnami/charts/pull/31161 and https://github.com/bitnami/containers/pull/75906

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
