### PR TITLE
[bitnami/nginx] Release 19.0.0

### DIFF
--- a/bitnami/nginx/Chart.yaml
+++ b/bitnami/nginx/Chart.yaml
@@ -34,4 +34,4 @@ maintainers:
 name: nginx
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/nginx
-version: 18.3.6
+version: 19.0.0

--- a/bitnami/nginx/README.md
+++ b/bitnami/nginx/README.md
@@ -449,6 +449,10 @@ Find more information about how to deal with common errors related to Bitnami's 
 
 ## Upgrading
 
+### To 19.0.0
+
+The [module ngx_http_dav_module](http://nginx.org/en/docs/http/ngx_http_dav_module.html), WebDAV protocol, has been converted into a dynamic module under the `/opt/bitnami/nginx/modules` directory. You need to include a `load_module /opt/bitnami/nginx/modules/ngx_http_dav_module.so;` directive to use it.
+
 ### To 18.3.0
 
 This version introduces image verification for security purposes. To disable it, set `global.security.allowInsecureImages` to `true`. More details at [GitHub issue](https://github.com/bitnami/charts/issues/30850).

--- a/bitnami/nginx/values.yaml
+++ b/bitnami/nginx/values.yaml
@@ -86,7 +86,7 @@ diagnosticMode:
 image:
   registry: docker.io
   repository: bitnami/nginx
-  tag: 1.27.4-debian-12-r0
+  tag: 1.27.4-debian-12-r1
   digest: ""
   ## Specify a imagePullPolicy
   ## ref: https://kubernetes.io/docs/concepts/containers/images/#pre-pulled-images


### PR DESCRIPTION
### Description of the change

The NGINX [Module ngx_http_dav_module](https://nginx.org/en/docs/http/ngx_http_dav_module.html) is now available in the NGINX image as a dynamic module instead of a built-in. It is now required to explicitly load this module from the NGINX configuration

```
load_module /opt/bitnami/nginx/modules/ngx_http_dav_module.so;
```

### Benefits

It enhances security.

### Possible drawbacks

Additional config is now required.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
