### PR TITLE
[bitnami/redis] Redis ACL support to the Bitnami Redis Helm Chart

### DIFF
--- a/bitnami/redis/CHANGELOG.md
+++ b/bitnami/redis/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 20.7.0 (2025-02-02)
+## 20.7.0 (2025-02-03)
 
 * [bitnami/redis] Redis ACL support to the Bitnami Redis Helm Chart ([#31707](https://github.com/bitnami/charts/pull/31707))
 

--- a/bitnami/redis/CHANGELOG.md
+++ b/bitnami/redis/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 20.6.3 (2025-01-14)
+## 20.7.0 (2025-02-02)
 
-* [bitnami/redis] fix: update JSON schema to allow string values for values passed to tpl ([#30526](https://github.com/bitnami/charts/pull/30526))
+* [bitnami/redis] Redis ACL support to the Bitnami Redis Helm Chart ([#31707](https://github.com/bitnami/charts/pull/31707))
+
+## <small>20.6.3 (2025-01-14)</small>
+
+* [bitnami/redis] fix: update JSON schema to allow string values for values passed to tpl (#30526) ([2c78a06](https://github.com/bitnami/charts/commit/2c78a06e5e351506a02a4ebbd7b706ebbe987169)), closes [#30526](https://github.com/bitnami/charts/issues/30526)
 
 ## <small>20.6.2 (2025-01-07)</small>
 

--- a/bitnami/redis/Chart.yaml
+++ b/bitnami/redis/Chart.yaml
@@ -36,4 +36,4 @@ maintainers:
 name: redis
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/redis
-version: 20.6.3
+version: 20.7.0

--- a/bitnami/redis/README.md
+++ b/bitnami/redis/README.md
@@ -511,6 +511,8 @@ helm install my-release --set master.persistence.existingClaim=PVC_NAME oci://RE
 | `auth.existingSecretPasswordKey` | Password key to be retrieved from existing secret                                     | `""`          |
 | `auth.usePasswordFiles`          | Mount credentials as files instead of using an environment variable                   | `false`       |
 | `auth.usePasswordFileFromSecret` | Mount password file from secret                                                       | `true`        |
+| `auth.acl.enabled`               | Enables the support of the Redis ACL system                                           | `false`       |
+| `auth.acl.users`                 | A list of the configured users in the Redis ACL system                                | `[]`          |
 | `commonConfiguration`            | Common configuration to be added into the ConfigMap                                   | `""`          |
 | `existingConfigmap`              | The name of an existing ConfigMap with your custom configuration for Redis&reg; nodes | `""`          |
 

--- a/bitnami/redis/templates/configmap.yaml
+++ b/bitnami/redis/templates/configmap.yaml
@@ -19,6 +19,10 @@ data:
     {{- if .Values.commonConfiguration }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonConfiguration "context" $ ) | nindent 4 }}
     {{- end }}
+    {{- if .Values.auth.acl.enabled }}
+    # The file with Redis ACL rules
+    aclfile /opt/bitnami/redis/etc/users.acl
+    {{- end }}
     # End of common configuration
   master.conf: |-
     dir {{ .Values.master.persistence.path }}
@@ -44,6 +48,20 @@ data:
     {{- end }}
     {{- end }}
     # End of replica configuration
+  users.acl: |-
+    {{- /* User-supplied ACL configuration */ -}}
+    {{- if .Values.auth.acl.enabled}}
+    {{- /* The default user uses the same password from `redis.password`; otherwise, it sets the nopass value. */ -}}
+    {{- $password := include "redis.password" . }}
+    user default on {{ if $password}}#{{ sha256sum $password}}{{ else }}nopass{{ end }} ~* &* +@all
+    {{- if .Values.auth.acl.users -}}
+    {{- /* custom users */ -}}
+    {{- range .Values.auth.acl.users }}
+    user {{ .username }} {{ default "on" .enabled}} {{ if .password}}#{{ sha256sum .password}}{{ else }}nopass{{ end }} {{ default "~*" .keys}} {{ default "&*" .channels }} {{ default "+@all" .commands }}
+    {{- end }}
+    {{- end }}
+    {{- end }}
+    {{- /* End of ACL configuration */ -}}
   {{- if .Values.sentinel.enabled }}
   sentinel.conf: |-
     dir "/tmp"

--- a/bitnami/redis/templates/scripts-configmap.yaml
+++ b/bitnami/redis/templates/scripts-configmap.yaml
@@ -136,6 +136,10 @@ data:
         debug "$(cat /opt/bitnami/redis-sentinel/etc/sentinel.conf | grep monitor)"
     fi
 
+    if [[ -f /opt/bitnami/redis/mounted-etc/users.acl ]];then
+        cp /opt/bitnami/redis/mounted-etc/users.acl /opt/bitnami/redis/etc/users.acl
+    fi
+
     if [[ $redisRetVal -ne 0 ]]; then
         if [[ "$master_in_persisted_conf" == "$(get_full_hostname "$HOSTNAME")" ]]; then
             # Case 1: No active sentinel and in previous sentinel.conf we were the master --> MASTER
@@ -631,6 +635,9 @@ data:
     if [[ -f /opt/bitnami/redis/mounted-etc/redis.conf ]];then
         cp /opt/bitnami/redis/mounted-etc/redis.conf /opt/bitnami/redis/etc/redis.conf
     fi
+    if [[ -f /opt/bitnami/redis/mounted-etc/users.acl ]];then
+        cp /opt/bitnami/redis/mounted-etc/users.acl /opt/bitnami/redis/etc/users.acl
+    fi
     {{- if .Values.tls.enabled }}
     ARGS=("--port" "0")
     ARGS+=("--tls-port" "${REDIS_TLS_PORT}")
@@ -735,6 +742,9 @@ data:
     fi
     if [[ -f /opt/bitnami/redis/mounted-etc/redis.conf ]];then
         cp /opt/bitnami/redis/mounted-etc/redis.conf /opt/bitnami/redis/etc/redis.conf
+    fi
+    if [[ -f /opt/bitnami/redis/mounted-etc/users.acl ]];then
+        cp /opt/bitnami/redis/mounted-etc/users.acl /opt/bitnami/redis/etc/users.acl
     fi
 
     echo "" >> /opt/bitnami/redis/etc/replica.conf

--- a/bitnami/redis/values.schema.json
+++ b/bitnami/redis/values.schema.json
@@ -222,6 +222,22 @@
                     "type": "boolean",
                     "description": "Mount password file from secret",
                     "default": true
+                },
+                "acl": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enables the support of the Redis ACL system",
+                            "default": false
+                        },
+                        "users": {
+                            "type": "array",
+                            "description": "A list of the configured users in the Redis ACL system",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
                 }
             }
         },

--- a/bitnami/redis/values.yaml
+++ b/bitnami/redis/values.yaml
@@ -159,6 +159,24 @@ auth:
   ## @param auth.usePasswordFileFromSecret Mount password file from secret
   ##
   usePasswordFileFromSecret: true
+  ## Redis ACL restricts connections by limiting commands and key access with auth management.
+  ## ref: https://redis.io/docs/latest/operate/oss_and_stack/management/security/acl/
+  ##
+  acl:
+    ## @param auth.acl.enabled Enables the support of the Redis ACL system
+    ##
+    enabled: false
+    ## @param auth.acl.users A list of the configured users in the Redis ACL system
+    ##
+    ## Example:
+    ## users:
+    ##   - username: "my-user"
+    ##     password: "mypassword"
+    ##     enabled: "on"
+    ##     commands: "+@all"
+    ##     keys: "~*"
+    ##     channels: "&*"
+    users: [ ]
 ## @param commonConfiguration [string] Common configuration to be added into the ConfigMap
 ## ref: https://redis.io/topics/config
 ##


### PR DESCRIPTION
### Description of the change

This PR introduces support for Redis ACL (`aclfile`) in the Redis Helm chart. It includes the following enhancements:
- An option to enable/disable ACL support (`auth.acl.enabled`, default: `false`).
- Configuration for ACL users (`auth.acl.users`), including username, password, and permissions for commands, keys, and Pub/Sub channels.

### Benefits

- Adds support for Redis ACL system, enabling fine-grained access control for commands, keys, and channels.
- Enhances security by restricting connections based on user-defined ACL rules.
- Improves flexibility with customizable user configurations and permissions.

### Possible drawbacks

- None identified.

### Additional information

When `auth.acl.enabled` is set to `true`, the `default` user will be automatically created in the aclfile with a SHA-256 hash of the password from `global.auth.password`, `auth.password`, or `auth.existingSecret` value, or `nopass` if no password was set.

```
user default on #somepasswordhashhere ~* &* +@all
```

### Example Configuration

```yaml
redis:
  # ...
  auth:
    # ...
    acl:
      enabled: true
      users:
        - username: "app"
          password: "some-password-here"
          enabled: "on"     # optional, default `on`
          commands: "+@all" # optional, default `+@all`
          keys: "~*"        # optional, default `~*`
          channels: "&*"    # optional, default `&*`
```

### Checklist

- [X] Bumped chart version in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Documented variables in `values.yaml` and updated `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm).
- [X] Title of the pull request follows the pattern `[bitnami/<name_of_the_chart>] Descriptive title`.
- [X] All commits signed off and in agreement with the [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work).