### PR TITLE
bitnami/zipkin Remove quote for the host

### DIFF
--- a/bitnami/zipkin/CHANGELOG.md
+++ b/bitnami/zipkin/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 1.1.1 (2025-01-07)
+## 1.1.2 (2025-01-15)
 
-* [bitnami/zipkin] Release 1.1.1 ([#31228](https://github.com/bitnami/charts/pull/31228))
+* bitnami/zipkin Remove quote for the host ([#31374](https://github.com/bitnami/charts/pull/31374))
+
+## <small>1.1.1 (2025-01-07)</small>
+
+* [bitnami/zipkin] Release 1.1.1 (#31228) ([a71714c](https://github.com/bitnami/charts/commit/a71714cd224837c124b989f7ffd5b795ca0fb699)), closes [#31228](https://github.com/bitnami/charts/issues/31228)
 
 ## 1.1.0 (2024-12-10)
 

--- a/bitnami/zipkin/CHANGELOG.md
+++ b/bitnami/zipkin/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.1.2 (2025-01-20)
+## 1.1.2 (2025-01-21)
 
 * bitnami/zipkin Remove quote for the host ([#31374](https://github.com/bitnami/charts/pull/31374))
 

--- a/bitnami/zipkin/CHANGELOG.md
+++ b/bitnami/zipkin/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.1.2 (2025-01-15)
+## 1.1.2 (2025-01-20)
 
 * bitnami/zipkin Remove quote for the host ([#31374](https://github.com/bitnami/charts/pull/31374))
 

--- a/bitnami/zipkin/Chart.yaml
+++ b/bitnami/zipkin/Chart.yaml
@@ -35,4 +35,4 @@ sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/zipkin
 - https://github.com/bitnami/containers/tree/main/bitnami/zipkin
 - https://github.com/openzipkin/zipkin
-version: 1.1.2
+version: 1.1.1

--- a/bitnami/zipkin/Chart.yaml
+++ b/bitnami/zipkin/Chart.yaml
@@ -35,4 +35,4 @@ sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/zipkin
 - https://github.com/bitnami/containers/tree/main/bitnami/zipkin
 - https://github.com/openzipkin/zipkin
-version: 1.1.1
+version: 1.1.2

--- a/bitnami/zipkin/templates/_helpers.tpl
+++ b/bitnami/zipkin/templates/_helpers.tpl
@@ -29,7 +29,7 @@ Create the cassandra host
 */}}
 {{- define "zipkin.cassandra.host" -}}
     {{- if not .Values.cassandra.enabled -}}
-        {{- .Values.externalDatabase.host | quote -}}
+        {{- .Values.externalDatabase.host -}}
     {{- else -}}
         {{- include "common.names.dependency.fullname" (dict "chartName" "cassandra" "chartValues" .Values.cassandra "context" $) -}}
     {{- end }}

--- a/bitnami/zipkin/templates/_helpers.tpl
+++ b/bitnami/zipkin/templates/_helpers.tpl
@@ -29,7 +29,7 @@ Create the cassandra host
 */}}
 {{- define "zipkin.cassandra.host" -}}
     {{- if not .Values.cassandra.enabled -}}
-        {{- .Values.externalDatabase.host -}}
+        {{- .Values.externalDatabase.host | quote -}}
     {{- else -}}
         {{- include "common.names.dependency.fullname" (dict "chartName" "cassandra" "chartValues" .Values.cassandra "context" $) -}}
     {{- end }}

--- a/bitnami/zipkin/templates/configmap.yaml
+++ b/bitnami/zipkin/templates/configmap.yaml
@@ -13,7 +13,7 @@ QUERY_PORT: {{ .Values.containerPorts.http | quote }}
 STORAGE_TYPE: "mem"
 {{- else if eq .Values.storageType "cassandra3" }}
 STORAGE_TYPE: "cassandra3"
-CASSANDRA_CONTACT_POINTS: {{ include "zipkin.cassandra.host" . }}:{{ include "zipkin.cassandra.port" . }}
+CASSANDRA_CONTACT_POINTS: {{ printf "%s:%d" ( include "zipkin.cassandra.host" . ) ( include "zipkin.cassandra.port" . ) }}
 CASSANDRA_USERNAME: {{ include "zipkin.cassandra.user" . | quote }}
 CASSANDRA_KEYSPACE: {{ include "zipkin.cassandra.keyspace" . | quote }}
 CASSANDRA_LOCAL_DC: {{ include "zipkin.cassandra.datacenter" . | quote }}

--- a/bitnami/zipkin/templates/configmap.yaml
+++ b/bitnami/zipkin/templates/configmap.yaml
@@ -13,7 +13,7 @@ QUERY_PORT: {{ .Values.containerPorts.http | quote }}
 STORAGE_TYPE: "mem"
 {{- else if eq .Values.storageType "cassandra3" }}
 STORAGE_TYPE: "cassandra3"
-CASSANDRA_CONTACT_POINTS: {{ printf "%s:%d" ( include "zipkin.cassandra.host" . ) ( include "zipkin.cassandra.port" . ) }}
+CASSANDRA_CONTACT_POINTS: {{ printf "%s:%d" ( include "zipkin.cassandra.host" . ) ( include "zipkin.cassandra.port" . | int ) }}
 CASSANDRA_USERNAME: {{ include "zipkin.cassandra.user" . | quote }}
 CASSANDRA_KEYSPACE: {{ include "zipkin.cassandra.keyspace" . | quote }}
 CASSANDRA_LOCAL_DC: {{ include "zipkin.cassandra.datacenter" . | quote }}


### PR DESCRIPTION
This is needed because it will later be combined with the port in the configmap.

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Removed the quote from the host value so it can be combined in configmap with the port.

### Benefits

Now it is possible to use external database.

### Possible drawbacks

None

### Applicable issues

None

### Additional information

Nothing.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
