### PR TITLE
[bitnami/kubernetes-event-exporter] feat: use new helper for checking API versions

### DIFF
--- a/.vib/kubernetes-event-exporter/ginkgo/integration_suite_test.go
+++ b/.vib/kubernetes-event-exporter/ginkgo/integration_suite_test.go
@@ -67,8 +67,8 @@ func createPodOrDie(ctx context.Context, c cv1.PodsGetter, name string, image st
 		Spec: v1.PodSpec{
 			Containers: []v1.Container{
 				{
-					Name:  name,
-					Image: image,
+					Name:            name,
+					Image:           image,
 					SecurityContext: securityContext,
 				},
 			},
@@ -124,6 +124,9 @@ func containerLogsContainPattern(ctx context.Context, c cv1.PodsGetter, podLabel
 	var containerLogs []string
 
 	k8seePods = getPodsByLabelOrDie(ctx, c, podLabel)
+	if len(k8seePods.Items) == 0 {
+		return false, fmt.Errorf("No pods found with label %q", podLabel)
+	}
 	containerLogs = getContainerLogsOrDie(ctx, c, k8seePods.Items[0].GetName(), containerName)
 
 	return containsPattern(containerLogs, pattern)

--- a/.vib/kubernetes-event-exporter/ginkgo/kubernetes_event_exporter.go
+++ b/.vib/kubernetes-event-exporter/ginkgo/kubernetes_event_exporter.go
@@ -43,7 +43,7 @@ var _ = Describe("Kubernetes Event Exporter:", func() {
 
 		Describe("the exporter logs", func() {
 			It("shows its kubernetes events", func() {
-				pattern := "event=.*Created container nginx-" + *namespace + ".*sink=.*dump"
+				pattern := "event=.*Created container: nginx-" + *namespace + ".*sink=.*dump"
 				podLabel := "app.kubernetes.io/name=kubernetes-event-exporter"
 				containerName := "event-exporter"
 

--- a/bitnami/kubernetes-event-exporter/CHANGELOG.md
+++ b/bitnami/kubernetes-event-exporter/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
-## 3.3.5 (2025-02-12)
+## 3.3.6 (2025-02-20)
 
-* [bitnami/kubernetes-event-exporter] Release 3.3.5 ([#31894](https://github.com/bitnami/charts/pull/31894))
+* [bitnami/kubernetes-event-exporter] feat: use new helper for checking API versions ([#32055](https://github.com/bitnami/charts/pull/32055))
+
+## <small>3.3.5 (2025-02-12)</small>
+
+* [bitnami/*] Use CDN url for the Bitnami Application Icons (#31881) ([d9bb11a](https://github.com/bitnami/charts/commit/d9bb11a9076b9bfdcc70ea022c25ef50e9713657)), closes [#31881](https://github.com/bitnami/charts/issues/31881)
+* [bitnami/kubernetes-event-exporter] Release 3.3.5 (#31894) ([cd0fea6](https://github.com/bitnami/charts/commit/cd0fea6315f24d97c50e26951ad70f644ed37787)), closes [#31894](https://github.com/bitnami/charts/issues/31894)
 
 ## <small>3.3.4 (2025-02-05)</small>
 

--- a/bitnami/kubernetes-event-exporter/CHANGELOG.md
+++ b/bitnami/kubernetes-event-exporter/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 3.3.6 (2025-02-20)
+## 3.4.0 (2025-02-20)
 
 * [bitnami/kubernetes-event-exporter] feat: use new helper for checking API versions ([#32055](https://github.com/bitnami/charts/pull/32055))
 

--- a/bitnami/kubernetes-event-exporter/Chart.lock
+++ b/bitnami/kubernetes-event-exporter/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.29.1
-digest: sha256:0d3abbd4a9bdc95c1a5f504d253e347f723d9565222939020973dd3c4e1dd1f4
-generated: "2025-01-24T14:53:27.729582267Z"
+  version: 2.30.0
+digest: sha256:46afdf79eae69065904d430f03f7e5b79a148afed20aa45ee83ba88adc036169
+generated: "2025-02-20T08:56:27.199403+01:00"

--- a/bitnami/kubernetes-event-exporter/Chart.yaml
+++ b/bitnami/kubernetes-event-exporter/Chart.yaml
@@ -31,4 +31,4 @@ maintainers:
 name: kubernetes-event-exporter
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/kubernetes-event-exporter
-version: 3.3.6
+version: 3.4.0

--- a/bitnami/kubernetes-event-exporter/Chart.yaml
+++ b/bitnami/kubernetes-event-exporter/Chart.yaml
@@ -10,25 +10,25 @@ annotations:
 apiVersion: v2
 appVersion: 1.7.0
 dependencies:
-- name: common
-  repository: oci://registry-1.docker.io/bitnamicharts
-  tags:
-  - bitnami-common
-  version: 2.x.x
+  - name: common
+    repository: oci://registry-1.docker.io/bitnamicharts
+    tags:
+      - bitnami-common
+    version: 2.x.x
 description: Kubernetes Event Exporter makes it easy to export Kubernetes events to other tools, thereby enabling better event observability, custom alerts and aggregation.
 home: https://bitnami.com
 icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/kubernetes-event-exporter/img/kubernetes-event-exporter-stack-220x234.png
 keywords:
-- alerting
-- event exporting
-- events
-- kubernetes events
-- monitoring
-- observability
+  - alerting
+  - event exporting
+  - events
+  - kubernetes events
+  - monitoring
+  - observability
 maintainers:
-- name: Broadcom, Inc. All Rights Reserved.
-  url: https://github.com/bitnami/charts
+  - name: Broadcom, Inc. All Rights Reserved.
+    url: https://github.com/bitnami/charts
 name: kubernetes-event-exporter
 sources:
-- https://github.com/bitnami/charts/tree/main/bitnami/kubernetes-event-exporter
-version: 3.3.5
+  - https://github.com/bitnami/charts/tree/main/bitnami/kubernetes-event-exporter
+version: 3.3.6

--- a/bitnami/kubernetes-event-exporter/README.md
+++ b/bitnami/kubernetes-event-exporter/README.md
@@ -103,6 +103,7 @@ To back up and restore Helm chart deployments on Kubernetes, you need to back up
 | Name                     | Description                                                                                              | Value          |
 | ------------------------ | -------------------------------------------------------------------------------------------------------- | -------------- |
 | `kubeVersion`            | Override Kubernetes version                                                                              | `""`           |
+| `apiVersions`            | Override Kubernetes API versions reported by .Capabilities                                               | `[]`           |
 | `nameOverride`           | String to partially override kubernetes-event-exporter.fullname include (will maintain the release name) | `""`           |
 | `fullnameOverride`       | String to fully override kubernetes-event-exporter.fullname template                                     | `""`           |
 | `commonAnnotations`      | Annotations to add to all deployed objects                                                               | `{}`           |

--- a/bitnami/kubernetes-event-exporter/templates/vpa.yaml
+++ b/bitnami/kubernetes-event-exporter/templates/vpa.yaml
@@ -3,7 +3,7 @@ Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- if and (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1/VerticalPodAutoscaler") .Values.autoscaling.vpa.enabled }}
+{{- if and (include "common.capabilities.apiVersions.has" ( dict "version" "autoscaling.k8s.io/v1/VerticalPodAutoscaler" "context" . )) .Values.autoscaling.vpa.enabled }}
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:

--- a/bitnami/kubernetes-event-exporter/values.yaml
+++ b/bitnami/kubernetes-event-exporter/values.yaml
@@ -35,6 +35,9 @@ global:
 ## @param kubeVersion Override Kubernetes version
 ##
 kubeVersion: ""
+## @param apiVersions Override Kubernetes API versions reported by .Capabilities
+##
+apiVersions: []
 ## @param nameOverride String to partially override kubernetes-event-exporter.fullname include (will maintain the release name)
 ##
 nameOverride: ""


### PR DESCRIPTION
### Description of the change

Replace references to ".Capabilities.APIVersions.Has" with the new common helper added at #31969

### Benefits

Rendering templates doesn't require a K8s cluster connection to check the API versions.

### Possible drawbacks

None

### Applicable issues

None

### Additional information

N/A

### Checklist

- [x] Chart version bumped in Chart.yaml according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
