### PR TITLE
[bitnami/redis] Add ACL Authentication for Sentinel Nodes

### DIFF
--- a/bitnami/redis/CHANGELOG.md
+++ b/bitnami/redis/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 * [bitnami/redis] Release 20.7.2 (#32033) ([829c44e](https://github.com/bitnami/charts/commit/829c44eddcc0f0fdc3e80d49acd7b4ee41b0408a)), closes [#32033](https://github.com/bitnami/charts/issues/32033)
 
+## <small>20.7.2 (2025-02-20)</small>
+
+* [bitnami/redis] Release 20.7.2 (#32033) ([829c44e](https://github.com/bitnami/charts/commit/829c44eddcc0f0fdc3e80d49acd7b4ee41b0408a)), closes [#32033](https://github.com/bitnami/charts/issues/32033)
+
 ## <small>20.7.1 (2025-02-16)</small>
 
 * [bitnami/*] Use CDN url for the Bitnami Application Icons (#31881) ([d9bb11a](https://github.com/bitnami/charts/commit/d9bb11a9076b9bfdcc70ea022c25ef50e9713657)), closes [#31881](https://github.com/bitnami/charts/issues/31881)

--- a/bitnami/redis/CHANGELOG.md
+++ b/bitnami/redis/CHANGELOG.md
@@ -1,12 +1,12 @@
 # Changelog
 
+## 20.9.0 (2025-02-20)
+
+* [bitnami/redis] Add ACL Authentication for Sentinel Nodes ([#31974](https://github.com/bitnami/charts/pull/31974))
+
 ## 20.8.0 (2025-02-20)
 
-* [bitnami/redis] feat: add parameter to disable checksums ([#31948](https://github.com/bitnami/charts/pull/31948))
-
-## <small>20.7.2 (2025-02-20)</small>
-
-* [bitnami/redis] Release 20.7.2 (#32033) ([829c44e](https://github.com/bitnami/charts/commit/829c44eddcc0f0fdc3e80d49acd7b4ee41b0408a)), closes [#32033](https://github.com/bitnami/charts/issues/32033)
+* [bitnami/redis] feat: add parameter to disable checksums (#31948) ([990014f](https://github.com/bitnami/charts/commit/990014f4d627d9a681d9775af69d11ad207c156a)), closes [#31948](https://github.com/bitnami/charts/issues/31948)
 
 ## <small>20.7.2 (2025-02-20)</small>
 

--- a/bitnami/redis/Chart.yaml
+++ b/bitnami/redis/Chart.yaml
@@ -36,4 +36,4 @@ maintainers:
 name: redis
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/redis
-version: 20.8.0
+version: 20.9.0

--- a/bitnami/redis/README.md
+++ b/bitnami/redis/README.md
@@ -507,13 +507,14 @@ helm install my-release --set master.persistence.existingClaim=PVC_NAME oci://RE
 | -------------------------------- | ------------------------------------------------------------------------------------- | ------------- |
 | `architecture`                   | Redis&reg; architecture. Allowed values: `standalone` or `replication`                | `replication` |
 | `auth.enabled`                   | Enable password authentication                                                        | `true`        |
-| `auth.sentinel`                  | Enable password authentication on sentinels too                                       | `true`        |
+| `auth.sentinel`                  | Enable authentication on sentinels too                                                | `true`        |
 | `auth.password`                  | Redis&reg; password                                                                   | `""`          |
 | `auth.existingSecret`            | The name of an existing secret with Redis&reg; credentials                            | `""`          |
 | `auth.existingSecretPasswordKey` | Password key to be retrieved from existing secret                                     | `""`          |
 | `auth.usePasswordFiles`          | Mount credentials as files instead of using an environment variable                   | `false`       |
 | `auth.usePasswordFileFromSecret` | Mount password file from secret                                                       | `true`        |
 | `auth.acl.enabled`               | Enables the support of the Redis ACL system                                           | `false`       |
+| `auth.acl.sentinel`              | Enables the support of the Redis ACL system for Sentinel Nodes                        | `false`       |
 | `auth.acl.users`                 | A list of the configured users in the Redis ACL system                                | `[]`          |
 | `commonConfiguration`            | Common configuration to be added into the ConfigMap                                   | `""`          |
 | `existingConfigmap`              | The name of an existing ConfigMap with your custom configuration for Redis&reg; nodes | `""`          |

--- a/bitnami/redis/templates/configmap.yaml
+++ b/bitnami/redis/templates/configmap.yaml
@@ -73,6 +73,16 @@ data:
     {{- if or .Values.sentinel.masterService.enabled .Values.sentinel.service.createMaster }}
       sentinel client-reconfig-script {{ .Values.sentinel.masterSet }} /opt/bitnami/scripts/start-scripts/push-master-label.sh
     {{- end }}
+    {{- if .Values.auth.acl.sentinel }}
+    {{- range .Values.auth.acl.users }}
+    # Sentinel ACL configuration, only for users with password
+    {{ if .password }}
+    user {{ .username }} {{ default "on" .enabled }} {{ if .password }}#{{ sha256sum .password }}{{ else }}nopass{{ end }} ~* &* +@all
+    sentinel sentinel-user {{ .username }}
+    sentinel sentinel-pass {{ .password }} 
+    {{- end }}
+    {{- end }}
+    {{- end }}
     # User-supplied sentinel configuration:
     {{- if .Values.sentinel.configuration }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.sentinel.configuration "context" $ ) | nindent 4 }}

--- a/bitnami/redis/values.yaml
+++ b/bitnami/redis/values.yaml
@@ -145,7 +145,7 @@ auth:
   ## @param auth.enabled Enable password authentication
   ##
   enabled: true
-  ## @param auth.sentinel Enable password authentication on sentinels too
+  ## @param auth.sentinel Enable authentication on sentinels too
   ##
   sentinel: true
   ## @param auth.password Redis&reg; password
@@ -173,6 +173,9 @@ auth:
     ## @param auth.acl.enabled Enables the support of the Redis ACL system
     ##
     enabled: false
+    ## @param auth.acl.sentinel Enables the support of the Redis ACL system for Sentinel Nodes
+    ##
+    sentinel: false
     ## @param auth.acl.users A list of the configured users in the Redis ACL system
     ##
     ## Example:


### PR DESCRIPTION
As described in #31952 , the redis helm chart does not support acl-based authentication for Sentinel Mode. This PR uses the configured users to enable this; clients can then authenticate both to redis and to sentinel with the same user credentials.

### Description of the change

Introduces changes to the configmap containing the `sentinel.conf`, in order to enable ACL authentication to the sentinel nodes.

### Benefits

Make it easier for clients to authenticate and connect both to redis and sentinel. Previously, clients needed to provide credentials for redis (6379) as well as for sentinel (26379) separately (either the default user´s password, or turning off the authentication on sentinel).
With the change, clients can now use the same credentials to authenticate both to redis and sentinel, taken from the configured users in the acl list.

### Possible drawbacks

None

### Applicable issues

- fixes #31952 

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
