### PR TITLE
[bitnami/cassandra] bugfix #32369

### DIFF
--- a/bitnami/cassandra/CHANGELOG.md
+++ b/bitnami/cassandra/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 12.2.1 (2025-03-05)
+## 12.2.2 (2025-03-12)
 
-* [bitnami/cassandra] Release 12.2.1 ([#32322](https://github.com/bitnami/charts/pull/32322))
+* [bitnami/cassandra] bugfix #32369 ([#32415](https://github.com/bitnami/charts/pull/32415))
+
+## <small>12.2.1 (2025-03-05)</small>
+
+* [bitnami/cassandra] Release 12.2.1 (#32322) ([5543930](https://github.com/bitnami/charts/commit/554393025cd9165c851b4b139c1ec5bf012fc4e5)), closes [#32322](https://github.com/bitnami/charts/issues/32322)
 
 ## 12.2.0 (2025-02-27)
 

--- a/bitnami/cassandra/Chart.yaml
+++ b/bitnami/cassandra/Chart.yaml
@@ -32,4 +32,4 @@ maintainers:
 name: cassandra
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/cassandra
-version: 12.2.1
+version: 12.2.2

--- a/bitnami/cassandra/templates/statefulset.yaml
+++ b/bitnami/cassandra/templates/statefulset.yaml
@@ -172,8 +172,8 @@ spec:
             fi
             {{- else }}
             if [[ -f "/certs/truststore" ]] && [[ -f "/certs/keystore" ]]; then
-                cp "/certs/truststore" "/opt/bitnami/cassandra/certs/truststore"
-                cp "/certs/keystore" "/opt/bitnami/cassandra/certs/keystore"
+                [[ -f "/opt/bitnami/cassandra/certs/truststore" ]] || cp "/certs/truststore" "/opt/bitnami/cassandra/certs/truststore"
+                [[ -f "/opt/bitnami/cassandra/certs/keystore" ]] || cp "/certs/keystore" "/opt/bitnami/cassandra/certs/keystore"
             else
                 echo "Couldn't find the expected Java Key Stores (JKS) files! They are mandatory when encryption via TLS is enabled."
                 exit 1


### PR DESCRIPTION
### Description of the change

On 'init-certs' init-container, don't attempt overwriting read only ssl certs when they already exist (from previous runs of the init-container) 

### Benefits

Avoids an issue where the cassandra pod is stuck in a init:crashLoopBackoff because the previously copied certs cannot be overwritten.

### Possible drawbacks

If the certs exist from some process other than the init-container, they may not be overwritten correctly from the configured k8s secret.

### Applicable issues

- fixes #32369 

### Additional information

This will fix the 12.X.X version of the cassandra charts, which by default use cassandra 5.0.x.  Are the charts intended to be backwards compatible for cassandra 4.1?  If not, is there a way to patch the 11.X version of the cassandra charts?

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
