### PR TITLE
ci: Skip hardcoded images check on NOTES.txt files

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -111,7 +111,7 @@ jobs:
             if [[ -n "$image" && $image != {{*}} ]]; then
               hardcoded_images+=("${image}")
             fi
-          done <<< "$(grep -REoh "\s*image:\s+[\"']*.+[\"']*\s*$" "charts/bitnami/${CHART}/templates" | sed "s/image: [\"']*//" | sed "s/[\"']*$//")"
+          done <<< "$(grep --exclude "NOTES.txt" -REoh "\s*image:\s+[\"']*.+[\"']*\s*$" "charts/bitnami/${CHART}/templates" | sed "s/image: [\"']*//" | sed "s/[\"']*$//")"
 
           echo "${hardcoded_images[@]}"
           if [[ ${#hardcoded_images[@]} -gt 0 ]] ; then


### PR DESCRIPTION
### Description of the change

This PR adapts the "Look for hardcoded images" job on "CI Pipeline" workflow so we skip looking for hardcoded images on 
NOTES.txt files.

We usually include instructions to create "client pods" on the notes and, when using images for the clients not included in the chart (e.g. using a `bitnami/golang:latest` to compile some Go example app and use it as a client) it's useful to use hardcoded images with rolling tags.
