### PR TITLE
[bitnami/argo-cd] Add support for `usePasswordFiles`

### DIFF
--- a/.vib/argo-cd/cypress/cypress/e2e/argo_cd.cy.js
+++ b/.vib/argo-cd/cypress/cypress/e2e/argo_cd.cy.js
@@ -58,6 +58,9 @@ it('allows deploying a healthy app for a new project', () => {
       cy.contains(`${applications.newApplication.name}-${random}`, {timeout: 60000}).click({force: true});
     });
   });
+  // Wait and reload to prevent stationary issues
+  cy.wait(5000);
+  cy.reload();
   // Ensure that UI shows the basic K8s objects
   cy.contains('svc');
   cy.contains('deploy');

--- a/bitnami/argo-cd/CHANGELOG.md
+++ b/bitnami/argo-cd/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 7.1.10 (2025-02-06)
+## 7.2.0 (2025-02-20)
 
-* [bitnami/argo-cd] Release 7.1.10 ([#31804](https://github.com/bitnami/charts/pull/31804))
+* [bitnami/argo-cd] Add support for `usePasswordFiles` ([#32079](https://github.com/bitnami/charts/pull/32079))
+
+## <small>7.1.10 (2025-02-06)</small>
+
+* [bitnami/argo-cd] Release 7.1.10 (#31804) ([c0db7b0](https://github.com/bitnami/charts/commit/c0db7b02d6129b86c343c8d65fa920b8e848670f)), closes [#31804](https://github.com/bitnami/charts/issues/31804)
 
 ## <small>7.1.9 (2025-02-04)</small>
 

--- a/bitnami/argo-cd/CHANGELOG.md
+++ b/bitnami/argo-cd/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 7.2.0 (2025-02-20)
+## 7.2.0 (2025-02-21)
 
 * [bitnami/argo-cd] Add support for `usePasswordFiles` ([#32079](https://github.com/bitnami/charts/pull/32079))
 

--- a/bitnami/argo-cd/CHANGELOG.md
+++ b/bitnami/argo-cd/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 7.2.0 (2025-02-21)
+## 7.2.0 (2025-02-24)
 
 * [bitnami/argo-cd] Add support for `usePasswordFiles` ([#32079](https://github.com/bitnami/charts/pull/32079))
 

--- a/bitnami/argo-cd/Chart.yaml
+++ b/bitnami/argo-cd/Chart.yaml
@@ -39,4 +39,4 @@ maintainers:
 name: argo-cd
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/argo-cd
-version: 7.1.10
+version: 7.2.0

--- a/bitnami/argo-cd/README.md
+++ b/bitnami/argo-cd/README.md
@@ -329,15 +329,16 @@ As an alternative, use one of the preset configurations for pod affinity, pod an
 
 ### Common parameters
 
-| Name                | Description                                        | Value           |
-| ------------------- | -------------------------------------------------- | --------------- |
-| `kubeVersion`       | Override Kubernetes version                        | `""`            |
-| `nameOverride`      | String to partially override common.names.fullname | `""`            |
-| `fullnameOverride`  | String to fully override common.names.fullname     | `""`            |
-| `commonLabels`      | Labels to add to all deployed objects              | `{}`            |
-| `commonAnnotations` | Annotations to add to all deployed objects         | `{}`            |
-| `clusterDomain`     | Kubernetes cluster domain name                     | `cluster.local` |
-| `extraDeploy`       | Array of extra objects to deploy with the release  | `[]`            |
+| Name                | Description                                                       | Value           |
+| ------------------- | ----------------------------------------------------------------- | --------------- |
+| `kubeVersion`       | Override Kubernetes version                                       | `""`            |
+| `nameOverride`      | String to partially override common.names.fullname                | `""`            |
+| `fullnameOverride`  | String to fully override common.names.fullname                    | `""`            |
+| `commonLabels`      | Labels to add to all deployed objects                             | `{}`            |
+| `commonAnnotations` | Annotations to add to all deployed objects                        | `{}`            |
+| `clusterDomain`     | Kubernetes cluster domain name                                    | `cluster.local` |
+| `extraDeploy`       | Array of extra objects to deploy with the release                 | `[]`            |
+| `usePasswordFiles`  | Mount credentials as files instead of using environment variables | `true`          |
 
 ### Argo CD image parameters
 

--- a/bitnami/argo-cd/templates/application-controller/_pod.tpl
+++ b/bitnami/argo-cd/templates/application-controller/_pod.tpl
@@ -78,6 +78,10 @@ initContainers:
             fi
           }
 
+          {{- if .Values.usePasswordFiles }}
+            export REDISCLI_AUTH="$(< $REDISCLI_AUTH_FILE)"
+          {{- end }}
+
           info "Checking redis connection..."
           if ! retry_while "check_redis_connection"; then
               error "Could not connect to the Redis server"

--- a/bitnami/argo-cd/templates/repo-server/deployment.yaml
+++ b/bitnami/argo-cd/templates/repo-server/deployment.yaml
@@ -121,6 +121,10 @@ spec:
                   fi
                 }
 
+                {{- if .Values.usePasswordFiles }}
+                  export REDISCLI_AUTH="$(< $REDISCLI_AUTH_FILE)"
+                {{- end }}
+
                 info "Checking redis connection..."
                 if ! retry_while "check_redis_connection"; then
                     error "Could not connect to the Redis server"

--- a/bitnami/argo-cd/templates/repo-server/deployment.yaml
+++ b/bitnami/argo-cd/templates/repo-server/deployment.yaml
@@ -130,11 +130,21 @@ spec:
                 fi
           {{- if include "argocd.redis.auth.enabled" . }}
           env:
+            {{- if .Values.usePasswordFiles }}
+            - name: REDISCLI_AUTH_FILE
+              value: {{ printf "/opt/bitnami/argo-cd/secrets/%s" (include "argocd.redis.secretPasswordKey" .) }}
+            {{- else }}
             - name: REDISCLI_AUTH
               valueFrom:
                 secretKeyRef:
                   name: {{ include "argocd.redis.secretName" . }}
                   key: {{ include "argocd.redis.secretPasswordKey" . }}
+            {{- end }}
+          {{- if and .Values.usePasswordFiles }}
+          volumeMounts:
+            - name: argocd-secrets
+              mountPath: /opt/bitnami/argo-cd/secrets
+          {{- end }}
           {{- end }}
         {{- end }}
         {{- if .Values.repoServer.initContainers }}
@@ -178,22 +188,17 @@ spec:
               containerPort: {{ .Values.repoServer.containerPorts.metrics }}
               protocol: TCP
           env:
-            {{- if and .Values.redis.enabled (include "argocd.redis.auth.enabled" .) }}
+            {{- if (include "argocd.redis.auth.enabled" .) }}
+            {{- if .Values.usePasswordFiles }}
+            - name: REDISCLI_PASSWORD_FILE
+              value: {{ printf "/opt/bitnami/argo-cd/secrets/%s" (include "argocd.redis.secretPasswordKey" .) }}
+            {{- else }}
             - name: REDIS_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ include "argocd.redis.secretName" . }}
                   key: {{ include "argocd.redis.secretPasswordKey" . }}
-            {{- else if .Values.externalRedis.enabled }}
-            - name: REDIS_PASSWORD
-              {{- if not ( eq "" .Values.externalRedis.password ) }}
-              value: {{ .Values.externalRedis.password }}
-              {{- else }}
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.externalRedis.existingSecret }}
-                  key: {{ .Values.externalRedis.existingSecretPasswordKey }}
-              {{- end }}
+            {{- end }}
             {{- end }}
             {{- if .Values.repoServer.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.repoServer.extraEnvVars "context" $) | nindent 12 }}
@@ -273,6 +278,10 @@ spec:
             - name: empty-dir
               mountPath: /tmp
               subPath: tmp-dir
+            {{- if and .Values.usePasswordFiles (include "argocd.redis.auth.enabled" .)}}
+            - name: argocd-secrets
+              mountPath: /opt/bitnami/argo-cd/secrets
+            {{- end }}
           {{- if .Values.repoServer.extraVolumeMounts }}
           {{- include "common.tplvalues.render" (dict "value" .Values.repoServer.extraVolumeMounts "context" $) | nindent 12 }}
           {{- end }}
@@ -283,6 +292,13 @@ spec:
         - name: ssh-known-hosts
           configMap:
             name: argocd-ssh-known-hosts-cm
+        {{- if and .Values.usePasswordFiles (include "argocd.redis.auth.enabled" .)}}
+        - name: argocd-secrets
+          projected:
+            sources:
+              - secret:
+                  name: {{ include "argocd.redis.secretName" . }}
+        {{- end }}
         {{- if .Values.config.tlsCerts }}
         - configMap:
             name: argocd-tls-certs-cm

--- a/bitnami/argo-cd/templates/server/deployment.yaml
+++ b/bitnami/argo-cd/templates/server/deployment.yaml
@@ -103,6 +103,10 @@ spec:
                   fi
                 }
 
+                {{- if .Values.usePasswordFiles }}
+                  export REDISCLI_AUTH="$(< $REDISCLI_AUTH_FILE)"
+                {{- end }}
+
                 info "Checking redis connection..."
                 if ! retry_while "check_redis_connection"; then
                     error "Could not connect to the Redis server"

--- a/bitnami/argo-cd/templates/server/deployment.yaml
+++ b/bitnami/argo-cd/templates/server/deployment.yaml
@@ -112,11 +112,21 @@ spec:
                 fi
           {{- if include "argocd.redis.auth.enabled" . }}
           env:
+            {{- if .Values.usePasswordFiles }}
+            - name: REDISCLI_AUTH_FILE
+              value: {{ printf "/opt/bitnami/argo-cd/secrets/%s" (include "argocd.redis.secretPasswordKey" .) }}
+            {{- else }}
             - name: REDISCLI_AUTH
               valueFrom:
                 secretKeyRef:
                   name: {{ include "argocd.redis.secretName" . }}
                   key: {{ include "argocd.redis.secretPasswordKey" . }}
+            {{- end }}
+          {{- if .Values.usePasswordFiles }}
+          volumeMounts:
+            - name: argocd-secrets
+              mountPath: /opt/bitnami/argo-cd/secrets
+          {{- end }}
           {{- end }}
         {{- end }}
       containers:
@@ -173,22 +183,17 @@ spec:
             - name: ARGOCD_API_SERVER_REPLICAS
               value: {{ .Values.server.replicaCount | quote }}
             {{- end }}
-            {{- if and .Values.redis.enabled (include "argocd.redis.auth.enabled" .) }}
+            {{- if (include "argocd.redis.auth.enabled" .) }}
+            {{- if .Values.usePasswordFiles }}
+            - name: REDISCLI_PASSWORD_FILE
+              value: {{ printf "/opt/bitnami/argo-cd/secrets/%s" (include "argocd.redis.secretPasswordKey" .) }}
+            {{- else }}
             - name: REDIS_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ include "argocd.redis.secretName" . }}
                   key: {{ include "argocd.redis.secretPasswordKey" . }}
