### PR TITLE
[bitnami/chainloop] Add support for `usePasswordFiles`

### DIFF
--- a/bitnami/chainloop/Chart.yaml
+++ b/bitnami/chainloop/Chart.yaml
@@ -63,4 +63,4 @@ sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/chainloop-control-plane-migrations
   - https://github.com/bitnami/containers/tree/main/bitnami/chainloop-artifact-cas
   - https://github.com/chainloop-dev/chainloop
-version: 2.2.0
+version: 2.3.0

--- a/bitnami/chainloop/templates/controlplane/deployment.yaml
+++ b/bitnami/chainloop/templates/controlplane/deployment.yaml
@@ -82,15 +82,29 @@ spec:
             - migrate
             - apply
             - --url
+            {{- if .Values.usePasswordFiles }}
             - $(CONNECTION_STRING)
+            {{- else }}
+            - "$(< $CONNECTION_STRING_FILE)"
+            {{- end }}
             - --dir
             - file:///migrations
           env:
+            {{- if .Values.usePasswordFiles }}
+            - name: CONNECTION_STRING_FILE
+              value: "/opt/bitnami/chainloop/secrets/db_migrate_source"
+            {{- else }}
             - name: CONNECTION_STRING
               valueFrom:
                 secretKeyRef:
                   name: {{ include "chainloop.controlplane.fullname" . }}
                   key: db_migrate_source
+            {{- end }}
+          {{- if .Values.usePasswordFiles }}
+          volumeMounts:
+            - name: chainloop-secrets
+              mountPath: /opt/bitnami/chainloop/secrets
+          {{- end }}
       containers:
         - name: controlplane
           {{- if .Values.controlplane.containerSecurityContext.enabled }}
@@ -187,12 +201,19 @@ spec:
                 name: {{ include "chainloop.controlplane.fullname" . }}
             - configMap:
                name: {{ include "chainloop.controlplane.fullname" . }}
+        {{- if .Values.usePasswordFiles }}
+        - name: chainloop-secrets
+          projected:
+            sources:
+              - secret:
+                  name: {{ include "chainloop.controlplane.fullname" . }}
+        {{- end }}
         {{- if (not (empty .Values.controlplane.customCAs)) }}
         - name: custom-cas
           projected:
             sources:
             - secret:
-               name: {{ include "chainloop.controlplane.fullname" . }}-custom-cas
+                name: {{ include "chainloop.controlplane.fullname" . }}-custom-cas
         {{- end }}
         # required for the plugins to store the socket files
         - name: tmp

--- a/bitnami/chainloop/values.yaml
+++ b/bitnami/chainloop/values.yaml
@@ -68,6 +68,10 @@ commonLabels: {}
 ##
 extraDeploy: []
 
+## @param usePasswordFiles Mount credentials as files instead of using environment variables
+##
+usePasswordFiles: true
+
 ## RBAC configuration
 ##
 rbac:


### PR DESCRIPTION
### Description of the change

Adds support for `usePasswordFiles` and enables it by default.

### Benefits

With this change, the chart will mount the secrets as files by default instead of directly setting them into environment variables.

Variables are renamed with the `_FILE` suffix and point to the mounted secret file.

### Possible drawbacks

None

### Applicable issues

None

### Additional information

N/A

### Checklist

- [x] Chart version bumped in Chart.yaml according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
