### PR TITLE
[bitnami/mongodb] Update dns-check init container condition

### DIFF
--- a/bitnami/mongodb/CHANGELOG.md
+++ b/bitnami/mongodb/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 16.4.6 (2025-02-27)
+## 16.4.7 (2025-03-11)
 
-* [bitnami/mongodb] Use actual hostname instead of localhost for mongodb_exporter URI string ([#32192](https://github.com/bitnami/charts/pull/32192))
+* [bitnami/mongodb] Update dns-check init container condition ([#32394](https://github.com/bitnami/charts/pull/32394))
+
+## <small>16.4.6 (2025-03-10)</small>
+
+* [bitnami/mongodb] Use actual hostname instead of localhost for mongodb_exporter URI string (#32192) ([cbfec4f](https://github.com/bitnami/charts/commit/cbfec4f962119b505b5c81b6d61448506b7a6216)), closes [#32192](https://github.com/bitnami/charts/issues/32192)
 
 ## <small>16.4.5 (2025-02-21)</small>
 

--- a/bitnami/mongodb/Chart.yaml
+++ b/bitnami/mongodb/Chart.yaml
@@ -39,4 +39,4 @@ maintainers:
 name: mongodb
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/mongodb
-version: 16.4.6
+version: 16.4.7

--- a/bitnami/mongodb/templates/arbiter/statefulset.yaml
+++ b/bitnami/mongodb/templates/arbiter/statefulset.yaml
@@ -87,7 +87,7 @@ spec:
         {{- if .Values.arbiter.initContainers }}
         {{- include "common.tplvalues.render" (dict "value" .Values.arbiter.initContainers "context" $) | nindent 8 }}
         {{- end }}
-        {{- if and .Values.externalAccess.enabled ( or .Values.externalAccess.service.publicNames  .Values.externalAccess.service.domain ) }}
+        {{- if and .Values.externalAccess.enabled .Values.externalAccess.service.publicNames }}
         {{- include "mongodb.initContainers.dnsCheck" . | nindent 8 }}
         {{- end }}
         {{- if and .Values.tls.enabled .Values.arbiter.enabled }}

--- a/bitnami/mongodb/templates/hidden/statefulset.yaml
+++ b/bitnami/mongodb/templates/hidden/statefulset.yaml
@@ -96,7 +96,7 @@ spec:
         {{- if and .Values.externalAccess.hidden.enabled .Values.externalAccess.autoDiscovery.enabled (eq .Values.externalAccess.hidden.service.type "LoadBalancer") }}
         {{- include "mongodb.initContainers.autoDiscovery" . | indent 8 }}
         {{- end }}
-        {{- if and .Values.externalAccess.enabled ( or .Values.externalAccess.service.publicNames  .Values.externalAccess.service.domain ) }}
+        {{- if and .Values.externalAccess.enabled .Values.externalAccess.service.publicNames }}
         {{- include "mongodb.initContainers.dnsCheck" . | indent 8 }}
         {{- end }}
         {{- include "mongodb.initContainer.prepareLogDir" . | nindent 8 }}

--- a/bitnami/mongodb/templates/replicaset/statefulset.yaml
+++ b/bitnami/mongodb/templates/replicaset/statefulset.yaml
@@ -97,7 +97,7 @@ spec:
         {{- if and .Values.externalAccess.enabled .Values.externalAccess.autoDiscovery.enabled (eq .Values.externalAccess.service.type "LoadBalancer") }}
         {{- include "mongodb.initContainers.autoDiscovery" . | nindent 8 }}
         {{- end }}
-        {{- if and .Values.externalAccess.enabled ( or .Values.externalAccess.service.publicNames  .Values.externalAccess.service.domain ) }}
+        {{- if and .Values.externalAccess.enabled .Values.externalAccess.service.publicNames }}
         {{- include "mongodb.initContainers.dnsCheck" . | nindent 8 }}
         {{- end }}
         {{- include "mongodb.initContainer.prepareLogDir" . | nindent 8 }}


### PR DESCRIPTION
### Description of the change

Updates the `dns-check` init container conditional to not include `.Values.externalAccess.service.domain`.

The value `externalAccess.service.domain` didn't interfere in any way with the `dns-check` init container, which led us to two possible scenarios:

- When `externalAccess.service.publicNames` is set, the dns-check will ensure that indeed the pod is able to resolve the DNS.
- When `externalAccess.service.publicNames` is **NOT** set, but `externalAccess.service.domain` is, the `dns-check` will perform a check on the pod's FQDN, e.g. `mongodb-0.svc.mongodb-hl.my-ns.cluster.local`.

This second scenario doesn't really make sense, because the headless service is configured with `publishNotReadyAddresses=true`, and performing a DNS check on a headless service is unnecessary.

### Benefits

Simplifies the logic and fixes an existing issue with the `dns-check` init container, where check would never pass because variable `MY_POD_NAMESPACE` was never defined.

### Possible drawbacks

None known.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #30798

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
