### PR TITLE
[bitnami/redis] Support retrieving Redis ACL user passwords from Kubernetes Secrets 

### DIFF
--- a/bitnami/redis/CHANGELOG.md
+++ b/bitnami/redis/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 20.11.5 (2025-03-26)
+## 20.12.0 (2025-04-12)
 
-* [bitnami/redis] Handle SIGTERM in `kubectl-shared` container ([#32085](https://github.com/bitnami/charts/pull/32085))
+* [bitnami/redis] Support retrieving Redis ACL user passwords from Kubernetes Secrets  ([#32434](https://github.com/bitnami/charts/pull/32434))
+
+## <small>20.11.5 (2025-04-09)</small>
+
+* [bitnami/redis] Handle SIGTERM in `kubectl-shared` container (#32085) ([dad454d](https://github.com/bitnami/charts/commit/dad454d7912fa3328dd1ba528d3be370d6c00342)), closes [#32085](https://github.com/bitnami/charts/issues/32085)
 
 ## <small>20.11.4 (2025-03-22)</small>
 

--- a/bitnami/redis/Chart.yaml
+++ b/bitnami/redis/Chart.yaml
@@ -37,4 +37,4 @@ maintainers:
 name: redis
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/redis
-version: 20.11.5
+version: 20.12.0

--- a/bitnami/redis/README.md
+++ b/bitnami/redis/README.md
@@ -503,21 +503,22 @@ helm install my-release --set master.persistence.existingClaim=PVC_NAME oci://RE
 
 ### Redis&reg; common configuration parameters
 
-| Name                             | Description                                                                           | Value         |
-| -------------------------------- | ------------------------------------------------------------------------------------- | ------------- |
-| `architecture`                   | Redis&reg; architecture. Allowed values: `standalone` or `replication`                | `replication` |
-| `auth.enabled`                   | Enable password authentication                                                        | `true`        |
-| `auth.sentinel`                  | Enable authentication on sentinels too                                                | `true`        |
-| `auth.password`                  | Redis&reg; password                                                                   | `""`          |
-| `auth.existingSecret`            | The name of an existing secret with Redis&reg; credentials                            | `""`          |
-| `auth.existingSecretPasswordKey` | Password key to be retrieved from existing secret                                     | `""`          |
-| `auth.usePasswordFiles`          | Mount credentials as files instead of using an environment variable                   | `true`        |
-| `auth.usePasswordFileFromSecret` | Mount password file from secret                                                       | `true`        |
-| `auth.acl.enabled`               | Enables the support of the Redis ACL system                                           | `false`       |
-| `auth.acl.sentinel`              | Enables the support of the Redis ACL system for Sentinel Nodes                        | `false`       |
-| `auth.acl.users`                 | A list of the configured users in the Redis ACL system                                | `[]`          |
-| `commonConfiguration`            | Common configuration to be added into the ConfigMap                                   | `""`          |
-| `existingConfigmap`              | The name of an existing ConfigMap with your custom configuration for Redis&reg; nodes | `""`          |
+| Name                             | Description                                                                               | Value         |
+| -------------------------------- | ----------------------------------------------------------------------------------------- | ------------- |
+| `architecture`                   | Redis&reg; architecture. Allowed values: `standalone` or `replication`                    | `replication` |
+| `auth.enabled`                   | Enable password authentication                                                            | `true`        |
+| `auth.sentinel`                  | Enable authentication on sentinels too                                                    | `true`        |
+| `auth.password`                  | Redis&reg; password                                                                       | `""`          |
+| `auth.existingSecret`            | The name of an existing secret with Redis&reg; credentials                                | `""`          |
+| `auth.existingSecretPasswordKey` | Password key to be retrieved from existing secret                                         | `""`          |
+| `auth.usePasswordFiles`          | Mount credentials as files instead of using an environment variable                       | `true`        |
+| `auth.usePasswordFileFromSecret` | Mount password file from secret                                                           | `true`        |
+| `auth.acl.enabled`               | Enables the support of the Redis ACL system                                               | `false`       |
+| `auth.acl.sentinel`              | Enables the support of the Redis ACL system for Sentinel Nodes                            | `false`       |
+| `auth.acl.users`                 | A list of the configured users in the Redis ACL system                                    | `[]`          |
+| `auth.acl.userSecret`            | Name of the Secret, containing user credentials for ACL users. Keys must match usernames. | `""`          |
+| `commonConfiguration`            | Common configuration to be added into the ConfigMap                                       | `""`          |
+| `existingConfigmap`              | The name of an existing ConfigMap with your custom configuration for Redis&reg; nodes     | `""`          |
 
 ### Redis&reg; master configuration parameters
 

--- a/bitnami/redis/templates/_helpers.tpl
+++ b/bitnami/redis/templates/_helpers.tpl
@@ -231,6 +231,19 @@ Return Redis&reg; password
 {{- end }}
 {{- end }}
 
+{{/*
+Returns the secret value if found or an empty string otherwise
+Used for fetching Redis ACL user passwords from Kubernetes Secrets
+*/}}
+{{- define "common.secrets.get" -}} 
+{{- $secret := (lookup "v1" "Secret" .context.Release.Namespace .secret) -}}
+{{- if and $secret (index $secret.data .key) -}}
+    {{- index $secret.data .key | b64dec -}}
+{{- else -}}
+    {{- "" -}}
+{{- end }}
+{{- end }}
+
 {{/* Check if there are rolling tags in the images */}}
 {{- define "redis.checkRollingTags" -}}
 {{- include "common.warnings.rollingTag" .Values.image }}

--- a/bitnami/redis/templates/configmap.yaml
+++ b/bitnami/redis/templates/configmap.yaml
@@ -56,8 +56,11 @@ data:
     user default on {{ if $password}}#{{ sha256sum $password}}{{ else }}nopass{{ end }} ~* &* +@all
     {{- if .Values.auth.acl.users -}}
     {{- /* custom users */ -}}
+    {{- $userSecret := .Values.auth.acl.userSecret -}}
     {{- range .Values.auth.acl.users }}
-    user {{ .username }} {{ default "on" .enabled}} {{ if .password}}#{{ sha256sum .password}}{{ else }}nopass{{ end }} {{ default "~*" .keys}} {{ default "&*" .channels }} {{ default "+@all" .commands }}
+    {{- $userPassword := .password | default "" }}
+    {{- $secretPassword := (include "common.secrets.get" (dict "secret" $userSecret "key" .username "context" $))}}
+    user {{ .username }} {{ default "on" .enabled }} {{ if $secretPassword }}#{{ sha256sum $secretPassword }}{{ else if $userPassword }}#{{ sha256sum $userPassword }}{{ else }}nopass{{ end }} {{ default "~*" .keys }} {{ default "&*" .channels }} {{ default "+@all" .commands }}
     {{- end }}
     {{- end }}
     {{- end }}

--- a/bitnami/redis/values.yaml
+++ b/bitnami/redis/values.yaml
@@ -186,7 +186,9 @@ auth:
     ##     commands: "+@all"
     ##     keys: "~*"
     ##     channels: "&*"
-    users: [ ]
+    users: []
+    ## @param auth.acl.userSecret Name of the Secret, containing user credentials for ACL users. Keys must match usernames.
+    userSecret: ""
 ## @param commonConfiguration [string] Common configuration to be added into the ConfigMap
 ## ref: https://redis.io/topics/config
 ##


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.


 -->

### Description of the change
- Introduced auth.acl.userSecret for specifying the secret containing user credentials.
- Added helper function common.secrets.get to fetch user credentials from a Secret.
- Updated Redis ACL user configuration to prioritize secrets over plain-text passwords.
- Ensured backward compatibility by falling back to .password when no secret is found.

### Benefits

- Allows passwords to be managed in Kubernetes secrets instead of being hardcoded in `values.yaml`.

### Possible drawbacks

- None. The change is backward compatible, and previous users can continue using the chart without any issues.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
