### PR TITLE
[bitnami/airflow] Fix missing directory in Airflow configmap-based dag

### DIFF
--- a/bitnami/airflow/CHANGELOG.md
+++ b/bitnami/airflow/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 22.4.6 (2025-01-21)
+## 22.4.6 (2025-01-22)
 
 * [bitnami/airflow] Fix missing directory in Airflow configmap-based dag ([#31499](https://github.com/bitnami/charts/pull/31499))
 

--- a/bitnami/airflow/CHANGELOG.md
+++ b/bitnami/airflow/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 22.4.5 (2025-01-09)
+## 22.4.6 (2025-01-21)
 
-* [bitnami/airflow] Release 22.4.5 ([#31235](https://github.com/bitnami/charts/pull/31235))
+* [bitnami/airflow] Fix missing directory in Airflow configmap-based dag ([#31499](https://github.com/bitnami/charts/pull/31499))
+
+## <small>22.4.5 (2025-01-09)</small>
+
+* [bitnami/airflow] Release 22.4.5 (#31235) ([c3f19be](https://github.com/bitnami/charts/commit/c3f19beaaf393f1b7167e5c6af89a7b0fe01690b)), closes [#31235](https://github.com/bitnami/charts/issues/31235)
 
 ## <small>22.4.4 (2025-01-07)</small>
 

--- a/bitnami/airflow/Chart.yaml
+++ b/bitnami/airflow/Chart.yaml
@@ -39,4 +39,4 @@ maintainers:
 name: airflow
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/airflow
-version: 22.4.5
+version: 22.4.6

--- a/bitnami/airflow/templates/_init_containers_sidecars.tpl
+++ b/bitnami/airflow/templates/_init_containers_sidecars.tpl
@@ -311,7 +311,8 @@ Returns an init-container that loads DAGs from a ConfigMap or Git repositories
       is_dir_empty "/dags/{{ include "airflow.dagsPlugins.repository.name" . }}" && git clone {{ .repository }} --depth 1 --branch {{ .branch }} /dags/{{ include "airflow.dagsPlugins.repository.name" . }}
     {{- end }}
     {{- if not (empty .Values.dags.existingConfigmap) }}
-      cp /configmap/* /dags/external
+      mkdir -p /dags/external
+      cp -v /configmap/* /dags/external
     {{- end }}
   {{- end }}
   name: load-dags


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->
When using configmap-based DAGs, the directory being copied to `/dags/external` fails to correctly copy the dags from the configmap folder if the directory does not exist. This creates the directory first.

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #31224 

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
