### PR TITLE
[bitnami/keycloak] Update secret-external-db namespace to use common helper value

### DIFF
--- a/bitnami/keycloak/CHANGELOG.md
+++ b/bitnami/keycloak/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 24.4.12 (2025-03-10)
+## 24.4.12 (2025-03-11)
 
 * [bitnami/keycloak] Update secret-external-db namespace to use common helper value ([#32379](https://github.com/bitnami/charts/pull/32379))
 

--- a/bitnami/keycloak/CHANGELOG.md
+++ b/bitnami/keycloak/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 24.4.11 (2025-02-28)
+## 24.4.12 (2025-03-10)
 
-* [bitnami/keycloak] Release 24.4.11 ([#32211](https://github.com/bitnami/charts/pull/32211))
+* [bitnami/keycloak] Update secret-external-db namespace to use common helper value ([#32379](https://github.com/bitnami/charts/pull/32379))
+
+## <small>24.4.11 (2025-02-28)</small>
+
+* [bitnami/keycloak] Release 24.4.11 (#32211) ([932c291](https://github.com/bitnami/charts/commit/932c2910f0b648bbdb006a1122792e6363b3b17a)), closes [#32211](https://github.com/bitnami/charts/issues/32211)
 
 ## <small>24.4.10 (2025-02-17)</small>
 

--- a/bitnami/keycloak/Chart.yaml
+++ b/bitnami/keycloak/Chart.yaml
@@ -33,4 +33,4 @@ maintainers:
 name: keycloak
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/keycloak
-version: 24.4.11
+version: 24.4.12

--- a/bitnami/keycloak/templates/secret-external-db.yaml
+++ b/bitnami/keycloak/templates/secret-external-db.yaml
@@ -8,7 +8,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ printf "%s-externaldb" .Release.Name }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" (dict "customLabels" .Values.commonLabels "context" $) | nindent 4 }}
   {{- if or .Values.externalDatabase.annotations .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.merge" (dict "values" (list .Values.externalDatabase.annotations .Values.commonAnnotations) "context" $) | nindent 4 }}


### PR DESCRIPTION
### Description of the change

Update namespace value in `secret-external-db.yaml` template to use the namespace value from common helper, and not use the Release namespace.

### Benefits

This will allow to use the value from `namespaceOverride` if needed, instead of always adding the secret in the "default" namespace. This also follows the value in rest of templates in the same chart.

### Possible drawbacks

N/A

### Applicable issues

N/A

### Additional information

N/A

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
