### PR TITLE
 [bitnami/jaeger] Migration job not using namespace overwrite 31207

### DIFF
--- a/bitnami/jaeger/CHANGELOG.md
+++ b/bitnami/jaeger/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## 5.1.3 (2025-01-08)
 
 * [bitnami/jaeger] Release 5.1.3 ([#31251](https://github.com/bitnami/charts/pull/31251))
+## 5.1.3 (2025-01-04)
+
+* [bitnami/jaeger]  (fix) migration job not using namespaceOverwrite  ([#31216](https://github.com/bitnami/charts/pull/31216))
 
 ## <small>5.1.2 (2024-12-12)</small>
 

--- a/bitnami/jaeger/CHANGELOG.md
+++ b/bitnami/jaeger/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-## 5.1.4 (2025-01-14)
+## 5.1.4 (2025-01-16)
 
-* [bitnami/jaeger]  migration job not using namespaceOverwrite  ([#31216](https://github.com/bitnami/charts/pull/31216))
+*  [bitnami/jaeger] Migration job not using namespace overwrite 31207 ([#31405](https://github.com/bitnami/charts/pull/31405))
 
 ## <small>5.1.3 (2025-01-08)</small>
 

--- a/bitnami/jaeger/CHANGELOG.md
+++ b/bitnami/jaeger/CHANGELOG.md
@@ -1,11 +1,13 @@
 # Changelog
 
-## 5.1.3 (2025-01-08)
+## 5.1.4 (2025-01-13)
 
-* [bitnami/jaeger] Release 5.1.3 ([#31251](https://github.com/bitnami/charts/pull/31251))
-## 5.1.3 (2025-01-04)
+* [bitnami/jaeger]  migration job not using namespaceOverwrite  ([#31216](https://github.com/bitnami/charts/pull/31216))
 
-* [bitnami/jaeger]  (fix) migration job not using namespaceOverwrite  ([#31216](https://github.com/bitnami/charts/pull/31216))
+## <small>5.1.3 (2025-01-08)</small>
+
+* [bitnami/*] Fix typo in README (#31052) ([b41a51d](https://github.com/bitnami/charts/commit/b41a51d1bd04841fc108b78d3b8357a5292771c8)), closes [#31052](https://github.com/bitnami/charts/issues/31052)
+* [bitnami/jaeger] Release 5.1.3 (#31251) ([accc2a4](https://github.com/bitnami/charts/commit/accc2a409a6e4c3f52ccc0dd574680c8d645dd4e)), closes [#31251](https://github.com/bitnami/charts/issues/31251)
 
 ## <small>5.1.2 (2024-12-12)</small>
 

--- a/bitnami/jaeger/CHANGELOG.md
+++ b/bitnami/jaeger/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 5.1.4 (2025-01-13)
+## 5.1.4 (2025-01-14)
 
 * [bitnami/jaeger]  migration job not using namespaceOverwrite  ([#31216](https://github.com/bitnami/charts/pull/31216))
 

--- a/bitnami/jaeger/CHANGELOG.md
+++ b/bitnami/jaeger/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 5.1.4 (2025-01-16)
+## 5.1.4 (2025-01-17)
 
 *  [bitnami/jaeger] Migration job not using namespace overwrite 31207 ([#31405](https://github.com/bitnami/charts/pull/31405))
 

--- a/bitnami/jaeger/Chart.yaml
+++ b/bitnami/jaeger/Chart.yaml
@@ -34,4 +34,4 @@ maintainers:
 name: jaeger
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/jaeger
-version: 5.1.3
+version: 5.1.4

--- a/bitnami/jaeger/templates/migrate-job.yaml
+++ b/bitnami/jaeger/templates/migrate-job.yaml
@@ -7,7 +7,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ include "common.names.fullname" . }}-migrate
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: migration
   {{- if or .Values.migration.annotations .Values.commonAnnotations }}


### PR DESCRIPTION
Date: Sa Jan 4 20:42 2028 +01:00

- Fixes https://github.com/bitnami/charts/issues/31207

Signed-off-by: Marco Fuykschot <marcof@titaniumit.nl>

**Description of the change**
namespace of the migration-job is now using the include common.names.namespace

**Benefits**
namespaceOverride is consistent again

**Checklist**
- [X] Chart version bumped in Chart.yaml according to [semver](http://semver.org/). This is not necessary when the changes only affect README.md files.
(https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)

See other pr (rename of branch only)