### PR TITLE
[bitnami/nats] Improve NATS routes configuration

### DIFF
--- a/bitnami/nats/CHANGELOG.md
+++ b/bitnami/nats/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 8.5.3 (2025-01-17)
+## 8.5.4 (2025-01-23)
 
-* [bitnami/nats] Release 8.5.3 ([#31435](https://github.com/bitnami/charts/pull/31435))
+* [bitnami/nats] Improve NATS routes configuration ([#31523](https://github.com/bitnami/charts/pull/31523))
+
+## <small>8.5.3 (2025-01-17)</small>
+
+* [bitnami/nats] Release 8.5.3 (#31435) ([cac021d](https://github.com/bitnami/charts/commit/cac021d449a1235e44e88bb383ad377518710340)), closes [#31435](https://github.com/bitnami/charts/issues/31435)
 
 ## <small>8.5.2 (2024-12-17)</small>
 

--- a/bitnami/nats/Chart.yaml
+++ b/bitnami/nats/Chart.yaml
@@ -31,4 +31,4 @@ maintainers:
 name: nats
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/nats
-version: 8.5.3
+version: 8.5.4

--- a/bitnami/nats/values.yaml
+++ b/bitnami/nats/values.yaml
@@ -255,11 +255,12 @@ configuration: |-
     # Routes are actively solicited and connected to from this server.
     # Other servers can connect to us if they supply the correct credentials
     # in their routes definitions from above
+    {{- $auth := ternary ( printf "%s:%s@" .Values.cluster.auth.user $clusterAuthPwd) "" .Values.cluster.auth.enabled }}
+    {{- $domain := (printf "%s-headless" (include "common.names.fullname" .) | trunc 63 | trimSuffix "-" ) }}
+    {{- $stsPrefix := include "common.names.fullname" . }}
     routes = [
-      {{- if .Values.cluster.auth.enabled }}
-      nats://{{ .Values.cluster.auth.user }}:{{ $clusterAuthPwd }}@{{ include "common.names.fullname" . }}:{{ .Values.service.ports.cluster }}
-      {{- else }}
-      nats://{{ template "common.names.fullname" . }}:{{ .Values.service.ports.cluster }}
+      {{- range $podIndex := until (.Values.replicaCount|int) }}
+      nats://{{ $auth }}{{ $stsPrefix }}-{{ $podIndex }}.{{ $domain }}:{{ $.Values.service.ports.cluster }}
       {{- end }}
     ]
     {{- if .Values.cluster.connectRetries }}


### PR DESCRIPTION
### Description of the change

This improves the generated nats-server.conf file, to include all the routes to each pod, rather than the current single route that points to the general service.

### Benefits

This will prevent improper routing of messages in a cluster.

### Possible drawbacks

n/a

### Applicable issues

- fixes #30124

### Additional information

n/a

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
