### PR TITLE
[bitnami/charts] chore(workflows): Avoid running workflows in forked repositories

### DIFF
--- a/.github/workflows/index-monitor.yml
+++ b/.github/workflows/index-monitor.yml
@@ -106,7 +106,7 @@ jobs:
   upload:
     name: Re-upload index.yaml
     needs: [validation-check, integrity-check]
-    if: ${{ always() && (needs.validation-check.outputs.result != 'ok' || needs.integrity-check.outputs.result != 'ok') }}
+    if: ${{ always() && github.repository_owner == 'bitnami' && (needs.validation-check.outputs.result != 'ok' || needs.integrity-check.outputs.result != 'ok') }}
     uses: bitnami/charts/.github/workflows/sync-chart-cloudflare-index.yml@index
     secrets: inherit
     permissions:
@@ -114,7 +114,7 @@ jobs:
   notify:
     name: Send notification
     needs: [validation-check, integrity-check]
-    if: ${{ always() && (needs.validation-check.outputs.result != 'ok' || needs.integrity-check.outputs.result != 'ok') }}
+    if: ${{ always() && github.repository_owner == 'bitnami' && (needs.validation-check.outputs.result != 'ok' || needs.integrity-check.outputs.result != 'ok') }}
     uses: bitnami/support/.github/workflows/gchat-notification.yml@main
     with:
       workflow: ${{ github.workflow }}


### PR DESCRIPTION
### Description of the change

Skip notifications on index-monitor workflow when running on forked repositories.

### Benefits

Avoid unnecessary executions and failures.

### Possible drawbacks

None

### Additional information

Follow up: #31863

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [ ] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
