### PR TITLE
[bitnami/Ghost] Correctly handle smtpExistingSecret value

### DIFF
--- a/bitnami/ghost/CHANGELOG.md
+++ b/bitnami/ghost/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 22.1.2 (2024-12-13)
+## 22.1.3 (2024-12-28)
 
-* [bitnami/ghost] Release 22.1.2 ([#31038](https://github.com/bitnami/charts/pull/31038))
+* [bitnami/Ghost] Correctly handle smtpExistingSecret value ([#31179](https://github.com/bitnami/charts/pull/31179))
+
+## <small>22.1.2 (2024-12-13)</small>
+
+* [bitnami/ghost] Release 22.1.2 (#31038) ([b5d4c51](https://github.com/bitnami/charts/commit/b5d4c5136f4da9c15b23fa036fc2f826f3852adf)), closes [#31038](https://github.com/bitnami/charts/issues/31038)
 
 ## <small>22.1.1 (2024-12-11)</small>
 

--- a/bitnami/ghost/CHANGELOG.md
+++ b/bitnami/ghost/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 22.1.3 (2024-12-29)
+## 22.1.3 (2025-01-07)
 
 * [bitnami/Ghost] Correctly handle smtpExistingSecret value ([#31179](https://github.com/bitnami/charts/pull/31179))
 

--- a/bitnami/ghost/CHANGELOG.md
+++ b/bitnami/ghost/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 22.1.3 (2024-12-28)
+## 22.1.3 (2024-12-29)
 
 * [bitnami/Ghost] Correctly handle smtpExistingSecret value ([#31179](https://github.com/bitnami/charts/pull/31179))
 

--- a/bitnami/ghost/Chart.yaml
+++ b/bitnami/ghost/Chart.yaml
@@ -40,4 +40,4 @@ maintainers:
 name: ghost
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/ghost
-version: 22.1.2
+version: 22.1.3

--- a/bitnami/ghost/templates/_helpers.tpl
+++ b/bitnami/ghost/templates/_helpers.tpl
@@ -137,6 +137,17 @@ Return the MySQL Secret Name
 {{- end -}}
 
 {{/*
+Return the SMTP Secret Name
+*/}}
+{{- define "ghost.smtpSecretName" -}}
+{{- if .Values.smtpExistingSecret }}
+    {{- printf "%s" .Values.smtpExistingSecret -}}
+{{- else -}}
+    {{- printf "%s-smtp" (include "common.names.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Compile all warnings into a single message.
 */}}
 {{- define "ghost.validateValues" -}}

--- a/bitnami/ghost/templates/deployment.yaml
+++ b/bitnami/ghost/templates/deployment.yaml
@@ -204,13 +204,11 @@ spec:
             - name: GHOST_SMTP_USER
               value: {{ .Values.smtpUser | quote }}
             {{- end }}
-            {{- if .Values.smtpPassword }}
             - name: GHOST_SMTP_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "common.secrets.name" (dict "existingSecret" .Values.existingSecret "context" $) }}
-                  key: {{ include "common.secrets.key" (dict "existingSecret" .Values.existingSecret "key" "smtp-password") }}
-            {{- end }}
+                  name: {{ include "ghost.smtpSecretName" . }}
+                  key: smtp-password
             {{- if .Values.smtpService }}
             - name: GHOST_SMTP_SERVICE
               value: {{ .Values.smtpService | quote }}

--- a/bitnami/ghost/templates/secrets.yaml
+++ b/bitnami/ghost/templates/secrets.yaml
@@ -3,7 +3,7 @@ Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- if or (not .Values.existingSecret) (and (not .Values.smtpExistingSecret) .Values.smtpPassword) }}
+{{- if not .Values.existingSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -22,9 +22,23 @@ data:
   ghost-password: {{ randAlphaNum 10 | b64enc | quote }}
   {{- end }}
   {{- end }}
-  {{- if and .Values.smtpPassword (not .Values.smtpExistingSecret) }}
+---
+{{- end }}
+
+{{- if not .Values.smtpExistingSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "common.names.fullname" . }}-smtp
+  namespace: {{ .Release.Namespace | quote }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+type: Opaque
+data:
   {{- if .Values.smtpPassword }}
   smtp-password: {{ .Values.smtpPassword | b64enc | quote }}
   {{- end }}
-  {{- end }}
+---
 {{- end }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Correctly handles setting either `.Values.smtpPassword` or `.Values.smtpExistingSecret`. Default smtp-password is now created in its own Secret if an existing is not provided.

### Benefits

<!-- What benefits will be realized by the code change? -->

Fixes the need to provide a dummy `smtpPassword` value when using an external secret.

### Possible drawbacks

<!-- Describe any known limitations with your change -->

The SMTP secret, if an existing Secret resource is not provided, is now in its own Secret resource rather than the one used for the Ghost auth credentials (to be more in-line with the database secret)

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes https://github.com/bitnami/charts/issues/8916

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
