### PR TITLE
[bitnami/cilium] feat: use new helper for checking API versions

### DIFF
--- a/bitnami/cilium/Chart.lock
+++ b/bitnami/cilium/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: etcd
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 11.0.6
+  version: 11.0.7
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.29.1
-digest: sha256:b22444e7739995e0653ca6f14fec07b97effdc6bc4d52f343919c62ea7796307
-generated: "2025-02-12T16:39:06.385475912Z"
+  version: 2.30.0
+digest: sha256:780abe3984083fa67b1b3341af9e6088a53c795e8e098c89eff2a9772bffb7ab
+generated: "2025-02-20T08:55:38.02497+01:00"

--- a/bitnami/cilium/Chart.yaml
+++ b/bitnami/cilium/Chart.yaml
@@ -20,36 +20,36 @@ annotations:
 apiVersion: v2
 appVersion: 1.17.1
 dependencies:
-- condition: etcd.enabled
-  name: etcd
-  repository: oci://registry-1.docker.io/bitnamicharts
-  tags:
-  - cilium-database
-  version: 11.x.x
-- name: common
-  repository: oci://registry-1.docker.io/bitnamicharts
-  tags:
-  - bitnami-common
-  version: 2.x.x
+  - condition: etcd.enabled
+    name: etcd
+    repository: oci://registry-1.docker.io/bitnamicharts
+    tags:
+      - cilium-database
+    version: 11.x.x
+  - name: common
+    repository: oci://registry-1.docker.io/bitnamicharts
+    tags:
+      - bitnami-common
+    version: 2.x.x
 description: Cilium is an eBPF-based networking, observability, and security for Linux container management platforms like Docker and Kubernetes.
 home: https://bitnami.com
 icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/cilium/img/cilium-stack-220x234.png
 keywords:
-- cilium
-- cni
-- networking
-- observability
-- security
+  - cilium
+  - cni
+  - networking
+  - observability
+  - security
 maintainers:
-- name: Broadcom, Inc. All Rights Reserved.
-  url: https://github.com/bitnami/charts
+  - name: Broadcom, Inc. All Rights Reserved.
+    url: https://github.com/bitnami/charts
 name: cilium
 sources:
-- https://github.com/bitnami/charts/tree/main/bitnami/cilium
-- https://github.com/bitnami/containers/tree/main/bitnami/cilium
-- https://github.com/bitnami/containers/tree/main/bitnami/cilium-operator
-- https://github.com/bitnami/containers/tree/main/bitnami/cilium-proxy
-- https://github.com/bitnami/containers/tree/main/bitnami/hubble-relay
-- https://github.com/bitnami/containers/tree/main/bitnami/hubble-ui
-- https://github.com/bitnami/containers/tree/main/bitnami/hubble-ui-backend
-version: 2.0.4
+  - https://github.com/bitnami/charts/tree/main/bitnami/cilium
+  - https://github.com/bitnami/containers/tree/main/bitnami/cilium
+  - https://github.com/bitnami/containers/tree/main/bitnami/cilium-operator
+  - https://github.com/bitnami/containers/tree/main/bitnami/cilium-proxy
+  - https://github.com/bitnami/containers/tree/main/bitnami/hubble-relay
+  - https://github.com/bitnami/containers/tree/main/bitnami/hubble-ui
+  - https://github.com/bitnami/containers/tree/main/bitnami/hubble-ui-backend
+version: 2.0.5

--- a/bitnami/cilium/README.md
+++ b/bitnami/cilium/README.md
@@ -198,6 +198,7 @@ As an alternative, use one of the preset configurations for pod affinity, pod an
 | Name                     | Description                                                                                                         | Value           |
 | ------------------------ | ------------------------------------------------------------------------------------------------------------------- | --------------- |
 | `kubeVersion`            | Override Kubernetes version                                                                                         | `""`            |
