### PR TITLE
[bitnami/superset] Fix README.md app-name typo

### DIFF
--- a/bitnami/superset/CHANGELOG.md
+++ b/bitnami/superset/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.1.1 (2025-01-29)
+## 0.2.0 (2025-01-29)
 
 * [bitnami/superset] Fix README.md app-name typo ([#31650](https://github.com/bitnami/charts/pull/31650))
 

--- a/bitnami/superset/CHANGELOG.md
+++ b/bitnami/superset/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.1 (2025-01-29)
+
+* [bitnami/superset] Fix README.md app-name typo ([#31650](https://github.com/bitnami/charts/pull/31650))
+
 ## 0.1.0 (2025-01-28)
 
-* [bitnami/superset] Add chart ([#26713](https://github.com/bitnami/charts/pull/26713))
+* [bitnami/superset] Add chart (#26713) ([8a91a48](https://github.com/bitnami/charts/commit/8a91a4864d11cd079ca6dfe15cbdd8cc5654008c)), closes [#26713](https://github.com/bitnami/charts/issues/26713)

--- a/bitnami/superset/Chart.yaml
+++ b/bitnami/superset/Chart.yaml
@@ -37,4 +37,4 @@ sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/superset
   - https://github.com/bitnami/containers/tree/main/bitnami/superset
   - https://github.com/apache/superset
-version: 0.1.1
+version: 0.2.0

--- a/bitnami/superset/Chart.yaml
+++ b/bitnami/superset/Chart.yaml
@@ -8,7 +8,7 @@ annotations:
     - name: superset
       image: docker.io/bitnami/superset:4.1.1-debian-12-r1
 apiVersion: v2
-appVersion: 4.0.0
+appVersion: 4.1.1
 dependencies:
   - condition: redis.enabled
     name: redis
@@ -37,4 +37,4 @@ sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/superset
   - https://github.com/bitnami/containers/tree/main/bitnami/superset
   - https://github.com/apache/superset
-version: 0.1.0
+version: 0.1.1

--- a/bitnami/superset/README.md
+++ b/bitnami/superset/README.md
@@ -1,4 +1,4 @@
-<!--- app-name: superset -->
+<!--- app-name: Apache Superset -->
 
 # Bitnami package for Apache Superset
 


### PR DESCRIPTION
### Description of the change

Fixes typo in Apache superset README.md and Chart.yaml

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
