### PR TITLE
[Index] Add 'ref: index' to index upload workflow checkout

### DIFF
--- a/.github/workflows/sync-chart-cloudflare-index.yml
+++ b/.github/workflows/sync-chart-cloudflare-index.yml
@@ -26,6 +26,8 @@ jobs:
       result: ${{ steps.upload.outputs.result }}
     steps:
     - uses: actions/checkout@master
+      with:
+        ref: 'index'
     - name: Upload to Cloudflare using a BCOM upload proxy
       id: upload
       env:


### PR DESCRIPTION
### Description of the change

Fixes an issue with the '.github/workflows/sync-chart-cloudflare-index.yml' when called from the 'main' branch, by specifying the checkout branch 'index' (by default, it uses the current branch).

### Benefits

This allows the workflow to be called from other branches, not only 'index' branch.

### Possible drawbacks

None known.

### Applicable issues

- fixes issues with monitor workflow: https://github.com/bitnami/charts/actions/runs/12902662888

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
