### PR TITLE
[bitnami/keycloak] Allow to provide additional JAVA_OPTS_APPEND

### DIFF
--- a/bitnami/keycloak/CHANGELOG.md
+++ b/bitnami/keycloak/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
-## 24.4.10 (2025-02-17)
+## 24.5.0 (2025-02-20)
 
-* [bitnami/keycloak] Release 24.4.10 ([#31951](https://github.com/bitnami/charts/pull/31951))
+* [bitnami/keycloak] Allow to provide additional JAVA_OPTS_APPEND ([#32072](https://github.com/bitnami/charts/pull/32072))
+
+## <small>24.4.10 (2025-02-17)</small>
+
+* [bitnami/*] Use CDN url for the Bitnami Application Icons (#31881) ([d9bb11a](https://github.com/bitnami/charts/commit/d9bb11a9076b9bfdcc70ea022c25ef50e9713657)), closes [#31881](https://github.com/bitnami/charts/issues/31881)
+* [bitnami/keycloak] Release 24.4.10 (#31951) ([0e98679](https://github.com/bitnami/charts/commit/0e98679e34dd8dd0098f4b0e4db96f8c69aa5a58)), closes [#31951](https://github.com/bitnami/charts/issues/31951)
 
 ## <small>24.4.9 (2025-02-05)</small>
 

--- a/bitnami/keycloak/Chart.yaml
+++ b/bitnami/keycloak/Chart.yaml
@@ -33,4 +33,4 @@ maintainers:
 name: keycloak
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/keycloak
-version: 24.4.10
+version: 24.5.0

--- a/bitnami/keycloak/README.md
+++ b/bitnami/keycloak/README.md
@@ -408,6 +408,7 @@ As an alternative, you can use of the preset configurations for pod affinity, po
 | `extraEnvVars`                   | Extra environment variables to be set on Keycloak container                                                                                            | `[]`                          |
 | `extraEnvVarsCM`                 | Name of existing ConfigMap containing extra env vars                                                                                                   | `""`                          |
 | `extraEnvVarsSecret`             | Name of existing Secret containing extra env vars                                                                                                      | `""`                          |
+| `extraJavaOptsAppend`            | Extra Java options to append to the default ones                                                                                                       | `[]`                          |
 
 ### Keycloak statefulset parameters
 

--- a/bitnami/keycloak/README.md
+++ b/bitnami/keycloak/README.md
@@ -408,7 +408,7 @@ As an alternative, you can use of the preset configurations for pod affinity, po
 | `extraEnvVars`                   | Extra environment variables to be set on Keycloak container                                                                                            | `[]`                          |
 | `extraEnvVarsCM`                 | Name of existing ConfigMap containing extra env vars                                                                                                   | `""`                          |
 | `extraEnvVarsSecret`             | Name of existing Secret containing extra env vars                                                                                                      | `""`                          |
-| `extraJavaOptsAppend`            | Extra Java options to append to the default ones                                                                                                       | `[]`                          |
+| `extraJavaOptsAppend`            | Additional Java options to append to the default options                                                                                               | `[]`                          |
 
 ### Keycloak statefulset parameters
 

--- a/bitnami/keycloak/templates/configmap-env-vars.yaml
+++ b/bitnami/keycloak/templates/configmap-env-vars.yaml
@@ -85,6 +85,7 @@ data:
   {{- end }}
   KEYCLOAK_SPI_TRUSTSTORE_FILE: {{ printf "/opt/bitnami/keycloak/spi-certs/%s" .Values.spi.truststoreFilename }}
   {{- end }}
+  {{- $javaOptsAppend := "" -}}
   {{- if .Values.cache.enabled }}
   KEYCLOAK_CACHE_TYPE: "ispn"
   {{- if .Values.cache.stackName }}
@@ -93,13 +94,22 @@ data:
   {{- if .Values.cache.stackFile }}
   KEYCLOAK_CACHE_CONFIG_FILE: {{ .Values.cache.stackFile | quote }}
   {{- end }}
+  {{- $javaOptsAppend = printf "-Djgroups.dns.query=%s-headless.%s.svc.%s" (include "common.names.fullname" .) (include "common.names.namespace" .) .Values.clusterDomain -}}
   {{- if .Values.cache.useHeadlessServiceWithAppVersion }}
-  JAVA_OPTS_APPEND: {{ printf "-Djgroups.dns.query=%s-headless-ispn-%s.%s.svc.%s" (include "common.names.fullname" .) (replace "." "-" .Chart.AppVersion) (include "common.names.namespace" .) .Values.clusterDomain | quote }}
-  {{- else }}
-  JAVA_OPTS_APPEND: {{ printf "-Djgroups.dns.query=%s-headless.%s.svc.%s" (include "common.names.fullname" .) (include "common.names.namespace" .) .Values.clusterDomain | quote }}
+    {{- $javaOptsAppend = printf "-Djgroups.dns.query=%s-headless-ispn-%s.%s.svc.%s" (include "common.names.fullname" .) (replace "." "-" .Chart.AppVersion) (include "common.names.namespace" .) .Values.clusterDomain -}}
   {{- end }}
   {{- else }}
   KEYCLOAK_CACHE_TYPE: "local"
+  {{- end }}
+  {{- if .Values.extraJavaOptsAppend }}
+    {{- $space := "" -}}
+    {{- if and (ne $javaOptsAppend "") }}
+      {{- $space = " " -}}
+    {{- end }}
+    {{- $javaOptsAppend = printf "%s%s%s" ($javaOptsAppend) ($space) (join " " .Values.extraJavaOptsAppend) -}}
+  {{- end }}
+  {{- if (ne $javaOptsAppend "") }}
+  JAVA_OPTS_APPEND: {{ $javaOptsAppend | quote }}
   {{- end }}
   {{- if .Values.logging }}
   KEYCLOAK_LOG_OUTPUT: {{ .Values.logging.output | quote }}

--- a/bitnami/keycloak/values.yaml
+++ b/bitnami/keycloak/values.yaml
@@ -288,6 +288,14 @@ extraEnvVarsCM: ""
 ## @param extraEnvVarsSecret Name of existing Secret containing extra env vars
 ##
 extraEnvVarsSecret: ""
+## @param extraJavaOptsAppend Additional Java options to append to the default options
+## Example:
+## extraJavaOptsAppend:
+##   - "-XX:+UseContainerSupport"
+##   - "-XX:MaxRAMPercentage=75.0"
+##   - "-Dorg.infinispan.threads.virtual=false"
+##
+extraJavaOptsAppend: []
 ## @section Keycloak statefulset parameters
 
 ## @param replicaCount Number of Keycloak replicas to deploy


### PR DESCRIPTION
### Description of the change

Changed construction of `JAVA_OPTS_APPEND` env variable in config map

### Benefits

Allow for adding additional custom `JAVA_OPTS_APPEND` parameters

### Applicable issues

- fixes #31847

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
