### PR TITLE
[bitnami/valkey] bugfix: instructions to obtain password on installation notes

### DIFF
--- a/bitnami/valkey/Chart.yaml
+++ b/bitnami/valkey/Chart.yaml
@@ -36,4 +36,4 @@ maintainers:
 name: valkey
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/valkey
-version: 2.2.2
+version: 2.2.3

--- a/bitnami/valkey/templates/NOTES.txt
+++ b/bitnami/valkey/templates/NOTES.txt
@@ -100,7 +100,7 @@ Valkey can be accessed via port {{ .Values.primary.service.ports.valkey }} on th
 
 To get your password run:
 
-    export VALKEY_PASSWORD=$(kubectl get secret --namespace {{ include "common.names.namespace" . }} {{ template "valkey.secretName" . }} -o jsonpath="{.data.valkey-password}" | base64 -d)
+    export VALKEY_PASSWORD=$(kubectl get secret --namespace {{ include "common.names.namespace" . }} {{ include "valkey.secretName" . }} -o jsonpath="{.data.{{ include "valkey.secretPasswordKey" . }}}" | base64 -d)
 
 {{- end }}
 


### PR DESCRIPTION
### Description of the change

This PR fixes Valkey installation notes by ensuring the instructions to obtain password take into account that the secret key could be different when using an existing secret.

### Benefits

Accurante installation notes.

### Possible drawbacks

None

### Applicable issues

None

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
