### PR TITLE
[bitnami/valkey] Fix usePasswordFile typo in metrics container

### DIFF
--- a/bitnami/valkey/CHANGELOG.md
+++ b/bitnami/valkey/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 2.4.2 (2025-02-27)
+## 2.4.3 (2025-03-04)
 
-* [bitnami]/valkey update _helpers.tpl to be in line with Valkey-Cluster. ([#32203](https://github.com/bitnami/charts/pull/32203))
+* [bitnami/valkey] Fix usePasswordFile typo in metrics container ([#32260](https://github.com/bitnami/charts/pull/32260))
+
+## <small>2.4.2 (2025-03-03)</small>
+
+* [bitnami]/valkey update _helpers.tpl to be in line with Valkey-Cluster. (#32203) ([5619378](https://github.com/bitnami/charts/commit/5619378c4014210b2934ad3e803bf72361cafdea)), closes [#32203](https://github.com/bitnami/charts/issues/32203)
 
 ## <small>2.4.1 (2025-02-27)</small>
 

--- a/bitnami/valkey/Chart.yaml
+++ b/bitnami/valkey/Chart.yaml
@@ -36,4 +36,4 @@ maintainers:
 name: valkey
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/valkey
-version: 2.4.2
+version: 2.4.3

--- a/bitnami/valkey/templates/primary/application.yaml
+++ b/bitnami/valkey/templates/primary/application.yaml
@@ -320,7 +320,7 @@ spec:
             - /bin/bash
             - -c
             - |
-              {{- if .Values.usePasswordFiles }}
+              {{- if and .Values.auth.enabled .Values.auth.usePasswordFiles }}
               export REDIS_PASSWORD="$(< $REDIS_PASSWORD_FILE)"
               {{- end }}
               redis_exporter{{- range $key, $value := .Values.metrics.extraArgs }} --{{ $key }}={{ $value }}{{- end }}

--- a/bitnami/valkey/templates/replicas/application.yaml
+++ b/bitnami/valkey/templates/replicas/application.yaml
@@ -340,7 +340,7 @@ spec:
             - /bin/bash
             - -c
             - |
-              {{- if .Values.usePasswordFiles }}
+              {{- if and .Values.auth.enabled .Values.auth.usePasswordFiles }}
               export REDIS_PASSWORD="$(< $REDIS_PASSWORD_FILE)"
               {{- end }}
               redis_exporter{{- range $key, $value := .Values.metrics.extraArgs }} --{{ $key }}={{ $value }}{{- end }}

--- a/bitnami/valkey/templates/sentinel/statefulset.yaml
+++ b/bitnami/valkey/templates/sentinel/statefulset.yaml
@@ -546,7 +546,7 @@ spec:
             - /bin/bash
             - -c
             - |
-              {{- if and .Values.usePasswordFiles }}
+              {{- if and .Values.auth.enabled .Values.auth.usePasswordFiles }}
               export REDIS_PASSWORD="$(< $REDIS_PASSWORD_FILE)"
               {{- end }}
               redis_exporter{{- range $key, $value := .Values.metrics.extraArgs }} --{{ $key }}={{ $value }}{{- end }}


### PR DESCRIPTION
### Description of the change

Fixes issue when `usePasswordFile=true` and metrics are enabled.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
