### PR TITLE
[bitnami/mysql] Fix network policy extraEgress bug

### DIFF
--- a/bitnami/mysql/CHANGELOG.md
+++ b/bitnami/mysql/CHANGELOG.md
@@ -1,12 +1,12 @@
 # Changelog
 
-## <small>12.3.1 (2025-03-05)</small>
+## 12.3.1 (2025-03-05)
 
 * [bitnami/mysql] Fix network policy extraEgress bug ([#32328](https://github.com/bitnami/charts/pull/32328))
 
-## 12.3.0 (2025-02-21)
+## 12.3.0 (2025-02-24)
 
-* [bitnami/mysql] Set `usePasswordFiles=true` by default ([#32113](https://github.com/bitnami/charts/pull/32113))
+* [bitnami/mysql] Set `usePasswordFiles=true` by default (#32113) ([b5b921b](https://github.com/bitnami/charts/commit/b5b921b063f21ec5e3c023869bd8bb01ffaf92a2)), closes [#32113](https://github.com/bitnami/charts/issues/32113)
 
 ## <small>12.2.4 (2025-02-19)</small>
 

--- a/bitnami/mysql/CHANGELOG.md
+++ b/bitnami/mysql/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 12.3.1 (2025-03-05)
+## 12.3.1 (2025-03-06)
 
 * [bitnami/mysql] Fix network policy extraEgress bug ([#32328](https://github.com/bitnami/charts/pull/32328))
 

--- a/bitnami/mysql/CHANGELOG.md
+++ b/bitnami/mysql/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## <small>12.3.1 (2025-03-05)</small>
+
+* [bitnami/mysql] Fix network policy extraEgress bug ([#32328](https://github.com/bitnami/charts/pull/32328))
+
 ## 12.3.0 (2025-02-21)
 
 * [bitnami/mysql] Set `usePasswordFiles=true` by default ([#32113](https://github.com/bitnami/charts/pull/32113))

--- a/bitnami/mysql/Chart.yaml
+++ b/bitnami/mysql/Chart.yaml
@@ -34,4 +34,4 @@ maintainers:
 name: mysql
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/mysql
-version: 12.3.0
+version: 12.3.1

--- a/bitnami/mysql/templates/networkpolicy.yaml
+++ b/bitnami/mysql/templates/networkpolicy.yaml
@@ -47,7 +47,7 @@ spec:
         - podSelector:
             matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 14 }}
     {{- if .Values.networkPolicy.extraEgress }}
-    {{- include "common.tplvalues.render" ( dict "value" .Values.rts.networkPolicy.extraEgress "context" $ ) | nindent 4 }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.networkPolicy.extraEgress "context" $ ) | nindent 4 }}
     {{- end }}
   {{- end }}
   ingress:


### PR DESCRIPTION
### Description of the change

This PR fixes an issue with the `networkpolicy.yaml` template that causes the following error to be raised when `networkPolicy.allowExternalEgress` is set to `false`:

> Error: template: mysql/templates/networkpolicy.yaml:50:64: executing "mysql/templates/networkpolicy.yaml" at <.Values.rts.networkPolicy.extraEgress>: nil pointer evaluating interface {}.networkPolicy

Setting the `networkPolicy.allowExternal` variable as `true` or `false` did not stop the error from occurring.

### Benefits

Chart can be deployed successfully.

### Possible drawbacks

None known.

### Applicable issues

N/A

### Additional information

Values used:

```YAML
networkPolicy:
  enabled: true
  allowExternal: true
  allowExternalEgress: false
  extraIngress:
    - ports:
        - port: 3306
        - port: 9104
      from:
        - podSelector:
            matchLabels:
              app.kubernetes.io/name: example
        - podSelector:
            matchLabels:
              app.kubernetes.io/part-of: example
  extraEgress:
    - ports:
        - port: 3306
        - port: 9104
      to:
        - podSelector:
            matchLabels:
              app.kubernetes.io/name: example
```

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
