### PR TITLE
[bitnami/pinniped] bugfix: remove deprecated vars to configure OpenLDAP on VIB

### DIFF
--- a/.vib/pinniped/runtime-parameters.yaml
+++ b/.vib/pinniped/runtime-parameters.yaml
@@ -111,14 +111,10 @@ extraDeploy:
                 value: "admin123"
               - name: LDAP_ROOT
                 value: {{ printf "dc=%s" (include "pinniped.supervisor.fullname" . ) }}
-              - name: LDAP_USER_DC
-                value: "users"
               - name: LDAP_USERS
                 value: "vibuser"
               - name: LDAP_PASSWORDS
                 value: "vibUser123"
-              - name: LDAP_GROUP
-                value: "users"
               - name: LDAP_ENABLE_TLS
                 value: "yes"
               - name: LDAP_TLS_CERT_FILE

--- a/bitnami/pinniped/CHANGELOG.md
+++ b/bitnami/pinniped/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 2.4.1 (2024-12-10)
+## 2.4.2 (2025-01-13)
 
-* [bitnami/pinniped] Release 2.4.1 ([#30975](https://github.com/bitnami/charts/pull/30975))
+* [bitnami/pinniped] bugfix: remove deprecated vars to configure OpenLDAP on VIB ([#31337](https://github.com/bitnami/charts/pull/31337))
+
+## <small>2.4.1 (2024-12-10)</small>
+
+* [bitnami/pinniped] Release 2.4.1 (#30975) ([0505a7e](https://github.com/bitnami/charts/commit/0505a7eadfbcd76a857100c0676f36069b03bf79)), closes [#30975](https://github.com/bitnami/charts/issues/30975)
 
 ## 2.4.0 (2024-12-10)
 

--- a/bitnami/pinniped/Chart.yaml
+++ b/bitnami/pinniped/Chart.yaml
@@ -27,4 +27,4 @@ maintainers:
 name: pinniped
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/pinniped
-version: 2.4.1
+version: 2.4.2


### PR DESCRIPTION
### Description of the change

We use the Bitnami OpenLDAP container for our integration test suite. This PR removes some env. vars that we're setting and were deprecated.

### Benefits

The setup is aligned with latest changes in OpenLDAP container.

### Possible drawbacks

None

### Applicable issues

None

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
