### PR TITLE
[bitnami/valkey] Set `usePasswordFiles=true` by default

### DIFF
--- a/bitnami/valkey/CHANGELOG.md
+++ b/bitnami/valkey/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
+## 2.4.0 (2025-02-21)
+
+* [bitnami/valkey] Set `usePasswordFiles=true` by default ([#32121](https://github.com/bitnami/charts/pull/32121))
+
 ## 2.3.0 (2025-02-20)
 
-* [bitnami/valkey] feat: use new helper for checking API versions ([#32064](https://github.com/bitnami/charts/pull/32064))
+* [bitnami/valkey] feat: use new helper for checking API versions (#32064) ([b780cc1](https://github.com/bitnami/charts/commit/b780cc181c1f22e89f01aa5f2eb5f2516a0986de)), closes [#32064](https://github.com/bitnami/charts/issues/32064)
 
 ## <small>2.2.5 (2025-02-20)</small>
 

--- a/bitnami/valkey/Chart.yaml
+++ b/bitnami/valkey/Chart.yaml
@@ -36,4 +36,4 @@ maintainers:
 name: valkey
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/valkey
-version: 2.3.0
+version: 2.4.0

--- a/bitnami/valkey/README.md
+++ b/bitnami/valkey/README.md
@@ -480,7 +480,7 @@ helm install my-release --set primary.persistence.existingClaim=PVC_NAME oci://R
 | `auth.password`                  | Valkey password                                                                   | `""`          |
 | `auth.existingSecret`            | The name of an existing secret with Valkey credentials                            | `""`          |
 | `auth.existingSecretPasswordKey` | Password key to be retrieved from existing secret                                 | `""`          |
-| `auth.usePasswordFiles`          | Mount credentials as files instead of using an environment variable               | `false`       |
+| `auth.usePasswordFiles`          | Mount credentials as files instead of using an environment variable               | `true`        |
 | `auth.usePasswordFileFromSecret` | Mount password file from secret                                                   | `true`        |
 | `commonConfiguration`            | Common configuration to be added into the ConfigMap                               | `""`          |
 | `existingConfigmap`              | The name of an existing ConfigMap with your custom configuration for Valkey nodes | `""`          |

--- a/bitnami/valkey/templates/primary/application.yaml
+++ b/bitnami/valkey/templates/primary/application.yaml
@@ -180,7 +180,7 @@ spec:
             {{- if .Values.auth.enabled }}
             {{- if .Values.auth.usePasswordFiles }}
             - name: VALKEY_PASSWORD_FILE
-              value: "/opt/bitnami/valkey/secrets/valkey-password"
+              value: {{ printf "/opt/bitnami/valkey/secrets/%s" (include "valkey.secretPasswordKey" .) }}
             {{- else }}
             - name: VALKEY_PASSWORD
               valueFrom:
@@ -320,9 +320,9 @@ spec:
             - /bin/bash
             - -c
             - |
-              if [[ -f '/secrets/valkey-password' ]]; then
-              export REDIS_PASSWORD=$(cat /secrets/valkey-password)
-              fi
+              {{- if .Values.usePasswordFiles }}
+              export REDIS_PASSWORD="$(< $REDIS_PASSWORD_FILE)"
+              {{- end }}
               redis_exporter{{- range $key, $value := .Values.metrics.extraArgs }} --{{ $key }}={{ $value }}{{- end }}
           {{- end }}
           {{- if .Values.diagnosticMode.enabled }}
@@ -336,7 +336,10 @@ spec:
             {{- if .Values.auth.enabled }}
             - name: REDIS_USER
               value: default
-            {{- if (not .Values.auth.usePasswordFiles) }}
+            {{- if .Values.auth.usePasswordFiles }}
+            - name: REDIS_PASSWORD_FILE
+              value: {{ printf "/secrets/%s" (include "valkey.secretPasswordKey" .) }}
+            {{- else }}
             - name: REDIS_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/bitnami/valkey/templates/replicas/application.yaml
+++ b/bitnami/valkey/templates/replicas/application.yaml
@@ -194,9 +194,9 @@ spec:
             {{- if .Values.auth.enabled }}
             {{- if .Values.auth.usePasswordFiles }}
             - name: VALKEY_PASSWORD_FILE
-              value: "/opt/bitnami/valkey/secrets/valkey-password"
+              value: {{ printf "/opt/bitnami/valkey/secrets/%s" (include "valkey.secretPasswordKey" .) }}
             - name: VALKEY_PRIMARY_PASSWORD_FILE
-              value: "/opt/bitnami/valkey/secrets/valkey-password"
+              value: {{ printf "/opt/bitnami/valkey/secrets/%s" (include "valkey.secretPasswordKey" .) }}
             {{- else }}
             - name: VALKEY_PASSWORD
               valueFrom:
@@ -340,9 +340,9 @@ spec:
             - /bin/bash
             - -c
             - |
-              if [[ -f '/secrets/valkey-password' ]]; then
-              export REDIS_PASSWORD=$(cat /secrets/redis-password)
-              fi
+              {{- if .Values.usePasswordFiles }}
+              export REDIS_PASSWORD="$(< $REDIS_PASSWORD_FILE)"
+              {{- end }}
               redis_exporter{{- range $key, $value := .Values.metrics.extraArgs }} --{{ $key }}={{ $value }}{{- end }}
           {{- end }}
           {{- if .Values.diagnosticMode.enabled }}
@@ -356,7 +356,10 @@ spec:
             {{- if .Values.auth.enabled }}
             - name: REDIS_USER
               value: default
-            {{- if (not .Values.auth.usePasswordFiles) }}
+            {{- if .Values.auth.usePasswordFiles }}
+            - name: REDIS_PASSWORD_FILE
+              value: {{ printf "/secrets/%s" (include "valkey.secretPasswordKey" .) }}
+            {{- else }}
             - name: REDIS_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/bitnami/valkey/templates/sentinel/statefulset.yaml
+++ b/bitnami/valkey/templates/sentinel/statefulset.yaml
@@ -186,9 +186,9 @@ spec:
             {{- if .Values.auth.enabled }}
             {{- if .Values.auth.usePasswordFiles }}
             - name: VALKEY_PASSWORD_FILE
-              value: "/opt/bitnami/valkey/secrets/valkey-password"
+              value: {{ printf "/opt/bitnami/valkey/secrets/%s" (include "valkey.secretPasswordKey" .) }}
             - name: VALKEY_PRIMARY_PASSWORD_FILE
-              value: "/opt/bitnami/valkey/secrets/valkey-password"
+              value: {{ printf "/opt/bitnami/valkey/secrets/%s" (include "valkey.secretPasswordKey" .) }}
             {{- else }}
             - name: VALKEY_PASSWORD
               valueFrom:
@@ -392,7 +392,7 @@ spec:
             {{- if .Values.auth.enabled }}
             {{- if .Values.auth.usePasswordFiles }}
             - name: VALKEY_PASSWORD_FILE
-              value: "/opt/bitnami/valkey/secrets/valkey-password"
+              value: {{ printf "/opt/bitnami/valkey/secrets/%s" (include "valkey.secretPasswordKey" .) }}
             {{- else }}
             - name: VALKEY_PASSWORD
               valueFrom:
@@ -546,9 +546,9 @@ spec:
             - /bin/bash
             - -c
             - |
-              if [[ -f '/secrets/valkey-password' ]]; then
-                  export REDIS_PASSWORD=$(cat /secrets/valkey-password)
-              fi
+              {{- if and .Values.usePasswordFiles }}
+              export REDIS_PASSWORD="$(< $REDIS_PASSWORD_FILE)"
+              {{- end }}
               redis_exporter{{- range $key, $value := .Values.metrics.extraArgs }} --{{ $key }}={{ $value }}{{- end }}
           {{- end }}
           {{- if .Values.diagnosticMode.enabled }}
@@ -562,7 +562,10 @@ spec:
             {{- if .Values.auth.enabled }}
             - name: REDIS_USER
               value: default
-            {{- if (not .Values.auth.usePasswordFiles) }}
+            {{- if .Values.auth.usePasswordFiles }}
+            - name: REDIS_PASSWORD_FILE
+              value: {{ printf "/secrets/%s" (include "valkey.secretPasswordKey" .) }}
+            {{- else }}
             - name: REDIS_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/bitnami/valkey/values.yaml
+++ b/bitnami/valkey/values.yaml
@@ -158,7 +158,7 @@ auth:
   existingSecretPasswordKey: ""
   ## @param auth.usePasswordFiles Mount credentials as files instead of using an environment variable
   ##
-  usePasswordFiles: false
+  usePasswordFiles: true
   ## @param auth.usePasswordFileFromSecret Mount password file from secret
   ##
   usePasswordFileFromSecret: true


### PR DESCRIPTION
### Description of the change

Sets default value for `usePasswordFiles` to true.

### Benefits

With this change, the chart will mount the secrets as files by default instead of directly setting them into environment variables.

### Possible drawbacks

None

### Applicable issues

None

### Additional information

N/A

### Checklist

- [x] Chart version bumped in Chart.yaml according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
