### PR TITLE
 [bitnami/clickhouse] Fix: bind ipv6 and ipv4 by default 

### DIFF
--- a/bitnami/clickhouse/CHANGELOG.md
+++ b/bitnami/clickhouse/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 7.1.6 (2025-01-17)
+## 7.2.0 (2025-01-17)
 
-* [bitnami/clickhouse] Release 7.1.6 ([#31450](https://github.com/bitnami/charts/pull/31450))
+*  [bitnami/clickhouse] Fix: bind ipv6 and ipv4 by default  ([#31200](https://github.com/bitnami/charts/pull/31200))
+
+## <small>7.1.6 (2025-01-17)</small>
+
+* [bitnami/clickhouse] Release 7.1.6 (#31450) ([aca9954](https://github.com/bitnami/charts/commit/aca99540e8ba61cfab493704c56520fc2f010849)), closes [#31450](https://github.com/bitnami/charts/issues/31450)
 
 ## <small>7.1.5 (2025-01-14)</small>
 

--- a/bitnami/clickhouse/Chart.yaml
+++ b/bitnami/clickhouse/Chart.yaml
@@ -33,4 +33,4 @@ maintainers:
 name: clickhouse
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/clickhouse
-version: 7.1.6
+version: 7.2.0

--- a/bitnami/clickhouse/templates/scripts-configmap.yaml
+++ b/bitnami/clickhouse/templates/scripts-configmap.yaml
@@ -31,4 +31,4 @@ data:
             exit 1
         fi
     fi
-    exec /opt/bitnami/scripts/clickhouse/entrypoint.sh /opt/bitnami/scripts/clickhouse/run.sh -- --listen_host=0.0.0.0
+    exec /opt/bitnami/scripts/clickhouse/entrypoint.sh /opt/bitnami/scripts/clickhouse/run.sh  "$@"

--- a/bitnami/clickhouse/values.yaml
+++ b/bitnami/clickhouse/values.yaml
@@ -415,6 +415,9 @@ defaultConfigurationOverrides: |
         <asynchronous_metrics>true</asynchronous_metrics>
     </prometheus>
     {{- end }}
+    <listen_host>0.0.0.0</listen_host>
+    <listen_host>::</listen_host>
+    <listen_try>1</listen_try>
   </clickhouse>
 ## @param existingOverridesConfigmap The name of an existing ConfigMap with your custom configuration for ClickHouse
 ##


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->
### Note

This PR is re-open of #31168 (see https://github.com/bitnami/charts/pull/31168#issuecomment-2567439700)

### Motivation

The current clickhouse helm chart don't support ipv6 only cluster.

### Context

By default clickhouse bind localhost on ipv4 and ipv6 (see https://github.com/ClickHouse/ClickHouse/blob/master/programs/server/config.xml#L253).

The bitnami container override this behaviors and bind to any ipv4 by passing `-- --listen_host=0.0.0.0` to `clickhouse-server` via the `CMD` (see https://github.com/bitnami/containers/blob/main/bitnami/clickhouse/24/debian-12/Dockerfile#L60).
this is easily override to listen on ivp6 by changing the container command to `/opt/bitnami/scripts/clickhouse/run.sh -- --listen_host="::"`.

The helm chart use an hard coded script as it's entry with no possibility to pass/override argument to `clickhouse-server`. (see https://github.com/bitnami/charts/blob/main/bitnami/clickhouse/templates/scripts-configmap.yaml) 

### Description of the change

this PR:

- remove the default `clickhouse-server` arguments.
- allow to specify `clickhouse-server` arguments.
- use the `defaultConfigurationOverrides` to listen on ipv4 and ipv6 

### Benefits

Add Support for ipv6 only cluster

### Possible drawbacks

It's harder to change `listen_host` in the xml config file.

### Applicable issues

related with https://github.com/OneUptime/oneuptime/issues/1348

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
