### PR TITLE
fix: change svc target port in servicemonitor

### DIFF
--- a/bitnami/keydb/CHANGELOG.md
+++ b/bitnami/keydb/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 0.5.0 (2025-02-21)
+## 0.5.1 (2025-03-03)
 
-* [bitnami/keydb] Set `usePasswordFiles=true` by default ([#32108](https://github.com/bitnami/charts/pull/32108))
+* fix: change svc target port in servicemonitor ([#32236](https://github.com/bitnami/charts/pull/32236))
+
+## 0.5.0 (2025-02-27)
+
+* [bitnami/keydb] Set `usePasswordFiles=true` by default (#32108) ([68a1f40](https://github.com/bitnami/charts/commit/68a1f4048a6aac040a9a6567508bddf8bbe061a6)), closes [#32108](https://github.com/bitnami/charts/issues/32108)
 
 ## 0.4.0 (2025-02-20)
 

--- a/bitnami/keydb/Chart.yaml
+++ b/bitnami/keydb/Chart.yaml
@@ -34,4 +34,4 @@ name: keydb
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/keydb
   - https://github.com/bitnami/containers/tree/main/bitnami/keydb
-version: 0.5.0
+version: 0.5.1

--- a/bitnami/keydb/templates/servicemonitor.yaml
+++ b/bitnami/keydb/templates/servicemonitor.yaml
@@ -27,7 +27,7 @@ spec:
       {{- include "common.tplvalues.render" (dict "value" .Values.metrics.serviceMonitor.selector "context" $) | nindent 6 }}
       {{- end }}
   endpoints:
-    - port: tcp-metrics
+    - port: http-metrics
       path: "/metrics"
       {{- if .Values.metrics.serviceMonitor.interval }}
       interval: {{ .Values.metrics.serviceMonitor.interval }}


### PR DESCRIPTION
### Description of the change

The KeyDB service port name did not match the expected port name in the ServiceMonitor configuration.  
This mismatch prevented Prometheus from discovering and scraping KeyDB metrics.  
This change updates the service port name to ensure consistency, allowing proper metric collection.

### Benefits

- Enables Prometheus (Prometheus Operator) to correctly scrape KeyDB metrics.  
- Fixes the mismatch between the Service and ServiceMonitor configurations.  

### Possible drawbacks

- No known drawbacks.  

### Applicable issues

- Fixes

### Additional information

- This change does not introduce breaking changes.  
- No additional configuration is required.  

### Checklist

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [ ] Title of the pull request follows this pattern `[bitnami/keydb] Fix ServiceMonitor port name mismatch`
- [ ] All commits signed off and in agreement with [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
