### PR TITLE
[bitnami/common] Add helper to check API versions

### DIFF
--- a/bitnami/common/CHANGELOG.md
+++ b/bitnami/common/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 2.29.1 (2025-01-10)
+## 2.30.0 (2025-02-18)
 
-* [bitnami/common] Removing seLinuxOptions from omission ([#31279](https://github.com/bitnami/charts/pull/31279))
+* [bitnami/common] Add helper to check API versions ([#31969](https://github.com/bitnami/charts/pull/31969))
+
+## <small>2.29.1 (2025-01-23)</small>
+
+* [bitnami/common] Removing seLinuxOptions from omission (#31279) ([e7cb168](https://github.com/bitnami/charts/commit/e7cb168ca2bccd57e28bb985e099953a4f7e3b38)), closes [#31279](https://github.com/bitnami/charts/issues/31279) [#31278](https://github.com/bitnami/charts/issues/31278)
 
 ## 2.29.0 (2025-01-03)
 
@@ -269,7 +273,7 @@
 
 ## <small>2.1.2 (2022-10-31)</small>
 
-* [bitnami/common] Do not explicitly specify namespace in affinity term. (#12932) ([638a48e](https://github.com/bitnami/charts/commit/638a48e4d3ec7b5d160f4b525ec40218512c464b)), closes [#12932](https://github.com/bitnami/charts/issues/12932) [/kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#podaffinityterm-v1](https://github.com//kubernetes.io/docs/reference/generated/kubernetes-api/v1.23//issues/podaffinityterm-v1) [#12668](https://github.com/bitnami/charts/issues/12668)
+* [bitnami/common] Do not explicitly specify namespace in affinity term. (#12932) ([638a48e](https://github.com/bitnami/charts/commit/638a48e4d3ec7b5d160f4b525ec40218512c464b)), closes [#12932](https://github.com/bitnami/charts/issues/12932) [#12668](https://github.com/bitnami/charts/issues/12668)
 
 ## <small>2.1.1 (2022-10-27)</small>
 

--- a/bitnami/common/CHANGELOG.md
+++ b/bitnami/common/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2.30.0 (2025-02-18)
+## 2.30.0 (2025-02-19)
 
 * [bitnami/common] Add helper to check API versions ([#31969](https://github.com/bitnami/charts/pull/31969))
 

--- a/bitnami/common/Chart.yaml
+++ b/bitnami/common/Chart.yaml
@@ -6,7 +6,7 @@ annotations:
   licenses: Apache-2.0
 apiVersion: v2
 # Please make sure that version and appVersion are always the same.
-appVersion: 2.29.1
+appVersion: 2.29.2
 description: A Library Helm Chart for grouping common logic between bitnami charts. This chart is not deployable by itself.
 home: https://bitnami.com
 icon: https://dyltqmyl993wv.cloudfront.net/downloads/logos/bitnami-mark.png
@@ -23,4 +23,4 @@ name: common
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/common
 type: library
-version: 2.29.1
+version: 2.29.2

--- a/bitnami/common/Chart.yaml
+++ b/bitnami/common/Chart.yaml
@@ -6,7 +6,7 @@ annotations:
   licenses: Apache-2.0
 apiVersion: v2
 # Please make sure that version and appVersion are always the same.
-appVersion: 2.29.2
+appVersion: 2.30.0
 description: A Library Helm Chart for grouping common logic between bitnami charts. This chart is not deployable by itself.
 home: https://bitnami.com
 icon: https://dyltqmyl993wv.cloudfront.net/downloads/logos/bitnami-mark.png
@@ -23,4 +23,4 @@ name: common
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/common
 type: library
-version: 2.29.2
+version: 2.30.0

--- a/bitnami/common/templates/_capabilities.tpl
+++ b/bitnami/common/templates/_capabilities.tpl
@@ -13,6 +13,20 @@ Return the target Kubernetes version
 {{- end -}}
 
 {{/*
+Return true if the apiVersion is supported
+Usage:
+{{ include "common.capabilities.apiVersions.has" (dict "version" "batch/v1" "context" $) }}
+*/}}
+{{- define "common.capabilities.apiVersions.has" -}}
+{{- $providedAPIVersions := default .context.Values.apiVersions ((.context.Values.global).apiVersions) -}}
+{{- if and (empty $providedAPIVersions) (.context.Capabilities.APIVersions.Has .version) -}}
+    {{- true -}}
+{{- else if has .version $providedAPIVersions -}}
+    {{- true -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Return the appropriate apiVersion for poddisruptionbudget.
 */}}
 {{- define "common.capabilities.policy.apiVersion" -}}


### PR DESCRIPTION
### Description of the change

This PR adds a helper to check if a specific API version is supported. The helper allows running this check without relying on the `.Capabilities.APIVersions` built-in object but chart values instead (if defined).

### Benefits

Users can define the Kubernetes API versions using a parameter such as the one below:

```yaml
## @param apiVersions Override Kubernetes API versions reported by .Capabilities
##
apiVersions: []
```

Use conditional like the one below in their templates:

```yaml
{{- if include "common.capabilities.apiVersions.has" ( dict "version" "batch/v1" "context" . ) }}
foo: bar
{{- end }}
```

Then, render templates (`helm template [NAME] [CHART]`) and obtain sth like this:

```yaml
$ helm template [NAME] [CHART] -s templates/xxx.yaml
Error: could not find template templates/xxx.yaml in chart
$ helm template [NAME] [CHART] --set apiVersions[0]="batch/v1" -s templates/xxx.yaml
---
# Source: NAME/templates/xxx.yaml
foo: bar
```

### Possible drawbacks

None

### Applicable issues

Related to https://github.com/bitnami/charts/issues/31815

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
