### PR TITLE
[bitnami/redis-cluster] Use ternary yes/no for useAOFPersistence

### DIFF
--- a/bitnami/redis-cluster/CHANGELOG.md
+++ b/bitnami/redis-cluster/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 11.4.3 (2025-02-20)
+## 11.4.5 (2025-03-12)
 
-* [bitnami/redis-cluster] Release 11.4.3 ([#32032](https://github.com/bitnami/charts/pull/32032))
+* [bitnami/redis-cluster] Use ternary yes/no for useAOFPersistence ([#32418](https://github.com/bitnami/charts/pull/32418))
+
+## <small>11.4.3 (2025-02-20)</small>
+
+* [bitnami/redis-cluster] Release 11.4.3 (#32032) ([e652611](https://github.com/bitnami/charts/commit/e65261189935c2a97a9998e9fca715c08a262e44)), closes [#32032](https://github.com/bitnami/charts/issues/32032)
 
 ## <small>11.4.2 (2025-02-16)</small>
 

--- a/bitnami/redis-cluster/Chart.yaml
+++ b/bitnami/redis-cluster/Chart.yaml
@@ -32,4 +32,4 @@ maintainers:
 name: redis-cluster
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/redis-cluster
-version: 11.4.3
+version: 11.4.5

--- a/bitnami/redis-cluster/templates/_helpers.tpl
+++ b/bitnami/redis-cluster/templates/_helpers.tpl
@@ -172,6 +172,19 @@ Return Redis&reg; password
 {{- end -}}
 
 {{/*
+Returns true if useAOFPersistence should be enabled
+YAML will transform 'yes'/'no' into 'true'/'false' when quotes are missing, because it interprets the variable as boolean.
+Redis expects explicit 'yes'/'no', so this helper avoids issues when providing a boolean instead of a string.
+*/}}
+{{- define "redis-cluster.useAOFPersistence" -}}
+{{- if kindOf .Values.redis.useAOFPersistence | eq "bool" -}}
+    {{ ternary "yes" "no" .Values.redis.useAOFPersistence }}
+{{- else -}}
+    {{ print .Values.redis.useAOFPersistence }}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Determines whether or not to create the Statefulset
 */}}
 {{- define "redis-cluster.createStatefulSet" -}}

--- a/bitnami/redis-cluster/templates/redis-statefulset.yaml
+++ b/bitnami/redis-cluster/templates/redis-statefulset.yaml
@@ -181,7 +181,7 @@ spec:
               value: "yes"
             {{- end }}
             - name: REDIS_AOF_ENABLED
-              value: {{ .Values.redis.useAOFPersistence | quote }}
+              value: {{ include "redis-cluster.useAOFPersistence" . | quote }}
             - name: REDIS_TLS_ENABLED
               value: {{ ternary "yes" "no" .Values.tls.enabled | quote }}
             {{- if .Values.tls.enabled }}


### PR DESCRIPTION
### Description of the change

Fixes an issue when, in the values yaml, the yes/no value for `redis.useAOFPersistence` is provided without quotes.

If provided without quotes, YAML will interpret yes/no as true/false, and when `{{ .Values.redis.useAOFPersistence | quote }}` is interpreted, it will print "true"/"false" instead of the expected "yes"/"no".

The new helper makes the chart tolerant to using both string and boolean values for `redis.useAOFPersistence`.

### Benefits

Avoid issues when users accidentally use the value `useAOFPersistence` without quotes and yaml interprets it as boolean.

### Possible drawbacks

None known.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #31883

### Additional information

https://www.bram.us/2022/01/11/yaml-the-norway-problem/

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
