### PR TITLE
[bitnami/nessie]fix(runtime-parameters.yaml): Set long postgresql password

### DIFF
--- a/.vib/nessie/runtime-parameters.yaml
+++ b/.vib/nessie/runtime-parameters.yaml
@@ -1,3 +1,6 @@
+postgresql:
+  auth:
+    password: ComplicatedPassword123!4
 podSecurityContext:
   fsGroup: 1002
 containerSecurityContext:

--- a/bitnami/nessie/CHANGELOG.md
+++ b/bitnami/nessie/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 1.1.2 (2024-12-18)
+## 1.1.3 (2024-12-26)
 
-* [bitnami/nessie] Release 1.1.2 ([#31096](https://github.com/bitnami/charts/pull/31096))
+* [bitnami/nessie]fix(runtime-parameters.yaml): Set long postgresql password ([#31165](https://github.com/bitnami/charts/pull/31165))
+
+## <small>1.1.2 (2024-12-18)</small>
+
+* [bitnami/nessie] Release 1.1.2 (#31096) ([31f73fe](https://github.com/bitnami/charts/commit/31f73fe9c561b996028a11550eeaf9292969d4ff)), closes [#31096](https://github.com/bitnami/charts/issues/31096)
 
 ## <small>1.1.1 (2024-12-12)</small>
 

--- a/bitnami/nessie/Chart.yaml
+++ b/bitnami/nessie/Chart.yaml
@@ -38,4 +38,4 @@ sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/nessie
 - https://github.com/bitnami/containers/tree/main/bitnami/nessie
 - https://github.com/nessie/nessie
-version: 1.1.2
+version: 1.1.3


### PR DESCRIPTION
### Description of the change

Set explicitly a long postgresql password in `runtime-parameters.yaml` file.

### Benefits

Default postgresql password has 10 characters (80 bits). This length is not enough for some test scenarios. 

### Possible drawbacks

None

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
