### PR TITLE
[bitnami/(kube-prometheus|kube-state-metrics)] metricRelabelings keep metrics added

### DIFF
--- a/bitnami/kube-prometheus/templates/exporters/core-dns/servicemonitor.yaml
+++ b/bitnami/kube-prometheus/templates/exporters/core-dns/servicemonitor.yaml
@@ -39,4 +39,10 @@ spec:
       {{- if .Values.coreDns.serviceMonitor.relabelings }}
       relabelings: {{- include "common.tplvalues.render" (dict "value" .Values.coreDns.serviceMonitor.relabelings "context" $) | nindent 6 }}
       {{- end }}
+      {{- if .Values.coreDns.serviceMonitor.keepMetrics }}
+      metricRelabelings:
+        - sourceLabels: [__name__]
+          regex: "{{ .Values.coreDns.serviceMonitor.keepMetrics | default (list ".*") | join "|" }}"
+          action: keep
+      {{- end }}
 {{- end }}

--- a/bitnami/kube-prometheus/templates/exporters/kube-apiserver/servicemonitor.yaml
+++ b/bitnami/kube-prometheus/templates/exporters/kube-apiserver/servicemonitor.yaml
@@ -45,4 +45,10 @@ spec:
       {{- if .Values.kubeApiServer.serviceMonitor.relabelings }}
       relabelings: {{- include "common.tplvalues.render" ( dict "value" .Values.kubeApiServer.serviceMonitor.relabelings "context" $) | nindent 8 }}
       {{- end }}
+      {{- if .Values.kubeApiServer.serviceMonitor.keepMetrics }}
+      metricRelabelings:
+        - sourceLabels: [__name__]
+          regex: "{{ .Values.kubeApiServer.serviceMonitor.keepMetrics | default (list ".*") | join "|" }}"
+          action: keep
+      {{- end }}
 {{- end }}

--- a/bitnami/kube-prometheus/templates/exporters/kube-controller-manager/servicemonitor.yaml
+++ b/bitnami/kube-prometheus/templates/exporters/kube-controller-manager/servicemonitor.yaml
@@ -50,4 +50,10 @@ spec:
       {{- if .Values.kubeControllerManager.serviceMonitor.relabelings }}
       relabelings: {{- include "common.tplvalues.render" (dict "value" .Values.kubeControllerManager.serviceMonitor.relabelings "context" $) | nindent 6 }}
       {{- end }}
+      {{- if .Values.kubeControllerManager.serviceMonitor.keepMetrics }}
+      metricRelabelings:
+        - sourceLabels: [__name__]
+          regex: "{{ .Values.kubeControllerManager.serviceMonitor.keepMetrics | default (list ".*") | join "|" }}"
+          action: keep
+      {{- end }}
 {{- end }}

--- a/bitnami/kube-prometheus/templates/exporters/kube-proxy/servicemonitor.yaml
+++ b/bitnami/kube-prometheus/templates/exporters/kube-proxy/servicemonitor.yaml
@@ -44,4 +44,10 @@ spec:
       {{- if .Values.kubeProxy.serviceMonitor.relabelings }}
       relabelings: {{- toYaml .Values.kubeProxy.serviceMonitor.relabelings | nindent 8 }}
       {{- end }}
+      {{- if .Values.kubeProxy.serviceMonitor.keepMetrics }}
+      metricRelabelings:
+        - sourceLabels: [__name__]
+          regex: "{{ .Values.kubeProxy.serviceMonitor.keepMetrics | default (list ".*") | join "|" }}"
+          action: keep
+      {{- end }}
 {{- end }}

--- a/bitnami/kube-prometheus/templates/exporters/kube-scheduler/servicemonitor.yaml
+++ b/bitnami/kube-prometheus/templates/exporters/kube-scheduler/servicemonitor.yaml
@@ -50,4 +50,10 @@ spec:
       {{- if .Values.kubeScheduler.serviceMonitor.relabelings }}
       relabelings: {{- include "common.tplvalues.render" (dict "value" .Values.kubeScheduler.serviceMonitor.relabelings "context" $) | nindent 6 }}
       {{- end }}
+      {{- if .Values.kubeScheduler.serviceMonitor.keepMetrics }}
+      metricRelabelings:
+        - sourceLabels: [__name__]
+          regex: "{{ .Values.kubeScheduler.serviceMonitor.keepMetrics | default (list ".*") | join "|" }}"
+          action: keep
+      {{- end }}
 {{- end }}

--- a/bitnami/kube-prometheus/templates/exporters/kubelet/servicemonitor.yaml
+++ b/bitnami/kube-prometheus/templates/exporters/kubelet/servicemonitor.yaml
@@ -51,6 +51,12 @@ spec:
       {{- if .Values.kubelet.serviceMonitor.relabelings }}
       relabelings: {{- include "common.tplvalues.render" ( dict "value" .Values.kubelet.serviceMonitor.relabelings "context" $) | nindent 8 }}
       {{- end }}
+      {{- if .Values.kubelet.serviceMonitor.keepMetrics }}
+      metricRelabelings:
+        - sourceLabels: [__name__]
+          regex: "{{ .Values.kubelet.serviceMonitor.keepMetrics | default (list ".*") | join "|" }}"
+          action: keep
+      {{- end }}
       {{- if .Values.kubelet.serviceMonitor.cAdvisor }}
     - port: {{ printf "%s-metrics" $scheme }}
       scheme: {{$scheme}}

