### PR TITLE
[Index] Make sync-chart-cloudflare-index more resilient

### DIFF
--- a/.github/workflows/sync-chart-cloudflare-index.yml
+++ b/.github/workflows/sync-chart-cloudflare-index.yml
@@ -4,6 +4,14 @@ on:
   push:
     branches:
     - index
+  workflow_call:
+    secrets:
+      CLOUDFLARE_CLIENT_ID:
+        required: true
+      CLOUDFLARE_CLIENT_SECRET:
+        required: true
+      CLOUDFLARE_USER_AUTH:
+        required: true
 
 # Remove all permissions by default
 permissions: {}
@@ -14,23 +22,70 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    outputs:
+      result: ${{ steps.upload.outputs.result }}
     steps:
     - uses: actions/checkout@master
     - name: Upload to Cloudflare using a BCOM upload proxy
+      id: upload
       env:
         CLOUDFLARE_CLIENT_ID: ${{ secrets.CLOUDFLARE_CLIENT_ID }}
         CLOUDFLARE_CLIENT_SECRET: ${{ secrets.CLOUDFLARE_CLIENT_SECRET }}
         CLOUDFLARE_USER_AUTH: ${{ secrets.CLOUDFLARE_USER_AUTH }}
       run: |
-        export TOKEN=$(curl -s --location 'https://api-esp.broadcom.com/auth/oauth/v2/token' \
-        --data-urlencode "client_id=${CLOUDFLARE_CLIENT_ID}" \
-        --data-urlencode "client_secret=${CLOUDFLARE_CLIENT_SECRET}" \
-        --data-urlencode 'grant_type=client_credentials' | jq .access_token -r )
+        status="fail"
+        retries=0
+        while [[ "${status}" != "ok" && "$retries" -lt 3 ]]; do
+          export TOKEN=$(curl -s --location 'https://api-esp.broadcom.com/auth/oauth/v2/token' \
+          --data-urlencode "client_id=${CLOUDFLARE_CLIENT_ID}" \
+          --data-urlencode "client_secret=${CLOUDFLARE_CLIENT_SECRET}" \
+          --data-urlencode 'grant_type=client_credentials' | jq .access_token -r )
 
-
-        curl --location --request PUT 'https://api-esp.broadcom.com/crushftp/fileUpload' \
-        --header "userAuth: Basic ${CLOUDFLARE_USER_AUTH}" \
-        --header 'filePath: /index.yaml' \
-        --header 'Content-Type: text/yaml' \
-        --header "Authorization: Bearer $TOKEN" \
-        --upload-file bitnami/index.yaml
+          curl_args=(
+            "--location" "--request" "PUT"
+            "--fail" "--max-time" "10"
+            "--header" "userAuth: Basic ${CLOUDFLARE_USER_AUTH}"
+            "--header" "filePath: /index.yaml"
+            "--header" "Content-Type: text/yaml"
+            "--header" "Authorization: Bearer $TOKEN"
+            "--upload-file" "bitnami/index.yaml"
+          )
+          echo "Uploading index.yaml to Cloudflare"
+          # To avoid the action from failing, we run the request inside a conditional so we can retry
+          if curl "${curl_args[@]}" 'https://api-esp.broadcom.com/crushftp/fileUpload'; then
+            echo "Index upload request succeeded, waiting 20 seconds before integrity check..."
+            # Wait for 20 seconds to ensure the new index.yaml is available
+            sleep 20
+            # Compare the index.yaml checksums remote and locally
+            REMOTE_MD5=($(curl -Ls https://charts.bitnami.com/bitnami/index.yaml | md5sum))
+            REPOSITORY_MD5=($(md5sum bitnami/index.yaml))
+            if [[ "${REPOSITORY_MD5[0]}" == "${REMOTE_MD5[0]}" ]]; then
+              status='ok'
+            else
+              echo "Integrity check failed. Uploading index.yaml again.";
+            fi
+          else
+            echo "Index upload request failed or timed out. Retrying again in 20 seconds...";
+            sleep 20
+          fi
+          retries=$((retries+1))
+        done
+        echo "result=${status}" >> $GITHUB_OUTPUT
+    - name: Show messages
+      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
+      with:
+        script: |
+          if ("${{ steps.upload.outputs.result }}" != "ok" ) {
+            core.setFailed("Index upload failed");
+          } else {
+            core.info("Index upload succeeded")
+          }
+  notify:
+    name: Send notification
+    needs: [deploy]
+    if: ${{ always() && needs.deploy.outputs.result != 'ok' }}
+    uses: bitnami/charts/.github/workflows/gchat-notification.yml@main
+    with:
+      workflow: ${{ github.workflow }}
+      job-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+    secrets: inherit


### PR DESCRIPTION
### Description of the change

Improves the 'sync-chart-cloudflare-index.yml' workflow by implementing a retry mechanism and a integrity check.

### Benefits

These changes aim to prevent the recent index failures, which we suspect may be related to the upload of the index.yaml

### Additional information

Changes implemented:

- Added `--fail` flag to the curl command.
- Added `--max-time 10` to limit the command.
- Retry after 20 seconds, if the curl failed.
- Retry if the integrity check fails. The integrity check compares the local index md5sum to the index available at 'http://charts.bitnami.com/bitnami/index.yaml'. The integrity check waits 20 seconds to ensure synchronization.
- Notify if the max number of retries (3) have been exceeded.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
