### PR TITLE
[bitnami/mastodon] Avoid mkdir issue when restarting

### DIFF
--- a/bitnami/mastodon/CHANGELOG.md
+++ b/bitnami/mastodon/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
+## 9.1.1 (2024-12-30)
+
+* [bitnami/mastodon] Avoid mkdir issue when restarting ([#31183](https://github.com/bitnami/charts/pull/31183))
+
 ## 9.1.0 (2024-12-10)
 
-* [bitnami/mastodon] Detect non-standard images ([#30921](https://github.com/bitnami/charts/pull/30921))
+* [bitnami/*] Add Bitnami Premium to NOTES.txt (#30854) ([3dfc003](https://github.com/bitnami/charts/commit/3dfc00376df6631f0ce54b8d440d477f6caa6186)), closes [#30854](https://github.com/bitnami/charts/issues/30854)
+* [bitnami/mastodon] Detect non-standard images (#30921) ([eea0814](https://github.com/bitnami/charts/commit/eea08143bfe95dfbd356d5f5fa8eb663b9bf130e)), closes [#30921](https://github.com/bitnami/charts/issues/30921)
 
 ## <small>9.0.5 (2024-12-03)</small>
 

--- a/bitnami/mastodon/Chart.yaml
+++ b/bitnami/mastodon/Chart.yaml
@@ -49,4 +49,4 @@ maintainers:
 name: mastodon
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/mastodon
-version: 9.1.0
+version: 9.1.1

--- a/bitnami/mastodon/templates/web/deployment.yaml
+++ b/bitnami/mastodon/templates/web/deployment.yaml
@@ -83,7 +83,7 @@ spec:
               #!/bin/bash
               # HACK: Mastodon does not allow having a /tmp directory world-writable, so we need to create a /tmp dir
               # with more restricted permissions
-              mkdir /tmp/tmp-dir
+              mkdir -p /tmp/tmp-dir
           {{- if .Values.defaultInitContainers.prepareDirs.resources }}
           resources: {{- toYaml .Values.defaultInitContainers.prepareDirs.resources | nindent 12 }}
           {{- else if ne .Values.defaultInitContainers.prepareDirs.resourcesPreset "none" }}


### PR DESCRIPTION
### Description of the change

Avoid `mkdir` error when restarting if the directory already exists.

### Benefits

Allow restarting web deployment correctly.

### Possible drawbacks

N/A

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #31025

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
