### PR TITLE
[bitnami/keydb] feat: use new helper for checking API versions

### DIFF
--- a/bitnami/keydb/CHANGELOG.md
+++ b/bitnami/keydb/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
-## 0.3.4 (2025-02-19)
+## 0.3.5 (2025-02-20)
 
-* [bitnami/keydb] Release 0.3.4 ([#32007](https://github.com/bitnami/charts/pull/32007))
+* [bitnami/keydb] feat: use new helper for checking API versions ([#32052](https://github.com/bitnami/charts/pull/32052))
+
+## <small>0.3.4 (2025-02-19)</small>
+
+* [bitnami/*] Use CDN url for the Bitnami Application Icons (#31881) ([d9bb11a](https://github.com/bitnami/charts/commit/d9bb11a9076b9bfdcc70ea022c25ef50e9713657)), closes [#31881](https://github.com/bitnami/charts/issues/31881)
+* [bitnami/keydb] Release 0.3.4 (#32007) ([ef47c33](https://github.com/bitnami/charts/commit/ef47c33b9933fe9404ac26c535aec9b4c4fdfd15)), closes [#32007](https://github.com/bitnami/charts/issues/32007)
 
 ## <small>0.3.3 (2025-02-05)</small>
 

--- a/bitnami/keydb/CHANGELOG.md
+++ b/bitnami/keydb/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.3.5 (2025-02-20)
+## 0.4.0 (2025-02-20)
 
 * [bitnami/keydb] feat: use new helper for checking API versions ([#32052](https://github.com/bitnami/charts/pull/32052))
 

--- a/bitnami/keydb/Chart.yaml
+++ b/bitnami/keydb/Chart.yaml
@@ -34,4 +34,4 @@ name: keydb
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/keydb
   - https://github.com/bitnami/containers/tree/main/bitnami/keydb
-version: 0.3.5
+version: 0.4.0

--- a/bitnami/keydb/Chart.yaml
+++ b/bitnami/keydb/Chart.yaml
@@ -14,24 +14,24 @@ annotations:
 apiVersion: v2
 appVersion: 6.3.4
 dependencies:
-- name: common
-  repository: oci://registry-1.docker.io/bitnamicharts
-  tags:
-  - bitnami-common
-  version: 2.x.x
+  - name: common
+    repository: oci://registry-1.docker.io/bitnamicharts
+    tags:
+      - bitnami-common
+    version: 2.x.x
 description: KeyDB is a high performance fork of Redis with a focus on multithreading, memory efficiency, and high throughput.
 home: https://bitnami.com
 icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/keydb/img/keydb-stack-220x234.png
 keywords:
-- keydb
-- keyvalue
-- database
-- cache
+  - keydb
+  - keyvalue
+  - database
+  - cache
 maintainers:
-- name: Broadcom, Inc. All Rights Reserved.
-  url: https://github.com/bitnami/charts
+  - name: Broadcom, Inc. All Rights Reserved.
+    url: https://github.com/bitnami/charts
 name: keydb
 sources:
-- https://github.com/bitnami/charts/tree/main/bitnami/keydb
-- https://github.com/bitnami/containers/tree/main/bitnami/keydb
-version: 0.3.4
+  - https://github.com/bitnami/charts/tree/main/bitnami/keydb
+  - https://github.com/bitnami/containers/tree/main/bitnami/keydb
+version: 0.3.5

--- a/bitnami/keydb/README.md
+++ b/bitnami/keydb/README.md
@@ -250,6 +250,7 @@ If you encounter errors when working with persistent volumes, refer to our [trou
 | Name                     | Description                                                                             | Value           |
 | ------------------------ | --------------------------------------------------------------------------------------- | --------------- |
 | `kubeVersion`            | Override Kubernetes version                                                             | `""`            |
+| `apiVersions`            | Override Kubernetes API versions reported by .Capabilities                              | `[]`            |
 | `nameOverride`           | String to partially override common.names.name                                          | `""`            |
 | `fullnameOverride`       | String to fully override common.names.fullname                                          | `""`            |
 | `namespaceOverride`      | String to fully override common.names.namespace                                         | `""`            |

--- a/bitnami/keydb/templates/master/vpa.yaml
+++ b/bitnami/keydb/templates/master/vpa.yaml
@@ -3,7 +3,7 @@ Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- if and (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1/VerticalPodAutoscaler") .Values.master.autoscaling.vpa.enabled }}
+{{- if and (include "common.capabilities.apiVersions.has" ( dict "version" "autoscaling.k8s.io/v1/VerticalPodAutoscaler" "context" . )) .Values.master.autoscaling.vpa.enabled }}
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:

--- a/bitnami/keydb/templates/replica/vpa.yaml
+++ b/bitnami/keydb/templates/replica/vpa.yaml
@@ -3,7 +3,7 @@ Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- if and (eq .Values.architecture "replication") (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1/VerticalPodAutoscaler") .Values.replica.autoscaling.vpa.enabled }}
+{{- if and (eq .Values.architecture "replication") (include "common.capabilities.apiVersions.has" ( dict "version" "autoscaling.k8s.io/v1/VerticalPodAutoscaler" "context" . )) .Values.replica.autoscaling.vpa.enabled }}
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:

--- a/bitnami/keydb/values.yaml
+++ b/bitnami/keydb/values.yaml
@@ -43,6 +43,9 @@ global:
 ## @param kubeVersion Override Kubernetes version
 ##
 kubeVersion: ""
+## @param apiVersions Override Kubernetes API versions reported by .Capabilities
+##
+apiVersions: []
 ## @param nameOverride String to partially override common.names.name
 ##
 nameOverride: ""


### PR DESCRIPTION
### Description of the change

Replace references to ".Capabilities.APIVersions.Has" with the new common helper added at #31969

### Benefits

Rendering templates doesn't require a K8s cluster connection to check the API versions.

### Possible drawbacks

None

### Applicable issues

None

### Additional information

N/A

### Checklist

- [x] Chart version bumped in Chart.yaml according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
