### PR TITLE
[bitnami/harbor] Clarify usage of custom POSTGRESQL_PASSWORD

### DIFF
--- a/bitnami/harbor/CHANGELOG.md
+++ b/bitnami/harbor/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 24.1.7 (2025-01-17)
+## 24.1.8 (2025-01-23)
 
-* [bitnami/harbor] Release 24.1.7 ([#31457](https://github.com/bitnami/charts/pull/31457))
+* [bitnami/harbor] Clarify usage of custom POSTGRESQL_PASSWORD ([#31507](https://github.com/bitnami/charts/pull/31507))
+
+## <small>24.1.7 (2025-01-17)</small>
+
+* [bitnami/harbor] Release 24.1.7 (#31457) ([a607b9f](https://github.com/bitnami/charts/commit/a607b9faa767ef8ed65f535c0a4563ebfb39429e)), closes [#31457](https://github.com/bitnami/charts/issues/31457)
 
 ## <small>24.1.6 (2025-01-07)</small>
 

--- a/bitnami/harbor/Chart.yaml
+++ b/bitnami/harbor/Chart.yaml
@@ -55,4 +55,4 @@ maintainers:
 name: harbor
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/harbor
-version: 24.1.7
+version: 24.1.8

--- a/bitnami/harbor/values.yaml
+++ b/bitnami/harbor/values.yaml
@@ -1475,7 +1475,7 @@ core:
   ## The secret must contain the keys:
   ## `CSRF_KEY` (optional - alternatively auto-generated),
   ## `HARBOR_ADMIN_PASSWORD` (optional - alternatively auto-generated),
-  ## `POSTGRESQL_PASSWORD` (optional - alternatively uses weak upstream default. Read below if you set it),
+  ## `POSTGRESQL_PASSWORD` (optional - alternatively uses weak upstream default. Read below if you set it. You must also set postgresql.auth.existingSecret to the same value as core.existingEnvVarsSecret for this to work!),
   ## `postgres-password` (required if POSTGRESQL_PASSWORD is set & must be the same as POSTGRESQL_PASSWORD.)
   ## `HARBOR_DATABASE_PASSWORD` (required if POSTGRESQL_PASSWORD is set & must be the same as POSTGRESQL_PASSWORD.)
   ## `REGISTRY_CREDENTIAL_USERNAME` (optional - alternatively weak defaults),


### PR DESCRIPTION
If you use an existingEnvVarsSecret, the documentation implies that everything will work as long as you change postgres-password and HARBOR_DATABASE_PASSWORD. However, you must also change the postgresql.auth.existingSecret to point at the same secret because the postgresql chart doesn't automatically inherit the secrets/variables.

### Description of the change
Documentation only.  Added clarity to an issue that had me confused as to why things weren't working as documented until I dug into it deeper.

### Benefits
Should prevent confusion in the future and save people some time.

### Possible drawbacks

None

### Applicable issues

N/A

### Additional information
N/A

### Checklist
- [X] (readme only) Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
