### PR TITLE
[bitnami/etcd] bugfix: probes to use healthcheck when TLS client-to-server authentication

### DIFF
--- a/bitnami/etcd/CHANGELOG.md
+++ b/bitnami/etcd/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 11.1.0 (2025-02-21)
+## 11.1.1 (2025-03-04)
 
-* [bitnami/etcd] feat: basic customization params for etcd upgrade-job ([#32099](https://github.com/bitnami/charts/pull/32099))
+* [bitnami/etcd] bugfix: probes to use healthcheck when TLS client-to-server authentication ([#32258](https://github.com/bitnami/charts/pull/32258))
+
+## 11.1.0 (2025-02-24)
+
+* [bitnami/etcd] feat: basic customization params for etcd upgrade-job (#32099) ([b820c10](https://github.com/bitnami/charts/commit/b820c10df5a2066e25ef101f1a279819a83c238b)), closes [#32099](https://github.com/bitnami/charts/issues/32099)
 
 ## <small>11.0.8 (2025-02-19)</small>
 

--- a/bitnami/etcd/Chart.yaml
+++ b/bitnami/etcd/Chart.yaml
@@ -32,4 +32,4 @@ maintainers:
 name: etcd
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/etcd
-version: 11.1.0
+version: 11.1.1

--- a/bitnami/etcd/templates/statefulset.yaml
+++ b/bitnami/etcd/templates/statefulset.yaml
@@ -286,10 +286,16 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customLivenessProbe "context" $) | nindent 12 }}
           {{- else if .Values.livenessProbe.enabled }}
           livenessProbe:
+            {{- if .Values.auth.client.secureTransport }}
+            exec:
+              command:
+                - /opt/bitnami/scripts/etcd/healthcheck.sh
+            {{- else }}
             httpGet:
               port: {{ .Values.containerPorts.client }} 
               path: /livez
-              scheme: {{ ternary "HTTPS" "HTTP" .Values.auth.client.secureTransport | quote }}
+              scheme: "HTTP"
+            {{- end }}
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}


### PR DESCRIPTION
### Description of the change

Liveness probes should use the health check script when TLS client-to-server authentication is enabled given we don't ship `curl` nor `wget` in the container and it's not possible to customize the K8s native "httpGet" to include certificates.

### Benefits

Default liveness probes don't fail when setting `auth.client.secureTransport` to `true`.

### Possible drawbacks

None

### Applicable issues

Reported at [#78362](https://github.com/bitnami/containers/issues/78362)

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
