### PR TITLE
[bitnami/neo4j] feat: use new helper for checking API versions

### DIFF
--- a/bitnami/neo4j/CHANGELOG.md
+++ b/bitnami/neo4j/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
-## 0.2.5 (2025-02-19)
+## 0.2.6 (2025-02-20)
 
-* [bitnami/neo4j] Release 0.2.5 ([#32022](https://github.com/bitnami/charts/pull/32022))
+* [bitnami/neo4j] feat: use new helper for checking API versions ([#32059](https://github.com/bitnami/charts/pull/32059))
+
+## <small>0.2.5 (2025-02-20)</small>
+
+* [bitnami/*] Use CDN url for the Bitnami Application Icons (#31881) ([d9bb11a](https://github.com/bitnami/charts/commit/d9bb11a9076b9bfdcc70ea022c25ef50e9713657)), closes [#31881](https://github.com/bitnami/charts/issues/31881)
+* [bitnami/neo4j] Release 0.2.5 (#32022) ([0fe999a](https://github.com/bitnami/charts/commit/0fe999af5041f466a4b0913670c16adf766ef693)), closes [#32022](https://github.com/bitnami/charts/issues/32022)
 
 ## <small>0.2.4 (2025-02-05)</small>
 

--- a/bitnami/neo4j/CHANGELOG.md
+++ b/bitnami/neo4j/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.2.6 (2025-02-20)
+## 0.3.0 (2025-02-20)
 
 * [bitnami/neo4j] feat: use new helper for checking API versions ([#32059](https://github.com/bitnami/charts/pull/32059))
 

--- a/bitnami/neo4j/Chart.yaml
+++ b/bitnami/neo4j/Chart.yaml
@@ -12,27 +12,27 @@ annotations:
 apiVersion: v2
 appVersion: 5.26.2
 dependencies:
-- name: common
-  repository: oci://registry-1.docker.io/bitnamicharts
-  tags:
-  - bitnami-common
-  version: 2.x.x
+  - name: common
+    repository: oci://registry-1.docker.io/bitnamicharts
+    tags:
+      - bitnami-common
+    version: 2.x.x
 description: Neo4j is a high performance graph store with all the features expected of a mature and robust database, like a friendly query language and ACID transactions.
 home: https://bitnami.com
 icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/neo4j/img/neo4j-stack-220x234.png
 keywords:
-- database
-- neo4j
-- graph
-- graphdb
-- graph-database
-- nosql
+  - database
+  - neo4j
+  - graph
+  - graphdb
+  - graph-database
+  - nosql
 maintainers:
-- name: Broadcom, Inc. All Rights Reserved.
-  url: https://github.com/bitnami/charts
+  - name: Broadcom, Inc. All Rights Reserved.
+    url: https://github.com/bitnami/charts
 name: neo4j
 sources:
-- https://github.com/bitnami/charts/tree/main/bitnami/neo4j
-- https://github.com/bitnami/containers/tree/main/bitnami/neo4j
-- https://github.com/neo4j/neo4j
-version: 0.2.5
+  - https://github.com/bitnami/charts/tree/main/bitnami/neo4j
+  - https://github.com/bitnami/containers/tree/main/bitnami/neo4j
+  - https://github.com/neo4j/neo4j
+version: 0.2.6

--- a/bitnami/neo4j/Chart.yaml
+++ b/bitnami/neo4j/Chart.yaml
@@ -35,4 +35,4 @@ sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/neo4j
   - https://github.com/bitnami/containers/tree/main/bitnami/neo4j
   - https://github.com/neo4j/neo4j
-version: 0.2.6
+version: 0.3.0

--- a/bitnami/neo4j/README.md
+++ b/bitnami/neo4j/README.md
@@ -192,6 +192,7 @@ If you encounter errors when working with persistent volumes, refer to our [trou
 | Name                     | Description                                                                             | Value           |
 | ------------------------ | --------------------------------------------------------------------------------------- | --------------- |
 | `kubeVersion`            | Override Kubernetes version                                                             | `""`            |
+| `apiVersions`            | Override Kubernetes API versions reported by .Capabilities                              | `[]`            |
 | `nameOverride`           | String to partially override common.names.name                                          | `""`            |
 | `fullnameOverride`       | String to fully override common.names.fullname                                          | `""`            |
 | `namespaceOverride`      | String to fully override common.names.namespace                                         | `""`            |

--- a/bitnami/neo4j/templates/vpa.yaml
+++ b/bitnami/neo4j/templates/vpa.yaml
@@ -3,7 +3,7 @@ Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- if and (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1/VerticalPodAutoscaler") .Values.autoscaling.vpa.enabled }}
+{{- if and (include "common.capabilities.apiVersions.has" ( dict "version" "autoscaling.k8s.io/v1/VerticalPodAutoscaler" "context" . )) .Values.autoscaling.vpa.enabled }}
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:

--- a/bitnami/neo4j/values.yaml
+++ b/bitnami/neo4j/values.yaml
@@ -42,6 +42,9 @@ global:
 ## @param kubeVersion Override Kubernetes version
 ##
 kubeVersion: ""
+## @param apiVersions Override Kubernetes API versions reported by .Capabilities
+##
+apiVersions: []
 ## @param nameOverride String to partially override common.names.name
 ##
 nameOverride: ""


### PR DESCRIPTION
### Description of the change

Replace references to ".Capabilities.APIVersions.Has" with the new common helper added at #31969

### Benefits

Rendering templates doesn't require a K8s cluster connection to check the API versions.

### Possible drawbacks

None

### Applicable issues

None

### Additional information

N/A

### Checklist

- [x] Chart version bumped in Chart.yaml according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
