### PR TITLE
[bitnami/cert-manager] Update rules for controller-certificates ClusterRole

### DIFF
--- a/bitnami/cert-manager/CHANGELOG.md
+++ b/bitnami/cert-manager/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 1.4.7 (2025-02-04)
+## 1.4.8 (2025-02-05)
 
-* [bitnami/cert-manager] Release 1.4.7 ([#31744](https://github.com/bitnami/charts/pull/31744))
+* [bitnami/cert-manager] Update rules for controller-certificates ClusterRole ([#31794](https://github.com/bitnami/charts/pull/31794))
+
+## <small>1.4.7 (2025-02-04)</small>
+
+* [bitnami/cert-manager] Release 1.4.7 (#31744) ([cb8d670](https://github.com/bitnami/charts/commit/cb8d670d78acdaa9dfbc271b9b0ffe7160c838e3)), closes [#31744](https://github.com/bitnami/charts/issues/31744)
 
 ## <small>1.4.6 (2025-02-04)</small>
 

--- a/bitnami/cert-manager/Chart.yaml
+++ b/bitnami/cert-manager/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: cert-manager
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/cert-manager
-version: 1.4.7
+version: 1.4.8

--- a/bitnami/cert-manager/templates/controller/rbac.yaml
+++ b/bitnami/cert-manager/templates/controller/rbac.yaml
@@ -110,7 +110,7 @@ metadata:
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["certificates", "certificates/status", "certificaterequests", "certificaterequests/status"]
-    verbs: ["update"]
+    verbs: ["update", "patch"]
   - apiGroups: ["cert-manager.io"]
     resources: ["certificates", "certificaterequests", "clusterissuers", "issuers"]
     verbs: ["get", "list", "watch"]


### PR DESCRIPTION
### Description of the change

This PR adds a missing RBAC permission for `controller-certificates` ClusterRole.

### Benefits

[Server-Side Apply](https://cert-manager.io/docs/devops-tips/scaling-cert-manager/#enable-server-side-apply) can be enabled.

### Possible drawbacks

None

### Applicable issues

- https://github.com/bitnami/charts/issues/31724

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
