### PR TITLE
[bitnami/redis]: only use auth.usePasswordFiles if auth.enabled is set

### DIFF
--- a/bitnami/redis/CHANGELOG.md
+++ b/bitnami/redis/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
+## 20.10.1 (2025-02-28)
+
+* [bitnami/redis]: only use auth.usePasswordFiles if auth.enabled is set ([#32208](https://github.com/bitnami/charts/pull/32208))
+
 ## 20.10.0 (2025-02-27)
 
-* [bitnami/redis] Set `usePasswordFiles=true` by default ([#32117](https://github.com/bitnami/charts/pull/32117))
+* [bitnami/redis] Set `usePasswordFiles=true` by default (#32117) ([2f80b74](https://github.com/bitnami/charts/commit/2f80b749c9a2e692d51beb3e001708694b94c17f)), closes [#32117](https://github.com/bitnami/charts/issues/32117)
 
 ## 20.9.0 (2025-02-24)
 

--- a/bitnami/redis/Chart.yaml
+++ b/bitnami/redis/Chart.yaml
@@ -36,4 +36,4 @@ maintainers:
 name: redis
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/redis
-version: 20.10.0
+version: 20.10.1

--- a/bitnami/redis/templates/NOTES.txt
+++ b/bitnami/redis/templates/NOTES.txt
@@ -55,7 +55,7 @@ For Redis Sentinel:
 {{- end }}
 {{- end }}
 
-{{- if and .Values.auth.usePasswordFiles (not .Values.auth.usePasswordFileFromSecret) (or (empty .Values.master.initContainers) (empty .Values.replica.initContainers)) }}
+{{- if and .Values.auth.enabled .Values.auth.usePasswordFiles (not .Values.auth.usePasswordFileFromSecret) (or (empty .Values.master.initContainers) (empty .Values.replica.initContainers)) }}
 
 -------------------------------------------------------------------------------
  WARNING

--- a/bitnami/redis/templates/master/application.yaml
+++ b/bitnami/redis/templates/master/application.yaml
@@ -245,7 +245,7 @@ spec:
               mountPath: /opt/bitnami/scripts/start-scripts
             - name: health
               mountPath: /health
-            {{- if .Values.auth.usePasswordFiles }}
+            {{- if and .Values.auth.enabled .Values.auth.usePasswordFiles }}
             - name: redis-password
               mountPath: /opt/bitnami/redis/secrets/
             {{- end }}
@@ -288,7 +288,7 @@ spec:
             - /bin/bash
             - -c
             - |
-              {{- if .Values.usePasswordFiles }}
+              {{- if and .Values.auth.enabled .Values.usePasswordFiles }}
               export REDIS_PASSWORD="$(< $REDIS_PASSWORD_FILE)"
               {{- end }}
               redis_exporter{{- range $key, $value := .Values.metrics.extraArgs }} --{{ $key }}={{ $value }}{{- end }}
@@ -368,7 +368,7 @@ spec:
             - name: empty-dir
               mountPath: /tmp
               subPath: app-tmp-dir
-            {{- if .Values.auth.usePasswordFiles }}
+            {{- if and .Values.auth.enabled .Values.auth.usePasswordFiles }}
             - name: redis-password
               mountPath: /secrets/
             {{- end }}
@@ -463,7 +463,7 @@ spec:
           configMap:
             name: {{ printf "%s-health" (include "common.names.fullname" .) }}
             defaultMode: 0755
-        {{- if .Values.auth.usePasswordFiles }}
+        {{- if and .Values.auth.enabled .Values.auth.usePasswordFiles }}
         - name: redis-password
           {{ if .Values.auth.usePasswordFileFromSecret }}
           secret:


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

These changes limit all effects of `auth.usePasswordFiles` unless `auth.enabled` is also true.

### Benefits

This fixes a Pod scheduling issue for users that want to install the chart with auth disabled. Even with `auth.enabled: false`, the chart rendered with a `redis-password` volume mount that referenced a `redis-password` secret which doesn't exist when auth is disabled.

Here's a rendering diff with `auth.enabled: false` after these changes:
```diff
@@ -421,8 +421,6 @@
               mountPath: /opt/bitnami/scripts/start-scripts
             - name: health
               mountPath: /health
-            - name: redis-password
-              mountPath: /opt/bitnami/redis/secrets/
             - name: redis-data
               mountPath: /data
             - name: config
@@ -442,13 +440,6 @@
           configMap:
             name: redis-health
             defaultMode: 0755
-        - name: redis-password
-
-          secret:
-            secretName: redis
-            items:
-            - key: redis-password
-              path: redis-password
         - name: config
           configMap:
             name: redis-configuration
```

### Possible drawbacks

None that I'm aware of.

### Applicable issues

I didn't see a relevant issue but this became noticeable after the default was changed to `auth.usePasswordFiles: true` in https://github.com/bitnami/charts/commit/2f80b749c9a2e692d51beb3e001708694b94c17f.

### Additional information

Just for reference, here is the exact pod scheduling failure message:

```
  Warning  FailedMount  1s (x4 over 5s)  kubelet            MountVolume.SetUp failed for volume "redis-password" : secret "redis" not found
```

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
