### PR TITLE
[bitnami/*] Use CDN url for the Bitnami Application Icons

### DIFF
--- a/bitnami/airflow/Chart.yaml
+++ b/bitnami/airflow/Chart.yaml
@@ -27,7 +27,7 @@ dependencies:
   version: 2.x.x
 description: Apache Airflow is a tool to express and execute workflows as directed acyclic graphs (DAGs). It includes utilities to schedule tasks, monitor task progress and handle task dependencies.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/airflow/img/airflow-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/airflow/img/airflow-stack-220x234.png
 keywords:
 - apache
 - airflow

--- a/bitnami/apache/Chart.yaml
+++ b/bitnami/apache/Chart.yaml
@@ -21,7 +21,7 @@ dependencies:
   version: 2.x.x
 description: Apache HTTP Server is an open-source HTTP server. The goal of this project is to provide a secure, efficient and extensible server that provides HTTP services in sync with the current HTTP standards.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/apache/img/apache-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/apache/img/apache-stack-220x234.png
 keywords:
 - apache
 - http

--- a/bitnami/apisix/Chart.yaml
+++ b/bitnami/apisix/Chart.yaml
@@ -27,7 +27,7 @@ dependencies:
   version: 2.x.x
 description: Apache APISIX is high-performance, real-time API Gateway. Features load balancing, dynamic upstream, canary release, circuit breaking, authentication, observability, amongst others.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/apisix/img/apisix-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/apisix/img/apisix-stack-220x234.png
 keywords:
 - apisix
 - ingress

--- a/bitnami/appsmith/Chart.yaml
+++ b/bitnami/appsmith/Chart.yaml
@@ -29,7 +29,7 @@ dependencies:
   version: 2.x.x
 description: Appsmith is an open source platform for building and maintaining internal tools, such as custom dashboards, admin panels or CRUD apps.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/appsmith/img/appsmith-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/appsmith/img/appsmith-stack-220x234.png
 keywords:
 - development
 - dashboards

--- a/bitnami/argo-cd/Chart.yaml
+++ b/bitnami/argo-cd/Chart.yaml
@@ -27,7 +27,7 @@ dependencies:
   version: 2.x.x
 description: Argo CD is a continuous delivery tool for Kubernetes based on GitOps.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/argo-cd/img/argo-cd-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/argo-cd/img/argo-cd-stack-220x234.png
 keywords:
 - Continuous delivery
 - Continuous deployment

--- a/bitnami/argo-workflows/Chart.yaml
+++ b/bitnami/argo-workflows/Chart.yaml
@@ -29,7 +29,7 @@ dependencies:
   version: 2.x.x
 description: Argo Workflows is meant to orchestrate Kubernetes jobs in parallel. It uses DAG and step-based workflows
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/argo-workflows/img/argo-workflows-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/argo-workflows/img/argo-workflows-stack-220x234.png
 keywords:
 - Devops
 - Kubernetes

--- a/bitnami/aspnet-core/Chart.yaml
+++ b/bitnami/aspnet-core/Chart.yaml
@@ -21,7 +21,7 @@ dependencies:
   version: 2.x.x
 description: ASP.NET Core is an open-source framework for web application development created by Microsoft. It runs on both the full .NET Framework, on Windows, and the cross-platform .NET Core.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/aspnet-core/img/aspnet-core-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/aspnet-core/img/aspnet-core-stack-220x234.png
 keywords:
 - asp.net
 - dotnet

--- a/bitnami/cassandra/Chart.yaml
+++ b/bitnami/cassandra/Chart.yaml
@@ -21,7 +21,7 @@ dependencies:
   version: 2.x.x
 description: Apache Cassandra is an open source distributed database management system designed to handle large amounts of data across many servers, providing high availability with no single point of failure.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/cassandra/img/cassandra-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/cassandra/img/cassandra-stack-220x234.png
 keywords:
 - cassandra
 - database

--- a/bitnami/cert-manager/Chart.yaml
+++ b/bitnami/cert-manager/Chart.yaml
@@ -23,7 +23,7 @@ dependencies:
   version: 2.x.x
 description: cert-manager is a Kubernetes add-on to automate the management and issuance of TLS certificates from various issuing sources.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/cert-manager/img/cert-manager-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/cert-manager/img/cert-manager-stack-220x234.png
 keywords:
 - go
 - security

--- a/bitnami/chainloop/Chart.yaml
+++ b/bitnami/chainloop/Chart.yaml
@@ -31,7 +31,7 @@ dependencies:
   version: 1.4.x
 description: Chainloop is an open-source Software Supply Chain control plane, a single source of truth for metadata and artifacts, plus a declarative attestation process.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/chainloop/img/chainloop-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/chainloop/img/chainloop-stack-220x234.png
 keywords:
 - chainloop
 - evidence-store

--- a/bitnami/cilium/Chart.yaml
+++ b/bitnami/cilium/Chart.yaml
@@ -33,7 +33,7 @@ dependencies:
   version: 2.x.x
 description: Cilium is an eBPF-based networking, observability, and security for Linux container management platforms like Docker and Kubernetes.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/cilium/img/cilium-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/cilium/img/cilium-stack-220x234.png
 keywords:
 - cilium
 - cni

--- a/bitnami/clickhouse/Chart.yaml
+++ b/bitnami/clickhouse/Chart.yaml
@@ -23,7 +23,7 @@ dependencies:
   version: 2.x.x
 description: ClickHouse is an open-source column-oriented OLAP database management system. Use it to boost your database performance while providing linear scalability and hardware efficiency.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/clickhouse/img/clickhouse-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/clickhouse/img/clickhouse-stack-220x234.png
 keywords:
 - database
 - sharding

--- a/bitnami/common/Chart.yaml
+++ b/bitnami/common/Chart.yaml
@@ -9,7 +9,7 @@ apiVersion: v2
 appVersion: 2.29.1
 description: A Library Helm Chart for grouping common logic between bitnami charts. This chart is not deployable by itself.
 home: https://bitnami.com
-icon: https://bitnami.com/downloads/logos/bitnami-mark.png
+icon: https://dyltqmyl993wv.cloudfront.net/downloads/logos/bitnami-mark.png
 keywords:
   - common
   - helper

--- a/bitnami/concourse/Chart.yaml
+++ b/bitnami/concourse/Chart.yaml
@@ -23,7 +23,7 @@ dependencies:
   version: 2.x.x
 description: Concourse is an automation system written in Go. It is most commonly used for CI/CD, and is built to scale to any kind of automation pipeline, from simple to complex.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/concourse/img/concourse-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/concourse/img/concourse-stack-220x234.png
 keywords:
 - concourse
 - ci

--- a/bitnami/consul/Chart.yaml
+++ b/bitnami/consul/Chart.yaml
@@ -21,7 +21,7 @@ dependencies:
   version: 2.x.x
 description: HashiCorp Consul is a tool for discovering and configuring services in your infrastructure.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/consul/img/consul-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/consul/img/consul-stack-220x234.png
 keywords:
 - discovering
 - configuring

--- a/bitnami/contour/Chart.yaml
+++ b/bitnami/contour/Chart.yaml
@@ -21,7 +21,7 @@ dependencies:
   version: 2.x.x
 description: Contour is an open source Kubernetes ingress controller that works by deploying the Envoy proxy as a reverse proxy and load balancer.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/contour/img/contour-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/contour/img/contour-stack-220x234.png
 keywords:
 - ingress
 - envoy

--- a/bitnami/deepspeed/Chart.yaml
+++ b/bitnami/deepspeed/Chart.yaml
@@ -21,7 +21,7 @@ dependencies:
   version: 2.x.x
 description: DeepSpeed is deep learning software suite for empowering ChatGPT-like model training. Features dense or sparse model inference, high throughput and high compression.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/deepspeed/img/deepspeed-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/deepspeed/img/deepspeed-stack-220x234.png
 keywords:
 - deepspeed
 - pytorch

--- a/bitnami/discourse/Chart.yaml
+++ b/bitnami/discourse/Chart.yaml
@@ -27,7 +27,7 @@ dependencies:
   version: 2.x.x
 description: Discourse is an open source discussion platform with built-in moderation and governance systems that let discussion communities protect themselves from bad actors even without official moderators.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/discourse/img/discourse-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/discourse/img/discourse-stack-220x234.png
 keywords:
 - community
 - forum

--- a/bitnami/dremio/Chart.yaml
+++ b/bitnami/dremio/Chart.yaml
@@ -29,7 +29,7 @@ dependencies:
   version: 2.x.x
 description: Dremio is an open-source self-service data access tool that provides high-performance queries for interactive analytics on data lakes.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/dremio/img/dremio-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/dremio/img/dremio-stack-220x234.png
 keywords:
 - dremio
 - data-lake

--- a/bitnami/drupal/Chart.yaml
+++ b/bitnami/drupal/Chart.yaml
@@ -25,7 +25,7 @@ dependencies:
   version: 2.x.x
 description: Drupal is one of the most versatile open source content management systems in the world. It is pre-configured with the Ctools and Views modules, Drush and Let's Encrypt auto-configuration support.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/drupal/img/drupal-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/drupal/img/drupal-stack-220x234.png
 keywords:
 - drupal
 - cms

--- a/bitnami/ejbca/Chart.yaml
+++ b/bitnami/ejbca/Chart.yaml
@@ -23,7 +23,7 @@ dependencies:
   version: 2.x.x
 description: EJBCA is an enterprise class PKI Certificate Authority software, built using Java (JEE) technology.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/ejbca/img/ejbca-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/ejbca/img/ejbca-stack-220x234.png
 keywords:
 - ejbca
 - ca

--- a/bitnami/elasticsearch/Chart.yaml
+++ b/bitnami/elasticsearch/Chart.yaml
@@ -25,7 +25,7 @@ dependencies:
   version: 2.x.x
 description: Elasticsearch is a distributed search and analytics engine. It is used for web search, log monitoring, and real-time analytics. Ideal for Big Data applications.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/elasticsearch/img/elasticsearch-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/elasticsearch/img/elasticsearch-stack-220x234.png
 keywords:
 - elasticsearch
 maintainers:

--- a/bitnami/etcd/Chart.yaml
+++ b/bitnami/etcd/Chart.yaml
@@ -19,7 +19,7 @@ dependencies:
   version: 2.x.x
 description: etcd is a distributed key-value store designed to securely store data across a cluster. etcd is widely used in production on account of its reliability, fault-tolerance and ease of use.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/etcd/img/etcd-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/etcd/img/etcd-stack-220x234.png
 keywords:
 - etcd
 - cluster

--- a/bitnami/external-dns/Chart.yaml
+++ b/bitnami/external-dns/Chart.yaml
@@ -17,7 +17,7 @@ dependencies:
   version: 2.x.x
 description: ExternalDNS is a Kubernetes addon that configures public DNS servers with information about exposed Kubernetes services to make them discoverable.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/external-dns/img/external-dns-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/external-dns/img/external-dns-stack-220x234.png
 keywords:
 - external-dns
 - network

--- a/bitnami/flink/Chart.yaml
+++ b/bitnami/flink/Chart.yaml
@@ -17,7 +17,7 @@ dependencies:
   version: 2.x.x
 description: Apache Flink is a framework and distributed processing engine for stateful computations over unbounded and bounded data streams.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/flink/img/flink-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/flink/img/flink-stack-220x234.png
 keywords:
 - flink
 - stream-processing

--- a/bitnami/fluent-bit/Chart.yaml
+++ b/bitnami/fluent-bit/Chart.yaml
@@ -17,7 +17,7 @@ dependencies:
   version: 2.x.x
 description: Fluent Bit is a Fast and Lightweight Log Processor and Forwarder. It has been made with a strong focus on performance to allow the collection of events from different sources without complexity.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/fluent-bit/img/fluent-bit-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/fluent-bit/img/fluent-bit-stack-220x234.png
 keywords:
 - fluent-bit
 - logging

--- a/bitnami/fluentd/Chart.yaml
+++ b/bitnami/fluentd/Chart.yaml
@@ -17,7 +17,7 @@ dependencies:
   version: 2.x.x
 description: Fluentd collects events from various data sources and writes them to files, RDBMS, NoSQL, IaaS, SaaS, Hadoop and so on.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/fluentd/img/fluentd-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/fluentd/img/fluentd-stack-220x234.png
 keywords:
 - fluentd
 - logging

--- a/bitnami/flux/Chart.yaml
+++ b/bitnami/flux/Chart.yaml
@@ -29,7 +29,7 @@ dependencies:
   version: 2.x.x
 description: Source Controller is a component of Flux. Flux is a tool for keeping Kubernetes clusters in sync with sources of configuration.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/fluxcd-kustomize-controller/img/fluxcd-kustomize-controller-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/fluxcd-kustomize-controller/img/fluxcd-kustomize-controller-stack-220x234.png
 keywords:
 - deployment
 - gitops

--- a/bitnami/ghost/Chart.yaml
+++ b/bitnami/ghost/Chart.yaml
@@ -25,7 +25,7 @@ dependencies:
   version: 2.x.x
 description: Ghost is an open source publishing platform designed to create blogs, magazines, and news sites. It includes a simple markdown editor with preview, theming, and SEO built-in to simplify editing.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/ghost/img/ghost-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/ghost/img/ghost-stack-220x234.png
 keywords:
 - ghost
 - blog

--- a/bitnami/gitea/Chart.yaml
+++ b/bitnami/gitea/Chart.yaml
@@ -23,7 +23,7 @@ dependencies:
   version: 2.x.x
 description: Gitea is a lightweight code hosting solution. Written in Go, features low resource consumption, easy upgrades and multiple databases.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/gitea/img/gitea-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/gitea/img/gitea-stack-220x234.png
 keywords:
 - gitea
 - analytics

--- a/bitnami/grafana-loki/Chart.yaml
+++ b/bitnami/grafana-loki/Chart.yaml
@@ -43,7 +43,7 @@ dependencies:
   version: 2.x.x
 description: Grafana Loki is a horizontally scalable, highly available, and multi-tenant log aggregation system. It provides real-time long tailing and full persistence to object storage.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/grafana-loki/img/grafana-loki-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/grafana-loki/img/grafana-loki-stack-220x234.png
 keywords:
 - grafana
 - tracing

--- a/bitnami/grafana-mimir/Chart.yaml
+++ b/bitnami/grafana-mimir/Chart.yaml
@@ -47,7 +47,7 @@ dependencies:
   version: 2.x.x
 description: Grafana Mimir is an open source, horizontally scalable, highly available, multi-tenant, long-term storage for Prometheus.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/grafana-mimir/img/grafana-mimir-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/grafana-mimir/img/grafana-mimir-stack-220x234.png
 keywords:
 - grafana
 - tracing

--- a/bitnami/grafana-operator/Chart.yaml
+++ b/bitnami/grafana-operator/Chart.yaml
@@ -19,7 +19,7 @@ dependencies:
   version: 2.x.x
 description: Grafana Operator is a Kubernetes operator that enables the installation and management of Grafana instances, dashboards and plugins.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/grafana/img/grafana-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/grafana/img/grafana-stack-220x234.png
 keywords:
 - grafana
 - operator

--- a/bitnami/grafana-tempo/Chart.yaml
+++ b/bitnami/grafana-tempo/Chart.yaml
@@ -27,7 +27,7 @@ dependencies:
   version: 2.x.x
 description: Grafana Tempo is a distributed tracing system that has out-of-the-box integration with Grafana. It is highly scalable and works with many popular tracing protocols.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/grafana-tempo/img/grafana-tempo-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/grafana-tempo/img/grafana-tempo-stack-220x234.png
 keywords:
 - grafana
 - tracing

--- a/bitnami/grafana/Chart.yaml
+++ b/bitnami/grafana/Chart.yaml
@@ -19,7 +19,7 @@ dependencies:
   version: 2.x.x
 description: Grafana is an open source metric analytics and visualization suite for visualizing time series data that supports various types of data sources.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/grafana/img/grafana-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/grafana/img/grafana-stack-220x234.png
 keywords:
 - analytics
 - monitoring

--- a/bitnami/haproxy/Chart.yaml
+++ b/bitnami/haproxy/Chart.yaml
@@ -17,7 +17,7 @@ dependencies:
   version: 2.x.x
 description: HAProxy is a TCP proxy and a HTTP reverse proxy. It supports SSL termination and offloading, TCP and HTTP normalization, traffic regulation, caching and protection against DDoS attacks.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/haproxy/img/haproxy-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/haproxy/img/haproxy-stack-220x234.png
 keywords:
 - haproxy
 - proxy

--- a/bitnami/harbor/Chart.yaml
+++ b/bitnami/harbor/Chart.yaml
@@ -43,7 +43,7 @@ dependencies:
   version: 2.x.x
 description: Harbor is an open source trusted cloud-native registry to store, sign, and scan content. It adds functionalities like security, identity, and management to the open source Docker distribution.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/harbor-core/img/harbor-core-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/harbor-core/img/harbor-core-stack-220x234.png
 keywords:
 - docker
 - registry

--- a/bitnami/influxdb/Chart.yaml
+++ b/bitnami/influxdb/Chart.yaml
@@ -25,7 +25,7 @@ dependencies:
   version: 2.x.x
 description: InfluxDB(TM) is an open source time-series database. It is a core component of the TICK (Telegraf, InfluxDB(TM), Chronograf, Kapacitor) stack.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/influxdb/img/influxdb-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/influxdb/img/influxdb-stack-220x234.png
 keywords:
 - influxdb
 - tick

--- a/bitnami/jaeger/Chart.yaml
+++ b/bitnami/jaeger/Chart.yaml
@@ -23,7 +23,7 @@ dependencies:
   version: 12.x.x
 description: Jaeger is a distributed tracing system. It is used for monitoring and troubleshooting microservices-based distributed systems.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/jaeger/img/jaeger-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/jaeger/img/jaeger-stack-220x234.png
 keywords:
 - jaeger
 - tracing

--- a/bitnami/janusgraph/Chart.yaml
+++ b/bitnami/janusgraph/Chart.yaml
@@ -25,7 +25,7 @@ dependencies:
   version: 2.x.x
 description: JanusGraph is a scalable graph database optimized for storing and querying graphs containing hundreds of billions of vertices and edges distributed across a multi-machine cluster.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/janusgraph/img/janusgraph-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/janusgraph/img/janusgraph-stack-220x234.png
 keywords:
 - janusgraph
 - graph

--- a/bitnami/jenkins/Chart.yaml
+++ b/bitnami/jenkins/Chart.yaml
@@ -21,7 +21,7 @@ dependencies:
   version: 2.x.x
 description: Jenkins is an open source Continuous Integration and Continuous Delivery (CI/CD) server designed to automate the building, testing, and deploying of any software project.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/jenkins/img/jenkins-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/jenkins/img/jenkins-stack-220x234.png
 keywords:
 - jenkins
 - ci

--- a/bitnami/jupyterhub/Chart.yaml
+++ b/bitnami/jupyterhub/Chart.yaml
@@ -27,7 +27,7 @@ dependencies:
   version: 2.x.x
 description: JupyterHub brings the power of notebooks to groups of users. It gives users access to computational environments and resources without burdening the users with installation and maintenance tasks.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/jupyterhub/img/jupyterhub-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/jupyterhub/img/jupyterhub-stack-220x234.png
 keywords:
 - python
 - scientific

--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -27,7 +27,7 @@ dependencies:
   version: 2.x.x
 description: Apache Kafka is a distributed streaming platform designed to build real-time pipelines and can be used as a message broker or as a replacement for a log aggregation solution for big data applications.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/kafka/img/kafka-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/kafka/img/kafka-stack-220x234.png
 keywords:
 - kafka
 - zookeeper

--- a/bitnami/keycloak/Chart.yaml
+++ b/bitnami/keycloak/Chart.yaml
@@ -23,7 +23,7 @@ dependencies:
   version: 2.x.x
 description: Keycloak is a high performance Java-based identity and access management solution. It lets developers add an authentication layer to their applications with minimum effort.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/keycloak/img/keycloak-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/keycloak/img/keycloak-stack-220x234.png
 keywords:
 - keycloak
 - access-management

--- a/bitnami/keydb/Chart.yaml
+++ b/bitnami/keydb/Chart.yaml
@@ -21,7 +21,7 @@ dependencies:
   version: 2.x.x
 description: KeyDB is a high performance fork of Redis with a focus on multithreading, memory efficiency, and high throughput.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/keydb/img/keydb-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/keydb/img/keydb-stack-220x234.png
 keywords:
 - keydb
 - keyvalue

--- a/bitnami/kiam/Chart.yaml
+++ b/bitnami/kiam/Chart.yaml
@@ -17,7 +17,7 @@ dependencies:
   version: 2.x.x
 description: kiam is a proxy that captures AWS Metadata API requests. It allows AWS IAM roles to be set for Kubernetes workloads.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/kiam/img/kiam-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/kiam/img/kiam-stack-220x234.png
 keywords:
 - aws
 - iam

--- a/bitnami/kibana/Chart.yaml
+++ b/bitnami/kibana/Chart.yaml
@@ -19,7 +19,7 @@ dependencies:
   version: 2.x.x
 description: Kibana is an open source, browser based analytics and search dashboard for Elasticsearch. Kibana strives to be easy to get started with, while also being flexible and powerful.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/kibana/img/kibana-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/kibana/img/kibana-stack-220x234.png
 keywords:
 - kibana
 - analytics

--- a/bitnami/kong/Chart.yaml
+++ b/bitnami/kong/Chart.yaml
@@ -27,7 +27,7 @@ dependencies:
   version: 12.x.x
 description: Kong is an open source Microservice API gateway and platform designed for managing microservices requests of high-availability, fault-tolerance, and distributed systems.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/kong/img/kong-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/kong/img/kong-stack-220x234.png
 keywords:
 - kong
 - ingress

--- a/bitnami/kube-prometheus/Chart.yaml
+++ b/bitnami/kube-prometheus/Chart.yaml
@@ -36,7 +36,7 @@ dependencies:
   version: 0.x.x
 description: Prometheus Operator provides easy monitoring definitions for Kubernetes services and deployment and management of Prometheus instances.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/prometheus-operator/img/prometheus-operator-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/prometheus-operator/img/prometheus-operator-stack-220x234.png
 keywords:
 - prometheus
 - alertmanager

--- a/bitnami/kube-prometheus/charts/kube-prometheus-crds/Chart.yaml
+++ b/bitnami/kube-prometheus/charts/kube-prometheus-crds/Chart.yaml
@@ -9,7 +9,7 @@ appVersion: 0.1.0
 dependencies:
 description: Prometheus Operator provides easy monitoring definitions for Kubernetes services and deployment and management of Prometheus instances.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/prometheus-operator/img/prometheus-operator-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/prometheus-operator/img/prometheus-operator-stack-220x234.png
 keywords:
 - prometheus
 - alertmanager

--- a/bitnami/kube-state-metrics/Chart.yaml
+++ b/bitnami/kube-state-metrics/Chart.yaml
@@ -17,7 +17,7 @@ dependencies:
   version: 2.x.x
 description: kube-state-metrics is a simple service that listens to the Kubernetes API server and generates metrics about the state of the objects.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/kube-state-metrics/img/kube-state-metrics-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/kube-state-metrics/img/kube-state-metrics-stack-220x234.png
 keywords:
 - prometheus
 - kube-state-metrics

--- a/bitnami/kubeapps/Chart.yaml
+++ b/bitnami/kubeapps/Chart.yaml
@@ -39,7 +39,7 @@ dependencies:
   version: 2.x.x
 description: Kubeapps is a web-based UI for launching and managing applications on Kubernetes. It allows users to deploy trusted applications and operators to control users access to the cluster.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/kubeapps/img/kubeapps-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/kubeapps/img/kubeapps-stack-220x234.png
 keywords:
 - helm
 - dashboard

--- a/bitnami/kuberay/Chart.yaml
+++ b/bitnami/kuberay/Chart.yaml
@@ -21,7 +21,7 @@ dependencies:
   version: 2.x.x
 description: KubeRay is a Kubernetes operator for deploying and management of Ray applications on Kubernetes using CustomResourceDefinitions.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/kuberay/img/kuberay-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/kuberay/img/kuberay-stack-220x234.png
 keywords:
 - ray
 - machine-learning

--- a/bitnami/kubernetes-event-exporter/Chart.yaml
+++ b/bitnami/kubernetes-event-exporter/Chart.yaml
@@ -17,7 +17,7 @@ dependencies:
   version: 2.x.x
 description: Kubernetes Event Exporter makes it easy to export Kubernetes events to other tools, thereby enabling better event observability, custom alerts and aggregation.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/kubernetes-event-exporter/img/kubernetes-event-exporter-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/kubernetes-event-exporter/img/kubernetes-event-exporter-stack-220x234.png
 keywords:
 - alerting
 - event exporting

--- a/bitnami/logstash/Chart.yaml
+++ b/bitnami/logstash/Chart.yaml
@@ -19,7 +19,7 @@ dependencies:
   version: 2.x.x
 description: Logstash is an open source data processing engine. It ingests data from multiple sources, processes it, and sends the output to final destination in real-time. It is a core component of the ELK stack.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/logstash/img/logstash-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/logstash/img/logstash-stack-220x234.png
 keywords:
 - logstash
 - logging

--- a/bitnami/mariadb-galera/Chart.yaml
+++ b/bitnami/mariadb-galera/Chart.yaml
@@ -19,7 +19,7 @@ dependencies:
   version: 2.x.x
 description: MariaDB Galera is a multi-primary database cluster solution for synchronous replication and high availability.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/mariadb-galera/img/mariadb-galera-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/mariadb-galera/img/mariadb-galera-stack-220x234.png
 keywords:
 - mariadb
 - mysql

--- a/bitnami/mariadb/Chart.yaml
+++ b/bitnami/mariadb/Chart.yaml
@@ -21,7 +21,7 @@ dependencies:
   version: 2.x.x
 description: MariaDB is an open source, community-developed SQL database server that is widely in use around the world due to its enterprise features, flexibility, and collaboration with leading tech firms.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/mariadb/img/mariadb-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/mariadb/img/mariadb-stack-220x234.png
 keywords:
 - mariadb
 - mysql

--- a/bitnami/mastodon/Chart.yaml
+++ b/bitnami/mastodon/Chart.yaml
@@ -39,7 +39,7 @@ dependencies:
   version: 2.x.x
 description: Mastodon is self-hosted social network server based on ActivityPub. Written in Ruby, features real-time updates, multimedia attachments and no vendor lock-in.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/mastodon/img/mastodon-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/mastodon/img/mastodon-stack-220x234.png
 keywords:
 - development
 - dashboards

--- a/bitnami/matomo/Chart.yaml
+++ b/bitnami/matomo/Chart.yaml
@@ -25,7 +25,7 @@ dependencies:
   version: 2.x.x
 description: Matomo, formerly known as Piwik, is a real time web analytics program. It provides detailed reports on website visitors.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/matomo/img/matomo-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/matomo/img/matomo-stack-220x234.png
 keywords:
 - matomo
 - analytics

--- a/bitnami/memcached/Chart.yaml
+++ b/bitnami/memcached/Chart.yaml
@@ -21,7 +21,7 @@ dependencies:
   version: 2.x.x
 description: Memcached is an high-performance, distributed memory object caching system, generic in nature, but intended for use in speeding up dynamic web applications by alleviating database load.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/memcached/img/memcached-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/memcached/img/memcached-stack-220x234.png
 keywords:
 - memcached
 - cache

--- a/bitnami/metallb/Chart.yaml
+++ b/bitnami/metallb/Chart.yaml
@@ -19,7 +19,7 @@ dependencies:
   version: 2.x.x
 description: MetalLB is a load-balancer implementation for bare metal Kubernetes clusters, using standard routing protocols.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/metallb-speaker/img/metallb-speaker-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/metallb-speaker/img/metallb-speaker-stack-220x234.png
 keywords:
 - load-balancer
 - balancer

--- a/bitnami/metrics-server/Chart.yaml
+++ b/bitnami/metrics-server/Chart.yaml
@@ -17,7 +17,7 @@ dependencies:
   version: 2.x.x
 description: Metrics Server aggregates resource usage data, such as container CPU and memory usage, in a Kubernetes cluster and makes it available via the Metrics API.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/metrics-server/img/metrics-server-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/metrics-server/img/metrics-server-stack-220x234.png
 keywords:
 - metrics-server
 - cluster

--- a/bitnami/milvus/Chart.yaml
+++ b/bitnami/milvus/Chart.yaml
@@ -35,7 +35,7 @@ dependencies:
   version: 2.x.x
 description: Milvus is a cloud-native, open-source vector database solution for AI applications and similarity search. Features high scalability, hibrid search and unified lambda structure.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/milvus/img/milvus-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/milvus/img/milvus-stack-220x234.png
 keywords:
 - milvus
 - ai

--- a/bitnami/minio/Chart.yaml
+++ b/bitnami/minio/Chart.yaml
@@ -21,7 +21,7 @@ dependencies:
   version: 2.x.x
 description: MinIO(R) is an object storage server, compatible with Amazon S3 cloud storage service, mainly used for storing unstructured data (such as photos, videos, log files, etc.).
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/minio/img/minio-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/minio/img/minio-stack-220x234.png
 keywords:
 - minio
 - storage

--- a/bitnami/mlflow/Chart.yaml
+++ b/bitnami/mlflow/Chart.yaml
@@ -29,7 +29,7 @@ dependencies:
   version: 2.x.x
 description: MLflow is an open-source platform designed to manage the end-to-end machine learning lifecycle. It allows you to track experiments, package code into reproducible runs, and share and deploy models.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/mlflow/img/mlflow-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/mlflow/img/mlflow-stack-220x234.png
 keywords:
 - mlflow
 - models

--- a/bitnami/mongodb-sharded/Chart.yaml
+++ b/bitnami/mongodb-sharded/Chart.yaml
@@ -21,7 +21,7 @@ dependencies:
   version: 2.x.x
 description: MongoDB(R) is an open source NoSQL database that uses JSON for data storage. MongoDB(TM) Sharded improves scalability and reliability for large datasets by distributing data across multiple machines.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/mongodb/img/mongodb-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/mongodb/img/mongodb-stack-220x234.png
 keywords:
 - mongodb
 - database

--- a/bitnami/mongodb/Chart.yaml
+++ b/bitnami/mongodb/Chart.yaml
@@ -25,7 +25,7 @@ dependencies:
   version: 2.x.x
 description: MongoDB(R) is a relational open source NoSQL database. Easy to use, it stores data in JSON-like documents. Automated scalability and high-performance. Ideal for developing cloud native applications.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/mongodb/img/mongodb-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/mongodb/img/mongodb-stack-220x234.png
 keywords:
 - mongodb
 - database

--- a/bitnami/moodle/Chart.yaml
+++ b/bitnami/moodle/Chart.yaml
@@ -25,7 +25,7 @@ dependencies:
   version: 2.x.x
 description: Moodle(TM) LMS is an open source online Learning Management System widely used at universities, schools, and corporations. It is modular and highly adaptable to any type of online learning.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/moodle/img/moodle-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/moodle/img/moodle-stack-220x234.png
 keywords:
 - moodle
 - learning

--- a/bitnami/multus-cni/Chart.yaml
+++ b/bitnami/multus-cni/Chart.yaml
@@ -17,7 +17,7 @@ dependencies:
   version: 2.x.x
 description: Multus is a CNI plugin for Kubernetes clusters. Written in Go, features adding multiple network interfaces to pods.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/multus-cni/img/multus-cni-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/multus-cni/img/multus-cni-stack-220x234.png
 keywords:
 - multus-cni
 - cni

--- a/bitnami/mysql/Chart.yaml
+++ b/bitnami/mysql/Chart.yaml
@@ -21,7 +21,7 @@ dependencies:
   version: 2.x.x
 description: MySQL is a fast, reliable, scalable, and easy to use open source relational database system. Designed to handle mission-critical, heavy-load production applications.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/mysql/img/mysql-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/mysql/img/mysql-stack-220x234.png
 keywords:
 - mysql
 - database

--- a/bitnami/nats/Chart.yaml
+++ b/bitnami/nats/Chart.yaml
@@ -19,7 +19,7 @@ dependencies:
   version: 2.x.x
 description: NATS is an open source, lightweight and high-performance messaging system. It is ideal for distributed systems and supports modern cloud architectures and pub-sub, request-reply and queuing models.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/nats/img/nats-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/nats/img/nats-stack-220x234.png
 keywords:
 - nats
 - messaging

--- a/bitnami/neo4j/Chart.yaml
+++ b/bitnami/neo4j/Chart.yaml
@@ -19,7 +19,7 @@ dependencies:
   version: 2.x.x
 description: Neo4j is a high performance graph store with all the features expected of a mature and robust database, like a friendly query language and ACID transactions.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/neo4j/img/neo4j-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/neo4j/img/neo4j-stack-220x234.png
 keywords:
 - database
 - neo4j

--- a/bitnami/nessie/Chart.yaml
+++ b/bitnami/nessie/Chart.yaml
@@ -25,7 +25,7 @@ dependencies:
   version: 2.x.x
 description: Nessie is an open-source version control system for data lakes, enabling isolated data experimentation before committing changes.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/nessie/img/nessie-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/nessie/img/nessie-stack-220x234.png
 keywords:
 - nessie
 - graph

--- a/bitnami/nginx-ingress-controller/Chart.yaml
+++ b/bitnami/nginx-ingress-controller/Chart.yaml
@@ -19,7 +19,7 @@ dependencies:
   version: 2.x.x
 description: NGINX Ingress Controller is an Ingress controller that manages external access to HTTP services in a Kubernetes cluster using NGINX.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/nginx-ingress-controller/img/nginx-ingress-controller-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/nginx-ingress-controller/img/nginx-ingress-controller-stack-220x234.png
 keywords:
 - ingress
 - nginx

--- a/bitnami/nginx/Chart.yaml
+++ b/bitnami/nginx/Chart.yaml
@@ -21,7 +21,7 @@ dependencies:
   version: 2.x.x
 description: NGINX Open Source is a web server that can be also used as a reverse proxy, load balancer, and HTTP cache. Recommended for high-demanding sites due to its ability to provide faster content.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/nginx/img/nginx-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/nginx/img/nginx-stack-220x234.png
 keywords:
 - nginx
 - http

--- a/bitnami/node-exporter/Chart.yaml
+++ b/bitnami/node-exporter/Chart.yaml
@@ -17,7 +17,7 @@ dependencies:
   version: 2.x.x
 description: Prometheus exporter for hardware and OS metrics exposed by UNIX kernels, with pluggable metric collectors.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/node-exporter/img/node-exporter-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/node-exporter/img/node-exporter-stack-220x234.png
 keywords:
 - prometheus
 - node-exporter

--- a/bitnami/oauth2-proxy/Chart.yaml
+++ b/bitnami/oauth2-proxy/Chart.yaml
@@ -21,7 +21,7 @@ dependencies:
   version: 2.x.x
 description: A reverse proxy and static file server that provides authentication using Providers (Google, GitHub, and others) to validate accounts by email, domain or group.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/oauth2-proxy/img/oauth2-proxy-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/oauth2-proxy/img/oauth2-proxy-stack-220x234.png
 keywords:
 - kubernetes
 - oauth

--- a/bitnami/odoo/Chart.yaml
+++ b/bitnami/odoo/Chart.yaml
@@ -21,7 +21,7 @@ dependencies:
   version: 2.x.x
 description: Odoo is an open source ERP and CRM platform, formerly known as OpenERP, that can connect a wide variety of business operations such as sales, supply chain, finance, and project management.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/odoo/img/odoo-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/odoo/img/odoo-stack-220x234.png
 keywords:
 - odoo
 - crm

--- a/bitnami/opensearch/Chart.yaml
+++ b/bitnami/opensearch/Chart.yaml
@@ -21,7 +21,7 @@ dependencies:
   version: 2.x.x
 description: OpenSearch is a scalable open-source solution for search, analytics, and observability. Features full-text queries, natural language processing, custom dictionaries, amongst others.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/opensearch/img/opensearch-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/opensearch/img/opensearch-stack-220x234.png
 keywords:
 - opensearch
 maintainers:

--- a/bitnami/parse/Chart.yaml
+++ b/bitnami/parse/Chart.yaml
@@ -24,7 +24,7 @@ dependencies:
   version: 2.x.x
 description: Parse is a platform that enables users to add a scalable and powerful backend to launch a full-featured app for iOS, Android, JavaScript, Windows, Unity, and more.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/parse/img/parse-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/parse/img/parse-stack-220x234.png
 keywords:
 - parse
 - backend

--- a/bitnami/phpmyadmin/Chart.yaml
+++ b/bitnami/phpmyadmin/Chart.yaml
@@ -25,7 +25,7 @@ dependencies:
   version: 2.x.x
 description: phpMyAdmin is a free software tool written in PHP, intended to handle the administration of MySQL over the Web. phpMyAdmin supports a wide range of operations on MySQL and MariaDB.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/phpmyadmin/img/phpmyadmin-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/phpmyadmin/img/phpmyadmin-stack-220x234.png
 keywords:
 - mariadb
 - mysql

--- a/bitnami/pinniped/Chart.yaml
+++ b/bitnami/pinniped/Chart.yaml
@@ -17,7 +17,7 @@ dependencies:
   version: 2.x.x
 description: Pinniped is an identity service provider for Kubernetes. It supplies a consistent and unified login experience across all your clusters. Pinniped is securely integrated with enterprise IDP protocols.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/pinniped/img/pinniped-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/pinniped/img/pinniped-stack-220x234.png
 keywords:
 - identity
 - infrastructure

--- a/bitnami/postgresql-ha/Chart.yaml
+++ b/bitnami/postgresql-ha/Chart.yaml
@@ -23,7 +23,7 @@ dependencies:
   version: 2.x.x
 description: This PostgreSQL cluster solution includes the PostgreSQL replication manager, an open-source tool for managing replication and failover on PostgreSQL clusters.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/postgresql/img/postgresql-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/postgresql/img/postgresql-stack-220x234.png
 keywords:
 - postgresql
 - repmgr

--- a/bitnami/postgresql/Chart.yaml
+++ b/bitnami/postgresql/Chart.yaml
@@ -21,7 +21,7 @@ dependencies:
   version: 2.x.x
 description: PostgreSQL (Postgres) is an open source object-relational database known for reliability and data integrity. ACID-compliant, it supports foreign keys, joins, views, triggers and stored procedures.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/postgresql/img/postgresql-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/postgresql/img/postgresql-stack-220x234.png
 keywords:
 - postgresql
 - postgres

--- a/bitnami/prometheus/Chart.yaml
+++ b/bitnami/prometheus/Chart.yaml
@@ -23,7 +23,7 @@ dependencies:
   version: 2.x.x
 description: Prometheus is an open source monitoring and alerting system. It enables sysadmins to monitor their infrastructures by collecting metrics from configured targets at given intervals.
 home: https://github.com/prometheus/prometheus
-icon: https://bitnami.com/assets/stacks/prometheus/img/prometheus-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/prometheus/img/prometheus-stack-220x234.png
 keywords:
 - prometheus
 - monitoring

--- a/bitnami/pytorch/Chart.yaml
+++ b/bitnami/pytorch/Chart.yaml
@@ -21,7 +21,7 @@ dependencies:
   version: 2.x.x
 description: PyTorch is a deep learning platform that accelerates the transition from research prototyping to production deployment. Bitnami image includes Torchvision for specific computer vision support.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/pytorch/img/pytorch-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/pytorch/img/pytorch-stack-220x234.png
 keywords:
 - pytorch
 - python

--- a/bitnami/rabbitmq-cluster-operator/Chart.yaml
+++ b/bitnami/rabbitmq-cluster-operator/Chart.yaml
@@ -23,7 +23,7 @@ dependencies:
   version: 2.x.x
 description: The RabbitMQ Cluster Kubernetes Operator automates provisioning, management, and operations of RabbitMQ clusters running on Kubernetes.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/rabbitmq-cluster-operator/img/rabbitmq-cluster-operator-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/rabbitmq-cluster-operator/img/rabbitmq-cluster-operator-stack-220x234.png
 keywords:
 - rabbitmq
 - operator

--- a/bitnami/rabbitmq/Chart.yaml
+++ b/bitnami/rabbitmq/Chart.yaml
@@ -19,7 +19,7 @@ dependencies:
   version: 2.x.x
 description: RabbitMQ is an open source general-purpose message broker that is designed for consistent, highly-available messaging scenarios (both synchronous and asynchronous).
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/rabbitmq/img/rabbitmq-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/rabbitmq/img/rabbitmq-stack-220x234.png
 keywords:
 - rabbitmq
 - message queue

--- a/bitnami/redis-cluster/Chart.yaml
+++ b/bitnami/redis-cluster/Chart.yaml
@@ -21,7 +21,7 @@ dependencies:
   version: 2.x.x
 description: Redis(R) is an open source, scalable, distributed in-memory cache for applications. It can be used to store and serve data in the form of strings, hashes, lists, sets and sorted sets.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/redis/img/redis-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/redis/img/redis-stack-220x234.png
 keywords:
 - redis
 - keyvalue

--- a/bitnami/redis/Chart.yaml
+++ b/bitnami/redis/Chart.yaml
@@ -25,7 +25,7 @@ dependencies:
   version: 2.x.x
 description: Redis(R) is an open source, advanced key-value store. It is often referred to as a data structure server since keys can contain strings, hashes, lists, sets and sorted sets.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/redis/img/redis-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/redis/img/redis-stack-220x234.png
 keywords:
 - redis
 - keyvalue

--- a/bitnami/redmine/Chart.yaml
+++ b/bitnami/redmine/Chart.yaml
@@ -27,7 +27,7 @@ dependencies:
   version: 2.x.x
 description: Redmine is an open source management application. It includes a tracking issue system, Gantt charts for a visual view of projects and deadlines, and supports SCM integration for version control.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/redmine/img/redmine-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/redmine/img/redmine-stack-220x234.png
 keywords:
 - redmine
 - project management

--- a/bitnami/schema-registry/Chart.yaml
+++ b/bitnami/schema-registry/Chart.yaml
@@ -21,7 +21,7 @@ dependencies:
   version: 2.x.x
 description: Confluent Schema Registry provides a RESTful interface by adding a serving layer for your metadata on top of Kafka. It expands Kafka enabling support for Apache Avro, JSON, and Protobuf schemas.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/schema-registry/img/schema-registry-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/schema-registry/img/schema-registry-stack-220x234.png
 keywords:
 - schema-registry
 - confluent

--- a/bitnami/scylladb/Chart.yaml
+++ b/bitnami/scylladb/Chart.yaml
@@ -19,7 +19,7 @@ dependencies:
   version: 2.x.x
 description: ScyllaDB is an open-source, distributed NoSQL wide-column data store. Written in C++, it is designed for high throughput and low latency, compatible with Apache Cassandra.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/scylladb/img/scylladb-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/scylladb/img/scylladb-stack-220x234.png
 keywords:
 - scylladb
 - database

--- a/bitnami/sealed-secrets/Chart.yaml
+++ b/bitnami/sealed-secrets/Chart.yaml
@@ -17,7 +17,7 @@ dependencies:
   version: 2.x.x
 description: Sealed Secrets are "one-way" encrypted K8s Secrets that can be created by anyone, but can only be decrypted by the controller running in the target cluster recovering the original object.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/sealed-secrets/img/sealed-secrets-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/sealed-secrets/img/sealed-secrets-stack-220x234.png
 keywords:
 - secrets
 - sealed-secrets

--- a/bitnami/seaweedfs/Chart.yaml
+++ b/bitnami/seaweedfs/Chart.yaml
@@ -35,7 +35,7 @@ dependencies:
   version: 2.x.x
 description: SeaweedFS is a simple and highly scalable distributed file system.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/seaweedfs/img/seaweedfs-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/seaweedfs/img/seaweedfs-stack-220x234.png
 keywords:
 - seaweedfs
 - storage

--- a/bitnami/solr/Chart.yaml
+++ b/bitnami/solr/Chart.yaml
@@ -23,7 +23,7 @@ dependencies:
   version: 2.x.x
 description: Apache Solr is an extremely powerful, open source enterprise search platform built on Apache Lucene. It is highly reliable and flexible, scalable, and designed to add value very quickly after launch.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/solr/img/solr-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/solr/img/solr-stack-220x234.png
 keywords:
 - solr
 - zookeeper

--- a/bitnami/sonarqube/Chart.yaml
+++ b/bitnami/sonarqube/Chart.yaml
@@ -25,7 +25,7 @@ dependencies:
   version: 2.x.x
 description: SonarQube(TM) is an open source quality management platform that analyzes and measures code's technical quality. It enables developers to detect code issues, vulnerabilities, and bugs in early stages.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/sonarqube/img/sonarqube-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/sonarqube/img/sonarqube-stack-220x234.png
 keywords:
 - sonarqube
 - code-quality

--- a/bitnami/spark/Chart.yaml
+++ b/bitnami/spark/Chart.yaml
@@ -17,7 +17,7 @@ dependencies:
   version: 2.x.x
 description: Apache Spark is a high-performance engine for large-scale computing tasks, such as data processing, machine learning and real-time data streaming. It includes APIs for Java, Python, Scala and R.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/spark/img/spark-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/spark/img/spark-stack-220x234.png
 keywords:
 - apache
 - spark

--- a/bitnami/spring-cloud-dataflow/Chart.yaml
+++ b/bitnami/spring-cloud-dataflow/Chart.yaml
@@ -41,7 +41,7 @@ dependencies:
   version: 2.x.x
 description: Spring Cloud Data Flow is a microservices-based toolkit for building streaming and batch data processing pipelines in Cloud Foundry and Kubernetes.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/spring-cloud-dataflow/img/spring-cloud-dataflow-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/spring-cloud-dataflow/img/spring-cloud-dataflow-stack-220x234.png
 keywords:
 - spring-cloud
 - dataflow

--- a/bitnami/superset/Chart.yaml
+++ b/bitnami/superset/Chart.yaml
@@ -25,7 +25,7 @@ dependencies:
   version: 2.x.x
 description: Superset is a modern data exploration and data visualization platform. 
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/superset/img/superset-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/superset/img/superset-stack-220x234.png
 keywords:
 - superset
 - analytics

--- a/bitnami/tensorflow-resnet/Chart.yaml
+++ b/bitnami/tensorflow-resnet/Chart.yaml
@@ -19,7 +19,7 @@ dependencies:
   version: 2.x.x
 description: TensorFlow ResNet is a client utility for use with TensorFlow Serving and ResNet models.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/tensorflow-inception/img/tensorflow-inception-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/tensorflow-inception/img/tensorflow-inception-stack-220x234.png
 keywords:
 - tensorflow
 - serving

--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -23,7 +23,7 @@ dependencies:
   version: 2.x.x
 description: Thanos is a highly available metrics system that can be added on top of existing Prometheus deployments, providing a global query view across all Prometheus installations.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/thanos/img/thanos-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/thanos/img/thanos-stack-220x234.png
 keywords:
 - analytics
 - monitoring

--- a/bitnami/tomcat/Chart.yaml
+++ b/bitnami/tomcat/Chart.yaml
@@ -21,7 +21,7 @@ dependencies:
   version: 2.x.x
 description: Apache Tomcat is an open-source web server designed to host and run Java-based web applications. It is a lightweight server with a good performance for applications running in production environments.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/tomcat/img/tomcat-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/tomcat/img/tomcat-stack-220x234.png
 keywords:
 - tomcat
 - java

--- a/bitnami/valkey-cluster/Chart.yaml
+++ b/bitnami/valkey-cluster/Chart.yaml
@@ -21,7 +21,7 @@ dependencies:
   version: 2.x.x
 description: Valkey is an open source (BSD) high-performance key/value datastore that supports a variety workloads such as caching, message queues, and can act as a primary database.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/valkey/img/valkey-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/valkey/img/valkey-stack-220x234.png
 keywords:
 - valkey
 - keyvalue

--- a/bitnami/valkey/Chart.yaml
+++ b/bitnami/valkey/Chart.yaml
@@ -25,7 +25,7 @@ dependencies:
   version: 2.x.x
 description: Valkey is an open source (BSD) high-performance key/value datastore that supports a variety workloads such as caching, message queues, and can act as a primary database.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/valkey/img/valkey-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/valkey/img/valkey-stack-220x234.png
 keywords:
 - valkey
 - keyvalue

--- a/bitnami/vault/Chart.yaml
+++ b/bitnami/vault/Chart.yaml
@@ -23,7 +23,7 @@ dependencies:
   version: 2.x.x
 description: Vault is a tool for securely managing and accessing secrets using a unified interface. Features secure storage, dynamic secrets, data encryption and revocation.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/vault/img/vault-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/vault/img/vault-stack-220x234.png
 keywords:
 - security
 - secrets

--- a/bitnami/whereabouts/Chart.yaml
+++ b/bitnami/whereabouts/Chart.yaml
@@ -17,7 +17,7 @@ dependencies:
   version: 2.x.x
 description: Whereabouts is a CNI IPAM plugin for Kubernetes clusters. It dynamically assigns IP addresses cluster-wide. Features both IPv4 and IPv6 addressing.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/whereabouts/img/whereabouts-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/whereabouts/img/whereabouts-stack-220x234.png
 keywords:
 - whereabouts
 - cni

--- a/bitnami/wildfly/Chart.yaml
+++ b/bitnami/wildfly/Chart.yaml
@@ -19,7 +19,7 @@ dependencies:
   version: 2.x.x
 description: Wildfly is a lightweight, open source application server, formerly known as JBoss, that implements the latest enterprise Java standards.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/wildfly/img/wildfly-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/wildfly/img/wildfly-stack-220x234.png
 keywords:
 - wildfly
 - java

--- a/bitnami/wordpress/Chart.yaml
+++ b/bitnami/wordpress/Chart.yaml
@@ -29,7 +29,7 @@ dependencies:
   version: 2.x.x
 description: WordPress is the world's most popular blogging and content management platform. Powerful yet simple, everyone from students to global corporations use it to build beautiful, functional websites.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/wordpress/img/wordpress-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/wordpress/img/wordpress-stack-220x234.png
 keywords:
 - application
 - blog

--- a/bitnami/zipkin/Chart.yaml
+++ b/bitnami/zipkin/Chart.yaml
@@ -23,7 +23,7 @@ dependencies:
   version: 2.x.x
 description: Zipkin is a distributed tracing system that helps collect and analyze timing data to troubleshoot latency issues in service architectures, providing visibility into service call performance.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/zipkin/img/zipkin-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/zipkin/img/zipkin-stack-220x234.png
 keywords:
 - zipkin
 - tracing

--- a/bitnami/zookeeper/Chart.yaml
+++ b/bitnami/zookeeper/Chart.yaml
@@ -19,7 +19,7 @@ dependencies:
   version: 2.x.x
 description: Apache ZooKeeper provides a reliable, centralized register of configuration data and services for distributed applications.
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/zookeeper/img/zookeeper-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/zookeeper/img/zookeeper-stack-220x234.png
 keywords:
 - zookeeper
 maintainers:

--- a/template/CHART_NAME/Chart.yaml
+++ b/template/CHART_NAME/Chart.yaml
@@ -18,7 +18,7 @@ dependencies:
     version: 2.x.x
 description: %%DESCRIPTION%%
 home: https://bitnami.com
-icon: https://bitnami.com/assets/stacks/%%IMAGE_NAME%%/img/%%IMAGE_NAME%%-stack-220x234.png
+icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/%%IMAGE_NAME%%/img/%%IMAGE_NAME%%-stack-220x234.png
 keywords:
   - %%UPSTREAM_PROJECT_KEYWORD%%
   - %%UPSTREAM_PROJECT_KEYWORD%%


### PR DESCRIPTION
### Description of the change

Replace the bitnami.com website references to a direct URL to the CDN containing the application logos.

### Benefits

Remove dependency with the bitnami.com website.

### Possible drawbacks

None known.

### Checklist

- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
