### PR TITLE
[bitnami/mlflow] feat: use new helper for checking API versions

### DIFF
--- a/bitnami/mlflow/CHANGELOG.md
+++ b/bitnami/mlflow/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2.4.2 (2025-02-20)
+## 2.5.0 (2025-02-20)
 
 * [bitnami/mlflow] feat: use new helper for checking API versions ([#32058](https://github.com/bitnami/charts/pull/32058))
 

--- a/bitnami/mlflow/CHANGELOG.md
+++ b/bitnami/mlflow/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 2.4.1 (2025-01-30)
+## 2.4.2 (2025-02-20)
 
-* [bitnami/mlflow] Release 2.4.1 ([#31679](https://github.com/bitnami/charts/pull/31679))
+* [bitnami/mlflow] feat: use new helper for checking API versions ([#32058](https://github.com/bitnami/charts/pull/32058))
+
+## <small>2.4.1 (2025-01-30)</small>
+
+* [bitnami/mlflow] Release 2.4.1 (#31679) ([c06f0c7](https://github.com/bitnami/charts/commit/c06f0c7ebd4860319a1f0282c775be9c7e27d147)), closes [#31679](https://github.com/bitnami/charts/issues/31679)
 
 ## 2.4.0 (2025-01-29)
 

--- a/bitnami/mlflow/Chart.lock
+++ b/bitnami/mlflow/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: minio
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 15.0.0
+  version: 15.0.3
 - name: postgresql
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 16.4.5
+  version: 16.4.9
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.29.1
-digest: sha256:a20df562796651ec5f8a367fb5a3fc5db4291e7a3199f9550cfbcaaae0de1d3d
-generated: "2025-01-29T14:33:30.041874+01:00"
+  version: 2.30.0
+digest: sha256:7e4bca2f1925f0c326e444928bfb908f44d6595353e9a5efffd84630d6b1611d
+generated: "2025-02-20T08:56:48.847871+01:00"

--- a/bitnami/mlflow/Chart.yaml
+++ b/bitnami/mlflow/Chart.yaml
@@ -44,4 +44,4 @@ sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/mlflow
   - https://github.com/bitnami/containers/tree/main/bitnami/mlflow
   - https://github.com/mlflow/mlflow
-version: 2.4.2
+version: 2.5.0

--- a/bitnami/mlflow/Chart.yaml
+++ b/bitnami/mlflow/Chart.yaml
@@ -14,34 +14,34 @@ annotations:
 apiVersion: v2
 appVersion: 2.20.1
 dependencies:
-- condition: minio.enabled
-  name: minio
-  repository: oci://registry-1.docker.io/bitnamicharts
-  version: 15.x.x
-- condition: postgresql.enabled
-  name: postgresql
-  repository: oci://registry-1.docker.io/bitnamicharts
-  version: 16.x.x
-- name: common
-  repository: oci://registry-1.docker.io/bitnamicharts
-  tags:
-  - bitnami-common
-  version: 2.x.x
+  - condition: minio.enabled
+    name: minio
+    repository: oci://registry-1.docker.io/bitnamicharts
+    version: 15.x.x
+  - condition: postgresql.enabled
+    name: postgresql
+    repository: oci://registry-1.docker.io/bitnamicharts
+    version: 16.x.x
+  - name: common
+    repository: oci://registry-1.docker.io/bitnamicharts
+    tags:
+      - bitnami-common
+    version: 2.x.x
 description: MLflow is an open-source platform designed to manage the end-to-end machine learning lifecycle. It allows you to track experiments, package code into reproducible runs, and share and deploy models.
 home: https://bitnami.com
 icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/mlflow/img/mlflow-stack-220x234.png
 keywords:
-- mlflow
-- models
-- python
-- machine
-- learning
+  - mlflow
+  - models
+  - python
+  - machine
+  - learning
 maintainers:
-- name: Broadcom, Inc. All Rights Reserved.
-  url: https://github.com/bitnami/charts
+  - name: Broadcom, Inc. All Rights Reserved.
+    url: https://github.com/bitnami/charts
 name: mlflow
 sources:
-- https://github.com/bitnami/charts/tree/main/bitnami/mlflow
-- https://github.com/bitnami/containers/tree/main/bitnami/mlflow
-- https://github.com/mlflow/mlflow
-version: 2.4.1
+  - https://github.com/bitnami/charts/tree/main/bitnami/mlflow
+  - https://github.com/bitnami/containers/tree/main/bitnami/mlflow
+  - https://github.com/mlflow/mlflow
+version: 2.4.2

--- a/bitnami/mlflow/README.md
+++ b/bitnami/mlflow/README.md
@@ -100,6 +100,7 @@ To back up and restore Helm chart deployments on Kubernetes, you need to back up
 | Name                     | Description                                                                             | Value           |
 | ------------------------ | --------------------------------------------------------------------------------------- | --------------- |
 | `kubeVersion`            | Override Kubernetes version                                                             | `""`            |
+| `apiVersions`            | Override Kubernetes API versions reported by .Capabilities                              | `[]`            |
 | `nameOverride`           | String to partially override common.names.name                                          | `""`            |
 | `fullnameOverride`       | String to fully override common.names.fullname                                          | `""`            |
 | `namespaceOverride`      | String to fully override common.names.namespace                                         | `""`            |

--- a/bitnami/mlflow/templates/tracking/vpa.yaml
+++ b/bitnami/mlflow/templates/tracking/vpa.yaml
@@ -3,7 +3,7 @@ Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- if and (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1/VerticalPodAutoscaler") .Values.tracking.autoscaling.vpa.enabled }}
+{{- if and (include "common.capabilities.apiVersions.has" ( dict "version" "autoscaling.k8s.io/v1/VerticalPodAutoscaler" "context" . )) .Values.tracking.autoscaling.vpa.enabled }}
 apiVersion: {{ include "common.capabilities.vpa.apiVersion" . }}
 kind: VerticalPodAutoscaler
 metadata:

--- a/bitnami/mlflow/values.yaml
+++ b/bitnami/mlflow/values.yaml
@@ -41,6 +41,9 @@ global:
 ## @param kubeVersion Override Kubernetes version
 ##
 kubeVersion: ""
+## @param apiVersions Override Kubernetes API versions reported by .Capabilities
+##
+apiVersions: []
 ## @param nameOverride String to partially override common.names.name
 ##
 nameOverride: ""


### PR DESCRIPTION
### Description of the change

Replace references to ".Capabilities.APIVersions.Has" with the new common helper added at #31969

### Benefits

Rendering templates doesn't require a K8s cluster connection to check the API versions.

### Possible drawbacks

None

### Applicable issues

None

### Additional information

N/A

### Checklist

- [x] Chart version bumped in Chart.yaml according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
