### PR TITLE
[bitnami/pinniped] Update rbac.yaml so it is not created if `supervisor.rbac.create=false`

### DIFF
--- a/.vib/apisix/goss/goss.yaml
+++ b/.vib/apisix/goss/goss.yaml
@@ -19,9 +19,6 @@ http:
   http://127.0.0.1:{{ .Vars.dataPlane.containerPorts.control }}/v1/healthcheck:
     status: 200
   https://apisix-control-plane:{{ .Vars.controlPlane.service.ports.adminAPI }}/apisix/admin/routes:
-    status: 401
-    allow-insecure: true
-  https://apisix-control-plane:{{ .Vars.controlPlane.service.ports.adminAPI }}/apisix/admin/routes:
     status: 200
     request-headers:
       - "X-API-KEY: {{ .Vars.controlPlane.apiTokenAdmin }}"

--- a/.vib/prometheus/goss/goss.yaml
+++ b/.vib/prometheus/goss/goss.yaml
@@ -27,6 +27,17 @@ command:
     stdout:
     - /serviceaccount.*name.*{{.Env.BITNAMI_APP_NAME }}/
   {{ end }}
+  check-config-files:
+    exec: promtool check config /opt/bitnami/prometheus/conf/{{ .Vars.server.existingConfigmapKey }}
+    exit-status: 0
+    stdout:
+    - "SUCCESS"
+  check-metrics:
+    exec: promtool query instant http://localhost:{{ .Vars.server.containerPorts.http }} prometheus_http_requests_total
+    exit-status: 0
+    stdout:
+    - "/-/healthy"
+    - "/-/ready"
 file:
   /opt/bitnami/prometheus/conf/{{ .Vars.server.existingConfigmapKey }}:
     exists: true
@@ -65,15 +76,3 @@ http:
     body:
     - "{{ (first (first .Vars.server.alertingRules.groups).rules).annotations.summary }}"
   {{- end }}
-command:
-  check-config-files:
-    exec: promtool check config /opt/bitnami/prometheus/conf/{{ .Vars.server.existingConfigmapKey }}
-    exit-status: 0
-    stdout:
-    - "SUCCESS"
-  check-metrics:
-    exec: promtool query instant http://localhost:{{ .Vars.server.containerPorts.http }} prometheus_http_requests_total
-    exit-status: 0
-    stdout:
-    - "/-/healthy"
-    - "/-/ready"

--- a/bitnami/apisix/CHANGELOG.md
+++ b/bitnami/apisix/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 3.7.2 (2025-01-17)
+## 4.0.0 (2025-01-22)
 
