### PR TITLE
[bitnami/clickhouse][bitnami/moodle] Remove references to deprecated kube-lego

### DIFF
--- a/bitnami/clickhouse/README.md
+++ b/bitnami/clickhouse/README.md
@@ -134,7 +134,7 @@ ingress:
 
 ### Ingress TLS
 
-If your cluster allows automatic creation/retrieval of TLS certificates (e.g. [kube-lego](https://github.com/jetstack/kube-lego)), please refer to the documentation for that mechanism.
+If your cluster allows automatic creation/retrieval of TLS certificates, please refer to the documentation for that mechanism.
 
 To manually configure TLS, first create/retrieve a key & certificate pair for the address(es) you wish to protect. Then create a TLS secret (named `clickhouse-server-tls` in this example) in the namespace. Include the secret's name, along with the desired hostnames, in the Ingress TLS section of your custom `values.yaml` file:
 

--- a/bitnami/moodle/README.md
+++ b/bitnami/moodle/README.md
@@ -105,7 +105,7 @@ These are the *3 mandatory parameters* when *Ingress* is desired: `ingress.enabl
 
 ### Ingress TLS
 
-If your cluster allows automatic creation/retrieval of TLS certificates (e.g. [kube-lego](https://github.com/jetstack/kube-lego)), please refer to the documentation for that mechanism.
+If your cluster allows automatic creation/retrieval of TLS certificates, please refer to the documentation for that mechanism.
 
 To manually configure TLS, first create/retrieve a key & certificate pair for the address(es) you wish to protect. Then create a TLS secret (named `moodle-server-tls` in this example) in the namespace. Include the secret's name, along with the desired hostnames, in the Ingress TLS section of your custom `values.yaml` file:
 


### PR DESCRIPTION
kube-lego is deprecated, see https://github.com/jetstack/kube-lego