### PR TITLE
bitnami/postgresql Fix missing dot in include statement for passwordUpdate job template

### DIFF
--- a/bitnami/postgresql/CHANGELOG.md
+++ b/bitnami/postgresql/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 16.4.2 (2025-01-13)
+## 16.4.3 (2025-01-14)
 
-* [bitnami/postgresql] Release 16.4.2 ([#31342](https://github.com/bitnami/charts/pull/31342))
+* bitnami/postgresql Fix missing dot in include statement for passwordUpdate job template ([#31364](https://github.com/bitnami/charts/pull/31364))
+
+## <small>16.4.2 (2025-01-13)</small>
+
+* [bitnami/postgresql] Release 16.4.2 (#31342) ([946b638](https://github.com/bitnami/charts/commit/946b638fd63e2d7e74865d591ef403b4dce229b3)), closes [#31342](https://github.com/bitnami/charts/issues/31342)
 
 ## <small>16.4.1 (2025-01-13)</small>
 

--- a/bitnami/postgresql/Chart.yaml
+++ b/bitnami/postgresql/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: postgresql
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/postgresql
-version: 16.4.2
+version: 16.4.3

--- a/bitnami/postgresql/templates/update-password/job.yaml
+++ b/bitnami/postgresql/templates/update-password/job.yaml
@@ -57,7 +57,7 @@ spec:
           args:
             - |
               {{- $customUser := include "postgresql.v1.username" . }}
-              {{- $customDatabase := include "postgresql.v1.database" | default "postgres" }}
+              {{- $customDatabase := include "postgresql.v1.database" . | default "postgres" }}
               {{- if .Values.usePasswordFiles }}
               # We need to load all the secret env vars to the system
               for file in $(find /bitnami/postgresql/secrets -type f); do


### PR DESCRIPTION
### Description of the change


### Benefits
Fix missing dot in include statement for passwordUpdate job template

```
Error: template: idp/charts/keycloak/charts/postgresql/templates/update-password/job.yaml:60:37: 
executing "idp/charts/keycloak/charts/postgresql/templates/update-password/job.yaml" 
at <include>: wrong number of args for include: want 2 got 1
```

### Possible drawbacks

<!-- Not known -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes # Bug of rendering of paswordUpdate job

### Additional information
Chart has been rendered locally (as a subchart of keycloak) and the issue appears fixed
```yaml
# Source: idp/charts/keycloak/charts/postgresql/templates/update-password/job.yaml
apiVersion: batch/v1
kind: Job
metadata:
  name: idp-postgresql-password-update
  namespace: "idp"
  labels:
    app.kubernetes.io/instance: idp
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: postgresql
    app.kubernetes.io/version: 17.2.0
    helm.sh/chart: postgresql-16.4.2
    app.kubernetes.io/part-of: postgresql
    app.kubernetes.io/component: update-job
  annotations:
    helm.sh/hook: pre-upgrade
    helm.sh/hook-delete-policy: hook-succeeded
spec:
  backoffLimit: 10
  template:
    metadata:
      labels:
        app.kubernetes.io/instance: idp
        app.kubernetes.io/managed-by: Helm
        app.kubernetes.io/name: postgresql
        app.kubernetes.io/version: 17.2.0
        helm.sh/chart: postgresql-16.4.2
        app.kubernetes.io/part-of: postgresql
        app.kubernetes.io/component: update-job
    spec:

      restartPolicy: OnFailure
      securityContext:
        fsGroup: 1001
        fsGroupChangePolicy: Always
        supplementalGroups: []
        sysctls: []
      automountServiceAccountToken: false
      initContainers:
      containers:
        - name: update-credentials
          image: rt.imperva-services.net/docker/postgresql:16.6.0-debian-12-r2
          imagePullPolicy: Always
          command:
            - /bin/bash
            - -ec
          args:
            - |

              . /opt/bitnami/scripts/postgresql-env.sh
              . /opt/bitnami/scripts/libpostgresql.sh
              . /opt/bitnami/scripts/liblog.sh

              primary_host=idp-postgresql-0.idp-postgresql-hl
              info "Starting password update job"
              if [[ -f /job-status/postgres-password-changed ]]; then
                  info "Postgres password already updated. Skipping"
              else
                  info "Updating postgres password"
                  echo "ALTER USER postgres WITH PASSWORD '$POSTGRESQL_NEW_POSTGRES_PASSWORD';" | postgresql_remote_execute $primary_host 5432 "" postgres $POSTGRESQL_PREVIOUS_POSTGRES_PASSWORD
                  touch /job-status/postgres-password-changed
                  info "Postgres password successfully updated"
              fi
              if [[ -f /job-status/password-changed ]]; then
                  info "User password already updated. Skipping"
              else
                  info "Updating user password"
                  echo "ALTER USER ico_keycloak WITH PASSWORD '$POSTGRESQL_NEW_PASSWORD';" | postgresql_remote_execute $primary_host 5432 "keycloak" $POSTGRESQL_USER $POSTGRESQL_PREVIOUS_PASSWORD
                  touch /job-status/password-changed
                  info "User password successfully updated"
              fi
              info "Password update job finished successfully"
```

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [ X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [ X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