-            {{- else if .Values.externalRedis.enabled }}
-            - name: REDIS_PASSWORD
-              {{- if not ( eq "" .Values.externalRedis.password ) }}
-              value: {{ .Values.externalRedis.password }}
-              {{- else }}
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.externalRedis.existingSecret }}
-                  key: {{ .Values.externalRedis.existingSecretPasswordKey }}
-              {{- end }}
+            {{- end }}
             {{- end }}
             {{- if .Values.server.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.server.extraEnvVars "context" $) | nindent 12 }}
@@ -270,6 +275,10 @@ spec:
             # Ref: https://argoproj.github.io/argo-cd/operator-manual/tls/#inbound-tls-certificates-used-by-argocd-repo-sever
             - mountPath: /app/config/server/tls
               name: argocd-repo-server-tls
+            {{- if and .Values.usePasswordFiles (include "argocd.redis.auth.enabled" .)}}
+            - name: argocd-secrets
+              mountPath: /opt/bitnami/argo-cd/secrets
+            {{- end }}
           {{- if .Values.server.extraVolumeMounts }}
           {{- include "common.tplvalues.render" (dict "value" .Values.server.extraVolumeMounts "context" $) | nindent 12 }}
           {{- end }}
@@ -282,6 +291,13 @@ spec:
         - name: ssh-known-hosts
           configMap:
             name: argocd-ssh-known-hosts-cm
