### PR TITLE
[bitnami/etcd] bugfix: skip TLS verification with self-signed certs

### DIFF
--- a/bitnami/etcd/CHANGELOG.md
+++ b/bitnami/etcd/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 11.1.4 (2025-03-11)
+## 11.1.5 (2025-03-12)
 
-* [bitnami/etcd] Release 11.1.4 ([#32397](https://github.com/bitnami/charts/pull/32397))
+* [bitnami/etcd] bugfix: skip TLS verification with self-signed certs ([#32417](https://github.com/bitnami/charts/pull/32417))
+
+## <small>11.1.4 (2025-03-11)</small>
+
+* [bitnami/etcd] Release 11.1.4 (#32397) ([0ce5db9](https://github.com/bitnami/charts/commit/0ce5db9b0e37162cec32789580d4892264783a88)), closes [#32397](https://github.com/bitnami/charts/issues/32397)
 
 ## <small>11.1.3 (2025-03-05)</small>
 

--- a/bitnami/etcd/Chart.yaml
+++ b/bitnami/etcd/Chart.yaml
@@ -32,4 +32,4 @@ maintainers:
 name: etcd
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/etcd
-version: 11.1.4
+version: 11.1.5

--- a/bitnami/etcd/templates/NOTES.txt
+++ b/bitnami/etcd/templates/NOTES.txt
@@ -88,7 +88,7 @@ To connect to your etcd server from outside the cluster execute the following co
 {{- if .Values.auth.client.secureTransport }}
 {{- if .Values.auth.client.useAutoTLS }}
 
- * As TLS is enabled you should add the flag `--cert-file /bitnami/etcd/data/fixtures/client/cert.pem --key-file /bitnami/etcd/data/fixtures/client/key.pem` to the etcdctl commands.
+ * As TLS is enabled you should add the flag `--cert-file /bitnami/etcd/data/fixtures/client/cert.pem --key-file /bitnami/etcd/data/fixtures/client/key.pem --insecure-skip-tls-verify` to the etcdctl commands.
 
 {{- else }}
 

--- a/bitnami/etcd/templates/_helpers.tpl
+++ b/bitnami/etcd/templates/_helpers.tpl
@@ -54,8 +54,9 @@ Return the proper etcdctl authentication options
 {{- define "etcd.authOptions" -}}
 {{- $rbacOption := "--user root:$ROOT_PASSWORD" -}}
 {{- $certsOption := " --cert $ETCD_CERT_FILE --key $ETCD_KEY_FILE" -}}
-{{- $autoCertsOption := " --cert /bitnami/etcd/data/fixtures/client/cert.pem --key /bitnami/etcd/data/fixtures/client/key.pem" -}}
+{{- $autoCertsOption := " --cert /bitnami/etcd/data/fixtures/client/cert.pem --key /bitnami/etcd/data/fixtures/client/key.pem --insecure-skip-tls-verify" -}}
 {{- $caOption := " --cacert $ETCD_TRUSTED_CA_FILE" -}}
+{{- $insecureTlsOption := " --insecure-skip-tls-verify" -}}
 {{- if or .Values.auth.rbac.create .Values.auth.rbac.enabled -}}
     {{- printf "%s" $rbacOption -}}
 {{- end -}}
@@ -63,8 +64,10 @@ Return the proper etcdctl authentication options
     {{- printf "%s" $autoCertsOption -}}
 {{- else if and .Values.auth.client.secureTransport (not .Values.auth.client.useAutoTLS) -}}
     {{- printf "%s" $certsOption -}}
-    {{- if .Values.auth.client.enableAuthentication -}}
+    {{- if or .Values.auth.client.enableAuthentication .Values.auth.client.caFilename -}}
         {{- printf "%s" $caOption -}}
+    {{- else -}}
+        {{- printf "%s" $insecureTlsOption -}}
     {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/bitnami/etcd/templates/cronjob-snapshotter.yaml
+++ b/bitnami/etcd/templates/cronjob-snapshotter.yaml
@@ -110,7 +110,10 @@ spec:
                   value: "/opt/bitnami/etcd/certs/client/{{ .Values.auth.client.caFilename | default "ca.crt" }}"
                 {{- else if .Values.auth.client.caFilename }}
                 - name: ETCD_TRUSTED_CA_FILE
-                  value: "/opt/bitnami/etcd/certs/client/{{ .Values.auth.client.caFilename | default "ca.crt" }}"
+                  value: "/opt/bitnami/etcd/certs/client/{{ .Values.auth.client.caFilename }}"
+                {{- else }}
+                - name: ETCD_EXTRA_AUTH_FLAGS
+                  value: "--insecure-skip-tls-verify"
                 {{- end }}
                 {{- end }}
                 {{- if or .Values.auth.rbac.create .Values.auth.rbac.enabled }}

--- a/bitnami/etcd/templates/preupgrade-hook-job.yaml
+++ b/bitnami/etcd/templates/preupgrade-hook-job.yaml
@@ -111,7 +111,10 @@ spec:
               value: "/opt/bitnami/etcd/certs/client/{{ .Values.auth.client.caFilename | default "ca.crt" }}"
             {{- else if .Values.auth.client.caFilename }}
             - name: ETCD_TRUSTED_CA_FILE
-              value: "/opt/bitnami/etcd/certs/client/{{ .Values.auth.client.caFilename | default "ca.crt" }}"
+              value: "/opt/bitnami/etcd/certs/client/{{ .Values.auth.client.caFilename }}"
+            {{- else }}
+            - name: ETCD_EXTRA_AUTH_FLAGS
+              value: "--insecure-skip-tls-verify"
             {{- end }}
             {{- end }}
             {{- if .Values.extraEnvVars }}


### PR DESCRIPTION
### Description of the change

This PR ensures we add the `--insecure-skip-tls-verify` flag to etcdctl command when self-signed certs (with no CA provided) are used.

### Benefits

pre-upgrade hook works if self-signed certs with no CA are used.

### Possible drawbacks

None

### Applicable issues

- fixes #https://github.com/bitnami/containers/issues/78362

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
