### PR TITLE
[bitnami/wordpress] fix network policy when metrics enabled

### DIFF
--- a/bitnami/wordpress/CHANGELOG.md
+++ b/bitnami/wordpress/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 24.1.17 (2025-03-06)
+## 24.1.18 (2025-03-06)
 
-* [bitnami/wordpress] Release 24.1.17 ([#32335](https://github.com/bitnami/charts/pull/32335))
+* [bitnami/wordpress] fix network policy when metrics enabled ([#32338](https://github.com/bitnami/charts/pull/32338))
+
+## <small>24.1.17 (2025-03-06)</small>
+
+* [bitnami/wordpress] Release 24.1.17 (#32335) ([1dec218](https://github.com/bitnami/charts/commit/1dec21880650c8b459025016068493a9fa063e01)), closes [#32335](https://github.com/bitnami/charts/issues/32335)
 
 ## <small>24.1.16 (2025-03-04)</small>
 

--- a/bitnami/wordpress/Chart.yaml
+++ b/bitnami/wordpress/Chart.yaml
@@ -14,34 +14,34 @@ annotations:
 apiVersion: v2
 appVersion: 6.7.2
 dependencies:
-- condition: memcached.enabled
-  name: memcached
-  repository: oci://registry-1.docker.io/bitnamicharts
-  version: 7.x.x
-- condition: mariadb.enabled
-  name: mariadb
-  repository: oci://registry-1.docker.io/bitnamicharts
-  version: 20.x.x
-- name: common
-  repository: oci://registry-1.docker.io/bitnamicharts
-  tags:
-  - bitnami-common
-  version: 2.x.x
+  - condition: memcached.enabled
+    name: memcached
+    repository: oci://registry-1.docker.io/bitnamicharts
+    version: 7.x.x
+  - condition: mariadb.enabled
+    name: mariadb
+    repository: oci://registry-1.docker.io/bitnamicharts
+    version: 20.x.x
+  - name: common
+    repository: oci://registry-1.docker.io/bitnamicharts
+    tags:
+      - bitnami-common
+    version: 2.x.x
 description: WordPress is the world's most popular blogging and content management platform. Powerful yet simple, everyone from students to global corporations use it to build beautiful, functional websites.
 home: https://bitnami.com
 icon: https://dyltqmyl993wv.cloudfront.net/assets/stacks/wordpress/img/wordpress-stack-220x234.png
 keywords:
-- application
-- blog
-- cms
-- http
-- php
-- web
-- wordpress
+  - application
+  - blog
+  - cms
+  - http
+  - php
+  - web
+  - wordpress
 maintainers:
-- name: Broadcom, Inc. All Rights Reserved.
-  url: https://github.com/bitnami/charts
+  - name: Broadcom, Inc. All Rights Reserved.
+    url: https://github.com/bitnami/charts
 name: wordpress
 sources:
-- https://github.com/bitnami/charts/tree/main/bitnami/wordpress
-version: 24.1.17
+  - https://github.com/bitnami/charts/tree/main/bitnami/wordpress
+version: 24.1.18

--- a/bitnami/wordpress/templates/networkpolicy.yaml
+++ b/bitnami/wordpress/templates/networkpolicy.yaml
@@ -35,7 +35,7 @@ spec:
     - ports:
         - port: {{ include "wordpress.databasePort" . }}
       {{- if .Values.mariadb.enabled }}
-      to: 
+      to:
         - podSelector:
             matchLabels:
               app.kubernetes.io/name: mariadb
@@ -61,6 +61,9 @@ spec:
     - ports:
         - port: {{ .Values.containerPorts.http }}
         - port: {{ .Values.containerPorts.https }}
+        {{- if .Values.metrics.enabled }}
+        - port: {{ .Values.metrics.containerPorts.metrics }}
+        {{- end}}
         {{- range .Values.extraContainerPorts }}
         - port: {{ . }}
         {{- end }}


### PR DESCRIPTION
### Description of the change

This PR fixes an issue discovered while enabling metrics on WordPress. 
Metrics were no present in Prometheus, experiencing a connection refused issue.
Connection issue cause by the `networkPolicy` specification. Per default, only 'frontend' ports are enabled (8080, 8443).
However, when we activate metrics scraping with Prometheus, it also takes the 'metrics port' (default 9117) to be enabled

### Benefits

:+1: 'metrics port' (9117) is allowed per default when metrics are enabled.
:-1: Instead of using `extraIngress` entry in the `values.yaml` file
```yaml
[...]
networkPolicy:
  extraIngress:
    - ports:
        - port: 9117
```

### Possible drawbacks

None seen

### Applicable issues

N/A

### Additional information

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
