### PR TITLE
[bitnami/rabbitmq] allow to configure trafficDistribution

### DIFF
--- a/bitnami/rabbitmq/CHANGELOG.md
+++ b/bitnami/rabbitmq/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 15.3.3 (2025-02-26)
+## 15.3.4 (2025-03-13)
 
-* [bitnami/rabbitmq] Release 15.3.3 ([#32187](https://github.com/bitnami/charts/pull/32187))
+* [bitnami/rabbitmq] allow to configure trafficDistribution ([#32443](https://github.com/bitnami/charts/pull/32443))
+
+## <small>15.3.3 (2025-02-26)</small>
+
+* [bitnami/rabbitmq] Release 15.3.3 (#32187) ([e4af5c8](https://github.com/bitnami/charts/commit/e4af5c8b3510c166a38cd5bc03074a39bf63da4d)), closes [#32187](https://github.com/bitnami/charts/issues/32187)
 
 ## <small>15.3.2 (2025-02-21)</small>
 

--- a/bitnami/rabbitmq/CHANGELOG.md
+++ b/bitnami/rabbitmq/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 15.3.4 (2025-03-13)
+## 15.4.0 (2025-03-17)
 
 * [bitnami/rabbitmq] allow to configure trafficDistribution ([#32443](https://github.com/bitnami/charts/pull/32443))
 

--- a/bitnami/rabbitmq/Chart.yaml
+++ b/bitnami/rabbitmq/Chart.yaml
@@ -31,4 +31,4 @@ maintainers:
 name: rabbitmq
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/rabbitmq
-version: 15.3.3
+version: 15.4.0

--- a/bitnami/rabbitmq/README.md
+++ b/bitnami/rabbitmq/README.md
@@ -659,6 +659,7 @@ Because they expose different sets of data, a valid use case is to scrape metric
 | `service.headless.annotations`          | Annotations for the headless service.                                                                                            | `{}`                     |
 | `service.sessionAffinity`               | Session Affinity for Kubernetes service, can be "None" or "ClientIP"                                                             | `None`                   |
 | `service.sessionAffinityConfig`         | Additional settings for the sessionAffinity                                                                                      | `{}`                     |
+| `service.trafficDistribution`           | Traffic Distribution provides another                                                                                            | `PreferClose`            |
 | `ingress.enabled`                       | Enable ingress resource for Management console                                                                                   | `false`                  |
 | `ingress.path`                          | Path for the default host. You may need to set this to '/*' in order to use this with ALB ingress controllers.                   | `/`                      |
 | `ingress.pathType`                      | Ingress path type                                                                                                                | `ImplementationSpecific` |

--- a/bitnami/rabbitmq/templates/svc-headless.yaml
+++ b/bitnami/rabbitmq/templates/svc-headless.yaml
@@ -43,3 +43,6 @@ spec:
   {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.podLabels .Values.commonLabels ) "context" . ) }}
   selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
   publishNotReadyAddresses: true
+  {{- if semverCompare ">=1.31-0" (include "common.capabilities.kubeVersion" .) }}
+  trafficDistribution: {{ .Values.service.trafficDistribution }}
+  {{- end }}

--- a/bitnami/rabbitmq/values.yaml
+++ b/bitnami/rabbitmq/values.yaml
@@ -1169,6 +1169,10 @@ service:
   ##     timeoutSeconds: 300
   ##
   sessionAffinityConfig: {}
+  ## @param service.trafficDistribution Traffic Distribution provides another
+  ## way to influence traffic routing within a Kubernetes Service.
+  ##
+  trafficDistribution: "PreferClose"
 ## Configure the ingress resource that allows you to access the
 ## RabbitMQ installation. Set up the URL
 ## ref: https://kubernetes.io/docs/concepts/services-networking/ingress/


### PR DESCRIPTION
Hello !

### Description of the change

Add trafficDistribution feature on svc-headless of RabbitMQ. 
This feature is available since k8s v1.31.

### Benefits

Take advantage of the new feature trafficDistribution.
cf. https://kubernetes.io/docs/concepts/services-networking/service/#traffic-distribution

### Possible drawbacks

Normally, no drawbacks.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
