### PR TITLE
[bitnami/valkey] Check is auth.enabled before auth.usePasswordFiles

### DIFF
--- a/bitnami/valkey/CHANGELOG.md
+++ b/bitnami/valkey/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2.4.1 (2025-02-26)
+## 2.4.1 (2025-02-27)
 
 * [bitnami/valkey] Check is auth.enabled before auth.usePasswordFiles ([#32157](https://github.com/bitnami/charts/pull/32157))
 

--- a/bitnami/valkey/CHANGELOG.md
+++ b/bitnami/valkey/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 2.4.0 (2025-02-21)
+## 2.4.1 (2025-02-25)
 
-* [bitnami/valkey] Set `usePasswordFiles=true` by default ([#32121](https://github.com/bitnami/charts/pull/32121))
+* [bitnami/valkey] Check is auth.enabled before auth.usePasswordFiles ([#32157](https://github.com/bitnami/charts/pull/32157))
+
+## 2.4.0 (2025-02-24)
+
+* [bitnami/valkey] Set `usePasswordFiles=true` by default (#32121) ([9c8e329](https://github.com/bitnami/charts/commit/9c8e32945c31ba7ac0d74f70c928fb598cae761b)), closes [#32121](https://github.com/bitnami/charts/issues/32121)
 
 ## 2.3.0 (2025-02-20)
 

--- a/bitnami/valkey/CHANGELOG.md
+++ b/bitnami/valkey/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2.4.1 (2025-02-25)
+## 2.4.1 (2025-02-26)
 
 * [bitnami/valkey] Check is auth.enabled before auth.usePasswordFiles ([#32157](https://github.com/bitnami/charts/pull/32157))
 

--- a/bitnami/valkey/Chart.yaml
+++ b/bitnami/valkey/Chart.yaml
@@ -36,4 +36,4 @@ maintainers:
 name: valkey
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/valkey
-version: 2.4.0
+version: 2.4.1

--- a/bitnami/valkey/templates/primary/application.yaml
+++ b/bitnami/valkey/templates/primary/application.yaml
@@ -402,7 +402,6 @@ spec:
             - name: valkey-password
               mountPath: /secrets/
             {{- end }}
-            {{- end }}
             {{- if .Values.tls.enabled }}
             - name: valkey-certificates
               mountPath: /opt/bitnami/valkey/certs

--- a/bitnami/valkey/templates/primary/application.yaml
+++ b/bitnami/valkey/templates/primary/application.yaml
@@ -423,8 +423,7 @@ spec:
           configMap:
             name: {{ printf "%s-health" (include "common.names.fullname" .) }}
             defaultMode: 0755
-        {{- if .Values.auth.enabled }}
-        {{- if .Values.auth.usePasswordFiles }}
+            {{- if and .Values.auth.enabled .Values.auth.usePasswordFiles }}
         - name: valkey-password
           {{ if .Values.auth.usePasswordFileFromSecret }}
           secret:

--- a/bitnami/valkey/templates/primary/application.yaml
+++ b/bitnami/valkey/templates/primary/application.yaml
@@ -281,7 +281,6 @@ spec:
             - name: valkey-password
               mountPath: /opt/bitnami/valkey/secrets/
             {{- end }}
-            {{- end }}
             - name: valkey-data
               mountPath: {{ .Values.primary.persistence.path }}
               {{- if .Values.primary.persistence.subPath }}

--- a/bitnami/valkey/templates/primary/application.yaml
+++ b/bitnami/valkey/templates/primary/application.yaml
@@ -277,8 +277,7 @@ spec:
               mountPath: /opt/bitnami/scripts/start-scripts
             - name: health
               mountPath: /health
-            {{- if .Values.auth.enabled }}
-            {{- if .Values.auth.usePasswordFiles }}
+            {{- if and .Values.auth.enabled .Values.auth.usePasswordFiles }}
             - name: valkey-password
               mountPath: /opt/bitnami/valkey/secrets/
             {{- end }}

--- a/bitnami/valkey/templates/primary/application.yaml
+++ b/bitnami/valkey/templates/primary/application.yaml
@@ -398,8 +398,7 @@ spec:
             - name: empty-dir
               mountPath: /tmp
               subPath: app-tmp-dir
-            {{- if .Values.auth.enabled }}
-            {{- if .Values.auth.usePasswordFiles }}
+            {{- if and .Values.auth.enabled .Values.auth.usePasswordFiles }}
             - name: valkey-password
               mountPath: /secrets/
             {{- end }}

--- a/bitnami/valkey/templates/primary/application.yaml
+++ b/bitnami/valkey/templates/primary/application.yaml
@@ -277,9 +277,11 @@ spec:
               mountPath: /opt/bitnami/scripts/start-scripts
             - name: health
               mountPath: /health
+            {{- if .Values.auth.enabled }}
             {{- if .Values.auth.usePasswordFiles }}
             - name: valkey-password
               mountPath: /opt/bitnami/valkey/secrets/
+            {{- end }}
             {{- end }}
             - name: valkey-data
               mountPath: {{ .Values.primary.persistence.path }}
@@ -398,9 +400,11 @@ spec:
             - name: empty-dir
               mountPath: /tmp
               subPath: app-tmp-dir
+            {{- if .Values.auth.enabled }}
             {{- if .Values.auth.usePasswordFiles }}
             - name: valkey-password
               mountPath: /secrets/
+            {{- end }}
             {{- end }}
             {{- if .Values.tls.enabled }}
             - name: valkey-certificates
@@ -423,6 +427,7 @@ spec:
           configMap:
             name: {{ printf "%s-health" (include "common.names.fullname" .) }}
             defaultMode: 0755
+        {{- if .Values.auth.enabled }}
         {{- if .Values.auth.usePasswordFiles }}
         - name: valkey-password
           {{ if .Values.auth.usePasswordFileFromSecret }}
@@ -434,6 +439,7 @@ spec:
           {{- else }}
           emptyDir: {}
           {{- end }}
+        {{- end }}
         {{- end }}
         - name: config
           configMap:

--- a/bitnami/valkey/templates/primary/application.yaml
+++ b/bitnami/valkey/templates/primary/application.yaml
@@ -435,7 +435,6 @@ spec:
           emptyDir: {}
           {{- end }}
         {{- end }}
-        {{- end }}
         - name: config
           configMap:
             name: {{ include "valkey.configmapName" . }}

--- a/bitnami/valkey/templates/replicas/application.yaml
+++ b/bitnami/valkey/templates/replicas/application.yaml
@@ -455,7 +455,6 @@ spec:
           emptyDir: {}
           {{- end }}
         {{- end }}
-        {{- end }}
         - name: config
           configMap:
             name: {{ include "valkey.configmapName" . }}

--- a/bitnami/valkey/templates/replicas/application.yaml
+++ b/bitnami/valkey/templates/replicas/application.yaml
@@ -422,7 +422,6 @@ spec:
             - name: valkey-password
               mountPath: /secrets/
             {{- end }}
-            {{- end }}
             {{- if .Values.tls.enabled }}
             - name: valkey-certificates
               mountPath: /opt/bitnami/valkey/certs

--- a/bitnami/valkey/templates/replicas/application.yaml
+++ b/bitnami/valkey/templates/replicas/application.yaml
@@ -418,8 +418,7 @@ spec:
             - name: empty-dir
               mountPath: /tmp
               subPath: tmp-dir
-            {{- if .Values.auth.enabled }}
-            {{- if .Values.auth.usePasswordFiles }}
+            {{- if and .Values.auth.enabled .Values.auth.usePasswordFiles }}
             - name: valkey-password
               mountPath: /secrets/
             {{- end }}

--- a/bitnami/valkey/templates/replicas/application.yaml
+++ b/bitnami/valkey/templates/replicas/application.yaml
@@ -297,8 +297,7 @@ spec:
               mountPath: /opt/bitnami/scripts/start-scripts
             - name: health
               mountPath: /health
-            {{- if .Values.auth.enabled }}
-            {{- if .Values.auth.usePasswordFiles }}
+            {{- if and .Values.auth.enabled .Values.auth.usePasswordFiles }}
             - name: valkey-password
               mountPath: /opt/bitnami/valkey/secrets/
             {{- end }}

--- a/bitnami/valkey/templates/replicas/application.yaml
+++ b/bitnami/valkey/templates/replicas/application.yaml
@@ -297,9 +297,11 @@ spec:
               mountPath: /opt/bitnami/scripts/start-scripts
             - name: health
               mountPath: /health
+            {{- if .Values.auth.enabled }}
             {{- if .Values.auth.usePasswordFiles }}
             - name: valkey-password
               mountPath: /opt/bitnami/valkey/secrets/
+            {{- end }}
             {{- end }}
             - name: valkey-data
               mountPath: /data
@@ -418,9 +420,11 @@ spec:
             - name: empty-dir
               mountPath: /tmp
               subPath: tmp-dir
+            {{- if .Values.auth.enabled }}
             {{- if .Values.auth.usePasswordFiles }}
             - name: valkey-password
               mountPath: /secrets/
+            {{- end }}
             {{- end }}
             {{- if .Values.tls.enabled }}
             - name: valkey-certificates
@@ -443,6 +447,7 @@ spec:
           configMap:
             name: {{ printf "%s-health" (include "common.names.fullname" .) }}
             defaultMode: 0755
+        {{- if .Values.auth.enabled }}
         {{- if .Values.auth.usePasswordFiles }}
         - name: valkey-password
           {{ if .Values.auth.usePasswordFileFromSecret }}
@@ -454,6 +459,7 @@ spec:
           {{- else }}
           emptyDir: {}
           {{- end }}
+        {{- end }}
         {{- end }}
         - name: config
           configMap:

--- a/bitnami/valkey/templates/replicas/application.yaml
+++ b/bitnami/valkey/templates/replicas/application.yaml
@@ -301,7 +301,6 @@ spec:
             - name: valkey-password
               mountPath: /opt/bitnami/valkey/secrets/
             {{- end }}
-            {{- end }}
             - name: valkey-data
               mountPath: /data
               {{- if .Values.replica.persistence.subPath }}

--- a/bitnami/valkey/templates/replicas/application.yaml
+++ b/bitnami/valkey/templates/replicas/application.yaml
@@ -443,8 +443,7 @@ spec:
           configMap:
             name: {{ printf "%s-health" (include "common.names.fullname" .) }}
             defaultMode: 0755
-        {{- if .Values.auth.enabled }}
-        {{- if .Values.auth.usePasswordFiles }}
+        {{- if and .Values.auth.enabled .Values.auth.usePasswordFiles }}
         - name: valkey-password
           {{ if .Values.auth.usePasswordFileFromSecret }}
           secret:

--- a/bitnami/valkey/templates/sentinel/statefulset.yaml
+++ b/bitnami/valkey/templates/sentinel/statefulset.yaml
@@ -518,7 +518,6 @@ spec:
             - name: valkey-password
               mountPath: /opt/bitnami/valkey/secrets/
             {{- end }}
-            {{- end }}
             - name: valkey-data
               mountPath: {{ .Values.replica.persistence.path }}
               {{- if .Values.replica.persistence.subPath }}

--- a/bitnami/valkey/templates/sentinel/statefulset.yaml
+++ b/bitnami/valkey/templates/sentinel/statefulset.yaml
@@ -677,8 +677,7 @@ spec:
             name: {{ printf "%s-kubectl-scripts" (include "common.names.fullname" .) }}
             defaultMode: 0755
         {{- end }}
-        {{- if .Values.auth.enabled }}
-        {{- if .Values.auth.usePasswordFiles }}
+            {{- if and .Values.auth.enabled .Values.auth.usePasswordFiles }}
         - name: valkey-password
           {{ if .Values.auth.usePasswordFileFromSecret }}
           secret:

--- a/bitnami/valkey/templates/sentinel/statefulset.yaml
+++ b/bitnami/valkey/templates/sentinel/statefulset.yaml
@@ -513,8 +513,7 @@ spec:
             {{- end }}
             - name: sentinel-data
               mountPath: /opt/bitnami/valkey-sentinel/etc
-            {{- if .Values.auth.enabled }}
-            {{- if .Values.auth.usePasswordFiles }}
+            {{- if and .Values.auth.enabled .Values.auth.usePasswordFiles }}
             - name: valkey-password
               mountPath: /opt/bitnami/valkey/secrets/
             {{- end }}

--- a/bitnami/valkey/templates/sentinel/statefulset.yaml
+++ b/bitnami/valkey/templates/sentinel/statefulset.yaml
@@ -323,8 +323,7 @@ spec:
               mountPath: /health
             - name: sentinel-data
               mountPath: /opt/bitnami/valkey-sentinel/etc
-            {{- if .Values.auth.enabled }}
-            {{- if .Values.auth.usePasswordFiles }}
+            {{- if and .Values.auth.enabled .Values.auth.usePasswordFiles }}
             - name: valkey-password
               mountPath: /opt/bitnami/valkey/secrets/
             {{- end }}

--- a/bitnami/valkey/templates/sentinel/statefulset.yaml
+++ b/bitnami/valkey/templates/sentinel/statefulset.yaml
@@ -327,7 +327,6 @@ spec:
             - name: valkey-password
               mountPath: /opt/bitnami/valkey/secrets/
             {{- end }}
-            {{- end }}
             - name: valkey-data
               mountPath: {{ .Values.replica.persistence.path }}
               {{- if .Values.replica.persistence.subPath }}

--- a/bitnami/valkey/templates/sentinel/statefulset.yaml
+++ b/bitnami/valkey/templates/sentinel/statefulset.yaml
@@ -323,9 +323,11 @@ spec:
               mountPath: /health
             - name: sentinel-data
               mountPath: /opt/bitnami/valkey-sentinel/etc
+            {{- if .Values.auth.enabled }}
             {{- if .Values.auth.usePasswordFiles }}
             - name: valkey-password
               mountPath: /opt/bitnami/valkey/secrets/
+            {{- end }}
             {{- end }}
             - name: valkey-data
               mountPath: {{ .Values.replica.persistence.path }}
@@ -511,9 +513,11 @@ spec:
             {{- end }}
             - name: sentinel-data
               mountPath: /opt/bitnami/valkey-sentinel/etc
+            {{- if .Values.auth.enabled }}
             {{- if .Values.auth.usePasswordFiles }}
             - name: valkey-password
               mountPath: /opt/bitnami/valkey/secrets/
+            {{- end }}
             {{- end }}
             - name: valkey-data
               mountPath: {{ .Values.replica.persistence.path }}
@@ -624,9 +628,11 @@ spec:
             - name: empty-dir
               mountPath: /tmp
               subPath: tmp-dir
+            {{- if .Values.auth.enabled }}
             {{- if .Values.auth.usePasswordFiles }}
             - name: valkey-password
               mountPath: /secrets/
+            {{- end }}
             {{- end }}
             {{- if .Values.tls.enabled }}
             - name: valkey-certificates
@@ -674,6 +680,7 @@ spec:
             name: {{ printf "%s-kubectl-scripts" (include "common.names.fullname" .) }}
             defaultMode: 0755
         {{- end }}
+        {{- if .Values.auth.enabled }}
         {{- if .Values.auth.usePasswordFiles }}
         - name: valkey-password
           {{ if .Values.auth.usePasswordFileFromSecret }}
@@ -685,6 +692,7 @@ spec:
           {{- else }}
           emptyDir: {}
           {{- end }}
+        {{- end }}
         {{- end }}
         - name: config
           configMap:

--- a/bitnami/valkey/templates/sentinel/statefulset.yaml
+++ b/bitnami/valkey/templates/sentinel/statefulset.yaml
@@ -627,8 +627,7 @@ spec:
             - name: empty-dir
               mountPath: /tmp
               subPath: tmp-dir
-            {{- if .Values.auth.enabled }}
-            {{- if .Values.auth.usePasswordFiles }}
+            {{- if and .Values.auth.enabled .Values.auth.usePasswordFiles }}
             - name: valkey-password
               mountPath: /secrets/
             {{- end }}

--- a/bitnami/valkey/templates/sentinel/statefulset.yaml
+++ b/bitnami/valkey/templates/sentinel/statefulset.yaml
@@ -689,7 +689,6 @@ spec:
           emptyDir: {}
           {{- end }}
         {{- end }}
-        {{- end }}
         - name: config
           configMap:
             name: {{ include "valkey.configmapName" . }}

--- a/bitnami/valkey/templates/sentinel/statefulset.yaml
+++ b/bitnami/valkey/templates/sentinel/statefulset.yaml
@@ -631,7 +631,6 @@ spec:
             - name: valkey-password
               mountPath: /secrets/
             {{- end }}
-            {{- end }}
             {{- if .Values.tls.enabled }}
             - name: valkey-certificates
               mountPath: /opt/bitnami/valkey/certs


### PR DESCRIPTION
### Description of the change

Add missing check of `auth.enabled` value before `auth.usePasswordFiles`

### Benefits

Makes chart behave as expected with disabled auth and disable mounting password secrets when they does not exists

### Possible drawbacks

None

### Applicable issues

- fixes #32154

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
