### PR TITLE
[bitnami/mariadb-galera] Set `usePasswordFiles=true` by default

### DIFF
--- a/bitnami/mariadb-galera/Chart.yaml
+++ b/bitnami/mariadb-galera/Chart.yaml
@@ -33,4 +33,4 @@ maintainers:
 name: mariadb-galera
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/mariadb-galera
-version: 14.1.4
+version: 14.2.0

--- a/bitnami/mariadb-galera/values.yaml
+++ b/bitnami/mariadb-galera/values.yaml
@@ -345,7 +345,7 @@ rootUser:
 existingSecret: ""
 ## @param usePasswordFiles Mount credentials as a files instead of using an environment variable.
 ##
-usePasswordFiles: false
+usePasswordFiles: true
 ## @param customPasswordFiles Use custom password files when `usePasswordFiles` is set to `true`. Define path for keys `root`, `user`, and `mariabackup`.
 ## Example:
 ## customPasswordFiles:
@@ -859,9 +859,9 @@ customLivenessProbe: {}
 ##
 customReadinessProbe: {}
 ## Pod disruption budget configuration
-## 
+##
 ## @param podDisruptionBudget DEPRECATED podDisruptionBudget will be removed in a future release. Please use pdb instead
-## 
+##
 podDisruptionBudget: {}
 pdb:
   ## @param pdb.create Specifies whether a Pod disruption budget should be created


### PR DESCRIPTION
### Description of the change

Sets default value for `usePasswordFiles` to true.

### Benefits

With this change, the chart will mount the secrets as files by default instead of directly setting them into environment variables.

### Possible drawbacks

None

### Applicable issues

None

### Additional information

N/A

### Checklist

- [x] Chart version bumped in Chart.yaml according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
