### PR TITLE
[bitnami/keycloak] add option to use dedicated version bound headless service for jgroups discovery

### DIFF
--- a/bitnami/keycloak/CHANGELOG.md
+++ b/bitnami/keycloak/CHANGELOG.md
@@ -1,12 +1,13 @@
 # Changelog
 
-## 24.4.0 (2025-01-XX)
+## 24.4.0 (2025-01-09)
 
-* [bitnami/keycloak] Add support to bind the headless-service to the app version to allow for rolling upgrades, even with breaking changes in the infinispan cache (closes [#31072](https://github.com/bitnami/charts/issues/31072)).
+* [bitnami/keycloak] add option to use dedicated version bound headless service for jgroups discovery ([#31271](https://github.com/bitnami/charts/pull/31271))
 
-## 24.3.2 (2024-12-20)
+## <small>24.3.2 (2024-12-30)</small>
 
-* [bitnami/keycloak] Update KEYCLOAK_ADMIN env variables deprecation ([#30636](https://github.com/bitnami/charts/pull/30636))
+* [bitnami/*] Fix typo in README (#31052) ([b41a51d](https://github.com/bitnami/charts/commit/b41a51d1bd04841fc108b78d3b8357a5292771c8)), closes [#31052](https://github.com/bitnami/charts/issues/31052)
+* [bitnami/keycloak] Update KEYCLOAK_ADMIN env variables deprecation (#30636) ([668bd27](https://github.com/bitnami/charts/commit/668bd2772c5ea45af7b1b57141c1776ccf4169f4)), closes [#30636](https://github.com/bitnami/charts/issues/30636)
 
 ## <small>24.3.1 (2024-12-16)</small>
 

--- a/bitnami/keycloak/CHANGELOG.md
+++ b/bitnami/keycloak/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 24.4.0 (2025-01-XX)
+
+* [bitnami/keycloak] Add support to bind the headless-service to the app version to allow for rolling upgrades, even with breaking changes in the infinispan cache (closes [#31072](https://github.com/bitnami/charts/issues/31072)).
+
 ## 24.3.2 (2024-12-20)
 
 * [bitnami/keycloak] Update KEYCLOAK_ADMIN env variables deprecation ([#30636](https://github.com/bitnami/charts/pull/30636))

--- a/bitnami/keycloak/Chart.yaml
+++ b/bitnami/keycloak/Chart.yaml
@@ -33,4 +33,4 @@ maintainers:
 name: keycloak
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/keycloak
-version: 24.3.2
+version: 24.4.0

--- a/bitnami/keycloak/README.md
+++ b/bitnami/keycloak/README.md
@@ -685,12 +685,12 @@ As an alternative, you can use of the preset configurations for pod affinity, po
 
 ### Keycloak Cache parameters
 
-| Name                                     | Description                                                                          | Value        |
-| ---------------------------------------- | ------------------------------------------------------------------------------------ | ------------ |
-| `cache.enabled`                          | Switch to enable or disable the keycloak distributed cache for kubernetes.           | `true`       |
-| `cache.stackName`                        | Set infinispan cache stack to use                                                    | `kubernetes` |
-| `cache.stackFile`                        | Set infinispan cache stack filename to use                                           | `""`         |
-| `cache.useHeadlessServiceWithAppVersion` | Set to true to use dedicated version bound headless service for jgroups discovery    | `false`      |
+| Name                                     | Description                                                                         | Value        |
+| ---------------------------------------- | ----------------------------------------------------------------------------------- | ------------ |
+| `cache.enabled`                          | Switch to enable or disable the keycloak distributed cache for kubernetes.          | `true`       |
+| `cache.stackName`                        | Set infinispan cache stack to use                                                   | `kubernetes` |
+| `cache.stackFile`                        | Set infinispan cache stack filename to use                                          | `""`         |
+| `cache.useHeadlessServiceWithAppVersion` | Set to true to create the headless service used for ispn containing the app version | `false`      |
 
 ### Keycloak Logging parameters
 

--- a/bitnami/keycloak/README.md
+++ b/bitnami/keycloak/README.md
@@ -685,11 +685,12 @@ As an alternative, you can use of the preset configurations for pod affinity, po
 
 ### Keycloak Cache parameters
 
-| Name              | Description                                                                | Value        |
-| ----------------- | -------------------------------------------------------------------------- | ------------ |
-| `cache.enabled`   | Switch to enable or disable the keycloak distributed cache for kubernetes. | `true`       |
-| `cache.stackName` | Set infinispan cache stack to use                                          | `kubernetes` |
-| `cache.stackFile` | Set infinispan cache stack filename to use                                 | `""`         |
+| Name                                     | Description                                                                          | Value        |
+| ---------------------------------------- | ------------------------------------------------------------------------------------ | ------------ |
+| `cache.enabled`                          | Switch to enable or disable the keycloak distributed cache for kubernetes.           | `true`       |
+| `cache.stackName`                        | Set infinispan cache stack to use                                                    | `kubernetes` |
+| `cache.stackFile`                        | Set infinispan cache stack filename to use                                           | `""`         |
+| `cache.useHeadlessServiceWithAppVersion` | Set to true to use dedicated version bound headless service for jgroups discovery    | `false`      |
 
 ### Keycloak Logging parameters
 

--- a/bitnami/keycloak/templates/configmap-env-vars.yaml
+++ b/bitnami/keycloak/templates/configmap-env-vars.yaml
@@ -95,7 +95,11 @@ data:
   {{- if .Values.cache.stackFile }}
   KEYCLOAK_CACHE_CONFIG_FILE: {{ .Values.cache.stackFile | quote }}
   {{- end }}
+  {{- if .Values.cache.useHeadlessServiceWithAppVersion }}
+  JAVA_OPTS_APPEND: {{ printf "-Djgroups.dns.query=%s-headless-ispn-%s.%s.svc.%s" (include "common.names.fullname" .) (replace "." "-" .Chart.AppVersion) (include "common.names.namespace" .) .Values.clusterDomain | quote }}
+  {{- else }}
   JAVA_OPTS_APPEND: {{ printf "-Djgroups.dns.query=%s-headless.%s.svc.%s" (include "common.names.fullname" .) (include "common.names.namespace" .) .Values.clusterDomain | quote }}
+  {{- end }}
   {{- else }}
   KEYCLOAK_CACHE_TYPE: "local"
   {{- end }}

--- a/bitnami/keycloak/templates/headless-service-ispn.yaml
+++ b/bitnami/keycloak/templates/headless-service-ispn.yaml
@@ -1,0 +1,43 @@
+{{- /*
+Copyright Broadcom, Inc. All Rights Reserved.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+{{- if and .Values.cache.enabled .Values.cache.useHeadlessServiceWithAppVersion }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ printf "%s-headless-ispn-%s" (include "common.names.fullname" .) (replace "." "-" .Chart.AppVersion) | trunc 63 | trimSuffix "-" }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+    app.kubernetes.io/component: keycloak
+  {{- if or .Values.commonAnnotations .Values.service.headless.annotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.service.headless.annotations .Values.commonAnnotations ) "context" . ) }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
+  {{- end }}
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - name: http
+      port: {{ .Values.containerPorts.http }}
+      protocol: TCP
+      targetPort: http
+    {{- if .Values.tls.enabled }}
+    - name: https
+      port: {{ .Values.containerPorts.https }}
+      protocol: TCP
+      targetPort: https
+    {{- end }}
+    {{- if .Values.service.extraHeadlessPorts }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.service.extraHeadlessPorts "context" $) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.service.headless.extraPorts }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.service.headless.extraPorts "context" $) | nindent 4 }}
+    {{- end }}
+  publishNotReadyAddresses: true
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.podLabels .Values.commonLabels ) "context" . ) }}
+  selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
+    app.kubernetes.io/component: keycloak
+    app.kubernetes.io/app-version: {{ .Chart.AppVersion }}
+{{- end }}

--- a/bitnami/keycloak/templates/statefulset.yaml
+++ b/bitnami/keycloak/templates/statefulset.yaml
@@ -44,6 +44,7 @@ spec:
         {{- end }}
       labels: {{- include "common.labels.standard" ( dict "customLabels" $podLabels "context" $ ) | nindent 8 }}
         app.kubernetes.io/component: keycloak
+        app.kubernetes.io/app-version: {{ .Chart.AppVersion }}
     spec:
       serviceAccountName: {{ template "keycloak.serviceAccountName" . }}
       {{- include "keycloak.imagePullSecrets" . | nindent 6 }}

--- a/bitnami/keycloak/values.yaml
+++ b/bitnami/keycloak/values.yaml
@@ -1371,11 +1371,13 @@ externalDatabase:
 ## NOTE: Set to false to use 'local' cache (only supported when replicaCount=1).
 ## @param cache.stackName Set infinispan cache stack to use
 ## @param cache.stackFile Set infinispan cache stack filename to use
+## @param cache.useHeadlessServiceWithAppVersion Set to true to create the headless service used for ispn containing the app version
 ##
 cache:
   enabled: true
   stackName: kubernetes
   stackFile: ""
+  useHeadlessServiceWithAppVersion: false
 ## @section Keycloak Logging parameters
 
 ## Keycloak logging configuration


### PR DESCRIPTION
Add possibility to version bind the ispn discovery. The new config property is `.cache.useHeadlessServiceWithAppVersion`. This solution is inspired by: https://github.com/keycloak/keycloak/discussions/21067#discussioncomment-8855429 

### Description of the change

Added a config property `.cache.useHeadlessServiceWithAppVersion`. When this is set to `false` (default) the behavior stays the same as before and the Keycloak ISPN Cache will continue to use the default headless service for discovery. 

If the value is set to true:
- New headless service "`(include "common.names.fullname" .)-headless-ispn-(replace "." "-" .Chart.AppVersion)`"  is created that contains an additional selector for `app.kubernetes.io/app-version: {{ .Chart.AppVersion }}`. This headless service will only discover for keycloak pods that are running the corresponding appVersion
- Env variable `JAVA_OPTS_APPEND` is adapted to use the new headless service for jgroups discovery.

An additional label `app.kubernetes.io/app-version: {{ .Chart.AppVersion }}` has been added to the statefulset to allow for selecting pods by their app version.

<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

Enable the possibility to do rolling upgrades, even with breaking changes in the infinispan update. Previously, when there were breaking changes with infinispan, the new version Keycloak pods can not startup, as they would try to connect to the incompatible cluster. This rendered it necessary to kill all Keycloak pods to proceed with the upgrade, causing a downtime.

### Possible drawbacks

With the new property enabled, when deploying a new app version the infinispan cache will not be synched over to the new Keycloak instances, as these will create a new cluster for themselves. This might result in data loss and slower response times shortly after the update.

### Applicable issues

- fixes #31072

### Additional information

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)