+| `apiVersions`            | Override Kubernetes API versions reported by .Capabilities                                                          | `[]`            |
 | `nameOverride`           | String to partially override common.names.name                                                                      | `""`            |
 | `fullnameOverride`       | String to fully override common.names.fullname                                                                      | `""`            |
 | `namespaceOverride`      | String to fully override common.names.namespace                                                                     | `""`            |

--- a/bitnami/cilium/templates/agent/vpa.yaml
+++ b/bitnami/cilium/templates/agent/vpa.yaml
@@ -3,7 +3,7 @@ Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- if and (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1/VerticalPodAutoscaler") .Values.agent.autoscaling.vpa.enabled }}
+{{- if and (include "common.capabilities.apiVersions.has" ( dict "version" "autoscaling.k8s.io/v1/VerticalPodAutoscaler" "context" . )) .Values.agent.autoscaling.vpa.enabled }}
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:

--- a/bitnami/cilium/templates/envoy/vpa.yaml
+++ b/bitnami/cilium/templates/envoy/vpa.yaml
@@ -3,7 +3,7 @@ Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- if and .Values.envoy.useDaemonSet (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1/VerticalPodAutoscaler") .Values.envoy.autoscaling.vpa.enabled }}
+{{- if and .Values.envoy.useDaemonSet (include "common.capabilities.apiVersions.has" ( dict "version" "autoscaling.k8s.io/v1/VerticalPodAutoscaler" "context" . )) .Values.envoy.autoscaling.vpa.enabled }}
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:

--- a/bitnami/cilium/templates/hubble-relay/vpa.yaml
+++ b/bitnami/cilium/templates/hubble-relay/vpa.yaml
@@ -3,7 +3,7 @@ Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- if and .Values.hubble.relay.enabled (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1/VerticalPodAutoscaler") .Values.hubble.relay.autoscaling.vpa.enabled }}
+{{- if and .Values.hubble.relay.enabled (include "common.capabilities.apiVersions.has" ( dict "version" "autoscaling.k8s.io/v1/VerticalPodAutoscaler" "context" . )) .Values.hubble.relay.autoscaling.vpa.enabled }}
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:

--- a/bitnami/cilium/templates/hubble-ui/vpa.yaml
+++ b/bitnami/cilium/templates/hubble-ui/vpa.yaml
@@ -3,7 +3,7 @@ Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- if and .Values.hubble.relay.enabled  .Values.hubble.ui.enabled (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1/VerticalPodAutoscaler") .Values.hubble.ui.autoscaling.vpa.enabled }}
+{{- if and .Values.hubble.relay.enabled  .Values.hubble.ui.enabled (include "common.capabilities.apiVersions.has" ( dict "version" "autoscaling.k8s.io/v1/VerticalPodAutoscaler" "context" . )) .Values.hubble.ui.autoscaling.vpa.enabled }}
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:

--- a/bitnami/cilium/templates/operator/vpa.yaml
+++ b/bitnami/cilium/templates/operator/vpa.yaml
@@ -3,7 +3,7 @@ Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- if and (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1/VerticalPodAutoscaler") .Values.operator.autoscaling.vpa.enabled }}
+{{- if and (include "common.capabilities.apiVersions.has" ( dict "version" "autoscaling.k8s.io/v1/VerticalPodAutoscaler" "context" . )) .Values.operator.autoscaling.vpa.enabled }}
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:

--- a/bitnami/cilium/values.yaml
+++ b/bitnami/cilium/values.yaml
@@ -42,6 +42,9 @@ global:
 ## @param kubeVersion Override Kubernetes version
 ##
 kubeVersion: ""
+## @param apiVersions Override Kubernetes API versions reported by .Capabilities
+##
+apiVersions: []
 ## @param nameOverride String to partially override common.names.name
 ##
 nameOverride: ""


### PR DESCRIPTION
### Description of the change

Replace references to ".Capabilities.APIVersions.Has" with the new common helper added at #31969

### Benefits

Rendering templates doesn't require a K8s cluster connection to check the API versions.

### Possible drawbacks

None

### Applicable issues

None

### Additional information

N/A

### Checklist

- [x] Chart version bumped in Chart.yaml according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
