### PR TITLE
[bitnami/metrics-server] feat: use new helper for checking API versions

### DIFF
--- a/bitnami/metrics-server/CHANGELOG.md
+++ b/bitnami/metrics-server/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 7.3.6 (2025-02-19)
+## 7.3.7 (2025-02-20)
 
-* [bitnami/metrics-server] Release 7.3.6 ([#32017](https://github.com/bitnami/charts/pull/32017))
+* [bitnami/metrics-server] feat: use new helper for checking API versions ([#32056](https://github.com/bitnami/charts/pull/32056))
+
+## <small>7.3.6 (2025-02-19)</small>
+
+* [bitnami/metrics-server] Release 7.3.6 (#32017) ([acd94b1](https://github.com/bitnami/charts/commit/acd94b1f2c3fa2f62d6340f8394b3fddc0144724)), closes [#32017](https://github.com/bitnami/charts/issues/32017)
 
 ## <small>7.3.5 (2025-02-12)</small>
 

--- a/bitnami/metrics-server/CHANGELOG.md
+++ b/bitnami/metrics-server/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 7.3.7 (2025-02-20)
+## 7.4.0 (2025-02-20)
 
 * [bitnami/metrics-server] feat: use new helper for checking API versions ([#32056](https://github.com/bitnami/charts/pull/32056))
 

--- a/bitnami/metrics-server/Chart.yaml
+++ b/bitnami/metrics-server/Chart.yaml
@@ -28,4 +28,4 @@ maintainers:
 name: metrics-server
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/metrics-server
-version: 7.3.7
+version: 7.4.0

--- a/bitnami/metrics-server/Chart.yaml
+++ b/bitnami/metrics-server/Chart.yaml
@@ -10,22 +10,22 @@ annotations:
 apiVersion: v2
 appVersion: 0.7.2
 dependencies:
-- name: common
-  repository: oci://registry-1.docker.io/bitnamicharts
-  tags:
-  - bitnami-common
-  version: 2.x.x
+  - name: common
+    repository: oci://registry-1.docker.io/bitnamicharts
+    tags:
+      - bitnami-common
+    version: 2.x.x
 description: Metrics Server aggregates resource usage data, such as container CPU and memory usage, in a Kubernetes cluster and makes it available via the Metrics API.
 home: https://bitnami.com
 icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/metrics-server/img/metrics-server-stack-220x234.png
 keywords:
-- metrics-server
-- cluster
-- metrics
+  - metrics-server
+  - cluster
+  - metrics
 maintainers:
-- name: Broadcom, Inc. All Rights Reserved.
-  url: https://github.com/bitnami/charts
+  - name: Broadcom, Inc. All Rights Reserved.
+    url: https://github.com/bitnami/charts
 name: metrics-server
 sources:
-- https://github.com/bitnami/charts/tree/main/bitnami/metrics-server
-version: 7.3.6
+  - https://github.com/bitnami/charts/tree/main/bitnami/metrics-server
+version: 7.3.7

--- a/bitnami/metrics-server/README.md
+++ b/bitnami/metrics-server/README.md
@@ -89,6 +89,7 @@ To back up and restore Helm chart deployments on Kubernetes, you need to back up
 | Name                     | Description                                                                                  | Value          |
 | ------------------------ | -------------------------------------------------------------------------------------------- | -------------- |
 | `kubeVersion`            | Force target Kubernetes version (using Helm capabilities if not set)                         | `""`           |
+| `apiVersions`            | Override Kubernetes API versions reported by .Capabilities                                   | `[]`           |
 | `nameOverride`           | String to partially override common.names.fullname template (will maintain the release name) | `""`           |
 | `fullnameOverride`       | String to fully override common.names.fullname template                                      | `""`           |
 | `namespaceOverride`      | String to fully override common.names.namespace                                              | `""`           |

--- a/bitnami/metrics-server/templates/NOTES.txt
+++ b/bitnami/metrics-server/templates/NOTES.txt
@@ -8,7 +8,7 @@ Did you know there are enterprise versions of the Bitnami catalog? For enhanced 
 
 The metric server has been deployed.
 
-{{- if or .Values.apiService.create (.Capabilities.APIVersions.Has "metrics.k8s.io/v1beta1") }}
+{{- if or .Values.apiService.create (include "common.capabilities.apiVersions.has" ( dict "version" "metrics.k8s.io/v1beta1" "context" . )) }}
 {{- if .Values.diagnosticMode.enabled }}
 The chart has been deployed in diagnostic mode. All probes have been disabled and the command has been overwritten with:
 

--- a/bitnami/metrics-server/values.yaml
+++ b/bitnami/metrics-server/values.yaml
@@ -35,6 +35,9 @@ global:
 ## @param kubeVersion Force target Kubernetes version (using Helm capabilities if not set)
 ##
 kubeVersion: ""
+## @param apiVersions Override Kubernetes API versions reported by .Capabilities
+##
+apiVersions: []
 ## @param nameOverride String to partially override common.names.fullname template (will maintain the release name)
 ##
 nameOverride: ""


### PR DESCRIPTION
### Description of the change

Replace references to ".Capabilities.APIVersions.Has" with the new common helper added at #31969

### Benefits

Rendering templates doesn't require a K8s cluster connection to check the API versions.

### Possible drawbacks

None

### Applicable issues

None

### Additional information

N/A

### Checklist

- [x] Chart version bumped in Chart.yaml according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
