### PR TITLE
Revert "[bitnami/postgresql] Add Storage Class Configuration to Templates (#30858)"

### DIFF
--- a/bitnami/postgresql/CHANGELOG.md
+++ b/bitnami/postgresql/CHANGELOG.md
@@ -19,8 +19,7 @@
 
 ## 16.3.0 (2024-12-10)
 
-* [bitnami/*] Add Bitnami Premium to NOTES.txt (#30854) ([3dfc003](https://github.com/bitnami/charts/commit/3dfc00376df6631f0ce54b8d440d477f6caa6186)), closes [#30854](https://github.com/bitnami/charts/issues/30854)
-* [bitnami/postgresql] Detect non-standard images (#30936) ([ac96151](https://github.com/bitnami/charts/commit/ac96151bdbe5e99b00dcde62a4d72f1827fa46b2)), closes [#30936](https://github.com/bitnami/charts/issues/30936)
+* [bitnami/postgresql] Detect non-standard images ([#30936](https://github.com/bitnami/charts/pull/30936))
 
 ## <small>16.2.5 (2024-12-03)</small>
 

--- a/bitnami/postgresql/CHANGELOG.md
+++ b/bitnami/postgresql/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 16.3.4 (2024-12-23)
+## 16.3.5 (2025-01-03)
 
-* [bitnami/postgresql] Release 16.3.4 ([#31143](https://github.com/bitnami/charts/pull/31143))
+* Revert "[bitnami/postgresql] Add Storage Class Configuration to Templates (#30858)" ([#31204](https://github.com/bitnami/charts/pull/31204))
+
+## <small>16.3.4 (2024-12-23)</small>
+
+* [bitnami/postgresql] Release 16.3.4 (#31143) ([05a9583](https://github.com/bitnami/charts/commit/05a9583f949b49fab2673774a4f56ff686d959f4)), closes [#31143](https://github.com/bitnami/charts/issues/31143)
 
 ## <small>16.3.3 (2024-12-20)</small>
 

--- a/bitnami/postgresql/CHANGELOG.md
+++ b/bitnami/postgresql/CHANGELOG.md
@@ -19,7 +19,8 @@
 
 ## 16.3.0 (2024-12-10)
 
-* [bitnami/postgresql] Detect non-standard images ([#30936](https://github.com/bitnami/charts/pull/30936))
+* [bitnami/*] Add Bitnami Premium to NOTES.txt (#30854) ([3dfc003](https://github.com/bitnami/charts/commit/3dfc00376df6631f0ce54b8d440d477f6caa6186)), closes [#30854](https://github.com/bitnami/charts/issues/30854)
+* [bitnami/postgresql] Detect non-standard images (#30936) ([ac96151](https://github.com/bitnami/charts/commit/ac96151bdbe5e99b00dcde62a4d72f1827fa46b2)), closes [#30936](https://github.com/bitnami/charts/issues/30936)
 
 ## <small>16.2.5 (2024-12-03)</small>
 

--- a/bitnami/postgresql/Chart.yaml
+++ b/bitnami/postgresql/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: postgresql
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/postgresql
-version: 16.3.4
+version: 16.3.5

--- a/bitnami/postgresql/templates/primary/statefulset.yaml
+++ b/bitnami/postgresql/templates/primary/statefulset.yaml
@@ -695,9 +695,6 @@ spec:
         {{- if .Values.primary.persistence.dataSource }}
         dataSource: {{- include "common.tplvalues.render" (dict "value" .Values.primary.persistence.dataSource "context" $) | nindent 10 }}
         {{- end }}
-        {{- if .Values.primary.persistence.storageClass }}
-        storageClassName: {{ .Values.primary.persistence.storageClass }}
-        {{- end }}
         resources:
           requests:
             storage: {{ .Values.primary.persistence.size | quote }}

--- a/bitnami/postgresql/templates/read/statefulset.yaml
+++ b/bitnami/postgresql/templates/read/statefulset.yaml
@@ -577,9 +577,6 @@ spec:
         {{- if .Values.readReplicas.persistence.dataSource }}
         dataSource: {{- include "common.tplvalues.render" (dict "value" .Values.readReplicas.persistence.dataSource "context" $) | nindent 10 }}
         {{- end }}
-        {{- if .Values.readReplicas.persistence.storageClass }}
-        storageClassName: {{ .Values.readReplicas.persistence.storageClass }}
-        {{- end }}
         resources:
           requests:
             storage: {{ .Values.readReplicas.persistence.size | quote }}


### PR DESCRIPTION
### Description of the change

This PR reverts the changes introduced at https://github.com/juan131/charts/commit/b0d2c2e53c9033d3827597c561931fbb331eb99b given they add a conflict with storage class name.

### Possible drawbacks

None

### Applicable issues

- fixes https://github.com/bitnami/charts/issues/31140

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
