### PR TITLE
[bitnami/apisix] Update ETCD to major 11

### DIFF
--- a/.vib/apisix/goss/goss.yaml
+++ b/.vib/apisix/goss/goss.yaml
@@ -19,9 +19,6 @@ http:
   http://127.0.0.1:{{ .Vars.dataPlane.containerPorts.control }}/v1/healthcheck:
     status: 200
   https://apisix-control-plane:{{ .Vars.controlPlane.service.ports.adminAPI }}/apisix/admin/routes:
-    status: 401
-    allow-insecure: true
-  https://apisix-control-plane:{{ .Vars.controlPlane.service.ports.adminAPI }}/apisix/admin/routes:
     status: 200
     request-headers:
       - "X-API-KEY: {{ .Vars.controlPlane.apiTokenAdmin }}"

--- a/bitnami/apisix/CHANGELOG.md
+++ b/bitnami/apisix/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 3.7.2 (2025-01-17)
+## 4.0.0 (2025-01-22)
 
-* [bitnami/apisix] feat: :recycle: Use os-shell for config generation ([#31455](https://github.com/bitnami/charts/pull/31455))
+* [bitnami/apisix] Update ETCD to major 11 ([#31508](https://github.com/bitnami/charts/pull/31508))
+
+## <small>3.7.2 (2025-01-17)</small>
+
+* [bitnami/apisix] feat: :recycle: Use os-shell for config generation (#31455) ([e808ba0](https://github.com/bitnami/charts/commit/e808ba010c008023c7dfc1c1ee5bafb2f9acf38c)), closes [#31455](https://github.com/bitnami/charts/issues/31455)
 
 ## <small>3.7.1 (2025-01-09)</small>
 

--- a/bitnami/apisix/Chart.lock
+++ b/bitnami/apisix/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: etcd
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 10.7.1
+  version: 11.0.1
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 2.29.0
-digest: sha256:6fc5fa97897717b27e985da35f8235f195e4f9d143c066914d5846803cc7ad27
-generated: "2025-01-09T11:02:59.202874125Z"
+digest: sha256:b209124fc614df1ddc91d60a0881c5ffe03ef1a6f264a51479d224d79e3d751c
+generated: "2025-01-22T11:24:08.352507+01:00"

--- a/bitnami/apisix/Chart.yaml
+++ b/bitnami/apisix/Chart.yaml
@@ -19,7 +19,7 @@ dependencies:
 - name: etcd
   repository: oci://registry-1.docker.io/bitnamicharts
   condition: etcd.enabled
-  version: 10.x.x
+  version: 11.x.x
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
   tags:
@@ -45,4 +45,4 @@ sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/apisix
 - https://github.com/bitnami/charts/tree/main/bitnami/apisix-dashboard
 - https://github.com/bitnami/charts/tree/main/bitnami/apisix-ingress-controller
-version: 3.7.2
+version: 4.0.0

--- a/bitnami/apisix/README.md
+++ b/bitnami/apisix/README.md
@@ -1099,7 +1099,7 @@ Find more information about how to deal with common errors related to Bitnami's 
 
 ### To 4.0.0
 
-This major updates the `etcd` subchart to it newest major,1.0.0. For more information on this subchart's major, please refer to [etcd upgrade notes](https://github.com/bitnami/charts/tree/main/bitnami/etcd#to-1100).
+This major updates the `etcd` subchart to it newest major, 11.0.0. For more information on this subchart's major, please refer to [etcd upgrade notes](https://github.com/bitnami/charts/tree/main/bitnami/etcd#to-1100).
 
 ### To 3.7.0
 

--- a/bitnami/apisix/README.md
+++ b/bitnami/apisix/README.md
@@ -1097,6 +1097,10 @@ Find more information about how to deal with common errors related to Bitnami's 
 
 ## Upgrading
 
+### To 4.0.0
+
+This major updates the `etcd` subchart to it newest major,1.0.0. For more information on this subchart's major, please refer to [etcd upgrade notes](https://github.com/bitnami/charts/tree/main/bitnami/etcd#to-1100).
+
 ### To 3.7.0
 
 This version introduces image verification for security purposes. To disable it, set `global.security.allowInsecureImages` to `true`. More details at [GitHub issue](https://github.com/bitnami/charts/issues/30850).


### PR DESCRIPTION
### Description of the change

Update ETCD to major 11

### Benefits

Use the latest version of ETCD subchart

### Possible drawbacks

Regarding ETCD, upgrading of any kind including increasing replica count must be done with helm upgrade exclusively.

### Additional information

https://github.com/bitnami/charts/tree/main/bitnami/etcd#to-1100

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
