### PR TITLE
[bitnami/keycloak] Fix quotes for handling KC_PROXY_HEADER when options is set to passthrough

### DIFF
--- a/bitnami/keycloak/CHANGELOG.md
+++ b/bitnami/keycloak/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 24.4.4 (2025-01-15)
+## 24.4.5 (2025-01-17)
 
-* [bitnami/keycloak] Release 24.4.4 ([#31380](https://github.com/bitnami/charts/pull/31380))
+* [bitnami/keycloak] Fix quotes for handling KC_PROXY_HEADER when options is set to passthrough ([#31459](https://github.com/bitnami/charts/pull/31459))
+
+## <small>24.4.4 (2025-01-15)</small>
+
+* [bitnami/keycloak] Release 24.4.4 (#31380) ([820f59b](https://github.com/bitnami/charts/commit/820f59b6f9be409f7c9f0a3881975f451fe49174)), closes [#31380](https://github.com/bitnami/charts/issues/31380)
 
 ## <small>24.4.3 (2025-01-14)</small>
 

--- a/bitnami/keycloak/Chart.yaml
+++ b/bitnami/keycloak/Chart.yaml
@@ -33,4 +33,4 @@ maintainers:
 name: keycloak
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/keycloak
-version: 24.4.4
+version: 24.4.5

--- a/bitnami/keycloak/templates/configmap-env-vars.yaml
+++ b/bitnami/keycloak/templates/configmap-env-vars.yaml
@@ -17,7 +17,7 @@ data:
   KC_BOOTSTRAP_ADMIN_USERNAME: {{ .Values.auth.adminUser | quote }}
   KEYCLOAK_HTTP_PORT: {{ .Values.containerPorts.http | quote }}
   {{- if and .Values.proxy (empty .Values.proxyHeaders) }}
-  KEYCLOAK_PROXY_HEADERS: {{ ternary "" "xforwarded" (eq .Values.proxy "passthrough") }}
+  KEYCLOAK_PROXY_HEADERS: {{ ternary "" "xforwarded" (eq .Values.proxy "passthrough") | quote }}
   {{- else }}
   KEYCLOAK_PROXY_HEADERS: {{ .Values.proxyHeaders | quote }}
   {{- end }}


### PR DESCRIPTION
Dear Bitnami Team, 

with this PR I want to address an issue, where in the values.yml file the option proxy is set to "passthrough".

Our ArgoCD is not very happy with the ConfigMap. See:
![Screenshot 2025-01-17 at 16 23 36](https://github.com/user-attachments/assets/4433a5d0-7214-43b3-be39-4a2a3a9792ee)
As you can see, the value is just empty. I assume it should be "". So I made a little tiny change.

With my change:
![Screenshot 2025-01-17 at 16 23 55](https://github.com/user-attachments/assets/eed55bf3-6879-4797-9d35-6e5a7f82490d)

Now it's valid yaml. 

I did not add any documentation, as it is not changing the expected behavior.

### Description of the change

Added quotes for ConfigMap, that contains "KEYCLOAK_PROXY_HEADERS"

### Benefits

For us ArgoCD wasn't happy with the following data(helm template)
`KEYCLOAK_PROXY_HEADERS:`
It will now be:
`KEYCLOAK_PROXY_HEADERS: ""`

### Possible drawbacks

There should not be a drawback. It just fixes a problem that is present since at least 22.2.6

### Applicable issues

None

### Additional information

none

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
