### PR TITLE
[bitnami/appsmith] Add support for `usePasswordFiles`

### DIFF
--- a/bitnami/appsmith/Chart.yaml
+++ b/bitnami/appsmith/Chart.yaml
@@ -39,4 +39,4 @@ maintainers:
 name: appsmith
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/appsmith
-version: 5.1.12
+version: 5.2.0

--- a/bitnami/appsmith/templates/_helpers.tpl
+++ b/bitnami/appsmith/templates/_helpers.tpl
@@ -236,15 +236,25 @@ Return the MongoDB Secret Name
       value: {{ include "appsmith.mongodb.hosts" . | quote }}
     - name: APPSMITH_DATABASE_PORT_NUMBER
       value: {{ include "appsmith.mongodb.port" . | quote }}
+    {{- if .Values.usePasswordFiles }}
+    - name: APPSMITH_DATABASE_PASSWORD_FILE
+      value: {{ printf "/opt/bitnami/appsmith/secrets/%s" (include "appsmith.mongodb.secretKey" .) }}
+    {{- else }}
     - name: APPSMITH_DATABASE_PASSWORD
       valueFrom:
         secretKeyRef:
           name: {{ include "appsmith.mongodb.secretName" . }}
           key: {{ include "appsmith.mongodb.secretKey" . }}
+    {{- end }}
     - name: APPSMITH_DATABASE_USER
       value: {{ ternary (index .Values.mongodb.auth.usernames 0) .Values.externalDatabase.username .Values.mongodb.enabled | quote }}
     - name: APPSMITH_DATABASE_NAME
       value: {{ ternary (index .Values.mongodb.auth.databases 0) .Values.externalDatabase.database .Values.mongodb.enabled | quote }}
+  {{- if  .Values.usePasswordFiles }}
+  volumeMounts:
+    - name: appsmith-secrets
+      mountPath: /opt/bitnami/appsmith/secrets
+  {{- end }}
 {{- end -}}
 
 {{- define "appsmith.waitForBackendInitContainer" -}}

--- a/bitnami/appsmith/templates/backend/deployment.yaml
+++ b/bitnami/appsmith/templates/backend/deployment.yaml
@@ -145,6 +145,14 @@ spec:
               value: {{ .Values.backend.adminUser | quote }}
             - name: APPSMITH_EMAIL
               value: {{ .Values.backend.adminEmail | quote }}
+            {{- if .Values.usePasswordFiles }}
+            - name: APPSMITH_PASSWORD_FILE
+              value: {{ printf "/opt/bitnami/appsmith/secrets/%s" (include "appsmith.backend.password.secretKey" .) }}
+            - name: APPSMITH_ENCRYPTION_PASSWORD_FILE
+              value: {{ printf "/opt/bitnami/appsmith/secrets/%s" (include "appsmith.backend.encryptionPassword.secretKey" .) }}
+            - name: APPSMITH_ENCRYPTION_SALT_FILE
+              value: {{ printf "/opt/bitnami/appsmith/secrets/%s" (include "appsmith.backend.encryptionSalt.secretKey" .) }}
+            {{- else }}
             - name: APPSMITH_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -160,15 +168,21 @@ spec:
                 secretKeyRef:
                   name: {{ include "appsmith.backend.secretName" . }}
                   key: {{ include "appsmith.backend.encryptionSalt.secretKey" . }}
+            {{- end }}
             - name: APPSMITH_DATABASE_HOST
               value: {{ include "appsmith.mongodb.hosts" . | quote }}
             - name: APPSMITH_DATABASE_PORT_NUMBER
               value: {{ include "appsmith.mongodb.port" . | quote }}
+            {{- if .Values.usePasswordFiles }}
+            - name: APPSMITH_DATABASE_PASSWORD_FILE
+              value: {{ printf "/opt/bitnami/appsmith/secrets/%s" (include "appsmith.mongodb.secretKey" .) }}
+            {{- else }}
             - name: APPSMITH_DATABASE_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ include "appsmith.mongodb.secretName" . }}
                   key: {{ include "appsmith.mongodb.secretKey" . }}
+            {{- end }}
             - name: APPSMITH_DATABASE_USER
               value: {{ ternary (index .Values.mongodb.auth.usernames 0) .Values.externalDatabase.username .Values.mongodb.enabled | quote }}
             - name: APPSMITH_DATABASE_NAME
@@ -179,11 +193,16 @@ spec:
               value: {{ include "appsmith.redis.host" . | quote }}
             - name: APPSMITH_REDIS_PORT_NUMBER
               value: {{ include "appsmith.redis.port" . | quote }}
