### PR TITLE
[bitnami/minio] chore: :recycle: Do not use wait-for-port in minio image

### DIFF
--- a/bitnami/minio/CHANGELOG.md
+++ b/bitnami/minio/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 14.10.4 (2025-01-17)
+## 14.10.5 (2025-01-20)
 
-* [bitnami/minio] Release 14.10.4 ([#31433](https://github.com/bitnami/charts/pull/31433))
+* [bitnami/minio] chore: :recycle: Do not use wait-for-port in minio image ([#31475](https://github.com/bitnami/charts/pull/31475))
+
+## <small>14.10.4 (2025-01-17)</small>
+
+* [bitnami/minio] Release 14.10.4 (#31433) ([163a43f](https://github.com/bitnami/charts/commit/163a43f4443e89720a5eb931309c1f41d26f8fcf)), closes [#31433](https://github.com/bitnami/charts/issues/31433)
 
 ## <small>14.10.3 (2024-12-20)</small>
 

--- a/bitnami/minio/Chart.yaml
+++ b/bitnami/minio/Chart.yaml
@@ -34,4 +34,4 @@ maintainers:
 name: minio
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/minio
-version: 14.10.4
+version: 14.10.5

--- a/bitnami/minio/templates/provisioning-job.yaml
+++ b/bitnami/minio/templates/provisioning-job.yaml
@@ -44,7 +44,7 @@ spec:
       serviceAccountName: {{ template "minio.serviceAccountName" . }}
       initContainers:
         - name: wait-for-available-minio
-          image: {{ include "minio.image" . }}
+          image: {{ include "minio.volumePermissions.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
           {{- if .Values.provisioning.containerSecurityContext.enabled }}
           securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.provisioning.containerSecurityContext "context" $) | nindent 12 }}
@@ -82,6 +82,20 @@ spec:
             - |-
               set -e;
               echo "Start Minio provisioning";
+
+              retry_while() {
+                local -r cmd="${1:?cmd is missing}"
+                local -r retries="${2:-12}"
+                local -r sleep_time="${3:-5}"
+                local return_value=1
+
+                read -r -a command <<< "$cmd"
+                for ((i = 1 ; i <= retries ; i+=1 )); do
+                    "${command[@]}" && return_value=0 && break
+                    sleep "$sleep_time"
+                done
+                return $return_value
+              }
 
               function attachPolicy() {
                 local tmp=$(mc admin $1 info {{ $minioAlias }} $2 | sed -n -e 's/^Policy.*: \(.*\)$/\1/p');
@@ -148,11 +162,10 @@ spec:
               # "mc admin service restart --wait" command is not working as expected
               sleep {{ .Values.provisioning.sleepTime | default 5 }};
               echo "Waiting for Minio to be available after restart";
-              wait-for-port \
-                --host={{ include "common.names.fullname" . }} \
-                --state=inuse \
-                --timeout=120 \
-                {{ .Values.service.ports.api | int64 }};
+              if ! retry_while "mc admin info {{ $minioAlias }}"; then
+                  echo "Error connecting to Minio"
+                  exit 1
+              fi
               echo "Minio is available. Executing provisioning commands";
 
               {{- range $policy := .Values.provisioning.policies }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

This PR changes the Minio provisioning job so we can remove `wait-for-port` in the bitnami/minio image.

### Benefits

Smaller bitnami/minio image
<!-- What benefits will be realized by the code change? -->

### Possible drawbacks
n/a
<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [ ] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [ ] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
