### PR TITLE
[bitnami/common] Option to add "app.kubernetes.io/component" label

### DIFF
--- a/bitnami/common/templates/_affinities.tpl
+++ b/bitnami/common/templates/_affinities.tpl
@@ -71,10 +71,7 @@ Return a soft podAffinity/podAntiAffinity definition
 preferredDuringSchedulingIgnoredDuringExecution:
   - podAffinityTerm:
       labelSelector:
-        matchLabels: {{- (include "common.labels.matchLabels" ( dict "customLabels" $customLabels "context" .context )) | nindent 10 }}
-          {{- if not (empty $component) }}
-          {{ printf "app.kubernetes.io/component: %s" $component }}
-          {{- end }}
+        matchLabels: {{- (include "common.labels.matchLabels" (dict "customLabels" $customLabels "context" .context "component" $component)) | nindent 10 }}
           {{- range $key, $value := $extraMatchLabels }}
           {{ $key }}: {{ $value | quote }}
           {{- end }}
@@ -82,7 +79,7 @@ preferredDuringSchedulingIgnoredDuringExecution:
       namespaces:
         - {{ .context.Release.Namespace }}
         {{- with $extraNamespaces }}
-        {{ include "common.tplvalues.render" (dict "value" . "context" $) | nindent 8 }}
+        {{- include "common.tplvalues.render" (dict "value" . "context" $) | nindent 8 }}
         {{- end }}
       {{- end }}
       topologyKey: {{ include "common.affinities.topologyKey" (dict "topologyKey" .topologyKey) }}
@@ -90,10 +87,7 @@ preferredDuringSchedulingIgnoredDuringExecution:
   {{- range $extraPodAffinityTerms }}
   - podAffinityTerm:
       labelSelector:
-        matchLabels: {{- (include "common.labels.matchLabels" ( dict "customLabels" $customLabels "context" $.context )) | nindent 10 }}
-          {{- if not (empty $component) }}
-          {{ printf "app.kubernetes.io/component: %s" $component }}
-          {{- end }}
+        matchLabels: {{- (include "common.labels.matchLabels" (dict "customLabels" $customLabels "context" $.context "component" $component)) | nindent 10 }}
           {{- range $key, $value := .extraMatchLabels }}
           {{ $key }}: {{ $value | quote }}
           {{- end }}
@@ -114,10 +108,7 @@ Return a hard podAffinity/podAntiAffinity definition
 {{- $extraNamespaces := default (list) .extraNamespaces -}}
 requiredDuringSchedulingIgnoredDuringExecution:
   - labelSelector:
-      matchLabels: {{- (include "common.labels.matchLabels" ( dict "customLabels" $customLabels "context" .context )) | nindent 8 }}
-        {{- if not (empty $component) }}
-        {{ printf "app.kubernetes.io/component: %s" $component }}
-        {{- end }}
+      matchLabels: {{- (include "common.labels.matchLabels" (dict "customLabels" $customLabels "context" .context "component" $component)) | nindent 8 }}
         {{- range $key, $value := $extraMatchLabels }}
         {{ $key }}: {{ $value | quote }}
         {{- end }}
@@ -125,16 +116,13 @@ requiredDuringSchedulingIgnoredDuringExecution:
       namespaces:
         - {{ .context.Release.Namespace }}
         {{- with $extraNamespaces }}
-        {{ include "common.tplvalues.render" (dict "value" . "context" $) | nindent 8 }}
+        {{- include "common.tplvalues.render" (dict "value" . "context" $) | nindent 8 }}
         {{- end }}
       {{- end }}
     topologyKey: {{ include "common.affinities.topologyKey" (dict "topologyKey" .topologyKey) }}
   {{- range $extraPodAffinityTerms }}
   - labelSelector:
-      matchLabels: {{- (include "common.labels.matchLabels" ( dict "customLabels" $customLabels "context" $.context )) | nindent 8 }}
-        {{- if not (empty $component) }}
-        {{ printf "app.kubernetes.io/component: %s" $component }}
-        {{- end }}
+      matchLabels: {{- (include "common.labels.matchLabels" (dict "customLabels" $customLabels "context" $.context "component" $component)) | nindent 8 }}
         {{- range $key, $value := .extraMatchLabels }}
         {{ $key }}: {{ $value | quote }}
         {{- end }}

--- a/bitnami/common/templates/_labels.tpl
+++ b/bitnami/common/templates/_labels.tpl
@@ -7,29 +7,34 @@ SPDX-License-Identifier: APACHE-2.0
 
 {{/*
 Kubernetes standard labels
-{{ include "common.labels.standard" (dict "customLabels" .Values.commonLabels "context" $) -}}
+{{- include "common.labels.standard" $ }}
+{{- include "common.labels.standard" (dict "customLabels" .Values.commonLabels "context" $) }}
+{{- include "common.labels.standard" (dict "customLabels" .Values.commonLabels "context" $ "component" "FOO") }}
 */}}
 {{- define "common.labels.standard" -}}