+            {{- if .Values.usePasswordFiles }}
+            - name: APPSMITH_REDIS_PASSWORD_FILE
+              value: {{ printf "/opt/bitnami/appsmith/secrets/%s" (include "appsmith.redis.secretKey" .) }}
+            {{- else }}
             - name: APPSMITH_REDIS_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ include "appsmith.redis.secretName" . }}
                   key: {{ include "appsmith.redis.secretKey" . }}
+            {{- end }}
             - name: APPSMITH_RTS_PORT
               value: {{ .Values.rts.containerPorts.http | quote }}
             {{- if .Values.backend.persistence.gitDataPath }}
@@ -263,6 +282,10 @@ spec:
             - name: empty-dir
               mountPath: /tmp
               subPath: tmp-dir
+            {{- if .Values.usePasswordFiles }}
+            - name: appsmith-secrets
+              mountPath: /opt/bitnami/appsmith/secrets
+            {{- end }}
             - name: data
               mountPath: {{ .Values.backend.persistence.mountPath }}
               {{- if .Values.backend.persistence.subPath }}
@@ -356,6 +379,17 @@ spec:
         - name: haproxy-conf
           configMap:
             name: {{ include "appsmith.redirect.fullname" . }}
+        {{- if .Values.usePasswordFiles }}
+        - name: appsmith-secrets
+          projected:
+            sources:
+              - secret:
+                  name:  {{ include "appsmith.backend.secretName" . }}
+              - secret:
+                  name:  {{ include "appsmith.mongodb.secretName" . }}
+              - secret:
+                  name:  {{ include "appsmith.redis.secretName" . }}
+        {{- end }}
         - name: data
         {{- if .Values.backend.persistence.enabled }}
           persistentVolumeClaim:

--- a/bitnami/appsmith/templates/rts/deployment.yaml
+++ b/bitnami/appsmith/templates/rts/deployment.yaml
@@ -99,11 +99,16 @@ spec:
               value: {{ include "appsmith.mongodb.hosts" . | quote }}
             - name: APPSMITH_DATABASE_PORT_NUMBER
               value: {{ include "appsmith.mongodb.port" . | quote }}
+            {{- if .Values.usePasswordFiles }}
+            - name: APPSMITH_DATABASE_PASSWORD_FILE
+              value: {{ printf "/opt/bitnami/appsmith/secrets/%s" (include "appsmith.mongodb.secretKey" .) }}
+            {{- else }}
             - name: APPSMITH_DATABASE_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ include "appsmith.mongodb.secretName" . }}
                   key: {{ include "appsmith.mongodb.secretKey" . }}
+            {{- end }}
             - name: APPSMITH_DATABASE_USER
               value: {{ ternary (index .Values.mongodb.auth.usernames 0) .Values.externalDatabase.username .Values.mongodb.enabled | quote }}
             - name: APPSMITH_DATABASE_NAME
@@ -187,6 +192,10 @@ spec:
             - name: empty-dir
               mountPath: /tmp
               subPath: tmp-dir
+            {{- if .Values.usePasswordFiles }}
+            - name: appsmith-secrets
+              mountPath: /opt/bitnami/appsmith/secrets
+            {{- end }}
           {{- if .Values.rts.extraVolumeMounts }}
           {{- include "common.tplvalues.render" (dict "value" .Values.rts.extraVolumeMounts "context" $) | nindent 12 }}
           {{- end }}
@@ -196,6 +205,17 @@ spec:
       volumes:
         - name: empty-dir
           emptyDir: {}
+        {{- if .Values.usePasswordFiles }}
+        - name: appsmith-secrets
+          projected:
+            sources:
+              - secret:
+                  name:  {{ include "appsmith.mongodb.secretName" . }}
+                  items:
+                    # Only copy database password
+                    - key: {{ include "appsmith.mongodb.secretKey" . }}
+                      path: {{ include "appsmith.mongodb.secretKey" . }}
+        {{- end }}
         {{- if .Values.rts.extraVolumes }}
         {{- include "common.tplvalues.render" (dict "value" .Values.rts.extraVolumes "context" $) | nindent 8 }}
         {{- end }}

--- a/bitnami/appsmith/values.yaml
+++ b/bitnami/appsmith/values.yaml
@@ -60,6 +60,9 @@ clusterDomain: cluster.local
 ## @param extraDeploy Array of extra objects to deploy with the release
 ##
 extraDeploy: []
+## @param usePasswordFiles Mount credentials as files instead of using environment variables
+##
+usePasswordFiles: true
 ## Enable diagnostic mode in the deployment
 ##
 diagnosticMode:


### PR DESCRIPTION
### Description of the change

Adds support for `usePasswordFiles` and enables it by default.

### Benefits

With this change, the chart will mount the secrets as files by default instead of directly setting them into environment variables.

Variables are renamed with the `_FILE` suffix and point to the mounted secret file.

### Possible drawbacks

None

### Applicable issues

None

### Additional information

N/A

### Checklist

- [x] Chart version bumped in Chart.yaml according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
