### PR TITLE
[bitnami/kong] feat: use new helper for checking API versions

### DIFF
--- a/bitnami/kong/CHANGELOG.md
+++ b/bitnami/kong/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
-## 15.1.3 (2025-02-19)
+## 15.1.4 (2025-02-20)
 
-* [bitnami/kong] Release 15.1.3 ([#32009](https://github.com/bitnami/charts/pull/32009))
+* [bitnami/kong] feat: use new helper for checking API versions ([#32053](https://github.com/bitnami/charts/pull/32053))
+
+## <small>15.1.3 (2025-02-19)</small>
+
+* [bitnami/*] Use CDN url for the Bitnami Application Icons (#31881) ([d9bb11a](https://github.com/bitnami/charts/commit/d9bb11a9076b9bfdcc70ea022c25ef50e9713657)), closes [#31881](https://github.com/bitnami/charts/issues/31881)
+* [bitnami/kong] Release 15.1.3 (#32009) ([3a82c75](https://github.com/bitnami/charts/commit/3a82c757bc8f0a231eb9884aebca1f11d58949e6)), closes [#32009](https://github.com/bitnami/charts/issues/32009)
 
 ## <small>15.1.2 (2025-02-04)</small>
 

--- a/bitnami/kong/CHANGELOG.md
+++ b/bitnami/kong/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 15.1.4 (2025-02-20)
+## 15.2.0 (2025-02-20)
 
 * [bitnami/kong] feat: use new helper for checking API versions ([#32053](https://github.com/bitnami/charts/pull/32053))
 

--- a/bitnami/kong/Chart.yaml
+++ b/bitnami/kong/Chart.yaml
@@ -43,4 +43,4 @@ maintainers:
 name: kong
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/kong
-version: 15.1.4
+version: 15.2.0

--- a/bitnami/kong/Chart.yaml
+++ b/bitnami/kong/Chart.yaml
@@ -12,35 +12,35 @@ annotations:
 apiVersion: v2
 appVersion: 3.9.0
 dependencies:
-- condition: postgresql.enabled
-  name: postgresql
-  repository: oci://registry-1.docker.io/bitnamicharts
-  version: 16.x.x
-- name: common
-  repository: oci://registry-1.docker.io/bitnamicharts
-  tags:
-  - bitnami-common
-  version: 2.x.x
-- condition: cassandra.enabled
-  name: cassandra
-  repository: oci://registry-1.docker.io/bitnamicharts
-  version: 12.x.x
+  - condition: postgresql.enabled
+    name: postgresql
+    repository: oci://registry-1.docker.io/bitnamicharts
+    version: 16.x.x
+  - name: common
+    repository: oci://registry-1.docker.io/bitnamicharts
+    tags:
+      - bitnami-common
+    version: 2.x.x
+  - condition: cassandra.enabled
+    name: cassandra
+    repository: oci://registry-1.docker.io/bitnamicharts
+    version: 12.x.x
 description: Kong is an open source Microservice API gateway and platform designed for managing microservices requests of high-availability, fault-tolerance, and distributed systems.
 home: https://bitnami.com
 icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/kong/img/kong-stack-220x234.png
 keywords:
-- kong
-- ingress
-- openresty
-- controller
-- http
-- web
-- www
-- reverse proxy
+  - kong
+  - ingress
+  - openresty
+  - controller
+  - http
+  - web
+  - www
+  - reverse proxy
 maintainers:
-- name: Broadcom, Inc. All Rights Reserved.
-  url: https://github.com/bitnami/charts
+  - name: Broadcom, Inc. All Rights Reserved.
+    url: https://github.com/bitnami/charts
 name: kong
 sources:
-- https://github.com/bitnami/charts/tree/main/bitnami/kong
-version: 15.1.3
+  - https://github.com/bitnami/charts/tree/main/bitnami/kong
+version: 15.1.4

--- a/bitnami/kong/README.md
+++ b/bitnami/kong/README.md
@@ -242,6 +242,7 @@ As an alternative, you can use of the preset configurations for pod affinity, po
 | Name                     | Description                                                                                               | Value           |
 | ------------------------ | --------------------------------------------------------------------------------------------------------- | --------------- |
 | `kubeVersion`            | Force target Kubernetes version (using Helm capabilities if not set)                                      | `""`            |
+| `apiVersions`            | Override Kubernetes API versions reported by .Capabilities                                                | `[]`            |
 | `nameOverride`           | String to partially override common.names.fullname template with a string (will prepend the release name) | `""`            |
 | `fullnameOverride`       | String to fully override common.names.fullname template with a string                                     | `""`            |
 | `commonAnnotations`      | Common annotations to add to all Kong resources (sub-charts are not considered). Evaluated as a template  | `{}`            |

--- a/bitnami/kong/templates/ingress-controller-rbac.yaml
+++ b/bitnami/kong/templates/ingress-controller-rbac.yaml
@@ -340,7 +340,7 @@ rules:
   - kongcustomentities
   verbs:
   - list
-{{- if or (.Capabilities.APIVersions.Has "gateway.networking.k8s.io/v1alpha2") (.Capabilities.APIVersions.Has "gateway.networking.k8s.io/v1beta1") (.Capabilities.APIVersions.Has "gateway.networking.k8s.io/v1")}}
+{{- if or (include "common.capabilities.apiVersions.has" ( dict "version" "gateway.networking.k8s.io/v1alpha2" "context" . )) (include "common.capabilities.apiVersions.has" ( dict "version" "gateway.networking.k8s.io/v1beta1" "context" . )) (include "common.capabilities.apiVersions.has" ( dict "version" "gateway.networking.k8s.io/v1" "context" . )) }}
 - apiGroups:
   - gateway.networking.k8s.io
   resources:
@@ -463,7 +463,7 @@ rules:
   - patch
   - update
 {{- end }}
-{{- if (.Capabilities.APIVersions.Has "networking.internal.knative.dev/v1alpha1") }}
+{{- if include "common.capabilities.apiVersions.has" ( dict "version" "networking.internal.knative.dev/v1alpha1" "context" . ) }}
 - apiGroups:
   - networking.internal.knative.dev
   resources:
@@ -576,7 +576,7 @@ rules:
   verbs:
   - list
   - watch
-{{- if or (.Capabilities.APIVersions.Has "gateway.networking.k8s.io/v1alpha2") (.Capabilities.APIVersions.Has "gateway.networking.k8s.io/v1beta1") (.Capabilities.APIVersions.Has "gateway.networking.k8s.io/v1")}}
+{{- if or (include "common.capabilities.apiVersions.has" ( dict "version" "gateway.networking.k8s.io/v1alpha2" "context" . )) (include "common.capabilities.apiVersions.has" ( dict "version" "gateway.networking.k8s.io/v1beta1" "context" . )) (include "common.capabilities.apiVersions.has" ( dict "version" "gateway.networking.k8s.io/v1" "context" . )) }}
 - apiGroups:
   - gateway.networking.k8s.io
   resources:

--- a/bitnami/kong/values.yaml
+++ b/bitnami/kong/values.yaml
@@ -40,6 +40,9 @@ global:
 ## @param kubeVersion Force target Kubernetes version (using Helm capabilities if not set)
 ##
 kubeVersion: ""
+## @param apiVersions Override Kubernetes API versions reported by .Capabilities
+##
+apiVersions: []
 ## @param nameOverride String to partially override common.names.fullname template with a string (will prepend the release name)
 ##
 nameOverride: ""


### PR DESCRIPTION
### Description of the change

Replace references to ".Capabilities.APIVersions.Has" with the new common helper added at #31969

### Benefits

Rendering templates doesn't require a K8s cluster connection to check the API versions.

### Possible drawbacks

None

### Applicable issues

None

### Additional information

N/A

### Checklist

- [x] Chart version bumped in Chart.yaml according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
