### PR TITLE
[bitnami/ghost] Set `usePasswordFiles=true` by default

### DIFF
--- a/bitnami/ghost/Chart.yaml
+++ b/bitnami/ghost/Chart.yaml
@@ -40,4 +40,4 @@ maintainers:
 name: ghost
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/ghost
-version: 22.1.18
+version: 22.2.0

--- a/bitnami/ghost/templates/deployment.yaml
+++ b/bitnami/ghost/templates/deployment.yaml
@@ -156,11 +156,16 @@ spec:
               value: {{ include "ghost.databaseName" . | quote }}
             - name: GHOST_DATABASE_USER
               value: {{ include "ghost.databaseUser" . | quote }}
+            {{- if .Values.usePasswordFiles }}
+            - name: GHOST_DATABASE_PASSWORD_FILE
+              value: "/opt/bitnami/ghost/secrets/mysql-password"
+            {{- else }}
             - name: GHOST_DATABASE_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ include "ghost.databaseSecretName" . }}
                   key: mysql-password
+            {{- end -}}
             {{- if (and (not .Values.mysql.enabled) .Values.externalDatabase.ssl) }}
             - name: GHOST_DATABASE_ENABLE_SSL
               value: {{ .Values.externalDatabase.ssl | quote }}
@@ -175,11 +180,16 @@ spec:
               value: {{ ternary .Values.containerPorts.https .Values.containerPorts.http .Values.ghostEnableHttps | quote }}
             - name: GHOST_USERNAME
               value: {{ .Values.ghostUsername | quote }}
+            {{- if .Values.usePasswordFiles }}
+            - name: GHOST_PASSWORD_FILE
+              value: {{ printf "/opt/bitnami/ghost/secrets/%s" (include "common.secrets.key" (dict "existingSecret" .Values.existingSecret "key" "ghost-password")) }}
+            {{- else }}
             - name: GHOST_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ include "common.secrets.name" (dict "existingSecret" .Values.existingSecret "context" $) }}
                   key: {{ include "common.secrets.key" (dict "existingSecret" .Values.existingSecret "key" "ghost-password") }}
+            {{- end }}
             - name: GHOST_EMAIL
               value: {{ .Values.ghostEmail | quote }}
             - name: GHOST_BLOG_TITLE
@@ -205,11 +215,16 @@ spec:
               value: {{ .Values.smtpUser | quote }}
             {{- end }}
             {{- if .Values.smtpPassword }}
+            {{- if .Values.usePasswordFiles }}
+            - name: GHOST_PASSWORD_FILE
+              value: {{ printf "/opt/bitnami/ghost/secrets/%s" (include "common.secrets.key" (dict "existingSecret" .Values.existingSecret "key" "smtp-password")) }}
+            {{- else }}
             - name: GHOST_SMTP_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ include "common.secrets.name" (dict "existingSecret" .Values.existingSecret "context" $) }}
                   key: {{ include "common.secrets.key" (dict "existingSecret" .Values.existingSecret "key" "smtp-password") }}
+            {{- end }}
             {{- end }}
             {{- if .Values.smtpService }}
             - name: GHOST_SMTP_SERVICE
@@ -312,6 +327,10 @@ spec:
               subPath: tmp-dir
             - name: ghost-data
               mountPath: /bitnami/ghost
+            {{- if and .Values.usePasswordFiles }}
+            - name: ghost-secrets
+              mountPath: /opt/bitnami/ghost/secrets
+            {{- end }}
             {{- if .Values.persistence.subPath }}
               subPath: {{ .Values.persistence.subPath }}
             {{- end }}
@@ -324,6 +343,13 @@ spec:
       volumes:
         - name: empty-dir
           emptyDir: {}
+        {{- if and .Values.usePasswordFiles }}
+        - name: ghost-secrets
+          projected:
+            sources:
+              - secret:
+                  name:  {{ include "ghost.secretName" . }}
+        {{- end }}
         - name: ghost-data
         {{- if .Values.persistence.enabled }}
           persistentVolumeClaim:

--- a/bitnami/ghost/values.yaml
+++ b/bitnami/ghost/values.yaml
@@ -55,6 +55,9 @@ clusterDomain: cluster.local
 ## @param extraDeploy Array of extra objects to deploy with the release
 ##
 extraDeploy: []
+## @param usePasswordFiles Mount credentials as files instead of using environment variables
+##
+usePasswordFiles: true
 ## Enable diagnostic mode in the deployment
 ##
 diagnosticMode:


### PR DESCRIPTION
### Description of the change

Sets default value for `usePasswordFiles` to true.

### Benefits

With this change, the chart will mount the secrets as files by default instead of directly setting them into environment variables.

### Possible drawbacks

None

### Applicable issues

None

### Additional information

N/A

### Checklist

- [x] Chart version bumped in Chart.yaml according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
