### PR TITLE
[bitnami/airflow] feat: timeouts for probes

### DIFF
--- a/.vib/airflow/goss/goss.yaml
+++ b/.vib/airflow/goss/goss.yaml
@@ -3,7 +3,7 @@
 
 command:
   airflow-trigger-dag:
-    exec: airflow dags trigger example_bash_operator
+    exec: airflow dags trigger UI_dag
     exit-status: 0
     timeout: 40000
   {{- $uid := .Vars.web.containerSecurityContext.runAsUser }}

--- a/.vib/airflow/runtime-parameters.yaml
+++ b/.vib/airflow/runtime-parameters.yaml
@@ -3,7 +3,7 @@ auth:
 overrideConfiguration:
   logging:
     colored_console_log: 'True'
-loadExamples: true
+loadExamples: false
 defaultInitContainers:
   prepareConfig:
     containerSecurityContext:

--- a/bitnami/airflow/CHANGELOG.md
+++ b/bitnami/airflow/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
+## 22.6.1 (2025-03-03)
+
+* [bitnami/airflow] feat: timeouts for probes ([#32235](https://github.com/bitnami/charts/pull/32235))
+
 ## 22.6.0 (2025-02-27)
 
-* [bitnami/airflow] Add support for `usePasswordFiles` ([#32076](https://github.com/bitnami/charts/pull/32076))
+* [bitnami/airflow] Add support for `usePasswordFiles` (#32076) ([186a302](https://github.com/bitnami/charts/commit/186a302e024765179c80bae1594d80ae2361f5b9)), closes [#32076](https://github.com/bitnami/charts/issues/32076)
 
 ## 22.5.0 (2025-02-20)
 

--- a/bitnami/airflow/Chart.yaml
+++ b/bitnami/airflow/Chart.yaml
@@ -6,9 +6,9 @@ annotations:
   licenses: Apache-2.0
   images: |
     - name: airflow
-      image: docker.io/bitnami/airflow:2.10.5-debian-12-r0
+      image: docker.io/bitnami/airflow:2.10.5-debian-12-r6
     - name: statsd-exporter
-      image: docker.io/bitnami/statsd-exporter:0.28.0-debian-12-r5
+      image: docker.io/bitnami/statsd-exporter:0.28.0-debian-12-r9
 apiVersion: v2
 appVersion: 2.10.5
 dependencies:
@@ -39,4 +39,4 @@ maintainers:
 name: airflow
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/airflow
-version: 22.5.0
+version: 22.6.0

--- a/bitnami/airflow/Chart.yaml
+++ b/bitnami/airflow/Chart.yaml
@@ -39,4 +39,4 @@ maintainers:
 name: airflow
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/airflow
-version: 22.6.0
+version: 22.6.1

--- a/bitnami/airflow/templates/dag-processor/deployment.yaml
+++ b/bitnami/airflow/templates/dag-processor/deployment.yaml
@@ -143,35 +143,40 @@ spec:
           {{- if .Values.dagProcessor.customLivenessProbe }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.dagProcessor.customLivenessProbe "context" $) | trim | nindent 12 }}
           {{- else if .Values.dagProcessor.livenessProbe.enabled }}
+          {{- $livenessTimeout := sub (int .Values.dagProcessor.livenessProbe.timeoutSeconds) 1 }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.dagProcessor.livenessProbe "enabled") "context" $) | nindent 12 }}
             exec:
               command:
                 - /bin/bash
                 - -ec
                 - |
-                  CONNECTION_CHECK_MAX_COUNT=0 airflow jobs check --job-type DagProcessorJob --local {{- if not .Values.diagnosticMode.enabled }} 2>/dev/null {{- end }}
+                  export CONNECTION_CHECK_MAX_COUNT=0
+                  timeout {{ $livenessTimeout }} airflow jobs check --job-type DagProcessorJob --local {{- if not .Values.diagnosticMode.enabled }} 2>/dev/null {{- end }}
           {{- end }}
           {{- if .Values.dagProcessor.customReadinessProbe }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.dagProcessor.customReadinessProbe "context" $) | trim | nindent 12 }}
           {{- else if .Values.dagProcessor.readinessProbe.enabled }}
+          {{- $readinessTimeout := sub (int .Values.dagProcessor.readinessProbe.timeoutSeconds) 1 }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.dagProcessor.readinessProbe "enabled") "context" $) | nindent 12 }}
             exec:
               command:
                 - /bin/bash
                 - -ec
                 - |