--- a/bitnami/kube-prometheus/values.yaml
+++ b/bitnami/kube-prometheus/values.yaml
@@ -2515,6 +2515,9 @@ kubelet:
     ## ref: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
     ##
     relabelings: []
+    ## @param serviceMonitor.keepMetrics ServiceMonitor keepMetrics
+    ##
+    keepMetrics: []
     ## @param kubelet.serviceMonitor.cAdvisor Enable scraping /metrics/cadvisor from kubelet's service
     ## ref: https://prometheus.io/docs/guides/cadvisor/#exploring-metrics-in-the-expression-browser
     ##
@@ -3011,6 +3014,9 @@ kubeApiServer:
     ## ref: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
     ##
     relabelings: []
+    ## @param serviceMonitor.keepMetrics ServiceMonitor keepMetrics
+    ##
+    keepMetrics: []
     ## @param kubeApiServer.serviceMonitor.labels Extra labels for the ServiceMonitor
     ##
     labels: {}
@@ -3081,6 +3087,9 @@ kubeControllerManager:
     ## ref: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
     ##
     relabelings: []
+    ## @param serviceMonitor.keepMetrics ServiceMonitor keepMetrics
+    ##
+    keepMetrics: []
     ## @param kubeControllerManager.serviceMonitor.labels Extra labels for the ServiceMonitor
     ##
     labels: {}
@@ -3159,6 +3168,9 @@ kubeScheduler:
     ##    action: replace
     ##
     relabelings: []
+    ## @param serviceMonitor.keepMetrics ServiceMonitor keepMetrics
+    ##
+    keepMetrics: []
     ## @param kubeScheduler.serviceMonitor.labels Extra labels for the ServiceMonitor
     ##
     labels: {}
@@ -3220,6 +3232,9 @@ coreDns:
     ##    action: replace
     ##
     relabelings: []
+    ## @param serviceMonitor.keepMetrics ServiceMonitor keepMetrics
+    ##
+    keepMetrics: []
     ## @param coreDns.serviceMonitor.labels Extra labels for the ServiceMonitor
     ##
     labels: {}
@@ -3283,6 +3298,9 @@ kubeProxy:
     ## ref: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
     ##
     relabelings: []
+    ## @param serviceMonitor.keepMetrics ServiceMonitor keepMetrics
+    ##
+    keepMetrics: []
     ## @param kubeProxy.serviceMonitor.labels Extra labels for the ServiceMonitor
     ##
     labels: {}

--- a/bitnami/kube-state-metrics/templates/servicemonitor.yaml
+++ b/bitnami/kube-state-metrics/templates/servicemonitor.yaml
@@ -61,6 +61,12 @@ spec:
       {{- if .Values.serviceMonitor.metricRelabelings }}
       metricRelabelings: {{- include "common.tplvalues.render" ( dict "value" .Values.serviceMonitor.metricRelabelings "context" $) | nindent 8 }}
       {{- end }}
+      {{- if .Values.serviceMonitor.keepMetrics }}
+      metricRelabelings:
+        - sourceLabels: [__name__]
+          regex: "{{ .Values.serviceMonitor.keepMetrics | default (list ".*") | join "|" }}"
+          action: keep
+      {{- end }}
       {{- if .Values.serviceMonitor.extraParameters }}
       {{- toYaml .Values.serviceMonitor.extraParameters | nindent 6 }}
       {{- end }}

--- a/bitnami/kube-state-metrics/values.yaml
+++ b/bitnami/kube-state-metrics/values.yaml
@@ -636,6 +636,9 @@ serviceMonitor:
   ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#relabelconfig
   ##
   metricRelabelings: []
+  ## @param serviceMonitor.keepMetrics ServiceMonitor keepMetrics
+  ##
+  keepMetrics: []
   ## @param serviceMonitor.labels Extra labels for the ServiceMonitor
   ##
   labels: {}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Added the `keepMetrics` mechanism in `ServiceMonitor`, allowing users to filter and keep only specified metrics before they are sent to Prometheus. This enhancement provides better control over collected metrics, reducing unnecessary data ingestion.

Changes have been applied to all `ServiceMonitor` configurations in the chart.
Example usage:
```yaml
serviceMonitor:
  keepMetrics:
    - kube_pod_status_phase
    - kube_pod_container_status_ready
    - kube_pod_start_time
    - kube_pod_container_status_last_terminated_reason
```

Code changes:
```yaml
{{- if .Values.serviceMonitor.keepMetrics }}
metricRelabelings:
  - sourceLabels: [__name__]
    regex: "{{ .Values.serviceMonitor.keepMetrics | default (list ".*") | join "|" }}"
    action: keep
{{- end }}
```
### Benefits

- Reduces Prometheus resource consumption by collecting only relevant metrics.
- Improves flexibility by allowing users to define which metrics should be retained.

### Possible drawbacks

- Users must explicitly define the metrics they want to keep; otherwise, all metrics are collected by default.

### Applicable issues

N/A
- fixes #

### Additional information

N/A

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->


- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
