### PR TITLE
[bitnami/jenkins] Fix initHookScriptsSecret

### DIFF
--- a/bitnami/jenkins/CHANGELOG.md
+++ b/bitnami/jenkins/CHANGELOG.md
@@ -1,8 +1,15 @@
 # Changelog
 
+## 13.5.1 (2024-12-27)
+
+* [bitnami/jenkins] Fix initHookScriptsSecret ([#31175](https://github.com/bitnami/charts/pull/31175))
+
 ## 13.5.0 (2024-12-10)
 
-* [bitnami/jenkins] Detect non-standard images ([#30905](https://github.com/bitnami/charts/pull/30905))
+* [bitnami/*] Add Bitnami Premium to NOTES.txt (#30854) ([3dfc003](https://github.com/bitnami/charts/commit/3dfc00376df6631f0ce54b8d440d477f6caa6186)), closes [#30854](https://github.com/bitnami/charts/issues/30854)
+* [bitnami/*] docs: :memo: Add "Backup & Restore" section (#30711) ([35ab536](https://github.com/bitnami/charts/commit/35ab5363741e7548f4076f04da6e62d10153c60c)), closes [#30711](https://github.com/bitnami/charts/issues/30711)
+* [bitnami/*] docs: :memo: Add "Update Credentials" (batch 2) (#30687) ([c457848](https://github.com/bitnami/charts/commit/c457848b2a111aad59830b98f85ffa1e29918e10)), closes [#30687](https://github.com/bitnami/charts/issues/30687)
+* [bitnami/jenkins] Detect non-standard images (#30905) ([59a3b68](https://github.com/bitnami/charts/commit/59a3b68c1b43deabc3a6eb08002baab4e2943bcf)), closes [#30905](https://github.com/bitnami/charts/issues/30905)
 
 ## <small>13.4.28 (2024-11-28)</small>
 

--- a/bitnami/jenkins/Chart.yaml
+++ b/bitnami/jenkins/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: jenkins
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/jenkins
-version: 13.5.0
+version: 13.5.1

--- a/bitnami/jenkins/templates/deployment.yaml
+++ b/bitnami/jenkins/templates/deployment.yaml
@@ -547,6 +547,7 @@ spec:
         {{- if or .Values.initHookScripts .Values.initHookScriptsCM .Values.initHookScriptsSecret }}
         - name: jenkins-init-hook-scripts
           projected:
+            defaultMode: 0755
             sources:
               {{- if or .Values.initHookScripts .Values.initHookScriptsCM }}
               - configMap:
@@ -554,8 +555,7 @@ spec:
               {{- end }}
               {{- if .Values.initHookScriptsSecret }}
               - secret:
-                  secretName: {{ print (tpl .Values.initHookScriptsSecret .) }}
-                  defaultMode: 0755
+                  name: {{ print (tpl .Values.initHookScriptsSecret .) }}
               {{- end }}
         {{- end }}
         {{- if .Values.extraVolumes }}


### PR DESCRIPTION
### Description of the change

Use `name` instead of `secretName` for projected volume when using `initHookScriptsSecret`.

### Benefits

Allos using `initHookScriptsSecret`

### Possible drawbacks

N/A

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #31167

### Additional information

```
Each projected volume source is listed in the spec under sources. The parameters are nearly the same with two exceptions:

For secrets, the secretName field has been changed to name to be consistent with ConfigMap naming.
The defaultMode can only be specified at the projected level and not for each volume source. However, as illustrated above, you can explicitly set the mode for each individual projection.
```

https://kubernetes.io/docs/concepts/storage/projected-volumes/#example-configuration-secrets-nondefault-permission-mode

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
