### PR TITLE
[bitnami/keydb] fix: Update "volume-permissions" initContainers command

### DIFF
--- a/bitnami/keydb/CHANGELOG.md
+++ b/bitnami/keydb/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.3.2 (2025-01-22)
+## 0.3.2 (2025-01-23)
 
 * [bitnami/keydb] fix: Update "volume-permissions" initContainers command ([#31518](https://github.com/bitnami/charts/pull/31518))
 

--- a/bitnami/keydb/CHANGELOG.md
+++ b/bitnami/keydb/CHANGELOG.md
@@ -2,11 +2,12 @@
 
 ## 0.3.2 (2025-01-22)
 
-* [bitnami/keydb] Release 0.3.2 ([#31518](https://github.com/bitnami/charts/pull/31518))
+* [bitnami/keydb] fix: Update "volume-permissions" initContainers command ([#31518](https://github.com/bitnami/charts/pull/31518))
 
-## 0.3.1 (2024-12-27)
+## <small>0.3.1 (2024-12-27)</small>
 
-* [bitnami/keydb] Release 0.3.1 ([#31176](https://github.com/bitnami/charts/pull/31176))
+* [bitnami/*] Fix typo in README (#31052) ([b41a51d](https://github.com/bitnami/charts/commit/b41a51d1bd04841fc108b78d3b8357a5292771c8)), closes [#31052](https://github.com/bitnami/charts/issues/31052)
+* [bitnami/keydb] Release 0.3.1 (#31176) ([28ede84](https://github.com/bitnami/charts/commit/28ede84eddc77f9a87e4197bd0067e8e42178649)), closes [#31176](https://github.com/bitnami/charts/issues/31176)
 
 ## 0.3.0 (2024-12-10)
 

--- a/bitnami/keydb/CHANGELOG.md
+++ b/bitnami/keydb/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.3.2 (2025-01-22)
+
+* [bitnami/keydb] Release 0.3.2 ([#31518](https://github.com/bitnami/charts/pull/31518))
+
 ## 0.3.1 (2024-12-27)
 
 * [bitnami/keydb] Release 0.3.1 ([#31176](https://github.com/bitnami/charts/pull/31176))

--- a/bitnami/keydb/Chart.yaml
+++ b/bitnami/keydb/Chart.yaml
@@ -34,4 +34,4 @@ name: keydb
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/keydb
 - https://github.com/bitnami/containers/tree/main/bitnami/keydb
-version: 0.3.1
+version: 0.3.2

--- a/bitnami/keydb/templates/master/statefulset.yaml
+++ b/bitnami/keydb/templates/master/statefulset.yaml
@@ -94,7 +94,7 @@ spec:
             - /bin/bash
             - -ec
             - |
-              find {{ .Values.master.persistence.path }} -mindepth 1 -maxdepth 1 -not -name ".snapshot" -not -name "lost+found" | xargs chown -R {{ printf "%d:%d" (int .Values.master.containerSecurityContext.runAsUser) (int .Values.master.podSecurityContext.fsGroup) }}
+              find {{ .Values.master.persistence.mountPath }} -mindepth 1 -maxdepth 1 -not -name ".snapshot" -not -name "lost+found" | xargs -r chown -R {{ printf "%d:%d" (int .Values.master.containerSecurityContext.runAsUser) (int .Values.master.podSecurityContext.fsGroup) }}
           {{- if .Values.volumePermissions.containerSecurityContext.enabled }}
           securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.volumePermissions.containerSecurityContext "context" $) | nindent 12 }}
           {{- end }}

--- a/bitnami/keydb/templates/replica/statefulset.yaml
+++ b/bitnami/keydb/templates/replica/statefulset.yaml
@@ -97,7 +97,7 @@ spec:
             - /bin/bash
             - -ec
             - |
-              find {{ .Values.replica.persistence.path }} -mindepth 1 -maxdepth 1 -not -name ".snapshot" -not -name "lost+found" | xargs chown -R {{ printf "%d:%d" (int .Values.replica.containerSecurityContext.runAsUser) (int .Values.replica.podSecurityContext.fsGroup) }}
+              find {{ .Values.replica.persistence.mountPath }} -mindepth 1 -maxdepth 1 -not -name ".snapshot" -not -name "lost+found" | xargs -r chown -R {{ printf "%d:%d" (int .Values.replica.containerSecurityContext.runAsUser) (int .Values.replica.podSecurityContext.fsGroup) }}
           {{- if .Values.volumePermissions.containerSecurityContext.enabled }}
           securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.volumePermissions.containerSecurityContext "context" $) | nindent 12 }}
           {{- end }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

This change fixes the commands of `volume-permissions` initContainers.

There are no default values set for `.Values.master.persistence.path`, `.Values.replica.persistence.path` in `values.yaml`, so the command have been updated to use `*.mountPath`.

Also, the `-r` argument for `xargs` added.

### Benefits

Init container starts to work when `.Values.volumePermissions.enabled: true`

### Possible drawbacks

Maybe it is worth to consider the further parameterization of initContainer `command` in helm values.

### Applicable issues

N/A

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