-{{- if and (hasKey . "customLabels") (hasKey . "context") -}}
-{{- $default := dict "app.kubernetes.io/name" (include "common.names.name" .context) "helm.sh/chart" (include "common.names.chart" .context) "app.kubernetes.io/instance" .context.Release.Name "app.kubernetes.io/managed-by" .context.Release.Service -}}
-{{- with .context.Chart.AppVersion -}}
-{{- $_ := set $default "app.kubernetes.io/version" . -}}
+{{- $context := default . .context -}}
+{{- $default := dict
+  "app.kubernetes.io/instance" $context.Release.Name
+  "app.kubernetes.io/managed-by" $context.Release.Service
+  "app.kubernetes.io/name" (include "common.names.name" $context)
+  "helm.sh/chart" (include "common.names.chart" $context)
+-}}
+{{- with $context.Chart.AppVersion -}}
+  {{- $_ := set $default "app.kubernetes.io/version" . -}}
 {{- end -}}
-{{ template "common.tplvalues.merge" (dict "values" (list .customLabels $default) "context" .context) }}
-{{- else -}}
-app.kubernetes.io/name: {{ include "common.names.name" . }}
-helm.sh/chart: {{ include "common.names.chart" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
-app.kubernetes.io/managed-by: {{ .Release.Service }}
-{{- with .Chart.AppVersion }}
-app.kubernetes.io/version: {{ . | quote }}
+{{- $component := dict -}}
+{{- with .component -}}
+  {{- $_ := set $component "app.kubernetes.io/component" . -}}
 {{- end -}}
-{{- end -}}
+{{- /* If "component" key is present it will overwrite label from .customLabels for compatibility with selector */ -}}
+{{- include "common.tplvalues.merge" (dict "values" (compact (list $component .customLabels $default)) "context" $context) }}
 {{- end -}}
 
 {{/*
 Labels used on immutable fields such as deploy.spec.selector.matchLabels or svc.spec.selector
-{{ include "common.labels.matchLabels" (dict "customLabels" .Values.podLabels "context" $) -}}
+{{- include "common.labels.matchLabels" $ }}
+{{- include "common.labels.matchLabels" (dict "customLabels" .Values.podLabels "context" $) }}
+{{- include "common.labels.matchLabels" (dict "customLabels" .Values.podLabels "context" $ "component" "FOO") }}
 
 We don't want to loop over custom labels appending them to the selector
 since it's very likely that it will break deployments, services, etc.
@@ -37,10 +42,24 @@ However, it's important to overwrite the standard labels if the user
 overwrote them on metadata.labels fields.
 */}}
 {{- define "common.labels.matchLabels" -}}
-{{- if and (hasKey . "customLabels") (hasKey . "context") -}}
-{{ merge (pick (include "common.tplvalues.render" (dict "value" .customLabels "context" .context) | fromYaml) "app.kubernetes.io/name" "app.kubernetes.io/instance") (dict "app.kubernetes.io/name" (include "common.names.name" .context) "app.kubernetes.io/instance" .context.Release.Name ) | toYaml }}
+{{- $context := default . .context -}}
+{{- $default := dict
+  "app.kubernetes.io/instance" $context.Release.Name
+  "app.kubernetes.io/name" (include "common.names.name" $context)
+-}}
+{{- with .component -}}
+  {{- $_ := set $default "app.kubernetes.io/component" . -}}
+{{- end -}}
+{{- if .customLabels -}}
+{{- merge
+  (pick
+    (include "common.tplvalues.render" (dict "value" .customLabels "context" $context) | fromYaml)
+    "app.kubernetes.io/name"
+    "app.kubernetes.io/instance"
+  )
+  $default | toYaml
+-}}
 {{- else -}}
-app.kubernetes.io/name: {{ include "common.names.name" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
+  {{- $default | toYaml }}
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Provide option for labels templates to include ` app.kubernetes.io/component` label

### Benefits

Reduce code duplication in multi-component charts.

For example:
```yaml
spec:
  selector:
    matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
      app.kubernetes.io/component: controller
  template:
    metadata:
      labels: {{- include "common.labels.standard" ( dict "customLabels" $podLabels "context" $ ) | nindent 8 }}
        app.kubernetes.io/component: controller
``` 
Could be changed to:
```yaml
spec:
  selector:
    matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ "component" "controller" ) | nindent 6 }}
  template:
    metadata:
      labels: {{- include "common.labels.standard" ( dict "customLabels" $podLabels "context" $ "component" "controller") | nindent 8 }}
```
### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
