### PR TITLE
[bitnami/keydb] Fix issue when using custom password secret key

### DIFF
--- a/bitnami/keydb/CHANGELOG.md
+++ b/bitnami/keydb/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 0.5.2 (2025-03-10)
+## 0.5.3 (2025-03-10)
 
-* [bitnami/keydb] only use password files if auth is enabled ([#32358](https://github.com/bitnami/charts/pull/32358))
+* [bitnami/keydb] Fix issue when using custom password secret key ([#32376](https://github.com/bitnami/charts/pull/32376))
+
+## <small>0.5.2 (2025-03-10)</small>
+
+* [bitnami/keydb] only use password files if auth is enabled (#32358) ([dcdf3ca](https://github.com/bitnami/charts/commit/dcdf3caf48f91f1055b6e124ed2b62611a599c26)), closes [#32358](https://github.com/bitnami/charts/issues/32358)
 
 ## <small>0.5.1 (2025-03-04)</small>
 

--- a/bitnami/keydb/Chart.yaml
+++ b/bitnami/keydb/Chart.yaml
@@ -34,4 +34,4 @@ name: keydb
 sources:
   - https://github.com/bitnami/charts/tree/main/bitnami/keydb
   - https://github.com/bitnami/containers/tree/main/bitnami/keydb
-version: 0.5.2
+version: 0.5.3

--- a/bitnami/keydb/templates/master/statefulset.yaml
+++ b/bitnami/keydb/templates/master/statefulset.yaml
@@ -154,7 +154,7 @@ spec:
             {{- if .Values.auth.enabled }}
             {{- if .Values.auth.usePasswordFiles }}
             - name: KEYDB_PASSWORD_FILE
-              value: {{ printf "/opt/bitnami/keydb/secrets/%s" (include "keydb.secretPasswordKey" .) }}
+              value: "/opt/bitnami/keydb/secrets/keydb-password"
             {{- else }}
             - name: KEYDB_PASSWORD
               valueFrom:
@@ -282,7 +282,7 @@ spec:
               value: default
             {{- if .Values.auth.usePasswordFiles }}
             - name: REDIS_PASSWORD_FILE
-              value: {{ printf "/secrets/%s" (include "keydb.secretPasswordKey" .) }}
+              value: "/secrets/keydb-password"
             {{- else }}
             - name: REDIS_PASSWORD
               valueFrom:

--- a/bitnami/keydb/templates/replica/statefulset.yaml
+++ b/bitnami/keydb/templates/replica/statefulset.yaml
@@ -169,9 +169,9 @@ spec:
             {{- if .Values.auth.enabled }}
             {{- if .Values.auth.usePasswordFiles }}
             - name: KEYDB_PASSWORD_FILE
-              value: {{ printf "/opt/bitnami/keydb/secrets/%s" (include "keydb.secretPasswordKey" .) }}
+              value: "/opt/bitnami/keydb/secrets/keydb-password"
             - name: KEYDB_MASTER_PASSWORD_FILE
-              value: {{ printf "/opt/bitnami/keydb/secrets/%s" (include "keydb.secretPasswordKey" .) }}
+              value: "/opt/bitnami/keydb/secrets/keydb-password"
             {{- else }}
             - name: KEYDB_PASSWORD
               valueFrom:
@@ -304,7 +304,7 @@ spec:
               value: default
             {{- if .Values.auth.usePasswordFiles }}
             - name: REDIS_PASSWORD_FILE
-              value: {{ printf "/secrets/%s" (include "keydb.secretPasswordKey" .) }}
+              value: "/secrets/keydb-password"
             {{- else }}
             - name: REDIS_PASSWORD
               valueFrom:


### PR DESCRIPTION
### Description of the change

Implements #32215 for the bitnami/keydb chart.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
