### PR TITLE
[bitnami/apisix] feat: :recycle: Use os-shell for config generation

### DIFF
--- a/bitnami/apisix/CHANGELOG.md
+++ b/bitnami/apisix/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
-## 3.7.1 (2025-01-09)
+## 3.7.2 (2025-01-17)
 
-* [bitnami/apisix] Release 3.7.1 ([#31272](https://github.com/bitnami/charts/pull/31272))
+* [bitnami/apisix] feat: :recycle: Use os-shell for config generation ([#31455](https://github.com/bitnami/charts/pull/31455))
+
+## <small>3.7.1 (2025-01-09)</small>
+
+* [bitnami/*] Fix typo in README (#31052) ([b41a51d](https://github.com/bitnami/charts/commit/b41a51d1bd04841fc108b78d3b8357a5292771c8)), closes [#31052](https://github.com/bitnami/charts/issues/31052)
+* [bitnami/apisix] Release 3.7.1 (#31272) ([199b715](https://github.com/bitnami/charts/commit/199b7151ef54c3cc81ca09813e28e2b2ade50f2d)), closes [#31272](https://github.com/bitnami/charts/issues/31272)
 
 ## 3.7.0 (2024-12-10)
 

--- a/bitnami/apisix/Chart.yaml
+++ b/bitnami/apisix/Chart.yaml
@@ -45,4 +45,4 @@ sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/apisix
 - https://github.com/bitnami/charts/tree/main/bitnami/apisix-dashboard
 - https://github.com/bitnami/charts/tree/main/bitnami/apisix-ingress-controller
-version: 3.7.3
+version: 3.7.2

--- a/bitnami/apisix/Chart.yaml
+++ b/bitnami/apisix/Chart.yaml
@@ -45,4 +45,4 @@ sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/apisix
 - https://github.com/bitnami/charts/tree/main/bitnami/apisix-dashboard
 - https://github.com/bitnami/charts/tree/main/bitnami/apisix-ingress-controller
-version: 3.7.1
+version: 3.7.3

--- a/bitnami/apisix/templates/control-plane/dep-ds.yaml
+++ b/bitnami/apisix/templates/control-plane/dep-ds.yaml
@@ -83,6 +83,7 @@ spec:
       {{- end }}
       initContainers:
         {{- include "apisix.waitForETCDInitContainer" . | nindent 8 }}
+        {{- include "apisix.renderConfInitContainer" (dict "component" "control-plane" "context" $) | nindent 8 }}
         {{- include "apisix.prepareApisixInitContainer" (dict "component" "control-plane" "context" $) | nindent 8 }}
         {{- if .Values.controlPlane.initContainers }}
         {{- include "common.tplvalues.render" (dict "value" .Values.controlPlane.initContainers "context" $) | nindent 8 }}

--- a/bitnami/apisix/templates/data-plane/dep-ds.yaml
+++ b/bitnami/apisix/templates/data-plane/dep-ds.yaml
@@ -85,6 +85,7 @@ spec:
         {{- if .Values.controlPlane.enabled }}
         {{- include "apisix.waitForControlPlaneInitContainer" . | nindent 8 }}
         {{- end }}
+        {{- include "apisix.renderConfInitContainer" (dict "component" "data-plane" "context" $) | nindent 8 }}
         {{- include "apisix.prepareApisixInitContainer" (dict "component" "data-plane" "context" $) | nindent 8 }}
         {{- if .Values.dataPlane.initContainers }}
           {{- include "common.tplvalues.render" (dict "value" .Values.dataPlane.initContainers "context" $) | nindent 8 }}


### PR DESCRIPTION
### Description of the change

This PR changes the APISIX init containers so os-shell is used instead of apisix. This helps to remove useless go-tools in the bitnami/apisix image.

### Benefits

Reduce bitnami/apisix image size
<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

n/a
<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [ ] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [ ] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
