### PR TITLE
[bitnami/pinniped] Ensure rbac and networkpolicy is not created for s…

### DIFF
--- a/bitnami/pinniped/CHANGELOG.md
+++ b/bitnami/pinniped/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 2.4.4 (2025-01-17)
+## 2.4.5 (2025-01-22)
 
-* [bitnami/pinniped] Release 2.4.4 ([#31440](https://github.com/bitnami/charts/pull/31440))
+* [bitnami/pinniped] Ensure rbac and networkpolicy is not created for s… ([#31515](https://github.com/bitnami/charts/pull/31515))
+
+## <small>2.4.4 (2025-01-17)</small>
+
+* [bitnami/pinniped] Release 2.4.4 (#31440) ([c198f0f](https://github.com/bitnami/charts/commit/c198f0f46df6ceec39eda8f66177fc586a791082)), closes [#31440](https://github.com/bitnami/charts/issues/31440)
 
 ## <small>2.4.3 (2025-01-15)</small>
 

--- a/bitnami/pinniped/Chart.yaml
+++ b/bitnami/pinniped/Chart.yaml
@@ -27,4 +27,4 @@ maintainers:
 name: pinniped
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/pinniped
-version: 2.4.4
+version: 2.4.5

--- a/bitnami/pinniped/templates/supervisor/networkpolicy.yaml
+++ b/bitnami/pinniped/templates/supervisor/networkpolicy.yaml
@@ -3,7 +3,7 @@ Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- if .Values.supervisor.networkPolicy.enabled }}
+{{- if and .Values.supervisor.enabled .Values.supervisor.networkPolicy.enabled }}
 kind: NetworkPolicy
 apiVersion: {{ include "common.capabilities.networkPolicy.apiVersion" . }}
 metadata:
@@ -79,7 +79,7 @@ spec:
         {{- end }}
         - podSelector:
             matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 14 }}
-              app.kubernetes.io/part-of: vault        
+              app.kubernetes.io/part-of: vault
       {{- end }}
     {{- if .Values.supervisor.networkPolicy.extraIngress }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.supervisor.networkPolicy.extraIngress "context" $ ) | nindent 4 }}

--- a/bitnami/pinniped/templates/supervisor/rbac.yaml
+++ b/bitnami/pinniped/templates/supervisor/rbac.yaml
@@ -3,7 +3,8 @@ Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- if .Values.supervisor.rbac.create }}
+// and
+{{- if and .Values.supervisor.enabled .Values.supervisor.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -173,7 +174,6 @@ roleRef:
   kind: Role
   name: {{ template "pinniped.supervisor.fullname" . }}
   apiGroup: rbac.authorization.k8s.io
-{{- end }}
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -282,3 +282,4 @@ roleRef:
   kind: ClusterRole
   name: {{ printf "%s-%s" (include "pinniped.supervisor.fullname.namespace" .) "aggregated-api-server" | trunc 63 | trimSuffix "-" }}
   apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/bitnami/pinniped/templates/supervisor/rbac.yaml
+++ b/bitnami/pinniped/templates/supervisor/rbac.yaml
@@ -3,7 +3,6 @@ Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-// and
 {{- if and .Values.supervisor.enabled .Values.supervisor.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

When setting `supervisor.enabled=false` network polices and rbac is still included.

This PR ensures that:

- Both `supervisor.enabled=true` and `supervisor.networkPolicy.enabled=true` to generate a network policy for supervisor.
- Both `supervisor.enabled=true` and `supervisor.rbac.create=true` to generate rbac resources for supervisor.
- 
### Benefits

It is possible to disable network policy and rbac resource generation for supervisor, if supervisor is disabled.

### Possible drawbacks

None as far as I know.

### Applicable issues

N/A

### Additional information

N/A

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
