### PR TITLE
 [bitnami/kube-prometheus] Bump deps node-exporter and kube-state-metrics

### DIFF
--- a/bitnami/kube-prometheus/CHANGELOG.md
+++ b/bitnami/kube-prometheus/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 10.2.5 (2025-01-27)
+## 10.2.6 (2025-02-03)
 
-* [bitnami/kube-prometheus] Release 10.2.5 ([#31579](https://github.com/bitnami/charts/pull/31579))
+*  [bitnami/kube-prometheus] bump deps node-exporter and kube-state-metrics ([#31713](https://github.com/bitnami/charts/pull/31713))
+
+## <small>10.2.5 (2025-01-29)</small>
+
+* [bitnami/kube-prometheus] Release 10.2.5 (#31579) ([6a1d15b](https://github.com/bitnami/charts/commit/6a1d15bffebfd1788a6ab737c80a2e77c4540a01)), closes [#31579](https://github.com/bitnami/charts/issues/31579)
 
 ## <small>10.2.4 (2025-01-21)</small>
 

--- a/bitnami/kube-prometheus/Chart.lock
+++ b/bitnami/kube-prometheus/Chart.lock
@@ -1,15 +1,15 @@
 dependencies:
 - name: node-exporter
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 4.5.2
+  version: 4.5.3
 - name: kube-state-metrics
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 4.3.3
+  version: 4.4.0
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 2.29.1
 - name: kube-prometheus-crds
   repository: file://./charts/kube-prometheus-crds
   version: 0.1.0
-digest: sha256:cef87665033fb4d78129ecadf12fddec071f9a1530eb234011c4f725621e4eaa
-generated: "2025-01-24T16:14:37.623323451Z"
+digest: sha256:75103e1802395f03164792c099d49704d0819d50741e6b90865e2a4ffdba2821
+generated: "2025-02-03T16:34:57.62311333+01:00"

--- a/bitnami/kube-prometheus/Chart.yaml
+++ b/bitnami/kube-prometheus/Chart.yaml
@@ -49,4 +49,4 @@ maintainers:
 name: kube-prometheus
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/kube-prometheus
-version: 10.2.5
+version: 10.2.6


### PR DESCRIPTION
### Description of the change

To follow up on PRs from the `kube-state-metrics`, I need to bump the deps from `kube-prometheus`

I bumped the version without the breaking of `kube-state-metrics`.

### Benefits

Have a `kube-prometheus` chart that supports custom resource state metrics from `kube-state-metrics`

### Possible drawbacks

### Applicable issues

Related to https://github.com/bitnami/charts/issues/31686

### Additional information

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
