### PR TITLE
[bitnami/superset] feat: use new helper for checking API versions

### DIFF
--- a/bitnami/superset/CHANGELOG.md
+++ b/bitnami/superset/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.0.1 (2025-02-20)
+## 1.1.0 (2025-02-20)
 
 * [bitnami/superset] feat: use new helper for checking API versions ([#32063](https://github.com/bitnami/charts/pull/32063))
 

--- a/bitnami/superset/CHANGELOG.md
+++ b/bitnami/superset/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
-## 1.0.0 (2025-01-31)
+## 1.0.1 (2025-02-20)
 
-* [bitnami/superset] Update subcharts ([#31691](https://github.com/bitnami/charts/pull/31691))
+* [bitnami/superset] feat: use new helper for checking API versions ([#32063](https://github.com/bitnami/charts/pull/32063))
+
+## 1.0.0 (2025-02-03)
+
+* [bitnami/superset] Update subcharts (#31691) ([c4640ab](https://github.com/bitnami/charts/commit/c4640ab98dfa968e515b90528533aaf489e7adaa)), closes [#31691](https://github.com/bitnami/charts/issues/31691)
+* Update README.md ([7754178](https://github.com/bitnami/charts/commit/7754178ec5befb5d5c4915708613a8b580bbc58d))
 
 ## <small>0.2.1 (2025-01-29)</small>
 

--- a/bitnami/superset/Chart.lock
+++ b/bitnami/superset/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: redis
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 20.6.3
+  version: 20.7.1
 - name: postgresql
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 16.4.5
+  version: 16.4.9
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.29.1
-digest: sha256:05ffc7ea93d609ff3e67d06e621c611c292c22942024d802af8a4118918f54cc
-generated: "2025-01-31T17:06:25.29541+01:00"
+  version: 2.30.0
+digest: sha256:81f7c35c9c1adfc29675afe46108f71c6538aad18863e89a9e8540ca4b9cd5e7
+generated: "2025-02-20T08:57:16.744211+01:00"

--- a/bitnami/superset/Chart.yaml
+++ b/bitnami/superset/Chart.yaml
@@ -37,4 +37,4 @@ sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/superset
   - https://github.com/bitnami/containers/tree/main/bitnami/superset
   - https://github.com/apache/superset
-version: 1.0.1
+version: 1.1.0

--- a/bitnami/superset/Chart.yaml
+++ b/bitnami/superset/Chart.yaml
@@ -10,31 +10,31 @@ annotations:
 apiVersion: v2
 appVersion: 4.1.1
 dependencies:
-- condition: redis.enabled
-  name: redis
-  repository: oci://registry-1.docker.io/bitnamicharts
-  version: 20.x.x
-- condition: postgresql.enabled
-  name: postgresql
-  repository: oci://registry-1.docker.io/bitnamicharts
-  version: 16.x.x
-- name: common
-  repository: oci://registry-1.docker.io/bitnamicharts
-  tags:
-  - bitnami-common
-  version: 2.x.x
-description: Superset is a modern data exploration and data visualization platform. 
+  - condition: redis.enabled
+    name: redis
+    repository: oci://registry-1.docker.io/bitnamicharts
+    version: 20.x.x
+  - condition: postgresql.enabled
+    name: postgresql
+    repository: oci://registry-1.docker.io/bitnamicharts
+    version: 16.x.x
+  - name: common
+    repository: oci://registry-1.docker.io/bitnamicharts
+    tags:
+      - bitnami-common
+    version: 2.x.x
+description: Superset is a modern data exploration and data visualization platform.
 home: https://bitnami.com
 icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/superset/img/superset-stack-220x234.png
 keywords:
-- superset
-- analytics
+  - superset
+  - analytics
 maintainers:
-- name: Broadcom, Inc. All Rights Reserved.
-  url: https://github.com/bitnami/charts
+  - name: Broadcom, Inc. All Rights Reserved.
+    url: https://github.com/bitnami/charts
 name: superset
 sources:
-- https://github.com/bitnami/charts/tree/main/bitnami/superset
-- https://github.com/bitnami/containers/tree/main/bitnami/superset
-- https://github.com/apache/superset
-version: 1.0.0
+  - https://github.com/bitnami/charts/tree/main/bitnami/superset
+  - https://github.com/bitnami/containers/tree/main/bitnami/superset
+  - https://github.com/apache/superset
+version: 1.0.1

--- a/bitnami/superset/README.md
+++ b/bitnami/superset/README.md
@@ -164,6 +164,7 @@ As an alternative, use one of the preset configurations for pod affinity, pod an
 | Name                     | Description                                                                             | Value           |
 | ------------------------ | --------------------------------------------------------------------------------------- | --------------- |
 | `kubeVersion`            | Override Kubernetes version                                                             | `""`            |
+| `apiVersions`            | Override Kubernetes API versions reported by .Capabilities                              | `[]`            |
 | `nameOverride`           | String to partially override common.names.name                                          | `""`            |
 | `fullnameOverride`       | String to fully override common.names.fullname                                          | `""`            |
 | `namespaceOverride`      | String to fully override common.names.namespace                                         | `""`            |

--- a/bitnami/superset/templates/flower/vpa.yaml
+++ b/bitnami/superset/templates/flower/vpa.yaml
@@ -3,7 +3,7 @@ Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- if and .Values.flower.enabled (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1/VerticalPodAutoscaler") .Values.flower.autoscaling.vpa.enabled }}
+{{- if and .Values.flower.enabled (include "common.capabilities.apiVersions.has" ( dict "version" "autoscaling.k8s.io/v1/VerticalPodAutoscaler" "context" . )) .Values.flower.autoscaling.vpa.enabled }}
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:

--- a/bitnami/superset/templates/web/vpa.yaml
+++ b/bitnami/superset/templates/web/vpa.yaml
@@ -3,7 +3,7 @@ Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- if and (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1/VerticalPodAutoscaler") .Values.web.autoscaling.vpa.enabled }}
+{{- if and (include "common.capabilities.apiVersions.has" ( dict "version" "autoscaling.k8s.io/v1/VerticalPodAutoscaler" "context" . )) .Values.web.autoscaling.vpa.enabled }}
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:

--- a/bitnami/superset/templates/worker/vpa.yaml
+++ b/bitnami/superset/templates/worker/vpa.yaml
@@ -3,7 +3,7 @@ Copyright Broadcom, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- if and (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1/VerticalPodAutoscaler") .Values.worker.autoscaling.vpa.enabled }}
+{{- if and (include "common.capabilities.apiVersions.has" ( dict "version" "autoscaling.k8s.io/v1/VerticalPodAutoscaler" "context" . )) .Values.worker.autoscaling.vpa.enabled }}
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:

--- a/bitnami/superset/values.yaml
+++ b/bitnami/superset/values.yaml
@@ -35,6 +35,9 @@ global:
 ## @param kubeVersion Override Kubernetes version
 ##
 kubeVersion: ""
+## @param apiVersions Override Kubernetes API versions reported by .Capabilities
+##
+apiVersions: []
 ## @param nameOverride String to partially override common.names.name
 ##
 nameOverride: ""


### PR DESCRIPTION
### Description of the change

Replace references to ".Capabilities.APIVersions.Has" with the new common helper added at #31969

### Benefits

Rendering templates doesn't require a K8s cluster connection to check the API versions.

### Possible drawbacks

None

### Applicable issues

None

### Additional information

N/A

### Checklist

- [x] Chart version bumped in Chart.yaml according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