-                  airflow jobs check --job-type DagProcessorJob --local {{- if not .Values.diagnosticMode.enabled }} 2>/dev/null {{- end }}
+                  timeout {{ $readinessTimeout }} airflow jobs check --job-type DagProcessorJob --local {{- if not .Values.diagnosticMode.enabled }} 2>/dev/null {{- end }}
           {{- end }}
           {{- if .Values.dagProcessor.customStartupProbe }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.dagProcessor.customStartupProbe "context" $) | nindent 12 }}
           {{- else if .Values.dagProcessor.startupProbe.enabled }}
+          {{- $startupTimeout := sub (int .Values.dagProcessor.startupProbe.timeoutSeconds) 1 }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.dagProcessor.startupProbe "enabled") "context" $) | nindent 12 }}
             exec:
               command:
                 - /bin/bash
                 - -ec
                 - |
-                  CONNECTION_CHECK_MAX_COUNT=0 airflow jobs check --job-type DagProcessorJob --local {{- if not .Values.diagnosticMode.enabled }} 2>/dev/null {{- end }}
+                  export CONNECTION_CHECK_MAX_COUNT=0
+                  timeout {{ $startupTimeout }} airflow jobs check --job-type DagProcessorJob --local {{- if not .Values.diagnosticMode.enabled }} 2>/dev/null {{- end }}
           {{- end }}
           {{- end }}
           {{- if .Values.dagProcessor.lifecycleHooks }}

--- a/bitnami/airflow/templates/scheduler/deployment.yaml
+++ b/bitnami/airflow/templates/scheduler/deployment.yaml
@@ -155,35 +155,40 @@ spec:
           {{- if .Values.scheduler.customLivenessProbe }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.scheduler.customLivenessProbe "context" $) | trim | nindent 12 }}
           {{- else if .Values.scheduler.livenessProbe.enabled }}
+          {{- $readinessTimeout := sub (int .Values.scheduler.readinessProbe.timeoutSeconds) 1 }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.scheduler.livenessProbe "enabled") "context" $) | nindent 12 }}
             exec:
               command:
                 - /bin/bash
                 - -ec
                 - |
-                  CONNECTION_CHECK_MAX_COUNT=0 airflow jobs check --job-type SchedulerJob --local {{- if not .Values.diagnosticMode.enabled }} 2>/dev/null {{- end }}
+                  export CONNECTION_CHECK_MAX_COUNT=0
+                  timeout {{ $livenessTimeout }} airflow jobs check --job-type SchedulerJob --local {{- if not .Values.diagnosticMode.enabled }} 2>/dev/null {{- end }}
           {{- end }}
           {{- if .Values.scheduler.customReadinessProbe }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.scheduler.customReadinessProbe "context" $) | trim | nindent 12 }}
           {{- else if .Values.scheduler.readinessProbe.enabled }}
+          {{- $readinessTimeout := sub (int .Values.scheduler.readinessProbe.timeoutSeconds) 1 }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.scheduler.readinessProbe "enabled") "context" $) | nindent 12 }}
             exec:
               command:
                 - /bin/bash
                 - -ec
                 - |
-                  airflow jobs check --job-type SchedulerJob --local {{- if not .Values.diagnosticMode.enabled }} 2>/dev/null {{- end }}
+                  timeout {{ $readinessTimeout }} airflow jobs check --job-type SchedulerJob --local {{- if not .Values.diagnosticMode.enabled }} 2>/dev/null {{- end }}
           {{- end }}
           {{- if .Values.scheduler.customStartupProbe }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.scheduler.customStartupProbe "context" $) | nindent 12 }}
           {{- else if .Values.scheduler.startupProbe.enabled }}
+          {{- $startupTimeout := sub (int .Values.scheduler.startupProbe.timeoutSeconds) 1 }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.scheduler.startupProbe "enabled") "context" $) | nindent 12 }}
             exec:
               command:
                 - /bin/bash
                 - -ec
                 - |
-                  CONNECTION_CHECK_MAX_COUNT=0 airflow jobs check --job-type SchedulerJob --local {{- if not .Values.diagnosticMode.enabled }} 2>/dev/null {{- end }}
+                  export CONNECTION_CHECK_MAX_COUNT=0
+                  timeout {{ $startupTimeout }} airflow jobs check --job-type SchedulerJob --local {{- if not .Values.diagnosticMode.enabled }} 2>/dev/null {{- end }}
           {{- end }}
           {{- end }}
           {{- if .Values.scheduler.lifecycleHooks }}

--- a/bitnami/airflow/templates/scheduler/deployment.yaml
+++ b/bitnami/airflow/templates/scheduler/deployment.yaml
@@ -155,7 +155,7 @@ spec:
           {{- if .Values.scheduler.customLivenessProbe }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.scheduler.customLivenessProbe "context" $) | trim | nindent 12 }}
           {{- else if .Values.scheduler.livenessProbe.enabled }}
