### PR TITLE
[bitnami/valkey]: add apiVersion and kind to sentinel statefulset

### DIFF
--- a/bitnami/valkey/CHANGELOG.md
+++ b/bitnami/valkey/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 2.4.4 (2025-03-05)
+## 2.4.5 (2025-03-06)
 
-* [bitnami/valkey] Fix usage of valkey .metrics.serviceMonitor.additionalEndpoints ([#32217](https://github.com/bitnami/charts/pull/32217))
+* [bitnami/valkey]: add apiVersion and kind to sentinel statefulset ([#32356](https://github.com/bitnami/charts/pull/32356))
+
+## <small>2.4.4 (2025-03-05)</small>
+
+* [bitnami/valkey] Fix usage of valkey .metrics.serviceMonitor.additionalEndpoints (#32217) ([304c018](https://github.com/bitnami/charts/commit/304c018c6ffbf6146eb88f095d7064daf878c793)), closes [#32217](https://github.com/bitnami/charts/issues/32217)
 
 ## <small>2.4.3 (2025-03-04)</small>
 

--- a/bitnami/valkey/Chart.yaml
+++ b/bitnami/valkey/Chart.yaml
@@ -36,4 +36,4 @@ maintainers:
 name: valkey
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/valkey
-version: 2.4.4
+version: 2.4.5

--- a/bitnami/valkey/templates/sentinel/statefulset.yaml
+++ b/bitnami/valkey/templates/sentinel/statefulset.yaml
@@ -776,7 +776,9 @@ spec:
         {{- end }}
         {{- include "common.storage.class" (dict "persistence" .Values.replica.persistence "global" .Values.global) | nindent 8 }}
     {{- if .Values.sentinel.persistence.enabled }}
-    - metadata:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
         name: sentinel-data
         {{- $claimLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.sentinel.persistence.labels .Values.commonLabels ) "context" . ) }}
         labels: {{- include "common.labels.matchLabels" ( dict "customLabels" $claimLabels "context" $ ) | nindent 10 }}


### PR DESCRIPTION
Exactly as #29678, but for Valkey

### Description of the change

Before this change, ArgoCD kept on complaining about the application not being in sync:
![20250306_20h36m34s_grim](https://github.com/user-attachments/assets/d7765d06-534c-4203-aefa-a7a26023e8aa)

This is due to the fact that the Valkey Sentinel StatefulSet is missing the `apiVersion` and `kind` on the `sentinel-data` volume specification, exactly as #29678.

### Benefits

No more sync issues in ArgoCD

### Possible drawbacks

None

### Applicable issues

N/A

### Additional information

N/A

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
