### PR TITLE
[bitnami/thanos] Fix Helm Template Error For Storegateway and HPA

### DIFF
--- a/bitnami/thanos/CHANGELOG.md
+++ b/bitnami/thanos/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 15.10.1 (2025-01-17)
+## 15.10.2 (2025-01-20)
 
-* [bitnami/thanos] Release 15.10.1 ([#31444](https://github.com/bitnami/charts/pull/31444))
+* [bitnami/thanos] Fix Helm Template Error For Storegateway and HPA ([#31486](https://github.com/bitnami/charts/pull/31486))
+
+## <small>15.10.1 (2025-01-17)</small>
+
+* [bitnami/thanos] Release 15.10.1 (#31444) ([7767445](https://github.com/bitnami/charts/commit/7767445e87f3846c4f57b62ba25382ba5732cde0)), closes [#31444](https://github.com/bitnami/charts/issues/31444)
 
 ## 15.10.0 (2025-01-16)
 

--- a/bitnami/thanos/CHANGELOG.md
+++ b/bitnami/thanos/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 15.10.2 (2025-01-20)
+## 15.10.2 (2025-01-21)
 
 * [bitnami/thanos] Fix Helm Template Error For Storegateway and HPA ([#31486](https://github.com/bitnami/charts/pull/31486))
 

--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: thanos
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/thanos
-version: 15.10.1
+version: 15.10.2

--- a/bitnami/thanos/templates/storegateway/hpa-sharded.yaml
+++ b/bitnami/thanos/templates/storegateway/hpa-sharded.yaml
@@ -14,7 +14,7 @@ SPDX-License-Identifier: APACHE-2.0
 {{- if not (empty .Values.storegateway.sharded.timePartitioning) }}
   {{- $timeShards = len .Values.storegateway.sharded.timePartitioning }}
 {{- end }}
-{{- $shards = mul $hashShards $timeShards }}
+{{- $shards = mul $hashShards $timeShards | int }}
 
 {{- range $index, $_ := until $shards }}
 apiVersion: {{ include "common.capabilities.hpa.apiVersion" ( dict "context" $ ) }}


### PR DESCRIPTION
### Description of the change

Fixes bug in helm chart template. When using Thanos Storegateway and HPA, an error appears due. This PR corrects the template.
Error message
`Error: template: thanos/templates/storegateway/hpa-sharded.yaml:19:30: executing "thanos/templates/storegateway/hpa-sharded.yaml" at <$shards>: wrong type for value; expected int; got int64`

Use --debug flag to render out invalid YAML`

### Benefits

No more template errors :) 

### Possible drawbacks

None

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes https://github.com/bitnami/charts/issues/31059

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
