### PR TITLE
[bitnami/apisix] Add support for `usePasswordFiles`

### DIFF
--- a/bitnami/apisix/CHANGELOG.md
+++ b/bitnami/apisix/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 4.2.0 (2025-02-21)
+## 4.2.0 (2025-02-24)
 
 * [bitnami/apisix] Add support for `usePasswordFiles` ([#32077](https://github.com/bitnami/charts/pull/32077))
 

--- a/bitnami/apisix/CHANGELOG.md
+++ b/bitnami/apisix/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
+## 4.2.0 (2025-02-20)
+
+* [bitnami/apisix] Add support for `usePasswordFiles` ([#32077](https://github.com/bitnami/charts/pull/32077))
+
 ## 4.1.0 (2025-02-20)
 
-* [bitnami/apisix] feat: use new helper for checking API versions ([#32045](https://github.com/bitnami/charts/pull/32045))
+* [bitnami/apisix] feat: use new helper for checking API versions (#32045) ([c327f4b](https://github.com/bitnami/charts/commit/c327f4ba9cf6889d452e0f3fce495c10c6d1c106)), closes [#32045](https://github.com/bitnami/charts/issues/32045)
 
 ## <small>4.0.2 (2025-02-18)</small>
 

--- a/bitnami/apisix/CHANGELOG.md
+++ b/bitnami/apisix/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 4.2.0 (2025-02-20)
+## 4.2.0 (2025-02-21)
 
 * [bitnami/apisix] Add support for `usePasswordFiles` ([#32077](https://github.com/bitnami/charts/pull/32077))
 

--- a/bitnami/apisix/Chart.yaml
+++ b/bitnami/apisix/Chart.yaml
@@ -45,4 +45,4 @@ sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/apisix
   - https://github.com/bitnami/charts/tree/main/bitnami/apisix-dashboard
   - https://github.com/bitnami/charts/tree/main/bitnami/apisix-ingress-controller
-version: 4.1.0
+version: 4.2.0

--- a/bitnami/apisix/README.md
+++ b/bitnami/apisix/README.md
@@ -301,6 +301,7 @@ As an alternative, use one of the preset configurations for pod affinity, pod an
 | `commonAnnotations`      | Annotations to add to all deployed objects                                                                                                        | `{}`                     |
 | `clusterDomain`          | Kubernetes cluster domain name                                                                                                                    | `cluster.local`          |
 | `extraDeploy`            | Array of extra objects to deploy with the release                                                                                                 | `[]`                     |
+| `usePasswordFiles`       | Mount credentials as files instead of using environment variables                                                                                 | `true`                   |
 | `diagnosticMode.enabled` | Enable diagnostic mode (all probes will be disabled and the command will be overridden)                                                           | `false`                  |
 | `diagnosticMode.command` | Command to override all containers in the deployment                                                                                              | `["sleep"]`              |
 | `diagnosticMode.args`    | Args to override all containers in the deployment                                                                                                 | `["infinity"]`           |

--- a/bitnami/apisix/templates/_helpers.tpl
+++ b/bitnami/apisix/templates/_helpers.tpl
@@ -336,7 +336,7 @@ Init container definition for waiting for the database to be ready
       ln -sf /opt/bitnami/apisix/deps /usr/local/apisix
       ln -sf /opt/bitnami/apisix/openresty/luajit/share/lua/*/apisix /usr/local/apisix
       mkdir -p /usr/local/apisix/logs
-    {{- if .Values.usePasswordFiles }}
+    {{- if .context.Values.usePasswordFiles }}
       {{- if .context.Values.controlPlane.enabled }}
       export APISIX_ADMIN_API_TOKEN="$(< $APISIX_ADMIN_API_TOKEN_FILE)"
       export APISIX_VIEWER_API_TOKEN="$(< $APISIX_VIEWER_API_TOKEN_FILE)"
@@ -364,7 +364,7 @@ Init container definition for waiting for the database to be ready
     - name: BITNAMI_DEBUG
       value: {{ ternary "true" "false" (or .context.Values.image.debug .context.Values.diagnosticMode.enabled) | quote }}
     {{- if .context.Values.controlPlane.enabled }}
-    {{- if .Values.usePasswordFiles }}
+    {{- if .context.Values.usePasswordFiles }}
     - name: APISIX_ADMIN_API_TOKEN_FILE
       value: {{ printf "/opt/bitnami/apisix/secrets/%s" (include "apisix.control-plane.adminTokenKey" .context) }}
     - name: APISIX_VIEWER_API_TOKEN_FILE
@@ -385,7 +385,7 @@ Init container definition for waiting for the database to be ready
     {{- if (include "apisix.etcd.authEnabled" .context) }}
     - name: APISIX_ETCD_USER
       value: {{ include "apisix.etcd.user" .context }}
-    {{- if .Values.usePasswordFiles }}
+    {{- if .context.Values.usePasswordFiles }}
     - name: APISIX_ETCD_PASSWORD_FILE
       value: {{ printf "/opt/bitnami/apisix/secrets/%s" (include "apisix.etcd.secretPasswordKey" .context) }}
     {{- else }}
@@ -418,7 +418,7 @@ Init container definition for waiting for the database to be ready
     - name: empty-dir
       mountPath: /tmp
       subPath: tmp-dir
-    {{- if .Values.usePasswordFiles }}
+    {{- if .context.Values.usePasswordFiles }}
     - name: apisix-secrets
       mountPath: /opt/bitnami/apisix/secrets
     {{- end }}
@@ -587,7 +587,7 @@ Render configuration for the dashboard and ingress-controller components
     - |
       #!/bin/bash
       # Build final config.yaml with the sections of the different files
-    {{- if .Values.usePasswordFiles }}
+    {{- if .context.Values.usePasswordFiles }}
       {{- if .context.Values.controlPlane.enabled }}
       export APISIX_ADMIN_API_TOKEN="$(< $APISIX_ADMIN_API_TOKEN_FILE)"
       export APISIX_VIEWER_API_TOKEN="$(< $APISIX_VIEWER_API_TOKEN_FILE)"
@@ -607,7 +607,7 @@ Render configuration for the dashboard and ingress-controller components
     - name: BITNAMI_DEBUG
       value: {{ ternary "true" "false" (or .context.Values.image.debug .context.Values.diagnosticMode.enabled) | quote }}
     {{- if .context.Values.controlPlane.enabled }}
-    {{- if .Values.usePasswordFiles }}
+    {{- if .context.Values.usePasswordFiles }}
     - name: APISIX_ADMIN_API_TOKEN_FILE
       value: {{ printf "/opt/bitnami/apisix/secrets/%s" (include "apisix.control-plane.adminTokenKey" .context) }}
     - name: APISIX_VIEWER_API_TOKEN_FILE
@@ -628,7 +628,7 @@ Render configuration for the dashboard and ingress-controller components
     {{- if (include "apisix.etcd.authEnabled" .context) }}
     - name: APISIX_ETCD_USER
       value: {{ include "apisix.etcd.user" .context }}
-    {{- if .Values.usePasswordFiles }}
+    {{- if .context.Values.usePasswordFiles }}
     - name: APISIX_ETCD_PASSWORD_FILE
       value: {{ printf "/opt/bitnami/apisix/secrets/%s" (include "apisix.etcd.secretPasswordKey" .context) }}
     {{- else }}
@@ -642,7 +642,7 @@ Render configuration for the dashboard and ingress-controller components
     {{- if eq .component "dashboard" }}
     - name: APISIX_DASHBOARD_USER
       value: {{ $block.username | quote }}
-    {{- if .Values.usePasswordFiles }}
+    {{- if .context.Values.usePasswordFiles }}
     - name: APISIX_DASHBOARD_PASSWORD_FILE
       value: {{ printf "/opt/bitnami/apisix/secrets/%s" (include "apisix.dashboard.secretPasswordKey" .context) }}
     {{- else }}
@@ -671,7 +671,7 @@ Render configuration for the dashboard and ingress-controller components
       subPath: app-conf-dir
     - name: config
       mountPath: /bitnami/apisix/conf/00_default
-    {{- if .Values.usePasswordFiles }}
+    {{- if .context.Values.usePasswordFiles }}
     - name: apisix-secrets
       mountPath: /opt/bitnami/apisix/secrets
     {{- end }}

--- a/bitnami/apisix/templates/_helpers.tpl
+++ b/bitnami/apisix/templates/_helpers.tpl
@@ -418,7 +418,7 @@ Init container definition for waiting for the database to be ready
     - name: empty-dir
       mountPath: /tmp
       subPath: tmp-dir
-    {{- if .context.Values.usePasswordFiles }}
+    {{- if and .context.Values.usePasswordFiles (or (eq .component "dashboard") .context.Values.controlPlane.enabled (include "apisix.etcd.authEnabled" .)) }}
     - name: apisix-secrets
       mountPath: /opt/bitnami/apisix/secrets
     {{- end }}
@@ -671,7 +671,7 @@ Render configuration for the dashboard and ingress-controller components
       subPath: app-conf-dir
     - name: config
       mountPath: /bitnami/apisix/conf/00_default
-    {{- if .context.Values.usePasswordFiles }}
+    {{- if and .context.Values.usePasswordFiles (or (eq .component "dashboard") .context.Values.controlPlane.enabled (include "apisix.etcd.authEnabled" .)) }}
     - name: apisix-secrets
       mountPath: /opt/bitnami/apisix/secrets
     {{- end }}

--- a/bitnami/apisix/templates/control-plane/dep-ds.yaml
+++ b/bitnami/apisix/templates/control-plane/dep-ds.yaml
@@ -192,6 +192,17 @@ spec:
         - name: config
           configMap:
             name: {{ include "apisix.control-plane.defaultConfigmapName" . }}
+        {{- if .Values.usePasswordFiles }}
+        - name: apisix-secrets
+          projected:
+            sources:
+              - secret:
+                  name: {{ include "apisix.control-plane.secretName" . }}
+              {{- if (include "apisix.etcd.authEnabled" .) }}
+              - secret:
+                  name:  {{ include "apisix.etcd.secretName" . }}
+              {{- end }}
+        {{- end }}
         {{- if or .Values.controlPlane.extraConfig .Values.controlPlane.extraConfigExistingConfigMap }}
         - name: extra-config
           configMap:

--- a/bitnami/apisix/templates/dashboard/deployment.yaml
+++ b/bitnami/apisix/templates/dashboard/deployment.yaml
@@ -181,6 +181,21 @@ spec:
         - name: config
           configMap:
             name: {{ include "apisix.dashboard.defaultConfigmapName" . }}
+        {{- if .Values.usePasswordFiles }}
+        - name: apisix-secrets
+          projected:
+            sources:
+              - secret:
+                  name:  {{ include "apisix.dashboard.secretName" . }}
+              {{- if (include "apisix.etcd.authEnabled" .) }}
+              - secret:
+                  name:  {{ include "apisix.etcd.secretName" . }}
+              {{- end }}
+              {{- if .Values.controlPlane.enabled }}
+              - secret:
+                  name: {{ include "apisix.control-plane.secretName" . }}
+              {{- end }}
+        {{- end }}
         {{- if or .Values.dashboard.extraConfig .Values.dashboard.extraConfigExistingConfigMap }}
         - name: extra-config
           configMap:

--- a/bitnami/apisix/templates/data-plane/dep-ds.yaml
+++ b/bitnami/apisix/templates/data-plane/dep-ds.yaml
@@ -196,12 +196,10 @@ spec:
         {{- include "common.tplvalues.render" ( dict "value" .Values.dataPlane.sidecars "context" $) | nindent 8 }}
         {{- end }}
       volumes:
-        {{- if .Values.usePasswordFiles }}
+        {{- if and .Values.usePasswordFiles (or .Values.controlPlane.enabled (include "apisix.etcd.authEnabled" .)) }}
         - name: apisix-secrets
           projected:
             sources:
-              - secret:
-                  name:  {{ include "apisix.dashboard.secretName" . }}
               {{- if (include "apisix.etcd.authEnabled" .) }}
               - secret:
                   name:  {{ include "apisix.etcd.secretName" . }}

--- a/bitnami/apisix/templates/data-plane/dep-ds.yaml
+++ b/bitnami/apisix/templates/data-plane/dep-ds.yaml
@@ -196,6 +196,21 @@ spec:
         {{- include "common.tplvalues.render" ( dict "value" .Values.dataPlane.sidecars "context" $) | nindent 8 }}
         {{- end }}
       volumes:
+        {{- if .Values.usePasswordFiles }}
+        - name: apisix-secrets
+          projected:
+            sources:
+              - secret:
+                  name:  {{ include "apisix.dashboard.secretName" . }}
+              {{- if (include "apisix.etcd.authEnabled" .) }}
+              - secret:
+                  name:  {{ include "apisix.etcd.secretName" . }}
+              {{- end }}
+              {{- if .Values.controlPlane.enabled }}
+              - secret:
+                  name: {{ include "apisix.control-plane.secretName" . }}
+              {{- end }}
+        {{- end }}
         - name: config
           configMap:
             name: {{ include "apisix.data-plane.defaultConfigmapName" . }}

--- a/bitnami/apisix/templates/ingress-controller/deployment.yaml
+++ b/bitnami/apisix/templates/ingress-controller/deployment.yaml
@@ -187,6 +187,19 @@ spec:
         - name: config
           configMap:
             name: {{ include "apisix.ingress-controller.defaultConfigmapName" . }}
+        {{- if and .Values.usePasswordFiles (or .Values.controlPlane.enabled (include "apisix.etcd.authEnabled" .)) }}
+        - name: apisix-secrets
+          projected:
+            sources:
+              {{- if (include "apisix.etcd.authEnabled" .) }}
+              - secret:
+                  name:  {{ include "apisix.etcd.secretName" . }}
+              {{- end }}
+              {{- if .Values.controlPlane.enabled }}
+              - secret:
+                  name: {{ include "apisix.control-plane.secretName" . }}
+              {{- end }}
+        {{- end }}
         {{- if or .Values.ingressController.extraConfig .Values.ingressController.extraConfigExistingConfigMap }}
         - name: extra-config
           configMap:

--- a/bitnami/apisix/values.yaml
+++ b/bitnami/apisix/values.yaml
@@ -65,6 +65,9 @@ clusterDomain: cluster.local
 ## @param extraDeploy Array of extra objects to deploy with the release
 ##
 extraDeploy: []
+## @param usePasswordFiles Mount credentials as files instead of using environment variables
+##
+usePasswordFiles: true
 ## Enable diagnostic mode in the deployment
 ##
 diagnosticMode:
@@ -1845,7 +1848,7 @@ dashboard:
       - ai
       - cas-auth
       - multi-auth
-      
+
   ## @param dashboard.extraConfig extra configuration settings for APISIX Dashboard
   ##
   extraConfig: {}


### PR DESCRIPTION
### Description of the change

Adds support for `usePasswordFiles` and enables it by default.

### Benefits

With this change, the chart will mount the secrets as files by default instead of directly setting them into environment variables.

Variables are renamed with the `_FILE` suffix and point to the mounted secret file.

### Possible drawbacks

None

### Applicable issues

None

### Additional information

N/A

### Checklist

- [x] Chart version bumped in Chart.yaml according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
