### PR TITLE
[bitnami/chainloop] feat: use new helper for checking API versions

### DIFF
--- a/bitnami/chainloop/CHANGELOG.md
+++ b/bitnami/chainloop/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2.1.31 (2025-02-20)
+## 2.2.0 (2025-02-20)
 
 * [bitnami/chainloop] feat: use new helper for checking API versions ([#32046](https://github.com/bitnami/charts/pull/32046))
 

--- a/bitnami/chainloop/CHANGELOG.md
+++ b/bitnami/chainloop/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 2.1.30 (2025-02-18)
+## 2.1.31 (2025-02-20)
 
-* [bitnami/chainloop] Release 2.1.30 ([#31968](https://github.com/bitnami/charts/pull/31968))
+* [bitnami/chainloop] feat: use new helper for checking API versions ([#32046](https://github.com/bitnami/charts/pull/32046))
+
+## <small>2.1.30 (2025-02-18)</small>
+
+* [bitnami/chainloop] Release 2.1.30 (#31968) ([fb759e9](https://github.com/bitnami/charts/commit/fb759e97967b7e7dd860687a02444d6c08da40d2)), closes [#31968](https://github.com/bitnami/charts/issues/31968)
 
 ## <small>2.1.29 (2025-02-18)</small>
 

--- a/bitnami/chainloop/Chart.lock
+++ b/bitnami/chainloop/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.29.1
+  version: 2.30.0
 - name: postgresql
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 16.4.9
 - name: vault
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 1.4.31
-digest: sha256:511148fbb056edee4e92604c5acc26e99d69e4347ae0eaf200797a45f4012577
-generated: "2025-02-18T11:40:41.411355377Z"
+digest: sha256:675c0a3cbc3a546746775902ff8ab50bbbe8e839275489a677e65159cddde944
+generated: "2025-02-20T08:55:30.621068+01:00"

--- a/bitnami/chainloop/Chart.yaml
+++ b/bitnami/chainloop/Chart.yaml
@@ -16,51 +16,51 @@ annotations:
 apiVersion: v2
 appVersion: 0.165.0
 dependencies:
-- name: common
-  repository: oci://registry-1.docker.io/bitnamicharts
-  tags:
-  - bitnami-common
-  version: 2.x.x
-- condition: postgresql.enabled
-  name: postgresql
-  repository: oci://registry-1.docker.io/bitnamicharts
-  version: 16.x.x
-- condition: development
-  name: vault
-  repository: oci://registry-1.docker.io/bitnamicharts
-  version: 1.4.x
+  - name: common
+    repository: oci://registry-1.docker.io/bitnamicharts
+    tags:
+      - bitnami-common
+    version: 2.x.x
+  - condition: postgresql.enabled
+    name: postgresql
+    repository: oci://registry-1.docker.io/bitnamicharts
+    version: 16.x.x
+  - condition: development
+    name: vault
+    repository: oci://registry-1.docker.io/bitnamicharts
+    version: 1.4.x
 description: Chainloop is an open-source Software Supply Chain control plane, a single source of truth for metadata and artifacts, plus a declarative attestation process.
 home: https://bitnami.com
 icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/chainloop/img/chainloop-stack-220x234.png
 keywords:
-- chainloop
-- evidence-store
-- supply-chain-security
-- devops
-- devsecops
-- security
-- compliance
-- cyclonedx
-- spdx
-- sbom
-- attestation
-- oss-compliance
-- in-toto
-- slsa
-- sbom-distribution
-- open-source-licensing
-- slsa-provenance
-- metadata-platform
-- sbom-discovery
-- regulated-industry
+  - chainloop
+  - evidence-store
+  - supply-chain-security
+  - devops
+  - devsecops
+  - security
+  - compliance
+  - cyclonedx
+  - spdx
+  - sbom
+  - attestation
+  - oss-compliance
+  - in-toto
+  - slsa
+  - sbom-distribution
+  - open-source-licensing
+  - slsa-provenance
+  - metadata-platform
+  - sbom-discovery
+  - regulated-industry
 maintainers:
-- name: Broadcom, Inc. All Rights Reserved.
-  url: https://github.com/bitnami/charts
+  - name: Broadcom, Inc. All Rights Reserved.
+    url: https://github.com/bitnami/charts
 name: chainloop
 sources:
-- https://github.com/bitnami/charts/tree/main/bitnami/chainloop
-- https://github.com/bitnami/containers/tree/main/bitnami/chainloop-control-plane
-- https://github.com/bitnami/containers/tree/main/bitnami/chainloop-control-plane-migrations
-- https://github.com/bitnami/containers/tree/main/bitnami/chainloop-artifact-cas
-- https://github.com/chainloop-dev/chainloop
-version: 2.1.30
+  - https://github.com/bitnami/charts/tree/main/bitnami/chainloop
+  - https://github.com/bitnami/containers/tree/main/bitnami/chainloop-control-plane
+  - https://github.com/bitnami/containers/tree/main/bitnami/chainloop-control-plane-migrations
+  - https://github.com/bitnami/containers/tree/main/bitnami/chainloop-artifact-cas
+  - https://github.com/chainloop-dev/chainloop
+version: 2.1.31

--- a/bitnami/chainloop/Chart.yaml
+++ b/bitnami/chainloop/Chart.yaml
@@ -63,4 +63,4 @@ sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/chainloop-control-plane-migrations
   - https://github.com/bitnami/containers/tree/main/bitnami/chainloop-artifact-cas
   - https://github.com/chainloop-dev/chainloop
-version: 2.1.31
+version: 2.2.0

--- a/bitnami/chainloop/README.md
+++ b/bitnami/chainloop/README.md
@@ -493,14 +493,18 @@ chainloop config save \
 
 ### Common parameters
 
-| Name                | Description                                        | Value   |
-| ------------------- | -------------------------------------------------- | ------- |
-| `kubeVersion`       | Override Kubernetes version                        | `""`    |
-| `commonAnnotations` | Annotations to add to all deployed objects         | `{}`    |
-| `commonLabels`      | Labels to add to all deployed objects              | `{}`    |
-| `extraDeploy`       | Array of extra objects to deploy with the release  | `[]`    |
-| `rbac.create`       | Specifies whether RBAC resources should be created | `false` |
-| `rbac.rules`        | Custom RBAC rules to set                           | `[]`    |
+| Name                | Description                                                | Value   |
+| ------------------- | ---------------------------------------------------------- | ------- |
+| `kubeVersion`       | Override Kubernetes version                                | `""`    |
+| `apiVersions`       | Override Kubernetes API versions reported by .Capabilities | `[]`    |
+| `nameOverride`      | String to partially override common.names.name             | `""`    |
+| `fullnameOverride`  | String to fully override common.names.fullname             | `""`    |
+| `namespaceOverride` | String to fully override common.names.namespace            | `""`    |
+| `commonAnnotations` | Annotations to add to all deployed objects                 | `{}`    |
+| `commonLabels`      | Labels to add to all deployed objects                      | `{}`    |
+| `extraDeploy`       | Array of extra objects to deploy with the release          | `[]`    |
+| `rbac.create`       | Specifies whether RBAC resources should be created         | `false` |
+| `rbac.rules`        | Custom RBAC rules to set                                   | `[]`    |
 
 ### Secrets Backend
 

--- a/bitnami/chainloop/templates/cas/vpa.yaml
+++ b/bitnami/chainloop/templates/cas/vpa.yaml
@@ -3,7 +3,7 @@ Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- if and (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1/VerticalPodAutoscaler") .Values.cas.autoscaling.vpa.enabled }}
+{{- if and (include "common.capabilities.apiVersions.has" ( dict "version" "autoscaling.k8s.io/v1/VerticalPodAutoscaler" "context" . )) .Values.cas.autoscaling.vpa.enabled }}
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:

--- a/bitnami/chainloop/templates/controlplane/vpa.yaml
+++ b/bitnami/chainloop/templates/controlplane/vpa.yaml
@@ -3,7 +3,7 @@ Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- if and (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1/VerticalPodAutoscaler") .Values.controlplane.autoscaling.vpa.enabled }}
+{{- if and (include "common.capabilities.apiVersions.has" ( dict "version" "autoscaling.k8s.io/v1/VerticalPodAutoscaler" "context" . )) .Values.controlplane.autoscaling.vpa.enabled }}
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:

--- a/bitnami/chainloop/values.yaml
+++ b/bitnami/chainloop/values.yaml
@@ -43,6 +43,18 @@ development: true
 ## @param kubeVersion Override Kubernetes version
 ##
 kubeVersion: ""
+## @param apiVersions Override Kubernetes API versions reported by .Capabilities
+##
+apiVersions: []
+## @param nameOverride String to partially override common.names.name
+##
+nameOverride: ""
+## @param fullnameOverride String to fully override common.names.fullname
+##
+fullnameOverride: ""
+## @param namespaceOverride String to fully override common.names.namespace
+##
+namespaceOverride: ""
 
 ## @param commonAnnotations Annotations to add to all deployed objects
 ##


### PR DESCRIPTION
### Description of the change

Replace references to ".Capabilities.APIVersions.Has" with the new common helper added at #31969

### Benefits

Rendering templates doesn't require a K8s cluster connection to check the API versions.

### Possible drawbacks

None

### Applicable issues

None

### Additional information

N/A

### Checklist

- [x] Chart version bumped in Chart.yaml according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
