### PR TITLE
[bitnami/apisix] feat: use new helper for checking API versions

### DIFF
--- a/bitnami/apisix/CHANGELOG.md
+++ b/bitnami/apisix/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 4.0.2 (2025-02-18)
+## 4.0.3 (2025-02-20)
 
-* [bitnami/apisix] Release 4.0.2 ([#31972](https://github.com/bitnami/charts/pull/31972))
+* [bitnami/apisix] feat: use new helper for checking API versions ([#32045](https://github.com/bitnami/charts/pull/32045))
+
+## <small>4.0.2 (2025-02-18)</small>
+
+* [bitnami/apisix] Release 4.0.2 (#31972) ([d014094](https://github.com/bitnami/charts/commit/d014094260366d1b17e60bbc9a2aee09542d3147)), closes [#31972](https://github.com/bitnami/charts/issues/31972)
 
 ## <small>4.0.1 (2025-02-18)</small>
 

--- a/bitnami/apisix/CHANGELOG.md
+++ b/bitnami/apisix/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 4.0.3 (2025-02-20)
+## 4.1.0 (2025-02-20)
 
 * [bitnami/apisix] feat: use new helper for checking API versions ([#32045](https://github.com/bitnami/charts/pull/32045))
 

--- a/bitnami/apisix/Chart.lock
+++ b/bitnami/apisix/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 11.0.7
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.29.1
-digest: sha256:0a307b9353b6d79d8ead55ae6a18fac77107aeefeb07d6550289c90976efdb16
-generated: "2025-02-18T10:36:40.304583067Z"
+  version: 2.30.0
+digest: sha256:dac75bef322408518f37d9018d65a27ba65f719bf1f1d99c39f328ef33725613
+generated: "2025-02-20T08:55:23.536416+01:00"

--- a/bitnami/apisix/Chart.yaml
+++ b/bitnami/apisix/Chart.yaml
@@ -45,4 +45,4 @@ sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/apisix
   - https://github.com/bitnami/charts/tree/main/bitnami/apisix-dashboard
   - https://github.com/bitnami/charts/tree/main/bitnami/apisix-ingress-controller
-version: 4.0.3
+version: 4.1.0

--- a/bitnami/apisix/Chart.yaml
+++ b/bitnami/apisix/Chart.yaml
@@ -16,33 +16,33 @@ annotations:
 apiVersion: v2
 appVersion: 3.11.0
 dependencies:
-- name: etcd
-  repository: oci://registry-1.docker.io/bitnamicharts
-  condition: etcd.enabled
-  version: 11.x.x
-- name: common
-  repository: oci://registry-1.docker.io/bitnamicharts
-  tags:
-  - bitnami-common
-  version: 2.x.x
+  - name: etcd
+    repository: oci://registry-1.docker.io/bitnamicharts
+    condition: etcd.enabled
+    version: 11.x.x
+  - name: common
+    repository: oci://registry-1.docker.io/bitnamicharts
+    tags:
+      - bitnami-common
+    version: 2.x.x
 description: Apache APISIX is high-performance, real-time API Gateway. Features load balancing, dynamic upstream, canary release, circuit breaking, authentication, observability, amongst others.
 home: https://bitnami.com
 icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/apisix/img/apisix-stack-220x234.png
 keywords:
-- apisix
-- ingress
-- openresty
-- controller
-- http
-- web
-- www
-- reverse proxy
+  - apisix
+  - ingress
+  - openresty
+  - controller
+  - http
+  - web
+  - www
+  - reverse proxy
 maintainers:
-- name: Broadcom, Inc. All Rights Reserved.
-  url: https://github.com/bitnami/charts
+  - name: Broadcom, Inc. All Rights Reserved.
+    url: https://github.com/bitnami/charts
 name: apisix
 sources:
-- https://github.com/bitnami/charts/tree/main/bitnami/apisix
-- https://github.com/bitnami/charts/tree/main/bitnami/apisix-dashboard
-- https://github.com/bitnami/charts/tree/main/bitnami/apisix-ingress-controller
-version: 4.0.2
+  - https://github.com/bitnami/charts/tree/main/bitnami/apisix
+  - https://github.com/bitnami/charts/tree/main/bitnami/apisix-dashboard
+  - https://github.com/bitnami/charts/tree/main/bitnami/apisix-ingress-controller
+version: 4.0.3

--- a/bitnami/apisix/README.md
+++ b/bitnami/apisix/README.md
@@ -293,6 +293,7 @@ As an alternative, use one of the preset configurations for pod affinity, pod an
 | Name                     | Description                                                                                                                                       | Value                    |
 | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------ |
 | `kubeVersion`            | Override Kubernetes version                                                                                                                       | `""`                     |
+| `apiVersions`            | Override Kubernetes API versions reported by .Capabilities                                                                                        | `[]`                     |
 | `nameOverride`           | String to partially override common.names.name                                                                                                    | `""`                     |
 | `fullnameOverride`       | String to fully override common.names.fullname                                                                                                    | `""`                     |
 | `namespaceOverride`      | String to fully override common.names.namespace                                                                                                   | `""`                     |

--- a/bitnami/apisix/templates/control-plane/vpa.yaml
+++ b/bitnami/apisix/templates/control-plane/vpa.yaml
@@ -3,7 +3,7 @@ Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- if and (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1/VerticalPodAutoscaler") .Values.controlPlane.autoscaling.vpa.enabled }}
+{{- if and (include "common.capabilities.apiVersions.has" ( dict "version" "autoscaling.k8s.io/v1/VerticalPodAutoscaler" "context" . )) .Values.controlPlane.autoscaling.vpa.enabled }}
 apiVersion: {{ include "common.capabilities.vpa.apiVersion" . }}
 kind: VerticalPodAutoscaler
 metadata:

--- a/bitnami/apisix/templates/dashboard/vpa.yaml
+++ b/bitnami/apisix/templates/dashboard/vpa.yaml
@@ -3,7 +3,7 @@ Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- if and (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1/VerticalPodAutoscaler") .Values.dashboard.autoscaling.vpa.enabled }}
+{{- if and (include "common.capabilities.apiVersions.has" ( dict "version" "autoscaling.k8s.io/v1/VerticalPodAutoscaler" "context" . )) .Values.dashboard.autoscaling.vpa.enabled }}
 apiVersion: {{ include "common.capabilities.vpa.apiVersion" . }}
 kind: VerticalPodAutoscaler
 metadata:

--- a/bitnami/apisix/templates/data-plane/vpa.yaml
+++ b/bitnami/apisix/templates/data-plane/vpa.yaml
@@ -3,7 +3,7 @@ Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- if and (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1/VerticalPodAutoscaler") .Values.dataPlane.autoscaling.vpa.enabled }}
+{{- if and (include "common.capabilities.apiVersions.has" ( dict "version" "autoscaling.k8s.io/v1/VerticalPodAutoscaler" "context" . )) .Values.dataPlane.autoscaling.vpa.enabled }}
 apiVersion: {{ include "common.capabilities.vpa.apiVersion" . }}
 kind: VerticalPodAutoscaler
 metadata:

--- a/bitnami/apisix/templates/ingress-controller/vpa.yaml
+++ b/bitnami/apisix/templates/ingress-controller/vpa.yaml
@@ -3,7 +3,7 @@ Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- if and (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1/VerticalPodAutoscaler") .Values.ingressController.autoscaling.vpa.enabled }}
+{{- if and (include "common.capabilities.apiVersions.has" ( dict "version" "autoscaling.k8s.io/v1/VerticalPodAutoscaler" "context" . )) .Values.ingressController.autoscaling.vpa.enabled }}
 apiVersion: {{ include "common.capabilities.vpa.apiVersion" . }}
 kind: VerticalPodAutoscaler
 metadata:

--- a/bitnami/apisix/values.yaml
+++ b/bitnami/apisix/values.yaml
@@ -41,6 +41,9 @@ global:
 ## @param kubeVersion Override Kubernetes version
 ##
 kubeVersion: ""
+## @param apiVersions Override Kubernetes API versions reported by .Capabilities
+##
+apiVersions: []
 ## @param nameOverride String to partially override common.names.name
 ##
 nameOverride: ""


### PR DESCRIPTION
### Description of the change

Replace references to ".Capabilities.APIVersions.Has" with the new common helper added at #31969

### Benefits

Rendering templates doesn't require a K8s cluster connection to check the API versions.

### Possible drawbacks

None

### Applicable issues

None

### Additional information

N/A

### Checklist

- [x] Chart version bumped in Chart.yaml according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
