### PR TITLE
[bitnami/milvus] Update ETCD to major 11

### DIFF
--- a/bitnami/milvus/Chart.lock
+++ b/bitnami/milvus/Chart.lock
@@ -1,15 +1,15 @@
 dependencies:
 - name: etcd
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 10.7.2
+  version: 11.0.1
 - name: kafka
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 31.2.0
 - name: minio
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 14.10.3
+  version: 14.10.5
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 2.29.0
-digest: sha256:e318d422a713ef5c25a18578450e82607baaaf633282b31bdede6c34a6fe93df
-generated: "2025-01-13T10:12:17.454538655Z"
+digest: sha256:8af9248c286a0b755cd9aaede99206b162c5477bd28e7f81919d56bfe5ac5f3e
+generated: "2025-01-22T11:31:32.633839+01:00"

--- a/bitnami/milvus/Chart.yaml
+++ b/bitnami/milvus/Chart.yaml
@@ -19,7 +19,7 @@ dependencies:
 - name: etcd
   repository: oci://registry-1.docker.io/bitnamicharts
   condition: etcd.enabled
-  version: 10.x.x
+  version: 11.x.x
 - condition: kafka.enabled
   name: kafka
   repository: oci://registry-1.docker.io/bitnamicharts
@@ -48,4 +48,4 @@ maintainers:
 name: milvus
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/milvus
-version: 10.1.7
+version: 11.0.0

--- a/bitnami/milvus/README.md
+++ b/bitnami/milvus/README.md
@@ -1865,6 +1865,10 @@ Find more information about how to deal with common errors related to Bitnami's 
 
 ## Upgrading
 
+### To 11.0.0
+
+This major updates the `etcd` subchart to it newest major,11.0.0. For more information on this subchart's major, please refer to [etcd upgrade notes](https://github.com/bitnami/charts/tree/main/bitnami/etcd#to-1100).
+
 ### To 10.1.0
 
 This version introduces image verification for security purposes. To disable it, set `global.security.allowInsecureImages` to `true`. More details at [GitHub issue](https://github.com/bitnami/charts/issues/30850).


### PR DESCRIPTION
### Description of the change

Update ETCD to major 11

### Benefits

Use the latest version of ETCD subchart

### Possible drawbacks

Regarding ETCD, upgrading of any kind including increasing replica count must be done with helm upgrade exclusively.

### Additional information

https://github.com/bitnami/charts/tree/main/bitnami/etcd#to-1100

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
