### PR TITLE
[bitnami/etcd] fixed tls enable handling and v3 environment variable support for defrag cronjob

### DIFF
--- a/bitnami/etcd/Chart.yaml
+++ b/bitnami/etcd/Chart.yaml
@@ -32,4 +32,4 @@ maintainers:
 name: etcd
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/etcd
-version: 10.7.1
+version: 10.7.2

--- a/bitnami/etcd/templates/cronjob-defrag.yaml
+++ b/bitnami/etcd/templates/cronjob-defrag.yaml
@@ -74,11 +74,11 @@ spec:
                   value: "root:$(ETCD_ROOT_PASSWORD)"
                 {{- end }}
                 {{- if or .Values.auth.client.enableAuthentication (and .Values.auth.client.secureTransport (not .Values.auth.client.useAutoTLS )) }}
-                - name: ETCDCTL_CA_FILE
+                - name: ETCDCTL_CACERT
                   value: "/opt/bitnami/etcd/certs/client/{{ .Values.auth.client.caFilename | default "ca.crt" }}"
-                - name: ETCDCTL_KEY_FILE
+                - name: ETCDCTL_KEY
                   value: "/opt/bitnami/etcd/certs/client/{{ .Values.auth.client.certKeyFilename }}"
-                - name: ETCDCTL_CERT_FILE
+                - name: ETCDCTL_CERT
                   value: "/opt/bitnami/etcd/certs/client/{{ .Values.auth.client.certFilename }}"
                 {{- end }}
               {{- if .Values.defrag.cronjob.command }}
@@ -101,8 +101,13 @@ spec:
                 {{- $replicaCount := (int .Values.replicaCount) }}
                 {{- $releaseNamespace := .Release.Namespace }}
                 {{- range $iEndpoint, $e := until $replicaCount }}
+                {{- if or $.Values.auth.client.enableAuthentication (and $.Values.auth.client.secureTransport (not $.Values.auth.client.useAutoTLS )) }}
+                {{- $endpoint := printf "https://%s-%d.%s.%s.svc.%s:%d" $etcdFullname $iEndpoint $etcdHeadlessServiceName $namespace $clusterDomain $port }}
+                {{- $endpointStr = printf "%s%s" $endpointStr $endpoint }}
+                {{- else }}
                 {{- $endpoint := printf "http://%s-%d.%s.%s.svc.%s:%d" $etcdFullname $iEndpoint $etcdHeadlessServiceName $namespace $clusterDomain $port }}
                 {{- $endpointStr = printf "%s%s" $endpointStr $endpoint }}
+                {{- end }}
                 {{- if ne $iEndpoint (sub $replicaCount 1) }}
                 {{- $endpointStr = printf "%s," $endpointStr }}
                 {{- end }}


### PR DESCRIPTION
### Description of the change

1. Modified Environment Variables in Defrag Cronjob to for etcdctl v3 as previously specified were only supported by etcdctl v2 and defrag cronjob was not able to use them.
  2. Added changing endpoints to have https:// instead of http:// if tls is enabled in defrag cronjob

### Benefits

With above changes defrag job is created properly and able to succeed without any issues.

### Checklist

- [ x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [ x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [ x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
