### PR TITLE
[bitnami/postgresql] use adminPassword for metrics user when custom user is not set on primary

### DIFF
--- a/bitnami/postgresql/CHANGELOG.md
+++ b/bitnami/postgresql/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
-## 16.4.6 (2025-02-02)
+## 16.4.7 (2025-02-08)
 
-* [bitnami/postgresql] Release 16.4.6 ([#31702](https://github.com/bitnami/charts/pull/31702))
+* fix(bitnami/postgresql): use adminPassword for metrics user when custom user is not set on primary ([#31840](https://github.com/bitnami/charts/pull/31840))
+
+## <small>16.4.6 (2025-02-03)</small>
+
+* [bitnami/postgresql] Release 16.4.6 (#31702) ([0a0a5d3](https://github.com/bitnami/charts/commit/0a0a5d33825e523f8fa780bdec97b685fd74d0e3)), closes [#31702](https://github.com/bitnami/charts/issues/31702)
+* Update copyright year (#31682) ([e9f02f5](https://github.com/bitnami/charts/commit/e9f02f5007068751f7eb2270fece811e685c99b6)), closes [#31682](https://github.com/bitnami/charts/issues/31682)
 
 ## <small>16.4.5 (2025-01-20)</small>
 

--- a/bitnami/postgresql/CHANGELOG.md
+++ b/bitnami/postgresql/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 16.4.7 (2025-02-08)
 
-* fix(bitnami/postgresql): use adminPassword for metrics user when custom user is not set on primary ([#31840](https://github.com/bitnami/charts/pull/31840))
+* [bitnami/postgresql] use adminPassword for metrics user when custom user is not set on primary ([#31840](https://github.com/bitnami/charts/pull/31840))
 
 ## <small>16.4.6 (2025-02-03)</small>
 

--- a/bitnami/postgresql/CHANGELOG.md
+++ b/bitnami/postgresql/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 16.4.7 (2025-02-08)
+## 16.4.7 (2025-02-09)
 
 * [bitnami/postgresql] use adminPassword for metrics user when custom user is not set on primary ([#31840](https://github.com/bitnami/charts/pull/31840))
 

--- a/bitnami/postgresql/Chart.yaml
+++ b/bitnami/postgresql/Chart.yaml
@@ -35,4 +35,4 @@ maintainers:
 name: postgresql
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/postgresql
-version: 16.4.6
+version: 16.4.7

--- a/bitnami/postgresql/templates/primary/statefulset.yaml
+++ b/bitnami/postgresql/templates/primary/statefulset.yaml
@@ -539,16 +539,16 @@ spec:
               value: {{ printf "127.0.0.1:%d/postgres?sslmode=disable" (int (include "postgresql.v1.service.port" .)) }}
             {{- if .Values.auth.usePasswordFiles }}
             - name: DATA_SOURCE_PASS_FILE
-              value: {{ printf "/opt/bitnami/postgresql/secrets/%s" (include "postgresql.v1.adminPasswordKey" .) }}
+              value: {{ printf "/opt/bitnami/postgresql/secrets/%s" (include (ternary "postgresql.v1.adminPasswordKey" "postgresql.v1.userPasswordKey" (empty $customUser)) .) }}
             {{- else }}
             - name: DATA_SOURCE_PASS
               valueFrom:
                 secretKeyRef:
                   name: {{ include "postgresql.v1.secretName" . }}
-                  key: {{ include "postgresql.v1.adminPasswordKey" . }}
+                  key: {{ include (ternary "postgresql.v1.adminPasswordKey" "postgresql.v1.userPasswordKey" (empty $customUser)) . }}
             {{- end }}
             - name: DATA_SOURCE_USER
-              value: "postgres"
+              value: {{ default "postgres" $customUser | quote }}
             {{- if .Values.metrics.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.metrics.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}


### PR DESCRIPTION
### Description of the change

This PR applies the same changes from #30720 to the primary statefulset.

### Benefits

Resolve error when creating primary postgresql pod with metrics enabled.

### Applicable issues

#30680
