### PR TITLE
[bitnami/keydb] only use password files if auth is enabled

### DIFF
--- a/bitnami/keydb/CHANGELOG.md
+++ b/bitnami/keydb/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.5.2 (2025-03-07)
+## 0.5.2 (2025-03-10)
 
 * [bitnami/keydb] only use password files if auth is enabled ([#32358](https://github.com/bitnami/charts/pull/32358))
 

--- a/bitnami/keydb/CHANGELOG.md
+++ b/bitnami/keydb/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 0.5.1 (2025-03-03)
+## 0.5.2 (2025-03-07)
 
-* fix: change svc target port in servicemonitor ([#32236](https://github.com/bitnami/charts/pull/32236))
+* [bitnami/keydb] only use password files if auth is enabled ([#32358](https://github.com/bitnami/charts/pull/32358))
+
+## <small>0.5.1 (2025-03-04)</small>
+
+* fix: change svc target port in servicemonitor (#32236) ([f5056c8](https://github.com/bitnami/charts/commit/f5056c8b66d7d83574c446d3779704b9a84c7b3c)), closes [#32236](https://github.com/bitnami/charts/issues/32236)
 
 ## 0.5.0 (2025-02-27)
 

--- a/bitnami/keydb/Chart.yaml
+++ b/bitnami/keydb/Chart.yaml
@@ -34,4 +34,4 @@ name: keydb
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/keydb
   - https://github.com/bitnami/containers/tree/main/bitnami/keydb
-version: 0.5.1
+version: 0.5.2

--- a/bitnami/keydb/templates/master/statefulset.yaml
+++ b/bitnami/keydb/templates/master/statefulset.yaml
@@ -280,7 +280,7 @@ spec:
             {{- if .Values.auth.enabled }}
             - name: REDIS_USER
               value: default
-            {{- if and .Values.auth.enabled .Values.auth.usePasswordFiles }}
+            {{- if .Values.auth.usePasswordFiles }}
             - name: REDIS_PASSWORD_FILE
               value: {{ printf "/secrets/%s" (include "keydb.secretPasswordKey" .) }}
             {{- else }}

--- a/bitnami/keydb/templates/master/statefulset.yaml
+++ b/bitnami/keydb/templates/master/statefulset.yaml
@@ -229,7 +229,7 @@ spec:
             - name: health-scripts
               mountPath: /opt/bitnami/scripts/health
               readOnly: true
-            {{- and .Values.auth.enabled .Values.auth.usePasswordFiles }}
+            {{- if and .Values.auth.enabled .Values.auth.usePasswordFiles }}
             - name: keydb-password
               mountPath: /opt/bitnami/keydb/secrets
               readOnly: true

--- a/bitnami/keydb/templates/master/statefulset.yaml
+++ b/bitnami/keydb/templates/master/statefulset.yaml
@@ -229,7 +229,7 @@ spec:
             - name: health-scripts
               mountPath: /opt/bitnami/scripts/health
               readOnly: true
-            {{- if .Values.auth.usePasswordFiles }}
+            {{- and .Values.auth.enabled .Values.auth.usePasswordFiles }}
             - name: keydb-password
               mountPath: /opt/bitnami/keydb/secrets
               readOnly: true
@@ -264,7 +264,7 @@ spec:
             - /bin/bash
             - -c
             - |
-              {{- if .Values.auth.usePasswordFiles }}
+              {{- if and .Values.auth.enabled .Values.auth.usePasswordFiles }}
               export REDIS_PASSWORD="$(< $REDIS_PASSWORD_FILE)"
               {{- end }}
               redis_exporter{{- range $key, $value := .Values.metrics.extraArgs }} --{{ $key }}={{ $value }}{{- end }}
@@ -280,7 +280,7 @@ spec:
             {{- if .Values.auth.enabled }}
             - name: REDIS_USER
               value: default
-            {{- if .Values.auth.usePasswordFiles }}
+            {{- if and .Values.auth.enabled .Values.auth.usePasswordFiles }}
             - name: REDIS_PASSWORD_FILE
               value: {{ printf "/secrets/%s" (include "keydb.secretPasswordKey" .) }}
             {{- else }}
@@ -340,7 +340,7 @@ spec:
             - name: empty-dir
               mountPath: /tmp
               subPath: app-tmp-dir
-            {{- if .Values.auth.usePasswordFiles }}
+            {{- if and .Values.auth.enabled .Values.auth.usePasswordFiles }}
             - name: keydb-password
               mountPath: /secrets
               readOnly: true
@@ -367,7 +367,7 @@ spec:
         - name: config
           configMap:
             name: {{ template "keydb.master.configmapName" . }}
-        {{- if .Values.auth.usePasswordFiles }}
+        {{- if and .Values.auth.enabled .Values.auth.usePasswordFiles }}
         - name: keydb-password
           secret:
             secretName: {{ template "keydb.secretName" . }}

--- a/bitnami/keydb/templates/replica/statefulset.yaml
+++ b/bitnami/keydb/templates/replica/statefulset.yaml
@@ -251,7 +251,7 @@ spec:
             - name: health-scripts
               mountPath: /opt/bitnami/scripts/health
               readOnly: true
-            {{- if .Values.auth.usePasswordFiles }}
+            {{- if and .Values.auth.enabled .Values.auth.usePasswordFiles }}
             - name: keydb-password
               mountPath: /opt/bitnami/keydb/secrets
               readOnly: true
@@ -286,7 +286,7 @@ spec:
             - /bin/bash
             - -c
             - |
-              {{- if .Values.auth.usePasswordFiles }}
+              {{- if and .Values.auth.enabled .Values.auth.usePasswordFiles }}
               export REDIS_PASSWORD="$(< $REDIS_PASSWORD_FILE)"
               {{- end }}
               redis_exporter{{- range $key, $value := .Values.metrics.extraArgs }} --{{ $key }}={{ $value }}{{- end }}
@@ -362,7 +362,7 @@ spec:
             - name: empty-dir
               mountPath: /tmp
               subPath: app-tmp-dir
-            {{- if .Values.auth.usePasswordFiles }}
+            {{- if and .Values.auth.enabled .Values.auth.usePasswordFiles }}
             - name: keydb-password
               mountPath: /secrets
               readOnly: true
@@ -389,7 +389,7 @@ spec:
         - name: config
           configMap:
             name: {{ template "keydb.replica.configmapName" . }}
-        {{- if .Values.auth.usePasswordFiles }}
+        {{- if and .Values.auth.enabled .Values.auth.usePasswordFiles }}
         - name: keydb-password
           secret:
             secretName: {{ template "keydb.secretName" . }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Do not mount secret if auth is disabled.
Regression of #32108
<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits
No need to set `auth.usePasswordFiles=false` when `auth.enabled=false`
<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->
none

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- #32353

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
