### PR TITLE
[bitnami/dremio] feat: use new helper for checking API versions

### DIFF
--- a/bitnami/dremio/CHANGELOG.md
+++ b/bitnami/dremio/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.4.2 (2025-02-20)
+## 0.5.0 (2025-02-20)
 
 * [bitnami/dremio] feat: use new helper for checking API versions ([#32048](https://github.com/bitnami/charts/pull/32048))
 

--- a/bitnami/dremio/CHANGELOG.md
+++ b/bitnami/dremio/CHANGELOG.md
@@ -1,8 +1,14 @@
 # Changelog
 
-## 0.4.1 (2025-02-19)
+## 0.4.2 (2025-02-20)
 
-* [bitnami/dremio] Release 0.4.1 ([#31986](https://github.com/bitnami/charts/pull/31986))
+* [bitnami/dremio] feat: use new helper for checking API versions ([#32048](https://github.com/bitnami/charts/pull/32048))
+
+## <small>0.4.1 (2025-02-19)</small>
+
+* [bitnami/*] Use CDN url for the Bitnami Application Icons (#31881) ([d9bb11a](https://github.com/bitnami/charts/commit/d9bb11a9076b9bfdcc70ea022c25ef50e9713657)), closes [#31881](https://github.com/bitnami/charts/issues/31881)
+* [bitnami/dremio] Release 0.4.1 (#31986) ([f8e6c4a](https://github.com/bitnami/charts/commit/f8e6c4a2bfb8abe94ba5d52a19a496860a1f1a4f)), closes [#31986](https://github.com/bitnami/charts/issues/31986)
+* Update copyright year (#31682) ([e9f02f5](https://github.com/bitnami/charts/commit/e9f02f5007068751f7eb2270fece811e685c99b6)), closes [#31682](https://github.com/bitnami/charts/issues/31682)
 
 ## 0.4.0 (2025-01-29)
 

--- a/bitnami/dremio/Chart.yaml
+++ b/bitnami/dremio/Chart.yaml
@@ -14,31 +14,31 @@ annotations:
 apiVersion: v2
 appVersion: 25.2.0
 dependencies:
-- condition: minio.enabled
-  name: minio
-  repository: oci://registry-1.docker.io/bitnamicharts
-  version: 15.x.x
-- condition: zookeeper.enabled
-  name: zookeeper
-  repository: oci://registry-1.docker.io/bitnamicharts
-  version: 13.x.x
-- name: common
-  repository: oci://registry-1.docker.io/bitnamicharts
-  tags:
-  - bitnami-common
-  version: 2.x.x
+  - condition: minio.enabled
+    name: minio
+    repository: oci://registry-1.docker.io/bitnamicharts
+    version: 15.x.x
+  - condition: zookeeper.enabled
+    name: zookeeper
+    repository: oci://registry-1.docker.io/bitnamicharts
+    version: 13.x.x
+  - name: common
+    repository: oci://registry-1.docker.io/bitnamicharts
+    tags:
+      - bitnami-common
+    version: 2.x.x
 description: Dremio is an open-source self-service data access tool that provides high-performance queries for interactive analytics on data lakes.
 home: https://bitnami.com
 icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/dremio/img/dremio-stack-220x234.png
 keywords:
-- dremio
-- data-lake
+  - dremio
+  - data-lake
 maintainers:
-- name: Broadcom, Inc. All Rights Reserved.
-  url: https://github.com/bitnami/charts
+  - name: Broadcom, Inc. All Rights Reserved.
+    url: https://github.com/bitnami/charts
 name: dremio
 sources:
-- https://github.com/bitnami/charts/tree/main/bitnami/dremio
-- https://github.com/bitnami/containers/tree/main/bitnami/dremio
-- https://github.com/dremio/dremio-oss
-version: 0.4.1
+  - https://github.com/bitnami/charts/tree/main/bitnami/dremio
+  - https://github.com/bitnami/containers/tree/main/bitnami/dremio
+  - https://github.com/dremio/dremio-oss
+version: 0.4.2

--- a/bitnami/dremio/Chart.yaml
+++ b/bitnami/dremio/Chart.yaml
@@ -41,4 +41,4 @@ sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/dremio
   - https://github.com/bitnami/containers/tree/main/bitnami/dremio
   - https://github.com/dremio/dremio-oss
-version: 0.4.2
+version: 0.5.0

--- a/bitnami/dremio/README.md
+++ b/bitnami/dremio/README.md
@@ -556,6 +556,7 @@ There are cases where you may want to deploy extra objects, such a ConfigMap con
 | Name                     | Description                                                                             | Value           |
 | ------------------------ | --------------------------------------------------------------------------------------- | --------------- |
 | `kubeVersion`            | Override Kubernetes version                                                             | `""`            |
+| `apiVersions`            | Override Kubernetes API versions reported by .Capabilities                              | `[]`            |
 | `nameOverride`           | String to partially override common.names.name                                          | `""`            |
 | `fullnameOverride`       | String to fully override common.names.fullname                                          | `""`            |
 | `namespaceOverride`      | String to fully override common.names.namespace                                         | `""`            |

--- a/bitnami/dremio/templates/coordinator/vpa.yaml
+++ b/bitnami/dremio/templates/coordinator/vpa.yaml
@@ -3,7 +3,7 @@ Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- if and (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1/VerticalPodAutoscaler") .Values.coordinator.autoscaling.vpa.enabled }}
+{{- if and (include "common.capabilities.apiVersions.has" ( dict "version" "autoscaling.k8s.io/v1/VerticalPodAutoscaler" "context" . )) .Values.coordinator.autoscaling.vpa.enabled }}
 apiVersion: {{ include "common.capabilities.vpa.apiVersion" (dict "context" $) }}
 kind: VerticalPodAutoscaler
 metadata:

--- a/bitnami/dremio/templates/executor/vpa.yaml
+++ b/bitnami/dremio/templates/executor/vpa.yaml
@@ -14,7 +14,7 @@ SPDX-License-Identifier: APACHE-2.0
 {{- range $engine := .Values.executor.engines }}
 {{- $executorValues := mustMergeOverwrite $.Values.executor.common $engine.overrides }}
 
-{{- if and ($.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1/VerticalPodAutoscaler") $executorValues.autoscaling.vpa.enabled }}
+{{- if and ($include "common.capabilities.apiVersions.has" ( dict "version" "autoscaling.k8s.io/v1/VerticalPodAutoscaler" "context" . )) $executorValues.autoscaling.vpa.enabled }}
 ---
 apiVersion: {{ include "common.capabilities.vpa.apiVersion" (dict "context" $) }}
 kind: VerticalPodAutoscaler

--- a/bitnami/dremio/templates/executor/vpa.yaml
+++ b/bitnami/dremio/templates/executor/vpa.yaml
@@ -14,7 +14,7 @@ SPDX-License-Identifier: APACHE-2.0
 {{- range $engine := .Values.executor.engines }}
 {{- $executorValues := mustMergeOverwrite $.Values.executor.common $engine.overrides }}
 
-{{- if and ($include "common.capabilities.apiVersions.has" ( dict "version" "autoscaling.k8s.io/v1/VerticalPodAutoscaler" "context" . )) $executorValues.autoscaling.vpa.enabled }}
+{{- if and (include "common.capabilities.apiVersions.has" ( dict "version" "autoscaling.k8s.io/v1/VerticalPodAutoscaler" "context" $ )) $executorValues.autoscaling.vpa.enabled }}
 ---
 apiVersion: {{ include "common.capabilities.vpa.apiVersion" (dict "context" $) }}
 kind: VerticalPodAutoscaler

--- a/bitnami/dremio/templates/master-coordinator/vpa.yaml
+++ b/bitnami/dremio/templates/master-coordinator/vpa.yaml
@@ -3,7 +3,7 @@ Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- if and (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1/VerticalPodAutoscaler") .Values.masterCoordinator.autoscaling.vpa.enabled }}
+{{- if and (include "common.capabilities.apiVersions.has" ( dict "version" "autoscaling.k8s.io/v1/VerticalPodAutoscaler" "context" . )) .Values.masterCoordinator.autoscaling.vpa.enabled }}
 apiVersion: {{ include "common.capabilities.vpa.apiVersion" (dict "context" $) }}
 kind: VerticalPodAutoscaler
 metadata:

--- a/bitnami/dremio/values.yaml
+++ b/bitnami/dremio/values.yaml
@@ -42,6 +42,9 @@ global:
 ## @param kubeVersion Override Kubernetes version
 ##
 kubeVersion: ""
+## @param apiVersions Override Kubernetes API versions reported by .Capabilities
+##
+apiVersions: []
 ## @param nameOverride String to partially override common.names.name
 ##
 nameOverride: ""


### PR DESCRIPTION
### Description of the change

Replace references to ".Capabilities.APIVersions.Has" with the new common helper added at #31969

### Benefits

Rendering templates doesn't require a K8s cluster connection to check the API versions.

### Possible drawbacks

None

### Applicable issues

None

### Additional information

N/A

### Checklist

- [x] Chart version bumped in Chart.yaml according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
