### PR TITLE
[bitnami/fluent-bit] feat: use new helper for checking API versions

### DIFF
--- a/bitnami/fluent-bit/CHANGELOG.md
+++ b/bitnami/fluent-bit/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
-## 2.4.5 (2025-02-07)
+## 2.4.6 (2025-02-20)
 
-* [bitnami/fluent-bit] Release 2.4.5 ([#31835](https://github.com/bitnami/charts/pull/31835))
+* [bitnami/fluent-bit] feat: use new helper for checking API versions ([#32049](https://github.com/bitnami/charts/pull/32049))
+
+## <small>2.4.5 (2025-02-07)</small>
+
+* [bitnami/fluent-bit] Release 2.4.5 (#31835) ([ade7a48](https://github.com/bitnami/charts/commit/ade7a48bd37b52a6d70cecb1fa2670eb25480c72)), closes [#31835](https://github.com/bitnami/charts/issues/31835)
+* Update copyright year (#31682) ([e9f02f5](https://github.com/bitnami/charts/commit/e9f02f5007068751f7eb2270fece811e685c99b6)), closes [#31682](https://github.com/bitnami/charts/issues/31682)
 
 ## <small>2.4.4 (2025-01-24)</small>
 

--- a/bitnami/fluent-bit/CHANGELOG.md
+++ b/bitnami/fluent-bit/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2.4.6 (2025-02-20)
+## 2.5.0 (2025-02-20)
 
 * [bitnami/fluent-bit] feat: use new helper for checking API versions ([#32049](https://github.com/bitnami/charts/pull/32049))
 

--- a/bitnami/fluent-bit/Chart.lock
+++ b/bitnami/fluent-bit/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.29.1
-digest: sha256:0d3abbd4a9bdc95c1a5f504d253e347f723d9565222939020973dd3c4e1dd1f4
-generated: "2025-01-24T12:13:30.468615242Z"
+  version: 2.30.0
+digest: sha256:46afdf79eae69065904d430f03f7e5b79a148afed20aa45ee83ba88adc036169
+generated: "2025-02-20T08:55:51.288313+01:00"

--- a/bitnami/fluent-bit/Chart.yaml
+++ b/bitnami/fluent-bit/Chart.yaml
@@ -28,4 +28,4 @@ maintainers:
 name: fluent-bit
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/fluent-bit
-version: 2.4.6
+version: 2.5.0

--- a/bitnami/fluent-bit/Chart.yaml
+++ b/bitnami/fluent-bit/Chart.yaml
@@ -10,22 +10,22 @@ annotations:
 apiVersion: v2
 appVersion: 3.2.6
 dependencies:
-- name: common
-  repository: oci://registry-1.docker.io/bitnamicharts
-  tags:
-  - bitnami-common
-  version: 2.x.x
+  - name: common
+    repository: oci://registry-1.docker.io/bitnamicharts
+    tags:
+      - bitnami-common
+    version: 2.x.x
 description: Fluent Bit is a Fast and Lightweight Log Processor and Forwarder. It has been made with a strong focus on performance to allow the collection of events from different sources without complexity.
 home: https://bitnami.com
 icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/fluent-bit/img/fluent-bit-stack-220x234.png
 keywords:
-- fluent-bit
-- logging
-- monitoring
+  - fluent-bit
+  - logging
+  - monitoring
 maintainers:
-- name: Broadcom, Inc. All Rights Reserved.
-  url: https://github.com/bitnami/charts
+  - name: Broadcom, Inc. All Rights Reserved.
+    url: https://github.com/bitnami/charts
 name: fluent-bit
 sources:
-- https://github.com/bitnami/charts/tree/main/bitnami/fluent-bit
-version: 2.4.5
+  - https://github.com/bitnami/charts/tree/main/bitnami/fluent-bit
+version: 2.4.6

--- a/bitnami/fluent-bit/README.md
+++ b/bitnami/fluent-bit/README.md
@@ -150,6 +150,7 @@ The [Bitnami Fluent Bit](https://github.com/bitnami/containers/tree/main/bitnami
 
 | Name                     | Description                                                                             | Value          |
 | ------------------------ | --------------------------------------------------------------------------------------- | -------------- |
+| `apiVersions`            | Override Kubernetes API versions reported by .Capabilities                              | `[]`           |
 | `nameOverride`           | String to partially override common.names.fullname                                      | `""`           |
 | `fullnameOverride`       | String to fully override common.names.fullname                                          | `""`           |
 | `kubeVersion`            | Force target Kubernetes version (using Helm capabilities if not set)                    | `""`           |

--- a/bitnami/fluent-bit/templates/vpa.yaml
+++ b/bitnami/fluent-bit/templates/vpa.yaml
@@ -3,7 +3,7 @@ Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- if and (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1/VerticalPodAutoscaler") .Values.autoscaling.vpa.enabled }}
+{{- if and (include "common.capabilities.apiVersions.has" ( dict "version" "autoscaling.k8s.io/v1/VerticalPodAutoscaler" "context" . )) .Values.autoscaling.vpa.enabled }}
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:

--- a/bitnami/fluent-bit/values.yaml
+++ b/bitnami/fluent-bit/values.yaml
@@ -38,6 +38,9 @@ global:
 ## @section Common parameters
 ##
 
+## @param apiVersions Override Kubernetes API versions reported by .Capabilities
+##
+apiVersions: []
 ## @param nameOverride String to partially override common.names.fullname
 ##
 nameOverride: ""


### PR DESCRIPTION
### Description of the change

Replace references to ".Capabilities.APIVersions.Has" with the new common helper added at #31969

### Benefits

Rendering templates doesn't require a K8s cluster connection to check the API versions.

### Possible drawbacks

None

### Applicable issues

None

### Additional information

N/A

### Checklist

- [x] Chart version bumped in Chart.yaml according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
