### PR TITLE
[bitnami/dremio] feature(minio): Bump MinIO subchart

### DIFF
--- a/bitnami/dremio/Chart.lock
+++ b/bitnami/dremio/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: minio
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 14.10.5
+  version: 15.0.0
 - name: zookeeper
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 13.7.2
+  version: 13.7.3
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 2.29.1
-digest: sha256:469d108b9e60c065601e59f982cb6dd43219aeaeec066397650f8aab309736da
-generated: "2025-01-28T16:13:15.025736781Z"
+digest: sha256:1b2877e2b68080dbfa3b1933c3c0b33796399bea9506880b415156fc9730ef04
+generated: "2025-01-29T14:14:25.976104+01:00"

--- a/bitnami/dremio/Chart.yaml
+++ b/bitnami/dremio/Chart.yaml
@@ -17,7 +17,7 @@ dependencies:
 - condition: minio.enabled
   name: minio
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 14.x.x
+  version: 15.x.x
 - condition: zookeeper.enabled
   name: zookeeper
   repository: oci://registry-1.docker.io/bitnamicharts
@@ -41,4 +41,4 @@ sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/dremio
 - https://github.com/bitnami/containers/tree/main/bitnami/dremio
 - https://github.com/dremio/dremio-oss
-version: 0.3.2
+version: 0.4.0


### PR DESCRIPTION
### Description of the change

Bump MinIO subchart.

### Benefits

Keep our charts up to date.

### Possible drawbacks

None

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
