### PR TITLE
[bitnami/redis-cluster] Address chart not working with external access enabled

### DIFF
--- a/bitnami/redis-cluster/CHANGELOG.md
+++ b/bitnami/redis-cluster/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
+## 11.4.1 (2025-01-21)
+
+* [bitnami/redis-cluster] Address chart not working with external access enabled ([#31494](https://github.com/bitnami/charts/pull/31494))
+
 ## 11.4.0 (2025-01-13)
 
-* [bitnami/redis-cluster] feat: add support for svc bindings ([#31330](https://github.com/bitnami/charts/pull/31330))
+* [bitnami/redis-cluster] feat: add support for svc bindings (#31330) ([c409f1f](https://github.com/bitnami/charts/commit/c409f1fc5d34e37299878f19718410493350344e)), closes [#31330](https://github.com/bitnami/charts/issues/31330)
 
 ## 11.3.0 (2025-01-10)
 

--- a/bitnami/redis-cluster/Chart.yaml
+++ b/bitnami/redis-cluster/Chart.yaml
@@ -32,4 +32,4 @@ maintainers:
 name: redis-cluster
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/redis-cluster
-version: 11.4.0
+version: 11.4.1

--- a/bitnami/redis-cluster/templates/svc-cluster-external-access.yaml
+++ b/bitnami/redis-cluster/templates/svc-cluster-external-access.yaml
@@ -15,7 +15,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "common.names.fullname" $ }}-{{ $i }}-svc
-  namespace: {{ include "common.names.namespace" . | quote }}
+  namespace: {{ include "common.names.namespace" $ | quote }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" $root.Values.commonLabels "context" $ ) | nindent 4 }}
     pod: {{ $targetPod }}
   {{- if or


### PR DESCRIPTION
Addresses redis-cluster chart not working with external access enabled.

### Description of the change

This is a simple one-line change where the wrong scope was being passed to "common.names.namespace" from svc-cluster-external-access.yaml but was only impacted when external access was enabled. With this change I was able to install using the chart as expected.

### Benefits

Allows the chart to be used to install redis-cluster with external access

### Possible drawbacks

None I can see or think off

### Applicable issues

N/A

### Additional information



### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
