### PR TITLE
[bitnami/nginx-ingress-controller] Add --enable-metrics command line argument

### DIFF
--- a/bitnami/nginx-ingress-controller/CHANGELOG.md
+++ b/bitnami/nginx-ingress-controller/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 11.6.6 (2025-01-24)
+## 11.6.7 (2025-01-27)
 
-* [bitnami/nginx-ingress-controller] Release 11.6.6 ([#31576](https://github.com/bitnami/charts/pull/31576))
+* [bitnami/nginx-ingress-controller] Add --enable-metrics command line argument ([#31605](https://github.com/bitnami/charts/pull/31605))
+
+## <small>11.6.6 (2025-01-24)</small>
+
+* [bitnami/nginx-ingress-controller] Release 11.6.6 (#31576) ([e107d55](https://github.com/bitnami/charts/commit/e107d55a9114bc30359e4c2805cd17b4eb6b78c2)), closes [#31576](https://github.com/bitnami/charts/issues/31576)
 
 ## <small>11.6.5 (2025-01-17)</small>
 

--- a/bitnami/nginx-ingress-controller/CHANGELOG.md
+++ b/bitnami/nginx-ingress-controller/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 11.6.7 (2025-01-27)
+## 11.6.7 (2025-01-28)
 
 * [bitnami/nginx-ingress-controller] Add --enable-metrics command line argument ([#31605](https://github.com/bitnami/charts/pull/31605))
 

--- a/bitnami/nginx-ingress-controller/Chart.yaml
+++ b/bitnami/nginx-ingress-controller/Chart.yaml
@@ -34,4 +34,4 @@ maintainers:
 name: nginx-ingress-controller
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/nginx-ingress-controller
-version: 11.6.6
+version: 11.6.7

--- a/bitnami/nginx-ingress-controller/templates/controller-daemonset.yaml
+++ b/bitnami/nginx-ingress-controller/templates/controller-daemonset.yaml
@@ -141,6 +141,9 @@ spec:
           {{- if .Values.watchIngressWithoutClass }}
             - --watch-ingress-without-class=true
           {{- end }}
+          {{- if .Values.metrics.enabled }}
+            - --enable-metrics
+          {{- end }}
           {{- range $key, $value := .Values.extraArgs }}
             {{- if $value }}
             - --{{ $key }}={{ $value }}

--- a/bitnami/nginx-ingress-controller/templates/controller-deployment.yaml
+++ b/bitnami/nginx-ingress-controller/templates/controller-deployment.yaml
@@ -152,6 +152,9 @@ spec:
           {{- if .Values.watchIngressWithoutClass }}
             - --watch-ingress-without-class=true
           {{- end }}
+          {{- if .Values.metrics.enabled }}
+            - --enable-metrics
+          {{- end }}
           {{- range $key, $value := .Values.extraArgs }}
             {{- if $value }}
             - --{{ $key }}={{ $value }}


### PR DESCRIPTION
### Description of the change

This PR adds the `--enable-metrics` command line argument when `metrics.enabled` is set to true in the chart

### Benefits

This will add many basic metric outputs to the prometheus exporter

### Possible drawbacks

None that I can think of

### Applicable issues

- fixes #31603 

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
