### PR TITLE
[bitnami/kafka] feat: use new helper for checking API versions

### DIFF
--- a/bitnami/kafka/CHANGELOG.md
+++ b/bitnami/kafka/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 31.3.3 (2025-02-20)
+## 31.4.0 (2025-02-20)
 
 * [bitnami/kafka] feat: use new helper for checking API versions ([#32051](https://github.com/bitnami/charts/pull/32051))
 

--- a/bitnami/kafka/CHANGELOG.md
+++ b/bitnami/kafka/CHANGELOG.md
@@ -1,8 +1,14 @@
 # Changelog
 
-## 31.3.2 (2025-02-20)
+## 31.3.3 (2025-02-20)
 
-* [bitnami/kafka] Release 31.3.2 ([#32034](https://github.com/bitnami/charts/pull/32034))
+* [bitnami/kafka] feat: use new helper for checking API versions ([#32051](https://github.com/bitnami/charts/pull/32051))
+
+## <small>31.3.2 (2025-02-20)</small>
+
+* [bitnami/*] Use CDN url for the Bitnami Application Icons (#31881) ([d9bb11a](https://github.com/bitnami/charts/commit/d9bb11a9076b9bfdcc70ea022c25ef50e9713657)), closes [#31881](https://github.com/bitnami/charts/issues/31881)
+* [bitnami/kafka] Release 31.3.2 (#32034) ([3f4ca72](https://github.com/bitnami/charts/commit/3f4ca729b3192c7cc742da1ccefc0676e93cdd38)), closes [#32034](https://github.com/bitnami/charts/issues/32034)
+* Update copyright year (#31682) ([e9f02f5](https://github.com/bitnami/charts/commit/e9f02f5007068751f7eb2270fece811e685c99b6)), closes [#31682](https://github.com/bitnami/charts/issues/31682)
 
 ## <small>31.3.1 (2025-01-28)</small>
 

--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -40,4 +40,4 @@ maintainers:
 name: kafka
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/kafka
-version: 31.3.3
+version: 31.4.0

--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -16,28 +16,28 @@ annotations:
 apiVersion: v2
 appVersion: 3.9.0
 dependencies:
-- condition: zookeeper.enabled
-  name: zookeeper
-  repository: oci://registry-1.docker.io/bitnamicharts
-  version: 13.x.x
-- name: common
-  repository: oci://registry-1.docker.io/bitnamicharts
-  tags:
-  - bitnami-common
-  version: 2.x.x
+  - condition: zookeeper.enabled
+    name: zookeeper
+    repository: oci://registry-1.docker.io/bitnamicharts
+    version: 13.x.x
+  - name: common
+    repository: oci://registry-1.docker.io/bitnamicharts
+    tags:
+      - bitnami-common
+    version: 2.x.x
 description: Apache Kafka is a distributed streaming platform designed to build real-time pipelines and can be used as a message broker or as a replacement for a log aggregation solution for big data applications.
 home: https://bitnami.com
 icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/kafka/img/kafka-stack-220x234.png
 keywords:
-- kafka
-- zookeeper
-- streaming
-- producer
-- consumer
+  - kafka
+  - zookeeper
+  - streaming
+  - producer
+  - consumer
 maintainers:
-- name: Broadcom, Inc. All Rights Reserved.
-  url: https://github.com/bitnami/charts
+  - name: Broadcom, Inc. All Rights Reserved.
+    url: https://github.com/bitnami/charts
 name: kafka
 sources:
-- https://github.com/bitnami/charts/tree/main/bitnami/kafka
-version: 31.3.2
+  - https://github.com/bitnami/charts/tree/main/bitnami/kafka
+version: 31.3.3

--- a/bitnami/kafka/README.md
+++ b/bitnami/kafka/README.md
@@ -453,6 +453,7 @@ You can enable this initContainer by setting `volumePermissions.enabled` to `tru
 | Name                      | Description                                                                             | Value           |
 | ------------------------- | --------------------------------------------------------------------------------------- | --------------- |
 | `kubeVersion`             | Override Kubernetes version                                                             | `""`            |
+| `apiVersions`             | Override Kubernetes API versions reported by .Capabilities                              | `[]`            |
 | `nameOverride`            | String to partially override common.names.fullname                                      | `""`            |
 | `fullnameOverride`        | String to fully override common.names.fullname                                          | `""`            |
 | `clusterDomain`           | Default Kubernetes cluster domain                                                       | `cluster.local` |

--- a/bitnami/kafka/templates/broker/vpa.yaml
+++ b/bitnami/kafka/templates/broker/vpa.yaml
@@ -4,7 +4,7 @@ SPDX-License-Identifier: APACHE-2.0
 */}}
 
 {{- $replicaCount := int .Values.broker.replicaCount }}
-{{- if and (gt $replicaCount 0) (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1/VerticalPodAutoscaler") .Values.broker.autoscaling.vpa.enabled }}
+{{- if and (gt $replicaCount 0) (include "common.capabilities.apiVersions.has" ( dict "version" "autoscaling.k8s.io/v1/VerticalPodAutoscaler" "context" . )) .Values.broker.autoscaling.vpa.enabled }}
 apiVersion: {{ include "common.capabilities.vpa.apiVersion" . }}
 kind: VerticalPodAutoscaler
 metadata:

--- a/bitnami/kafka/templates/controller-eligible/vpa.yaml
+++ b/bitnami/kafka/templates/controller-eligible/vpa.yaml
@@ -4,7 +4,7 @@ SPDX-License-Identifier: APACHE-2.0
 */}}
 
 {{- $replicaCount := int .Values.controller.replicaCount }}
-{{- if and .Values.kraft.enabled (gt $replicaCount 0) (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1/VerticalPodAutoscaler") .Values.controller.autoscaling.vpa.enabled }}
+{{- if and .Values.kraft.enabled (gt $replicaCount 0) (include "common.capabilities.apiVersions.has" ( dict "version" "autoscaling.k8s.io/v1/VerticalPodAutoscaler" "context" . )) .Values.controller.autoscaling.vpa.enabled }}
 apiVersion: {{ include "common.capabilities.vpa.apiVersion" . }}
 kind: VerticalPodAutoscaler
 metadata:

--- a/bitnami/kafka/values.yaml
+++ b/bitnami/kafka/values.yaml
@@ -41,6 +41,9 @@ global:
 ## @param kubeVersion Override Kubernetes version
 ##
 kubeVersion: ""
+## @param apiVersions Override Kubernetes API versions reported by .Capabilities
+##
+apiVersions: []
 ## @param nameOverride String to partially override common.names.fullname
 ##
 nameOverride: ""


### PR DESCRIPTION
### Description of the change

Replace references to ".Capabilities.APIVersions.Has" with the new common helper added at #31969

### Benefits

Rendering templates doesn't require a K8s cluster connection to check the API versions.

### Possible drawbacks

None

### Applicable issues

None

### Additional information

N/A

### Checklist

- [x] Chart version bumped in Chart.yaml according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