+        {{- if and .Values.usePasswordFiles (include "argocd.redis.auth.enabled" .)}}
+        - name: argocd-secrets
+          projected:
+            sources:
+              - secret:
+                  name: {{ include "argocd.redis.secretName" . }}
+        {{- end }}
         {{- if .Values.config.styles }}
         - configMap:
             name: {{ include "argocd.custom-styles.fullname" . }}

--- a/bitnami/argo-cd/values.yaml
+++ b/bitnami/argo-cd/values.yaml
@@ -57,6 +57,10 @@ clusterDomain: cluster.local
 ## @param extraDeploy Array of extra objects to deploy with the release
 ##
 extraDeploy: []
+## @param usePasswordFiles Mount credentials as files instead of using environment variables
+##
+usePasswordFiles: true
+
 ## @section Argo CD image parameters
 
 ## Bitnami Argo CD image


### PR DESCRIPTION
### Description of the change

Adds support for `usePasswordFiles` and enables it by default.

### Benefits

With this change, the chart will mount the secrets as files by default instead of directly setting them into environment variables.

Variables are renamed with the `_FILE` suffix and point to the mounted secret file.

### Possible drawbacks

None

### Applicable issues

None

### Additional information

N/A

### Checklist

- [x] Chart version bumped in Chart.yaml according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
