### PR TITLE
Increase timeout in pytorch goss tests

### DIFF
--- a/.vib/pytorch/goss/goss.yaml
+++ b/.vib/pytorch/goss/goss.yaml
@@ -11,7 +11,7 @@ command:
   run-git-example:
     exec: python ./pytorch/goss/testfiles/polynomial_tensor.py
     exit-status: 0
-    timeout: 20000
+    timeout: 30000
   {{- $uid := .Vars.containerSecurityContext.runAsUser }}
   {{- $gid := .Vars.podSecurityContext.fsGroup }}
   check-user-info:


### PR DESCRIPTION
Increase timeout in pytorch goss tests since it's taking ~15 secs in some platforms, so it's safer to give it more margin to succeed.