### PR TITLE
[bitnami/kuberay] feat: use new helper for checking API versions

### DIFF
--- a/bitnami/kuberay/CHANGELOG.md
+++ b/bitnami/kuberay/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 1.3.7 (2025-02-19)
+## 1.3.8 (2025-02-20)
 
-* [bitnami/kuberay] Release 1.3.7 ([#32012](https://github.com/bitnami/charts/pull/32012))
+* [bitnami/kuberay] feat: use new helper for checking API versions ([#32054](https://github.com/bitnami/charts/pull/32054))
+
+## <small>1.3.7 (2025-02-19)</small>
+
+* [bitnami/kuberay] Release 1.3.7 (#32012) ([3a282d6](https://github.com/bitnami/charts/commit/3a282d6e4d9a70037d7c4cde9bc7b009d113741c)), closes [#32012](https://github.com/bitnami/charts/issues/32012)
 
 ## <small>1.3.6 (2025-02-12)</small>
 

--- a/bitnami/kuberay/CHANGELOG.md
+++ b/bitnami/kuberay/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.3.8 (2025-02-20)
+## 1.4.0 (2025-02-20)
 
 * [bitnami/kuberay] feat: use new helper for checking API versions ([#32054](https://github.com/bitnami/charts/pull/32054))
 

--- a/bitnami/kuberay/Chart.yaml
+++ b/bitnami/kuberay/Chart.yaml
@@ -32,4 +32,4 @@ maintainers:
 name: kuberay
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/kuberay
-version: 1.3.8
+version: 1.4.0

--- a/bitnami/kuberay/Chart.yaml
+++ b/bitnami/kuberay/Chart.yaml
@@ -14,22 +14,22 @@ annotations:
 apiVersion: v2
 appVersion: 1.3.0
 dependencies:
-- name: common
-  repository: oci://registry-1.docker.io/bitnamicharts
-  tags:
-  - bitnami-common
-  version: 2.x.x
+  - name: common
+    repository: oci://registry-1.docker.io/bitnamicharts
+    tags:
+      - bitnami-common
+    version: 2.x.x
 description: KubeRay is a Kubernetes operator for deploying and management of Ray applications on Kubernetes using CustomResourceDefinitions.
 home: https://bitnami.com
 icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/kuberay/img/kuberay-stack-220x234.png
 keywords:
-- ray
-- machine-learning
-- kuberay
+  - ray
+  - machine-learning
+  - kuberay
 maintainers:
-- name: Broadcom, Inc. All Rights Reserved.
-  url: https://github.com/bitnami/charts
+  - name: Broadcom, Inc. All Rights Reserved.
+    url: https://github.com/bitnami/charts
 name: kuberay
 sources:
-- https://github.com/bitnami/charts/tree/main/bitnami/kuberay
-version: 1.3.7
+  - https://github.com/bitnami/charts/tree/main/bitnami/kuberay
+version: 1.3.8

--- a/bitnami/kuberay/README.md
+++ b/bitnami/kuberay/README.md
@@ -158,6 +158,7 @@ As an alternative, use one of the preset configurations for pod affinity, pod an
 | Name                     | Description                                                                                                                                      | Value                 |
 | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------- |
 | `kubeVersion`            | Override Kubernetes version                                                                                                                      | `""`                  |
+| `apiVersions`            | Override Kubernetes API versions reported by .Capabilities                                                                                       | `[]`                  |
 | `nameOverride`           | String to partially override common.names.name                                                                                                   | `""`                  |
 | `fullnameOverride`       | String to fully override common.names.fullname                                                                                                   | `""`                  |
 | `namespaceOverride`      | String to fully override common.names.namespace                                                                                                  | `""`                  |

--- a/bitnami/kuberay/templates/apiserver/vpa.yaml
+++ b/bitnami/kuberay/templates/apiserver/vpa.yaml
@@ -3,7 +3,7 @@ Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- if and (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1/VerticalPodAutoscaler") .Values.apiserver.autoscaling.vpa.enabled }}
+{{- if and (include "common.capabilities.apiVersions.has" ( dict "version" "autoscaling.k8s.io/v1/VerticalPodAutoscaler" "context" . )) .Values.apiserver.autoscaling.vpa.enabled }}
 apiVersion: {{ include "common.capabilities.vpa.apiVersion" . }}
 kind: VerticalPodAutoscaler
 metadata:

--- a/bitnami/kuberay/templates/operator/vpa.yaml
+++ b/bitnami/kuberay/templates/operator/vpa.yaml
@@ -3,7 +3,7 @@ Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- if and (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1/VerticalPodAutoscaler") .Values.operator.autoscaling.vpa.enabled }}
+{{- if and (include "common.capabilities.apiVersions.has" ( dict "version" "autoscaling.k8s.io/v1/VerticalPodAutoscaler" "context" . )) .Values.operator.autoscaling.vpa.enabled }}
 apiVersion: {{ include "common.capabilities.vpa.apiVersion" . }}
 kind: VerticalPodAutoscaler
 metadata:

--- a/bitnami/kuberay/values.yaml
+++ b/bitnami/kuberay/values.yaml
@@ -41,6 +41,9 @@ global:
 ## @param kubeVersion Override Kubernetes version
 ##
 kubeVersion: ""
+## @param apiVersions Override Kubernetes API versions reported by .Capabilities
+##
+apiVersions: []
 ## @param nameOverride String to partially override common.names.name
 ##
 nameOverride: ""


### PR DESCRIPTION
### Description of the change

Replace references to ".Capabilities.APIVersions.Has" with the new common helper added at #31969

### Benefits

Rendering templates doesn't require a K8s cluster connection to check the API versions.

### Possible drawbacks

None

### Applicable issues

None

### Additional information

N/A

### Checklist

- [x] Chart version bumped in Chart.yaml according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
