### PR TITLE
[bitnami/common] Removing seLinuxOptions from omission

### DIFF
--- a/bitnami/common/CHANGELOG.md
+++ b/bitnami/common/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2.29.1 (2025-01-09)
+## 2.29.1 (2025-01-10)
 
 * [bitnami/common] Removing seLinuxOptions from omission ([#31279](https://github.com/bitnami/charts/pull/31279))
 

--- a/bitnami/common/CHANGELOG.md
+++ b/bitnami/common/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 2.29.0 (2025-01-02)
+## 2.29.1 (2025-01-09)
 
-* [bitnami/common] Add "common.capabilities.job.apiVersion" template ([#31164](https://github.com/bitnami/charts/pull/31164))
+* [bitnami/common] Removing seLinuxOptions from omission ([#31279](https://github.com/bitnami/charts/pull/31279))
+
+## 2.29.0 (2025-01-03)
+
+* [bitnami/common] Add "common.capabilities.job.apiVersion" template (#31164) ([2ca979a](https://github.com/bitnami/charts/commit/2ca979a6add279384d60e6b35199eaf13553cefa)), closes [#31164](https://github.com/bitnami/charts/issues/31164)
 
 ## 2.28.0 (2024-12-10)
 

--- a/bitnami/common/Chart.yaml
+++ b/bitnami/common/Chart.yaml
@@ -6,7 +6,7 @@ annotations:
   licenses: Apache-2.0
 apiVersion: v2
 # Please make sure that version and appVersion are always the same.
-appVersion: 2.29.0
+appVersion: 2.29.1
 description: A Library Helm Chart for grouping common logic between bitnami charts. This chart is not deployable by itself.
 home: https://bitnami.com
 icon: https://bitnami.com/downloads/logos/bitnami-mark.png
@@ -23,4 +23,4 @@ name: common
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/common
 type: library
-version: 2.29.0
+version: 2.29.1

--- a/bitnami/common/templates/_compatibility.tpl
+++ b/bitnami/common/templates/_compatibility.tpl
@@ -40,7 +40,7 @@ Usage:
 {{- end -}}
 {{/* Remove fields that are disregarded when running the container in privileged mode */}}
 {{- if $adaptedContext.privileged -}}
-  {{- $adaptedContext = omit $adaptedContext "capabilities" "seLinuxOptions" -}}
+  {{- $adaptedContext = omit $adaptedContext "capabilities" -}}
 {{- end -}}
 {{- omit $adaptedContext "enabled" | toYaml -}}
 {{- end -}}


### PR DESCRIPTION
### Description of the change

There are some cases where we want to include `seLinuxOptions` with `privileged` containers.

### Benefits

Being able to use `seLinuxOptions` with `privileged`.

We use the `spc_t` on our minio deployment since it contains billions of small files. Without this, Openshift is unable to start the pods in a timely manner.

Adding the `spc_t` is a [Redhat recommendation](https://access.redhat.com/solutions/6221251) and it needs to be there even if the pods are privileged.

### Possible drawbacks

None

### Applicable issues

- fixes #31278 

### Additional information

Partial-Revert of 5f0bdde77cf05afa20cb4a800090748a8d102d02

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
