### PR TITLE
[bitnami/scylladb] feat: use new helper for checking API versions

### DIFF
--- a/bitnami/scylladb/CHANGELOG.md
+++ b/bitnami/scylladb/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 3.1.10 (2025-02-20)
+## 3.2.0 (2025-02-20)
 
 * [bitnami/scylladb] feat: use new helper for checking API versions ([#32062](https://github.com/bitnami/charts/pull/32062))
 

--- a/bitnami/scylladb/CHANGELOG.md
+++ b/bitnami/scylladb/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
-## 3.1.9 (2025-02-20)
+## 3.1.10 (2025-02-20)
 
-* [bitnami/scylladb] Release 3.1.9 ([#32036](https://github.com/bitnami/charts/pull/32036))
+* [bitnami/scylladb] feat: use new helper for checking API versions ([#32062](https://github.com/bitnami/charts/pull/32062))
+
+## <small>3.1.9 (2025-02-20)</small>
+
+* [bitnami/*] Use CDN url for the Bitnami Application Icons (#31881) ([d9bb11a](https://github.com/bitnami/charts/commit/d9bb11a9076b9bfdcc70ea022c25ef50e9713657)), closes [#31881](https://github.com/bitnami/charts/issues/31881)
+* [bitnami/scylladb] Release 3.1.9 (#32036) ([9d9a8aa](https://github.com/bitnami/charts/commit/9d9a8aabd2414041109b06df909eda3e203f1749)), closes [#32036](https://github.com/bitnami/charts/issues/32036)
 
 ## <small>3.1.8 (2025-02-09)</small>
 

--- a/bitnami/scylladb/Chart.yaml
+++ b/bitnami/scylladb/Chart.yaml
@@ -30,4 +30,4 @@ maintainers:
 name: scylladb
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/scylladb
-version: 3.1.10
+version: 3.2.0

--- a/bitnami/scylladb/Chart.yaml
+++ b/bitnami/scylladb/Chart.yaml
@@ -12,22 +12,22 @@ annotations:
 apiVersion: v2
 appVersion: 6.2.3
 dependencies:
-- name: common
-  repository: oci://registry-1.docker.io/bitnamicharts
-  tags:
-  - bitnami-common
-  version: 2.x.x
+  - name: common
+    repository: oci://registry-1.docker.io/bitnamicharts
+    tags:
+      - bitnami-common
+    version: 2.x.x
 description: ScyllaDB is an open-source, distributed NoSQL wide-column data store. Written in C++, it is designed for high throughput and low latency, compatible with Apache Cassandra.
 home: https://bitnami.com
 icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/scylladb/img/scylladb-stack-220x234.png
 keywords:
-- scylladb
-- database
-- nosql
+  - scylladb
+  - database
+  - nosql
 maintainers:
-- name: Broadcom, Inc. All Rights Reserved.
-  url: https://github.com/bitnami/charts
+  - name: Broadcom, Inc. All Rights Reserved.
+    url: https://github.com/bitnami/charts
 name: scylladb
 sources:
-- https://github.com/bitnami/charts/tree/main/bitnami/scylladb
-version: 3.1.9
+  - https://github.com/bitnami/charts/tree/main/bitnami/scylladb
+version: 3.1.10

--- a/bitnami/scylladb/README.md
+++ b/bitnami/scylladb/README.md
@@ -162,6 +162,7 @@ As the image run as non-root by default, it is necessary to adjust the ownership
 
 | Name                     | Description                                                                             | Value           |
 | ------------------------ | --------------------------------------------------------------------------------------- | --------------- |
+| `apiVersions`            | Override Kubernetes API versions reported by .Capabilities                              | `[]`            |
 | `nameOverride`           | String to partially override common.names.fullname                                      | `""`            |
 | `fullnameOverride`       | String to fully override common.names.fullname                                          | `""`            |
 | `kubeVersion`            | Force target Kubernetes version (using Helm capabilities if not set)                    | `""`            |

--- a/bitnami/scylladb/templates/vpa.yaml
+++ b/bitnami/scylladb/templates/vpa.yaml
@@ -3,7 +3,7 @@ Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- if and (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1/VerticalPodAutoscaler") .Values.autoscaling.vpa.enabled }}
+{{- if and (include "common.capabilities.apiVersions.has" ( dict "version" "autoscaling.k8s.io/v1/VerticalPodAutoscaler" "context" . )) .Values.autoscaling.vpa.enabled }}
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:

--- a/bitnami/scylladb/values.yaml
+++ b/bitnami/scylladb/values.yaml
@@ -38,6 +38,9 @@ global:
 ## @section Common parameters
 ##
 
+## @param apiVersions Override Kubernetes API versions reported by .Capabilities
+##
+apiVersions: []
 ## @param nameOverride String to partially override common.names.fullname
 ##
 nameOverride: ""


### PR DESCRIPTION
### Description of the change

Replace references to ".Capabilities.APIVersions.Has" with the new common helper added at #31969

### Benefits

Rendering templates doesn't require a K8s cluster connection to check the API versions.

### Possible drawbacks

None

### Applicable issues

None

### Additional information

N/A

### Checklist

- [x] Chart version bumped in Chart.yaml according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
