### PR TITLE
[bitnami/airflow] Add support for `usePasswordFiles`

### DIFF
--- a/bitnami/airflow/CHANGELOG.md
+++ b/bitnami/airflow/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 22.6.0 (2025-02-20)
+## 22.6.0 (2025-02-21)
 
 * [bitnami/airflow] Add support for `usePasswordFiles` ([#32076](https://github.com/bitnami/charts/pull/32076))
 

--- a/bitnami/airflow/CHANGELOG.md
+++ b/bitnami/airflow/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
+## 22.6.0 (2025-02-20)
+
+* [bitnami/airflow] Add support for `usePasswordFiles` ([#32076](https://github.com/bitnami/charts/pull/32076))
+
 ## 22.5.0 (2025-02-20)
 
-* [bitnami/airflow] feat: use new helper for checking API versions ([#32044](https://github.com/bitnami/charts/pull/32044))
+* [bitnami/*] Use CDN url for the Bitnami Application Icons (#31881) ([d9bb11a](https://github.com/bitnami/charts/commit/d9bb11a9076b9bfdcc70ea022c25ef50e9713657)), closes [#31881](https://github.com/bitnami/charts/issues/31881)
+* [bitnami/airflow] feat: use new helper for checking API versions (#32044) ([4c3e161](https://github.com/bitnami/charts/commit/4c3e161e24fc14625b9ceef0cdc213c9301466cf)), closes [#32044](https://github.com/bitnami/charts/issues/32044)
 
 ## <small>22.4.9 (2025-02-11)</small>
 

--- a/bitnami/airflow/CHANGELOG.md
+++ b/bitnami/airflow/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 22.6.0 (2025-02-21)
+## 22.6.0 (2025-02-25)
 
 * [bitnami/airflow] Add support for `usePasswordFiles` ([#32076](https://github.com/bitnami/charts/pull/32076))
 

--- a/bitnami/airflow/CHANGELOG.md
+++ b/bitnami/airflow/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 22.6.0 (2025-02-25)
+## 22.6.0 (2025-02-27)
 
 * [bitnami/airflow] Add support for `usePasswordFiles` ([#32076](https://github.com/bitnami/charts/pull/32076))
 

--- a/bitnami/airflow/Chart.yaml
+++ b/bitnami/airflow/Chart.yaml
@@ -39,4 +39,4 @@ maintainers:
 name: airflow
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/airflow
-version: 22.5.0
+version: 22.6.0

--- a/bitnami/airflow/README.md
+++ b/bitnami/airflow/README.md
@@ -391,6 +391,7 @@ The Bitnami Airflow chart relies on the PostgreSQL chart persistence. This means
 | `commonAnnotations`      | Annotations to add to all deployed objects                                              | `{}`            |
 | `clusterDomain`          | Kubernetes cluster domain name                                                          | `cluster.local` |
 | `extraDeploy`            | Array of extra objects to deploy with the release                                       | `[]`            |
+| `usePasswordFiles`       | Mount credentials as files instead of using environment variables                       | `true`          |
 | `diagnosticMode.enabled` | Enable diagnostic mode (all probes will be disabled and the command will be overridden) | `false`         |
 | `diagnosticMode.command` | Command to override all containers in the chart release                                 | `["sleep"]`     |
 | `diagnosticMode.args`    | Args to override all containers in the chart release                                    | `["infinity"]`  |

--- a/bitnami/airflow/templates/_helpers.tpl
+++ b/bitnami/airflow/templates/_helpers.tpl
@@ -347,7 +347,7 @@ Add environment variables to configure airflow common values
 {{- define "airflow.configure.airflow.common" -}}
 - name: BITNAMI_DEBUG
   value: {{ ternary "true" "false" (or .Values.image.debug .Values.diagnosticMode.enabled) | quote }}
-{{- if .Values.auth.usePasswordFiles }}
+{{- if .Values.usePasswordFiles }}
 - name: AIRFLOW__CORE__FERNET_KEY_CMD
   value: "cat /opt/bitnami/airflow/secrets/airflow-fernet-key"
 - name: AIRFLOW__WEBSERVER__SECRET_KEY_CMD

--- a/bitnami/airflow/templates/_helpers.tpl
+++ b/bitnami/airflow/templates/_helpers.tpl
@@ -347,6 +347,12 @@ Add environment variables to configure airflow common values
 {{- define "airflow.configure.airflow.common" -}}
 - name: BITNAMI_DEBUG
   value: {{ ternary "true" "false" (or .Values.image.debug .Values.diagnosticMode.enabled) | quote }}
+{{- if .Values.auth.usePasswordFiles }}
+- name: AIRFLOW__CORE__FERNET_KEY_CMD
+  value: "cat /opt/bitnami/airflow/secrets/airflow-fernet-key"
+- name: AIRFLOW__WEBSERVER__SECRET_KEY_CMD
+  value: "cat /opt/bitnami/airflow/secrets/airflow-secret-key"
+{{- else }}
 - name: AIRFLOW__CORE__FERNET_KEY
   valueFrom:
     secretKeyRef:
@@ -357,6 +363,7 @@ Add environment variables to configure airflow common values
     secretKeyRef:
       name: {{ include "airflow.secretName" . }}
       key: airflow-secret-key
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/bitnami/airflow/templates/_init_containers_sidecars.tpl
+++ b/bitnami/airflow/templates/_init_containers_sidecars.tpl
@@ -35,8 +35,15 @@ Returns an init-container that prepares the Airflow configuration files for main
       # Apply changes affecting credentials
       export AIRFLOW_CONF_FILE="/emptydir/app-base-dir/airflow.cfg"
     {{- if (include "airflow.database.useSqlConnection" .) }}
+    {{- if and .Values.auth.usePasswordFiles }}
+      export AIRFLOW_DATABASE_SQL_CONN="$(< $AIRFLOW_DATABASE_SQL_CONN_FILE)"
+    {{- end }}
       airflow_conf_set "database" "sql_alchemy_conn" "$AIRFLOW_DATABASE_SQL_CONN"
     {{- else }}
+      {{- if and .Values.auth.usePasswordFiles }}
+      ls -laR /opt/bitnami/airflow
+      export AIRFLOW_DATABASE_PASSWORD="$(< $AIRFLOW_DATABASE_PASSWORD_FILE)"
+      {{- end }}
       db_user="$(airflow_encode_url "$AIRFLOW_DATABASE_USERNAME")"
       db_password="$(airflow_encode_url "$AIRFLOW_DATABASE_PASSWORD")"
       airflow_conf_set "database" "sql_alchemy_conn" "postgresql+psycopg2://${db_user}:${db_password}@${AIRFLOW_DATABASE_HOST}:${AIRFLOW_DATABASE_PORT_NUMBER}/${AIRFLOW_DATABASE_NAME}"
@@ -66,21 +73,31 @@ Returns an init-container that prepares the Airflow configuration files for main
     - name: BITNAMI_DEBUG
       value: {{ ternary "true" "false" (or .Values.image.debug .Values.diagnosticMode.enabled) | quote }}
     {{- if (include "airflow.database.useSqlConnection" .) }}
+    {{- if .Values.auth.usePasswordFiles }}
+    - name: AIRFLOW_DATABASE_SQL_CONN_FILE
+      value: {{ printf "/opt/bitnami/airflow/secrets/%s" (include "airflow.database.secretKey" .) }}
+    {{- else }}
     - name: AIRFLOW_DATABASE_SQL_CONN
       valueFrom:
         secretKeyRef:
           name: {{ include "airflow.database.secretName" . }}
           key: {{ include "airflow.database.secretKey" . }}
+    {{- end }}
     {{- else }}
     - name: AIRFLOW_DATABASE_NAME
       value: {{ include "airflow.database.name" . }}
     - name: AIRFLOW_DATABASE_USERNAME
       value: {{ include "airflow.database.user" . }}
+    {{- if .Values.auth.usePasswordFiles }}
+    - name: AIRFLOW_DATABASE_PASSWORD_FILE
+      value: {{ printf "/opt/bitnami/airflow/secrets/%s" (include "airflow.database.secretKey" .) }}
+    {{- else }}
     - name: AIRFLOW_DATABASE_PASSWORD
       valueFrom:
         secretKeyRef:
           name: {{ include "airflow.database.secretName" . }}
           key: {{ include "airflow.database.secretKey" . }}
+    {{- end }}
     - name: AIRFLOW_DATABASE_HOST
       value: {{ include "airflow.database.host" . }}
     - name: AIRFLOW_DATABASE_PORT_NUMBER
@@ -95,11 +112,16 @@ Returns an init-container that prepares the Airflow configuration files for main
     - name: REDIS_USER
       value: {{ .Values.externalRedis.username | quote }}
     {{- end }}
+    {{- if .Values.auth.usePasswordFiles }}
+    - name: REDIS_PASSWORD_FILE
+      value: "/opt/bitnami/airflow/secrets/redis-password"
+    {{- else }}
     - name: REDIS_PASSWORD
       valueFrom:
         secretKeyRef:
           name: {{ include "airflow.redis.secretName" . }}
           key: redis-password
+    {{- end }}
     {{- end }}
   volumeMounts:
     - name: empty-dir
@@ -110,6 +132,10 @@ Returns an init-container that prepares the Airflow configuration files for main
     - name: configuration
       mountPath: /opt/bitnami/airflow/config/airflow_local_settings.py
       subPath: airflow_local_settings.py
+    {{- if  .Values.auth.usePasswordFiles }}
+    - name: airflow-secrets
+      mountPath: /opt/bitnami/airflow/secrets
+    {{- end }}
 {{- end -}}
 
 {{/*
@@ -137,6 +163,9 @@ Returns an init-container that prepares the Airflow Webserver configuration file
       # Copy the configuration files to the writable directory
       cp /opt/bitnami/airflow/webserver_config.py /emptydir/app-base-dir/webserver_config.py
     {{- if .Values.ldap.enabled }}
+      {{- if .Values.auth.usePasswordFiles }}
+      export AIRFLOW_LDAP_BIND_PASSWORD="$(< $AIRFLOW_LDAP_BIND_PASSWORD_FILE)"
+      {{- end }}
       export AIRFLOW_WEBSERVER_CONF_FILE="/emptydir/app-base-dir/webserver_config.py"
       airflow_webserver_conf_set "AUTH_LDAP_BIND_PASSWORD" "$AIRFLOW_LDAP_BIND_PASSWORD" "yes"
     {{- end }}
@@ -145,11 +174,16 @@ Returns an init-container that prepares the Airflow Webserver configuration file
     - name: BITNAMI_DEBUG
       value: {{ ternary "true" "false" (or .Values.image.debug .Values.diagnosticMode.enabled) | quote }}
     {{- if .Values.ldap.enabled }}
+    {{- if .Values.auth.usePasswordFiles }}
+    - name: AIRFLOW_LDAP_BIND_PASSWORD_FILE
+      value: "/opt/bitnami/airflow/secrets/bind-password"
+    {{- else }}
     - name: AIRFLOW_LDAP_BIND_PASSWORD
       valueFrom:
         secretKeyRef:
           name: {{ include "airflow.ldap.secretName" . }}
           key: bind-password
+    {{- end }}
     {{- end }}
   volumeMounts:
     - name: empty-dir
@@ -157,6 +191,10 @@ Returns an init-container that prepares the Airflow Webserver configuration file
     - name: webserver-configuration
       mountPath: /opt/bitnami/airflow/webserver_config.py
       subPath: webserver_config.py
+    {{- if  .Values.auth.usePasswordFiles }}
+    - name: airflow-secrets
+      mountPath: /opt/bitnami/airflow/secrets
+    {{- end }}
 {{- end -}}
 
 {{/*

--- a/bitnami/airflow/templates/_init_containers_sidecars.tpl
+++ b/bitnami/airflow/templates/_init_containers_sidecars.tpl
@@ -41,7 +41,6 @@ Returns an init-container that prepares the Airflow configuration files for main
       airflow_conf_set "database" "sql_alchemy_conn" "$AIRFLOW_DATABASE_SQL_CONN"
     {{- else }}
       {{- if and .Values.usePasswordFiles }}
-      ls -laR /opt/bitnami/airflow
       export AIRFLOW_DATABASE_PASSWORD="$(< $AIRFLOW_DATABASE_PASSWORD_FILE)"
       {{- end }}
       db_user="$(airflow_encode_url "$AIRFLOW_DATABASE_USERNAME")"

--- a/bitnami/airflow/templates/_init_containers_sidecars.tpl
+++ b/bitnami/airflow/templates/_init_containers_sidecars.tpl
@@ -35,12 +35,12 @@ Returns an init-container that prepares the Airflow configuration files for main
       # Apply changes affecting credentials
       export AIRFLOW_CONF_FILE="/emptydir/app-base-dir/airflow.cfg"
     {{- if (include "airflow.database.useSqlConnection" .) }}
-    {{- if and .Values.auth.usePasswordFiles }}
+    {{- if and .Values.usePasswordFiles }}
       export AIRFLOW_DATABASE_SQL_CONN="$(< $AIRFLOW_DATABASE_SQL_CONN_FILE)"
     {{- end }}
       airflow_conf_set "database" "sql_alchemy_conn" "$AIRFLOW_DATABASE_SQL_CONN"
     {{- else }}
-      {{- if and .Values.auth.usePasswordFiles }}
+      {{- if and .Values.usePasswordFiles }}
       ls -laR /opt/bitnami/airflow
       export AIRFLOW_DATABASE_PASSWORD="$(< $AIRFLOW_DATABASE_PASSWORD_FILE)"
       {{- end }}
@@ -73,7 +73,7 @@ Returns an init-container that prepares the Airflow configuration files for main
     - name: BITNAMI_DEBUG
       value: {{ ternary "true" "false" (or .Values.image.debug .Values.diagnosticMode.enabled) | quote }}
     {{- if (include "airflow.database.useSqlConnection" .) }}
-    {{- if .Values.auth.usePasswordFiles }}
+    {{- if .Values.usePasswordFiles }}
     - name: AIRFLOW_DATABASE_SQL_CONN_FILE
       value: {{ printf "/opt/bitnami/airflow/secrets/%s" (include "airflow.database.secretKey" .) }}
     {{- else }}
@@ -88,7 +88,7 @@ Returns an init-container that prepares the Airflow configuration files for main
       value: {{ include "airflow.database.name" . }}
     - name: AIRFLOW_DATABASE_USERNAME
       value: {{ include "airflow.database.user" . }}
-    {{- if .Values.auth.usePasswordFiles }}
+    {{- if .Values.usePasswordFiles }}
     - name: AIRFLOW_DATABASE_PASSWORD_FILE
       value: {{ printf "/opt/bitnami/airflow/secrets/%s" (include "airflow.database.secretKey" .) }}
     {{- else }}
@@ -112,7 +112,7 @@ Returns an init-container that prepares the Airflow configuration files for main
     - name: REDIS_USER
       value: {{ .Values.externalRedis.username | quote }}
     {{- end }}
-    {{- if .Values.auth.usePasswordFiles }}
+    {{- if .Values.usePasswordFiles }}
     - name: REDIS_PASSWORD_FILE
       value: "/opt/bitnami/airflow/secrets/redis-password"
     {{- else }}
@@ -132,7 +132,7 @@ Returns an init-container that prepares the Airflow configuration files for main
     - name: configuration
       mountPath: /opt/bitnami/airflow/config/airflow_local_settings.py
       subPath: airflow_local_settings.py
-    {{- if  .Values.auth.usePasswordFiles }}
+    {{- if  .Values.usePasswordFiles }}
     - name: airflow-secrets
       mountPath: /opt/bitnami/airflow/secrets
     {{- end }}
@@ -163,7 +163,7 @@ Returns an init-container that prepares the Airflow Webserver configuration file
       # Copy the configuration files to the writable directory
       cp /opt/bitnami/airflow/webserver_config.py /emptydir/app-base-dir/webserver_config.py
     {{- if .Values.ldap.enabled }}
-      {{- if .Values.auth.usePasswordFiles }}
+      {{- if .Values.usePasswordFiles }}
       export AIRFLOW_LDAP_BIND_PASSWORD="$(< $AIRFLOW_LDAP_BIND_PASSWORD_FILE)"
       {{- end }}
       export AIRFLOW_WEBSERVER_CONF_FILE="/emptydir/app-base-dir/webserver_config.py"
@@ -174,7 +174,7 @@ Returns an init-container that prepares the Airflow Webserver configuration file
     - name: BITNAMI_DEBUG
       value: {{ ternary "true" "false" (or .Values.image.debug .Values.diagnosticMode.enabled) | quote }}
     {{- if .Values.ldap.enabled }}
-    {{- if .Values.auth.usePasswordFiles }}
+    {{- if .Values.usePasswordFiles }}
     - name: AIRFLOW_LDAP_BIND_PASSWORD_FILE
       value: "/opt/bitnami/airflow/secrets/bind-password"
     {{- else }}
@@ -191,7 +191,7 @@ Returns an init-container that prepares the Airflow Webserver configuration file
     - name: webserver-configuration
       mountPath: /opt/bitnami/airflow/webserver_config.py
       subPath: webserver_config.py
-    {{- if  .Values.auth.usePasswordFiles }}
+    {{- if  .Values.usePasswordFiles }}
     - name: airflow-secrets
       mountPath: /opt/bitnami/airflow/secrets
     {{- end }}

--- a/bitnami/airflow/templates/_init_containers_sidecars.tpl
+++ b/bitnami/airflow/templates/_init_containers_sidecars.tpl
@@ -49,6 +49,9 @@ Returns an init-container that prepares the Airflow configuration files for main
       airflow_conf_set "database" "sql_alchemy_conn" "postgresql+psycopg2://${db_user}:${db_password}@${AIRFLOW_DATABASE_HOST}:${AIRFLOW_DATABASE_PORT_NUMBER}/${AIRFLOW_DATABASE_NAME}"
     {{- end }}
     {{- if or (eq .Values.executor "CeleryExecutor") (eq .Values.executor "CeleryKubernetesExecutor") }}
+      {{- if and .Values.usePasswordFiles }}
+      export REDIS_PASSWORD="$(< $REDIS_PASSWORD_FILE)"
+      {{- end }}
       redis_credentials=":$(airflow_encode_url "$REDIS_PASSWORD")"
       [[ -n "$REDIS_USER" ]] && redis_credentials="$(airflow_encode_url "$REDIS_USER")$redis_credentials"
     {{- if (include "airflow.database.useSqlConnection" .) }}

--- a/bitnami/airflow/templates/config/configmap-pod-template.yaml
+++ b/bitnami/airflow/templates/config/configmap-pod-template.yaml
@@ -202,7 +202,7 @@ data:
             - name: empty-dir
               mountPath: /opt/bitnami/airflow/webserver_config.py
               subPath: app-base-dir/webserver_config.py
-            {{- if  .Values.auth.usePasswordFiles }}
+            {{- if  .Values.usePasswordFiles }}
             - name: airflow-secrets
               mountPath: /opt/bitnami/airflow/secrets
             {{- end }}
@@ -238,7 +238,7 @@ data:
         - name: webserver-configuration
           configMap:
             name: {{ include "airflow.web.configMapName" . }}
-        {{- if .Values.auth.usePasswordFiles }}
+        {{- if .Values.usePasswordFiles }}
         - name: airflow-secrets
           projected:
             sources:

--- a/bitnami/airflow/templates/config/configmap-pod-template.yaml
+++ b/bitnami/airflow/templates/config/configmap-pod-template.yaml
@@ -202,6 +202,10 @@ data:
             - name: empty-dir
               mountPath: /opt/bitnami/airflow/webserver_config.py
               subPath: app-base-dir/webserver_config.py
+            {{- if  .Values.auth.usePasswordFiles }}
+            - name: airflow-secrets
+              mountPath: /opt/bitnami/airflow/secrets
+            {{- end }}
             {{- if .Values.dags.enabled }}
             {{- include "airflow.dags.volumeMounts" . | nindent 12 }}
             {{- end }}
@@ -234,6 +238,19 @@ data:
         - name: webserver-configuration
           configMap:
             name: {{ include "airflow.web.configMapName" . }}
+        {{- if .Values.auth.usePasswordFiles }}
+        - name: airflow-secrets
+          projected:
+            sources:
+              - secret:
+                  name: {{ include "airflow.secretName" . }}
+              - secret:
+                  name: {{ include "airflow.database.secretName" . }}
+              {{- if .Values.ldap.enabled }}
+              - secret:
+                  name: {{ include "airflow.ldap.secretName" . }}
+              {{- end }}
+        {{- end }}
         {{- if .Values.web.tls.enabled }}
         - name: tls-certificates
           secret:

--- a/bitnami/airflow/templates/config/configmap-pod-template.yaml
+++ b/bitnami/airflow/templates/config/configmap-pod-template.yaml
@@ -250,6 +250,10 @@ data:
               - secret:
                   name: {{ include "airflow.ldap.secretName" . }}
               {{- end }}
+              {{- if or (eq .Values.executor "CeleryExecutor") (eq .Values.executor "CeleryKubernetesExecutor") }}
+              - secret:
+                  name: {{ include "airflow.redis.secretName" . }}
+              {{- end }}
         {{- end }}
         {{- if .Values.web.tls.enabled }}
         - name: tls-certificates

--- a/bitnami/airflow/templates/dag-processor/deployment.yaml
+++ b/bitnami/airflow/templates/dag-processor/deployment.yaml
@@ -204,7 +204,7 @@ spec:
             - name: empty-dir
               mountPath: /opt/bitnami/airflow/config/airflow_local_settings.py
               subPath: app-conf-dir/airflow_local_settings.py
-            {{- if  .Values.auth.usePasswordFiles }}
+            {{- if  .Values.usePasswordFiles }}
             - name: airflow-secrets
               mountPath: /opt/bitnami/airflow/secrets
             {{- end }}
@@ -239,7 +239,7 @@ spec:
           configMap:
             name: {{ include "airflow.configMapName"  . }}
             optional: true
-        {{- if .Values.auth.usePasswordFiles }}
+        {{- if .Values.usePasswordFiles }}
         - name: airflow-secrets
           projected:
             sources:

--- a/bitnami/airflow/templates/dag-processor/deployment.yaml
+++ b/bitnami/airflow/templates/dag-processor/deployment.yaml
@@ -247,6 +247,10 @@ spec:
                   name:  {{ include "airflow.secretName" . }}
               - secret:
                   name: {{ include "airflow.database.secretName" . }}
+              {{- if or (eq .Values.executor "CeleryExecutor") (eq .Values.executor "CeleryKubernetesExecutor") }}
+              - secret:
+                  name: {{ include "airflow.redis.secretName" . }}
+              {{- end }}
         {{- end }}
         {{- if .Values.dags.enabled }}
         {{- include "airflow.dags.volumes" . | nindent 8 }}

--- a/bitnami/airflow/templates/dag-processor/deployment.yaml
+++ b/bitnami/airflow/templates/dag-processor/deployment.yaml
@@ -204,6 +204,10 @@ spec:
             - name: empty-dir
               mountPath: /opt/bitnami/airflow/config/airflow_local_settings.py
               subPath: app-conf-dir/airflow_local_settings.py
+            {{- if  .Values.auth.usePasswordFiles }}
+            - name: airflow-secrets
+              mountPath: /opt/bitnami/airflow/secrets
+            {{- end }}
             {{- if .Values.dags.enabled }}
             {{- include "airflow.dags.volumeMounts" . | nindent 12 }}
             {{- end }}
@@ -235,6 +239,15 @@ spec:
           configMap:
             name: {{ include "airflow.configMapName"  . }}
             optional: true
+        {{- if .Values.auth.usePasswordFiles }}
+        - name: airflow-secrets
+          projected:
+            sources:
+              - secret:
+                  name:  {{ include "airflow.secretName" . }}
+              - secret:
+                  name: {{ include "airflow.database.secretName" . }}
+        {{- end }}
         {{- if .Values.dags.enabled }}
         {{- include "airflow.dags.volumes" . | nindent 8 }}
         {{- end }}

--- a/bitnami/airflow/templates/scheduler/deployment.yaml
+++ b/bitnami/airflow/templates/scheduler/deployment.yaml
@@ -216,6 +216,10 @@ spec:
             - name: empty-dir
               mountPath: /opt/bitnami/airflow/config/airflow_local_settings.py
               subPath: app-conf-dir/airflow_local_settings.py
+            {{- if  .Values.auth.usePasswordFiles }}
+            - name: airflow-secrets
+              mountPath: /opt/bitnami/airflow/secrets
+            {{- end }}
             {{- if $kube }}
             - name: pod-template
               mountPath: /opt/bitnami/airflow/config/pod_template.yaml
@@ -252,6 +256,15 @@ spec:
           configMap:
             name: {{ include "airflow.configMapName"  . }}
             optional: true
+        {{- if .Values.auth.usePasswordFiles }}
+        - name: airflow-secrets
+          projected:
+            sources:
+              - secret:
+                  name:  {{ include "airflow.secretName" . }}
+              - secret:
+                  name: {{ include "airflow.database.secretName" . }}
+        {{- end }}
         {{- if $kube }}
         - name: pod-template
           configMap:

--- a/bitnami/airflow/templates/scheduler/deployment.yaml
+++ b/bitnami/airflow/templates/scheduler/deployment.yaml
@@ -264,6 +264,10 @@ spec:
                   name:  {{ include "airflow.secretName" . }}
               - secret:
                   name: {{ include "airflow.database.secretName" . }}
+              {{- if or (eq .Values.executor "CeleryExecutor") (eq .Values.executor "CeleryKubernetesExecutor") }}
+              - secret:
+                  name: {{ include "airflow.redis.secretName" . }}
+              {{- end }}
         {{- end }}
         {{- if $kube }}
         - name: pod-template

--- a/bitnami/airflow/templates/scheduler/deployment.yaml
+++ b/bitnami/airflow/templates/scheduler/deployment.yaml
@@ -216,7 +216,7 @@ spec:
             - name: empty-dir
               mountPath: /opt/bitnami/airflow/config/airflow_local_settings.py
               subPath: app-conf-dir/airflow_local_settings.py
-            {{- if  .Values.auth.usePasswordFiles }}
+            {{- if  .Values.usePasswordFiles }}
             - name: airflow-secrets
               mountPath: /opt/bitnami/airflow/secrets
             {{- end }}
@@ -256,7 +256,7 @@ spec:
           configMap:
             name: {{ include "airflow.configMapName"  . }}
             optional: true
-        {{- if .Values.auth.usePasswordFiles }}
+        {{- if .Values.usePasswordFiles }}
         - name: airflow-secrets
           projected:
             sources:

--- a/bitnami/airflow/templates/setup-db-job.yaml
+++ b/bitnami/airflow/templates/setup-db-job.yaml
@@ -84,7 +84,7 @@ spec:
               value: {{ ternary "true" "false" (or .Values.image.debug .Values.diagnosticMode.enabled) | quote }}
             - name: AIRFLOW_USERNAME
               value: {{ .Values.auth.username }}
-            {{- if .Values.auth.usePasswordFiles }}
+            {{- if .Values.usePasswordFiles }}
             - name: AIRFLOW_PASSWORD_FILE
               value: "/opt/bitnami/airflow/secrets/airflow-password"
             {{- else }}
@@ -124,7 +124,7 @@ spec:
             - name: empty-dir
               mountPath: /opt/bitnami/airflow/config/airflow_local_settings.py
               subPath: app-conf-dir/airflow_local_settings.py
-            {{- if  .Values.auth.usePasswordFiles }}
+            {{- if  .Values.usePasswordFiles }}
             - name: airflow-secrets
               mountPath: /opt/bitnami/airflow/secrets
             {{- end }}
@@ -141,7 +141,7 @@ spec:
           configMap:
             name: {{ include "airflow.configMapName"  . }}
             optional: true
-        {{- if .Values.auth.usePasswordFiles }}
+        {{- if .Values.usePasswordFiles }}
         - name: airflow-secrets
           projected:
             sources:

--- a/bitnami/airflow/templates/setup-db-job.yaml
+++ b/bitnami/airflow/templates/setup-db-job.yaml
@@ -84,11 +84,16 @@ spec:
               value: {{ ternary "true" "false" (or .Values.image.debug .Values.diagnosticMode.enabled) | quote }}
             - name: AIRFLOW_USERNAME
               value: {{ .Values.auth.username }}
+            {{- if .Values.auth.usePasswordFiles }}
+            - name: AIRFLOW_PASSWORD_FILE
+              value: "/opt/bitnami/airflow/secrets/airflow-password"
+            {{- else }}
             - name: AIRFLOW_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ include "airflow.secretName" . }}
                   key: airflow-password
+            {{- end}}
             {{- if .Values.setupDBJob.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.setupDBJob.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}
@@ -119,6 +124,10 @@ spec:
             - name: empty-dir
               mountPath: /opt/bitnami/airflow/config/airflow_local_settings.py
               subPath: app-conf-dir/airflow_local_settings.py
+            {{- if  .Values.auth.usePasswordFiles }}
+            - name: airflow-secrets
+              mountPath: /opt/bitnami/airflow/secrets
+            {{- end }}
             {{- if .Values.setupDBJob.extraVolumeMounts }}
             {{- include "common.tplvalues.render" (dict "value" .Values.setupDBJob.extraVolumeMounts "context" $) | nindent 12 }}
             {{- end }}
@@ -132,6 +141,15 @@ spec:
           configMap:
             name: {{ include "airflow.configMapName"  . }}
             optional: true
+        {{- if .Values.auth.usePasswordFiles }}
+        - name: airflow-secrets
+          projected:
+            sources:
+              - secret:
+                  name:  {{ include "airflow.secretName" . }}
+              - secret:
+                  name: {{ include "airflow.database.secretName" . }}
+        {{- end }}
         {{- if .Values.setupDBJob.extraVolumes }}
         {{- include "common.tplvalues.render" (dict "value" .Values.setupDBJob.extraVolumes "context" $) | nindent 8 }}
         {{- end }}

--- a/bitnami/airflow/templates/setup-db-job.yaml
+++ b/bitnami/airflow/templates/setup-db-job.yaml
@@ -149,6 +149,10 @@ spec:
                   name:  {{ include "airflow.secretName" . }}
               - secret:
                   name: {{ include "airflow.database.secretName" . }}
+              {{- if or (eq .Values.executor "CeleryExecutor") (eq .Values.executor "CeleryKubernetesExecutor") }}
+              - secret:
+                  name: {{ include "airflow.redis.secretName" . }}
+              {{- end }}
         {{- end }}
         {{- if .Values.setupDBJob.extraVolumes }}
         {{- include "common.tplvalues.render" (dict "value" .Values.setupDBJob.extraVolumes "context" $) | nindent 8 }}

--- a/bitnami/airflow/templates/triggerer/statefulset.yaml
+++ b/bitnami/airflow/templates/triggerer/statefulset.yaml
@@ -208,7 +208,7 @@ spec:
             - name: empty-dir
               mountPath: /opt/bitnami/airflow/config/airflow_local_settings.py
               subPath: app-conf-dir/airflow_local_settings.py
-            {{- if  .Values.auth.usePasswordFiles }}
+            {{- if  .Values.usePasswordFiles }}
             - name: airflow-secrets
               mountPath: /opt/bitnami/airflow/secrets
             {{- end }}
@@ -251,7 +251,7 @@ spec:
           configMap:
             name: {{ include "airflow.configMapName"  . }}
             optional: true
-        {{- if .Values.auth.usePasswordFiles }}
+        {{- if .Values.usePasswordFiles }}
         - name: airflow-secrets
           projected:
             sources:

--- a/bitnami/airflow/templates/triggerer/statefulset.yaml
+++ b/bitnami/airflow/templates/triggerer/statefulset.yaml
@@ -259,6 +259,10 @@ spec:
                   name:  {{ include "airflow.secretName" . }}
               - secret:
                   name: {{ include "airflow.database.secretName" . }}
+              {{- if or (eq .Values.executor "CeleryExecutor") (eq .Values.executor "CeleryKubernetesExecutor") }}
+              - secret:
+                  name: {{ include "airflow.redis.secretName" . }}
+              {{- end }}
         {{- end }}
         {{- if .Values.dags.enabled }}
         {{- include "airflow.dags.volumes" . | nindent 8 }}

--- a/bitnami/airflow/templates/triggerer/statefulset.yaml
+++ b/bitnami/airflow/templates/triggerer/statefulset.yaml
@@ -208,6 +208,10 @@ spec:
             - name: empty-dir
               mountPath: /opt/bitnami/airflow/config/airflow_local_settings.py
               subPath: app-conf-dir/airflow_local_settings.py
+            {{- if  .Values.auth.usePasswordFiles }}
+            - name: airflow-secrets
+              mountPath: /opt/bitnami/airflow/secrets
+            {{- end }}
             {{- if .Values.triggerer.persistence.enabled }}
             - name: logs
               mountPath: /opt/bitnami/airflow/logs
@@ -247,6 +251,15 @@ spec:
           configMap:
             name: {{ include "airflow.configMapName"  . }}
             optional: true
+        {{- if .Values.auth.usePasswordFiles }}
+        - name: airflow-secrets
+          projected:
+            sources:
+              - secret:
+                  name:  {{ include "airflow.secretName" . }}
+              - secret:
+                  name: {{ include "airflow.database.secretName" . }}
+        {{- end }}
         {{- if .Values.dags.enabled }}
         {{- include "airflow.dags.volumes" . | nindent 8 }}
         {{- end }}

--- a/bitnami/airflow/templates/web/deployment.yaml
+++ b/bitnami/airflow/templates/web/deployment.yaml
@@ -112,7 +112,7 @@ spec:
             {{- if not .Values.setupDBJob.enabled }}
             - name: AIRFLOW_USERNAME
               value: {{ .Values.auth.username }}
-            {{- if .Values.auth.usePasswordFiles }}
+            {{- if .Values.usePasswordFiles }}
             - name: AIRFLOW_PASSWORD_FILE
               value: "/opt/bitnami/airflow/secrets/airflow-password"
             {{- else }}
@@ -229,7 +229,7 @@ spec:
             - name: empty-dir
               mountPath: /opt/bitnami/airflow/webserver_config.py
               subPath: app-base-dir/webserver_config.py
-            {{- if  .Values.auth.usePasswordFiles }}
+            {{- if  .Values.usePasswordFiles }}
             - name: airflow-secrets
               mountPath: /opt/bitnami/airflow/secrets
             {{- end }}
@@ -277,7 +277,7 @@ spec:
         - name: webserver-configuration
           configMap:
             name: {{ include "airflow.web.configMapName" . }}
-        {{- if .Values.auth.usePasswordFiles }}
+        {{- if .Values.usePasswordFiles }}
         - name: airflow-secrets
           projected:
             sources:

--- a/bitnami/airflow/templates/web/deployment.yaml
+++ b/bitnami/airflow/templates/web/deployment.yaml
@@ -289,6 +289,10 @@ spec:
               - secret:
                   name: {{ include "airflow.ldap.secretName" . }}
               {{- end }}
+              {{- if or (eq .Values.executor "CeleryExecutor") (eq .Values.executor "CeleryKubernetesExecutor") }}
+              - secret:
+                  name: {{ include "airflow.redis.secretName" . }}
+              {{- end }}
         {{- end }}
         {{- if .Values.dags.enabled }}
         {{- include "airflow.dags.volumes" . | nindent 8 }}

--- a/bitnami/airflow/templates/web/deployment.yaml
+++ b/bitnami/airflow/templates/web/deployment.yaml
@@ -112,11 +112,16 @@ spec:
             {{- if not .Values.setupDBJob.enabled }}
             - name: AIRFLOW_USERNAME
               value: {{ .Values.auth.username }}
+            {{- if .Values.auth.usePasswordFiles }}
+            - name: AIRFLOW_PASSWORD_FILE
+              value: "/opt/bitnami/airflow/secrets/airflow-password"
+            {{- else }}
             - name: AIRFLOW_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ include "airflow.secretName" . }}
                   key: airflow-password
+            {{- end }}
             {{- end }}
             {{- if .Values.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.extraEnvVars "context" $) | nindent 12 }}
@@ -224,6 +229,10 @@ spec:
             - name: empty-dir
               mountPath: /opt/bitnami/airflow/webserver_config.py
               subPath: app-base-dir/webserver_config.py
+            {{- if  .Values.auth.usePasswordFiles }}
+            - name: airflow-secrets
+              mountPath: /opt/bitnami/airflow/secrets
+            {{- end }}
             {{- if and .Values.ldap.enabled .Values.ldap.tls.enabled }}
             - name: airflow-ldap-ca-certificate
               mountPath: {{ .Values.ldap.tls.certificatesMountPath }}
@@ -268,6 +277,19 @@ spec:
         - name: webserver-configuration
           configMap:
             name: {{ include "airflow.web.configMapName" . }}
+        {{- if .Values.auth.usePasswordFiles }}
+        - name: airflow-secrets
+          projected:
+            sources:
+              - secret:
+                  name:  {{ include "airflow.secretName" . }}
+              - secret:
+                  name: {{ include "airflow.database.secretName" . }}
+              {{- if .Values.ldap.enabled }}
+              - secret:
+                  name: {{ include "airflow.ldap.secretName" . }}
+              {{- end }}
+        {{- end }}
         {{- if .Values.dags.enabled }}
         {{- include "airflow.dags.volumes" . | nindent 8 }}
         {{- end }}

--- a/bitnami/airflow/templates/worker/statefulset.yaml
+++ b/bitnami/airflow/templates/worker/statefulset.yaml
@@ -282,6 +282,10 @@ spec:
               - secret:
                   name: {{ include "airflow.ldap.secretName" . }}
               {{- end }}
+              {{- if or (eq .Values.executor "CeleryExecutor") (eq .Values.executor "CeleryKubernetesExecutor") }}
+              - secret:
+                  name: {{ include "airflow.redis.secretName" . }}
+              {{- end }}
         {{- end }}
         {{- if .Values.dags.enabled }}
         {{- include "airflow.dags.volumes" . | nindent 8 }}

--- a/bitnami/airflow/templates/worker/statefulset.yaml
+++ b/bitnami/airflow/templates/worker/statefulset.yaml
@@ -221,6 +221,10 @@ spec:
             - name: empty-dir
               mountPath: /opt/bitnami/airflow/webserver_config.py
               subPath: app-base-dir/webserver_config.py
+            {{- if  .Values.auth.usePasswordFiles }}
+            - name: airflow-secrets
+              mountPath: /opt/bitnami/airflow/secrets
+            {{- end }}
             {{- if .Values.dags.enabled }}
             {{- include "airflow.dags.volumeMounts" . | nindent 12 }}
             {{- end }}
@@ -265,6 +269,19 @@ spec:
           secret:
             secretName: {{ template "airflow.web.tls.secretName" . }}
             defaultMode: 256
+        {{- end }}
+        {{- if .Values.auth.usePasswordFiles }}
+        - name: airflow-secrets
+          projected:
+            sources:
+              - secret:
+                  name:  {{ include "airflow.secretName" . }}
+              - secret:
+                  name: {{ include "airflow.database.secretName" . }}
+              {{- if .Values.ldap.enabled }}
+              - secret:
+                  name: {{ include "airflow.ldap.secretName" . }}
+              {{- end }}
         {{- end }}
         {{- if .Values.dags.enabled }}
         {{- include "airflow.dags.volumes" . | nindent 8 }}

--- a/bitnami/airflow/templates/worker/statefulset.yaml
+++ b/bitnami/airflow/templates/worker/statefulset.yaml
@@ -221,7 +221,7 @@ spec:
             - name: empty-dir
               mountPath: /opt/bitnami/airflow/webserver_config.py
               subPath: app-base-dir/webserver_config.py
-            {{- if  .Values.auth.usePasswordFiles }}
+            {{- if  .Values.usePasswordFiles }}
             - name: airflow-secrets
               mountPath: /opt/bitnami/airflow/secrets
             {{- end }}
@@ -270,7 +270,7 @@ spec:
             secretName: {{ template "airflow.web.tls.secretName" . }}
             defaultMode: 256
         {{- end }}
-        {{- if .Values.auth.usePasswordFiles }}
+        {{- if .Values.usePasswordFiles }}
         - name: airflow-secrets
           projected:
             sources:

--- a/bitnami/airflow/values.yaml
+++ b/bitnami/airflow/values.yaml
@@ -65,6 +65,9 @@ clusterDomain: cluster.local
 ## @param extraDeploy Array of extra objects to deploy with the release
 ##
 extraDeploy: []
+## @param usePasswordFiles Mount credentials as files instead of using environment variables
+##
+usePasswordFiles: true
 ## Diagnostic mode
 ## @param diagnosticMode.enabled Enable diagnostic mode (all probes will be disabled and the command will be overridden)
 ## @param diagnosticMode.command Command to override all containers in the chart release


### PR DESCRIPTION
### Description of the change

Adds support for `usePasswordFiles` and enables it by default.

### Benefits

With this change, the chart will mount the secrets as files by default instead of directly setting them into environment variables.

Variables are renamed with the `_FILE` suffix and point to the mounted secret file.

### Possible drawbacks

None

### Applicable issues

None

### Additional information

N/A

### Checklist

- [x] Chart version bumped in Chart.yaml according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
