### PR TITLE
[bitnami/valkey] Fix issue when using custom password secret key

### DIFF
--- a/bitnami/valkey/CHANGELOG.md
+++ b/bitnami/valkey/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 2.4.5 (2025-03-06)
+## 2.4.6 (2025-03-10)
 
-* [bitnami/valkey]: add apiVersion and kind to sentinel statefulset ([#32356](https://github.com/bitnami/charts/pull/32356))
+* [bitnami/valkey] Fix issue when using custom password secret key ([#32375](https://github.com/bitnami/charts/pull/32375))
+
+## <small>2.4.5 (2025-03-10)</small>
+
+* [bitnami/valkey]: add apiVersion and kind to sentinel statefulset (#32356) ([8c1620e](https://github.com/bitnami/charts/commit/8c1620e5cc40471808b0099a41d44fe7b1141f65)), closes [#32356](https://github.com/bitnami/charts/issues/32356)
 
 ## <small>2.4.4 (2025-03-05)</small>
 

--- a/bitnami/valkey/Chart.yaml
+++ b/bitnami/valkey/Chart.yaml
@@ -36,4 +36,4 @@ maintainers:
 name: valkey
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/valkey
-version: 2.4.5
+version: 2.4.6

--- a/bitnami/valkey/templates/primary/application.yaml
+++ b/bitnami/valkey/templates/primary/application.yaml
@@ -180,7 +180,7 @@ spec:
             {{- if .Values.auth.enabled }}
             {{- if .Values.auth.usePasswordFiles }}
             - name: VALKEY_PASSWORD_FILE
-              value: {{ printf "/opt/bitnami/valkey/secrets/%s" (include "valkey.secretPasswordKey" .) }}
+              value: "/opt/bitnami/valkey/secrets/valkey-password"
             {{- else }}
             - name: VALKEY_PASSWORD
               valueFrom:
@@ -338,7 +338,7 @@ spec:
               value: default
             {{- if .Values.auth.usePasswordFiles }}
             - name: REDIS_PASSWORD_FILE
-              value: {{ printf "/secrets/%s" (include "valkey.secretPasswordKey" .) }}
+              value: "/secrets/valkey-password"
             {{- else }}
             - name: REDIS_PASSWORD
               valueFrom:

--- a/bitnami/valkey/templates/replicas/application.yaml
+++ b/bitnami/valkey/templates/replicas/application.yaml
@@ -194,9 +194,9 @@ spec:
             {{- if .Values.auth.enabled }}
             {{- if .Values.auth.usePasswordFiles }}
             - name: VALKEY_PASSWORD_FILE
-              value: {{ printf "/opt/bitnami/valkey/secrets/%s" (include "valkey.secretPasswordKey" .) }}
+              value: "/opt/bitnami/valkey/secrets/valkey-password"
             - name: VALKEY_PRIMARY_PASSWORD_FILE
-              value: {{ printf "/opt/bitnami/valkey/secrets/%s" (include "valkey.secretPasswordKey" .) }}
+              value: "/opt/bitnami/valkey/secrets/valkey-password"
             {{- else }}
             - name: VALKEY_PASSWORD
               valueFrom:
@@ -358,7 +358,7 @@ spec:
               value: default
             {{- if .Values.auth.usePasswordFiles }}
             - name: REDIS_PASSWORD_FILE
-              value: {{ printf "/secrets/%s" (include "valkey.secretPasswordKey" .) }}
+              value: "/secrets/valkey-password"
             {{- else }}
             - name: REDIS_PASSWORD
               valueFrom:

--- a/bitnami/valkey/templates/sentinel/statefulset.yaml
+++ b/bitnami/valkey/templates/sentinel/statefulset.yaml
@@ -186,9 +186,9 @@ spec:
             {{- if .Values.auth.enabled }}
             {{- if .Values.auth.usePasswordFiles }}
             - name: VALKEY_PASSWORD_FILE
-              value: {{ printf "/opt/bitnami/valkey/secrets/%s" (include "valkey.secretPasswordKey" .) }}
+              value: "/opt/bitnami/valkey/secrets/valkey-password"
             - name: VALKEY_PRIMARY_PASSWORD_FILE
-              value: {{ printf "/opt/bitnami/valkey/secrets/%s" (include "valkey.secretPasswordKey" .) }}
+              value: "/opt/bitnami/valkey/secrets/valkey-password"
             {{- else }}
             - name: VALKEY_PASSWORD
               valueFrom:
@@ -392,7 +392,7 @@ spec:
             {{- if .Values.auth.enabled }}
             {{- if .Values.auth.usePasswordFiles }}
             - name: VALKEY_PASSWORD_FILE
-              value: {{ printf "/opt/bitnami/valkey/secrets/%s" (include "valkey.secretPasswordKey" .) }}
+              value: "/opt/bitnami/valkey/secrets/valkey-password"
             {{- else }}
             - name: VALKEY_PASSWORD
               valueFrom:
@@ -564,7 +564,7 @@ spec:
               value: default
             {{- if .Values.auth.usePasswordFiles }}
             - name: REDIS_PASSWORD_FILE
-              value: {{ printf "/secrets/%s" (include "valkey.secretPasswordKey" .) }}
+              value: "/secrets/valkey-password"
             {{- else }}
             - name: REDIS_PASSWORD
               valueFrom:


### PR DESCRIPTION
### Description of the change

Implements #32215 for the bitnami/valkey chart.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
