### PR TITLE
[bitnami/spring-cloud-dataflow] fix incorrect application of externalDatabase.skipper.password value

### DIFF
--- a/bitnami/spring-cloud-dataflow/CHANGELOG.md
+++ b/bitnami/spring-cloud-dataflow/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 34.2.1 (2025-03-02)
+## 34.2.2 (2025-03-04)
 
-* [bitnami/spring-cloud-dataflow] Release 34.2.1 ([#32230](https://github.com/bitnami/charts/pull/32230))
+* [bitnami/spring-cloud-dataflow] fix incorrect application of externalDatabase.skipper.password value ([#32251](https://github.com/bitnami/charts/pull/32251))
+
+## <small>34.2.1 (2025-03-02)</small>
+
+* [bitnami/spring-cloud-dataflow] Release 34.2.1 (#32230) ([4b9681d](https://github.com/bitnami/charts/commit/4b9681d82f879514596211815f7cb9f5e12d2667)), closes [#32230](https://github.com/bitnami/charts/issues/32230)
 
 ## 34.2.0 (2025-02-26)
 

--- a/bitnami/spring-cloud-dataflow/Chart.yaml
+++ b/bitnami/spring-cloud-dataflow/Chart.yaml
@@ -53,4 +53,4 @@ maintainers:
 name: spring-cloud-dataflow
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/spring-cloud-dataflow
-version: 34.2.1
+version: 34.2.2

--- a/bitnami/spring-cloud-dataflow/README.md
+++ b/bitnami/spring-cloud-dataflow/README.md
@@ -123,10 +123,11 @@ mariadb.enabled=false
 externalDatabase.scheme=mariadb
 externalDatabase.host=myexternalhost
 externalDatabase.port=3306
-externalDatabase.password=mypassword
-externalDatabase.dataflow.user=mydataflowuser
+externalDatabase.dataflow.username=mydataflowuser
+externalDatabase.dataflow.password=mydataflowpassword
 externalDatabase.dataflow.database=mydataflowdatabase
-externalDatabase.skipper.user=myskipperuser
+externalDatabase.skipper.username=myskipperuser
+externalDatabase.skipper.password=myskipperpassword
 externalDatabase.skipper.database=myskipperdatabase
 ```
 
@@ -136,11 +137,12 @@ To use an alternate database vendor (other than MariaDB) you can use the `extern
 
 ```console
 mariadb.enabled=false
-externalDatabase.password=mypassword
 externalDatabase.dataflow.url=jdbc:sqlserver://mssql-server:1433
-externalDatabase.dataflow.user=mydataflowuser
+externalDatabase.dataflow.username=mydataflowuser
+externalDatabase.dataflow.password=mydataflowpassword
 externalDatabase.skipper.url=jdbc:sqlserver://mssql-server:1433
-externalDatabase.skipper.user=myskipperuser
+externalDatabase.skipper.username=myskipperuser
+externalDatabase.skipper.password=myskipperpassword
 externalDatabase.hibernateDialect=org.hibernate.dialect.SQLServer2012Dialect
 ```
 

--- a/bitnami/spring-cloud-dataflow/templates/skipper/externaldb-secret.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/skipper/externaldb-secret.yaml
@@ -16,5 +16,5 @@ metadata:
   {{- end }}
 type: Opaque
 data:
-  datasource-password: {{ .Values.externalDatabase.password | b64enc | quote }}
+  datasource-password: {{ coalesce .Values.externalDatabase.skipper.password .Values.externalDatabase.password | b64enc | quote }}
 {{- end }}


### PR DESCRIPTION
### Description of the change

the documented `externalDatabase.skipper.password` will now be accepted by the chart and take precedence over `externalDatabase.password`.

### Benefits

implementation will reflect the documentation

### Possible drawbacks

none, ensured the change is backwards compatible by falling back to `externalDatabase.password` if `externalDatabase.skipper.password`is empty

### Applicable issues

N/A

### Additional information

N/A

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