-          {{- $readinessTimeout := sub (int .Values.scheduler.readinessProbe.timeoutSeconds) 1 }}
+          {{- $livenessTimeout := sub (int .Values.scheduler.livenessProbe.timeoutSeconds) 1 }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.scheduler.livenessProbe "enabled") "context" $) | nindent 12 }}
             exec:
               command:

--- a/bitnami/airflow/templates/triggerer/statefulset.yaml
+++ b/bitnami/airflow/templates/triggerer/statefulset.yaml
@@ -150,35 +150,40 @@ spec:
           {{- if .Values.triggerer.customLivenessProbe }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.triggerer.customLivenessProbe "context" $) | trim | nindent 12 }}
           {{- else if .Values.triggerer.livenessProbe.enabled }}
+          {{- $livenessTimeout := sub (int .Values.triggerer.livenessProbe.timeoutSeconds) 1 }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.triggerer.livenessProbe "enabled") "context" $) | nindent 12 }}
             exec:
               command:
                 - /bin/bash
                 - -ec
                 - |
-                  CONNECTION_CHECK_MAX_COUNT=0 airflow jobs check --job-type TriggererJob --local {{- if not .Values.diagnosticMode.enabled }} 2>/dev/null {{- end }}
+                  export CONNECTION_CHECK_MAX_COUNT=0
+                  timeout {{ $livenessTimeout }} airflow jobs check --job-type TriggererJob --local {{- if not .Values.diagnosticMode.enabled }} 2>/dev/null {{- end }}
           {{- end }}
           {{- if .Values.triggerer.customReadinessProbe }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.triggerer.customReadinessProbe "context" $) | trim | nindent 12 }}
           {{- else if .Values.triggerer.readinessProbe.enabled }}
+          {{- $readinessTimeout := sub (int .Values.triggerer.readinessProbe.timeoutSeconds) 1 }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.triggerer.readinessProbe "enabled") "context" $) | nindent 12 }}
             exec:
               command:
                 - /bin/bash
                 - -ec
                 - |
-                  airflow jobs check --job-type TriggererJob --local {{- if not .Values.diagnosticMode.enabled }} 2>/dev/null {{- end }}
+                  timeout {{ $readinessTimeout }} airflow jobs check --job-type TriggererJob --local {{- if not .Values.diagnosticMode.enabled }} 2>/dev/null {{- end }}
           {{- end }}
           {{- if .Values.triggerer.customStartupProbe }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.triggerer.customStartupProbe "context" $) | nindent 12 }}
           {{- else if .Values.triggerer.startupProbe.enabled }}
+          {{- $startupTimeout := sub (int .Values.triggerer.startupProbe.timeoutSeconds) 1 }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.triggerer.startupProbe "enabled") "context" $) | nindent 12 }}
             exec:
               command:
                 - /bin/bash
                 - -ec
                 - |
-                  CONNECTION_CHECK_MAX_COUNT=0 airflow jobs check --job-type TriggererJob --local {{- if not .Values.diagnosticMode.enabled }} 2>/dev/null {{- end }}
+                  export CONNECTION_CHECK_MAX_COUNT=0
+                  timeout {{ $startupTimeout }} airflow jobs check --job-type TriggererJob --local {{- if not .Values.diagnosticMode.enabled }} 2>/dev/null {{- end }}
           {{- end }}
           {{- end }}
           {{- if .Values.triggerer.lifecycleHooks }}

--- a/bitnami/airflow/values.yaml
+++ b/bitnami/airflow/values.yaml
@@ -91,7 +91,7 @@ diagnosticMode:
 image:
   registry: docker.io
   repository: bitnami/airflow
-  tag: 2.10.5-debian-12-r0
+  tag: 2.10.5-debian-12-r6
   digest: ""
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
@@ -2741,7 +2741,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/statsd-exporter
-    tag: 0.28.0-debian-12-r5
+    tag: 0.28.0-debian-12-r9
     digest: ""
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.


### PR DESCRIPTION
### Description of the change

This PR introduces timeout on readiness, liveness & startup probes' commands used on Triggerer, Scheduler and Dag Processor. This helps saving memory if these commands hang.

It also removes loading examples from "runtime parameters" given it's making tests very slow due to the big amount of DAGS to process.

### Benefits

Avoid probes causing an increase of memory usage due to periodical and concurrent executions that hang.

### Possible drawbacks

None

### Applicable issues

None

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