-* [bitnami/apisix] feat: :recycle: Use os-shell for config generation ([#31455](https://github.com/bitnami/charts/pull/31455))
+* [bitnami/apisix] Update ETCD to major 11 ([#31508](https://github.com/bitnami/charts/pull/31508))
+
+## <small>3.7.2 (2025-01-17)</small>
+
+* [bitnami/apisix] feat: :recycle: Use os-shell for config generation (#31455) ([e808ba0](https://github.com/bitnami/charts/commit/e808ba010c008023c7dfc1c1ee5bafb2f9acf38c)), closes [#31455](https://github.com/bitnami/charts/issues/31455)
 
 ## <small>3.7.1 (2025-01-09)</small>
 

--- a/bitnami/apisix/Chart.lock
+++ b/bitnami/apisix/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: etcd
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 10.7.1
+  version: 11.0.1
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 2.29.0
-digest: sha256:6fc5fa97897717b27e985da35f8235f195e4f9d143c066914d5846803cc7ad27
-generated: "2025-01-09T11:02:59.202874125Z"
+digest: sha256:b209124fc614df1ddc91d60a0881c5ffe03ef1a6f264a51479d224d79e3d751c
+generated: "2025-01-22T11:24:08.352507+01:00"

--- a/bitnami/apisix/Chart.yaml
+++ b/bitnami/apisix/Chart.yaml
@@ -19,7 +19,7 @@ dependencies:
 - name: etcd
   repository: oci://registry-1.docker.io/bitnamicharts
   condition: etcd.enabled
-  version: 10.x.x
+  version: 11.x.x
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
   tags:
@@ -45,4 +45,4 @@ sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/apisix
 - https://github.com/bitnami/charts/tree/main/bitnami/apisix-dashboard
 - https://github.com/bitnami/charts/tree/main/bitnami/apisix-ingress-controller
-version: 3.7.2
+version: 4.0.0

--- a/bitnami/apisix/README.md
+++ b/bitnami/apisix/README.md
@@ -1097,6 +1097,10 @@ Find more information about how to deal with common errors related to Bitnami's 
 
 ## Upgrading
 
+### To 4.0.0
+
+This major updates the `etcd` subchart to it newest major, 11.0.0. For more information on this subchart's major, please refer to [etcd upgrade notes](https://github.com/bitnami/charts/tree/main/bitnami/etcd#to-1100).
+
 ### To 3.7.0
 
 This version introduces image verification for security purposes. To disable it, set `global.security.allowInsecureImages` to `true`. More details at [GitHub issue](https://github.com/bitnami/charts/issues/30850).

--- a/bitnami/mysql/CHANGELOG.md
+++ b/bitnami/mysql/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
-## 12.2.1 (2025-01-04)
+## 12.2.2 (2025-01-22)
 
-* [bitnami/mysql] Release 12.2.1 ([#31215](https://github.com/bitnami/charts/pull/31215))
+* [bitnami/mysql] Release 12.2.2 ([#31512](https://github.com/bitnami/charts/pull/31512))
+
+## <small>12.2.1 (2025-01-04)</small>
+
+* [bitnami/*] Fix typo in README (#31052) ([b41a51d](https://github.com/bitnami/charts/commit/b41a51d1bd04841fc108b78d3b8357a5292771c8)), closes [#31052](https://github.com/bitnami/charts/issues/31052)
+* [bitnami/mysql] Release 12.2.1 (#31215) ([65fb2fa](https://github.com/bitnami/charts/commit/65fb2fa98b20f187dfecca09042fd8fbf70f6b95)), closes [#31215](https://github.com/bitnami/charts/issues/31215)
 
 ## 12.2.0 (2024-12-10)
 

--- a/bitnami/mysql/Chart.yaml
+++ b/bitnami/mysql/Chart.yaml
@@ -6,13 +6,13 @@ annotations:
   licenses: Apache-2.0
   images: |
     - name: mysql
-      image: docker.io/bitnami/mysql:8.4.3-debian-12-r5
+      image: docker.io/bitnami/mysql:8.4.4-debian-12-r0
     - name: mysqld-exporter
-      image: docker.io/bitnami/mysqld-exporter:0.16.0-debian-12-r4
+      image: docker.io/bitnami/mysqld-exporter:0.16.0-debian-12-r5
     - name: os-shell
-      image: docker.io/bitnami/os-shell:12-debian-12-r34
+      image: docker.io/bitnami/os-shell:12-debian-12-r35
 apiVersion: v2
-appVersion: 8.4.3
+appVersion: 8.4.4
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
@@ -34,4 +34,4 @@ maintainers:
 name: mysql
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/mysql
-version: 12.2.1
+version: 12.2.2

--- a/bitnami/mysql/values.yaml
+++ b/bitnami/mysql/values.yaml
@@ -97,7 +97,7 @@ diagnosticMode:
 image:
   registry: docker.io
   repository: bitnami/mysql
-  tag: 8.4.3-debian-12-r5
+  tag: 8.4.4-debian-12-r0
   digest: ""
   ## Specify a imagePullPolicy
   ## ref: https://kubernetes.io/docs/concepts/containers/images/#pre-pulled-images
@@ -1347,7 +1347,7 @@ volumePermissions:
   image:
     registry: docker.io
     repository: bitnami/os-shell
-    tag: 12-debian-12-r34
+    tag: 12-debian-12-r35
     digest: ""
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
@@ -1392,7 +1392,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/mysqld-exporter
-    tag: 0.16.0-debian-12-r4
+    tag: 0.16.0-debian-12-r5
     digest: ""
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.

--- a/bitnami/prometheus/CHANGELOG.md
+++ b/bitnami/prometheus/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 1.4.2 (2025-01-17)
+## 1.4.3 (2025-01-22)
 
-* [bitnami/prometheus] Release 1.4.2 ([#31446](https://github.com/bitnami/charts/pull/31446))
+* [bitnami/prometheus] Remove GOSS duplicated command ([#31513](https://github.com/bitnami/charts/pull/31513))
+
+## <small>1.4.2 (2025-01-17)</small>
+
+* [bitnami/prometheus] Release 1.4.2 (#31446) ([8d5a3a8](https://github.com/bitnami/charts/commit/8d5a3a81abd654712bdddeec3f7263890dabe9b8)), closes [#31446](https://github.com/bitnami/charts/issues/31446)
 
 ## <small>1.4.1 (2025-01-13)</small>
 

--- a/bitnami/prometheus/Chart.yaml
+++ b/bitnami/prometheus/Chart.yaml
@@ -36,4 +36,4 @@ sources:
 - https://github.com/bitnami/containers/tree/main/bitnami/prometheus
 - https://github.com/prometheus/prometheus
 - https://github.com/prometheus-community/helm-charts
-version: 1.4.2
+version: 1.4.3


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

When setting `supervisor.rbac.create=false` an `rbac.yaml` file with a set of roles and binding is still created.

### Benefits

It is possible to disable rbac generation for the supervisor, if it is not to be deployed.

### Possible drawbacks

None as far as I know.

### Applicable issues

N/A

### Additional information

Another improvement might be to ensure rbac and networkpolicies are excluded as default when `supervisor.enabled=false`, which is currently not the case either. This might also be applicable to `concierge.enabled=false`, but I have not tested that.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [ ] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
