### PR TITLE
[bitnami/cilium] Update ETCD to major 11

### DIFF
--- a/bitnami/cilium/CHANGELOG.md
+++ b/bitnami/cilium/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 1.3.4 (2025-01-21)
+## 2.0.0 (2025-01-22)
 
-* [bitnami/cilium] Release 1.3.4 ([#31502](https://github.com/bitnami/charts/pull/31502))
+* [bitnami/cilium] Update ETCD to major 11 ([#31510](https://github.com/bitnami/charts/pull/31510))
+
+## <small>1.3.4 (2025-01-21)</small>
+
+* [bitnami/cilium] Release 1.3.4 (#31502) ([c00512c](https://github.com/bitnami/charts/commit/c00512cf690cf67604d1c654231bb398d65f97bd)), closes [#31502](https://github.com/bitnami/charts/issues/31502)
 
 ## <small>1.3.3 (2025-01-17)</small>
 

--- a/bitnami/cilium/Chart.lock
+++ b/bitnami/cilium/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: etcd
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 10.7.3
+  version: 11.0.1
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 2.29.0
-digest: sha256:2f7019638b9c5faa79322b4e166dae5daf29e597aaa720e6fc1e95c331c78e2c
-generated: "2025-01-21T23:33:04.329058434Z"
+digest: sha256:6c995ddc95840364d42013d0532e0770551d56d0707760ec46c87bb8426572be
+generated: "2025-01-22T11:38:46.06963+01:00"

--- a/bitnami/cilium/Chart.yaml
+++ b/bitnami/cilium/Chart.yaml
@@ -25,7 +25,7 @@ dependencies:
   repository: oci://registry-1.docker.io/bitnamicharts
   tags:
   - cilium-database
-  version: 10.x.x
+  version: 11.x.x
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
   tags:
@@ -52,4 +52,4 @@ sources:
 - https://github.com/bitnami/containers/tree/main/bitnami/hubble-relay
 - https://github.com/bitnami/containers/tree/main/bitnami/hubble-ui
 - https://github.com/bitnami/containers/tree/main/bitnami/hubble-ui-backend
-version: 1.3.4
+version: 2.0.0

--- a/bitnami/cilium/README.md
+++ b/bitnami/cilium/README.md
@@ -1183,6 +1183,12 @@ helm install my-release -f values.yaml oci://REGISTRY_NAME/REPOSITORY_NAME/ciliu
 
 Find more information about how to deal with common errors related to Bitnami's Helm charts in [this troubleshooting guide](https://docs.bitnami.com/general/how-to/troubleshoot-helm-chart-issues).
 
+## Upgrading
+
+### To 2.0.0
+
+This major updates the `etcd` subchart to it newest major, 11.0.0. For more information on this subchart's major, please refer to [etcd upgrade notes](https://github.com/bitnami/charts/tree/main/bitnami/etcd#to-1100).
+
 ## License
 
 Copyright &copy; 2024 Broadcom. The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.


### PR DESCRIPTION
### Description of the change

Update ETCD to major 11

### Benefits

Use the latest version of ETCD subchart

### Possible drawbacks

Regarding ETCD, upgrading of any kind including increasing replica count must be done with helm upgrade exclusively.

### Additional information

https://github.com/bitnami/charts/tree/main/bitnami/etcd#to-1100

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
