### PR TITLE
[bitnami/moodle] #31199 Fix invalid imagePullSecrets on container level

### DIFF
--- a/bitnami/moodle/CHANGELOG.md
+++ b/bitnami/moodle/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
+## 25.1.1 (2025-01-03)
+
+* [bitnami/moodle] #31199 Fix invalid imagePullSecrets on container level ([#31208](https://github.com/bitnami/charts/pull/31208))
+
 ## 25.1.0 (2024-12-10)
 
-* [bitnami/moodle] Detect non-standard images ([#30960](https://github.com/bitnami/charts/pull/30960))
+* [bitnami/*] Add Bitnami Premium to NOTES.txt (#30854) ([3dfc003](https://github.com/bitnami/charts/commit/3dfc00376df6631f0ce54b8d440d477f6caa6186)), closes [#30854](https://github.com/bitnami/charts/issues/30854)
+* [bitnami/moodle] Detect non-standard images (#30960) ([3438d77](https://github.com/bitnami/charts/commit/3438d776d1fe43b64779e83fbccd69d7c67accdd)), closes [#30960](https://github.com/bitnami/charts/issues/30960)
 
 ## <small>25.0.2 (2024-12-09)</small>
 

--- a/bitnami/moodle/CHANGELOG.md
+++ b/bitnami/moodle/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 25.1.1 (2025-01-03)
+## 25.1.1 (2025-01-08)
 
 * [bitnami/moodle] #31199 Fix invalid imagePullSecrets on container level ([#31208](https://github.com/bitnami/charts/pull/31208))
 

--- a/bitnami/moodle/Chart.yaml
+++ b/bitnami/moodle/Chart.yaml
@@ -36,4 +36,4 @@ maintainers:
 name: moodle
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/moodle
-version: 25.1.0
+version: 25.1.1

--- a/bitnami/moodle/README.md
+++ b/bitnami/moodle/README.md
@@ -398,7 +398,6 @@ You may want to review the [PV reclaim policy](https://kubernetes.io/docs/tasks/
 | `certificates.image.repository`                      | Container sidecar image repository                                                                                | `REPOSITORY_NAME/os-shell`               |
 | `certificates.image.digest`                          | Container sidecar image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                                     |
 | `certificates.image.pullPolicy`                      | Container sidecar image pull policy                                                                               | `IfNotPresent`                           |
-| `certificates.image.pullSecrets`                     | Container sidecar image pull secrets                                                                              | `[]`                                     |
 
 ### NetworkPolicy parameters
 

--- a/bitnami/moodle/README.md
+++ b/bitnami/moodle/README.md
@@ -398,6 +398,7 @@ You may want to review the [PV reclaim policy](https://kubernetes.io/docs/tasks/
 | `certificates.image.repository`                      | Container sidecar image repository                                                                                | `REPOSITORY_NAME/os-shell`               |
 | `certificates.image.digest`                          | Container sidecar image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                                     |
 | `certificates.image.pullPolicy`                      | Container sidecar image pull policy                                                                               | `IfNotPresent`                           |
+| `certificates.image.pullSecrets`                     | Container sidecar image pull secrets                                                                              | `[]`                                     |
 
 ### NetworkPolicy parameters
 

--- a/bitnami/moodle/templates/_helpers.tpl
+++ b/bitnami/moodle/templates/_helpers.tpl
@@ -43,7 +43,7 @@ Return the proper image name (for the init container volume-permissions image)
 Return the proper Docker Image Registry Secret Names
 */}}
 {{- define "moodle.imagePullSecrets" -}}
-{{- include "common.images.pullSecrets" (dict "images" (list .Values.image .Values.metrics.image .Values.volumePermissions.image .Values.certificates.image) "global" .Values.global) -}}
+{{- include "common.images.renderPullSecrets" ( dict "images" (list .Values.image .Values.metrics.image .Values.volumePermissions.image .Values.certificates.image) "context" $ ) -}}
 {{- end -}}
 
 {{/*

--- a/bitnami/moodle/templates/deployment.yaml
+++ b/bitnami/moodle/templates/deployment.yaml
@@ -97,10 +97,6 @@ spec:
         - name: certificates
           image: {{ template "certificates.image" . }}
           imagePullPolicy: {{ default .Values.image.pullPolicy .Values.certificates.image.pullPolicy }}
-          imagePullSecrets:
-          {{- range (default .Values.image.pullSecrets .Values.certificates.image.pullSecrets) }}
-            - name: {{ . }}
-          {{- end }}
           command:
           {{- if .Values.certificates.command }}
           command: {{- include "common.tplvalues.render" (dict "value" .Values.certificates.command "context" $) | nindent 12 }}

--- a/bitnami/moodle/values.yaml
+++ b/bitnami/moodle/values.yaml
@@ -927,6 +927,7 @@ certificates:
   ## @skip certificates.image.tag Container sidecar image tag (immutable tags are recommended)
   ## @param certificates.image.digest Container sidecar image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
   ## @param certificates.image.pullPolicy Container sidecar image pull policy
+  ## @param certificates.image.pullSecrets Container sidecar image pull secrets
   ##
   image:
     registry: docker.io
@@ -937,6 +938,14 @@ certificates:
     ## ref: https://kubernetes.io/docs/concepts/containers/images/#pre-pulled-images
     ##
     pullPolicy: IfNotPresent
+    ## Optionally specify an array of imagePullSecrets.
+    ## Secrets must be manually created in the namespace.
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+    ## e.g:
+    ## pullSecrets:
+    ##   - myRegistryKeySecretName
+    ##
+    pullSecrets: []
 ## @section NetworkPolicy parameters
 
 ## Network Policy configuration

--- a/bitnami/moodle/values.yaml
+++ b/bitnami/moodle/values.yaml
@@ -87,7 +87,7 @@ image:
 ## @param replicaCount Number of Moodle replicas (requires ReadWriteMany PVC support)
 ## Setting this will fix the number replica count needed for Moodle&trade;
 ## This can be overridden by setting autoscaling.enabled to true
-## For upgrades set the autoscaling.enabled to false and replicaCount to the desired number of replicas 
+## For upgrades set the autoscaling.enabled to false and replicaCount to the desired number of replicas
 ##
 replicaCount: 1
 ## When enabled, the number of Moodle&trade; replicas will be automatically adjusted based on targets on given metrics.
@@ -927,7 +927,6 @@ certificates:
   ## @skip certificates.image.tag Container sidecar image tag (immutable tags are recommended)
   ## @param certificates.image.digest Container sidecar image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
   ## @param certificates.image.pullPolicy Container sidecar image pull policy
-  ## @param certificates.image.pullSecrets Container sidecar image pull secrets
   ##
   image:
     registry: docker.io
@@ -938,14 +937,6 @@ certificates:
     ## ref: https://kubernetes.io/docs/concepts/containers/images/#pre-pulled-images
     ##
     pullPolicy: IfNotPresent
-    ## Optionally specify an array of imagePullSecrets.
-    ## Secrets must be manually created in the namespace.
-    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
-    ## e.g:
-    ## pullSecrets:
-    ##   - myRegistryKeySecretName
-    ##
-    pullSecrets: []
 ## @section NetworkPolicy parameters
 
 ## Network Policy configuration


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->
Defining imagePullSecrets on container level is against spec (https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#containers). They have to be defined on pod level, which is already covered.

### Benefits

<!-- What benefits will be realized by the code change? -->
Being able to deploy without error with `certificates.customCAs` defined.

### Possible drawbacks

<!-- Describe any known limitations with your change -->
None as `imagePullSecrets` on pod level are already covered.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #31199 

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
