### PR TITLE
bitnami/redis-cluster -> doc: updated example install command to use redis-cluster as release name

### DIFF
--- a/bitnami/redis-cluster/README.md
+++ b/bitnami/redis-cluster/README.md
@@ -11,7 +11,7 @@ Disclaimer: Redis is a registered trademark of Redis Ltd. Any rights therein are
 ## TL;DR
 
 ```console
-helm install my-release oci://registry-1.docker.io/bitnamicharts/redis-cluster
+helm install redis-cluster oci://registry-1.docker.io/bitnamicharts/redis-cluster
 ```
 
 Looking to use Redisreg; Cluster in production? Try [VMware Tanzu Application Catalog](https://bitnami.com/enterprise), the commercial edition of the Bitnami catalog.


### PR DESCRIPTION
doc: fixed the install command to use name as "redis-cluster" instead of my-release to avoid extra prefix in installed resources

 - Describe the scope of your change - i.e. what the change does.
 Doc update, example installation command using `my-release` results in unnecessary prefix in the kubernetes resources, causing inconviniences in developer experience for `exec`, `logs`, etc
 - Describe any known limitations with your change.
 None
 - Please run any tests or examples that can exercise your modified code.
 Not applicable, docs


### Description of the change

 Doc update, example installation command using `my-release` results in unnecessary prefix in the kubernetes resources, causing inconviniences in developer experience for `exec`, `logs`, etc

### Benefits

Better developer experience for local experimentation and infra admins

### Possible drawbacks
None

### Applicable issues
None

### Additional information
None

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x ] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
