### PR TITLE
[bitnami/rabbitmq] remove undefined rts key from network policy template

### DIFF
--- a/bitnami/rabbitmq/CHANGELOG.md
+++ b/bitnami/rabbitmq/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 16.0.0 (2025-01-03)
+## 15.2.2 (2025-01-07)
 
 * [bitnami/rabbitmq] remove undefined rts key from network policy template ([#31210](https://github.com/bitnami/charts/pull/31210))
 

--- a/bitnami/rabbitmq/CHANGELOG.md
+++ b/bitnami/rabbitmq/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 15.2.1 (2024-12-16)
+## 16.0.0 (2025-01-03)
 
-* [bitnami/rabbitmq] Release 15.2.1 ([#31049](https://github.com/bitnami/charts/pull/31049))
+* [bitnami/rabbitmq] remove undefined rts key from network policy template ([#31210](https://github.com/bitnami/charts/pull/31210))
+
+## <small>15.2.1 (2024-12-16)</small>
+
+* [bitnami/rabbitmq] Release 15.2.1 (#31049) ([973da81](https://github.com/bitnami/charts/commit/973da81d773b2b834c83e8b7b90553d915899bc5)), closes [#31049](https://github.com/bitnami/charts/issues/31049)
 
 ## 15.2.0 (2024-12-10)
 

--- a/bitnami/rabbitmq/Chart.yaml
+++ b/bitnami/rabbitmq/Chart.yaml
@@ -30,4 +30,4 @@ maintainers:
 name: rabbitmq
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/rabbitmq
-version: 15.2.1
+version: 16.0.0

--- a/bitnami/rabbitmq/Chart.yaml
+++ b/bitnami/rabbitmq/Chart.yaml
@@ -30,4 +30,4 @@ maintainers:
 name: rabbitmq
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/rabbitmq
-version: 16.0.0
+version: 15.2.2

--- a/bitnami/rabbitmq/templates/networkpolicy.yaml
+++ b/bitnami/rabbitmq/templates/networkpolicy.yaml
@@ -48,7 +48,7 @@ spec:
         - podSelector:
             matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 14 }}
     {{- if .Values.networkPolicy.extraEgress }}
-    {{- include "common.tplvalues.render" ( dict "value" .Values.rts.networkPolicy.extraEgress "context" $ ) | nindent 4 }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.networkPolicy.extraEgress "context" $ ) | nindent 4 }}
     {{- end }}
   {{- end }}
   ingress:


### PR DESCRIPTION
### Description of the change

Removes a undefined `rts` key from `networkpolicy.yaml`

Currently, modifying the `.Values.extraEgress` fails chart rendering as the template is looking for an `rts` key, which is neither specified in the documentation of the `.Values` nor present _anywhere_ else in the chart for reference points as to how to use it.

The error produced when `.Values.extraEgress` is defined:
```
Helm upgrade failed: template: rabbitmq/templates/networkpolicy.yaml:47:64: executing "rabbitmq/templates/networkpolicy.yaml" at <.Values.rts.networkPolicy.extraEgress>: nil pointer evaluating interface {}.networkPolicy
```

The work around is to define both `.Values.extraEgress`  and `.Values.rts.extraEgress` to pass the initial feature flag and enable the block render

By removing the undefined `rts` key, the workaround is no longer necessary and the template matches the `.Values.extraEgress` documentation

### Benefits

*  `.Values.extraEgress` expected behavior reestablished
* Restores `.Values.extraEgress` documentation validity
* Matches the `extraIngress` interface

### Possible drawbacks

Nonbackwards compatibility for anyone who added a `.Values.rts` block to work around the issue

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes [#23032](https://github.com/bitnami/charts/issues/23032)

### Additional information

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
