### PR TITLE
bitnami/kafka Adjust parameters in example of section "Deploying extra resources" in README 

### DIFF
--- a/bitnami/kafka/README.md
+++ b/bitnami/kafka/README.md
@@ -386,7 +386,7 @@ extraDeploy:
         app.kubernetes.io/component: connector
     data:
       connect-standalone.properties: |-
-        bootstrap.servers = {{ include "common.names.fullname" . }}-0.{{ include "common.names.fullname" . }}-headless.{{ include "common.names.namespace" . }}.svc.{{ .Values.clusterDomain }}:{{ .Values.service.port }}
+        bootstrap.servers = {{ include "common.names.fullname" . }}-controller-0.{{ include "common.names.fullname" . }}-controller-headless.{{ include "common.names.namespace" . }}.svc.{{ .Values.clusterDomain }}:{{ .Values.service.ports.client }}
         ...
       mongodb.properties: |-
         connection.uri=mongodb://root:password@mongodb-hostname:27017

--- a/bitnami/kafka/README.md
+++ b/bitnami/kafka/README.md
@@ -415,7 +415,7 @@ FROM bitnami/kafka:latest
 RUN mkdir -p /opt/bitnami/kafka/plugins && \
     cd /opt/bitnami/kafka/plugins && \
     curl --remote-name --location --silent https://search.maven.org/remotecontent?filepath=org/mongodb/kafka/mongo-kafka-connect/1.2.0/mongo-kafka-connect-1.2.0-all.jar
-CMD /opt/bitnami/kafka/bin/connect-standalone.sh /opt/bitnami/kafka/config/connect-standalone.properties /opt/bitnami/kafka/config/mongo.properties
+CMD /opt/bitnami/kafka/bin/connect-standalone.sh /bitnami/kafka/config/connect-standalone.properties /bitnami/kafka/config/mongo.properties
 ```
 
 ### Backup and restore


### PR DESCRIPTION
### Description of the change

In the mongoDB Kafka Connector sink example of the "Deploying extra resources" section,

- corrected two paths in the `CMD` of the Dockerfile
- updated hostname and port of the example `bootstrap.servers` configuration.

### Benefits

The line 
```Dockerfile
CMD /opt/bitnami/kafka/bin/connect-standalone.sh /opt/bitnami/kafka/config/connect-standalone.properties /opt/bitnami/kafka/config/mongo.properties
```
points `connect-standalone.sh` to the configuration files that are by default in the docker image. This means that if a user of the chart builds this Dockerfile, the configurations that are made in the ConfigMap are not used since those configurations are mounted on a different path. This also means that by default the pod does not manage to connect to the controller since the default hostname is `localhost`. My change corrects this so that now configurations made in ConfigMap are also visible when running the chart.

Second the hostname in the `bootstrap.servers` parameter does not work either.

- The port is given with `{{ .Values.service.port }}` which seems to no longer exist so I updated it to `{{ .Values.service.ports.client }}`. 
- The hostname assumes an incorrect name of the controller pods and headless service, so I updated them to include the name `-controller`.

### Possible drawbacks

Writing `...-controller-...` in the `bootstrap.servers` parameter could be considered hard-coding and there could be a more dynamic method of describing the hostname. I'm not very familiar with all the details and possibilities of this chart (this is my first PR to an open source project).

### Checklist

- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
